### PR TITLE
chore: Bump version to 4.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "linkedin-scraper-mcp"
-version = "4.3.0"
+version = "4.4.0"
 description = "MCP server for LinkedIn profile, company, and job scraping with Claude AI integration. Supports direct profile/company/job URL scraping with secure credential storage."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -951,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "linkedin-scraper-mcp"
-version = "4.3.0"
+version = "4.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the package version from `4.3.0` to `4.4.0` in `pyproject.toml` and the corresponding `uv.lock` entry. The `__version__` in `linkedin_mcp_server/__init__.py` is resolved dynamically via `importlib.metadata`, so no source-code changes are needed there.

**However, two additional files outside this PR's changeset still reference the old version `4.3.0` and should be updated as part of this bump:**

- `docker-compose.yml` (line 3): `image: stickerdaniel/linkedin-mcp-server:4.3.0` — users running Docker Compose will pull the old image.
- `manifest.json` (line 5, 7, 29): `"version": "4.3.0"` and two Docker image tag references in `long_description` and `server.mcp_config.args` — the DXT extension manifest and its pull instructions will point to the old image tag.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for the Python package, but Docker and DXT users will be left on the old version until docker-compose.yml and manifest.json are updated.
- The two changed files are correct and consistent with each other. The `__version__` attribute is resolved dynamically and will automatically reflect 4.4.0 after install. However, `docker-compose.yml` and `manifest.json` still hardcode `4.3.0`, creating a mismatch that directly affects Docker Compose deployments and the DXT extension — both of which are primary distribution channels for this project.
- `docker-compose.yml` and `manifest.json` (not in changeset) still reference `4.3.0` and need updating.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Version field bumped from 4.3.0 to 4.4.0; no other changes. |
| uv.lock | Lock file entry for `linkedin-scraper-mcp` updated from 4.3.0 to 4.4.0 to match `pyproject.toml`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pyproject.toml\nversion = 4.4.0 ✅"] --> B["uv.lock\nlinkedin-scraper-mcp 4.4.0 ✅"]
    A --> C["linkedin_mcp_server/__init__.py\n__version__ via importlib.metadata ✅"]
    A -.->|"NOT updated in this PR"| D["docker-compose.yml\nimage: ...4.3.0 ⚠️"]
    A -.->|"NOT updated in this PR"| E["manifest.json\nversion: 4.3.0 ⚠️"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: pyproject.toml
Line: 3

Comment:
**Stale version references in other files**

`docker-compose.yml` and `manifest.json` were not updated as part of this version bump and still reference `4.3.0`. This means:

- Users running Docker Compose will pull the old `stickerdaniel/linkedin-mcp-server:4.3.0` image (`docker-compose.yml` line 3).
- The DXT extension manifest (`manifest.json`) reports version `4.3.0` (line 5), embeds a `docker pull stickerdaniel/linkedin-mcp-server:4.3.0` command in `long_description` (line 7), and passes the old image tag in `server.mcp_config.args` (line 29).

All four of these occurrences should be updated to `4.4.0` to keep the deployment artefacts consistent with the package version.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 9d306d2</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->