### PR TITLE
feat: add get_feed tool to fetch home feed posts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Optional additional keys:
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs only)
+- `posts: [{text, url?}, ...]` (get_feed only) — per-post text blocks in feed order; `url` omitted for promoted/suggested items
 
 ## Verifying Bug Reports
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -649,15 +649,7 @@ class LinkedInExtractor:
         self,
         num_posts: int = 10,
     ) -> ExtractedSection:
-        """Navigate to the LinkedIn home feed and scroll until *num_posts* are loaded.
-
-        LinkedIn's feed lives in its own scroll container — ``window.scrollY``
-        and ``document.body.scrollHeight`` never change while scrolling. Posts
-        are triggered by an IntersectionObserver on a sentinel element at the
-        bottom of the loaded list, firing in batches of ~5 every few seconds.
-        This method uses ``mouse.wheel`` to fire native scroll events on the
-        correct container and polls for new posts after each event.
-        """
+        """Scrape the LinkedIn home feed, scrolling until *num_posts* are loaded."""
         try:
             return await self._extract_feed_once(num_posts)
         except LinkedInScraperException:
@@ -686,7 +678,6 @@ class LinkedInExtractor:
 
         await handle_modal_close(self._page)
 
-        # Wait for initial feed content to render
         try:
             await self._page.wait_for_function(
                 """() => {
@@ -699,25 +690,16 @@ class LinkedInExtractor:
         except PlaywrightTimeoutError:
             logger.debug("Feed content did not appear on %s", url)
 
-        # LinkedIn's feed lives in its own scroll container — window.scrollY
-        # and document.body.scrollHeight never change while scrolling.
-        # Posts are loaded by an IntersectionObserver watching a sentinel at
-        # the bottom of the loaded list: batches of ~5 arrive every ~5-10s
-        # while the user is actively scrolling near the bottom.
-        #
-        # Strategy: move the mouse to the center of the viewport (over the
-        # feed), send repeated mouse.wheel events to keep the sentinel
-        # in view, and wait up to _BATCH_WAIT seconds after each wheel burst
-        # for a new batch to arrive before declaring it stale.
+        # The feed has its own scroll container — window.scrollTo is a no-op.
+        # mouse.wheel over the viewport center triggers the real scroll.
         _POST_MARKER = "Feed post"
         _MAX_SCROLLS = 20
         _MAX_STALE = 3
-        _BATCH_WAIT = 10.0  # seconds to wait for a new batch after scrolling
-        _WHEEL_DELTA = 2000  # px per wheel event
+        _BATCH_WAIT = 10.0
+        _WHEEL_DELTA = 2000
         stale_count = 0
         prev_count = 0
 
-        # Position mouse in the center of the viewport over the feed content.
         viewport = self._page.viewport_size or {"width": 1280, "height": 720}
         cx, cy = viewport["width"] // 2, viewport["height"] // 2
         await self._page.mouse.move(cx, cy)
@@ -735,10 +717,8 @@ class LinkedInExtractor:
             if count >= num_posts:
                 break
 
-            # Scroll down to trigger the IntersectionObserver sentinel.
             await self._page.mouse.wheel(0, _WHEEL_DELTA)
 
-            # Wait up to _BATCH_WAIT seconds for a new batch, polling every second.
             new_count = count
             for _ in range(int(_BATCH_WAIT)):
                 await asyncio.sleep(1.0)
@@ -751,7 +731,7 @@ class LinkedInExtractor:
                     _POST_MARKER,
                 )
                 if new_count > count:
-                    break  # batch arrived, move on
+                    break
 
             if new_count > prev_count:
                 stale_count = 0
@@ -768,10 +748,7 @@ class LinkedInExtractor:
                     break
             prev_count = new_count
 
-        # The home feed truncates posts with "… more" buttons.  Expand them
-        # so we capture the full text of every post.  We use a JS click
-        # because the buttons can be obscured by overlays (video players,
-        # modals) that cause Playwright's actionability checks to time out.
+        # Expand "… more" buttons via JS click (Playwright clicks time out on obscured buttons).
         expanded = await self._page.evaluate(
             """() => {
                 const main = document.querySelector('main');
@@ -786,7 +763,6 @@ class LinkedInExtractor:
         if expanded:
             await asyncio.sleep(0.5)
 
-        # Extract text from main content area
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -667,7 +667,7 @@ class LinkedInExtractor:
             return ExtractedSection(
                 text="",
                 references=[],
-                error=build_issue_diagnostics(e, "extract_feed"),
+                error=build_issue_diagnostics(e, context="extract_feed"),
             )
 
     async def _extract_feed_once(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -6,6 +6,7 @@ import asyncio
 from dataclasses import dataclass
 import logging
 import re
+import unicodedata
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import parse_qs, quote_plus, urljoin, urlparse
 
@@ -177,6 +178,105 @@ class ExtractedSection:
     text: str
     references: list[Reference]
     error: dict[str, Any] | None = None
+    posts: list[dict[str, Any]] | None = None
+
+
+_FEED_RSC_MARKER = "sduiid=com.linkedin.sdui.pagers.feed.mainFeed"
+# Matches a LinkedIn post permalink in either plain or JSON-escaped form
+# (the initial /feed/ HTML embeds the RSC flight data with \u002f for slashes,
+# while paginated responses use plain slashes). Captures the slug portion so
+# we can rebuild a canonical URL regardless of the source encoding.
+_POST_SLUG_URL_RE = re.compile(
+    r"linkedin\.com(?:\\u002[fF]|/)posts(?:\\u002[fF]|/)"
+    r"(?P<slug>[A-Za-z0-9_-]+?-(?:ugcPost|activity|share)-\d+-[A-Za-z0-9_-]+)"
+)
+_FEED_POST_SPLIT_RE = re.compile(r"(?:^|\n)Feed post\s*\n+")
+_FEED_DOCUMENT_URLS = {
+    "https://www.linkedin.com/feed",
+    "https://www.linkedin.com/feed/",
+}
+_POST_SLUG_PATH_RE = re.compile(
+    r"/posts/(?P<prefix>.+?)-(?:ugcPost|activity|share)-\d+-[A-Za-z0-9_-]+/?$"
+)
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]")
+# Minimum normalized length of a slug fingerprint before we'll try to match it
+# against a post block — guards against false positives from very short slugs.
+_MIN_FINGERPRINT_LEN = 12
+
+
+def _normalize_for_match(text: str) -> str:
+    # NFKC folds mathematical-bold / full-width / superscript characters to
+    # their ASCII equivalents, so posts styled with Unicode typography still
+    # substring-match their plain-text slugs.
+    return _NON_ALNUM_RE.sub("", unicodedata.normalize("NFKC", text).lower())
+
+
+def _is_feed_payload_response(url: str) -> bool:
+    """True if the response URL is one that carries `postSlugUrl` fields."""
+    if _FEED_RSC_MARKER in url:
+        return True
+    return url.split("?", 1)[0] in _FEED_DOCUMENT_URLS
+
+
+def _fingerprint_from_slug_url(slug_url: str) -> str | None:
+    """Derive a normalized content fingerprint from a post slug URL.
+
+    LinkedIn encodes the first several words of the post body into the slug:
+    ``/posts/<author>_<title-words>-<type>-<id>-<trk>`` (or just
+    ``/posts/<title-words>-<type>-<id>-<trk>`` for org posts). We extract the
+    title portion and strip non-alphanumerics so it substring-matches the
+    post's innerText regardless of punctuation/whitespace differences.
+    """
+    path = slug_url.split("?", 1)[0].split("#", 1)[0]
+    match = _POST_SLUG_PATH_RE.search(path)
+    if not match:
+        return None
+    prefix = match.group("prefix")
+    _, sep, title = prefix.partition("_")
+    if not sep:
+        title = prefix
+    normalized = _normalize_for_match(title)
+    return normalized if len(normalized) >= _MIN_FINGERPRINT_LEN else None
+
+
+def _build_feed_posts(
+    cleaned_text: str,
+    captured_urls: list[str],
+) -> list[dict[str, Any]]:
+    """Split feed innerText into per-post blocks and attach captured permalinks.
+
+    Matches each URL to a post by content fingerprint (first words of the
+    post body, encoded into the slug URL). Ordering between the captured-URL
+    list and the rendered DOM is not stable — posts from the initial HTML
+    document and subsequent pagination fetches interleave — so we key on
+    content instead. Promoted/suggested posts have no ``postSlugUrl`` and
+    simply receive no ``url`` field.
+    """
+    blocks = [
+        block.strip()
+        for block in _FEED_POST_SPLIT_RE.split(cleaned_text)
+        if block.strip()
+    ]
+    if blocks and not cleaned_text.lstrip().startswith("Feed post"):
+        blocks = blocks[1:]
+
+    url_pool: list[tuple[str, str]] = []
+    for url in captured_urls:
+        fingerprint = _fingerprint_from_slug_url(url)
+        if fingerprint:
+            url_pool.append((fingerprint, url))
+
+    posts: list[dict[str, Any]] = []
+    for block in blocks:
+        entry: dict[str, Any] = {"text": block}
+        normalized_block = _normalize_for_match(block)
+        for i, (fingerprint, url) in enumerate(url_pool):
+            if fingerprint in normalized_block:
+                entry["url"] = url
+                url_pool.pop(i)
+                break
+        posts.append(entry)
+    return posts
 
 
 def strip_linkedin_noise(text: str) -> str:
@@ -668,6 +768,48 @@ class LinkedInExtractor:
     ) -> ExtractedSection:
         """Single attempt: navigate, scroll until post count, extract."""
         url = "https://www.linkedin.com/feed/"
+
+        # Post permalinks aren't rendered in the feed DOM anymore — they only
+        # live in the SDUI pagination response (field: "postSlugUrl"). Listen
+        # for those responses during the whole scroll loop.
+        captured_urls: list[str] = []
+        seen_urls: set[str] = set()
+
+        def _handle_response(resp: Any) -> None:
+            if not _is_feed_payload_response(resp.url):
+                return
+
+            async def _read() -> None:
+                try:
+                    body = await resp.body()
+                except Exception:
+                    return
+                if not body:
+                    return
+                text = body.decode("utf-8", errors="replace")
+                for match in _POST_SLUG_URL_RE.finditer(text):
+                    post_url = f"https://www.linkedin.com/posts/{match.group('slug')}"
+                    if post_url not in seen_urls:
+                        seen_urls.add(post_url)
+                        captured_urls.append(post_url)
+
+            asyncio.create_task(_read())
+
+        self._page.on("response", _handle_response)
+        try:
+            return await self._extract_feed_body(url, num_posts, captured_urls)
+        finally:
+            try:
+                self._page.remove_listener("response", _handle_response)
+            except Exception:
+                pass
+
+    async def _extract_feed_body(
+        self,
+        url: str,
+        num_posts: int,
+        captured_urls: list[str],
+    ) -> ExtractedSection:
         await self._navigate_to_page(url)
         await detect_rate_limit(self._page)
 
@@ -761,6 +903,9 @@ class LinkedInExtractor:
         if expanded:
             await asyncio.sleep(0.5)
 
+        # Give any in-flight response reads a beat to finish recording URLs.
+        await asyncio.sleep(0.2)
+
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
 
@@ -773,9 +918,11 @@ class LinkedInExtractor:
             )
             return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
         cleaned = _filter_linkedin_noise_lines(truncated)
+        posts = _build_feed_posts(cleaned, captured_urls)
         return ExtractedSection(
             text=cleaned,
             references=build_references(raw_result["references"], "feed"),
+            posts=posts,
         )
 
     async def extract_page(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -645,6 +645,165 @@ class LinkedInExtractor:
             )
             await asyncio.sleep(pause_time)
 
+    async def extract_feed(
+        self,
+        num_posts: int = 10,
+    ) -> ExtractedSection:
+        """Navigate to the LinkedIn home feed and scroll until *num_posts* are loaded.
+
+        LinkedIn's feed lives in its own scroll container — ``window.scrollY``
+        and ``document.body.scrollHeight`` never change while scrolling. Posts
+        are triggered by an IntersectionObserver on a sentinel element at the
+        bottom of the loaded list, firing in batches of ~5 every few seconds.
+        This method uses ``mouse.wheel`` to fire native scroll events on the
+        correct container and polls for new posts after each event.
+        """
+        try:
+            return await self._extract_feed_once(num_posts)
+        except LinkedInScraperException:
+            raise
+        except Exception as e:
+            logger.warning("Failed to extract feed: %s", e)
+            return ExtractedSection(
+                text="",
+                references=[],
+                error=build_issue_diagnostics(e, "extract_feed"),
+            )
+
+    async def _extract_feed_once(
+        self,
+        num_posts: int,
+    ) -> ExtractedSection:
+        """Single attempt: navigate, scroll until post count, extract."""
+        url = "https://www.linkedin.com/feed/"
+        await self._navigate_to_page(url)
+        await detect_rate_limit(self._page)
+
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("No <main> element found on %s", url)
+
+        await handle_modal_close(self._page)
+
+        # Wait for initial feed content to render
+        try:
+            await self._page.wait_for_function(
+                """() => {
+                    const main = document.querySelector('main');
+                    if (!main) return false;
+                    return main.innerText.length > 200;
+                }""",
+                timeout=10000,
+            )
+        except PlaywrightTimeoutError:
+            logger.debug("Feed content did not appear on %s", url)
+
+        # LinkedIn's feed lives in its own scroll container — window.scrollY
+        # and document.body.scrollHeight never change while scrolling.
+        # Posts are loaded by an IntersectionObserver watching a sentinel at
+        # the bottom of the loaded list: batches of ~5 arrive every ~5-10s
+        # while the user is actively scrolling near the bottom.
+        #
+        # Strategy: move the mouse to the center of the viewport (over the
+        # feed), send repeated mouse.wheel events to keep the sentinel
+        # in view, and wait up to _BATCH_WAIT seconds after each wheel burst
+        # for a new batch to arrive before declaring it stale.
+        _POST_MARKER = "Feed post"
+        _MAX_SCROLLS = 20
+        _MAX_STALE = 3
+        _BATCH_WAIT = 10.0  # seconds to wait for a new batch after scrolling
+        _WHEEL_DELTA = 2000  # px per wheel event
+        stale_count = 0
+        prev_count = 0
+
+        # Position mouse in the center of the viewport over the feed content.
+        viewport = self._page.viewport_size or {"width": 1280, "height": 720}
+        cx, cy = viewport["width"] // 2, viewport["height"] // 2
+        await self._page.mouse.move(cx, cy)
+
+        for i in range(_MAX_SCROLLS):
+            count = await self._page.evaluate(
+                """(marker) => {
+                    const main = document.querySelector('main');
+                    if (!main) return 0;
+                    return main.innerText.split(marker).length - 1;
+                }""",
+                _POST_MARKER,
+            )
+            logger.debug("Feed scroll %d: %d posts loaded", i, count)
+            if count >= num_posts:
+                break
+
+            # Scroll down to trigger the IntersectionObserver sentinel.
+            await self._page.mouse.wheel(0, _WHEEL_DELTA)
+
+            # Wait up to _BATCH_WAIT seconds for a new batch, polling every second.
+            new_count = count
+            for _ in range(int(_BATCH_WAIT)):
+                await asyncio.sleep(1.0)
+                new_count = await self._page.evaluate(
+                    """(marker) => {
+                        const main = document.querySelector('main');
+                        if (!main) return 0;
+                        return main.innerText.split(marker).length - 1;
+                    }""",
+                    _POST_MARKER,
+                )
+                if new_count > count:
+                    break  # batch arrived, move on
+
+            if new_count > prev_count:
+                stale_count = 0
+            else:
+                stale_count += 1
+                logger.debug(
+                    "Feed stale scroll %d/%d (still at %d posts)",
+                    stale_count,
+                    _MAX_STALE,
+                    new_count,
+                )
+                if stale_count >= _MAX_STALE:
+                    logger.debug("Feed stopped producing new posts")
+                    break
+            prev_count = new_count
+
+        # The home feed truncates posts with "… more" buttons.  Expand them
+        # so we capture the full text of every post.  We use a JS click
+        # because the buttons can be obscured by overlays (video players,
+        # modals) that cause Playwright's actionability checks to time out.
+        expanded = await self._page.evaluate(
+            """() => {
+                const main = document.querySelector('main');
+                if (!main) return 0;
+                const btns = Array.from(main.querySelectorAll('button'))
+                    .filter(b => /^…?\\s*(see )?more$/i.test(b.innerText.trim()));
+                btns.forEach(b => b.click());
+                return btns.length;
+            }"""
+        )
+        logger.debug("Expanded %d truncated posts", expanded)
+        if expanded:
+            await asyncio.sleep(0.5)
+
+        # Extract text from main content area
+        raw_result = await self._extract_root_content(["main"])
+        raw = raw_result["text"]
+
+        if not raw:
+            return ExtractedSection(text="", references=[])
+        truncated = _truncate_linkedin_noise(raw)
+        if not truncated and raw.strip():
+            logger.warning(
+                "Page %s returned only LinkedIn chrome (likely rate-limited)", url
+            )
+            return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+        cleaned = _filter_linkedin_noise_lines(truncated)
+        return ExtractedSection(
+            text=cleaned,
+            references=build_references(raw_result["references"], "feed"),
+        )
+
     async def extract_page(
         self,
         url: str,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -698,7 +698,6 @@ class LinkedInExtractor:
         _BATCH_WAIT = 10.0
         _WHEEL_DELTA = 2000
         stale_count = 0
-        prev_count = 0
 
         viewport = self._page.viewport_size or {"width": 1280, "height": 720}
         cx, cy = viewport["width"] // 2, viewport["height"] // 2
@@ -733,7 +732,7 @@ class LinkedInExtractor:
                 if new_count > count:
                     break
 
-            if new_count > prev_count:
+            if new_count > count:
                 stale_count = 0
             else:
                 stale_count += 1
@@ -746,7 +745,6 @@ class LinkedInExtractor:
                 if stale_count >= _MAX_STALE:
                     logger.debug("Feed stopped producing new posts")
                     break
-            prev_count = new_count
 
         # Expand "… more" buttons via JS click (Playwright clicks time out on obscured buttons).
         expanded = await self._page.evaluate(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -693,9 +693,9 @@ class LinkedInExtractor:
         # The feed has its own scroll container — window.scrollTo is a no-op.
         # mouse.wheel over the viewport center triggers the real scroll.
         _POST_MARKER = "Feed post"
-        _MAX_SCROLLS = 20
+        _MAX_SCROLLS = 12
         _MAX_STALE = 3
-        _BATCH_WAIT = 10.0
+        _BATCH_WAIT = 6.0
         _WHEEL_DELTA = 2000
         stale_count = 0
 

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -23,6 +23,7 @@ from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
 from linkedin_mcp_server.tools.company import register_company_tools
+from linkedin_mcp_server.tools.feed import register_feed_tools
 from linkedin_mcp_server.tools.job import register_job_tools
 from linkedin_mcp_server.tools.messaging import register_messaging_tools
 from linkedin_mcp_server.tools.person import register_person_tools
@@ -60,6 +61,7 @@ def create_mcp_server() -> FastMCP:
     register_company_tools(mcp)
     register_job_tools(mcp)
     register_messaging_tools(mcp)
+    register_feed_tools(mcp)
 
     # Register session management tool
     @mcp.tool(

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -70,6 +70,11 @@ def register_feed_tools(mcp: FastMCP) -> None:
                 sections["feed"] = extracted.text
                 if extracted.references:
                     references["feed"] = extracted.references
+            elif extracted.text == _RATE_LIMITED_MSG:
+                section_errors["feed"] = {
+                    "error_type": "rate_limit",
+                    "error_message": extracted.text,
+                }
             elif extracted.error:
                 section_errors["feed"] = extracted.error
 

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -46,8 +46,10 @@ def register_feed_tools(mcp: FastMCP) -> None:
                        so the actual count may slightly exceed the target.
 
         Returns:
-            Dict with url, sections (name -> raw text), and optional references.
-            The LLM should parse the raw text to extract individual posts.
+            Dict with url, sections (name -> raw text), and optional keys:
+            - posts: list of {url, text} per post in feed order. Some posts
+              (promoted/suggested) have no url.
+            - references, section_errors.
         """
         try:
             extractor = extractor or await get_ready_extractor(
@@ -81,6 +83,8 @@ def register_feed_tools(mcp: FastMCP) -> None:
             await ctx.report_progress(progress=100, total=100, message="Complete")
 
             result: dict[str, Any] = {"url": url, "sections": sections}
+            if extracted.posts:
+                result["posts"] = extracted.posts
             if references:
                 result["references"] = references
             if section_errors:

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -1,0 +1,91 @@
+"""
+LinkedIn feed scraping tool.
+
+Fetches posts from the authenticated user's LinkedIn home feed
+using innerText extraction. Scrolls until the requested number
+of posts are visible in the DOM.
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context, FastMCP
+
+from linkedin_mcp_server.constants import TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.core.exceptions import AuthenticationError
+from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
+from linkedin_mcp_server.error_handler import raise_tool_error
+from linkedin_mcp_server.scraping.extractor import _RATE_LIMITED_MSG
+from linkedin_mcp_server.scraping.link_metadata import Reference
+
+logger = logging.getLogger(__name__)
+
+
+def register_feed_tools(mcp: FastMCP) -> None:
+    """Register feed-related tools with the MCP server."""
+
+    @mcp.tool(
+        timeout=TOOL_TIMEOUT_SECONDS,
+        title="Get Feed",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"feed", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_feed(
+        ctx: Context,
+        num_posts: int = 10,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get posts from the authenticated user's LinkedIn feed.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+            num_posts: Number of posts to fetch (1-50, default 10).
+                       Posts are loaded in batches of ~5 as the page scrolls,
+                       so the actual count may slightly exceed the target.
+
+        Returns:
+            Dict with url, sections (name -> raw text), and optional references.
+            The LLM should parse the raw text to extract individual posts.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_feed"
+            )
+            num_posts = max(1, min(num_posts, 50))
+            logger.info("Scraping feed (num_posts=%d)", num_posts)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Starting feed scrape"
+            )
+
+            extracted = await extractor.extract_feed(num_posts=num_posts)
+
+            url = "https://www.linkedin.com/feed/"
+            sections: dict[str, str] = {}
+            references: dict[str, list[Reference]] = {}
+            section_errors: dict[str, dict[str, Any]] = {}
+            if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+                sections["feed"] = extracted.text
+                if extracted.references:
+                    references["feed"] = extracted.references
+            elif extracted.error:
+                section_errors["feed"] = extracted.error
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            result: dict[str, Any] = {"url": url, "sections": sections}
+            if references:
+                result["references"] = references
+            if section_errors:
+                result["section_errors"] = section_errors
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_feed")
+        except Exception as e:
+            raise_tool_error(e, "get_feed")

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -17,6 +17,7 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _RATE_LIMITED_MSG,
+    _build_feed_posts,
     _truncate_linkedin_noise,
     strip_linkedin_noise,
 )
@@ -3397,3 +3398,66 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "sent"
         # Enter was pressed as fallback
         mock_keyboard.press.assert_awaited_once_with("Enter")
+
+
+class TestBuildFeedPosts:
+    def test_matches_urls_to_posts_by_content_fingerprint(self):
+        # URL order reversed vs DOM order — slug fingerprint matching should
+        # still pair each URL with the correct post.
+        text = (
+            "Feed post\n\nAlice\n\nMe and Charles, 7 years ago on graduation day\n\n"
+            "Feed post\n\nBob\n\nBuilding a company is almost inhuman and hard"
+        )
+        url_a = "https://www.linkedin.com/posts/alice_me-and-charles-7-years-ago-on-graduation-share-1-xx"
+        url_b = "https://www.linkedin.com/posts/building-a-company-is-almost-inhuman-and-ugcPost-2-yy"
+        posts = _build_feed_posts(text, [url_b, url_a])
+        assert posts == [
+            {"text": "Alice\n\nMe and Charles, 7 years ago on graduation day", "url": url_a},
+            {
+                "text": "Bob\n\nBuilding a company is almost inhuman and hard",
+                "url": url_b,
+            },
+        ]
+
+    def test_unmatched_post_gets_no_url(self):
+        text = "Feed post\n\nSuggested promo with no permalink"
+        posts = _build_feed_posts(text, [])
+        assert posts == [{"text": "Suggested promo with no permalink"}]
+
+    def test_drops_preamble_before_first_marker(self):
+        text = "site chrome\nmore chrome\nFeed post\n\nreal post body here"
+        posts = _build_feed_posts(text, [])
+        assert posts == [{"text": "real post body here"}]
+
+    def test_empty_text_yields_no_posts(self):
+        assert _build_feed_posts("", ["u1"]) == []
+
+    def test_urls_without_matching_post_are_dropped(self):
+        text = "Feed post\n\nHello world from the only post"
+        url = "https://www.linkedin.com/posts/alice_hello-world-from-the-only-post-ugcPost-1-xx"
+        extra = "https://www.linkedin.com/posts/unrelated-slug-that-matches-nothing-ugcPost-2-yy"
+        posts = _build_feed_posts(text, [extra, url])
+        assert posts == [
+            {"text": "Hello world from the only post", "url": url}
+        ]
+
+    def test_punctuation_differences_dont_block_match(self):
+        text = "Feed post\n\nLet's go, Paul! 15M from Benchmark."
+        url = "https://www.linkedin.com/posts/guillaumerx21_lets-go-paul-15m-from-benchmark-share-1-xx"
+        posts = _build_feed_posts(text, [url])
+        assert posts == [
+            {"text": "Let's go, Paul! 15M from Benchmark.", "url": url}
+        ]
+
+    def test_malformed_slug_url_is_ignored(self):
+        text = "Feed post\n\nSome post"
+        posts = _build_feed_posts(text, ["https://example.com/not-a-slug-url"])
+        assert posts == [{"text": "Some post"}]
+
+    def test_unicode_bold_post_body_matches_plain_slug(self):
+        # LinkedIn posts styled with mathematical-bold Unicode (U+1D400 block)
+        # should still match their plain-text slug after NFKC normalization.
+        text = "Feed post\n\n𝐈 𝐠𝐨𝐭 𝐟𝐢𝐫𝐞𝐝 𝐟𝐫𝐨𝐦 𝐦𝐲 𝐣𝐨𝐛 because I was bad"
+        url = "https://www.linkedin.com/posts/louis_i-got-fired-from-my-job-because-i-was-bad-share-1-xx"
+        posts = _build_feed_posts(text, [url])
+        assert posts == [{"text": text.split("\n\n", 1)[1], "url": url}]

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3412,7 +3412,10 @@ class TestBuildFeedPosts:
         url_b = "https://www.linkedin.com/posts/building-a-company-is-almost-inhuman-and-ugcPost-2-yy"
         posts = _build_feed_posts(text, [url_b, url_a])
         assert posts == [
-            {"text": "Alice\n\nMe and Charles, 7 years ago on graduation day", "url": url_a},
+            {
+                "text": "Alice\n\nMe and Charles, 7 years ago on graduation day",
+                "url": url_a,
+            },
             {
                 "text": "Bob\n\nBuilding a company is almost inhuman and hard",
                 "url": url_b,
@@ -3437,17 +3440,13 @@ class TestBuildFeedPosts:
         url = "https://www.linkedin.com/posts/alice_hello-world-from-the-only-post-ugcPost-1-xx"
         extra = "https://www.linkedin.com/posts/unrelated-slug-that-matches-nothing-ugcPost-2-yy"
         posts = _build_feed_posts(text, [extra, url])
-        assert posts == [
-            {"text": "Hello world from the only post", "url": url}
-        ]
+        assert posts == [{"text": "Hello world from the only post", "url": url}]
 
     def test_punctuation_differences_dont_block_match(self):
         text = "Feed post\n\nLet's go, Paul! 15M from Benchmark."
         url = "https://www.linkedin.com/posts/guillaumerx21_lets-go-paul-15m-from-benchmark-share-1-xx"
         posts = _build_feed_posts(text, [url])
-        assert posts == [
-            {"text": "Let's go, Paul! 15M from Benchmark.", "url": url}
-        ]
+        assert posts == [{"text": "Let's go, Paul! 15M from Benchmark.", "url": url}]
 
     def test_malformed_slug_url_is_ignored(self):
         text = "Feed post\n\nSome post"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -757,6 +757,32 @@ class TestFeedTools:
         assert result["url"] == "https://www.linkedin.com/feed/"
         assert "feed" in result["sections"]
         assert result["sections"]["feed"] == "Post 1\nPost 2"
+        assert "posts" not in result
+
+    async def test_get_feed_includes_posts(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_feed = AsyncMock(
+            return_value=ExtractedSection(
+                text="Feed post\n\nhello\n\nFeed post\n\nworld",
+                references=[],
+                posts=[
+                    {"text": "hello", "url": "https://www.linkedin.com/posts/a_hello-ugcPost-1-xx"},
+                    {"text": "world"},
+                ],
+            )
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_feed")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert result["posts"] == [
+            {"text": "hello", "url": "https://www.linkedin.com/posts/a_hello-ugcPost-1-xx"},
+            {"text": "world"},
+        ]
 
     async def test_get_feed_omits_rate_limited_sentinel(self, mock_context):
         mock_extractor = MagicMock()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -36,9 +36,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
     )
-    mock.extract_feed = AsyncMock(
-        return_value=ExtractedSection(text="", references=[])
-    )
+    mock.extract_feed = AsyncMock(return_value=ExtractedSection(text="", references=[]))
     return mock
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -766,7 +766,10 @@ class TestFeedTools:
                 text="Feed post\n\nhello\n\nFeed post\n\nworld",
                 references=[],
                 posts=[
-                    {"text": "hello", "url": "https://www.linkedin.com/posts/a_hello-ugcPost-1-xx"},
+                    {
+                        "text": "hello",
+                        "url": "https://www.linkedin.com/posts/a_hello-ugcPost-1-xx",
+                    },
                     {"text": "world"},
                 ],
             )
@@ -780,7 +783,10 @@ class TestFeedTools:
         tool_fn = await get_tool_fn(mcp, "get_feed")
         result = await tool_fn(mock_context, extractor=mock_extractor)
         assert result["posts"] == [
-            {"text": "hello", "url": "https://www.linkedin.com/posts/a_hello-ugcPost-1-xx"},
+            {
+                "text": "hello",
+                "url": "https://www.linkedin.com/posts/a_hello-ugcPost-1-xx",
+            },
             {"text": "world"},
         ]
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -739,6 +739,79 @@ class TestMessagingTools:
             )
 
 
+class TestFeedTools:
+    async def test_get_feed_success(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_feed = AsyncMock(
+            return_value=ExtractedSection(text="Post 1\nPost 2", references=[])
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_feed")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert result["url"] == "https://www.linkedin.com/feed/"
+        assert "feed" in result["sections"]
+        assert result["sections"]["feed"] == "Post 1\nPost 2"
+
+    async def test_get_feed_omits_rate_limited_sentinel(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_feed = AsyncMock(
+            return_value=ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_feed")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert result["sections"] == {}
+
+    async def test_get_feed_returns_section_errors(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_feed = AsyncMock(
+            return_value=ExtractedSection(
+                text="",
+                references=[],
+                error={"issue_template_path": "/tmp/feed-issue.md"},
+            )
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_feed")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert result["sections"] == {}
+        assert "feed" in result["section_errors"]
+
+    async def test_get_feed_clamps_num_posts(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_feed = AsyncMock(
+            return_value=ExtractedSection(text="Feed content", references=[])
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_feed")
+        await tool_fn(mock_context, num_posts=100, extractor=mock_extractor)
+        mock_extractor.extract_feed.assert_called_once_with(num_posts=50)
+
+        mock_extractor.extract_feed.reset_mock()
+        await tool_fn(mock_context, num_posts=0, extractor=mock_extractor)
+        mock_extractor.extract_feed.assert_called_once_with(num_posts=1)
+
+
 class TestToolTimeouts:
     async def test_all_tools_have_global_timeout(self):
         from linkedin_mcp_server.constants import TOOL_TIMEOUT_SECONDS
@@ -759,6 +832,7 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "get_feed",
             "close_session",
         )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -36,6 +36,9 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
     )
+    mock.extract_feed = AsyncMock(
+        return_value=ExtractedSection(text="", references=[])
+    )
     return mock
 
 


### PR DESCRIPTION
## Summary

- Adds a new `get_feed` MCP tool that scrapes the authenticated user's LinkedIn home feed with a configurable post count (1–50)
- Implements count-based scrolling using `mouse.wheel` events (LinkedIn's feed uses its own scroll container where `window.scrollTo` has no effect)
- Expands truncated "… more" buttons via JS click to capture full post text
- Includes 4 unit tests covering success, rate-limit filtering, error propagation, and input clamping

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run ty check` — passes
- [x] `uv run pytest` — 393 tests pass
- [x] Manual end-to-end test with live LinkedIn session (`num_posts=10`, `num_posts=20`)

Closes #373