### PR TITLE
fix(login): pass --chrome-path to BrowserManager during --login

### DIFF
--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -7,6 +7,7 @@ with persistent context. Profile state auto-persists to user_data_dir.
 
 import asyncio
 from pathlib import Path
+from typing import Any
 
 from linkedin_mcp_server.config import get_config
 from linkedin_mcp_server.core import (
@@ -47,7 +48,7 @@ async def interactive_login(
     print("   Please log in manually. You have 5 minutes to complete authentication.")
     print("   (This handles 2FA, captcha, and any security challenges)")
 
-    launch_options: dict[str, str] = {}
+    launch_options: dict[str, Any] = {}
     config = get_config()
     if config.browser.chrome_path:
         launch_options["executable_path"] = config.browser.chrome_path

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -40,9 +40,7 @@ async def test_interactive_login_writes_source_state_when_cookie_export_succeeds
         return_value=SimpleNamespace(login_generation="gen-123")
     )
 
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.get_config", lambda: AppConfig()
-    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.get_config", lambda: AppConfig())
     monkeypatch.setattr(
         "linkedin_mcp_server.setup.BrowserManager",
         lambda **kwargs: _BrowserContextManager(browser),
@@ -79,9 +77,7 @@ async def test_interactive_login_returns_false_when_cookie_export_fails(
     browser = _make_browser(export_cookies=False)
     write_source_state = MagicMock()
 
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.get_config", lambda: AppConfig()
-    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.get_config", lambda: AppConfig())
     monkeypatch.setattr(
         "linkedin_mcp_server.setup.BrowserManager",
         lambda **kwargs: _BrowserContextManager(browser),
@@ -109,3 +105,39 @@ async def test_interactive_login_returns_false_when_cookie_export_fails(
     captured = capsys.readouterr()
     assert "warning: cookie export failed" in captured.out.lower()
     assert "profile saved to" not in captured.out.lower()
+
+
+@pytest.mark.asyncio
+async def test_interactive_login_passes_chrome_path_to_browser_manager(
+    monkeypatch, tmp_path
+):
+    """When config.browser.chrome_path is set, executable_path must reach BrowserManager."""
+    browser = _make_browser(export_cookies=True)
+    captured_kwargs: dict = {}
+
+    def fake_browser_manager(**kwargs):
+        captured_kwargs.update(kwargs)
+        return _BrowserContextManager(browser)
+
+    config = AppConfig()
+    config.browser.chrome_path = "/custom/chrome"
+
+    monkeypatch.setattr("linkedin_mcp_server.setup.get_config", lambda: config)
+    monkeypatch.setattr(
+        "linkedin_mcp_server.setup.BrowserManager", fake_browser_manager
+    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.warm_up_browser", AsyncMock())
+    monkeypatch.setattr(
+        "linkedin_mcp_server.setup.resolve_remember_me_prompt",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.wait_for_manual_login", AsyncMock())
+    monkeypatch.setattr(
+        "linkedin_mcp_server.setup.write_source_state",
+        MagicMock(return_value=SimpleNamespace(login_generation="gen-1")),
+    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.asyncio.sleep", AsyncMock())
+
+    await interactive_login(tmp_path / "profile")
+
+    assert captured_kwargs.get("executable_path") == "/custom/chrome"


### PR DESCRIPTION
## Summary

- `--chrome-path` was ignored during `--login` because `setup.py:interactive_login()` created `BrowserManager` without passing `executable_path`
- Read `config.browser.chrome_path` and forward it as `executable_path` to `BrowserManager`, matching the existing server runtime behavior in `drivers/browser.py:_launch_options()`
- Updated tests to mock `get_config` in the setup module

Closes #260

**Prompt:** "The --chrome-path flag is being ignored during --login. Find where launch_persistent_context is called during the --login flow and make sure executable_path gets set from the --chrome-path argument."
## Test plan

- [x] All 289 existing tests pass
- [ ] Run `uv run -m linkedin_mcp_server --login --chrome-path "/path/to/browser"` and verify it launches the specified browser
- [ ] Run `uv run -m linkedin_mcp_server --login` (without `--chrome-path`) and verify default Chromium still works