### PR TITLE
feat: add --chrome-path flag for custom browser executable Add --chrome-path CLI flag and CHROME_PATH environment variable to allow users to specify a custom Chrome/Chromium executable path. Resolves: #118

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,6 @@ HTTP_PATH=/mcp
 SLOW_MO=0
 # Browser viewport size as WIDTHxHEIGHT (default: 1280x720)
 VIEWPORT=1280x720
+# Custom Chrome/Chromium executable path (optional)
+# Use this if Chrome is installed in a non-standard location
+CHROME_PATH=

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ uvx --from git+https://github.com/stickerdaniel/linkedin-mcp-server linkedin-mcp
 - `--path PATH` - HTTP server path (default: /mcp)
 - `--clear-session` - Clear stored LinkedIn session file
 - `--timeout MS` - Browser timeout for page operations in milliseconds (default: 5000)
+- `--chrome-path PATH` - Path to Chrome/Chromium executable (for custom browser installations)
 
 **Basic Usage Examples:**
 
@@ -165,6 +166,11 @@ uvx --from git+https://github.com/stickerdaniel/linkedin-mcp-server linkedin-mcp
 - If pages fail to load or elements aren't found, try increasing the timeout: `--timeout 10000`
 - Users on slow connections may need higher values (e.g., 15000-30000ms)
 - Can also set via environment variable: `TIMEOUT=10000`
+
+**Custom Chrome path:**
+
+- If Chrome is installed in a non-standard location, use `--chrome-path /path/to/chrome`
+- Can also set via environment variable: `CHROME_PATH=/path/to/chrome`
 
 </details>
 
@@ -259,6 +265,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 - `--path PATH` - HTTP server path (default: /mcp)
 - `--clear-session` - Clear stored LinkedIn session file
 - `--timeout MS` - Browser timeout for page operations in milliseconds (default: 5000)
+- `--chrome-path PATH` - Path to Chrome/Chromium executable (rarely needed in Docker)
 
 > [!NOTE]
 > `--get-session` and `--no-headless` are not available in Docker (no display server). Use the [uvx setup](#-uvx-setup-recommended---universal) to create sessions.
@@ -303,6 +310,11 @@ docker run -it --rm \
 - If pages fail to load or elements aren't found, try increasing the timeout: `--timeout 10000`
 - Users on slow connections may need higher values (e.g., 15000-30000ms)
 - Can also set via environment variable: `TIMEOUT=10000`
+
+**Custom Chrome path:**
+
+- If Chrome is installed in a non-standard location, use `--chrome-path /path/to/chrome`
+- Can also set via environment variable: `CHROME_PATH=/path/to/chrome`
 
 </details>
 
@@ -411,6 +423,7 @@ uv run -m linkedin_mcp_server
 - `--slow-mo MS` - Delay between browser actions in milliseconds (default: 0, useful for debugging)
 - `--user-agent STRING` - Custom browser user agent
 - `--viewport WxH` - Browser viewport size (default: 1280x720)
+- `--chrome-path PATH` - Path to Chrome/Chromium executable (for custom browser installations)
 - `--help` - Show help
 
 > **Note:** Most CLI options have environment variable equivalents. See `.env.example` for details.
@@ -466,6 +479,11 @@ uv run -m linkedin_mcp_server --transport streamable-http --host 127.0.0.1 --por
 - If pages fail to load or elements aren't found, try increasing the timeout: `--timeout 10000`
 - Users on slow connections may need higher values (e.g., 15000-30000ms)
 - Can also set via environment variable: `TIMEOUT=10000`
+
+**Custom Chrome path:**
+
+- If Chrome is installed in a non-standard location, use `--chrome-path /path/to/chrome`
+- Can also set via environment variable: `CHROME_PATH=/path/to/chrome`
 
 </details>
 

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -67,6 +67,7 @@ Create a session using the [uvx setup](https://github.com/stickerdaniel/linkedin
 | `HTTP_PATH` | `/mcp` | HTTP server path (for streamable-http transport) |
 | `SLOW_MO` | `0` | Delay between browser actions in ms (debugging) |
 | `VIEWPORT` | `1280x720` | Browser viewport size as WIDTHxHEIGHT |
+| `CHROME_PATH` | - | Path to Chrome/Chromium executable (rarely needed in Docker) |
 
 **Example with custom timeout:**
 

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -45,6 +45,7 @@ class EnvironmentKeys:
     HTTP_PATH = "HTTP_PATH"
     SLOW_MO = "SLOW_MO"
     VIEWPORT = "VIEWPORT"
+    CHROME_PATH = "CHROME_PATH"
 
 
 def is_interactive_environment() -> bool:
@@ -139,6 +140,10 @@ def load_from_env(config: AppConfig) -> AppConfig:
                 f"Invalid VIEWPORT: '{viewport_env}'. Must be in format WxH (e.g., 1280x720)."
             )
 
+    # Custom Chrome/Chromium executable path
+    if chrome_path_env := os.environ.get(EnvironmentKeys.CHROME_PATH):
+        config.browser.chrome_path = chrome_path_env
+
     return config
 
 
@@ -220,6 +225,14 @@ def load_from_args(config: AppConfig) -> AppConfig:
         help="Browser timeout for page operations in milliseconds (default: 5000)",
     )
 
+    parser.add_argument(
+        "--chrome-path",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to Chrome/Chromium executable (for custom browser installations)",
+    )
+
     # Session management
     parser.add_argument(
         "--get-session",
@@ -291,6 +304,9 @@ def load_from_args(config: AppConfig) -> AppConfig:
 
     if args.timeout is not None:
         config.browser.default_timeout = args.timeout
+
+    if args.chrome_path:
+        config.browser.chrome_path = args.chrome_path
 
     # Session management
     if args.get_session is not None:

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -6,6 +6,7 @@ structure with type-safe configuration objects and default values.
 """
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Literal
 
 
@@ -25,6 +26,7 @@ class BrowserConfig:
     viewport_width: int = 1280
     viewport_height: int = 720
     default_timeout: int = 5000  # Milliseconds for page operations
+    chrome_path: str | None = None  # Path to Chrome/Chromium executable
 
     def validate(self) -> None:
         """Validate browser configuration values."""
@@ -40,6 +42,16 @@ class BrowserConfig:
             raise ConfigurationError(
                 f"viewport dimensions must be positive, got {self.viewport_width}x{self.viewport_height}"
             )
+        if self.chrome_path:
+            chrome_path = Path(self.chrome_path)
+            if not chrome_path.exists():
+                raise ConfigurationError(
+                    f"chrome_path '{self.chrome_path}' does not exist"
+                )
+            if not chrome_path.is_file():
+                raise ConfigurationError(
+                    f"chrome_path '{self.chrome_path}' is not a file"
+                )
 
 
 @dataclass

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -71,6 +71,13 @@ async def get_or_create_browser(
         "width": config.browser.viewport_width,
         "height": config.browser.viewport_height,
     }
+
+    # Build launch options for custom browser path
+    launch_options: dict[str, str] = {}
+    if config.browser.chrome_path:
+        launch_options["executable_path"] = config.browser.chrome_path
+        logger.info("Using custom Chrome path: %s", config.browser.chrome_path)
+
     logger.info(
         "Creating new browser (headless=%s, slow_mo=%sms, viewport=%sx%s)",
         _headless,
@@ -83,6 +90,7 @@ async def get_or_create_browser(
         slow_mo=config.browser.slow_mo,
         user_agent=config.browser.user_agent,
         viewport=viewport,
+        **launch_options,
     )
     await _browser.start()
 


### PR DESCRIPTION
Add --chrome-path CLI flag and CHROME_PATH environment variable to allow users to specify a custom Chrome/Chromium executable path.
Resolves: #118