### PR TITLE
docs(readme): drop closed #304 status link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | Tool | Description | Status |
 |------|-------------|--------|
 | `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
-| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#304](https://github.com/stickerdaniel/linkedin-mcp-server/issues/304) [#365](https://github.com/stickerdaniel/linkedin-mcp-server/issues/365) |
+| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#365](https://github.com/stickerdaniel/linkedin-mcp-server/issues/365) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | [#307](https://github.com/stickerdaniel/linkedin-mcp-server/issues/307) |


### PR DESCRIPTION
Fixes #381

## Summary

The Features & Tool Status table in `README.md` still listed two issue links for `connect_with_person`: `#304` and `#365`. `#304` is closed, so this removes the stale link and leaves only the still-open tool-specific issue `#365`.

## Synthetic prompt

> Sync the README Features & Tool Status table with the current open GitHub issues. If a tool row still links a closed issue, verify that the underlying tool issue was resolved and remove the stale link so only active tool-specific limiting issues remain. Open a documentation issue for the mismatch and reference it from the PR so it closes on merge.

Generated with GPT-5 Codex

## Testing

- README status row verified against the current open issue list
- docs-only change; no code paths or tests affected
