### PR TITLE
fix(logging): filter noisy fastmcp debug logs

### DIFF
--- a/linkedin_mcp_server/logging_config.py
+++ b/linkedin_mcp_server/logging_config.py
@@ -111,3 +111,5 @@ def configure_logging(log_level: str = "WARNING", json_format: bool = False) -> 
     logging.getLogger("selenium").setLevel(logging.ERROR)
     logging.getLogger("urllib3").setLevel(logging.ERROR)
     logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
+    logging.getLogger("fakeredis").setLevel(logging.WARNING)
+    logging.getLogger("docket").setLevel(logging.WARNING)


### PR DESCRIPTION
Add fakeredis and docket loggers to noise reduction to prevent
DEBUG log pollution from FastMCP's internal task queue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Logging noise reduction**
> 
> - Sets `fakeredis` and `docket` loggers to `WARNING` in `logging_config.py` alongside existing noise filters, reducing internal FastMCP debug log spam.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 625cef54dce0548c2a30d66a0db9ad2b4ded3265. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->