### PR TITLE
feat(scraper): upgrade to linkedin-scraper 3.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,20 @@ This is a **LinkedIn MCP (Model Context Protocol) Server** that enables AI assis
 
 **Tool Categories:**
 
-- **Person Tools** (`tools/person.py`) - Profile scraping from LinkedIn URLs
-- **Company Tools** (`tools/company.py`) - Company profile extraction
+- **Person Tools** (`tools/person.py`) - Profile scraping with contacts, interests, experiences, education
+- **Company Tools** (`tools/company.py`) - Company profile and posts extraction
 - **Job Tools** (`tools/job.py`) - Job posting details and search functionality
+
+**Available MCP Tools:**
+
+| Tool | Description |
+|------|-------------|
+| `get_person_profile` | Get profile with contacts (email/phone/social), interests, experiences, education |
+| `get_company_profile` | Get company info with employees, affiliated companies, showcase pages |
+| `get_company_posts` | Get recent posts from company feed with reactions/comments/images |
+| `get_job_details` | Get job posting details including description and benefits |
+| `search_jobs` | Search jobs by keywords and location |
+| `close_session` | Close browser session and clean up resources |
 
 **Authentication Flow:**
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,18 @@ Get this company profile for partnership discussions https://www.linkedin.com/co
 Suggest improvements for my CV to target this job posting https://www.linkedin.com/jobs/view/4252026496
 ```
 
+```
+What has Anthropic been posting about recently? https://www.linkedin.com/company/anthropic/
+```
+
 ## Features & Tool Status
 
 | Tool | Description | Status |
 |------|-------------|--------|
-| `get_person_profile` | Get detailed profile info including work history, education, skills | Working |
-| `get_company_profile` | Extract company information from a LinkedIn company name | Working |
-| `search_jobs` | Search for jobs with keywords and location filters | Broken (upstream) |
+| `get_person_profile` | Get detailed profile info including work history, education, contacts, interests | Working |
+| `get_company_profile` | Extract company information including employees, affiliated companies | Working |
+| `get_company_posts` | Get recent posts from a company's LinkedIn feed | Working |
+| `search_jobs` | Search for jobs with keywords and location filters | Working |
 | `get_job_details` | Get detailed information about a specific job posting | Working |
 | `close_session` | Close browser session and clean up resources | Working |
 

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -7,7 +7,8 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Profile Access**: Get detailed LinkedIn profile information
 - **Company Profiles**: Extract comprehensive company data
 - **Job Details**: Retrieve job posting information
-- **Job Search**: Search for jobs with keywords and location filters (currently broken upstream)
+- **Job Search**: Search for jobs with keywords and location filters
+- **Company Posts**: Get recent posts from a company's LinkedIn feed
 
 ## Quick Start
 

--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -9,7 +9,7 @@ import logging
 from typing import Any, Dict
 
 from fastmcp import Context, FastMCP
-from linkedin_scraper import CompanyScraper
+from linkedin_scraper import CompanyPostsScraper, CompanyScraper
 from mcp.types import ToolAnnotations
 
 from linkedin_mcp_server.callbacks import MCPContextProgressCallback
@@ -47,8 +47,13 @@ def register_company_tools(mcp: FastMCP) -> None:
             ctx: FastMCP context for progress reporting
 
         Returns:
-            Structured data from the company's profile including name, about,
-            headquarters, industry, size, and more.
+            Structured data from the company's profile including:
+            - linkedin_url, name, about_us, website, phone
+            - headquarters, founded, industry, company_type, company_size
+            - specialties, headcount
+            - showcase_pages: List of showcase pages (linkedin_url, name, followers)
+            - affiliated_companies: List of affiliated companies
+            - employees: List of employees (name, designation, linkedin_url)
         """
         try:
             # Validate session before scraping
@@ -69,3 +74,50 @@ def register_company_tools(mcp: FastMCP) -> None:
 
         except Exception as e:
             return handle_tool_error(e, "get_company_profile")
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            title="Get Company Posts",
+            readOnlyHint=True,
+            destructiveHint=False,
+            openWorldHint=True,
+        )
+    )
+    async def get_company_posts(
+        company_name: str, ctx: Context, limit: int = 10
+    ) -> Dict[str, Any]:
+        """
+        Get recent posts from a company's LinkedIn feed.
+
+        Args:
+            company_name: LinkedIn company name (e.g., "docker", "anthropic", "microsoft")
+            ctx: FastMCP context for progress reporting
+            limit: Maximum number of posts to return (default: 10)
+
+        Returns:
+            Dict with posts list containing:
+            - linkedin_url, urn, text, posted_date
+            - reactions_count, comments_count, reposts_count
+            - image_urls: List of image URLs
+            - video_url: Video URL if present
+            - article_url: Article URL if present
+        """
+        try:
+            # Validate session before scraping
+            await ensure_authenticated()
+
+            # Construct LinkedIn URL from company name
+            linkedin_url = f"https://www.linkedin.com/company/{company_name}/"
+
+            logger.info(f"Scraping company posts: {linkedin_url} (limit: {limit})")
+
+            browser = await get_or_create_browser()
+            scraper = CompanyPostsScraper(
+                browser.page, callback=MCPContextProgressCallback(ctx)
+            )
+            posts = await scraper.scrape(linkedin_url, limit=limit)
+
+            return {"posts": [post.to_dict() for post in posts], "count": len(posts)}
+
+        except Exception as e:
+            return handle_tool_error(e, "get_company_posts")

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -49,8 +49,17 @@ def register_person_tools(mcp: FastMCP) -> None:
             ctx: FastMCP context for progress reporting
 
         Returns:
-            Structured data from the person's profile including name, about,
-            experiences, educations, and more.
+            Structured data from the person's profile including:
+            - linkedin_url, name, location, about, open_to_work
+            - experiences: List of work history (position_title, institution_name,
+              linkedin_url, from_date, to_date, duration, location, description)
+            - educations: List of education (institution_name, degree, linkedin_url,
+              from_date, to_date, description)
+            - interests: List of interests with category (company, group, school,
+              newsletter, influencer) and linkedin_url
+            - accomplishments: List of accomplishments (category, title)
+            - contacts: List of contact info (type: email/phone/website/linkedin/
+              twitter/birthday/address, value, label)
         """
         try:
             # Validate session before scraping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "fastmcp>=2.14.0",
     "inquirer>=3.4.0",
-    "linkedin-scraper>=3.0.0",
+    "linkedin-scraper>=3.1.0",
     "playwright>=1.40.0",
     "pyperclip>=1.9.0",
     "python-dotenv>=1.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.14.0" },
     { name = "inquirer", specifier = ">=3.4.0" },
-    { name = "linkedin-scraper", specifier = ">=3.0.0" },
+    { name = "linkedin-scraper", specifier = ">=3.1.0" },
     { name = "playwright", specifier = ">=1.40.0" },
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
@@ -872,7 +872,7 @@ dev = [
 
 [[package]]
 name = "linkedin-scraper"
-version = "3.0.1"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -882,9 +882,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/ac/af65e5359fcdd08d0cc194674e67106ce40027d5f55142243887681e0462/linkedin_scraper-3.0.1.tar.gz", hash = "sha256:6e9c54fd6b78003d0be370bbfacb69b52bb023c7c07bcc9d8b508d94048ea058", size = 39638, upload-time = "2026-01-07T03:09:52.482Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/30/967d78a67bc974e65491582e23993ca078d47c7b634842af13c8422162b9/linkedin_scraper-3.1.0.tar.gz", hash = "sha256:830bd3a4c16aeb667f5a00c0eed7528c80e0b360016f4c8eecd9cebad0d8728e", size = 46636, upload-time = "2026-01-18T23:55:47.77Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c5/7fc84e2fca5608b6c8eec36db4f14e8dd4e59a059da84deba94c49faa875/linkedin_scraper-3.0.1-py3-none-any.whl", hash = "sha256:e121f963d17e0fc1503a4fd1b7c37fb9ccdcfc587dae4ca3defc073a81aff522", size = 44724, upload-time = "2026-01-07T03:09:51.478Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/a7/ce6de57a4bd75bfadaa23fb8f3eaa0b86de779335c13be08f8bbf3846438/linkedin_scraper-3.1.0-py3-none-any.whl", hash = "sha256:1e3ad52cd858d25034cab5f82261bfe35451941faec6003714aff2e745939212", size = 52372, upload-time = "2026-01-18T23:55:45.745Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add get_company_posts tool for scraping company feed posts
- Enable browser warm-up during session creation
- Fix search_jobs (was broken upstream, now working)
- Expose new person fields: contacts, interests
- Update tool docstrings with enhanced field documentation