### PR TITLE
refactor: pin docker-compose.yml to version tag instead of digest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,25 +69,26 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
 
-      - name: Update manifest.json version and Docker image
+      - name: Update manifest.json and docker-compose.yml version
         run: |
           set -e
           sed -i 's/"version": ".*"/"version": "'$VERSION'"/' manifest.json
           sed -i 's/stickerdaniel\/linkedin-mcp-server:[^"]*/stickerdaniel\/linkedin-mcp-server:'$VERSION'/' manifest.json
-          echo "✅ Updated manifest.json to version $VERSION"
+          sed -i 's/stickerdaniel\/linkedin-mcp-server:[^ ]*/stickerdaniel\/linkedin-mcp-server:'$VERSION'/' docker-compose.yml
+          echo "✅ Updated manifest.json and docker-compose.yml to version $VERSION"
 
-      - name: Commit manifest update
+      - name: Commit version updates
         run: |
           set -e
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add manifest.json
+          git add manifest.json docker-compose.yml
           if git diff --staged --quiet; then
             echo "ℹ️ No changes to commit"
           else
-            git commit -m "chore(dxt): update manifest.json version to v$VERSION [skip ci]"
+            git commit -m "chore: update manifest.json and docker-compose.yml to v$VERSION [skip ci]"
             git push origin main
-            echo "✅ Committed manifest.json update"
+            echo "✅ Committed version updates"
           fi
 
       - name: Create release tag

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   linkedin-mcp:
-    image: stickerdaniel/linkedin-mcp-server:latest@sha256:29f0efbf77583303d6ae8128fafe8105b92d510cdfc388d5d7431664b547673c
+    image: stickerdaniel/linkedin-mcp-server:2.3.0
     volumes:
       - ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp
     environment:


### PR DESCRIPTION
Update release workflow to also update docker-compose.yml version.
This eliminates Renovate noise for digest updates.