### PR TITLE
fix: send_message fails with message_unavailable on modern LinkedIn UI

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -96,8 +96,12 @@ _MESSAGING_COMPOSE_SELECTOR = (
 )
 _MESSAGING_COMPOSE_FALLBACK_SELECTORS = (
     _MESSAGING_COMPOSE_SELECTOR,
+    'div[role="textbox"][contenteditable="true"]',  # overlay outside main, any language
     'main div[role="textbox"][contenteditable="true"]',
     'main [contenteditable="true"][aria-label*="message"]',
+    '[contenteditable="true"][aria-label*="message"]',
+    '[contenteditable="true"][aria-label*="messaggio"]',
+    '[contenteditable="true"][aria-label*="scrivi"]',
 )
 _MESSAGING_ENABLED_SEND_SELECTOR = (
     'button[type="submit"]:not([disabled]), '
@@ -1360,9 +1364,15 @@ class LinkedInExtractor:
         }
 
     async def _resolve_message_compose_href(self) -> str | None:
-        """Return the direct recipient-specific compose URL from a profile page."""
-        href = await self._page.evaluate(
-            """(selector) => {
+        """Return the direct recipient-specific compose URL from a profile page.
+
+        First tries to find an anchor tag with a /messaging/compose/ href.
+        Falls back to locating the Message button (which LinkedIn may render as
+        a <button> with no href in newer UI versions) and extracting the profile
+        URN from data attributes, ancestor elements, or embedded page scripts.
+        """
+        result = await self._page.evaluate(
+            """(anchorSelector) => {
                 const isVisible = element =>
                     !!(
                         element &&
@@ -1371,17 +1381,82 @@ class LinkedInExtractor:
                             element.getClientRects().length)
                     );
 
+                // Original approach: anchor tag with /messaging/compose/ href
                 const anchor = Array.from(
-                    document.querySelectorAll(selector)
+                    document.querySelectorAll(anchorSelector)
                 ).find(isVisible);
-                if (!anchor) return null;
-                return anchor.getAttribute('href') || anchor.href || null;
+                if (anchor) {
+                    const href = anchor.getAttribute('href') || anchor.href || null;
+                    if (href) return { type: 'href', value: href };
+                }
+
+                // Fallback: find the Message button by text or aria-label.
+                // LinkedIn's newer UI renders it as a <button> (no href).
+                const msgEl = Array.from(
+                    document.querySelectorAll('main a, main button')
+                ).find(el => {
+                    if (!isVisible(el)) return false;
+                    const label = (el.getAttribute('aria-label') || '').toLowerCase();
+                    const text = (el.innerText || el.textContent || '').trim().toLowerCase();
+                    return (
+                        label.includes('message') ||
+                        text === 'message' ||
+                        text === 'messaggio' ||
+                        text === 'nachr' ||
+                        text === 'mensaje'
+                    );
+                });
+                if (!msgEl) return null;
+
+                // If the button is actually an anchor with a non-compose href, use it.
+                const btnHref = msgEl.getAttribute('href') || '';
+                if (btnHref && !btnHref.startsWith('#') && btnHref !== 'javascript:void(0)') {
+                    return { type: 'href', value: btnHref };
+                }
+
+                // Try to extract the profile URN (ACoAA... format) from
+                // data attributes on the button or its ancestors.
+                const URN_RE = /ACoAA[A-Za-z0-9_-]{5,}/;
+                let el = msgEl;
+                for (let depth = 0; depth < 6 && el; depth++, el = el.parentElement) {
+                    for (const attr of Array.from(el.attributes)) {
+                        const m = (attr.value || '').match(URN_RE);
+                        if (m) return { type: 'urn', value: m[0] };
+                    }
+                }
+
+                // Last resort: scan inline scripts for the fsd_profile URN pattern.
+                for (const script of Array.from(document.querySelectorAll('script:not([src])'))) {
+                    const m = (script.textContent || '').match(/"fsd_profile:([A-Za-z0-9_-]{20,})"/);
+                    if (m) return { type: 'urn', value: m[1] };
+                }
+
+                return null;
             }""",
             _MESSAGING_COMPOSE_LINK_SELECTOR,
         )
-        if not isinstance(href, str) or not href.strip():
+
+        if result is None:
             return None
-        return urljoin("https://www.linkedin.com", href.strip())
+
+        result_type = result.get("type") if isinstance(result, dict) else None
+        result_value = result.get("value", "") if isinstance(result, dict) else ""
+
+        if result_type == "href" and isinstance(result_value, str) and result_value.strip():
+            return urljoin("https://www.linkedin.com", result_value.strip())
+
+        if result_type == "urn" and isinstance(result_value, str) and result_value.strip():
+            urn = result_value.strip()
+            _encoded = quote_plus(f"urn:li:fsd_profile:{urn}")
+            return (
+                f"https://www.linkedin.com/messaging/compose/"
+                f"?profileUrn={_encoded}"
+                f"&recipient={urn}"
+                f"&screenContext=NON_SELF_PROFILE_VIEW"
+                f"&interop=msgOverlay"
+            )
+
+        return None
 
     async def _read_profile_display_name(self) -> str | None:
         """Read the visible profile name from the current person page."""
@@ -2373,6 +2448,43 @@ class LinkedInExtractor:
             references=references,
         )
 
+    async def _click_profile_message_button(self) -> bool:
+        """Find and click the Message button on the current LinkedIn profile page.
+
+        Used as a fallback when the button does not carry a /messaging/compose/
+        href (LinkedIn's newer UI opens a floating overlay instead of navigating).
+        Matches by aria-label or visible button/anchor text across several
+        localisations.
+        """
+        return bool(
+            await self._page.evaluate(
+                """() => {
+                    const isVisible = el =>
+                        !!(el && (el.offsetWidth || el.offsetHeight || el.getClientRects().length));
+                    const normalize = s =>
+                        (s || '').replace(/\s+/g, ' ').trim().toLowerCase();
+                    const btn = Array.from(document.querySelectorAll('a, button')).find(el => {
+                        if (!isVisible(el)) return false;
+                        const label = normalize(el.getAttribute('aria-label') || '');
+                        const text  = normalize(el.innerText || el.textContent || '');
+                        return (
+                            label.includes('message') ||
+                            label.includes('messaggio') ||
+                            label.includes('messaggia') ||
+                            text === 'message' ||
+                            text === 'messaggio' ||
+                            text === 'messaggia' ||
+                            text.startsWith('messaggio') ||
+                            text.startsWith('message')
+                        );
+                    });
+                    if (!btn) return false;
+                    btn.click();
+                    return true;
+                }"""
+            )
+        )
+
     async def send_message(
         self,
         linkedin_username: str,
@@ -2417,22 +2529,38 @@ class LinkedInExtractor:
             )
         else:
             compose_url = await self._resolve_message_compose_href()
-        if not compose_url:
-            return self._message_action_result(
-                profile_url,
-                "message_unavailable",
-                "LinkedIn did not expose a usable Message action for this profile.",
-            )
 
-        await self._navigate_to_page(compose_url)
-        await detect_rate_limit(self._page)
+        if compose_url:
+            await self._navigate_to_page(compose_url)
+            await detect_rate_limit(self._page)
+            try:
+                await self._page.wait_for_selector("main")
+            except PlaywrightTimeoutError:
+                logger.debug("Compose page did not fully load for %s", linkedin_username)
+            await handle_modal_close(self._page)
+        else:
+            # LinkedIn's newer UI opens a floating overlay instead of navigating
+            # to /messaging/compose/. Try clicking the Message button directly.
+            clicked = await self._click_profile_message_button()
+            if not clicked:
+                return self._message_action_result(
+                    profile_url,
+                    "message_unavailable",
+                    "LinkedIn did not expose a usable Message action for this profile.",
+                )
+            # Wait for the compose textbox to appear in the floating overlay
+            # rather than using a fixed sleep — the overlay loads asynchronously.
+            try:
+                await self._page.wait_for_selector(
+                    'div[role="textbox"][contenteditable="true"]',
+                    timeout=8000,
+                )
+            except PlaywrightTimeoutError:
+                logger.debug(
+                    "Compose box did not appear after clicking message button for %s",
+                    linkedin_username,
+                )
 
-        try:
-            await self._page.wait_for_selector("main")
-        except PlaywrightTimeoutError:
-            logger.debug("Compose page did not fully load for %s", linkedin_username)
-
-        await handle_modal_close(self._page)
         message_surface = await self._wait_for_message_surface()
         logger.debug(
             "Message surface for %s before hydration was %s",


### PR DESCRIPTION
## Problem

`send_message` was returning `message_unavailable` for 1st-degree connections because the code assumed LinkedIn renders the Message button as an `<a href="/messaging/compose/...">` anchor tag. LinkedIn's current UI renders it as a `<button>` that opens a floating chat overlay via JavaScript — no href, no page navigation.

This caused three cascading failures:

1. `_resolve_message_compose_href` found no anchor → returned `None` → immediate bail-out
2. Even if the button had been clicked, the code checked for the compose textbox immediately (no wait), so it would miss the asynchronously rendered overlay
3. The compose box selectors were restricted to `main` and to the English `aria-label="Write a message"`, but the floating overlay sits outside `main` and uses localised labels (e.g. `"Scrivi un messaggio"` in Italian)

## Fix

**`_resolve_message_compose_href`** — extended with a fallback that searches for the Message button by `aria-label` or visible text (multilingual), then tries to extract the profile URN from data attributes or inline scripts to construct the compose URL directly.

**`_click_profile_message_button`** (new method) — clicks the Message button when no compose URL can be derived, triggering LinkedIn's overlay natively.

**`send_message`** — when `_resolve_message_compose_href` returns `None`, instead of bailing out immediately, calls `_click_profile_message_button` and then waits up to 8 seconds for the compose textbox to appear via `wait_for_selector`.

**`_MESSAGING_COMPOSE_FALLBACK_SELECTORS`** — added selectors that work outside `main` and cover localised `aria-label` values (`messaggio`, `scrivi`).

## Test

Verified on a real 1st-degree connection profile with LinkedIn UI set to Italian. `send_message` now returns `status: "sent"`.

## Note

This fix was implemented with [Claude Code](https://claude.ai/code) using **Claude Sonnet 4.6** (`claude-sonnet-4-6`) by Anthropic. The model analysed the server logs, debug screenshots, and source code to identify the root cause and iterate on the fix until the message was successfully delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)