### PR TITLE
feat(page): add linkedin page fetch tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | `search_jobs` | Search for jobs with keywords and location filters | working |
 | `search_people` | Search for people by keywords and location | working |
 | `get_job_details` | Get detailed information about a specific job posting | working |
+| `get_linkedin_page` | Get raw text from supported LinkedIn public pages like schools, newsletters, articles, feed posts, events, groups, services, products, and showcase pages | working |
 | `close_session` | Close browser session and clean up resources | working |
 
 <br/>
@@ -422,7 +423,7 @@ uv run -m linkedin_mcp_server --transport streamable-http --host 127.0.0.1 --por
 **Python/Patchright issues:**
 
 - Check Python version: `python --version` (should be 3.12+)
-- Reinstall Patchright: `uv run patchright install chromium`
+- Reinstall Patchright: `uv run python -m patchright install chromium`
 - Reinstall dependencies: `uv sync --reinstall`
 
 **Timeout issues:**

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -12,6 +12,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **People Search**: Search for people by keywords and location
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed
+- **Public Page Fetch**: Read supported LinkedIn pages such as schools, newsletters, articles, feed posts, events, groups, services, products, and showcase pages
 - **Compact References**: Return typed per-section links alongside readable text without shipping full-page markdown
 
 ## Quick Start

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -6,7 +6,8 @@ person profiles, company data, job information, and session management capabilit
 """
 
 import logging
-from typing import Any, AsyncIterator
+from collections.abc import AsyncIterator
+from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.server.lifespan import lifespan
@@ -25,6 +26,7 @@ from linkedin_mcp_server.sequential_tool_middleware import (
 from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.job import register_job_tools
 from linkedin_mcp_server.tools.messaging import register_messaging_tools
+from linkedin_mcp_server.tools.page import register_page_tools
 from linkedin_mcp_server.tools.person import register_person_tools
 
 logger = logging.getLogger(__name__)
@@ -60,6 +62,7 @@ def create_mcp_server() -> FastMCP:
     register_company_tools(mcp)
     register_job_tools(mcp)
     register_messaging_tools(mcp)
+    register_page_tools(mcp)
 
     # Register session management tool
     @mcp.tool(

--- a/linkedin_mcp_server/tools/page.py
+++ b/linkedin_mcp_server/tools/page.py
@@ -1,0 +1,148 @@
+"""LinkedIn page scraping tool for supported public routes outside core tools."""
+
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+from fastmcp import Context, FastMCP
+
+from linkedin_mcp_server.constants import TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.core.exceptions import AuthenticationError
+from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
+from linkedin_mcp_server.error_handler import raise_tool_error
+from linkedin_mcp_server.exceptions import LinkedInMCPError
+from linkedin_mcp_server.scraping.extractor import _RATE_LIMITED_MSG, ExtractedSection
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_ROUTE_FAMILIES = (
+    "/school/",
+    "/showcase/",
+    "/newsletters/",
+    "/pulse/",
+    "/feed/update/",
+    "/events/",
+    "/groups",
+    "/services",
+    "/products",
+)
+
+
+def _matches_supported_route(path: str) -> bool:
+    """Return True when the path matches one of the supported route families."""
+    for prefix in _SUPPORTED_ROUTE_FAMILIES:
+        if prefix.endswith("/"):
+            if path.startswith(prefix):
+                return True
+            continue
+        if path == prefix or path.startswith(f"{prefix}/"):
+            return True
+    return False
+
+
+def normalize_linkedin_page_url(linkedin_url: str) -> str:
+    """Normalize a supported LinkedIn URL or relative path into a full URL."""
+    raw = linkedin_url.strip()
+    if not raw:
+        raise LinkedInMCPError("LinkedIn URL is required.")
+
+    candidate = raw
+    if "://" not in candidate:
+        candidate = (
+            f"https://www.linkedin.com{candidate}"
+            if candidate.startswith("/")
+            else f"https://www.linkedin.com/{candidate}"
+        )
+
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"http", "https"}:
+        raise LinkedInMCPError("LinkedIn URL must use http or https.")
+
+    if parsed.netloc.lower() not in {"linkedin.com", "www.linkedin.com"}:
+        raise LinkedInMCPError("LinkedIn URL must point to linkedin.com.")
+
+    path = parsed.path or "/"
+    if not _matches_supported_route(path):
+        supported = ", ".join(_SUPPORTED_ROUTE_FAMILIES)
+        raise LinkedInMCPError(
+            f"Unsupported LinkedIn page URL. Supported route families: {supported}"
+        )
+
+    query = f"?{parsed.query}" if parsed.query else ""
+    return f"https://www.linkedin.com{path}{query}"
+
+
+def _build_page_result(url: str, extracted: ExtractedSection) -> dict[str, Any]:
+    """Build the MCP response payload for a single generic page scrape."""
+    sections: dict[str, str] = {}
+    references: dict[str, list[Any]] = {}
+    section_errors: dict[str, dict[str, Any]] = {}
+
+    if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+        sections["page"] = extracted.text
+        if extracted.references:
+            references["page"] = extracted.references
+    elif extracted.error:
+        section_errors["page"] = extracted.error
+
+    result: dict[str, Any] = {
+        "url": url,
+        "sections": sections,
+    }
+    if references:
+        result["references"] = references
+    if section_errors:
+        result["section_errors"] = section_errors
+    return result
+
+
+def register_page_tools(mcp: FastMCP) -> None:
+    """Register LinkedIn page tools with the MCP server."""
+
+    @mcp.tool(
+        timeout=TOOL_TIMEOUT_SECONDS,
+        title="Get LinkedIn Page",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"page", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_linkedin_page(
+        linkedin_url: str,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get a LinkedIn page from a supported public route family not covered by the
+        person/company/job tools.
+
+        Args:
+            linkedin_url: Full LinkedIn URL or relative LinkedIn path.
+                Supported route families: /school/, /showcase/, /newsletters/,
+                /pulse/, /feed/update/, /events/, /groups, /services, /products
+
+        Returns:
+            Dict with url, sections (page -> raw text), and optional references.
+        """
+        try:
+            url = normalize_linkedin_page_url(linkedin_url)
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_linkedin_page"
+            )
+
+            logger.info("Scraping LinkedIn page: %s", url)
+            await ctx.report_progress(
+                progress=0, total=100, message="Starting LinkedIn page scrape"
+            )
+
+            extracted = await extractor.extract_page(url, section_name="page")
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+            return _build_page_result(url, extracted)
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_linkedin_page")
+        except Exception as e:
+            raise_tool_error(e, "get_linkedin_page")  # NoReturn

--- a/manifest.json
+++ b/manifest.json
@@ -78,6 +78,10 @@
       "description": "Search for people on LinkedIn by keywords and location"
     },
     {
+      "name": "get_linkedin_page",
+      "description": "Fetch supported LinkedIn public pages such as schools, newsletters, articles, feed posts, events, groups, services, products, and showcase pages"
+    },
+    {
       "name": "get_inbox",
       "description": "List recent conversations from the LinkedIn messaging inbox"
     },

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -537,6 +537,64 @@ class TestJobTools:
         assert "pages_visited" not in result
 
 
+class TestPageTools:
+    async def test_get_linkedin_page(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_page = AsyncMock(
+            return_value=ExtractedSection(text="A LinkedIn article", references=[])
+        )
+
+        from linkedin_mcp_server.tools.page import register_page_tools
+
+        mcp = FastMCP("test")
+        register_page_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_linkedin_page")
+        result = await tool_fn("/pulse/test-post/", mock_context, extractor=mock_extractor)
+        assert result["url"] == "https://www.linkedin.com/pulse/test-post/"
+        assert result["sections"] == {"page": "A LinkedIn article"}
+        mock_extractor.extract_page.assert_awaited_once_with(
+            "https://www.linkedin.com/pulse/test-post/",
+            section_name="page",
+        )
+
+    async def test_get_linkedin_page_rejects_unsupported_routes(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.page import register_page_tools
+
+        mcp = FastMCP("test")
+        register_page_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_linkedin_page")
+        with pytest.raises(ToolError, match="Unsupported LinkedIn page URL"):
+            await tool_fn("https://www.linkedin.com/company/testcorp/", mock_context)
+
+    async def test_get_linkedin_page_returns_section_errors(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_page = AsyncMock(
+            return_value=ExtractedSection(
+                text="",
+                references=[],
+                error={"issue_template_path": "page-issue.md"},
+            )
+        )
+
+        from linkedin_mcp_server.tools.page import register_page_tools
+
+        mcp = FastMCP("test")
+        register_page_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_linkedin_page")
+        result = await tool_fn(
+            "/school/harvard-university/",
+            mock_context,
+            extractor=mock_extractor,
+        )
+        assert result["sections"] == {}
+        assert result["section_errors"]["page"]["issue_template_path"] == "page-issue.md"
+
+
 class TestGetSidebarProfilesTool:
     async def test_get_sidebar_profiles_success(self, mock_context):
         expected = {
@@ -755,6 +813,7 @@ class TestToolTimeouts:
             "get_company_posts",
             "get_job_details",
             "search_jobs",
+            "get_linkedin_page",
             "get_inbox",
             "get_conversation",
             "search_conversations",


### PR DESCRIPTION
## Summary
- add `get_linkedin_page` for supported public LinkedIn routes outside the existing person/company/job tools
- register the tool in the FastMCP server and document it in the README, Docker Hub docs, and MCP bundle manifest
- add focused tests for supported/unsupported page handling and timeout registration

## Notes
- I audited the two fork-only commits from `origin/main`.
- This PR ports the `feat(page): add linkedin page fetch tool` change onto current `upstream/main`.
- The older `fix(auth): pin browser fingerprint across login and server sessions` fork commit was not replayed directly because current upstream has already evolved the auth/session architecture independently and the raw cherry-pick produced broad conflicts across core runtime files.

## Validation
- `uv run pytest tests/test_tools.py tests/test_server.py`
- `uv run ruff check linkedin_mcp_server/server.py linkedin_mcp_server/tools/page.py`

Generated with GPT-5 Codex.
Prompt: "origin/main has 2 commits not in upstream that i want synced mand merged"