### PR TITLE
refactor(config): centralize validation in schema classes

### DIFF
--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -26,6 +26,21 @@ class BrowserConfig:
     viewport_height: int = 720
     default_timeout: int = 5000  # Milliseconds for page operations
 
+    def validate(self) -> None:
+        """Validate browser configuration values."""
+        if self.slow_mo < 0:
+            raise ConfigurationError(
+                f"slow_mo must be non-negative, got {self.slow_mo}"
+            )
+        if self.default_timeout <= 0:
+            raise ConfigurationError(
+                f"default_timeout must be positive, got {self.default_timeout}"
+            )
+        if self.viewport_width <= 0 or self.viewport_height <= 0:
+            raise ConfigurationError(
+                f"viewport dimensions must be positive, got {self.viewport_width}x{self.viewport_height}"
+            )
+
 
 @dataclass
 class ServerConfig:
@@ -54,8 +69,9 @@ class AppConfig:
     server: ServerConfig = field(default_factory=ServerConfig)
     is_interactive: bool = field(default=False)
 
-    def __post_init__(self) -> None:
-        """Validate configuration after initialization."""
+    def validate(self) -> None:
+        """Validate all configuration values. Call after modifying config."""
+        self.browser.validate()
         if self.server.transport == "streamable-http":
             self._validate_transport_config()
             self._validate_path_format()


### PR DESCRIPTION
Move semantic validation (ranges, positive values) from loaders to
schema classes. Add BrowserConfig.validate() for viewport, timeout,
and slow_mo validation. Call validate() at end of load_config().

- Add new env vars: TIMEOUT, USER_AGENT, HOST, PORT, HTTP_PATH, SLOW_MO, VIEWPORT
- Add --linkedin-cookie CLI argument
- Fix --viewport default to None (was overwriting env vars)
- Change viewport CLI error from warning to ConfigurationError

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts semantic validation from loaders into `BrowserConfig.validate()` and `AppConfig.validate()`, with a final `config.validate()` call in `load_config()`.
> 
> - Adds env vars: `TIMEOUT`, `USER_AGENT`, `HOST`, `PORT`, `HTTP_PATH`, `SLOW_MO`, `VIEWPORT`; removes `DEFAULT_TIMEOUT`
> - Adds CLI: `--linkedin-cookie`; sets `--viewport` default to `None` and raises `ConfigurationError` on bad format
> - Validates and parses integers for `TIMEOUT`, `PORT`, `SLOW_MO`; rejects invalid `TRANSPORT`
> - Keeps loaders focused on reading values; schema enforces ranges/format (viewport, timeout, slow_mo, port, path)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77e159f53f4d3d94b68419efcea177dbe4d76fbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->