### PR TITLE
fix(docker): remove non-existent /opt/python from chmod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,13 @@ RUN chown pwuser:pwuser /app
 # Copy project files with correct ownership
 COPY --chown=pwuser:pwuser . /app
 
-# Set paths for Playwright browsers and uv Python installs to shared locations
+# Set Playwright browser install location
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
-ENV UV_PYTHON_INSTALL_DIR=/opt/python
-
 # Install dependencies and Playwright with ONLY Chromium (not Firefox/WebKit)
 # --with-deps installs required system dependencies (fonts, libraries) via apt (needs root)
 RUN uv sync --frozen && \
     uv run playwright install --with-deps chromium && \
-    chmod -R 755 /opt/playwright /opt/python
+    chmod -R 755 /opt/playwright
 
 # Fix ownership of app directory (venv created by uv)
 RUN chown -R pwuser:pwuser /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "linkedin-mcp-server"
-version = "2.3.1"
+version = "2.3.2"
 description = "MCP server for LinkedIn profile, company, and job scraping with Claude AI integration. Supports direct profile/company/job URL scraping with secure credential storage."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1011,7 +1011,7 @@ wheels = [
 
 [[package]]
 name = "linkedin-mcp-server"
-version = "2.3.1"
+version = "2.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
The base image already provides Python, so uv doesn't install
a separate Python version to /opt/python. Remove the reference
to fix the Docker build failure.