### PR TITLE
fix(login): forward all browser config params during --login

### DIFF
--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -53,8 +53,18 @@ async def interactive_login(
     if config.browser.chrome_path:
         launch_options["executable_path"] = config.browser.chrome_path
 
+    viewport = {
+        "width": config.browser.viewport_width,
+        "height": config.browser.viewport_height,
+    }
+
     async with BrowserManager(
-        user_data_dir=user_data_dir, headless=False, **launch_options
+        user_data_dir=user_data_dir,
+        headless=False,
+        slow_mo=config.browser.slow_mo,
+        user_agent=config.browser.user_agent,
+        viewport=viewport,
+        **launch_options,
     ) as browser:
         # Warm up browser to appear more human-like and avoid security checkpoints
         if warm_up:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -31,6 +31,32 @@ def _make_browser(*, export_cookies: bool) -> MagicMock:
     return browser
 
 
+def _patch_login_deps(
+    monkeypatch,
+    *,
+    browser_factory,
+    config: AppConfig | None = None,
+    write_source_state: MagicMock | None = None,
+) -> None:
+    """Patch all interactive_login dependencies in one place."""
+    monkeypatch.setattr(
+        "linkedin_mcp_server.setup.get_config", lambda: config or AppConfig()
+    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.BrowserManager", browser_factory)
+    monkeypatch.setattr("linkedin_mcp_server.setup.warm_up_browser", AsyncMock())
+    monkeypatch.setattr(
+        "linkedin_mcp_server.setup.resolve_remember_me_prompt",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.wait_for_manual_login", AsyncMock())
+    monkeypatch.setattr(
+        "linkedin_mcp_server.setup.write_source_state",
+        write_source_state
+        or MagicMock(return_value=SimpleNamespace(login_generation="gen-1")),
+    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.asyncio.sleep", AsyncMock())
+
+
 @pytest.mark.asyncio
 async def test_interactive_login_writes_source_state_when_cookie_export_succeeds(
     monkeypatch, tmp_path, capsys
@@ -40,24 +66,11 @@ async def test_interactive_login_writes_source_state_when_cookie_export_succeeds
         return_value=SimpleNamespace(login_generation="gen-123")
     )
 
-    monkeypatch.setattr("linkedin_mcp_server.setup.get_config", lambda: AppConfig())
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.BrowserManager",
-        lambda **kwargs: _BrowserContextManager(browser),
+    _patch_login_deps(
+        monkeypatch,
+        browser_factory=lambda **kwargs: _BrowserContextManager(browser),
+        write_source_state=write_source_state,
     )
-    monkeypatch.setattr("linkedin_mcp_server.setup.warm_up_browser", AsyncMock())
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.resolve_remember_me_prompt",
-        AsyncMock(return_value=False),
-    )
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.wait_for_manual_login",
-        AsyncMock(),
-    )
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.write_source_state", write_source_state
-    )
-    monkeypatch.setattr("linkedin_mcp_server.setup.asyncio.sleep", AsyncMock())
 
     assert await interactive_login(tmp_path / "profile") is True
 
@@ -77,24 +90,11 @@ async def test_interactive_login_returns_false_when_cookie_export_fails(
     browser = _make_browser(export_cookies=False)
     write_source_state = MagicMock()
 
-    monkeypatch.setattr("linkedin_mcp_server.setup.get_config", lambda: AppConfig())
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.BrowserManager",
-        lambda **kwargs: _BrowserContextManager(browser),
+    _patch_login_deps(
+        monkeypatch,
+        browser_factory=lambda **kwargs: _BrowserContextManager(browser),
+        write_source_state=write_source_state,
     )
-    monkeypatch.setattr("linkedin_mcp_server.setup.warm_up_browser", AsyncMock())
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.resolve_remember_me_prompt",
-        AsyncMock(return_value=False),
-    )
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.wait_for_manual_login",
-        AsyncMock(),
-    )
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.write_source_state", write_source_state
-    )
-    monkeypatch.setattr("linkedin_mcp_server.setup.asyncio.sleep", AsyncMock())
 
     assert await interactive_login(tmp_path / "profile") is False
 
@@ -122,22 +122,105 @@ async def test_interactive_login_passes_chrome_path_to_browser_manager(
     config = AppConfig()
     config.browser.chrome_path = "/custom/chrome"
 
-    monkeypatch.setattr("linkedin_mcp_server.setup.get_config", lambda: config)
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.BrowserManager", fake_browser_manager
-    )
-    monkeypatch.setattr("linkedin_mcp_server.setup.warm_up_browser", AsyncMock())
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.resolve_remember_me_prompt",
-        AsyncMock(return_value=False),
-    )
-    monkeypatch.setattr("linkedin_mcp_server.setup.wait_for_manual_login", AsyncMock())
-    monkeypatch.setattr(
-        "linkedin_mcp_server.setup.write_source_state",
-        MagicMock(return_value=SimpleNamespace(login_generation="gen-1")),
-    )
-    monkeypatch.setattr("linkedin_mcp_server.setup.asyncio.sleep", AsyncMock())
+    _patch_login_deps(monkeypatch, browser_factory=fake_browser_manager, config=config)
 
     await interactive_login(tmp_path / "profile")
 
     assert captured_kwargs.get("executable_path") == "/custom/chrome"
+
+
+@pytest.mark.asyncio
+async def test_interactive_login_forwards_all_browser_params(monkeypatch, tmp_path):
+    """All browser config params must reach BrowserManager during --login."""
+    browser = _make_browser(export_cookies=True)
+    captured_kwargs: dict = {}
+
+    def fake_browser_manager(**kwargs):
+        captured_kwargs.update(kwargs)
+        return _BrowserContextManager(browser)
+
+    config = AppConfig()
+    config.browser.chrome_path = "/custom/chrome"
+    config.browser.slow_mo = 250
+    config.browser.user_agent = "CustomAgent/1.0"
+    config.browser.viewport_width = 1920
+    config.browser.viewport_height = 1080
+
+    _patch_login_deps(monkeypatch, browser_factory=fake_browser_manager, config=config)
+
+    profile = tmp_path / "profile"
+    await interactive_login(profile)
+
+    assert captured_kwargs["user_data_dir"] == profile
+    assert captured_kwargs["headless"] is False
+    assert captured_kwargs["slow_mo"] == 250
+    assert captured_kwargs["user_agent"] == "CustomAgent/1.0"
+    assert captured_kwargs["viewport"] == {"width": 1920, "height": 1080}
+    assert captured_kwargs["executable_path"] == "/custom/chrome"
+
+
+@pytest.mark.asyncio
+async def test_interactive_login_passes_slow_mo_to_browser_manager(
+    monkeypatch, tmp_path
+):
+    """When config.browser.slow_mo is set, it must reach BrowserManager."""
+    browser = _make_browser(export_cookies=True)
+    captured_kwargs: dict = {}
+
+    def fake_browser_manager(**kwargs):
+        captured_kwargs.update(kwargs)
+        return _BrowserContextManager(browser)
+
+    config = AppConfig()
+    config.browser.slow_mo = 250
+
+    _patch_login_deps(monkeypatch, browser_factory=fake_browser_manager, config=config)
+
+    await interactive_login(tmp_path / "profile")
+
+    assert captured_kwargs.get("slow_mo") == 250
+
+
+@pytest.mark.asyncio
+async def test_interactive_login_passes_user_agent_to_browser_manager(
+    monkeypatch, tmp_path
+):
+    """When config.browser.user_agent is set, it must reach BrowserManager."""
+    browser = _make_browser(export_cookies=True)
+    captured_kwargs: dict = {}
+
+    def fake_browser_manager(**kwargs):
+        captured_kwargs.update(kwargs)
+        return _BrowserContextManager(browser)
+
+    config = AppConfig()
+    config.browser.user_agent = "CustomAgent/1.0"
+
+    _patch_login_deps(monkeypatch, browser_factory=fake_browser_manager, config=config)
+
+    await interactive_login(tmp_path / "profile")
+
+    assert captured_kwargs.get("user_agent") == "CustomAgent/1.0"
+
+
+@pytest.mark.asyncio
+async def test_interactive_login_passes_viewport_to_browser_manager(
+    monkeypatch, tmp_path
+):
+    """Non-default viewport_width/viewport_height must reach BrowserManager as viewport."""
+    browser = _make_browser(export_cookies=True)
+    captured_kwargs: dict = {}
+
+    def fake_browser_manager(**kwargs):
+        captured_kwargs.update(kwargs)
+        return _BrowserContextManager(browser)
+
+    config = AppConfig()
+    config.browser.viewport_width = 1920
+    config.browser.viewport_height = 1080
+
+    _patch_login_deps(monkeypatch, browser_factory=fake_browser_manager, config=config)
+
+    await interactive_login(tmp_path / "profile")
+
+    assert captured_kwargs.get("viewport") == {"width": 1920, "height": 1080}


### PR DESCRIPTION
## Summary

- Forward `slow_mo`, `user_agent`, and `viewport` from config to `BrowserManager` during `--login`, matching the server runtime path in `drivers/browser.py:_make_browser()`
- These params were silently ignored after PR #261 fixed only `--chrome-path`
- Add comprehensive test asserting ALL 6 BrowserManager params (`user_data_dir`, `headless`, `slow_mo`, `user_agent`, `viewport`, `executable_path`) are correctly forwarded
- Add individual param tests for `slow_mo`, `user_agent`, and `viewport`

Closes #260 (remaining follow-up)

## Test plan

- [x] 3 new individual param tests pass (slow_mo, user_agent, viewport)
- [x] 1 new comprehensive test verifying all 6 params at once
- [x] All 282 tests pass (full suite excluding bootstrap)
- [ ] `uv run -m linkedin_mcp_server --login --slow-mo 100` respects the flag
- [ ] `uv run -m linkedin_mcp_server --login --viewport 1920x1080` respects the flag