### PR TITLE
fix(release): avoid YAML heredoc issue in restore step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,29 +102,29 @@ jobs:
 
       - name: Restore branch protection
         if: always()
-        run: |
-          gh api repos/${{ github.repository }}/branches/main/protection \
-            --method PUT \
-            --input - <<'EOF'
-          {
-            "required_status_checks": {
-              "strict": true,
-              "checks": [
-                {"context": "lint-and-check", "app_id": 15368},
-                {"context": "test", "app_id": 15368}
-              ]
-            },
-            "enforce_admins": true,
-            "required_pull_request_reviews": {
-              "dismiss_stale_reviews": false,
-              "require_code_owner_reviews": false,
-              "required_approving_review_count": 0
-            },
-            "restrictions": null
-          }
-          EOF
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAYLOAD: >-
+            {
+              "required_status_checks": {
+                "strict": true,
+                "checks": [
+                  {"context": "lint-and-check", "app_id": 15368},
+                  {"context": "test", "app_id": 15368}
+                ]
+              },
+              "enforce_admins": true,
+              "required_pull_request_reviews": {
+                "dismiss_stale_reviews": false,
+                "require_code_owner_reviews": false,
+                "required_approving_review_count": 0
+              },
+              "restrictions": null
+            }
+        run: |
+          echo "$PAYLOAD" | gh api repos/${{ github.repository }}/branches/main/protection \
+            --method PUT \
+            --input -
 
       - name: Create release tag
         run: |


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a YAML heredoc compatibility issue in the release workflow's "Restore branch protection" step. The previous approach used a shell heredoc (`<<'EOF'`) inside a YAML `run: |` block to pass a JSON payload to `gh api --input -`. This is a known source of parsing issues in GitHub Actions, where the YAML processor can misinterpret heredoc delimiters or content.

The fix replaces the heredoc with a YAML `>-` folded block scalar stored in the `PAYLOAD` environment variable, which is then piped to `gh api` via `echo "$PAYLOAD" | gh api ... --input -`. This is a more robust and idiomatic pattern for GitHub Actions workflows.

- Moved JSON payload from shell heredoc to YAML `>-` env variable (`PAYLOAD`)
- The `>-` folding operator correctly collapses the multi-line JSON into a single-line string (valid JSON)
- No functional change to the branch protection settings being restored
- The `if: always()` guard remains, ensuring protection is restored even on prior step failures

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped CI fix with no functional behavior change.
- The change is a straightforward refactor of how a JSON payload is passed to `gh api` in a GitHub Actions step. The JSON content is identical, the API call is identical, and the approach (env var with YAML folded block) is a well-known idiomatic pattern. No application code is affected.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Replaces shell heredoc (`<<'EOF'`) with YAML `>-` folded block scalar for the branch protection restore payload. The JSON is now stored in the `PAYLOAD` env var and piped to `gh api` via `echo "$PAYLOAD"`. This is a correct and idiomatic fix for YAML/heredoc interaction issues in GitHub Actions. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WF as Release Workflow
    participant GH as GitHub API
    participant BP as Branch Protection

    WF->>GH: DELETE /branches/main/protection
    GH->>BP: Remove protection rules
    Note over WF: Commit & push version updates
    WF->>WF: echo "$PAYLOAD" (from YAML >- env var)
    WF->>GH: PUT /branches/main/protection<br/>--input - (piped JSON)
    GH->>BP: Restore protection rules
    Note over WF,BP: Runs with if: always() guard
```

<sub>Last reviewed commit: e472680</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->