### PR TITLE
feat(messaging): add inbox, conversation, search, and send tools

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1362,6 +1362,224 @@ class LinkedInExtractor:
             result["section_errors"] = section_errors
         return result
 
+    # ------------------------------------------------------------------
+    # Messaging
+    # ------------------------------------------------------------------
+
+    async def get_inbox(self, *, limit: int = 20) -> dict[str, Any]:
+        """Scrape the LinkedIn messaging inbox.
+
+        Returns:
+            {url, sections: {inbox: raw text}, references?: {...}}
+        """
+        url = "https://www.linkedin.com/messaging/"
+        await self._navigate_to_page(url)
+
+        try:
+            await self._page.wait_for_selector(
+                '[class*="msg-conversations-container"], [class*="messaging"]',
+                timeout=10000,
+            )
+        except PlaywrightTimeoutError:
+            logger.debug("Messaging container not found, continuing with page text")
+
+        # Scroll the conversation list to load more entries
+        sidebar = self._page.locator(
+            '[class*="msg-conversations-container"], [class*="list-style-none"]'
+        ).first
+        try:
+            for _ in range(min(limit // 10, 5)):
+                await sidebar.evaluate("el => el.scrollTop = el.scrollHeight")
+                await asyncio.sleep(1)
+        except Exception:
+            logger.debug("Sidebar scroll failed, continuing with loaded content")
+
+        text = await self.get_page_text()
+        extracted = await self._extract_root_content(["main", "[role='main']", "body"])
+        refs = build_references(extracted.get("references", []), "inbox")
+
+        sections: dict[str, str] = {}
+        references: dict[str, list[Reference]] = {}
+        if text:
+            sections["inbox"] = text
+        if refs:
+            references["inbox"] = refs
+
+        result: dict[str, Any] = {"url": url, "sections": sections}
+        if references:
+            result["references"] = references
+        return result
+
+    async def get_conversation(self, linkedin_username: str) -> dict[str, Any]:
+        """Scrape the conversation thread with a specific person.
+
+        Navigates to the messaging thread via the profile's Message button
+        or the direct messaging URL.
+
+        Returns:
+            {url, sections: {conversation: raw text}, references?: {...}}
+        """
+        url = f"https://www.linkedin.com/messaging/thread/new/?recipient={linkedin_username}"
+        await self._navigate_to_page(url)
+
+        # Wait for conversation content to load
+        try:
+            await self._page.wait_for_selector(
+                '[class*="msg-s-message-list"], [class*="msg-thread"]',
+                timeout=10000,
+            )
+        except PlaywrightTimeoutError:
+            logger.debug("Conversation thread not found, trying profile approach")
+            # Fall back: navigate to profile and click Message
+            profile_url = f"https://www.linkedin.com/in/{linkedin_username}/"
+            await self._navigate_to_page(profile_url)
+            clicked = await self.click_button_by_text("Message")
+            if clicked:
+                try:
+                    await self._page.wait_for_selector(
+                        '[class*="msg-s-message-list"], [class*="msg-thread"]',
+                        timeout=10000,
+                    )
+                except PlaywrightTimeoutError:
+                    pass
+
+        # Scroll up in conversation to load older messages
+        thread = self._page.locator(
+            '[class*="msg-s-message-list"], [class*="msg-thread"]'
+        ).first
+        try:
+            for _ in range(3):
+                await thread.evaluate("el => el.scrollTop = 0")
+                await asyncio.sleep(1)
+        except Exception:
+            logger.debug("Thread scroll failed, continuing with loaded content")
+
+        text = await self.get_page_text()
+        extracted = await self._extract_root_content(["main", "[role='main']", "body"])
+        refs = build_references(extracted.get("references", []), "conversation")
+
+        sections: dict[str, str] = {}
+        references: dict[str, list[Reference]] = {}
+        if text:
+            sections["conversation"] = text
+        if refs:
+            references["conversation"] = refs
+
+        final_url = self._page.url
+        result: dict[str, Any] = {"url": final_url, "sections": sections}
+        if references:
+            result["references"] = references
+        return result
+
+    async def search_conversations(self, keywords: str) -> dict[str, Any]:
+        """Search LinkedIn messaging conversations by keywords.
+
+        Returns:
+            {url, sections: {search_results: raw text}, references?: {...}}
+        """
+        url = "https://www.linkedin.com/messaging/"
+        await self._navigate_to_page(url)
+
+        # Find and use the messaging search box
+        search_input = self._page.locator(
+            '[class*="msg-search-form"] input, '
+            'input[placeholder*="Search messages"], '
+            'input[aria-label*="Search messages"]'
+        ).first
+        try:
+            await search_input.click(timeout=5000)
+            await search_input.fill(keywords)
+            await self._page.keyboard.press("Enter")
+            await asyncio.sleep(2)
+        except Exception:
+            logger.debug("Search input interaction failed, trying URL approach")
+            # Fallback: navigate with search param
+            search_url = f"https://www.linkedin.com/messaging/?searchTerm={quote_plus(keywords)}"
+            await self._navigate_to_page(search_url)
+            await asyncio.sleep(2)
+
+        text = await self.get_page_text()
+        extracted = await self._extract_root_content(["main", "[role='main']", "body"])
+        refs = build_references(extracted.get("references", []), "search_results")
+
+        sections: dict[str, str] = {}
+        references: dict[str, list[Reference]] = {}
+        if text:
+            sections["search_results"] = text
+        if refs:
+            references["search_results"] = refs
+
+        result: dict[str, Any] = {"url": self._page.url, "sections": sections}
+        if references:
+            result["references"] = references
+        return result
+
+    async def send_message(
+        self, linkedin_username: str, message: str
+    ) -> dict[str, Any]:
+        """Send a direct message to a LinkedIn connection.
+
+        Navigates to the user's profile, clicks "Message", types the message,
+        and clicks Send.
+
+        Returns:
+            {url, status, message}
+        """
+        profile_url = f"https://www.linkedin.com/in/{linkedin_username}/"
+        await self._navigate_to_page(profile_url)
+
+        # Click the Message button on the profile
+        clicked = await self.click_button_by_text("Message")
+        if not clicked:
+            return {
+                "url": profile_url,
+                "status": "unavailable",
+                "message": f"Cannot message {linkedin_username}. Message button not found — may not be a 1st-degree connection.",
+            }
+
+        # Wait for the compose area
+        compose_selector = (
+            '[class*="msg-form__contenteditable"], '
+            '[role="textbox"][contenteditable="true"], '
+            'div[contenteditable="true"][aria-label*="message"]'
+        )
+        try:
+            await self._page.wait_for_selector(compose_selector, timeout=10000)
+        except PlaywrightTimeoutError:
+            return {
+                "url": profile_url,
+                "status": "send_failed",
+                "message": "Message compose area did not appear.",
+            }
+
+        # Type the message
+        compose_box = self._page.locator(compose_selector).first
+        await compose_box.click()
+        await compose_box.fill(message)
+        await asyncio.sleep(0.5)
+
+        # Click send
+        send_button = self._page.locator(
+            '[class*="msg-form__send-button"], '
+            'button[type="submit"][class*="msg-form"], '
+            'button:has-text("Send")'
+        ).first
+        try:
+            await send_button.click(timeout=5000)
+            await asyncio.sleep(1)
+            return {
+                "url": profile_url,
+                "status": "sent",
+                "message": f"Message sent to {linkedin_username}.",
+            }
+        except Exception as e:
+            logger.warning("Send button click failed: %s", e)
+            return {
+                "url": profile_url,
+                "status": "send_failed",
+                "message": f"Failed to send message: {e}",
+            }
+
     async def search_people(
         self,
         keywords: str,

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -24,6 +24,7 @@ from linkedin_mcp_server.sequential_tool_middleware import (
 )
 from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.job import register_job_tools
+from linkedin_mcp_server.tools.messaging import register_messaging_tools
 from linkedin_mcp_server.tools.person import register_person_tools
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ def create_mcp_server() -> FastMCP:
     register_person_tools(mcp)
     register_company_tools(mcp)
     register_job_tools(mcp)
+    register_messaging_tools(mcp)
 
     # Register session management tool
     @mcp.tool(

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -1,0 +1,215 @@
+"""
+LinkedIn messaging tools.
+
+Uses browser-based innerText extraction for inbox and conversation scraping,
+and DOM interaction for sending messages.
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context, FastMCP
+
+from linkedin_mcp_server.constants import TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.core.exceptions import AuthenticationError
+from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
+from linkedin_mcp_server.error_handler import raise_tool_error
+
+logger = logging.getLogger(__name__)
+
+
+def register_messaging_tools(mcp: FastMCP) -> None:
+    """Register all messaging-related tools with the MCP server."""
+
+    @mcp.tool(
+        timeout=TOOL_TIMEOUT_SECONDS,
+        title="Get Inbox",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"messaging", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_inbox(
+        ctx: Context,
+        limit: int = 20,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get recent LinkedIn inbox conversations.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+            limit: Maximum number of conversations to return (default 20)
+
+        Returns:
+            Dict with url, sections (name -> raw text), and optional references.
+            The LLM should parse the raw text to extract conversation previews.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_inbox"
+            )
+            logger.info("Fetching inbox (limit=%d)", limit)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Opening messaging inbox"
+            )
+
+            result = await extractor.get_inbox(limit=limit)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_inbox")
+        except Exception as e:
+            raise_tool_error(e, "get_inbox")  # NoReturn
+
+    @mcp.tool(
+        timeout=TOOL_TIMEOUT_SECONDS,
+        title="Get Conversation",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"messaging", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_conversation(
+        linkedin_username: str,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get the full conversation thread with a specific LinkedIn user.
+
+        Args:
+            linkedin_username: LinkedIn username (e.g., "johndoe", "williamhgates")
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, sections (name -> raw text), and optional references.
+            The LLM should parse the raw text to extract messages and timestamps.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_conversation"
+            )
+            logger.info("Fetching conversation with: %s", linkedin_username)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Opening conversation"
+            )
+
+            result = await extractor.get_conversation(linkedin_username)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_conversation")
+        except Exception as e:
+            raise_tool_error(e, "get_conversation")  # NoReturn
+
+    @mcp.tool(
+        timeout=TOOL_TIMEOUT_SECONDS,
+        title="Search Conversations",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"messaging", "search"},
+        exclude_args=["extractor"],
+    )
+    async def search_conversations(
+        keywords: str,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Search LinkedIn messaging conversations by keywords.
+
+        Args:
+            keywords: Search keywords to find in conversations
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, sections (name -> raw text), and optional references.
+            The LLM should parse the raw text to extract matching conversations.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="search_conversations"
+            )
+            logger.info("Searching conversations: '%s'", keywords)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Searching conversations"
+            )
+
+            result = await extractor.search_conversations(keywords)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "search_conversations")
+        except Exception as e:
+            raise_tool_error(e, "search_conversations")  # NoReturn
+
+    @mcp.tool(
+        timeout=TOOL_TIMEOUT_SECONDS,
+        title="Send Message",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"messaging", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def send_message(
+        linkedin_username: str,
+        message: str,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Send a direct message to a LinkedIn connection.
+
+        The tool is annotated with destructiveHint so MCP clients will
+        prompt for user confirmation before execution.
+
+        Args:
+            linkedin_username: LinkedIn username (e.g., "johndoe", "williamhgates")
+            message: The message text to send
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, status, and message.
+            Requires being a 1st-degree connection with the recipient.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="send_message"
+            )
+            logger.info("Sending message to: %s", linkedin_username)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Sending message"
+            )
+
+            result = await extractor.send_message(linkedin_username, message)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "send_message")
+        except Exception as e:
+            raise_tool_error(e, "send_message")  # NoReturn


### PR DESCRIPTION
## Summary

- Adds 4 new MCP tools for LinkedIn messaging: `get_inbox`, `get_conversation`, `search_conversations`, `send_message`
- Uses the same innerText extraction pattern as existing person/company/job tools
- `send_message` is annotated with `destructiveHint` for client-side confirmation
- New `tools/messaging.py` follows the existing tool registration pattern
- Extractor methods added to `scraping/extractor.py` with auth barrier handling, rate limit awareness, and fallback navigation strategies

## New Tools

| Tool | Type | Description |
|------|------|-------------|
| `get_inbox(limit)` | Read-only | Scrape recent inbox conversations with message previews |
| `get_conversation(linkedin_username)` | Read-only | Full message thread with a specific user |
| `search_conversations(keywords)` | Read-only | Search messaging by keywords |
| `send_message(linkedin_username, message)` | Destructive | Send a DM (requires 1st-degree connection) |

## Test plan

- [x] `get_inbox` tested — returns conversation list with participants and last message previews
- [x] Server starts without import errors
- [ ] `get_conversation` — needs testing with various profile slugs
- [ ] `search_conversations` — needs testing with keyword search
- [ ] `send_message` — needs testing with a 1st-degree connection

## Notes

- Aware of draft PR #235 which takes a similar approach — happy to consolidate if preferred
- The `get_conversation` method tries the direct messaging URL first, falls back to navigating to the profile and clicking "Message"
- Scrolling logic loads additional conversations in inbox and older messages in threads