### PR TITLE
fix: recover from browser context crash without server restart

### DIFF
--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -8,10 +8,20 @@ import time
 
 import mcp.types as mt
 
+from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 
 logger = logging.getLogger(__name__)
+
+# Patchright/Playwright error message emitted when the browser context dies.
+# Matched as a substring so it works across Playwright versions and transports.
+_BROWSER_CONTEXT_CLOSED = "Target page, context or browser has been closed"
+
+
+def _is_browser_context_closed(exc: Exception) -> bool:
+    """Return True if *exc* indicates the Patchright browser context has died."""
+    return _BROWSER_CONTEXT_CLOSED in str(exc)
 
 
 class SequentialToolExecutionMiddleware(Middleware):
@@ -63,6 +73,30 @@ class SequentialToolExecutionMiddleware(Middleware):
             hold_started = time.perf_counter()
             try:
                 return await call_next(context)
+            except Exception as exc:
+                if _is_browser_context_closed(exc):
+                    # The Patchright browser context died mid-operation.
+                    # Reset the browser singleton so the next tool call gets a
+                    # fresh context (cookies are safe on disk — no re-login needed).
+                    logger.warning(
+                        "Browser context closed during tool '%s' — resetting for next call",
+                        tool_name,
+                    )
+                    try:
+                        # Lazy import avoids a circular dependency at module load time.
+                        from linkedin_mcp_server.drivers.browser import close_browser
+                        await close_browser()
+                    except Exception:
+                        logger.debug(
+                            "close_browser() failed during crash recovery",
+                            exc_info=True,
+                        )
+                    raise ToolError(
+                        "The browser context crashed mid-operation. "
+                        "The browser has been reset — please retry this tool. "
+                        "Your LinkedIn session is still active."
+                    ) from exc
+                raise
             finally:
                 hold_seconds = time.perf_counter() - hold_started
                 logger.debug(


### PR DESCRIPTION
## Problem

When the Patchright browser context dies mid-operation, the MCP HTTP server
stays alive but every subsequent tool call fails with:

```
TargetClosedError: Page.evaluate: Target page, context or browser has been closed
```

Because the `_browser` singleton is still set (to the dead context), 
`get_or_create_browser()` keeps returning it. The server appears healthy to 
external monitors (HTTP 200) but cannot actually perform any LinkedIn operations. 
The only recovery is a manual process restart.

## Root cause

`SequentialToolExecutionMiddleware.on_call_tool()` is the single chokepoint for 
all tool calls, but it has no handling for browser-level errors — only a `finally` 
block for timing. `TargetClosedError` is also absent from `error_handler.py`.

## Fix

In `on_call_tool()`:

1. Detect `TargetClosedError` (matched by the Playwright error message substring, 
   which is stable across versions).
2. Call `close_browser()` to reset the `_browser` singleton to `None`.
3. Raise a `ToolError` with a clear "please retry" message.

On the next tool call, `get_or_create_browser()` finds `_browser is None` and 
reinitializes from the persistent on-disk profile — **no LinkedIn re-login 
required**, since cookies are stored in the profile directory.

## Behaviour after this fix

| Scenario | Before | After |
|----------|--------|-------|
| Browser context crashes | All subsequent calls fail forever | Crashing call returns "please retry"; next call succeeds |
| Time to recover | Manual restart required | ~5–10s (browser cold-start from cached profile) |
| LinkedIn session | Unaffected | Unaffected (cookies on disk) |

## Test

```python
# Simulate a TargetClosedError in a tool call and verify:
# 1. close_browser() is called (browser singleton reset to None)
# 2. A ToolError with the expected message is raised
# 3. A subsequent call to get_or_create_browser() succeeds
```

Tested manually: caused a browser context crash (via `close_session` tool 
mid-operation), confirmed the next tool call recovered automatically.