### PR TITLE
fix(browser): pass config options to BrowserManager

### DIFF
--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -71,7 +71,13 @@ async def get_or_create_browser(
         "width": config.browser.viewport_width,
         "height": config.browser.viewport_height,
     }
-    logger.info(f"Creating new browser (headless={_headless})")
+    logger.info(
+        "Creating new browser (headless=%s, slow_mo=%sms, viewport=%sx%s)",
+        _headless,
+        config.browser.slow_mo,
+        viewport["width"],
+        viewport["height"],
+    )
     _browser = BrowserManager(
         headless=_headless,
         slow_mo=config.browser.slow_mo,


### PR DESCRIPTION
Pass slow_mo, user_agent, and viewport from BrowserConfig to
BrowserManager when creating the browser instance.

Resolves: #85

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Applies runtime browser settings from `BrowserConfig` during initialization and improves visibility into startup parameters.
> 
> - Passes `slow_mo`, `user_agent`, and `viewport` to `BrowserManager` in `drivers/browser.py`
> - Logs headless mode, slow motion delay, and viewport dimensions when creating the browser
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d442832d8fdedfc50f5aec8689fc19e708f1a19b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->