### PR TITLE
refactor(server): Split lifespan into composable browser + auth lifespans

### DIFF
--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -6,7 +6,7 @@ person profiles, company data, job information, and session management capabilit
 """
 
 import logging
-from typing import Any, AsyncIterator, Dict
+from typing import Any, AsyncIterator
 
 from fastmcp import FastMCP
 from fastmcp.server.lifespan import lifespan
@@ -33,6 +33,7 @@ async def browser_lifespan(app: FastMCP) -> AsyncIterator[dict[str, Any]]:
 @lifespan
 async def auth_lifespan(app: FastMCP) -> AsyncIterator[dict[str, Any]]:
     """Validate authentication profile exists at startup."""
+    logger.info("Validating LinkedIn authentication...")
     get_authentication_source()
     yield {}
 
@@ -56,7 +57,7 @@ def create_mcp_server() -> FastMCP:
         annotations={"destructiveHint": True},
         tags={"session"},
     )
-    async def close_session() -> Dict[str, Any]:
+    async def close_session() -> dict[str, Any]:
         """Close the current browser session and clean up resources."""
         try:
             await close_browser()


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the single monolithic `lifespan` context manager into two focused, composable lifespans — `auth_lifespan` (validates authentication at startup) and `browser_lifespan` (manages browser setup and teardown) — composed via fastmcp's `|` operator as `auth_lifespan | browser_lifespan`. It also cleans up the legacy `Dict` import in favour of the built-in `dict`.

**Key changes:**
- Removes `@asynccontextmanager` in favour of fastmcp's `@lifespan` decorator, aligning with the framework's native composition API.
- `auth_lifespan` provides a fail-fast authentication check before the browser is ever started; if credentials are missing, startup aborts without initialising any browser resources.
- `browser_lifespan` retains the original startup/shutdown log messages and calls `close_browser()` on teardown.
- Shutdown order is correct: browser is torn down before auth lifespan completes (right-to-left for `|` composition), and since `auth_lifespan` has no cleanup code this is benign.
- Two minor style points: `auth_lifespan` does not log when `get_authentication_source()` raises an exception (making failure diagnosis harder), and the synchronous filesystem call inside the async generator could briefly block the event loop on startup.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the refactoring is functionally correct with only minor style concerns around error logging and a blocking I/O call in an async context.
- The logic is sound: `auth_lifespan` correctly fails fast before browser resources are allocated, and `browser_lifespan` preserves existing teardown behaviour. The two style concerns (no error log on auth failure, sync I/O in async context) do not affect correctness or safety in practice, only observability and strict async hygiene.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| linkedin_mcp_server/server.py | Refactors the single monolithic lifespan into two composable lifespans (`auth_lifespan` and `browser_lifespan`) using fastmcp's `|` composition operator. Also updates `Dict` to `dict` for consistency. Minor style concerns: no error logging in `auth_lifespan` on failure, and a synchronous blocking call inside an async context. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant F as FastMCP Framework
    participant AL as auth_lifespan
    participant BL as browser_lifespan
    participant AS as get_authentication_source()
    participant CB as close_browser()

    Note over F,CB: Startup Phase
    F->>AL: enter lifespan
    AL->>AL: log "Validating LinkedIn authentication..."
    AL->>AS: get_authentication_source()
    alt credentials missing
        AS-->>AL: raise CredentialsNotFoundError
        AL-->>F: propagate exception (server aborts)
    else credentials found
        AS-->>AL: return True
        AL->>AL: yield {} (startup complete)
        F->>BL: enter lifespan
        BL->>BL: log "LinkedIn MCP Server starting..."
        BL->>BL: yield {} (startup complete)
    end

    Note over F,CB: Server Running...

    Note over F,CB: Shutdown Phase
    F->>BL: resume after yield (shutdown)
    BL->>BL: log "LinkedIn MCP Server shutting down..."
    BL->>CB: close_browser()
    CB-->>BL: done
    F->>AL: resume after yield (shutdown)
    Note over AL: no cleanup needed
```

<sub>Last reviewed commit: 64ac267</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->