### PR TITLE
chore: Bump version to 4.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "linkedin-scraper-mcp"
-version = "4.9.0"
+version = "4.9.1"
 description = "MCP server for LinkedIn profile, company, and job scraping with Claude AI integration. Supports direct profile/company/job URL scraping with secure credential storage."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -951,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "linkedin-scraper-mcp"
-version = "4.9.0"
+version = "4.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Patch release bundling the fixes merged since v4.9.0:

- **fix(scraping):** Click "Show more" on detail pages to avoid truncation (#361, resolves #360)
- **feat(scraping):** Add `max_scrolls` parameter to `get_person_profile` (#361)
- **style(ci):** Simplify release download link (#359)

## Synthetic prompt

> Bump the package version to 4.9.1.

Generated with claude-opus-4-6
