### PR TITLE
fix(connect): detect state via DOM anchors and verify after action

### DIFF
--- a/linkedin_mcp_server/scraping/connection.py
+++ b/linkedin_mcp_server/scraping/connection.py
@@ -1,13 +1,21 @@
-"""Connection state detection from scraped LinkedIn profile text.
+"""Connection state detection from structural DOM signals.
 
-Parses the action area of a profile page (buttons near the top) to
-determine the relationship state.  The browser locale is forced to
-en-US so button text is always English.
+LinkedIn translates every visible label, but the URLs it links to do not
+get translated. The action area at the top of a profile page exposes the
+relationship state through anchor hrefs: a Connect button is always an
+``<a href="/preload/custom-invite/?vanityName=...">``; the Message button
+on a 1st-degree connection is always ``<a href="/messaging/compose/...">``.
+Editing your own profile exposes ``<a href=".../edit/intro/">``.
+
+These hrefs work as language-independent signals. Text-based fallbacks
+remain available for the niche states (Pending and incoming requests)
+where no anchor reliably exposes the state.
 """
 
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import Literal
 
 ConnectionState = Literal[
@@ -16,54 +24,90 @@ ConnectionState = Literal[
     "incoming_request",
     "connectable",
     "follow_only",
+    "self_profile",
     "unavailable",
 ]
 
-# Button text to click for each actionable state (en-US locale)
-STATE_BUTTON_MAP: dict[ConnectionState, str] = {
-    "connectable": "Connect",
-    "incoming_request": "Accept",
-}
 
-# Markers that end the action area (section headings after the buttons)
+@dataclass(frozen=True)
+class ActionSignals:
+    """Structural signals read from the profile action area.
+
+    Each flag corresponds to the presence of a specific anchor href in the
+    top of the page. None of them depend on visible text, so detection works
+    in any locale.
+    """
+
+    has_invite_anchor: bool
+    has_compose_anchor: bool
+    has_edit_intro_anchor: bool
+
+
+def detect_connection_state(
+    profile_text: str,
+    signals: ActionSignals | None = None,
+) -> ConnectionState:
+    """Determine the relationship state for a profile.
+
+    Structural signals (URL hrefs) take priority. Text fallbacks only handle
+    the rare states (Pending, incoming requests) that are not exposed via a
+    distinctive anchor. The text checks remain English-only and can be
+    extended without changing the structural happy path.
+    """
+    if signals is not None:
+        if signals.has_edit_intro_anchor:
+            return "self_profile"
+        if signals.has_invite_anchor:
+            return "connectable"
+
+    # Text fallbacks for states without a unique anchor href
+    if _has_incoming_request_text(profile_text):
+        return "incoming_request"
+    if _has_pending_text(profile_text):
+        return "pending"
+
+    if signals is not None and signals.has_compose_anchor:
+        return "already_connected"
+
+    if profile_text and "· 1st" in profile_text[:300]:
+        return "already_connected"
+
+    if signals is not None:
+        return "follow_only"
+
+    return _detect_from_text_only(profile_text)
+
+
 _ACTION_AREA_END = re.compile(
     r"^(?:About|Highlights|Featured|Activity|Experience|Education)\n",
     re.MULTILINE,
 )
 
 
-def _extract_action_area(profile_text: str) -> str:
-    """Return the top portion of profile text containing action buttons.
-
-    Cuts off at the first content section heading (About, Highlights, etc.)
-    to avoid matching "Follow" or "Connect" text that appears in sidebar
-    suggestions, interests, or post content.
-    """
+def _action_area(profile_text: str) -> str:
     match = _ACTION_AREA_END.search(profile_text)
     if match:
         return profile_text[: match.start()]
-    # Fallback: use first 500 chars if no section heading found
     return profile_text[:500]
 
 
-def detect_connection_state(profile_text: str) -> ConnectionState:
-    """Detect the connection relationship from scraped profile text.
+def _has_pending_text(profile_text: str) -> bool:
+    area = _action_area(profile_text)
+    return "\nPending\n" in area or area.endswith("\nPending")
 
-    Checks the degree indicator and action button labels that appear
-    as standalone lines in the profile action area.
-    """
-    # 1st-degree connection indicator appears near the top, before buttons
-    if "\u00b7 1st" in profile_text[:300]:
+
+def _has_incoming_request_text(profile_text: str) -> bool:
+    area = _action_area(profile_text)
+    return "\nAccept\n" in area and "\nIgnore\n" in area
+
+
+def _detect_from_text_only(profile_text: str) -> ConnectionState:
+    """Fallback when DOM signals are unavailable (e.g. unit tests)."""
+    if profile_text and "· 1st" in profile_text[:300]:
         return "already_connected"
-
-    action_area = _extract_action_area(profile_text)
-
-    if "\nPending\n" in action_area or action_area.endswith("\nPending"):
-        return "pending"
-    if "\nAccept\n" in action_area and "\nIgnore\n" in action_area:
-        return "incoming_request"
-    if "\nConnect\n" in action_area or action_area.endswith("\nConnect"):
+    area = _action_area(profile_text)
+    if "\nConnect\n" in area or area.endswith("\nConnect"):
         return "connectable"
-    if "\nFollow\n" in action_area or action_area.endswith("\nFollow"):
+    if "\nFollow\n" in area or area.endswith("\nFollow"):
         return "follow_only"
     return "unavailable"

--- a/linkedin_mcp_server/scraping/connection.py
+++ b/linkedin_mcp_server/scraping/connection.py
@@ -72,9 +72,9 @@ def detect_connection_state(
     if profile_text and "· 1st" in profile_text[:300]:
         return "already_connected"
 
-    if signals is not None:
-        return "follow_only"
-
+    # No structural or text marker matched. Fall back to text-only inspection
+    # so an unmatched profile can resolve to follow_only or unavailable based
+    # on the action area instead of being silently lumped into follow_only.
     return _detect_from_text_only(profile_text)
 
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -29,6 +29,7 @@ from linkedin_mcp_server.core.utils import (
     scroll_job_sidebar,
     scroll_to_bottom,
 )
+from linkedin_mcp_server.scraping.connection import ActionSignals
 from linkedin_mcp_server.scraping.link_metadata import (
     Reference,
     build_references,
@@ -983,6 +984,95 @@ class LinkedInExtractor:
 
         return result
 
+    async def _read_action_signals(self) -> ActionSignals:
+        """Read structural anchor signals from the top of the profile page.
+
+        LinkedIn translates labels but not URLs, so the action area's hrefs
+        are the only locale-independent signal of relationship state.
+        """
+        data = await self._page.evaluate(
+            """() => {
+                const main = document.querySelector('main');
+                if (!main) return null;
+                const links = Array.from(main.querySelectorAll('a[href]')).filter(
+                    (a) => {
+                        const r = a.getBoundingClientRect();
+                        return r.top < 600 && r.width > 20 && r.height > 12;
+                    }
+                );
+                const hrefs = links.map((a) => a.getAttribute('href') || '');
+                return {
+                    hasInvite: hrefs.some(
+                        (h) => h.includes('/preload/custom-invite/')
+                    ),
+                    hasCompose: hrefs.some(
+                        (h) => h.includes('/messaging/compose/')
+                    ),
+                    hasEditIntro: hrefs.some(
+                        (h) => h.includes('/edit/intro/')
+                    ),
+                };
+            }"""
+        )
+        if not isinstance(data, dict):
+            return ActionSignals(False, False, False)
+        return ActionSignals(
+            has_invite_anchor=bool(data.get("hasInvite")),
+            has_compose_anchor=bool(data.get("hasCompose")),
+            has_edit_intro_anchor=bool(data.get("hasEditIntro")),
+        )
+
+    async def _submit_invite_dialog(self, note: str | None) -> tuple[bool, bool]:
+        """Submit the invite dialog opened by the custom-invite deeplink.
+
+        Returns (submitted, note_sent). All interaction uses structural
+        selectors and positional indexing — no localized text matching.
+        """
+        if not await self._dialog_is_open(timeout=5000):
+            return False, False
+
+        note_sent = False
+        if note:
+            textarea_count = await self._page.locator(_DIALOG_TEXTAREA_SELECTOR).count()
+            if textarea_count == 0:
+                # Reveal the note textarea via the secondary action.
+                buttons = self._page.locator(
+                    f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
+                )
+                btn_count = await buttons.count()
+                if btn_count >= 2:
+                    await buttons.nth(btn_count - 2).click()
+                    try:
+                        await self._page.wait_for_selector(
+                            _DIALOG_TEXTAREA_SELECTOR,
+                            state="visible",
+                            timeout=3000,
+                        )
+                    except PlaywrightTimeoutError:
+                        logger.debug("Note textarea did not appear")
+
+            note_sent = await self._fill_dialog_textarea(note)
+            if not note_sent:
+                await self._dismiss_dialog()
+                return False, False
+
+        sent = await self._click_dialog_primary_button()
+        if not sent:
+            # Fallback: keyboard submit (Enter focuses primary in Send w/o
+            # note; Cmd+Enter submits form when note textarea is focused).
+            await self._page.keyboard.press("Enter")
+            sent = not await self._dialog_is_open(timeout=2000)
+
+        if sent:
+            try:
+                await self._page.wait_for_selector(
+                    _DIALOG_SELECTOR, state="hidden", timeout=5000
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Invite dialog did not close after submit")
+
+        return sent, note_sent
+
     async def connect_with_person(
         self,
         username: str,
@@ -991,18 +1081,18 @@ class LinkedInExtractor:
     ) -> dict[str, Any]:
         """Send a LinkedIn connection request or accept an incoming one.
 
-        Scrapes the profile page, parses the action area text to detect
-        the connection state, then clicks the appropriate button.  Dialog
-        interaction uses structural CSS selectors — no hardcoded button text.
+        Detection uses structural anchor hrefs read from the top-card area
+        (Connect, Message, Edit). Sending uses LinkedIn's
+        ``/preload/custom-invite/`` deeplink so no Connect button click is
+        required. The dialog is submitted via positional button indexing.
+        Success is only reported once a fresh re-read of the profile no
+        longer exposes a Connect anchor (or shows a 1st-degree marker for
+        accepted requests).
         """
-        from linkedin_mcp_server.scraping.connection import (
-            STATE_BUTTON_MAP,
-            detect_connection_state,
-        )
+        from linkedin_mcp_server.scraping.connection import detect_connection_state
 
         url = f"https://www.linkedin.com/in/{username}/"
 
-        # Scrape the profile to get the page text
         profile = await self.scrape_person(username, {"main_profile"})
         page_text = profile.get("sections", {}).get("main_profile", "")
         if not page_text:
@@ -1010,10 +1100,19 @@ class LinkedInExtractor:
                 url, "unavailable", "Could not read profile page."
             )
 
-        # Detect state from the scraped text
-        state = detect_connection_state(page_text)
-        logger.info("Connection state for %s: %s", username, state)
+        signals = await self._read_action_signals()
+        state = detect_connection_state(page_text, signals)
+        logger.info(
+            "Connection signals for %s: state=%s signals=%s", username, state, signals
+        )
 
+        if state == "self_profile":
+            return _connection_result(
+                url,
+                "connect_unavailable",
+                "Cannot send a connection request to your own profile.",
+                profile=page_text,
+            )
         if state == "already_connected":
             return _connection_result(
                 url,
@@ -1028,21 +1127,38 @@ class LinkedInExtractor:
                 "A connection request is already pending for this profile.",
                 profile=page_text,
             )
-        via_more_menu = False
-        if state == "follow_only":
-            # Connect may be hidden behind the More (three-dot) menu
-            if await self._open_more_menu():
-                state = "connectable"
-                via_more_menu = True
-            else:
+
+        if state == "incoming_request":
+            # Accept is rendered inline on the profile (no modal). The
+            # button text is locale-dependent but no anchor exposes the
+            # accept action; we accept this English-only fallback.
+            clicked = await self.click_button_by_text("Accept", scope="main")
+            if not clicked:
                 return _connection_result(
                     url,
-                    "follow_only",
-                    "This profile currently exposes Follow but not Connect.",
+                    "send_failed",
+                    "Could not find or click the Accept button.",
                     profile=page_text,
                 )
+            verified = await self.scrape_person(username, {"main_profile"})
+            verified_text = verified.get("sections", {}).get("main_profile", "")
+            verified_signals = await self._read_action_signals()
+            verified_state = detect_connection_state(verified_text, verified_signals)
+            if verified_state != "already_connected":
+                return _connection_result(
+                    url,
+                    "send_failed",
+                    "Accepted, but the profile did not transition to 1st-degree.",
+                    profile=verified_text or page_text,
+                )
+            return _connection_result(
+                url,
+                "accepted",
+                "Connection request accepted.",
+                profile=verified_text,
+            )
 
-        if state == "unavailable":
+        if state not in {"connectable", "follow_only"}:
             return _connection_result(
                 url,
                 "connect_unavailable",
@@ -1050,116 +1166,45 @@ class LinkedInExtractor:
                 profile=page_text,
             )
 
-        # state is "connectable" or "incoming_request"
-        button_text = STATE_BUTTON_MAP.get(state)
-        if not button_text:
+        # Connectable / follow_only: drive the invite via the deeplink.
+        # The deeplink works regardless of whether the visible button is
+        # behind the More menu or hidden by an intermediate UI state.
+        invite_url = (
+            f"https://www.linkedin.com/in/{quote_plus(username)}/preload/custom-invite/"
+        )
+        await self._navigate_to_page(invite_url)
+
+        submitted, note_sent = await self._submit_invite_dialog(note)
+        if not submitted:
+            await self._dismiss_dialog()
             return _connection_result(
                 url,
                 "connect_unavailable",
-                f"No button mapping for state '{state}'.",
+                "LinkedIn did not open a usable invite dialog for this profile.",
+                profile=page_text,
             )
 
-        # Click the button (page is already loaded from scrape_person)
-        click_scope = "[role='menu']" if via_more_menu else "main"
-        clicked = await self.click_button_by_text(button_text, scope=click_scope)
-        if not clicked:
+        verified = await self.scrape_person(username, {"main_profile"})
+        verified_text = verified.get("sections", {}).get("main_profile", "")
+        verified_signals = await self._read_action_signals()
+        verified_state = detect_connection_state(verified_text, verified_signals)
+
+        if verified_signals.has_invite_anchor:
             return _connection_result(
                 url,
                 "send_failed",
-                f"Could not find or click button '{button_text}'.",
+                "Submitted the invite dialog but the profile still exposes Connect.",
+                note_sent=note_sent,
+                profile=verified_text or page_text,
             )
 
-        # ---- Handle dialog (structural selectors only) ----
-        # Only wait for a dialog when sending a Connect request (Accept
-        # typically completes immediately without a dialog).
-        #
-        # LinkedIn's invitation modal uses role="dialog" on the inner
-        # container, so _DIALOG_SELECTOR matches it.  The modal typically
-        # has three buttons: [0] dismiss/X, [1] secondary, [2] primary.
-        # All interaction uses structural/positional selectors only.
-        note_sent = False
-
-        if state == "connectable":
-            try:
-                await self._page.wait_for_selector(
-                    _DIALOG_SELECTOR, state="visible", timeout=5000
-                )
-            except PlaywrightTimeoutError:
-                logger.debug("No dialog appeared after clicking '%s'", button_text)
-
-            if await self._dialog_is_open(timeout=3000):
-                # Locate all buttons inside the dialog.  We address
-                # action buttons from the end so the dismiss button
-                # position doesn't matter.
-                dialog_buttons = self._page.locator(
-                    f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
-                )
-                btn_count = await dialog_buttons.count()
-
-                if note and btn_count > 2:
-                    # Click the second-to-last button (secondary action) to
-                    # reveal the note textarea, then fill and send.
-                    await dialog_buttons.nth(btn_count - 2).click()
-                    # Wait for the textarea to render
-                    try:
-                        await self._page.wait_for_selector(
-                            _DIALOG_TEXTAREA_SELECTOR,
-                            state="visible",
-                            timeout=3000,
-                        )
-                    except PlaywrightTimeoutError:
-                        logger.debug("Textarea did not appear after note button")
-
-                    filled = await self._fill_dialog_textarea(note)
-                    if filled:
-                        note_sent = True
-                    else:
-                        await self._dismiss_dialog()
-                        return _connection_result(
-                            url,
-                            "note_not_supported",
-                            "LinkedIn did not offer note entry for this connection flow.",
-                        )
-                elif note:
-                    # Modal present but no secondary button — note not
-                    # supported in this connection flow.
-                    await self._dismiss_dialog()
-                    return _connection_result(
-                        url,
-                        "note_not_supported",
-                        "LinkedIn did not offer note entry for this connection flow.",
-                    )
-
-                # Click the primary (last) button to send.
-                # Re-query buttons as the modal content may have changed.
-                sent = await self._click_dialog_primary_button()
-                if not sent:
-                    await self._dismiss_dialog()
-                    return _connection_result(
-                        url,
-                        "send_failed",
-                        "Could not find the send button in the dialog.",
-                    )
-                # Wait for dialog to close
-                try:
-                    await self._page.wait_for_selector(
-                        _DIALOG_SELECTOR, state="hidden", timeout=5000
-                    )
-                except PlaywrightTimeoutError:
-                    logger.debug("Dialog did not close after clicking send")
-
-        # Read the current page text (already on the profile after the action)
-        updated_text = await self.get_page_text()
-
-        status = "accepted" if state == "incoming_request" else "connected"
         return _connection_result(
             url,
-            status,
+            "connected",
             "Connection request sent."
-            if status == "connected"
-            else "Connection request accepted.",
+            + (f" State after send: {verified_state}." if verified_state else ""),
             note_sent=note_sent,
-            profile=updated_text,
+            profile=verified_text or page_text,
         )
 
     async def _extract_profile_urn(self) -> str | None:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1167,10 +1167,12 @@ class LinkedInExtractor:
             )
 
         # Connectable / follow_only: drive the invite via the deeplink.
-        # The deeplink works regardless of whether the visible button is
-        # behind the More menu or hidden by an intermediate UI state.
+        # The URL pattern matches LinkedIn's own Connect anchor href, so it
+        # works regardless of locale or whether the visible button is behind
+        # the More menu.
         invite_url = (
-            f"https://www.linkedin.com/in/{quote_plus(username)}/preload/custom-invite/"
+            "https://www.linkedin.com/preload/custom-invite/"
+            f"?vanityName={quote_plus(username)}"
         )
         await self._navigate_to_page(invite_url)
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -499,6 +499,8 @@ class LinkedInExtractor:
         """Click the last (primary/Send) button in the open dialog.
 
         LinkedIn consistently places the primary action as the last button.
+        Returns False (rather than raising) when the click is intercepted or
+        times out, so callers can fall back to a keyboard submit.
         """
         buttons = self._page.locator(
             f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
@@ -506,8 +508,12 @@ class LinkedInExtractor:
         count = await buttons.count()
         if count == 0:
             return False
-        await buttons.nth(count - 1).click(timeout=timeout)
-        return True
+        try:
+            await buttons.nth(count - 1).click(timeout=timeout)
+            return True
+        except Exception:
+            logger.debug("Primary dialog button click failed", exc_info=True)
+            return False
 
     async def _fill_dialog_textarea(self, value: str, *, timeout: int = 5000) -> bool:
         """Fill the first textarea inside the open dialog (structural)."""

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1027,6 +1027,8 @@ class LinkedInExtractor:
 
         Returns (submitted, note_sent). All interaction uses structural
         selectors and positional indexing — no localized text matching.
+        Owns dialog cleanup: the dialog is dismissed on every failure path,
+        callers must not dismiss again.
         """
         if not await self._dialog_is_open(timeout=5000):
             return False, False
@@ -1035,12 +1037,15 @@ class LinkedInExtractor:
         if note:
             textarea_count = await self._page.locator(_DIALOG_TEXTAREA_SELECTOR).count()
             if textarea_count == 0:
-                # Reveal the note textarea via the secondary action.
+                # Reveal the note textarea via the secondary action. The note
+                # layout exposes three buttons (dismiss, secondary, primary);
+                # require all three before clicking the second-to-last so we
+                # never click dismiss on a no-note layout.
                 buttons = self._page.locator(
                     f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
                 )
                 btn_count = await buttons.count()
-                if btn_count >= 2:
+                if btn_count >= 3:
                     await buttons.nth(btn_count - 2).click()
                     try:
                         await self._page.wait_for_selector(
@@ -1058,20 +1063,32 @@ class LinkedInExtractor:
 
         sent = await self._click_dialog_primary_button()
         if not sent:
-            # Fallback: keyboard submit (Enter focuses primary in Send w/o
-            # note; Cmd+Enter submits form when note textarea is focused).
-            await self._page.keyboard.press("Enter")
-            sent = not await self._dialog_is_open(timeout=2000)
+            # Fallback: focus the primary button positionally so a subsequent
+            # Enter targets it instead of a focused textarea (where Enter
+            # would just insert a newline).
+            buttons = self._page.locator(
+                f"{_DIALOG_SELECTOR} button, {_DIALOG_SELECTOR} [role='button']"
+            )
+            btn_count = await buttons.count()
+            if btn_count > 0:
+                try:
+                    await buttons.nth(btn_count - 1).focus()
+                    await self._page.keyboard.press("Enter")
+                    sent = not await self._dialog_is_open(timeout=2000)
+                except Exception:
+                    logger.debug("Keyboard submit fallback failed", exc_info=True)
+            if not sent:
+                await self._dismiss_dialog()
+                return False, note_sent
 
-        if sent:
-            try:
-                await self._page.wait_for_selector(
-                    _DIALOG_SELECTOR, state="hidden", timeout=5000
-                )
-            except PlaywrightTimeoutError:
-                logger.debug("Invite dialog did not close after submit")
+        try:
+            await self._page.wait_for_selector(
+                _DIALOG_SELECTOR, state="hidden", timeout=5000
+            )
+        except PlaywrightTimeoutError:
+            logger.debug("Invite dialog did not close after submit")
 
-        return sent, note_sent
+        return True, note_sent
 
     async def connect_with_person(
         self,
@@ -1178,7 +1195,6 @@ class LinkedInExtractor:
 
         submitted, note_sent = await self._submit_invite_dialog(note)
         if not submitted:
-            await self._dismiss_dialog()
             return _connection_result(
                 url,
                 "connect_unavailable",

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -10,7 +10,8 @@ from linkedin_mcp_server.core.exceptions import (
     LinkedInScraperException,
 )
 from linkedin_mcp_server.scraping.connection import (
-    _extract_action_area,
+    ActionSignals,
+    _action_area,
     detect_connection_state,
 )
 from linkedin_mcp_server.scraping.extractor import (
@@ -878,28 +879,124 @@ class TestDetectConnectionState:
 
     def test_action_area_cuts_at_about(self):
         text = "Name\n\nConnect\nMore\nAbout\n\nFollow\nConnect"
-        area = _extract_action_area(text)
+        area = _action_area(text)
         assert "About" not in area
         assert "Follow" not in area
 
     def test_action_area_cuts_at_highlights(self):
         text = "Name\n\nMessage\nPending\nMore\nHighlights\n\nFollow"
-        area = _extract_action_area(text)
+        area = _action_area(text)
         assert "Follow" not in area
         assert "Pending" in area
 
 
 class TestConnectWithPerson:
-    def _mock_scrape(self, profile_text: str) -> AsyncMock:
-        """Return a mock for scrape_person that returns the given text."""
-        return AsyncMock(
-            return_value={
-                "url": "https://www.linkedin.com/in/testuser/",
-                "sections": {"main_profile": profile_text},
-            }
+    def _mock_scrape(
+        self, profile_text: str, *, follow_up_text: str | None = None
+    ) -> AsyncMock:
+        """Return a mock for scrape_person.
+
+        When ``follow_up_text`` is given, the second call returns that text
+        — used to simulate verification re-reads after an action.
+        """
+        first = {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "sections": {"main_profile": profile_text},
+        }
+        if follow_up_text is None:
+            return AsyncMock(return_value=first)
+        second = {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "sections": {"main_profile": follow_up_text},
+        }
+        return AsyncMock(side_effect=[first, second])
+
+    @staticmethod
+    def _signals(
+        invite: bool = False, compose: bool = False, edit: bool = False
+    ) -> ActionSignals:
+        return ActionSignals(
+            has_invite_anchor=invite,
+            has_compose_anchor=compose,
+            has_edit_intro_anchor=edit,
         )
 
-    async def test_connectable_clicks_connect(self, mock_page):
+    async def test_connectable_navigates_deeplink_and_verifies(self, mock_page):
+        """Connect via deeplink: dialog opens, submit succeeds, anchor disappears."""
+        extractor = LinkedInExtractor(mock_page)
+        text = "Jane\n\n· 3rd\n\nEngineer\n\nConnect\nMore\nAbout\n"
+        post_text = "Jane\n\n· 3rd\n\nEngineer\n\nMessage\nPending\nMore\nAbout\n"
+
+        with (
+            patch.object(
+                extractor,
+                "scrape_person",
+                self._mock_scrape(text, follow_up_text=post_text),
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                side_effect=[self._signals(invite=True), self._signals()],
+            ),
+            patch.object(
+                extractor,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+            ) as mock_nav,
+            patch.object(
+                extractor,
+                "_dialog_is_open",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                extractor,
+                "_click_dialog_primary_button",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+        assert result["status"] == "connected"
+        mock_nav.assert_awaited_once()
+        await_args = mock_nav.await_args
+        assert await_args is not None
+        assert "preload/custom-invite" in await_args.args[0]
+
+    async def test_connectable_send_failed_when_anchor_persists(self, mock_page):
+        """Dialog submitted but profile still exposes Connect → send_failed."""
+        extractor = LinkedInExtractor(mock_page)
+        text = "Jane\n\n· 3rd\n\nEngineer\n\nConnect\nMore\nAbout\n"
+
+        with (
+            patch.object(
+                extractor, "scrape_person", self._mock_scrape(text, follow_up_text=text)
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                side_effect=[self._signals(invite=True), self._signals(invite=True)],
+            ),
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_dialog_is_open", new_callable=AsyncMock, return_value=True
+            ),
+            patch.object(
+                extractor,
+                "_click_dialog_primary_button",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+        assert result["status"] == "send_failed"
+
+    async def test_connectable_no_dialog_returns_connect_unavailable(self, mock_page):
+        """Deeplink opened but no dialog appeared → connect_unavailable."""
         extractor = LinkedInExtractor(mock_page)
         text = "Jane\n\n· 3rd\n\nEngineer\n\nConnect\nMore\nAbout\n"
 
@@ -907,99 +1004,154 @@ class TestConnectWithPerson:
             patch.object(extractor, "scrape_person", self._mock_scrape(text)),
             patch.object(
                 extractor,
-                "click_button_by_text",
+                "_read_action_signals",
                 new_callable=AsyncMock,
-                return_value=True,
-            ) as mock_click,
+                return_value=self._signals(invite=True),
+            ),
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_dialog_is_open", new_callable=AsyncMock, return_value=False
+            ),
+            patch.object(extractor, "_dismiss_dialog", new_callable=AsyncMock),
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+        assert result["status"] == "connect_unavailable"
+
+    async def test_returns_already_connected_via_anchor(self, mock_page):
+        """1st-degree detected via /messaging/compose anchor."""
+        extractor = LinkedInExtractor(mock_page)
+        text = "Collin\n\n· 1st\n\nEngineer\n\nMessage\nMore\nAbout\n"
+
+        with (
+            patch.object(extractor, "scrape_person", self._mock_scrape(text)),
             patch.object(
                 extractor,
-                "_dialog_is_open",
+                "_read_action_signals",
                 new_callable=AsyncMock,
-                return_value=False,
+                return_value=self._signals(compose=True),
             ),
         ):
             result = await extractor.connect_with_person("testuser")
 
-        assert result["status"] == "connected"
-        assert result["url"] == "https://www.linkedin.com/in/testuser/"
-        mock_click.assert_awaited_once_with("Connect", scope="main")
+        assert result["status"] == "already_connected"
 
-    async def test_returns_already_connected(self, mock_page):
+    async def test_returns_self_profile_via_edit_intro_anchor(self, mock_page):
+        """Editing-your-own-profile anchor blocks connect attempts."""
         extractor = LinkedInExtractor(mock_page)
-        text = "Collin\n\n· 1st\n\nEngineer\n\nMessage\nMore\nAbout\n"
+        text = "Daniel\n\nEdit profile\n"
 
-        with patch.object(extractor, "scrape_person", self._mock_scrape(text)):
+        with (
+            patch.object(extractor, "scrape_person", self._mock_scrape(text)),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                return_value=self._signals(edit=True),
+            ),
+        ):
             result = await extractor.connect_with_person("testuser")
 
-        assert result["status"] == "already_connected"
+        assert result["status"] == "connect_unavailable"
+        assert "own profile" in result["message"]
 
     async def test_returns_pending(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         text = "Marinus\n\n· 2nd\n\nStudent\n\nMessage\nPending\nMore\nAbout\n"
 
-        with patch.object(extractor, "scrape_person", self._mock_scrape(text)):
+        with (
+            patch.object(extractor, "scrape_person", self._mock_scrape(text)),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                return_value=self._signals(),
+            ),
+        ):
             result = await extractor.connect_with_person("testuser")
 
         assert result["status"] == "pending"
 
     async def test_returns_incoming_request_accepted(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        text = "Aklasur\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore\nAbout\n"
+        pre = "Aklasur\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore\nAbout\n"
+        post = "Aklasur\n\n· 1st\n\nDhaka\n\nMessage\nMore\nAbout\n"
 
         with (
-            patch.object(extractor, "scrape_person", self._mock_scrape(text)),
+            patch.object(
+                extractor,
+                "scrape_person",
+                self._mock_scrape(pre, follow_up_text=post),
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                side_effect=[self._signals(), self._signals(compose=True)],
+            ),
             patch.object(
                 extractor,
                 "click_button_by_text",
                 new_callable=AsyncMock,
                 return_value=True,
             ) as mock_click,
-            patch.object(
-                extractor,
-                "_dialog_is_open",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
         ):
             result = await extractor.connect_with_person("testuser")
 
         assert result["status"] == "accepted"
         mock_click.assert_awaited_once_with("Accept", scope="main")
 
-    async def test_returns_follow_only(self, mock_page):
+    async def test_incoming_request_send_failed_when_no_first_degree(self, mock_page):
+        """Accept clicked but profile never transitions to 1st-degree."""
         extractor = LinkedInExtractor(mock_page)
-        text = "Public Figure\n\n· 3rd+\n\nCEO\n\nFollow\nMore\nAbout\n"
-
-        with patch.object(extractor, "scrape_person", self._mock_scrape(text)):
-            result = await extractor.connect_with_person("testuser")
-
-        assert result["status"] == "follow_only"
-
-    async def test_returns_unavailable(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        text = "Unknown\n\nSome text\nAbout\n"
-
-        with patch.object(extractor, "scrape_person", self._mock_scrape(text)):
-            result = await extractor.connect_with_person("testuser")
-
-        assert result["status"] == "connect_unavailable"
-
-    async def test_returns_send_failed_when_button_not_found(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        text = "Jane\n\n· 3rd\n\nEngineer\n\nConnect\nMore\nAbout\n"
+        pre = "Aklasur\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore\nAbout\n"
 
         with (
-            patch.object(extractor, "scrape_person", self._mock_scrape(text)),
+            patch.object(
+                extractor,
+                "scrape_person",
+                self._mock_scrape(pre, follow_up_text=pre),
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                side_effect=[self._signals(), self._signals()],
+            ),
             patch.object(
                 extractor,
                 "click_button_by_text",
                 new_callable=AsyncMock,
-                return_value=False,
+                return_value=True,
             ),
         ):
             result = await extractor.connect_with_person("testuser")
 
         assert result["status"] == "send_failed"
+
+    async def test_returns_unavailable_when_no_signals_and_text(self, mock_page):
+        """No structural signals, no actionable text → connect_unavailable."""
+        extractor = LinkedInExtractor(mock_page)
+        text = "Public Figure\n\n· 3rd+\n\nCEO\n\nFollow\nMore\nAbout\n"
+
+        with (
+            patch.object(extractor, "scrape_person", self._mock_scrape(text)),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                return_value=self._signals(),
+            ),
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_dialog_is_open", new_callable=AsyncMock, return_value=False
+            ),
+            patch.object(extractor, "_dismiss_dialog", new_callable=AsyncMock),
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+        # follow_only path goes through deeplink; no dialog opens → unavailable
+        assert result["status"] == "connect_unavailable"
 
     async def test_returns_unavailable_on_empty_page(self, mock_page):
         extractor = LinkedInExtractor(mock_page)


### PR DESCRIPTION
## Summary

Replaces the optimistic, English-only `connect_with_person` flow with a
language-agnostic detection + verification pipeline.

## What changed

- **Detection**: `_read_action_signals()` reads anchor hrefs from the top-card
  area instead of parsing translated button text. The three structural
  signals are `/preload/custom-invite/` (connectable), `/messaging/compose/`
  (1st-degree), and `/edit/intro/` (self-profile).
- **Sending**: navigate to LinkedIn's `/preload/custom-invite/` deeplink
  rather than click a Connect button — works regardless of locale or whether
  the button is hidden behind the More menu.
- **Submission**: positional last-button indexing in the modal; falls back to
  pressing Enter if the click is intercepted. No localized text matching.
- **Verification**: after submit, re-scrape the profile and confirm the
  Connect anchor disappeared (or 1st-degree marker appeared for accept).
- **Self-profile guard**: detected via `/edit/intro/` anchor, returns
  `connect_unavailable` instead of attempting to invite yourself.

Pending and incoming-request states keep their existing English text
fallback — no unique anchor exposes them.

## Validation

- `uv run pytest` — 391 passed, including 9 new connect-flow tests covering
  the deeplink path, anchor-based already-connected detection, self-profile
  detection, accept verification, and three send-failed paths.
- Live LinkedIn via streamable-http MCP server (valid session):
  - `connect_with_person(stickerdaniel)` → `connect_unavailable` /
    "Cannot send a connection request to your own profile" (via edit anchor).
  - `connect_with_person(david-beumers)` → `already_connected` (via compose
    anchor — profile is in German, detection still works).
  - `connect_with_person(marinus-prey-33079a392)` → `pending` (via fallback
    text after no-anchor signal).
  - `get_person_profile(stickerdaniel)` → unchanged, scraping unaffected.

The connectable→deeplink→submit path is unit-tested but not exercised live
against a third party (would send a real invite).

Resolves #365.