### PR TITLE
docs: add UV_HTTP_TIMEOUT to default uvx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ What has Anthropic been posting about recently? https://www.linkedin.com/company
   "mcpServers": {
     "linkedin": {
       "command": "uvx",
-      "args": ["linkedin-scraper-mcp"]
+      "args": ["linkedin-scraper-mcp"],
+      "env": { "UV_HTTP_TIMEOUT": "300" }
     }
   }
 }
@@ -147,18 +148,7 @@ parallel. Use `--log-level DEBUG` to see scraper lock wait/acquire/release logs.
 
 - Ensure you have uv installed: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 - Check uv version: `uv --version` (should be 0.4.0 or higher)
-- First-time `uvx` runs download all Python dependencies. On slow connections, uv's default 30s timeout may fail. Increase it with `UV_HTTP_TIMEOUT=300`:
-  ```json
-  {
-    "mcpServers": {
-      "linkedin": {
-        "command": "uvx",
-        "args": ["linkedin-scraper-mcp"],
-        "env": { "UV_HTTP_TIMEOUT": "300" }
-      }
-    }
-  }
-  ```
+- On first run, `uvx` downloads all Python dependencies. On slow connections, uv's default 30s HTTP timeout may be too short. The recommended config above already sets `UV_HTTP_TIMEOUT=300` (seconds) to avoid this.
 
 **Session issues:**
 


### PR DESCRIPTION
## Summary
- Move `UV_HTTP_TIMEOUT=300` into the main uvx config example so it's the default, not an optional troubleshooting step
- Fix grammar in the troubleshooting note (per Copilot review on #303)

## Test plan
- [ ] Verify config block renders correctly on GitHub