### PR TITLE
fix(docker): use Python 3.13 base image to fix permission denied error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use slim Python base instead of full Playwright image (saves ~300-400 MB)
 # Only Chromium is installed, not Firefox/WebKit
-FROM python:3.14-slim-bookworm@sha256:55e465cb7e50cd1d7217fcb5386aa87d0356ca2cd790872142ef68d9ef6812b4
+FROM python:3.13-slim-bookworm
 
 # Install uv package manager
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:3472e43b4e738cf911c99d41bb34331280efad54c73b1def654a6227bb59b2b4 /uv /uvx /bin/


### PR DESCRIPTION
The Python 3.14 base image doesn't satisfy the project's
requires-python "<3.14" constraint, causing uv to download Python 3.13
into /root/.local/share/uv/python/. The venv symlink then points into
/root/ which is inaccessible to the non-root pwuser, resulting in
"Permission denied (os error 13)" at startup.

Switching the base image to python:3.13-slim-bookworm means the system
Python satisfies the constraint directly, so uv uses it in-place and
the symlink issue disappears. Renovate will pin the digest automatically.

Fixes #257