### PR TITLE
fix(vscode): use --log-level DEBUG instead of --debug

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,7 +41,7 @@
             "problemMatcher": []
         },
         {
-            "label": "uv run -m linkedin_mcp_server --debug --no-headless --no-lazy-init",
+            "label": "uv run -m linkedin_mcp_server --log-level DEBUG --no-headless --no-lazy-init",
             "detail": "Run server in debug mode with visible window and login immediately",
             "type": "shell",
             "command": "uv",
@@ -49,7 +49,8 @@
                 "run",
                 "-m",
                 "linkedin_mcp_server",
-                "--debug",
+                "--log-level",
+                "DEBUG",
                 "--no-headless",
                 "--no-lazy-init"
             ],


### PR DESCRIPTION
The CLI uses --log-level {DEBUG,INFO,WARNING,ERROR} not --debug

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates VS Code task configuration to use the correct CLI flag for debugging.
> 
> - In `.vscode/tasks.json`, replaces `--debug` with `--log-level DEBUG` in the `linkedin_mcp_server` run task label and args
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b942d15fdf7fc8a754fcbaf717da9aec37cd8714. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->