### PR TITLE
fix(deps): use linkedin_scraper fork with rate limit fix

### DIFF
--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -2,9 +2,9 @@
 name: code-reviewer
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-variant: 'xhigh'
-# model: 'github-copilot/gpt-5.2-codex'
+model: 'openai/gpt-5.3-codex'
+variant: 'high'
+# model: 'github-copilot/gpt-5.3-codex'
 color: '#22c55e'
 description: |
   Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. This agent should be used proactively after writing or modifying code, especially before committing changes or creating pull requests. It will check for style violations, potential issues, and ensure code follows the established patterns in CLAUDE.md. Also the agent needs to know which files to focus on for the review. In most cases this will recently completed work which is unstaged in git (can be retrieved by doing a git diff). However there can be cases where this is different, make sure to specify this as the agent input when calling the agent.

--- a/.opencode/agents/code-simplifier.md
+++ b/.opencode/agents/code-simplifier.md
@@ -2,9 +2,9 @@
 name: code-simplifier
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-variant: 'xhigh'
-# model: 'github-copilot/gpt-5.2-codex'
+model: 'openai/gpt-5.3-codex'
+variant: 'high'
+# model: 'github-copilot/gpt-5.3-codex'
 color: '#3b82f6'
 description: |
   Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.

--- a/.opencode/agents/comment-analyzer.md
+++ b/.opencode/agents/comment-analyzer.md
@@ -2,9 +2,9 @@
 name: comment-analyzer
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-variant: 'xhigh'
-# model: 'github-copilot/gpt-5.2-codex'
+model: 'openai/gpt-5.3-codex'
+variant: 'high'
+# model: 'github-copilot/gpt-5.3-codex'
 color: '#10b981'
 description: |
   Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.

--- a/.opencode/agents/pr-test-analyzer.md
+++ b/.opencode/agents/pr-test-analyzer.md
@@ -2,9 +2,9 @@
 name: pr-test-analyzer
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-variant: 'xhigh'
-# model: 'github-copilot/gpt-5.2-codex'
+model: 'openai/gpt-5.3-codex'
+variant: 'high'
+# model: 'github-copilot/gpt-5.3-codex'
 color: '#06b6d4'
 description: |
   Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases. Examples:

--- a/.opencode/agents/silent-failure-hunter.md
+++ b/.opencode/agents/silent-failure-hunter.md
@@ -2,9 +2,9 @@
 name: silent-failure-hunter
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-variant: 'xhigh'
-# model: 'github-copilot/gpt-5.2-codex'
+model: 'openai/gpt-5.3-codex'
+variant: 'high'
+# model: 'github-copilot/gpt-5.3-codex'
 color: '#eab308'
 description: |
   Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors. Examples:

--- a/.opencode/agents/type-design-analyzer.md
+++ b/.opencode/agents/type-design-analyzer.md
@@ -2,9 +2,9 @@
 name: type-design-analyzer
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-variant: 'xhigh'
-# model: 'github-copilot/gpt-5.2-codex'
+model: 'openai/gpt-5.3-codex'
+variant: 'high'
+# model: 'github-copilot/gpt-5.3-codex'
 color: '#ec4899'
 description: |
   Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - Use `uv` for dependency management: `uv sync` (installs all dependencies)
 - Development dependencies: `uv sync --group dev`
-- Bump version: `uv version --bump minor` (or `major`, `patch`) - git tag is created automatically by release workflow. Once Docker image and PyPI package are published, manually file a PR in the MCP registry to update the version.
+- Bump version: `uv version --bump minor` (or `major`, `patch`) - this is the **only manual step** for a release. The GitHub Actions release workflow (`.github/workflows/release.yml`) automatically handles: manifest.json/docker-compose.yml version updates, git tag, Docker build & push, DXT extension, GitHub release, and PyPI publish. After the workflow completes, manually file a PR in the MCP registry to update the version.
 - Run server locally: `uv run -m linkedin_mcp_server --no-headless`
 - Run via uvx (PyPI): `uvx linkedin-scraper-mcp`
 - Run in Docker: `docker run -it --rm -v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp stickerdaniel/linkedin-mcp-server:latest`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "linkedin-scraper-mcp"
-version = "2.3.5"
+version = "2.3.6"
 description = "MCP server for LinkedIn profile, company, and job scraping with Claude AI integration. Supports direct profile/company/job URL scraping with secure credential storage."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -34,7 +34,7 @@ classifiers = [
 dependencies = [
     "fastmcp>=2.14.0",
     "inquirer>=3.4.0",
-    "linkedin-scraper>=3.1.1",
+    "linkedin-scraper",
     "playwright>=1.40.0",
     "pyperclip>=1.9.0",
     "python-dotenv>=1.1.1",
@@ -61,6 +61,9 @@ exclude = ["assets*", "docs*", "tests*"]
 
 [tool.setuptools.package-data]
 linkedin_mcp_server = ["py.typed"]
+
+[tool.uv.sources]
+linkedin-scraper = { git = "https://github.com/stickerdaniel/linkedin_scraper.git", rev = "fix/rate-limit-false-positive" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1012,7 +1012,7 @@ wheels = [
 [[package]]
 name = "linkedin-scraper"
 version = "3.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/stickerdaniel/linkedin_scraper.git?rev=fix%2Frate-limit-false-positive#092aef732a1a276b61052e5cefccfcfea0c3695d" }
 dependencies = [
     { name = "aiofiles" },
     { name = "lxml" },
@@ -1021,14 +1021,10 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/e0/389404ecd6d0efec2cc5be0d1c456d6b8f723865b03e0b6567945c713594/linkedin_scraper-3.1.1.tar.gz", hash = "sha256:3232a16a72053f8969464dc7386a7a0b2c262f9fe7c53f41734857ea9c908588", size = 47349, upload-time = "2026-01-27T06:05:53.871Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/f6/a17d0be0cf6c9a85709e287f137c9f1227c44e208e737ef371f83dc5829b/linkedin_scraper-3.1.1-py3-none-any.whl", hash = "sha256:5977a28dcaa2b1d14caa0e3ea28f6d7c16e393f1140088b22588200a8498657c", size = 53017, upload-time = "2026-01-27T06:05:52.48Z" },
-]
 
 [[package]]
 name = "linkedin-scraper-mcp"
-version = "2.3.5"
+version = "2.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1055,7 +1051,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.14.0" },
     { name = "inquirer", specifier = ">=3.4.0" },
-    { name = "linkedin-scraper", specifier = ">=3.1.1" },
+    { name = "linkedin-scraper", git = "https://github.com/stickerdaniel/linkedin_scraper.git?rev=fix%2Frate-limit-false-positive" },
     { name = "playwright", specifier = ">=1.40.0" },
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },


### PR DESCRIPTION
Point dependency at stickerdaniel/linkedin_scraper fork
(fix/rate-limit-false-positive) to fix detect_rate_limit()
false-firing on React RSC payloads.

Also update docs with detailed release workflow notes and
bump opencode agent models to gpt-5.3-codex.

See also: joeyism/linkedin_scraper#278

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the source of a core scraping dependency from a pinned PyPI version to a specific git revision, which can alter runtime behavior and reproducibility. Other changes are configuration/docs-only and low impact.
> 
> **Overview**
> **Switches the `linkedin-scraper` dependency to a git-sourced fork/branch** via `uv` (`[tool.uv.sources]` and `uv.lock`), replacing the previous `>=3.1.1` PyPI constraint.
> 
> Bumps the package version to `2.3.6` and updates release documentation in `AGENTS.md` to clarify that the GitHub Actions workflow performs most release steps.
> 
> Updates `.opencode` agent configs to use `openai/gpt-5.3-codex` with a lower `variant` setting (from `xhigh` to `high`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5de8ef777f1e753573c04d0ab919d540bd2aa7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->