### PR TITLE
feat: add French locale support for connection state detection

### DIFF
--- a/linkedin_mcp_server/scraping/connection.py
+++ b/linkedin_mcp_server/scraping/connection.py
@@ -2,7 +2,8 @@
 
 Parses the action area of a profile page (buttons near the top) to
 determine the relationship state.  The browser locale is forced to
-en-US so button text is always English.
+en-US so button text is always English, but we also support French
+(fr-FR) as a fallback for users whose LinkedIn interface is in French.
 """
 
 from __future__ import annotations
@@ -19,15 +20,23 @@ ConnectionState = Literal[
     "unavailable",
 ]
 
-# Button text to click for each actionable state (en-US locale)
+# Button text to click for each actionable state.
+# Detected language determines which label is used at click time.
 STATE_BUTTON_MAP: dict[ConnectionState, str] = {
     "connectable": "Connect",
     "incoming_request": "Accept",
 }
 
+STATE_BUTTON_MAP_FR: dict[ConnectionState, str] = {
+    "connectable": "Se connecter",
+    "incoming_request": "Accepter",
+}
+
 # Markers that end the action area (section headings after the buttons)
+# Supports both English and French headings.
 _ACTION_AREA_END = re.compile(
-    r"^(?:About|Highlights|Featured|Activity|Experience|Education)\n",
+    r"^(?:About|Highlights|Featured|Activity|Experience|Education"
+    r"|Infos|Sélection|Activité|Expérience|Formation|Infos ventes)\n",
     re.MULTILINE,
 )
 
@@ -46,24 +55,42 @@ def _extract_action_area(profile_text: str) -> str:
     return profile_text[:500]
 
 
-def detect_connection_state(profile_text: str) -> ConnectionState:
+def _contains(area: str, label: str) -> bool:
+    """Check if label appears as a standalone line in the action area."""
+    return f"\n{label}\n" in area or area.endswith(f"\n{label}")
+
+
+def detect_connection_state(profile_text: str) -> tuple[ConnectionState, bool]:
     """Detect the connection relationship from scraped profile text.
 
-    Checks the degree indicator and action button labels that appear
-    as standalone lines in the profile action area.
+    Returns a tuple of (state, is_french) so the caller knows which
+    button label to use when clicking.
     """
-    # 1st-degree connection indicator appears near the top, before buttons
-    if "\u00b7 1st" in profile_text[:300]:
-        return "already_connected"
+    # 1st-degree connection indicator (both · 1st and · 1er)
+    top = profile_text[:300]
+    if "\u00b7 1st" in top or "\u00b7 1er" in top:
+        return "already_connected", False
 
     action_area = _extract_action_area(profile_text)
 
-    if "\nPending\n" in action_area or action_area.endswith("\nPending"):
-        return "pending"
-    if "\nAccept\n" in action_area and "\nIgnore\n" in action_area:
-        return "incoming_request"
-    if "\nConnect\n" in action_area or action_area.endswith("\nConnect"):
-        return "connectable"
-    if "\nFollow\n" in action_area or action_area.endswith("\nFollow"):
-        return "follow_only"
-    return "unavailable"
+    # --- English detection ---
+    if _contains(action_area, "Pending"):
+        return "pending", False
+    if _contains(action_area, "Accept") and _contains(action_area, "Ignore"):
+        return "incoming_request", False
+    if _contains(action_area, "Connect"):
+        return "connectable", False
+    if _contains(action_area, "Follow"):
+        return "follow_only", False
+
+    # --- French detection ---
+    if _contains(action_area, "En attente"):
+        return "pending", True
+    if _contains(action_area, "Accepter") and _contains(action_area, "Ignorer"):
+        return "incoming_request", True
+    if _contains(action_area, "Se connecter"):
+        return "connectable", True
+    if _contains(action_area, "Suivre"):
+        return "follow_only", True
+
+    return "unavailable", False

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -536,7 +536,10 @@ class LinkedInExtractor:
         and ``[role="menu"]`` to detect the opened menu (structural).
         Returns True if the menu opened and contains a Connect option.
         """
-        more_btn = self._page.locator("main button[aria-label*='More']")
+        # aria-label varies by locale: "More" (en), "Plus" (fr)
+        more_btn = self._page.locator(
+            "main button[aria-label*='More'], main button[aria-label*='Plus']"
+        )
         try:
             if await more_btn.count() == 0:
                 return False
@@ -551,11 +554,11 @@ class LinkedInExtractor:
             logger.debug("More menu did not appear")
             return False
 
-        # Check if Connect is in the menu
+        # Check if Connect / Se connecter is in the menu
         menu_connect = (
             self._page.locator("[role='menu']")
             .locator("button, a, li, [role='menuitem'], [role='button']")
-            .filter(has_text=re.compile(r"^Connect$"))
+            .filter(has_text=re.compile(r"^(?:Connect|Se connecter)$"))
         )
         count = await menu_connect.count()
         logger.debug("More menu Connect matches: %d", count)
@@ -944,6 +947,7 @@ class LinkedInExtractor:
         """
         from linkedin_mcp_server.scraping.connection import (
             STATE_BUTTON_MAP,
+            STATE_BUTTON_MAP_FR,
             detect_connection_state,
         )
 
@@ -958,8 +962,8 @@ class LinkedInExtractor:
             )
 
         # Detect state from the scraped text
-        state = detect_connection_state(page_text)
-        logger.info("Connection state for %s: %s", username, state)
+        state, is_french = detect_connection_state(page_text)
+        logger.info("Connection state for %s: %s (fr=%s)", username, state, is_french)
 
         if state == "already_connected":
             return _connection_result(
@@ -998,7 +1002,8 @@ class LinkedInExtractor:
             )
 
         # state is "connectable" or "incoming_request"
-        button_text = STATE_BUTTON_MAP.get(state)
+        btn_map = STATE_BUTTON_MAP_FR if is_french else STATE_BUTTON_MAP
+        button_text = btn_map.get(state)
         if not button_text:
             return _connection_result(
                 url,

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -733,27 +733,27 @@ class TestDetectConnectionState:
 
     def test_already_connected(self):
         text = "Collin Pfeifer\n\n· 1st\n\nAI Engineer\n\nMessage\nMore"
-        assert detect_connection_state(text) == "already_connected"
+        assert detect_connection_state(text) == ("already_connected", False)
 
     def test_pending(self):
         text = "Marinus Prey\n\n· 2nd\n\nStudent\n\nMessage\nPending\nMore"
-        assert detect_connection_state(text) == "pending"
+        assert detect_connection_state(text) == ("pending", False)
 
     def test_incoming_request(self):
         text = "Aklasur Rahman\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore"
-        assert detect_connection_state(text) == "incoming_request"
+        assert detect_connection_state(text) == ("incoming_request", False)
 
     def test_connectable(self):
         text = "Jane Doe\n\n· 3rd\n\nEngineer\n\nConnect\nMore"
-        assert detect_connection_state(text) == "connectable"
+        assert detect_connection_state(text) == ("connectable", False)
 
     def test_follow_only(self):
         text = "Public Figure\n\n· 3rd+\n\nCEO\n\nFollow\nMore"
-        assert detect_connection_state(text) == "follow_only"
+        assert detect_connection_state(text) == ("follow_only", False)
 
     def test_unavailable(self):
         text = "Unknown Person\n\nSome text here"
-        assert detect_connection_state(text) == "unavailable"
+        assert detect_connection_state(text) == ("unavailable", False)
 
     def test_follow_in_interests_not_matched(self):
         """Follow in the Interests section should not cause a false positive."""
@@ -762,7 +762,31 @@ class TestDetectConnectionState:
             "About\n\nSome bio\n\nInterests\n\n"
             "Elon Musk\n101,000 followers\nFollow"
         )
-        assert detect_connection_state(text) == "connectable"
+        assert detect_connection_state(text) == ("connectable", False)
+
+    # --- French locale tests ---
+
+    def test_already_connected_fr(self):
+        text = "Laurent Delade\n\n· 1er\n\nChannel Account Manager\n\nMessage\nPlus"
+        assert detect_connection_state(text) == ("already_connected", False)
+
+    def test_connectable_fr(self):
+        text = "Laurent Delade\n\n· 2e\n\nChannel Account Manager\n\nSe connecter\nEnregistrer\nPlus"
+        assert detect_connection_state(text) == ("connectable", True)
+
+    def test_follow_only_fr(self):
+        text = "Dragan Radulović\n\n· 3e\n\nPresident\n\nSuivre\nEnregistrer\nPlus"
+        assert detect_connection_state(text) == ("follow_only", True)
+
+    def test_pending_fr(self):
+        text = "Jane Doe\n\n· 2e\n\nEngineer\n\nEn attente\nPlus"
+        assert detect_connection_state(text) == ("pending", True)
+
+    def test_action_area_cuts_at_french_headings(self):
+        text = "Name\n\nSe connecter\nPlus\nInfos\n\nSuivre\nSe connecter"
+        area = _extract_action_area(text)
+        assert "Infos" not in area
+        assert "Se connecter" in area
 
     def test_action_area_cuts_at_about(self):
         text = "Name\n\nConnect\nMore\nAbout\n\nFollow\nConnect"


### PR DESCRIPTION
## Summary

- `connect_with_person()` always returns `connect_unavailable` for users whose LinkedIn interface is in French
- Root cause: `detect_connection_state()` only matches English button labels (`Connect`, `Follow`, `Pending`) but French LinkedIn displays `Se connecter`, `Suivre`, `En attente`
- The `_ACTION_AREA_END` regex only matches English section headings (`About`, `Experience`) but French displays `Infos`, `Expérience`, `Activité`

## Changes

- **`connection.py`**: `detect_connection_state()` now returns `(state, is_french)` tuple, checking both English and French button labels. Added `STATE_BUTTON_MAP_FR` and French section headings to `_ACTION_AREA_END`.
- **`extractor.py`**: `connect_with_person()` selects the correct button map based on detected language. `_open_more_menu()` now matches both `More`/`Plus` aria-labels and `Connect`/`Se connecter` menu items.
- **Tests**: Updated 8 existing tests for tuple return value + added 5 new French locale tests (all 14 pass).

## Test plan

- [x] All 14 `TestDetectConnectionState` tests pass
- [ ] Manual test: `connect_with_person` on a French LinkedIn profile with `Se connecter` button
- [ ] Manual test: `connect_with_person` on a French LinkedIn profile with `Suivre` + More menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)