### PR TITLE
fix(vscode): correct entry point in VS Code tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,13 +41,14 @@
             "problemMatcher": []
         },
         {
-            "label": "uv run main.py --debug --no-headless --no-lazy-init",
-            "detail": "Run main.py in debug mode with visible window and login immediately",
+            "label": "uv run -m linkedin_mcp_server --debug --no-headless --no-lazy-init",
+            "detail": "Run server in debug mode with visible window and login immediately",
             "type": "shell",
             "command": "uv",
             "args": [
                 "run",
-                "main.py",
+                "-m",
+                "linkedin_mcp_server",
                 "--debug",
                 "--no-headless",
                 "--no-lazy-init"
@@ -64,13 +65,14 @@
             "problemMatcher": []
         },
         {
-            "label": "uv run main.py --no-headless --no-lazy-init",
-            "detail": "Run main.py with visible window and login immediately",
+            "label": "uv run -m linkedin_mcp_server --no-headless --no-lazy-init",
+            "detail": "Run server with visible window and login immediately",
             "type": "shell",
             "command": "uv",
             "args": [
                 "run",
-                "main.py",
+                "-m",
+                "linkedin_mcp_server",
                 "--no-headless",
                 "--no-lazy-init"
             ],
@@ -85,13 +87,14 @@
             "problemMatcher": []
         },
         {
-            "label": "uv run main.py --no-headless --no-lazy-init --transport streamable-http",
+            "label": "uv run -m linkedin_mcp_server --no-headless --no-lazy-init --transport streamable-http",
             "detail": "Start HTTP MCP server on localhost:8000/mcp",
             "type": "shell",
             "command": "uv",
             "args": [
                 "run",
-                "main.py",
+                "-m",
+                "linkedin_mcp_server",
                 "--no-headless",
                 "--no-lazy-init",
                 "--transport",


### PR DESCRIPTION
Replace non-existent main.py with module execution
(-m linkedin_mcp_server) in VS Code task configurations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Align VS Code tasks with module-based entry point.
> 
> - Replace `uv run main.py` with `uv run -m linkedin_mcp_server` across debug, standard run, and HTTP MCP server tasks
> - Update task `label` and `detail` to reflect server execution; preserve flags like `--debug`, `--no-headless`, `--no-lazy-init`, and `--transport streamable-http`
> - Config-only change in `.vscode/tasks.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0460c80584cae1fe905d83c1e27cf7b66906639. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->