### PR TITLE
docs: add UV_HTTP_TIMEOUT troubleshooting for slow connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ parallel. Use `--log-level DEBUG` to see scraper lock wait/acquire/release logs.
 
 - Ensure you have uv installed: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 - Check uv version: `uv --version` (should be 0.4.0 or higher)
+- First-time `uvx` runs download all Python dependencies. On slow connections, uv's default 30s timeout may fail. Increase it with `UV_HTTP_TIMEOUT=300`:
+  ```json
+  {
+    "mcpServers": {
+      "linkedin": {
+        "command": "uvx",
+        "args": ["linkedin-scraper-mcp"],
+        "env": { "UV_HTTP_TIMEOUT": "300" }
+      }
+    }
+  }
+  ```
 
 **Session issues:**
 


### PR DESCRIPTION
## Summary
- Add `UV_HTTP_TIMEOUT` note to uvx troubleshooting section for users on slow connections
- First-time `uvx` runs download ~77 Python packages (including 39MB patchright wheel) synchronously before the server starts — uv's default 30s timeout can silently fail

## Test plan
- [ ] Verify JSON block renders correctly inside the `<details>` collapse on GitHub