### PR TITLE
fix(security): pin CI deps, harden file permissions, warn on 0.0.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
           ls -lh dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           print-hash: true
           verbose: true

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -15,7 +15,7 @@ import sys
 from fastmcp import Context
 
 from linkedin_mcp_server.authentication import get_authentication_source
-from linkedin_mcp_server.common_utils import utcnow_iso
+from linkedin_mcp_server.common_utils import secure_mkdir, secure_write_text, utcnow_iso
 from linkedin_mcp_server.drivers.browser import get_profile_dir
 from linkedin_mcp_server.exceptions import (
     AuthenticationBootstrapFailedError,
@@ -186,7 +186,7 @@ def _start_browser_setup_task_locked() -> None:
 async def _run_browser_setup() -> None:
     browser_dir = configure_browser_environment()
     metadata_path = install_metadata_path()
-    browser_dir.mkdir(parents=True, exist_ok=True)
+    secure_mkdir(browser_dir)
 
     proc = await asyncio.create_subprocess_exec(
         sys.executable,
@@ -214,7 +214,9 @@ async def _run_browser_setup() -> None:
         "browser_name": "chromium",
         "installer_name": "patchright",
     }
-    metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+    secure_write_text(
+        metadata_path, json.dumps(metadata, indent=2, sort_keys=True) + "\n"
+    )
 
 
 def ensure_browser_installed() -> None:

--- a/linkedin_mcp_server/common_utils.py
+++ b/linkedin_mcp_server/common_utils.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime
+from pathlib import Path
 import re
+import tempfile
 
 
 def slugify_fragment(value: str) -> str:
@@ -14,3 +17,28 @@ def slugify_fragment(value: str) -> str:
 def utcnow_iso() -> str:
     """Return the current UTC timestamp in a compact ISO-8601 form."""
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def secure_mkdir(path: Path, mode: int = 0o700) -> None:
+    """Create a directory tree with restrictive permissions."""
+    path.mkdir(parents=True, exist_ok=True, mode=mode)
+
+
+def secure_write_text(path: Path, content: str, mode: int = 0o600) -> None:
+    """Atomically write *content* to *path* with owner-only permissions.
+
+    Uses a temp file + ``os.replace`` in the same directory so the write is
+    atomic on the same filesystem and avoids TOCTOU permission races.
+    """
+    secure_mkdir(path.parent)
+    fd = tempfile.NamedTemporaryFile(
+        mode="w", dir=path.parent, delete=False, suffix=".tmp"
+    )
+    try:
+        fd.write(content)
+        fd.close()
+        os.chmod(fd.name, mode)
+        os.replace(fd.name, path)
+    except BaseException:
+        os.unlink(fd.name)
+        raise

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -5,9 +5,12 @@ Defines the dataclass schemas that represent the application's configuration
 structure with type-safe configuration objects and default values.
 """
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigurationError(Exception):
@@ -91,6 +94,14 @@ class AppConfig:
             raise ConfigurationError("HTTP transport requires a valid host")
         if not self.server.port:
             raise ConfigurationError("HTTP transport requires a valid port")
+        if self.server.host in ("0.0.0.0", "::"):
+            logger.warning(
+                "HTTP transport is binding to %s which exposes the server to "
+                "all network interfaces. The MCP endpoint has no authentication "
+                "— anyone on your network can use your LinkedIn session. "
+                "Use 127.0.0.1 (default) unless you understand the risk.",
+                self.server.host,
+            )
 
     def _validate_port_range(self) -> None:
         """Validate port is in valid range."""

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -13,6 +13,8 @@ from patchright.async_api import (
     async_playwright,
 )
 
+from linkedin_mcp_server.common_utils import secure_mkdir, secure_write_text
+
 from .exceptions import NetworkError
 
 logger = logging.getLogger(__name__)
@@ -65,7 +67,7 @@ class BrowserManager:
         try:
             self._playwright = await async_playwright().start()
 
-            Path(self.user_data_dir).mkdir(parents=True, exist_ok=True)
+            secure_mkdir(Path(self.user_data_dir))
 
             context_options: dict[str, Any] = {
                 "headless": self.headless,
@@ -186,7 +188,7 @@ class BrowserManager:
                 for c in all_cookies
                 if "linkedin.com" in c.get("domain", "")
             ]
-            path.write_text(json.dumps(cookies, indent=2))
+            secure_write_text(path, json.dumps(cookies, indent=2))
             logger.info("Exported %d LinkedIn cookies to %s", len(cookies), path)
             return True
         except Exception:
@@ -202,7 +204,7 @@ class BrowserManager:
             return False
 
         storage_path = Path(path)
-        storage_path.parent.mkdir(parents=True, exist_ok=True)
+        secure_mkdir(storage_path.parent)
         try:
             await self._context.storage_state(
                 path=storage_path,

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -10,6 +10,7 @@ import logging
 import os
 from pathlib import Path
 
+from linkedin_mcp_server.common_utils import secure_mkdir
 from linkedin_mcp_server.core import (
     AuthenticationError,
     BrowserManager,
@@ -244,7 +245,7 @@ async def _bridge_runtime_profile(
     source_profile_dir = get_source_profile_dir()
     bridge_started_at = utcnow_iso()
     clear_runtime_profile(runtime_id, source_profile_dir)
-    profile_dir.parent.mkdir(parents=True, exist_ok=True)
+    secure_mkdir(profile_dir.parent)
     storage_state_path = runtime_storage_state_path(runtime_id, source_profile_dir)
     browser = _make_browser(
         profile_dir, launch_options=launch_options, viewport=viewport

--- a/linkedin_mcp_server/session_state.py
+++ b/linkedin_mcp_server/session_state.py
@@ -11,7 +11,7 @@ import shutil
 from typing import Any
 from uuid import uuid4
 
-from linkedin_mcp_server.common_utils import utcnow_iso
+from linkedin_mcp_server.common_utils import secure_write_text, utcnow_iso
 from linkedin_mcp_server.config import get_config
 
 logger = logging.getLogger(__name__)
@@ -327,5 +327,4 @@ def _load_json(path: Path) -> dict[str, Any] | None:
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    secure_write_text(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")


### PR DESCRIPTION
Pin pypa/gh-action-pypi-publish to SHA and bunx @anthropic-ai/mcpb to
v2.1.2. Tighten session file permissions to 0o600/0o700 via atomic
secure_write_text/secure_mkdir helpers. Warn when HTTP transport binds
to 0.0.0.0 exposing unauthenticated MCP endpoint.

Resolves: #271