### PR TITLE
docs(readme): mark connect tool working

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | Tool | Description | Status |
 |------|-------------|--------|
 | `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
-| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#392](https://github.com/stickerdaniel/linkedin-mcp-server/issues/392) |
+| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | working |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | [#307](https://github.com/stickerdaniel/linkedin-mcp-server/issues/307) |


### PR DESCRIPTION
## Summary

- update README Features & Tool Status so `connect_with_person` no longer links closed issue #392
- keep `get_conversation` linked to the still-open tool-specific issue #307

Closes #401

## Validation

- pre-commit during `git commit` passed visible checks for trailing whitespace, EOF, YAML, large files, merge conflicts, and skipped non-applicable Python checks
- not run: full test suite, documentation-only status table change

## Synthetic prompt

> Sync the README Features & Tool Status table with current GitHub issues by marking `connect_with_person` as working because its linked issue #392 is closed as fixed, while leaving still-open tool-specific issue #307 linked for `get_conversation`. File a docs issue for the mismatch and close it from the PR.

Generated with GPT-5 Codex
