### PR TITLE
chore(config): Update model and provider settings in btca.config.jsonc

### DIFF
--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -1,78 +1,78 @@
 {
-	"$schema": "https://btca.dev/btca.schema.json",
-	"resources": [
-		{
-			"name": "fastmcp",
-			"type": "git",
-			"url": "https://github.com/jlowin/fastmcp",
-			"branch": "main",
-			"specialNotes": "FastMCP server framework. Primary MCP library used in this project."
-		},
-		{
-			"name": "playwright",
-			"type": "git",
-			"url": "https://github.com/microsoft/playwright-python",
-			"branch": "main",
-			"specialNotes": "Playwright Python bindings for browser automation."
-		},
-		{
-			"name": "pytest",
-			"type": "git",
-			"url": "https://github.com/pytest-dev/pytest",
-			"branch": "main",
-			"specialNotes": "Python testing framework."
-		},
-		{
-			"name": "ruff",
-			"type": "git",
-			"url": "https://github.com/astral-sh/ruff",
-			"branch": "main",
-			"specialNotes": "Fast Python linter and formatter written in Rust."
-		},
-		{
-			"name": "ty",
-			"type": "git",
-			"url": "https://github.com/astral-sh/ty",
-			"branch": "main",
-			"specialNotes": "Fast Python type checker from Astral, written in Rust."
-		},
-		{
-			"name": "uv",
-			"type": "git",
-			"url": "https://github.com/astral-sh/uv",
-			"branch": "main",
-			"specialNotes": "Fast Python package manager from Astral, written in Rust."
-		},
-		{
-			"name": "inquirer",
-			"type": "git",
-			"url": "https://github.com/magmax/python-inquirer",
-			"branch": "master",
-			"specialNotes": "Python library for CLI interactive prompts."
-		},
-		{
-			"name": "pythonDotenv",
-			"type": "git",
-			"url": "https://github.com/theskumar/python-dotenv",
-			"branch": "main",
-			"specialNotes": "Python library for loading .env files."
-		},
-		{
-			"name": "pyperclip",
-			"type": "git",
-			"url": "https://github.com/asweigart/pyperclip",
-			"branch": "master",
-			"specialNotes": "Cross-platform Python clipboard module."
-		},
-		{
-			"name": "preCommit",
-			"type": "git",
-			"url": "https://github.com/pre-commit/pre-commit",
-			"branch": "main",
-			"specialNotes": "Framework for managing pre-commit hooks."
-		}
-	],
-	"model": "claude-haiku-4-5",
-	"provider": "anthropic",
-	"providerTimeoutMs": 300000
+  "$schema": "https://btca.dev/btca.schema.json",
+  "providerTimeoutMs": 300000,
+  "resources": [
+    {
+      "type": "git",
+      "name": "fastmcp",
+      "url": "https://github.com/jlowin/fastmcp",
+      "branch": "main",
+      "specialNotes": "FastMCP server framework. Primary MCP library used in this project."
+    },
+    {
+      "type": "git",
+      "name": "playwright",
+      "url": "https://github.com/microsoft/playwright-python",
+      "branch": "main",
+      "specialNotes": "Playwright Python bindings for browser automation."
+    },
+    {
+      "type": "git",
+      "name": "pytest",
+      "url": "https://github.com/pytest-dev/pytest",
+      "branch": "main",
+      "specialNotes": "Python testing framework."
+    },
+    {
+      "type": "git",
+      "name": "ruff",
+      "url": "https://github.com/astral-sh/ruff",
+      "branch": "main",
+      "specialNotes": "Fast Python linter and formatter written in Rust."
+    },
+    {
+      "type": "git",
+      "name": "ty",
+      "url": "https://github.com/astral-sh/ty",
+      "branch": "main",
+      "specialNotes": "Fast Python type checker from Astral, written in Rust."
+    },
+    {
+      "type": "git",
+      "name": "uv",
+      "url": "https://github.com/astral-sh/uv",
+      "branch": "main",
+      "specialNotes": "Fast Python package manager from Astral, written in Rust."
+    },
+    {
+      "type": "git",
+      "name": "inquirer",
+      "url": "https://github.com/magmax/python-inquirer",
+      "branch": "master",
+      "specialNotes": "Python library for CLI interactive prompts."
+    },
+    {
+      "type": "git",
+      "name": "pythonDotenv",
+      "url": "https://github.com/theskumar/python-dotenv",
+      "branch": "main",
+      "specialNotes": "Python library for loading .env files."
+    },
+    {
+      "type": "git",
+      "name": "pyperclip",
+      "url": "https://github.com/asweigart/pyperclip",
+      "branch": "master",
+      "specialNotes": "Cross-platform Python clipboard module."
+    },
+    {
+      "type": "git",
+      "name": "preCommit",
+      "url": "https://github.com/pre-commit/pre-commit",
+      "branch": "main",
+      "specialNotes": "Framework for managing pre-commit hooks."
+    }
+  ],
+  "model": "claude-haiku-4.5",
+  "provider": "github-copilot"
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `btca.config.jsonc` to switch the BTCA AI provider from `anthropic` to `github-copilot` and updates the model identifier from `claude-haiku-4-5` to `claude-haiku-4.5` (dot notation, consistent with GitHub Copilot's model naming). Additionally:

- **Indentation**: Changed from tabs to 2 spaces for consistency
- **Field reordering**: `providerTimeoutMs` moved to position 2 (after `$schema`); within each resource, `type` now precedes `name`
- **Resources**: `linkedinScraper` was removed (10 resources remain)

The changes are straightforward config housekeeping with no impact on application code, tests, or CI configuration.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a config-only change with no impact on application code, logic, or critical infrastructure.
- The PR modifies only `btca.config.jsonc`, a non-critical development tool configuration file. All changes are intentional and low-risk: the provider switch is explicit, the model name update follows GitHub Copilot conventions, and cosmetic reformatting poses no functional risk. No application code, tests, CI configuration, or dependencies are affected. The JSONC syntax is valid.
- No files require special attention.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[btca.config.jsonc] --> B{BTCA Tool}
    B --> C[Provider: github-copilot]
    B --> D[Model: claude-haiku-4.5]
    B --> E[Timeout: 300000 ms]
    B --> F[Resources: 10 git repos]
    C --> G[GitHub Copilot API]
    G --> D
    D --> H[AI-assisted dev tasks\non linkedin-mcp-server]
```

<sub>Last reviewed commit: 6ec04e0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->