### PR TITLE
fix(release): use PAT for branch protection API calls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ jobs:
       contents: write
       packages: write
       id-token: write  # Required for PyPI Trusted Publishing
-      administration: write  # needed to temporarily lift branch protection
 
     steps:
       - name: Checkout code
@@ -84,7 +83,7 @@ jobs:
           gh api repos/${{ github.repository }}/branches/main/protection \
             --method DELETE
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
 
       - name: Commit version updates
         run: |
@@ -103,7 +102,7 @@ jobs:
       - name: Restore branch protection
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
           PAYLOAD: >-
             {
               "required_status_checks": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "linkedin-scraper-mcp"
-version = "4.1.1"
+version = "4.1.2"
 description = "MCP server for LinkedIn profile, company, and job scraping with Claude AI integration. Supports direct profile/company/job URL scraping with secure credential storage."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1031,7 +1031,7 @@ wheels = [
 
 [[package]]
 name = "linkedin-scraper-mcp"
-version = "4.1.1"
+version = "4.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Bump version to 4.1.2 to trigger release workflow test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the GitHub Actions release workflow to properly handle branch protection by switching from the default `GITHUB_TOKEN` (with `administration: write` permission) to a Personal Access Token (`GH_ADMIN_TOKEN`) for branch protection API calls. The version was also bumped to 4.1.2 to trigger the release workflow for testing.

**Key changes:**
- Replaced `GITHUB_TOKEN` with `GH_ADMIN_TOKEN` for both the "Remove branch protection" and "Restore branch protection" steps
- Removed the `administration: write` permission from the workflow (GitHub's default token doesn't support this permission for branch protection operations)
- Bumped version from 4.1.1 to 4.1.2 to trigger the automated release workflow

This addresses the issue where the workflow was failing because the `GITHUB_TOKEN` lacks the necessary permissions to modify branch protection rules, even with `administration: write` specified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a straightforward permissions fix for the release workflow
- The changes correctly address a known GitHub Actions limitation where the default `GITHUB_TOKEN` cannot manage branch protection rules. Using a PAT with admin privileges is the standard solution for this use case. The version bump is minimal and follows the project's versioning pattern.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Switches from `GITHUB_TOKEN` to `GH_ADMIN_TOKEN` for branch protection API calls, removes `administration: write` permission |
| pyproject.toml | Version bumped from 4.1.1 to 4.1.2 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W as Release Workflow
    participant GH as GitHub API
    participant BP as Branch Protection
    participant PAT as GH_ADMIN_TOKEN (PAT)
    
    Note over W,PAT: Before: Used GITHUB_TOKEN (insufficient permissions)
    Note over W,PAT: After: Uses GH_ADMIN_TOKEN (PAT with admin rights)
    
    W->>PAT: Authenticate with PAT
    W->>GH: DELETE /branches/main/protection
    GH->>BP: Remove protection temporarily
    BP-->>GH: Success
    GH-->>W: 204 No Content
    
    W->>W: Commit version updates to main
    
    Note over W,BP: Restore step (runs even if previous steps fail)
    W->>GH: PUT /branches/main/protection
    GH->>BP: Restore protection rules
    BP-->>GH: Success
    GH-->>W: 200 OK
```

<sub>Last reviewed commit: 3294888</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->