### PR TITLE
fix(dxt): use ${HOME} instead of tilde in Docker volume mount

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,7 @@
       "command": "docker",
       "args": [
         "run", "--rm", "-i",
-        "-v", "~/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
+        "-v", "${HOME}/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
         "-e", "LOG_LEVEL=DEBUG",
         "stickerdaniel/linkedin-mcp-server:2.1.0"
       ]


### PR DESCRIPTION
Replace ~ with ${HOME} in manifest.json Docker volume mount path.
Tilde expansion only works in shell context, not when Docker is
invoked directly by Claude Desktop or DXT extension.

Resolves: #87

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Docker invocation config for reliability outside shell contexts.
> 
> - In `manifest.json`, switches volume mount from `~/.linkedin-mcp` to `${HOME}/.linkedin-mcp` in `docker run` args
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bb3148dc8343330f650fc7051ff6f55c29fdc7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->