### PR TITLE
chore: bump version to 4.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "linkedin-scraper-mcp"
-version = "4.5.3"
+version = "4.6.0"
 description = "MCP server for LinkedIn profile, company, and job scraping with Claude AI integration. Supports direct profile/company/job URL scraping with secure credential storage."
 readme = "README.md"
 requires-python = ">=3.12,<3.14"


### PR DESCRIPTION
## Summary

- Bump version to 4.6.0 for the --login browser param forwarding fix (#261, #262)