### PR TITLE
fix: handle invitation modal in connect_with_person using structural selectors

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -483,7 +483,7 @@ class LinkedInExtractor:
             logger.debug("Click failed for button '%s'", text, exc_info=True)
             return False
 
-    async def _dialog_is_open(self, *, timeout: int = 1000) -> bool:
+    async def _dialog_is_open(self, *, timeout: int = 3000) -> bool:
         """Return whether a dialog is currently open (structural check)."""
         locator = self._page.locator(_DIALOG_SELECTOR)
         try:
@@ -1072,46 +1072,71 @@ class LinkedInExtractor:
         # ---- Handle dialog (structural selectors only) ----
         # Only wait for a dialog when sending a Connect request (Accept
         # typically completes immediately without a dialog).
+        #
+        # LinkedIn's invitation modal uses role="dialog" on the inner
+        # container, so _DIALOG_SELECTOR matches it.  The modal has two
+        # buttons (secondary = first, primary = last).  All interaction
+        # uses structural/positional selectors only.
+        note_sent = False
+
         if state == "connectable":
             try:
-                await self._page.wait_for_selector(_DIALOG_SELECTOR)
+                await self._page.wait_for_selector(
+                    _DIALOG_SELECTOR, state="visible", timeout=5000
+                )
             except PlaywrightTimeoutError:
                 logger.debug("No dialog appeared after clicking '%s'", button_text)
 
-        note_sent = False
-        if note and await self._dialog_is_open():
-            # Try to find textarea directly; if not visible, click the first
-            # button in the dialog (typically "Add a note") to reveal it
-            textarea_count = await self._page.locator(_DIALOG_TEXTAREA_SELECTOR).count()
-            if textarea_count == 0:
-                buttons = self._page.locator(
-                    f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
-                )
-                if await buttons.count() > 1:
-                    await buttons.first.click()
-
-            filled = await self._fill_dialog_textarea(note)
-            if filled:
-                note_sent = True
-            else:
-                await self._dismiss_dialog()
-                return _connection_result(
-                    url,
-                    "note_not_supported",
-                    "LinkedIn did not offer note entry for this connection flow.",
-                )
-
-        # Click the primary (Send) button if a dialog is still open
         if await self._dialog_is_open():
+            # Locate all buttons inside the dialog.  LinkedIn's modal
+            # typically has: [0] dismiss/X, [1] secondary, [2] primary.
+            # We address action buttons from the end so the dismiss
+            # button position doesn't matter.
+            dialog_buttons = self._page.locator(
+                f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
+            )
+            btn_count = await dialog_buttons.count()
+
+            if note and btn_count > 2:
+                # Click the second-to-last button (secondary action) to
+                # reveal the note textarea, then fill and send.
+                await dialog_buttons.nth(btn_count - 2).click()
+                # Wait for the textarea to render
+                try:
+                    await self._page.wait_for_selector(
+                        _DIALOG_TEXTAREA_SELECTOR,
+                        state="visible",
+                        timeout=3000,
+                    )
+                except PlaywrightTimeoutError:
+                    logger.debug("Textarea did not appear after note button")
+
+                filled = await self._fill_dialog_textarea(note)
+                if filled:
+                    note_sent = True
+                else:
+                    await self._dismiss_dialog()
+                    return _connection_result(
+                        url,
+                        "note_not_supported",
+                        "LinkedIn did not offer note entry for this connection flow.",
+                    )
+
+            # Click the primary (last) button to send.
+            # Re-query buttons as the modal content may have changed.
             sent = await self._click_dialog_primary_button()
             if not sent:
                 await self._dismiss_dialog()
                 return _connection_result(
-                    url, "send_failed", "Could not find the send button in the dialog."
+                    url,
+                    "send_failed",
+                    "Could not find the send button in the dialog.",
                 )
             # Wait for dialog to close
             try:
-                await self._page.wait_for_selector(_DIALOG_SELECTOR, state="hidden")
+                await self._page.wait_for_selector(
+                    _DIALOG_SELECTOR, state="hidden", timeout=5000
+                )
             except PlaywrightTimeoutError:
                 logger.debug("Dialog did not close after clicking send")
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1074,9 +1074,9 @@ class LinkedInExtractor:
         # typically completes immediately without a dialog).
         #
         # LinkedIn's invitation modal uses role="dialog" on the inner
-        # container, so _DIALOG_SELECTOR matches it.  The modal has two
-        # buttons (secondary = first, primary = last).  All interaction
-        # uses structural/positional selectors only.
+        # container, so _DIALOG_SELECTOR matches it.  The modal typically
+        # has three buttons: [0] dismiss/X, [1] secondary, [2] primary.
+        # All interaction uses structural/positional selectors only.
         note_sent = False
 
         if state == "connectable":
@@ -1087,67 +1087,66 @@ class LinkedInExtractor:
             except PlaywrightTimeoutError:
                 logger.debug("No dialog appeared after clicking '%s'", button_text)
 
-        if await self._dialog_is_open(timeout=3000):
-            # Locate all buttons inside the dialog.  LinkedIn's modal
-            # typically has: [0] dismiss/X, [1] secondary, [2] primary.
-            # We address action buttons from the end so the dismiss
-            # button position doesn't matter.
-            dialog_buttons = self._page.locator(
-                f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
-            )
-            btn_count = await dialog_buttons.count()
+            if await self._dialog_is_open(timeout=3000):
+                # Locate all buttons inside the dialog.  We address
+                # action buttons from the end so the dismiss button
+                # position doesn't matter.
+                dialog_buttons = self._page.locator(
+                    f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
+                )
+                btn_count = await dialog_buttons.count()
 
-            if note and btn_count > 2:
-                # Click the second-to-last button (secondary action) to
-                # reveal the note textarea, then fill and send.
-                await dialog_buttons.nth(btn_count - 2).click()
-                # Wait for the textarea to render
-                try:
-                    await self._page.wait_for_selector(
-                        _DIALOG_TEXTAREA_SELECTOR,
-                        state="visible",
-                        timeout=3000,
-                    )
-                except PlaywrightTimeoutError:
-                    logger.debug("Textarea did not appear after note button")
+                if note and btn_count > 2:
+                    # Click the second-to-last button (secondary action) to
+                    # reveal the note textarea, then fill and send.
+                    await dialog_buttons.nth(btn_count - 2).click()
+                    # Wait for the textarea to render
+                    try:
+                        await self._page.wait_for_selector(
+                            _DIALOG_TEXTAREA_SELECTOR,
+                            state="visible",
+                            timeout=3000,
+                        )
+                    except PlaywrightTimeoutError:
+                        logger.debug("Textarea did not appear after note button")
 
-                filled = await self._fill_dialog_textarea(note)
-                if filled:
-                    note_sent = True
-                else:
+                    filled = await self._fill_dialog_textarea(note)
+                    if filled:
+                        note_sent = True
+                    else:
+                        await self._dismiss_dialog()
+                        return _connection_result(
+                            url,
+                            "note_not_supported",
+                            "LinkedIn did not offer note entry for this connection flow.",
+                        )
+                elif note:
+                    # Modal present but no secondary button — note not
+                    # supported in this connection flow.
                     await self._dismiss_dialog()
                     return _connection_result(
                         url,
                         "note_not_supported",
                         "LinkedIn did not offer note entry for this connection flow.",
                     )
-            elif note:
-                # Modal present but no secondary button — note not
-                # supported in this connection flow.
-                await self._dismiss_dialog()
-                return _connection_result(
-                    url,
-                    "note_not_supported",
-                    "LinkedIn did not offer note entry for this connection flow.",
-                )
 
-            # Click the primary (last) button to send.
-            # Re-query buttons as the modal content may have changed.
-            sent = await self._click_dialog_primary_button()
-            if not sent:
-                await self._dismiss_dialog()
-                return _connection_result(
-                    url,
-                    "send_failed",
-                    "Could not find the send button in the dialog.",
-                )
-            # Wait for dialog to close
-            try:
-                await self._page.wait_for_selector(
-                    _DIALOG_SELECTOR, state="hidden", timeout=5000
-                )
-            except PlaywrightTimeoutError:
-                logger.debug("Dialog did not close after clicking send")
+                # Click the primary (last) button to send.
+                # Re-query buttons as the modal content may have changed.
+                sent = await self._click_dialog_primary_button()
+                if not sent:
+                    await self._dismiss_dialog()
+                    return _connection_result(
+                        url,
+                        "send_failed",
+                        "Could not find the send button in the dialog.",
+                    )
+                # Wait for dialog to close
+                try:
+                    await self._page.wait_for_selector(
+                        _DIALOG_SELECTOR, state="hidden", timeout=5000
+                    )
+                except PlaywrightTimeoutError:
+                    logger.debug("Dialog did not close after clicking send")
 
         # Read the current page text (already on the profile after the action)
         updated_text = await self.get_page_text()

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -483,7 +483,7 @@ class LinkedInExtractor:
             logger.debug("Click failed for button '%s'", text, exc_info=True)
             return False
 
-    async def _dialog_is_open(self, *, timeout: int = 3000) -> bool:
+    async def _dialog_is_open(self, *, timeout: int = 1000) -> bool:
         """Return whether a dialog is currently open (structural check)."""
         locator = self._page.locator(_DIALOG_SELECTOR)
         try:
@@ -1087,7 +1087,7 @@ class LinkedInExtractor:
             except PlaywrightTimeoutError:
                 logger.debug("No dialog appeared after clicking '%s'", button_text)
 
-        if await self._dialog_is_open():
+        if await self._dialog_is_open(timeout=3000):
             # Locate all buttons inside the dialog.  LinkedIn's modal
             # typically has: [0] dismiss/X, [1] secondary, [2] primary.
             # We address action buttons from the end so the dismiss
@@ -1121,6 +1121,15 @@ class LinkedInExtractor:
                         "note_not_supported",
                         "LinkedIn did not offer note entry for this connection flow.",
                     )
+            elif note:
+                # Modal present but no secondary button — note not
+                # supported in this connection flow.
+                await self._dismiss_dialog()
+                return _connection_result(
+                    url,
+                    "note_not_supported",
+                    "LinkedIn did not offer note entry for this connection flow.",
+                )
 
             # Click the primary (last) button to send.
             # Re-query buttons as the modal content may have changed.


### PR DESCRIPTION
## Summary

`connect_with_person` failed to interact with LinkedIn's "Add a note to your invitation?" modal dialog, causing it to report success without actually sending the connection request. This PR fixes both the "send without note" and "send with note" flows.

### Root Cause

Two bugs prevented proper modal interaction:

1. **Dismiss button clicked instead of "Add a note"** — The modal contains three buttons: `[0]` dismiss/X, `[1]` secondary ("Add a note"), `[2]` primary ("Send without a note"). The previous code used `buttons.first.click()` for the note flow, which clicked the dismiss/X button (index 0), closing the modal entirely.

2. **Insufficient timeout for modal detection** — `_dialog_is_open` used a 1s timeout and `wait_for_selector` had no explicit `state="visible"`, causing the modal to go undetected when Connect was triggered via the More menu (menu closes → modal appears with slight delay).

### What Changed

**`linkedin_mcp_server/scraping/extractor.py`**:

| Change | Before | After |
|--------|--------|-------|
| Note flow button index | `dialog_buttons.first.click()` (index 0 = dismiss) | `dialog_buttons.nth(btn_count - 2).click()` (second-to-last = secondary action) |
| `_dialog_is_open` timeout | `1000ms` | `3000ms` |
| `wait_for_selector` for modal | No `state` param, default timeout | `state="visible", timeout=5000` |
| Textarea wait after "Add a note" | None | `wait_for_selector(_DIALOG_TEXTAREA_SELECTOR, visible, 3s)` |
| Button count guard for note flow | `btn_count > 1` | `btn_count > 2` (accounts for dismiss button) |

### Flow

#### Without Note

```mermaid
sequenceDiagram
    participant Tool as connect_with_person
    participant Page as LinkedIn Page
    participant Modal as Modal (role="dialog")

    Tool->>Page: Click "Connect" button
    Page->>Modal: Modal appears
    Tool->>Modal: wait_for_selector([role="dialog"], visible, 5s)
    Tool->>Modal: _dialog_is_open() → True
    Tool->>Modal: Count buttons → 3
    Note over Tool: No note → skip note flow
    Tool->>Modal: _click_dialog_primary_button() → last button
    Modal-->>Page: Invitation sent, modal closes
    Tool-->>Tool: status: "connected"
```

#### With Note

```mermaid
sequenceDiagram
    participant Tool as connect_with_person
    participant Page as LinkedIn Page
    participant Modal as Modal (role="dialog")

    Tool->>Page: Click "Connect" button
    Page->>Modal: Modal appears
    Tool->>Modal: wait_for_selector([role="dialog"], visible, 5s)
    Tool->>Modal: _dialog_is_open() → True
    Tool->>Modal: Count buttons → 3 (> 2 ✓)
    Tool->>Modal: Click nth(count-2) → secondary button
    Modal->>Modal: Textarea appears
    Tool->>Modal: wait_for_selector(textarea, visible, 3s)
    Tool->>Modal: Fill textarea with note
    Tool->>Modal: _click_dialog_primary_button() → last button
    Modal-->>Page: Invitation sent with note
    Tool-->>Tool: status: "connected", note_sent: true
```

### Design Decisions

- **Structural selectors only** — All selectors use standard HTML/ARIA: `[role="dialog"]`, `button`, `textarea`. No hardcoded LinkedIn class names or aria-labels. This follows the repo's scraping rule: *"Minimize DOM dependence. Prefer innerText and URL navigation over DOM selectors."*

- **Positional button addressing from the end** — `nth(count - 1)` for primary, `nth(count - 2)` for secondary. Resilient to LinkedIn adding elements before the action buttons.

- **Unified code path** — Both "with note" and "without note" flows share the same dialog detection and primary button click. The note flow adds a secondary button click + textarea fill before the shared send step.

### Related

- #348 — Similar fix for the note dialog, uses text-based button matching. This PR takes a structural/positional approach instead.
- #366 — Addresses false-positive success by verifying post-send state (complementary fix, different scope).

### Verified Scenarios

| Scenario | Before | After |
|----------|--------|-------|
| Connect without note | ❌ Modal stuck, false success | ✅ Sends invitation |
| Connect with note | ❌ Clicked dismiss/X, `note_not_supported` | ✅ Fills note, sends, `note_sent: true` |
| Connect via More menu | ❌ Modal not detected (1s timeout) | ✅ Detected with 5s wait |
| Accept incoming request | ✅ Worked | ✅ Still works |
| Already connected / pending | ✅ Worked | ✅ Still works |

## Test plan

- [x] `connect_with_person("suchi-patel-52807726b")` — sent invitation without note, `status: "connected"` ✅
- [x] `connect_with_person("riddhi-thakkar-4a2350289", note="Hi Riddhi, came across your profile and would love to connect. Looking forward to being in touch!")` — sent invitation with note, `status: "connected"`, `note_sent: true` ✅
- [x] Connect on follow-only profile (`chris-fisher-48b4a730`, More menu) — modal detected and handled ✅
- [x] Already-connected profile returns `already_connected` ✅
- [x] Pending profile (`sachin-brahmbhatt-74b2631a1`) returns `pending` ✅
- [ ] `uv run pytest` — all existing tests pass

Generated with Claude Opus 4.6