### PR TITLE
fix: use ty-native ignore syntax for add_cookies

### DIFF
--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -345,7 +345,9 @@ class BrowserManager:
                 logger.warning("No li_at cookie found in %s", path)
                 return False
 
-            await self._context.add_cookies(cookies)  # type: ignore[arg-type]
+            await self._context.add_cookies(
+                cookies  # ty: ignore[invalid-argument-type]
+            )
             logger.info(
                 "Imported %d LinkedIn bridge cookies from %s (preset=%s, li_at=%s): %s",
                 len(cookies),


### PR DESCRIPTION
## Summary

Replace `# type: ignore[arg-type]` (mypy syntax) with `# ty: ignore[invalid-argument-type]` (ty-native syntax) on the single suppression in `core/browser.py`. The mypy-style comment was inert under ty.

## Why

The pending lockfile maintenance PR (#227) bumps `ty` to 0.0.33, which adds stricter checks. With the mypy-style `# type: ignore[arg-type]` comment that ty doesn't honor, ty 0.0.33 flags the `BrowserContext.add_cookies(cookies)` call as a `dict[str, Any]` vs `Sequence[SetCookieParam]` mismatch, breaking `lint-and-check`.

The mismatch is intentional and runtime-safe: `cookies` is a hand-built list of dicts loaded from JSON, and patchright validates the shape at runtime. Only the suppression syntax needs updating.

## Test plan

- [x] Reproduced the failure: `uvx --from 'ty==0.0.33' ty check linkedin_mcp_server/core/browser.py` → `error[invalid-argument-type]` before the fix.
- [x] Verified silent after fix on ty 0.0.33.
- [x] Verified ty 0.0.20 (currently pinned in main) still passes after fix — backwards-compatible with the current lock.
- [x] Full pytest passes locally on Python 3.13.13 — 389 passed in 5.11s.
- [x] `pre-commit run` passes (ruff, ruff-format, ty all green).
- [ ] CI green on this PR.
- [ ] After merge, re-rebase #227 — its lint-and-check should pass.