### PR TITLE
refactor(tools): Simplify annotations to dict syntax and add tags

### DIFF
--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -39,7 +39,11 @@ def create_mcp_server() -> FastMCP:
     register_job_tools(mcp)
 
     # Register session management tool
-    @mcp.tool()
+    @mcp.tool(
+        title="Close Session",
+        annotations={"destructiveHint": True},
+        tags={"session"},
+    )
     async def close_session() -> Dict[str, Any]:
         """Close the current browser session and clean up resources."""
         try:

--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from fastmcp import Context, FastMCP
 from fastmcp.dependencies import Depends
-from mcp.types import ToolAnnotations
 
 from linkedin_mcp_server.dependencies import get_extractor
 from linkedin_mcp_server.error_handler import raise_tool_error
@@ -23,12 +22,9 @@ def register_company_tools(mcp: FastMCP) -> None:
     """Register all company-related tools with the MCP server."""
 
     @mcp.tool(
-        annotations=ToolAnnotations(
-            title="Get Company Profile",
-            readOnlyHint=True,
-            destructiveHint=False,
-            openWorldHint=True,
-        )
+        title="Get Company Profile",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"company", "scraping"},
     )
     async def get_company_profile(
         company_name: str,
@@ -79,12 +75,9 @@ def register_company_tools(mcp: FastMCP) -> None:
             raise_tool_error(e, "get_company_profile")  # NoReturn
 
     @mcp.tool(
-        annotations=ToolAnnotations(
-            title="Get Company Posts",
-            readOnlyHint=True,
-            destructiveHint=False,
-            openWorldHint=True,
-        )
+        title="Get Company Posts",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"company", "scraping"},
     )
     async def get_company_posts(
         company_name: str,

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from fastmcp import Context, FastMCP
 from fastmcp.dependencies import Depends
-from mcp.types import ToolAnnotations
 
 from linkedin_mcp_server.dependencies import get_extractor
 from linkedin_mcp_server.error_handler import raise_tool_error
@@ -22,12 +21,9 @@ def register_job_tools(mcp: FastMCP) -> None:
     """Register all job-related tools with the MCP server."""
 
     @mcp.tool(
-        annotations=ToolAnnotations(
-            title="Get Job Details",
-            readOnlyHint=True,
-            destructiveHint=False,
-            openWorldHint=True,
-        )
+        title="Get Job Details",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"job", "scraping"},
     )
     async def get_job_details(
         job_id: str,
@@ -62,12 +58,9 @@ def register_job_tools(mcp: FastMCP) -> None:
             raise_tool_error(e, "get_job_details")  # NoReturn
 
     @mcp.tool(
-        annotations=ToolAnnotations(
-            title="Search Jobs",
-            readOnlyHint=True,
-            destructiveHint=False,
-            openWorldHint=True,
-        )
+        title="Search Jobs",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"job", "search"},
     )
     async def search_jobs(
         keywords: str,

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from fastmcp import Context, FastMCP
 from fastmcp.dependencies import Depends
-from mcp.types import ToolAnnotations
 
 from linkedin_mcp_server.dependencies import get_extractor
 from linkedin_mcp_server.error_handler import raise_tool_error
@@ -23,12 +22,9 @@ def register_person_tools(mcp: FastMCP) -> None:
     """Register all person-related tools with the MCP server."""
 
     @mcp.tool(
-        annotations=ToolAnnotations(
-            title="Get Person Profile",
-            readOnlyHint=True,
-            destructiveHint=False,
-            openWorldHint=True,
-        )
+        title="Get Person Profile",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"person", "scraping"},
     )
     async def get_person_profile(
         linkedin_username: str,
@@ -80,12 +76,9 @@ def register_person_tools(mcp: FastMCP) -> None:
             raise_tool_error(e, "get_person_profile")  # NoReturn
 
     @mcp.tool(
-        annotations=ToolAnnotations(
-            title="Search People",
-            readOnlyHint=True,
-            destructiveHint=False,
-            openWorldHint=True,
-        )
+        title="Search People",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"person", "search"},
     )
     async def search_people(
         keywords: str,


### PR DESCRIPTION
Replace ToolAnnotations(...) with plain dicts, move title to
top-level @mcp.tool() param, and add category tags to all tools.

Resolves: #189

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a clean, well-scoped refactoring that modernises tool metadata across all four changed files to align with the FastMCP 3.x API. It introduces no functional or behavioural changes.

Key changes:
- Removes the `ToolAnnotations(...)` Pydantic wrapper in `company.py`, `job.py`, and `person.py`, replacing it with plain `dict` syntax for the `annotations` parameter — the simpler form supported by FastMCP 3.x.
- Moves `title` from inside `ToolAnnotations` to a top-level keyword argument on `@mcp.tool()`, matching the updated FastMCP 3.x decorator signature.
- Drops the now-redundant `destructiveHint=False` from all read-only tools. Per the MCP spec, `destructiveHint` is only meaningful when `readOnlyHint` is `false`, so omitting it from tools that already declare `readOnlyHint=True` is semantically equivalent.
- Adds `tags` (as Python `set` literals) to every tool for categorisation (`"company"`, `"job"`, `"person"`, `"scraping"`, `"search"`, `"session"`).
- Enriches the previously unannotated `close_session` tool in `server.py` with a title, `destructiveHint=True`, and the `"session"` tag — accurately describing its destructive nature.

The existing test suite in `tests/test_tools.py` covers all tool functions but does not assert on annotation metadata, so no test changes are required. The refactoring is consistent across all tool files and fits naturally within the project's layered registration pattern.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure metadata/annotation refactoring with no changes to tool logic, inputs, outputs, or error handling.
- All changes are limited to decorator parameters (`title`, `annotations`, `tags`). The `annotations` dict values are semantically equivalent to the removed `ToolAnnotations` objects, `destructiveHint=False` is correctly dropped only for `readOnlyHint=True` tools, and the new `close_session` annotations accurately reflect its destructive nature. No business logic, scraping behaviour, or error paths were altered.
- No files require special attention.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@mcp.tool() decorator"] --> B{Annotation style}
    B -->|Before| C["ToolAnnotations(title=..., readOnlyHint=..., destructiveHint=False, openWorldHint=...)"]
    B -->|After| D["title='...' (top-level param)\nannotations={'readOnlyHint': True, 'openWorldHint': True}\ntags={'category', 'type'}"]
    D --> E["person tools\n(get_person_profile, search_people)"]
    D --> F["company tools\n(get_company_profile, get_company_posts)"]
    D --> G["job tools\n(get_job_details, search_jobs)"]
    D --> H["session tool\n(close_session)\nannotations={'destructiveHint': True}"]
```

<sub>Last reviewed commit: c5bf554</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->