### PR TITLE
docs(manifest): add missing tools and features

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "LinkedIn MCP Server",
   "version": "4.1.2",
   "description": "Connect Claude to LinkedIn for profiles, companies, and job details",
-  "long_description": "# LinkedIn MCP Server\n\nConnect Claude to your LinkedIn account. Access profiles, companies, and job postings through a Docker container on your machine.\n\n## Features\n- **Profile Access**: Get detailed LinkedIn profile information including work history, education, and skills\n- **Company Profiles**: Extract comprehensive company information and details\n- **Job Details**: Retrieve job posting information from LinkedIn URLs\n- **Job Search**: Search for jobs with keywords and location filters\n\n## First-Time Setup\n\n### 1. Pre-pull Docker Image (Required)\nRun this command first to avoid connection timeouts:\n```\ndocker pull stickerdaniel/linkedin-mcp-server:4.1.2",
+  "long_description": "# LinkedIn MCP Server\n\nConnect Claude to your LinkedIn account. Access profiles, companies, and job postings through a Docker container on your machine.\n\n## Features\n- **Profile Access**: Get detailed LinkedIn profile information including work history, education, and skills\n- **Company Profiles**: Extract comprehensive company information and details\n- **Job Details**: Retrieve job posting information from LinkedIn URLs\n- **Job Search**: Search for jobs with keywords and location filters\n- **People Search**: Search for people by keywords and location\n- **Company Posts**: Get recent posts from a company's LinkedIn feed\n\n## First-Time Setup\n\n### 1. Pre-pull Docker Image (Required)\nRun this command first to avoid connection timeouts:\n```\ndocker pull stickerdaniel/linkedin-mcp-server:4.1.2",
   "author": {
     "name": "Daniel Sticker",
     "email": "daniel@sticker.name",
@@ -46,6 +46,14 @@
     {
       "name": "search_jobs",
       "description": "Search for jobs with filters like keywords and location"
+    },
+    {
+      "name": "get_company_posts",
+      "description": "Get recent posts from a company's LinkedIn feed"
+    },
+    {
+      "name": "search_people",
+      "description": "Search for people on LinkedIn by keywords and location"
     },
     {
       "name": "close_session",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `manifest.json` to document two previously missing tools — `get_company_posts` and `search_people` — by adding them to both the `tools` array and the `long_description` features list. Both tools are already fully implemented in the codebase, so this is a pure documentation catch-up with no functional changes.

**What was updated:**
- Added `get_company_posts` and `search_people` entries to the `tools` array
- Added "People Search" and "Company Posts" bullet points to the `## Features` section of `long_description`

**What was not updated:**
- The top-level `description` field (one-liner used in marketplace listings) still omits the new capabilities
- The `keywords` array was not updated and does not include `"people"` or `"posts"` to match the newly documented tools

These are both reasonable improvements that would enhance marketplace discoverability, though they fall outside the scope of what was changed in the PR.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — no functional or runtime impact, only documentation metadata updates.
- The PR correctly documents two already-implemented tools with no functional changes. The confidence is 4/5 rather than 5/5 because two straightforward marketplace metadata improvements (description and keywords) were not addressed. The core changes are solid and safe.
- manifest.json could be enhanced by updating the description field and keywords array (non-blocking improvements).

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Claude Desktop] -->|MCP Protocol| B[linkedin-mcp-server Docker]
    B --> C[get_person_profile]
    B --> D[get_company_profile]
    B --> E[get_job_details]
    B --> F[search_jobs]
    B --> G[get_company_posts\n✅ now documented]
    B --> H[search_people\n✅ now documented]
    B --> I[close_session]
    C & D & E & F & G & H --> J[LinkedIn via Playwright]
```

<sub>Last reviewed commit: ebc6503</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->