### PR TITLE
docs(readme): sync connect tool status issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | Tool | Description | Status |
 |------|-------------|--------|
 | `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
-| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#365](https://github.com/stickerdaniel/linkedin-mcp-server/issues/365) |
+| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#392](https://github.com/stickerdaniel/linkedin-mcp-server/issues/392) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | [#307](https://github.com/stickerdaniel/linkedin-mcp-server/issues/307) |


### PR DESCRIPTION
Closes #399

## Summary
- replace the stale `connect_with_person` status link from closed issue `#365`
- point the README tool-status table at the current open tool-specific issue `#392`
- leave the existing `get_conversation` issue reference `#307` unchanged

## Testing
- not run (README-only change)

## Synthetic prompt

> Check the README Features & Tool Status table against live open issues, and if a tool-specific status entry is stale, update only that row to reference the current open issue instead of a closed one.

Generated with GPT-5 Codex