### PR TITLE
fix: improve LinkedIn connection note dialog handling

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1042,21 +1042,41 @@ class LinkedInExtractor:
         # typically completes immediately without a dialog).
         if state == "connectable":
             try:
-                await self._page.wait_for_selector(_DIALOG_SELECTOR)
+                await self._page.wait_for_selector(
+                    _DIALOG_SELECTOR, state="visible", timeout=10000
+                )
             except PlaywrightTimeoutError:
                 logger.debug("No dialog appeared after clicking '%s'", button_text)
 
         note_sent = False
-        if note and await self._dialog_is_open():
-            # Try to find textarea directly; if not visible, click the first
-            # button in the dialog (typically "Add a note") to reveal it
+        if note and await self._dialog_is_open(timeout=3000):
+            # Try to find textarea directly; if not visible, look for an
+            # "Add a note" button to reveal it
             textarea_count = await self._page.locator(_DIALOG_TEXTAREA_SELECTOR).count()
             if textarea_count == 0:
-                buttons = self._page.locator(
-                    f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
-                )
-                if await buttons.count() > 1:
-                    await buttons.first.click()
+                # Look for "Add a note" button by text first
+                add_note_btn = self._page.locator(
+                    f"{_DIALOG_SELECTOR} button"
+                ).filter(has_text=re.compile(r"add a note", re.IGNORECASE))
+                if await add_note_btn.count() > 0:
+                    await add_note_btn.first.click()
+                    logger.debug("Clicked 'Add a note' button")
+                else:
+                    # Fallback: click first button in dialog (may be "Add a note")
+                    buttons = self._page.locator(
+                        f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
+                    )
+                    if await buttons.count() > 0:
+                        await buttons.first.click()
+                        logger.debug("Clicked first dialog button as fallback")
+
+                # Wait for textarea to appear after clicking "Add a note"
+                try:
+                    await self._page.wait_for_selector(
+                        _DIALOG_TEXTAREA_SELECTOR, timeout=5000
+                    )
+                except PlaywrightTimeoutError:
+                    logger.debug("Textarea did not appear after clicking note button")
 
             filled = await self._fill_dialog_textarea(note)
             if filled:


### PR DESCRIPTION
## Summary

Fixes connection note sending in `connect_with_person`. Three bugs prevented notes from being attached to connection requests:

1. **Dialog wait timeout too short** — default 5s wasn't enough for LinkedIn's dialog to render. Increased to 10s with explicit `state="visible"` check.
2. **"Add a note" button not found** — code blindly clicked the first button in the dialog instead of searching for the "Add a note" button by text. Now uses case-insensitive text match.
3. **No wait for textarea** — after clicking "Add a note", the code immediately tried to fill a textarea that hadn't rendered yet. Added explicit `wait_for_selector` with 5s timeout.

Also fixed: fallback button click guard changed from `> 1` to `> 0` to handle single-button dialog variants (caught by adversarial review).

## Test Coverage

- 372 existing tests pass (pytest, 4.58s)
- Changed code paths are browser-interaction code tested via live LinkedIn validation
- Live validation: `connect_with_person` with note returns `note_sent: true` (tested against real LinkedIn profiles)

## Pre-Landing Review

No issues found. Clean diff, no SQL, no security boundaries, no frontend.

## Adversarial Review

Claude adversarial subagent found 7 findings. 2 fixed (visibility race, button guard). 5 informational (pre-existing behavior outside diff scope).

## Test plan
- [x] All pytest tests pass (372 tests, 0 failures)
- [x] Live validation: connection with note sent successfully

Prompt: "LinkedIn connection notes fail to send. The connect_with_person tool returns note_not_supported or silently drops notes. Fix the dialog handling to find the 'Add a note' button by text, wait for the textarea to appear, and increase timeout for dialog rendering."

Generated with Claude Opus 4.6