### PR TITLE
fix(diagnostics): align issue report with bug form

### DIFF
--- a/linkedin_mcp_server/error_diagnostics.py
+++ b/linkedin_mcp_server/error_diagnostics.py
@@ -360,7 +360,7 @@ def _installation_method_lines(runtime: dict[str, Any]) -> list[str]:
     current_runtime_id = str(runtime.get("current_runtime_id") or "")
     docker_checked = "x" if "container" in current_runtime_id else " "
     return [
-        f"- [{docker_checked}] Docker (specify docker image version/tag): `stickerdaniel/linkedin-mcp-server:latest` with `~/.linkedin-mcp` mounted into `/home/pwuser/.linkedin-mcp`",
+        f"- [{docker_checked}] Docker (specify docker image version/tag): `stickerdaniel/linkedin-mcp-server:<version-or-latest>` with `~/.linkedin-mcp` mounted into `/home/pwuser/.linkedin-mcp`",
         "- [ ] Claude Desktop DXT extension (specify docker image version/tag): _._._",
         "- [ ] Local Python setup",
     ]
@@ -370,27 +370,10 @@ def _installation_method_summary(runtime: dict[str, Any]) -> str:
     current_runtime_id = str(runtime.get("current_runtime_id") or "")
     if "container" in current_runtime_id:
         return (
-            "Docker using `stickerdaniel/linkedin-mcp-server:latest` with "
+            "Docker using `stickerdaniel/linkedin-mcp-server:<version-or-latest>` with "
             "`~/.linkedin-mcp` mounted into `/home/pwuser/.linkedin-mcp`"
         )
     return "Local Python setup"
-
-
-def _tool_lines(payload: dict[str, Any]) -> list[str]:
-    selected_tool = _tool_name_for_context(payload)
-    tool_names = [
-        "get_person_profile",
-        "get_company_profile",
-        "get_company_posts",
-        "get_job_details",
-        "search_jobs",
-        "search_people",
-        "close_session",
-    ]
-    return [
-        f"  - [{'x' if tool_name == selected_tool else ' '}] {tool_name}"
-        for tool_name in tool_names
-    ]
 
 
 def _tool_name_for_context(payload: dict[str, Any]) -> str | None:

--- a/tests/test_error_diagnostics.py
+++ b/tests/test_error_diagnostics.py
@@ -12,7 +12,10 @@ def _required_issue_form_labels() -> list[str]:
     labels: list[str] = []
     current_label: str | None = None
     in_body = False
-    lines = Path(".github/ISSUE_TEMPLATE/bug_report.yml").read_text().splitlines()
+    issue_form_path = (
+        Path(__file__).resolve().parents[1] / ".github/ISSUE_TEMPLATE/bug_report.yml"
+    )
+    lines = issue_form_path.read_text().splitlines()
     for line in lines:
         stripped = line.strip()
         if stripped == "body:":


### PR DESCRIPTION
## Summary
- align generated scrape-failure diagnostics with the current GitHub bug form fields
- keep detailed runtime and session context in an additional diagnostics section
- add a drift test to ensure diagnostics still cover all required bug form fields

Generated with Codex GPT-5

Prompt:
"Keep error_diagnostics.py and bug_report.yml separate. Add a test that asserts the diagnostics template still covers the current bug form’s required fields: Setup, What Happened, Steps to Reproduce. Simplify error_diagnostics.py so it maps cleanly to those fields. But we dont want to drop lots of information. If this error is read by an ai and the user confirms and tells the ai to post this issue it should add as much detail as possible."