### PR TITLE
docs(readme): sync tool status table

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | Tool | Description | Status |
 |------|-------------|--------|
 | `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
-| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#304](https://github.com/stickerdaniel/linkedin-mcp-server/issues/304) |
+| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#304](https://github.com/stickerdaniel/linkedin-mcp-server/issues/304) [#365](https://github.com/stickerdaniel/linkedin-mcp-server/issues/365) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | [#307](https://github.com/stickerdaniel/linkedin-mcp-server/issues/307) |
 | `search_conversations` | Search messages by keyword | working |
-| `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#344](https://github.com/stickerdaniel/linkedin-mcp-server/issues/344) |
+| `send_message` | Send a message to a LinkedIn user (requires confirmation) | working |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs) | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_jobs` | Search for jobs with keywords and location filters | working |


### PR DESCRIPTION
Closes #370

## Summary

- sync `connect_with_person` status with open tool-specific issues `#304` and `#365`
- mark `send_message` as `working` because `#344` was fixed and closed by PR `#362`

## Synthetic prompt

> Sync the README Features & Tool Status table with current tool-specific issue state: list both open `connect_with_person` issues (`#304` and `#365`), remove the stale closed `send_message` issue (`#344`), and avoid listing broad runtime issues.

Generated with GPT-5 Codex