### PR TITLE
Fix/344 bypass patchright compose box actionability in send_message

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1466,6 +1466,10 @@ class LinkedInExtractor:
             if candidate_count and candidate_count > 0:
                 return locator.last
 
+            # Fallback: when count() raised an exception above (candidate_count
+            # is None), attempt the original wait_for path.  This is unlikely to
+            # succeed given the same patchright quirk, but preserves the prior
+            # behaviour for non-patchright drivers where wait_for works normally.
             candidate = locator.last
             try:
                 await candidate.wait_for(state="visible")

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2487,7 +2487,6 @@ class LinkedInExtractor:
             """() => {
                 const el = document.querySelector(
                     'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
-                    + 'div[role="textbox"][contenteditable="true"][aria-label*="Escribe un mensaje"],'
                     + 'div[role="textbox"][contenteditable="true"]'
                 );
                 if (!el) return false;

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1455,6 +1455,17 @@ class LinkedInExtractor:
                 candidate_count if candidate_count is not None else "unknown",
             )
 
+            # patchright quirk: locator.wait_for(state="visible") times out on
+            # the contenteditable compose div even though count() > 0 and the
+            # element is fully visible by every CSS/DOM criterion (display:block,
+            # visibility:visible, opacity:1, non-zero bbox, no inert ancestor).
+            # This appears to be a patchright bug with React-hydrated contenteditable
+            # elements in isolated worlds. Skip the actionability wait when count()
+            # already confirmed the element is present — downstream interactions
+            # use page.evaluate() which bypasses the same check.
+            if candidate_count and candidate_count > 0:
+                return locator.last
+
             candidate = locator.last
             try:
                 await candidate.wait_for(state="visible")
@@ -2322,8 +2333,18 @@ class LinkedInExtractor:
         await handle_modal_close(self._page)
         display_name = await self._read_profile_display_name()
         if profile_urn:
+            # Build the full compose URL that LinkedIn's own Message button
+            # generates. The minimal ?recipient=<URN> form works for established
+            # connections but shows a "Say hello" widget (no compose box) for new
+            # connections. Adding profileUrn + screenContext + interop=msgOverlay
+            # consistently opens the real composer regardless of connection age.
+            _encoded = quote_plus(f"urn:li:fsd_profile:{profile_urn}")
             compose_url: str | None = (
-                f"https://www.linkedin.com/messaging/compose/?recipient={profile_urn}"
+                f"https://www.linkedin.com/messaging/compose/"
+                f"?profileUrn={_encoded}"
+                f"&recipient={profile_urn}"
+                f"&screenContext=NON_SELF_PROFILE_VIEW"
+                f"&interop=msgOverlay"
             )
         else:
             compose_url = await self._resolve_message_compose_href()
@@ -2416,47 +2437,61 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
 
-        await compose_box.click()
-        await compose_box.press_sequentially(message, delay=30)
+        # patchright quirk: compose_box.click() and press_sequentially() use
+        # actionability checks internally and hit the same wait_for timeout.
+        # Instead: focus via page.evaluate() (no actionability check) and type
+        # via page.keyboard.type() which operates on the active element directly
+        # and fires the real keydown/input/keyup events React needs to enable Send.
+        #
+        # DOM dependency: innerText extraction is not applicable here — we need
+        # to call .focus() on the element reference, which requires querySelector.
+        # Selectors use only role + contenteditable + aria-label (ARIA attributes,
+        # not layout class names) so they are stable across LinkedIn UI changes.
+        focused = await self._page.evaluate(
+            """() => {
+                const el = document.querySelector(
+                    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
+                    + 'div[role="textbox"][contenteditable="true"][aria-label*="Escribe un mensaje"],'
+                    + 'div[role="textbox"][contenteditable="true"]'
+                );
+                if (!el) return false;
+                el.focus();
+                return true;
+            }"""
+        )
+        if not focused:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "compose_interact_failed",
+                "Could not focus compose box via JavaScript.",
+                recipient_selected=recipient_selected,
+            )
+        await asyncio.sleep(0.1)
+        await self._page.keyboard.type(message, delay=15)
         await asyncio.sleep(0.3)
 
-        try:
-            await self._page.wait_for_function(
-                """() => {
-                    const isVisible = element =>
-                        !!(
-                            element &&
-                            (element.offsetWidth ||
-                                element.offsetHeight ||
-                                element.getClientRects().length)
-                        );
-                    return Array.from(
-                        document.querySelectorAll(
-                            'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"]'
-                        )
-                    ).some(button => isVisible(button) && !button.disabled);
-                }""",
-            )
-        except PlaywrightTimeoutError:
-            await self._dismiss_message_ui()
-            return self._message_action_result(
-                self._page.url,
-                "send_unavailable",
-                "LinkedIn did not expose an enabled Send action for this draft.",
-                recipient_selected=recipient_selected,
-            )
-
-        send_button = self._page.locator(_MESSAGING_ENABLED_SEND_SELECTOR).last
-        try:
-            await send_button.click()
-        except PlaywrightTimeoutError:
-            await self._dismiss_message_ui()
-            return self._message_action_result(
-                self._page.url,
-                "send_unavailable",
-                "LinkedIn did not confirm that the message was sent.",
-                recipient_selected=recipient_selected,
-            )
+        # patchright actionability also blocks send_button.click(). Use JS click
+        # on any visible, enabled send button; fall back to Enter key which
+        # LinkedIn's composer also accepts for submission.
+        #
+        # DOM dependency: we need btn.click() on the element reference — not
+        # achievable via innerText or URL navigation. Selectors use only type,
+        # aria-label, and data attributes (no layout class names).
+        await asyncio.sleep(1.0)  # allow React to process keyboard input
+        sent_via_js = await self._page.evaluate(
+            """() => {
+                const btn = Array.from(document.querySelectorAll(
+                    'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
+                    + 'button[data-control-name="send"]'
+                )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
+                if (!btn) return false;
+                btn.click();
+                return true;
+            }"""
+        )
+        if not sent_via_js:
+            await self._page.keyboard.press("Enter")
 
         if not await self._message_text_visible(message):
             await self._dismiss_message_ui()

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3191,15 +3191,17 @@ class TestResolveMessageComposeBox:
         mock_locator = MagicMock()
         mock_locator.count = AsyncMock(return_value=1)
         sentinel = MagicMock(name="last_locator")
+        sentinel.wait_for = AsyncMock()
         mock_locator.last = sentinel
+        mock_locator.wait_for = AsyncMock()
         mock_page.locator = MagicMock(return_value=mock_locator)
 
         result = await extractor._resolve_message_compose_box()
 
         assert result is sentinel
-        # wait_for should NOT be called — the early return bypasses it
-        mock_locator.last.wait_for = AsyncMock()
-        mock_locator.wait_for = AsyncMock()
+        # wait_for should NOT be called on the early-return path
+        sentinel.wait_for.assert_not_called()
+        mock_locator.wait_for.assert_not_called()
 
     async def test_returns_none_when_all_selectors_miss(self, mock_page):
         """_resolve_message_compose_box returns None when no selector matches."""
@@ -3286,6 +3288,10 @@ class TestSendMessageComposerInteraction:
                 "_dismiss_message_ui",
                 new_callable=AsyncMock,
             ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
         )
 
     async def test_focus_and_type_via_evaluate_and_keyboard(self, mock_page):
@@ -3309,6 +3315,7 @@ class TestSendMessageComposerInteraction:
             patches[6],
             patches[7],
             patches[8],
+            patches[9],
             patch.object(
                 extractor,
                 "_message_text_visible",
@@ -3345,6 +3352,7 @@ class TestSendMessageComposerInteraction:
             patches[6],
             patches[7],
             patches[8],
+            patches[9],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
@@ -3374,6 +3382,7 @@ class TestSendMessageComposerInteraction:
             patches[6],
             patches[7],
             patches[8],
+            patches[9],
             patch.object(
                 extractor,
                 "_message_text_visible",

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2816,3 +2816,277 @@ class TestSendMessage:
         # _resolve_message_compose_href should NOT be called when profile_urn given
         mock_resolve_href.assert_not_awaited()
         assert result["status"] == "confirmation_required"
+
+    async def test_profile_urn_compose_url_includes_full_params(self, mock_page):
+        """send_message with profile_urn builds URL with profileUrn, screenContext, interop."""
+        extractor = LinkedInExtractor(mock_page)
+        navigate_calls = []
+
+        async def capture_navigate(url):
+            navigate_calls.append(url)
+
+        with (
+            patch.object(
+                extractor,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+                side_effect=capture_navigate,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_read_profile_display_name",
+                new_callable=AsyncMock,
+                return_value="Test User",
+            ),
+            patch.object(
+                extractor,
+                "_wait_for_message_surface",
+                new_callable=AsyncMock,
+                return_value="composer",
+            ),
+            patch.object(
+                extractor,
+                "_resolve_message_compose_box",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                extractor,
+                "_compose_page_matches_recipient",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                extractor,
+                "_dismiss_message_ui",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await extractor.send_message(
+                "testuser",
+                "Hello!",
+                confirm_send=False,
+                profile_urn="ACoAAB1IelEB",
+            )
+
+        # Second navigate call is the compose URL (first is the profile page)
+        compose_url = navigate_calls[1]
+        assert "profileUrn=" in compose_url
+        assert "urn%3Ali%3Afsd_profile%3AACoAAB1IelEB" in compose_url
+        assert "recipient=ACoAAB1IelEB" in compose_url
+        assert "screenContext=NON_SELF_PROFILE_VIEW" in compose_url
+        assert "interop=msgOverlay" in compose_url
+
+
+class TestResolveMessageComposeBox:
+    async def test_returns_locator_when_count_positive(self, mock_page):
+        """_resolve_message_compose_box returns locator.last when count() > 0."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_locator = MagicMock()
+        mock_locator.count = AsyncMock(return_value=1)
+        sentinel = MagicMock(name="last_locator")
+        mock_locator.last = sentinel
+        mock_page.locator = MagicMock(return_value=mock_locator)
+
+        result = await extractor._resolve_message_compose_box()
+
+        assert result is sentinel
+        # wait_for should NOT be called — the early return bypasses it
+        mock_locator.last.wait_for = AsyncMock()
+        mock_locator.wait_for = AsyncMock()
+
+    async def test_returns_none_when_all_selectors_miss(self, mock_page):
+        """_resolve_message_compose_box returns None when no selector matches."""
+        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        extractor = LinkedInExtractor(mock_page)
+        mock_locator = MagicMock()
+        mock_locator.count = AsyncMock(return_value=0)
+        mock_locator.last = MagicMock()
+        mock_locator.last.wait_for = AsyncMock(
+            side_effect=PlaywrightTimeoutError("timeout")
+        )
+        mock_page.locator = MagicMock(return_value=mock_locator)
+
+        result = await extractor._resolve_message_compose_box()
+
+        assert result is None
+
+    async def test_falls_through_when_count_raises(self, mock_page):
+        """_resolve_message_compose_box handles count() exceptions gracefully."""
+        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        extractor = LinkedInExtractor(mock_page)
+        mock_locator = MagicMock()
+        mock_locator.count = AsyncMock(side_effect=Exception("detached"))
+        mock_locator.last = MagicMock()
+        mock_locator.last.wait_for = AsyncMock(
+            side_effect=PlaywrightTimeoutError("timeout")
+        )
+        mock_page.locator = MagicMock(return_value=mock_locator)
+
+        result = await extractor._resolve_message_compose_box()
+
+        assert result is None
+
+
+class TestSendMessageComposerInteraction:
+    """Tests for the page.evaluate + keyboard.type send path (patchright workaround)."""
+
+    def _patch_send_message_to_compose(self, extractor, mock_page):
+        """Return a context manager that patches send_message up to the compose step."""
+        return (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_read_profile_display_name",
+                new_callable=AsyncMock,
+                return_value="Test User",
+            ),
+            patch.object(
+                extractor,
+                "_resolve_message_compose_href",
+                new_callable=AsyncMock,
+                return_value="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+            ),
+            patch.object(
+                extractor,
+                "_wait_for_message_surface",
+                new_callable=AsyncMock,
+                return_value="composer",
+            ),
+            patch.object(
+                extractor,
+                "_resolve_message_compose_box",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                extractor,
+                "_compose_page_matches_recipient",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                extractor,
+                "_dismiss_message_ui",
+                new_callable=AsyncMock,
+            ),
+        )
+
+    async def test_focus_and_type_via_evaluate_and_keyboard(self, mock_page):
+        """send_message uses page.evaluate to focus and page.keyboard.type to type."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        # evaluate returns: True (focus), True (send button click)
+        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "sent"
+        assert result["sent"] is True
+        # Verify keyboard.type was used (not press_sequentially)
+        mock_keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+
+    async def test_compose_interact_failed_when_focus_fails(self, mock_page):
+        """send_message returns compose_interact_failed when JS focus fails."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        # evaluate returns False (focus failed)
+        mock_page.evaluate = AsyncMock(return_value=False)
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "compose_interact_failed"
+        assert result["sent"] is False
+
+    async def test_enter_fallback_when_send_button_not_found(self, mock_page):
+        """send_message falls back to Enter key when JS cannot find send button."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        # evaluate returns: True (focus), False (no send button found)
+        mock_page.evaluate = AsyncMock(side_effect=[True, False])
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "sent"
+        # Enter was pressed as fallback
+        mock_keyboard.press.assert_awaited_once_with("Enter")


### PR DESCRIPTION
## Problem

  `send_message` was broken under patchright: `locator.wait_for(state="visible")`
  times out on the contenteditable compose div even though the element is
  fully visible by every CSS/DOM criterion (display:block, visibility:visible,
  non-zero bounding box, no inert ancestor). Same actionability check also
  blocked `compose_box.click()` and `press_sequentially()`.

  Root cause appears to be a patchright bug with React-hydrated contenteditable
  elements in isolated worlds.

  ## Changes

  **Compose box resolution** (`_resolve_message_compose_box`):
  Skip `wait_for` when `count() > 0` already confirms the element is present.
  Preserve the original `wait_for` path as a fallback for non-patchright drivers.

  **Compose URL** (`send_message` with `profile_urn`):
  Build the full URL LinkedIn's own Message button generates:
  `?profileUrn=...&recipient=...&screenContext=NON_SELF_PROFILE_VIEW&interop=msgOverlay`
  The minimal `?recipient=<URN>` form showed a "Say hello" widget (no compose
  box) for profiles not yet connected. The full URL consistently opens the
  real composer regardless of connection age.

  **Typing and send** (`send_message`):
  Replace `compose_box.click()` + `press_sequentially()` + `send_button.click()`
  (all blocked by actionability) with:
  1. `page.evaluate()` → `el.focus()` (bypasses actionability)
  2. `page.keyboard.type()` (operates on active element, fires real React events)
  3. `page.evaluate()` → `btn.click()` on first visible/enabled send button
  4. `page.keyboard.press("Enter")` as fallback if no send button found

  All selectors use only ARIA attributes (`role`, `contenteditable`, `aria-label`,
  `data-control-name`).

  ## Tests

  - `test_profile_urn_compose_url_includes_full_params` — verifies full URL params
  - `TestResolveMessageComposeBox` — early return, all-miss, count() exception paths
  - `TestSendMessageComposerInteraction` — focus+type path, focus failure, Enter fallback