### PR TITLE
fix(scraping): Wait for activity feed content before extracting

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -145,8 +145,26 @@ class LinkedInExtractor:
         # Dismiss any modals blocking content
         await handle_modal_close(self._page)
 
+        # Activity feed pages lazy-load post content after the tab header
+        is_activity = "/recent-activity/" in url
+        if is_activity:
+            try:
+                await self._page.wait_for_function(
+                    """() => {
+                        const main = document.querySelector('main');
+                        if (!main) return false;
+                        return main.innerText.length > 200;
+                    }""",
+                    timeout=10000,
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Activity feed content did not appear on %s", url)
+
         # Scroll to trigger lazy loading
-        await scroll_to_bottom(self._page, pause_time=0.5, max_scrolls=5)
+        if is_activity:
+            await scroll_to_bottom(self._page, pause_time=1.0, max_scrolls=10)
+        else:
+            await scroll_to_bottom(self._page, pause_time=0.5, max_scrolls=5)
 
         # Extract text from main content area
         raw = await self._page.evaluate(

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -992,3 +992,102 @@ class TestStripLinkedInNoise:
             "Select language\nEnglish (English)\nDeutsch (German)"
         )
         assert strip_linkedin_noise(text) == "Company info"
+
+
+class TestActivityFeedExtraction:
+    """Tests for activity page detection and wait behavior in _extract_page_once."""
+
+    async def test_activity_page_waits_for_content_and_uses_slow_scroll(
+        self, mock_page
+    ):
+        """Activity URLs should call wait_for_function and use slower scroll params."""
+        mock_page.evaluate = AsyncMock(return_value="Post content " * 50)
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/in/billgates/recent-activity/all/"
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        mock_scroll.assert_awaited_once()
+        _, kwargs = mock_scroll.call_args
+        assert kwargs["pause_time"] == 1.0
+        assert kwargs["max_scrolls"] == 10
+        assert len(result) > 200
+
+    async def test_non_activity_page_skips_wait_and_uses_fast_scroll(self, mock_page):
+        """Non-activity URLs should not call wait_for_function and use fast scroll."""
+        mock_page.evaluate = AsyncMock(return_value="Profile text")
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await extractor._extract_page_once(
+                "https://www.linkedin.com/in/billgates/details/experience/"
+            )
+
+        mock_page.wait_for_function.assert_not_awaited()
+        mock_scroll.assert_awaited_once()
+        _, kwargs = mock_scroll.call_args
+        assert kwargs["pause_time"] == 0.5
+        assert kwargs["max_scrolls"] == 5
+
+    async def test_activity_page_timeout_proceeds_gracefully(self, mock_page):
+        """When activity feed content never loads, extraction proceeds with available text."""
+        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        tab_headers = "All activity\nPosts\nComments\nVideos\nImages"
+        mock_page.evaluate = AsyncMock(return_value=tab_headers)
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("Timeout")
+        )
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/in/billgates/recent-activity/all/"
+            )
+
+        # Should return whatever text is available, not crash
+        assert result == tab_headers


### PR DESCRIPTION
Activity feed pages lazy-load post content after tab headers render.
Add wait_for_function check and slower scroll params for /recent-activity/
URLs so posts section returns actual content instead of just tab headers.

Resolves: #201

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully fixes a race condition in LinkedIn activity-feed extraction. Activity feed pages lazy-load post content _after_ tab headers render, causing `_extract_page_once` to return only empty tab headers. 

The fix is well-implemented:
- Detects activity URLs via `"/recent-activity/" in url`
- Adds a `wait_for_function` gate that polls `main.innerText.length > 200` with a 10-second timeout before scrolling
- Adjusts scroll parameters for activity pages (`pause_time=1.0`, `max_scrolls=10`) vs. normal pages (`pause_time=0.5`, `max_scrolls=5`)
- Handles timeout gracefully with debug logging and continues with available text

The test suite comprehensively covers:
- Activity page wait + slow-scroll path
- Non-activity fast-scroll path  
- Timeout-fallback graceful degradation

The implementation is minimal, focused, and includes proper error handling with no regressions to existing functionality.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the fix is well-scoped, correctly implements async/await patterns, and includes graceful timeout handling with no regressions.
- The implementation is correct, minimal, and focused on solving the specific race condition. The logic change (conditional wait + adjusted scroll params) is properly isolated to activity URLs. All error paths are handled gracefully. Tests provide good coverage of the key branches. No functional issues or regressions detected.
- No files require special attention.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant LinkedInExtractor
    participant Page as Patchright Page
    participant DOM

    Caller->>LinkedInExtractor: _extract_page_once(url)
    LinkedInExtractor->>Page: goto(url, wait_until="domcontentloaded")
    Page-->>LinkedInExtractor: loaded
    LinkedInExtractor->>Page: wait_for_selector("main")
    Page-->>LinkedInExtractor: main found
    LinkedInExtractor->>Page: handle_modal_close()
    Page-->>LinkedInExtractor: done

    alt "/recent-activity/" in url
        LinkedInExtractor->>Page: wait_for_function(main.innerText.length > 200, timeout=10s)
        alt Content loads in time
            DOM-->>Page: innerText > 200 chars
            Page-->>LinkedInExtractor: resolved
        else Timeout
            Page-->>LinkedInExtractor: PlaywrightTimeoutError
            LinkedInExtractor->>LinkedInExtractor: log debug, continue
        end
        LinkedInExtractor->>Page: scroll_to_bottom(pause=1.0, max=10)
    else Other URL
        LinkedInExtractor->>Page: scroll_to_bottom(pause=0.5, max=5)
    end

    LinkedInExtractor->>Page: evaluate(main.innerText)
    Page-->>LinkedInExtractor: raw text
    LinkedInExtractor->>LinkedInExtractor: strip_linkedin_noise(raw)
    LinkedInExtractor-->>Caller: cleaned text
```

<sub>Last reviewed commit: b76460d</sub>

<!-- /greptile_comment -->