### PR TITLE
docs(readme): sync tool status issue links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | Tool | Description | Status |
 |------|-------------|--------|
 | `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
-| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#304](https://github.com/stickerdaniel/linkedin-mcp-server/issues/304) [#365](https://github.com/stickerdaniel/linkedin-mcp-server/issues/365) |
+| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#365](https://github.com/stickerdaniel/linkedin-mcp-server/issues/365) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | [#307](https://github.com/stickerdaniel/linkedin-mcp-server/issues/307) |


### PR DESCRIPTION
Closes #376

## Summary
- remove the stale closed `#304` reference from the README tool status table
- keep `connect_with_person` linked only to the still-open tool issue `#365`
- leave broader runtime issues out of the per-tool status table

## Testing
- docs-only change
- pre-commit hooks passed during commit

## Synthetic prompt

> Sync the README Features & Tool Status table with the current open GitHub issues. If a tool row links a closed issue, verify the mismatch and remove the stale link so only still-open tool-specific limiting issues remain. Open a documentation issue for the mismatch and make the README change close it on merge.

Generated with GPT-5 Codex