### PR TITLE
fix(scraping): wait for search results content before extracting

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -428,6 +428,22 @@ class LinkedInExtractor:
             except PlaywrightTimeoutError:
                 logger.debug("Activity feed content did not appear on %s", url)
 
+        # Search results pages load a placeholder first then fill in results
+        # via JavaScript. Wait for actual content before extracting.
+        is_search = "/search/results/" in url
+        if is_search:
+            try:
+                await self._page.wait_for_function(
+                    """() => {
+                        const main = document.querySelector('main');
+                        if (!main) return false;
+                        return main.innerText.length > 100;
+                    }""",
+                    timeout=10000,
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Search results content did not appear on %s", url)
+
         # Scroll to trigger lazy loading
         if is_activity:
             await scroll_to_bottom(self._page, pause_time=1.0, max_scrolls=10)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1672,3 +1672,104 @@ class TestActivityFeedExtraction:
 
         # Should return whatever text is available, not crash
         assert result.text == tab_headers
+
+
+class TestSearchResultsExtraction:
+    """Tests for search results page detection and wait behavior in _extract_page_once."""
+
+    async def test_search_results_page_waits_for_content(self, mock_page):
+        """Search results URLs should call wait_for_function to wait for content."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Search results for John Doe. " * 10,
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/search/results/people/?keywords=John+Doe",
+                section_name="search_results",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        assert len(result.text) > 100
+
+    async def test_non_search_page_does_not_wait_for_search_content(self, mock_page):
+        """Non-search URLs should not trigger the search results wait."""
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": "Profile text", "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await extractor._extract_page_once(
+                "https://www.linkedin.com/in/billgates/",
+                section_name="main_profile",
+            )
+
+        mock_page.wait_for_function.assert_not_awaited()
+
+    async def test_search_results_timeout_proceeds_gracefully(self, mock_page):
+        """When search results never load, extraction proceeds with available text."""
+        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        placeholder = "Search results for John Doe. No results found"
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": placeholder, "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("Timeout")
+        )
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/search/results/people/?keywords=John+Doe",
+                section_name="search_results",
+            )
+
+        assert result.text == placeholder


### PR DESCRIPTION
Search results pages load a placeholder first, then fill in the actual
results via JavaScript. The extractor reads innerText before content
loads, causing search_people to return empty sections ~40% of the time.

Add wait_for_function for /search/results/ URLs, same pattern as the
activity feed fix in #203. Includes 3 tests mirroring TestActivityFeedExtraction.

Resolves: #224

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition where `search_people` returned empty results ~40% of the time because `_extract_page_once` read `innerText` before search results finished rendering via JavaScript. The fix adds a `wait_for_function` call for `/search/results/` URLs that blocks until `main.innerText.length > 100`, matching the pattern established in #203 for activity feeds. Three tests covering the happy path, non-search URL exclusion, and timeout graceful degradation are included.

- Adds search results content wait in `extractor.py:_extract_page_once` with a 10s timeout and `> 100` character threshold
- Gracefully degrades on timeout — logs a debug message and proceeds with whatever text is available
- Tests mirror the existing `TestActivityFeedExtraction` class structure

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a well-scoped wait condition that gracefully degrades on timeout, with good test coverage.
- Score of 4 reflects a clean, focused bug fix that follows an established pattern in the codebase (activity feed wait from #203). The logic is correct, the timeout handling is graceful, and three tests cover the key scenarios. Minor deduction because the threshold (100 characters) is a heuristic that could potentially still race in edge cases, though this matches the existing approach.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| linkedin_mcp_server/scraping/extractor.py | Adds a `wait_for_function` block for `/search/results/` URLs that waits until `main.innerText.length > 100`, mirroring the existing activity feed pattern. Clean, correct, and consistent with existing code. |
| tests/test_scraping.py | Adds 3 tests for search results wait behavior (wait triggered, not triggered for non-search URLs, graceful timeout). Mirrors the existing `TestActivityFeedExtraction` pattern. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as search_people()
    participant EPO as _extract_page_once()
    participant Page as Patchright Page

    Caller->>EPO: URL = /search/results/people/...
    EPO->>Page: navigate to URL
    EPO->>Page: detect_rate_limit()
    EPO->>Page: wait_for_selector("main", 5s)
    EPO->>Page: handle_modal_close()
    Note over EPO: is_activity = false
    Note over EPO: is_search = true
    EPO->>Page: wait_for_function(main.innerText > 100, 10s)
    alt Content loads in time
        Page-->>EPO: resolved
    else Timeout
        Page-->>EPO: PlaywrightTimeoutError
        Note over EPO: Log debug, continue
    end
    EPO->>Page: scroll_to_bottom(pause=0.5, max=5)
    EPO->>Page: evaluate (extract innerText)
    Page-->>EPO: raw text + references
    EPO-->>Caller: ExtractedSection
```

<sub>Last reviewed commit: 46a9fbe</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->