### PR TITLE
test: add minimal testing suite with CI integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source = linkedin_mcp_server
+branch = true
+omit = linkedin_mcp_server/__main__.py
+
+[report]
+fail_under = 45
+show_missing = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,21 @@ jobs:
 
       - name: Optimize uv cache for CI
         run: uv cache prune --ci
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7
+        with:
+          enable-cache: true
+
+      - run: uv python install 3.14
+
+      - run: uv sync --group dev
+
+      - name: Run tests
+        run: uv run pytest --cov --cov-report=term-missing -n auto -v -s
+
+      - run: uv cache prune --ci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "pytest>=8.3.5",
     "pytest-asyncio>=1.0.0",
     "pytest-cov>=6.1.1",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.11.11",
     "ty>=0.0.1a12",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+addopts = -v --strict-markers -ra

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    """Reset global state for test isolation."""
+    from linkedin_mcp_server.config import reset_config
+    from linkedin_mcp_server.drivers.browser import reset_browser_for_testing
+
+    reset_browser_for_testing()
+    reset_config()
+    yield
+    reset_browser_for_testing()
+    reset_config()
+
+
+@pytest.fixture(autouse=True)
+def isolate_session_path(tmp_path, monkeypatch):
+    """Redirect DEFAULT_SESSION_PATH to tmp_path."""
+    fake_session = tmp_path / "session.json"
+    for module in [
+        "linkedin_mcp_server.drivers.browser",
+        "linkedin_mcp_server.authentication",
+        "linkedin_mcp_server.cli_main",
+        "linkedin_mcp_server.setup",
+    ]:
+        try:
+            monkeypatch.setattr(f"{module}.DEFAULT_SESSION_PATH", fake_session)
+        except AttributeError:
+            pass  # Module may not be imported yet
+    return fake_session
+
+
+@pytest.fixture
+def session_file(isolate_session_path):
+    """Create valid session file."""
+    isolate_session_path.parent.mkdir(parents=True, exist_ok=True)
+    isolate_session_path.write_text(
+        json.dumps(
+            {"cookies": [{"name": "li_at", "value": "test", "domain": ".linkedin.com"}]}
+        )
+    )
+    return isolate_session_path
+
+
+@pytest.fixture
+def mock_context():
+    """Mock FastMCP Context."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    ctx = MagicMock()
+    ctx.report_progress = AsyncMock()
+    return ctx

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,0 +1,44 @@
+import pytest
+
+from linkedin_mcp_server.authentication import clear_session, get_authentication_source
+from linkedin_mcp_server.exceptions import CredentialsNotFoundError
+
+
+def test_get_auth_source_session(session_file, monkeypatch):
+    monkeypatch.setattr(
+        "linkedin_mcp_server.authentication.session_exists", lambda: True
+    )
+    assert get_authentication_source() == "session"
+
+
+def test_get_auth_source_cookie(monkeypatch):
+    monkeypatch.setattr(
+        "linkedin_mcp_server.authentication.session_exists", lambda: False
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.authentication.get_linkedin_cookie", lambda: "cookie"
+    )
+    assert get_authentication_source() == "cookie"
+
+
+def test_get_auth_source_none_raises(monkeypatch):
+    monkeypatch.setattr(
+        "linkedin_mcp_server.authentication.session_exists", lambda: False
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.authentication.get_linkedin_cookie", lambda: None
+    )
+    with pytest.raises(CredentialsNotFoundError):
+        get_authentication_source()
+
+
+def test_clear_session_removes_file(session_file):
+    assert session_file.exists()
+    result = clear_session(session_file)
+    assert result is True
+    assert not session_file.exists()
+
+
+def test_clear_session_no_file(isolate_session_path):
+    result = clear_session(isolate_session_path)
+    assert result is True  # No error even if file doesn't exist

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,157 @@
+import pytest
+
+from linkedin_mcp_server.config.schema import (
+    AppConfig,
+    BrowserConfig,
+    ConfigurationError,
+    ServerConfig,
+)
+
+
+class TestBrowserConfig:
+    def test_defaults(self):
+        config = BrowserConfig()
+        assert config.headless is True
+        assert config.default_timeout == 5000
+
+    def test_validate_passes(self):
+        BrowserConfig().validate()  # No error
+
+    def test_validate_negative_timeout(self):
+        with pytest.raises(ConfigurationError):
+            BrowserConfig(default_timeout=-1).validate()
+
+    def test_validate_negative_slow_mo(self):
+        with pytest.raises(ConfigurationError):
+            BrowserConfig(slow_mo=-1).validate()
+
+
+class TestServerConfig:
+    def test_defaults(self):
+        config = ServerConfig()
+        assert config.transport == "stdio"
+        assert config.port == 8000
+
+
+class TestAppConfig:
+    def test_validate_invalid_port(self):
+        config = AppConfig()
+        config.server.port = 99999
+        with pytest.raises(ConfigurationError):
+            config.validate()
+
+
+class TestConfigSingleton:
+    def test_get_config_returns_same_instance(self, monkeypatch):
+        # Mock sys.argv to prevent argparse from parsing pytest's arguments
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
+        from linkedin_mcp_server.config import get_config
+
+        assert get_config() is get_config()
+
+    def test_reset_config_clears_singleton(self, monkeypatch):
+        # Mock sys.argv to prevent argparse from parsing pytest's arguments
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
+        from linkedin_mcp_server.config import get_config, reset_config
+
+        first = get_config()
+        reset_config()
+        second = get_config()
+        assert first is not second
+
+
+class TestLoaders:
+    def test_load_from_env_headless_false(self, monkeypatch):
+        monkeypatch.setenv("HEADLESS", "false")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.headless is False
+
+    def test_load_from_env_headless_true(self, monkeypatch):
+        monkeypatch.setenv("HEADLESS", "true")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.headless is True
+
+    def test_load_from_env_log_level(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.server.log_level == "DEBUG"
+
+    def test_load_from_env_defaults(self, monkeypatch):
+        # Clear env vars
+        for var in ["HEADLESS", "LOG_LEVEL"]:
+            monkeypatch.delenv(var, raising=False)
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.headless is True  # default
+
+    def test_load_from_env_transport(self, monkeypatch):
+        monkeypatch.setenv("TRANSPORT", "streamable-http")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.server.transport == "streamable-http"
+        assert config.server.transport_explicitly_set is True
+
+    def test_load_from_env_invalid_transport(self, monkeypatch):
+        monkeypatch.setenv("TRANSPORT", "invalid")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        with pytest.raises(ConfigurationError, match="Invalid TRANSPORT"):
+            load_from_env(AppConfig())
+
+    def test_load_from_env_timeout(self, monkeypatch):
+        monkeypatch.setenv("TIMEOUT", "10000")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.default_timeout == 10000
+
+    def test_load_from_env_invalid_timeout(self, monkeypatch):
+        monkeypatch.setenv("TIMEOUT", "invalid")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        with pytest.raises(ConfigurationError, match="Invalid TIMEOUT"):
+            load_from_env(AppConfig())
+
+    def test_load_from_env_port(self, monkeypatch):
+        monkeypatch.setenv("PORT", "9000")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.server.port == 9000
+
+    def test_load_from_env_slow_mo(self, monkeypatch):
+        monkeypatch.setenv("SLOW_MO", "100")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.slow_mo == 100
+
+    def test_load_from_env_viewport(self, monkeypatch):
+        monkeypatch.setenv("VIEWPORT", "1920x1080")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.viewport_width == 1920
+        assert config.browser.viewport_height == 1080
+
+    def test_load_from_env_invalid_viewport(self, monkeypatch):
+        monkeypatch.setenv("VIEWPORT", "invalid")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        with pytest.raises(ConfigurationError, match="Invalid VIEWPORT"):
+            load_from_env(AppConfig())
+
+    def test_load_from_env_linkedin_cookie(self, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_COOKIE", "test_cookie_value")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.server.linkedin_cookie == "test_cookie_value"

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,44 @@
+from linkedin_scraper.core.exceptions import RateLimitError
+
+from linkedin_mcp_server.error_handler import handle_tool_error
+from linkedin_mcp_server.exceptions import (
+    CredentialsNotFoundError,
+    SessionExpiredError,
+)
+
+
+def test_handles_session_expired():
+    result = handle_tool_error(SessionExpiredError(), "test_tool")
+    assert result["error"] == "session_expired"
+    assert "message" in result
+    assert "resolution" in result
+
+
+def test_handles_credentials_not_found():
+    result = handle_tool_error(CredentialsNotFoundError("no creds"), "test_tool")
+    assert result["error"] == "authentication_not_found"
+
+
+def test_handles_generic_exception():
+    result = handle_tool_error(ValueError("oops"), "test_tool")
+    assert result["error"] == "unknown_error"
+    assert "oops" in result["message"]
+
+
+def test_handles_rate_limit_with_suggested_wait():
+    """Test RateLimitError with custom suggested_wait_time attribute."""
+    error = RateLimitError("Rate limited")
+    error.suggested_wait_time = 600  # type: ignore[attr-defined]
+    result = handle_tool_error(error, "test_tool")
+    assert result["error"] == "rate_limit"
+    assert result["suggested_wait_seconds"] == 600
+    assert "600" in result["resolution"]
+
+
+def test_handles_rate_limit_default_wait():
+    """Test RateLimitError without suggested_wait_time uses default 300."""
+    error = RateLimitError("Rate limited")
+    result = handle_tool_error(error, "test_tool")
+    assert result["error"] == "rate_limit"
+    assert result["suggested_wait_seconds"] == 300
+    assert "300" in result["resolution"]

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,32 @@
+from linkedin_mcp_server.exceptions import (
+    CookieAuthenticationError,
+    CredentialsNotFoundError,
+    LinkedInMCPError,
+    SessionExpiredError,
+)
+
+
+def test_base_exception():
+    err = LinkedInMCPError("test")
+    assert str(err) == "test"
+
+
+def test_session_expired_default_message():
+    err = SessionExpiredError()
+    assert "expired" in str(err).lower()
+
+
+def test_session_expired_custom_message():
+    err = SessionExpiredError("custom")
+    assert str(err) == "custom"
+
+
+def test_cookie_auth_default_message():
+    err = CookieAuthenticationError()
+    assert "cookie" in str(err).lower()
+
+
+def test_inheritance():
+    assert issubclass(SessionExpiredError, LinkedInMCPError)
+    assert issubclass(CookieAuthenticationError, LinkedInMCPError)
+    assert issubclass(CredentialsNotFoundError, LinkedInMCPError)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,154 @@
+from typing import Any, Callable, Coroutine
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp import FastMCP
+
+
+async def get_tool_fn(
+    mcp: FastMCP, name: str
+) -> Callable[..., Coroutine[Any, Any, dict[str, Any]]]:
+    """Extract tool function from FastMCP by name using public API."""
+    tool = await mcp.get_tool(name)
+    if tool is None:
+        raise ValueError(f"Tool '{name}' not found")
+    return tool.fn  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def patch_tool_deps(monkeypatch):
+    """Patch ensure_authenticated and get_or_create_browser for all tools."""
+    mock_browser = MagicMock()
+    mock_browser.page = MagicMock()
+
+    for module in ["person", "company", "job"]:
+        monkeypatch.setattr(
+            f"linkedin_mcp_server.tools.{module}.ensure_authenticated", AsyncMock()
+        )
+        monkeypatch.setattr(
+            f"linkedin_mcp_server.tools.{module}.get_or_create_browser",
+            AsyncMock(return_value=mock_browser),
+        )
+
+    return mock_browser
+
+
+class TestPersonTool:
+    async def test_get_person_profile_success(
+        self, mock_context, patch_tool_deps, monkeypatch
+    ):
+        mock_person = MagicMock()
+        mock_person.to_dict.return_value = {"full_name": "Test User"}
+        mock_scraper = MagicMock()
+        mock_scraper.scrape = AsyncMock(return_value=mock_person)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tools.person.PersonScraper",
+            lambda *a, **kw: mock_scraper,
+        )
+
+        from linkedin_mcp_server.tools.person import register_person_tools
+
+        mcp = FastMCP("test")
+        register_person_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_person_profile")
+        result = await tool_fn("test-user", mock_context)
+        assert result["full_name"] == "Test User"
+
+    async def test_get_person_profile_error(self, mock_context, monkeypatch):
+        from linkedin_mcp_server.exceptions import SessionExpiredError
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tools.person.ensure_authenticated",
+            AsyncMock(side_effect=SessionExpiredError()),
+        )
+
+        from linkedin_mcp_server.tools.person import register_person_tools
+
+        mcp = FastMCP("test")
+        register_person_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_person_profile")
+        result = await tool_fn("test-user", mock_context)
+        assert result["error"] == "session_expired"
+
+
+class TestCompanyTools:
+    async def test_get_company_profile(
+        self, mock_context, patch_tool_deps, monkeypatch
+    ):
+        mock_company = MagicMock()
+        mock_company.to_dict.return_value = {"name": "Test Corp"}
+        mock_scraper = MagicMock()
+        mock_scraper.scrape = AsyncMock(return_value=mock_company)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tools.company.CompanyScraper",
+            lambda *a, **kw: mock_scraper,
+        )
+
+        from linkedin_mcp_server.tools.company import register_company_tools
+
+        mcp = FastMCP("test")
+        register_company_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_company_profile")
+        result = await tool_fn("testcorp", mock_context)
+        assert result["name"] == "Test Corp"
+
+    async def test_get_company_posts(self, mock_context, patch_tool_deps, monkeypatch):
+        mock_post = MagicMock()
+        mock_post.to_dict.return_value = {"text": "Hello world"}
+        mock_scraper = MagicMock()
+        mock_scraper.scrape = AsyncMock(return_value=[mock_post])
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tools.company.CompanyPostsScraper",
+            lambda *a, **kw: mock_scraper,
+        )
+
+        from linkedin_mcp_server.tools.company import register_company_tools
+
+        mcp = FastMCP("test")
+        register_company_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_company_posts")
+        result = await tool_fn("testcorp", mock_context, limit=5)
+        assert result["count"] == 1
+        assert result["posts"][0]["text"] == "Hello world"
+
+
+class TestJobTools:
+    async def test_get_job_details(self, mock_context, patch_tool_deps, monkeypatch):
+        mock_job = MagicMock()
+        mock_job.to_dict.return_value = {"title": "Engineer"}
+        mock_scraper = MagicMock()
+        mock_scraper.scrape = AsyncMock(return_value=mock_job)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tools.job.JobScraper", lambda *a, **kw: mock_scraper
+        )
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_job_details")
+        result = await tool_fn("12345", mock_context)
+        assert result["title"] == "Engineer"
+
+    async def test_search_jobs(self, mock_context, patch_tool_deps, monkeypatch):
+        mock_scraper = MagicMock()
+        mock_scraper.search = AsyncMock(return_value=["url1", "url2"])
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tools.job.JobSearchScraper",
+            lambda *a, **kw: mock_scraper,
+        )
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "search_jobs")
+        result = await tool_fn("python", mock_context, location="Remote", limit=10)
+        assert result["count"] == 2
+        assert "url1" in result["job_urls"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+def test_get_linkedin_cookie_present(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_COOKIE", "test_cookie")
+    from linkedin_mcp_server.utils import get_linkedin_cookie
+
+    assert get_linkedin_cookie() == "test_cookie"
+
+
+def test_get_linkedin_cookie_missing(monkeypatch):
+    monkeypatch.delenv("LINKEDIN_COOKIE", raising=False)
+    from linkedin_mcp_server.utils import get_linkedin_cookie
+
+    assert get_linkedin_cookie() is None

--- a/uv.lock
+++ b/uv.lock
@@ -592,6 +592,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fakeredis"
 version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1020,6 +1029,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -1041,6 +1051,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.11.11" },
     { name = "ty", specifier = ">=0.0.1a12" },
 ]
@@ -1874,6 +1885,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add fast, high-ROI tests covering config, utils, exceptions, error
handling, authentication, and MCP tools (mocked). Includes pytest
configuration, coverage reporting, and CI test job.

- Add pytest.ini with async support and pytest-xdist for parallel tests
- Add .coveragerc with 45% threshold and branch coverage
- Add tests for config schema, loaders, and singleton pattern
- Add tests for exception hierarchy and error handler
- Add tests for authentication source detection
- Add mocked tests for all 5 MCP tools
- Add CI test job running Python 3.14 with coverage