### PR TITLE
fix(docker): install git for git-based dependency resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN chown pwuser:pwuser /app
 # Copy project files with correct ownership
 COPY --chown=pwuser:pwuser . /app
 
+# Install git (needed for git-based dependencies in pyproject.toml)
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
 # Set Playwright browser install location
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
 # Install dependencies and Playwright with ONLY Chromium (not Firefox/WebKit)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: Dockerfile-only change that adds a build dependency (`git`) and slightly increases image size, with no application behavior changes.
> 
> **Overview**
> Docker build now installs `git` (with `--no-install-recommends`) before running `uv sync`, enabling resolution of git-based dependencies defined in `pyproject.toml`.
> 
> No runtime/app logic changes; this only affects the container build environment and resulting image contents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1331c78d6af7f3a534b8efeade1233717b668d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->