### PR TITLE
ci(release): require 1 approving review on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
             "required_pull_request_reviews": {
               "dismiss_stale_reviews": false,
               "require_code_owner_reviews": false,
-              "required_approving_review_count": 0
+              "required_approving_review_count": 1
             },
             "restrictions": null
           }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated branch protection settings to require 1 approving review on the main branch, strengthening the release workflow's security posture by ensuring changes cannot be merged without peer review.

- Changed `required_approving_review_count` from 0 to 1 in the branch protection restoration step
- Aligns with the earlier commit (e3a9a0d) that introduced PR requirements and admin enforcement
- Ensures consistency between the temporary branch protection removal and restoration during automated releases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, single-line configuration update that strengthens security by requiring code review. The modification is straightforward, affects only the branch protection restoration logic, and follows the pattern already established in commit e3a9a0d.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Increased required approving reviews from 0 to 1 for main branch protection |

</details>



<sub>Last reviewed commit: 97b394c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->