### PR TITLE
docs(README): installation link for uv in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Tool responses keep readable `sections` text and may also include a compact `ref
 
 ## 🚀 uvx Setup (Recommended - Universal)
 
-**Prerequisites:** Install uv and run `uvx patchright install chromium` to set up the browser.
+**Prerequisites:** [Install uv](https://docs.astral.sh/uv/getting-started/installation/) and run `uvx patchright install chromium` to set up the browser.
 
 ### Installation
 


### PR DESCRIPTION
Updated the prerequisites section to include a link for installing uv.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the `README.md` by converting the plain text "Install uv" in the prerequisites section into a hyperlink pointing to the [official uv installation documentation](https://docs.astral.sh/uv/getting-started/installation/), making it easier for users to get started.

- The URL `https://docs.astral.sh/uv/getting-started/installation/` is correct and points to the official Astral uv installation guide.
- The change is minimal, targeted, and has no impact on functionality.
- No issues were found in this PR.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a purely additive documentation improvement with no functional changes.
- The only change is wrapping existing plain text with a valid, correct Markdown hyperlink pointing to the official uv documentation. There is zero risk of regression.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds a hyperlink to the official uv installation documentation in the prerequisites section — purely a documentation improvement with no issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant README as README.md (Prerequisites)
    participant UVDocs as docs.astral.sh/uv (Installation Guide)
    participant UVX as uvx
    participant Patchright as patchright (Chromium)

    User->>README: Reads prerequisites section
    README-->>User: [Install uv](link) — hyperlink added by this PR
    User->>UVDocs: Clicks link, installs uv
    User->>UVX: uvx patchright install chromium
    UVX->>Patchright: Downloads & installs Chromium
    Patchright-->>User: Browser ready
    User->>UVX: uvx linkedin-scraper-mcp --login
```

<sub>Last reviewed commit: ca55460</sub>

<!-- /greptile_comment -->