### PR TITLE
fix(manifest): remove stale get_recommended_jobs tool reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,6 @@ assignees: ''
   - [ ] get_company_profile
   - [ ] get_job_details
   - [ ] search_jobs
-  - [ ] get_recommended_jobs
   - [ ] close_session
 
 ## MCP Client Configuration

--- a/manifest.json
+++ b/manifest.json
@@ -48,10 +48,6 @@
       "description": "Search for jobs with filters like keywords and location"
     },
     {
-      "name": "get_recommended_jobs",
-      "description": "Get personalized job recommendations based on your profile"
-    },
-    {
       "name": "close_session",
       "description": "Properly close browser session and clean up resources"
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes stale references to a non-existent tool to align docs and config with actual capabilities.
> 
> - Deletes `get_recommended_jobs` from `manifest.json` `tools` list
> - Updates `.github/ISSUE_TEMPLATE/bug_report.md` to remove the `get_recommended_jobs` checkbox under tool call options
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed32fa08a446c6e747edca3368c525a265580db5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->