### PR TITLE
style: Add dynamic ASCII download button to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,13 +178,13 @@ jobs:
 
       - name: Generate release notes
         run: |
-          # Build a dynamic ASCII download button sized to the version string
+          # Build a dynamic Unicode box-drawing download button sized to the version string
           # Add +1 to WIDTH to compensate for the emoji taking 2 columns in monospace
           LABEL="  ⬇  Download linkedin-mcp-server-v${VERSION}.mcpb  "
           WIDTH=$(( ${#LABEL} + 1 ))
           TOP="╔$(printf '═%.0s' $(seq 1 $WIDTH))╗"
           PAD="║$(printf ' %.0s' $(seq 1 $WIDTH))║"
-          MID="║${LABEL} ║"
+          MID="║${LABEL}║"
           BOT="╚$(printf '═%.0s' $(seq 1 $WIDTH))╝"
           export DOWNLOAD_BTN=$(printf '%s\n%s\n%s\n%s\n%s' "$TOP" "$PAD" "$MID" "$PAD" "$BOT")
           envsubst < RELEASE_NOTES_TEMPLATE.md > RELEASE_NOTES.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,14 @@ jobs:
 
       - name: Generate release notes
         run: |
+          # Build a dynamic ASCII download button sized to the version string
+          LABEL="  ⬇  Download linkedin-mcp-server-v${VERSION}.mcpb  "
+          WIDTH=${#LABEL}
+          TOP="╔$(printf '═%.0s' $(seq 1 $WIDTH))╗"
+          PAD="║$(printf ' %.0s' $(seq 1 $WIDTH))║"
+          MID="║${LABEL}║"
+          BOT="╚$(printf '═%.0s' $(seq 1 $WIDTH))╝"
+          export DOWNLOAD_BTN=$(printf '%s\n%s\n%s\n%s\n%s' "$TOP" "$PAD" "$MID" "$PAD" "$BOT")
           envsubst < RELEASE_NOTES_TEMPLATE.md > RELEASE_NOTES.md
           echo "✅ Generated release notes from template"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,13 +179,12 @@ jobs:
       - name: Generate release notes
         run: |
           # Build a dynamic ASCII download button sized to the version string
-          LABEL="  ⬇  Download linkedin-mcp-server-v${VERSION}.mcpb  "
+          LABEL="   Download linkedin-mcp-server-v${VERSION}.mcpb   "
           WIDTH=${#LABEL}
-          TOP="╔$(printf '═%.0s' $(seq 1 $WIDTH))╗"
-          PAD="║$(printf ' %.0s' $(seq 1 $WIDTH))║"
-          MID="║${LABEL}║"
-          BOT="╚$(printf '═%.0s' $(seq 1 $WIDTH))╝"
-          export DOWNLOAD_BTN=$(printf '%s\n%s\n%s\n%s\n%s' "$TOP" "$PAD" "$MID" "$PAD" "$BOT")
+          BORDER=$(printf '+%s+' "$(printf -- '-%.0s' $(seq 1 $WIDTH))")
+          PAD=$(printf '|%s|' "$(printf ' %.0s' $(seq 1 $WIDTH))")
+          MID="|${LABEL}|"
+          export DOWNLOAD_BTN=$(printf '%s\n%s\n%s\n%s\n%s' "$BORDER" "$PAD" "$MID" "$PAD" "$BORDER")
           envsubst < RELEASE_NOTES_TEMPLATE.md > RELEASE_NOTES.md
           echo "✅ Generated release notes from template"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,12 +179,14 @@ jobs:
       - name: Generate release notes
         run: |
           # Build a dynamic ASCII download button sized to the version string
-          LABEL="   Download linkedin-mcp-server-v${VERSION}.mcpb   "
-          WIDTH=${#LABEL}
-          BORDER=$(printf '+%s+' "$(printf -- '-%.0s' $(seq 1 $WIDTH))")
-          PAD=$(printf '|%s|' "$(printf ' %.0s' $(seq 1 $WIDTH))")
-          MID="|${LABEL}|"
-          export DOWNLOAD_BTN=$(printf '%s\n%s\n%s\n%s\n%s' "$BORDER" "$PAD" "$MID" "$PAD" "$BORDER")
+          # Add +1 to WIDTH to compensate for the emoji taking 2 columns in monospace
+          LABEL="  ⬇  Download linkedin-mcp-server-v${VERSION}.mcpb  "
+          WIDTH=$(( ${#LABEL} + 1 ))
+          TOP="╔$(printf '═%.0s' $(seq 1 $WIDTH))╗"
+          PAD="║$(printf ' %.0s' $(seq 1 $WIDTH))║"
+          MID="║${LABEL} ║"
+          BOT="╚$(printf '═%.0s' $(seq 1 $WIDTH))╝"
+          export DOWNLOAD_BTN=$(printf '%s\n%s\n%s\n%s\n%s' "$TOP" "$PAD" "$MID" "$PAD" "$BOT")
           envsubst < RELEASE_NOTES_TEMPLATE.md > RELEASE_NOTES.md
           echo "✅ Generated release notes from template"
 

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -2,8 +2,13 @@ For an installation guide, refer to the [README](https://github.com/stickerdanie
 
 ## 📦 Update MCP Bundle Installation
 **For Claude Desktop users:**
-1. [Download the `.mcpb` bundle](https://github.com/stickerdaniel/linkedin-mcp-server/releases/download/v${VERSION}/linkedin-mcp-server-v${VERSION}.mcpb)
-2. Click the downloaded file to install in Claude Desktop
+
+```
+${DOWNLOAD_BTN}
+```
+**👆 [Click here to download](https://github.com/stickerdaniel/linkedin-mcp-server/releases/download/v${VERSION}/linkedin-mcp-server-v${VERSION}.mcpb)**
+
+Then click the downloaded file to install in Claude Desktop.
 
 > **Note:** MCP Bundles do not auto-update. You need to download and install the latest `.mcpb` file for each new release.
 


### PR DESCRIPTION
## Summary
- Replaces the plain download link in release notes with a dynamically generated ASCII-bordered download button
- The button scales to any version string length via bash in the release workflow
- Template uses `${DOWNLOAD_BTN}` placeholder, expanded by `envsubst`

## Example output (v4.8.3)
```
╔════════════════════════════════════════════════╗
║                                                ║
║  ⬇  Download linkedin-mcp-server-v4.8.3.mcpb   ║
║                                                ║
╚════════════════════════════════════════════════╝
```

## Synthetic prompt
> Replace the plain download link in RELEASE_NOTES_TEMPLATE.md with an ASCII-bordered download button. Generate the box dynamically in the release workflow so it scales with the version string length.

Generated with Claude Opus 4.6