### PR TITLE
feat(scraping): Add skills and projects sections to get_person_profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,12 @@ After the workflow completes, file a PR in the MCP registry to update the versio
 Always read [`CONTRIBUTING.md`](CONTRIBUTING.md) before filing an issue or working on this repository.
 
 - Include the model used for code generation in PR descriptions (e.g. "Generated with Claude Opus 4.6")
-- Write a short synthetic prompt that would reproduce the PR diff if given to a fresh Claude Code session. Don't copy the user's first message — distill the conversation into a single instruction that captures the full scope of changes. This tells the maintainer what was intended, which is often more useful than reviewing the full diff.
+- Write a short synthetic prompt that would reproduce the PR diff if given to a fresh Claude Code session. Don't copy the user's first message — distill the conversation into a single instruction that captures the full scope of changes. This tells the maintainer what was intended, which is often more useful than reviewing the full diff. Use a Markdown blockquote under a `## Synthetic prompt` heading:
+  ```
+  ## Synthetic prompt
+
+  > Add `skills` and `projects` sections to `get_person_profile`, following the certifications PR pattern. Update fields, tests, docs, and manifest.
+  ```
 - When implementing a new feature/fix:
   1. Check open issues. If no issue exists, create one following the templates in `.github/ISSUE_TEMPLATE/`. Fill in every section; delete optional sections if not applicable.
   2. Branch from `main`: `feature/issue-number-short-description`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,12 +79,13 @@ After the workflow completes, file a PR in the MCP registry to update the versio
 
 Always read [`CONTRIBUTING.md`](CONTRIBUTING.md) before filing an issue or working on this repository.
 
-- Include the model used for code generation in PR descriptions (e.g. "Generated with Claude Opus 4.6")
-- Write a short synthetic prompt that would reproduce the PR diff if given to a fresh Claude Code session. Don't copy the user's first message — distill the conversation into a single instruction that captures the full scope of changes. This tells the maintainer what was intended, which is often more useful than reviewing the full diff. Use a Markdown blockquote under a `## Synthetic prompt` heading:
+- Write a short synthetic prompt that would reproduce the PR diff if given to a fresh Claude Code session. Don't copy the user's first message — distill the conversation into a single instruction that captures the full scope of changes. This tells the maintainer what was intended, which is often more useful than reviewing the full diff. Use a Markdown blockquote under a `## Synthetic prompt` heading, followed by the model attribution:
   ```
   ## Synthetic prompt
 
   > Add `skills` and `projects` sections to `get_person_profile`, following the certifications PR pattern. Update fields, tests, docs, and manifest.
+
+  Generated with <model name and version>
   ```
 - When implementing a new feature/fix:
   1. Check open issues. If no issue exists, create one following the templates in `.github/ISSUE_TEMPLATE/`. Fill in every section; delete optional sections if not applicable.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 
 | Tool | Description | Status |
 |------|-------------|--------|
-| `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, contact_info, posts) | working |
+| `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
 | `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#304](https://github.com/stickerdaniel/linkedin-mcp-server/issues/304) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 
 ## Features
 
-- **Profile Access**: Get detailed LinkedIn profile information
+- **Profile Access**: Get detailed LinkedIn profile information including experience, education, skills, projects, certifications, and more
 - **Profile Connections**: Send connection requests or accept incoming ones, with optional notes
 - **Company Profiles**: Extract comprehensive company data
 - **Job Details**: Retrieve job posting information

--- a/linkedin_mcp_server/scraping/fields.py
+++ b/linkedin_mcp_server/scraping/fields.py
@@ -13,6 +13,8 @@ PERSON_SECTIONS: dict[str, tuple[str, bool]] = {
     "honors": ("/details/honors/", False),
     "languages": ("/details/languages/", False),
     "certifications": ("/details/certifications/", False),
+    "skills": ("/details/skills/", False),
+    "projects": ("/details/projects/", False),
     "contact_info": ("/overlay/contact-info/", True),
     "posts": ("/recent-activity/all/", False),
 }

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -44,8 +44,8 @@ def register_person_tools(mcp: FastMCP) -> None:
             ctx: FastMCP context for progress reporting
             sections: Comma-separated list of extra sections to scrape.
                 The main profile page is always included.
-                Available sections: experience, education, interests, honors, languages, certifications, contact_info, posts
-                Examples: "experience,education", "contact_info", "certifications", "honors,languages", "posts"
+                Available sections: experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts
+                Examples: "experience,education", "contact_info", "skills,projects", "honors,languages", "posts"
                 Default (None) scrapes only the main profile page.
 
         Returns:

--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,7 @@
   "tools": [
     {
       "name": "get_person_profile",
-      "description": "Get detailed information from a LinkedIn profile including work history, education, certifications, skills, connections, and recent posts"
+      "description": "Get detailed information from a LinkedIn profile including work history, education, certifications, skills, projects, connections, and recent posts"
     },
     {
       "name": "connect_with_person",

--- a/scripts/dump_snapshots.py
+++ b/scripts/dump_snapshots.py
@@ -32,9 +32,12 @@ OUTPUT_DIR = Path(__file__).parent / "snapshot_dumps"
 PERSON_TARGETS: list[tuple[str, str]] = [
     (
         "williamhgates",
-        "experience,education,interests,honors,languages,certifications,contact_info",
+        "experience,education,interests,honors,languages,certifications,skills,projects,contact_info",
     ),
-    ("anistji", "experience,education,honors,languages,certifications,contact_info"),
+    (
+        "anistji",
+        "experience,education,honors,languages,certifications,skills,projects,contact_info",
+    ),
 ]
 
 COMPANY_TARGETS: list[tuple[str, str]] = [

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -18,6 +18,8 @@ class TestPersonSections:
             "honors",
             "languages",
             "certifications",
+            "skills",
+            "projects",
             "contact_info",
             "posts",
         }
@@ -89,7 +91,7 @@ class TestParsePersonSections:
 
     def test_all_sections(self):
         requested, unknown = parse_person_sections(
-            "experience,education,interests,honors,languages,certifications,contact_info,posts"
+            "experience,education,interests,honors,languages,certifications,skills,projects,contact_info,posts"
         )
         assert requested == set(PERSON_SECTIONS)
         assert unknown == []

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -662,6 +662,8 @@ class TestScrapePersonUrls:
             "honors",
             "languages",
             "certifications",
+            "skills",
+            "projects",
             "contact_info",
             "posts",
         }
@@ -688,8 +690,8 @@ class TestScrapePersonUrls:
         page_urls = [call.args[0] for call in mock_extract.call_args_list]
         overlay_urls = [call.args[0] for call in mock_overlay.call_args_list]
         all_urls = page_urls + overlay_urls
-        # 8 full-page sections + 1 overlay (contact_info)
-        assert len(page_urls) == 8
+        # 10 full-page sections + 1 overlay (contact_info)
+        assert len(page_urls) == 10
         assert len(overlay_urls) == 1
         # Verify each expected suffix was navigated
         assert any(u.endswith("/in/testuser/") for u in all_urls)
@@ -699,6 +701,8 @@ class TestScrapePersonUrls:
         assert any("/details/honors/" in u for u in all_urls)
         assert any("/details/languages/" in u for u in all_urls)
         assert any("/details/certifications/" in u for u in all_urls)
+        assert any("/details/skills/" in u for u in all_urls)
+        assert any("/details/projects/" in u for u in all_urls)
         assert any("/overlay/contact-info/" in u for u in overlay_urls)
         assert any("/recent-activity/all/" in u for u in all_urls)
         assert set(result["sections"]) == all_sections
@@ -754,6 +758,58 @@ class TestScrapePersonUrls:
         urls = [call.args[0] for call in mock_extract.call_args_list]
         assert any("/details/certifications/" in url for url in urls)
         assert "certifications" in result["sections"]
+
+    async def test_skills_visits_details_page(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Python\nData Analysis"),
+            ) as mock_extract,
+            patch.object(
+                extractor,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_person("test-user", {"skills"})
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert any("/details/skills/" in url for url in urls)
+        assert "skills" in result["sections"]
+
+    async def test_projects_visits_details_page(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Portfolio Website\nBuilt with React"),
+            ) as mock_extract,
+            patch.object(
+                extractor,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_person("test-user", {"projects"})
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert any("/details/projects/" in url for url in urls)
+        assert "projects" in result["sections"]
 
 
 class TestDetectConnectionState:


### PR DESCRIPTION
## Summary

- Add `skills` and `projects` as selectable sections for `get_person_profile`, following the existing `/details/<section>/` pattern
- Update docstrings, tests, README, manifest, Docker Hub docs, and snapshot targets

Resolves #356
Discussed in https://github.com/stickerdaniel/linkedin-mcp-server/discussions/13#discussioncomment-16547342

## Synthetic prompt

> Add `skills` (`/details/skills/`) and `projects` (`/details/projects/`) sections to `get_person_profile`, following the same pattern as the certifications PR (#326). Update fields.py, person.py docstring, test_fields.py, test_scraping.py (all-sections + dedicated tests), manifest.json, README.md, docs/docker-hub.md, and dump_snapshots.py.

Generated with Claude Opus 4.6