### PR TITLE
fix(bootstrap): self-heal patchright Chromium across upgrades

### DIFF
--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from enum import Enum
+import importlib.metadata
 import json
 import logging
 import os
@@ -41,6 +42,17 @@ logger = logging.getLogger(__name__)
 _BROWSER_DIR = "patchright-browsers"
 _BROWSER_INSTALL_METADATA = "browser-install.json"
 _INVALID_STATE_PREFIX = "invalid-state-"
+_INSTALL_METADATA_SCHEMA = 2
+
+# Registry browser names mapped to on-disk dir prefixes for the binaries this
+# server actually launches. ffmpeg/firefox/webkit are excluded — ffmpeg is only
+# used for video recording (we don't), and chromium / chromium-headless-shell
+# entries have no revisionOverrides, so we avoid patchright's per-platform
+# special-prefix logic entirely.
+_REGISTRY_NAME_TO_DIR_PREFIX = {
+    "chromium": "chromium-",
+    "chromium-headless-shell": "chromium_headless_shell-",
+}
 
 
 class RuntimePolicy(str, Enum):
@@ -115,10 +127,55 @@ def install_metadata_path() -> Path:
 
 
 def configure_browser_environment() -> Path:
-    """Ensure the shared browser cache path is configured."""
-    browser_dir = browsers_path()
-    os.environ.setdefault("PLAYWRIGHT_BROWSERS_PATH", str(browser_dir))
-    return browser_dir
+    """Ensure the shared browser cache path is configured and return the effective path.
+
+    Honors a pre-set ``PLAYWRIGHT_BROWSERS_PATH`` so install metadata and
+    readiness checks operate on the same path patchright actually uses.
+    """
+    os.environ.setdefault("PLAYWRIGHT_BROWSERS_PATH", str(browsers_path()))
+    return Path(os.environ["PLAYWRIGHT_BROWSERS_PATH"])
+
+
+def _patchright_pkg_version() -> str | None:
+    try:
+        return importlib.metadata.version("patchright")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _patchright_install_targets() -> dict[str, str] | None:
+    """Resolve {dir_prefix: revision} from patchright's bundled browsers.json.
+
+    Reads ``<patchright>/driver/package/browsers.json`` — the authoritative
+    file patchright itself consults to know which revision it expects.
+    Returns ``None`` if the registry can't be read; callers treat ``None``
+    as "not ready" so the next gate triggers reinstall.
+    """
+    try:
+        import patchright
+
+        registry = (
+            Path(patchright.__file__).parent / "driver" / "package" / "browsers.json"
+        )
+        payload = json.loads(registry.read_text())
+    except (ImportError, OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    targets: dict[str, str] = {}
+    for entry in payload.get("browsers", []):
+        if not isinstance(entry, dict) or not entry.get("installByDefault"):
+            continue
+        prefix = _REGISTRY_NAME_TO_DIR_PREFIX.get(entry.get("name"))
+        if prefix is None or entry.get("revision") is None:
+            continue
+        targets[prefix] = str(entry["revision"])
+    return targets or None
+
+
+def _has_install_for(configured: Path, prefix: str, revision: str) -> bool:
+    return (configured / f"{prefix}{revision}" / "INSTALLATION_COMPLETE").is_file()
 
 
 def initialize_bootstrap(runtime_policy: RuntimePolicy | str | None = None) -> None:
@@ -146,29 +203,55 @@ async def start_background_browser_setup_if_needed() -> None:
             _state.setup_state = SetupState.READY
             _state.setup_completed_at = _state.setup_completed_at or utcnow_iso()
             return
+        if _state.setup_state == SetupState.READY:
+            invalidate_browser_setup()
         if _state.setup_task is not None and not _state.setup_task.done():
             return
         _start_browser_setup_task_locked()
 
 
 def browser_setup_ready() -> bool:
+    """Return whether the patchright Chromium install on disk is current.
+
+    Pure: no mutation of metadata or in-memory state. Mutation happens
+    in :func:`invalidate_browser_setup`, called by the gate paths.
+    """
     metadata_path = install_metadata_path()
     configured_browsers_path = Path(
         os.environ.get("PLAYWRIGHT_BROWSERS_PATH", str(browsers_path()))
     )
     if not metadata_path.exists() or not configured_browsers_path.exists():
         return False
-    if not any(configured_browsers_path.iterdir()):
-        return False
     try:
         payload = json.loads(metadata_path.read_text())
     except (OSError, json.JSONDecodeError):
         return False
-    return (
+    if not (
         isinstance(payload, dict)
         and payload.get("browser_name") == "chromium"
         and payload.get("installer_name") == "patchright"
-    )
+        and payload.get("version") == _INSTALL_METADATA_SCHEMA
+    ):
+        return False
+    if payload.get("browsers_path") != str(configured_browsers_path):
+        return False
+    if payload.get("patchright_version") != _patchright_pkg_version():
+        return False
+    targets = _patchright_install_targets()
+    if not targets:
+        return False
+    for prefix, revision in targets.items():
+        if not _has_install_for(configured_browsers_path, prefix, revision):
+            return False
+    return True
+
+
+def invalidate_browser_setup() -> None:
+    """Mark browser setup as not-ready: drop install metadata and reset cached READY state."""
+    install_metadata_path().unlink(missing_ok=True)
+    if _state.setup_state == SetupState.READY:
+        _state.setup_state = SetupState.IDLE
+        _state.setup_completed_at = None
 
 
 def _browser_setup_ready() -> bool:
@@ -208,12 +291,13 @@ async def _run_browser_setup() -> None:
         )
 
     metadata = {
-        "version": 1,
+        "version": _INSTALL_METADATA_SCHEMA,
         "runtime_id": get_runtime_id(),
         "installed_at": utcnow_iso(),
         "browsers_path": str(browser_dir),
         "browser_name": "chromium",
         "installer_name": "patchright",
+        "patchright_version": _patchright_pkg_version(),
     }
     secure_write_text(
         metadata_path, json.dumps(metadata, indent=2, sort_keys=True) + "\n"
@@ -295,6 +379,8 @@ async def ensure_tool_ready_or_raise(
     if _browser_setup_ready():
         _state.setup_state = SetupState.READY
     else:
+        if _state.setup_state == SetupState.READY:
+            invalidate_browser_setup()
         if _state.setup_state in {SetupState.IDLE, SetupState.FAILED} and (
             _state.setup_task is None or _state.setup_task.done()
         ):

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from enum import Enum
+import functools
 import importlib.metadata
 import json
 import logging
@@ -103,6 +104,10 @@ def reset_bootstrap_for_testing() -> None:
     _state = BootstrapState()
     _lock = asyncio.Lock()
     os.environ.pop("PLAYWRIGHT_BROWSERS_PATH", None)
+    # Tolerate monkeypatched stand-ins that lack `cache_clear`.
+    clear = getattr(_patchright_install_targets, "cache_clear", None)
+    if clear is not None:
+        clear()
 
 
 def get_runtime_policy() -> RuntimePolicy:
@@ -131,9 +136,14 @@ def configure_browser_environment() -> Path:
 
     Honors a pre-set ``PLAYWRIGHT_BROWSERS_PATH`` so install metadata and
     readiness checks operate on the same path patchright actually uses.
+    The path is normalized (``~`` expanded, made absolute) and written back
+    to the env var so metadata writes, readiness checks, and patchright
+    subprocesses all agree on the same string.
     """
-    os.environ.setdefault("PLAYWRIGHT_BROWSERS_PATH", str(browsers_path()))
-    return Path(os.environ["PLAYWRIGHT_BROWSERS_PATH"])
+    raw = os.environ.get("PLAYWRIGHT_BROWSERS_PATH") or str(browsers_path())
+    normalized = Path(raw).expanduser().absolute()
+    os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(normalized)
+    return normalized
 
 
 def _patchright_pkg_version() -> str | None:
@@ -143,6 +153,7 @@ def _patchright_pkg_version() -> str | None:
         return None
 
 
+@functools.cache
 def _patchright_install_targets() -> dict[str, str] | None:
     """Resolve {dir_prefix: revision} from patchright's bundled browsers.json.
 
@@ -150,6 +161,10 @@ def _patchright_install_targets() -> dict[str, str] | None:
     file patchright itself consults to know which revision it expects.
     Returns ``None`` if the registry can't be read; callers treat ``None``
     as "not ready" so the next gate triggers reinstall.
+
+    Cached for the process lifetime: the patchright revision only changes on
+    package upgrade, which requires a process restart. Tests reset the cache
+    via ``reset_bootstrap_for_testing()``.
     """
     try:
         import patchright

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -46,7 +46,6 @@ def _is_browser_binary_missing_error(error: Exception) -> bool:
     markers = (
         "executable doesn't exist at",
         "looks like playwright was just installed or updated",
-        "patchright install",
     )
     return any(marker in message for marker in markers)
 

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -10,6 +10,7 @@ from linkedin_mcp_server.bootstrap import (
     ensure_tool_ready_or_raise,
     get_runtime_policy,
     invalidate_auth_and_trigger_relogin,
+    invalidate_browser_setup,
 )
 from linkedin_mcp_server.core.exceptions import AuthenticationError, NetworkError
 from linkedin_mcp_server.drivers.browser import (
@@ -19,6 +20,7 @@ from linkedin_mcp_server.drivers.browser import (
 )
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.exceptions import (
+    BrowserBinaryMissingError,
     DockerHostLoginRequiredError,
     LinuxBrowserDependencyError,
 )
@@ -35,6 +37,16 @@ def _is_linux_browser_dependency_error(error: Exception) -> bool:
         "shared libraries",
         "libnss3",
         "libatk",
+    )
+    return any(marker in message for marker in markers)
+
+
+def _is_browser_binary_missing_error(error: Exception) -> bool:
+    message = str(error).lower()
+    markers = (
+        "executable doesn't exist at",
+        "looks like playwright was just installed or updated",
+        "patchright install",
     )
     return any(marker in message for marker in markers)
 
@@ -77,6 +89,14 @@ async def get_ready_extractor(
     except AuthenticationError as e:
         await handle_auth_error(e, ctx)  # always raises
     except Exception as e:
+        if isinstance(e, NetworkError) and _is_browser_binary_missing_error(e):
+            invalidate_browser_setup()
+            raise_tool_error(
+                BrowserBinaryMissingError(
+                    "Patchright Chromium browser is missing. Run 'uv run patchright install chromium', or restart the server to auto-install."
+                ),
+                tool_name,
+            )
         if isinstance(e, NetworkError) and _is_linux_browser_dependency_error(e):
             raise_tool_error(
                 LinuxBrowserDependencyError(

--- a/linkedin_mcp_server/error_handler.py
+++ b/linkedin_mcp_server/error_handler.py
@@ -25,6 +25,7 @@ from linkedin_mcp_server.exceptions import (
     AuthenticationBootstrapFailedError,
     AuthenticationInProgressError,
     AuthenticationStartedError,
+    BrowserBinaryMissingError,
     BrowserSetupFailedError,
     BrowserSetupInProgressError,
     CredentialsNotFoundError,
@@ -111,6 +112,10 @@ def raise_tool_error(exception: Exception, context: str = "") -> NoReturn:
 
     elif isinstance(exception, LinuxBrowserDependencyError):
         logger.warning("Linux browser dependency missing%s: %s", ctx, exception)
+        raise ToolError(str(exception)) from exception
+
+    elif isinstance(exception, BrowserBinaryMissingError):
+        logger.warning("Browser binary missing%s: %s", ctx, exception)
         raise ToolError(str(exception)) from exception
 
     elif isinstance(exception, SessionExpiredError):

--- a/linkedin_mcp_server/exceptions.py
+++ b/linkedin_mcp_server/exceptions.py
@@ -57,3 +57,7 @@ class DockerHostLoginRequiredError(LinkedInMCPError):
 
 class LinuxBrowserDependencyError(LinkedInMCPError):
     """Linux host dependencies required for Chromium are missing."""
+
+
+class BrowserBinaryMissingError(LinkedInMCPError):
+    """Patchright Chromium binary is absent or stale on disk."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,13 +8,18 @@ import pytest
 from linkedin_mcp_server.bootstrap import (
     AuthState,
     _force_move_auth_state_aside,
+    _has_install_for,
+    _patchright_install_targets,
+    browser_setup_ready,
+    browsers_path,
+    configure_browser_environment,
     ensure_tool_ready_or_raise,
     get_bootstrap_state,
     get_runtime_policy,
     initialize_bootstrap,
     install_metadata_path,
     invalidate_auth_and_trigger_relogin,
-    browsers_path,
+    invalidate_browser_setup,
     reset_bootstrap_for_testing,
     SetupState,
     start_background_browser_setup_if_needed,
@@ -223,3 +229,385 @@ class TestInvalidateAuthAndTriggerRelogin:
         assert not isolate_profile_dir.exists()
         assert not portable_cookie_path(isolate_profile_dir).exists()
         assert not source_state_path(isolate_profile_dir).exists()
+
+
+_DEFAULT_TARGETS = {
+    "chromium-": "1217",
+    "chromium_headless_shell-": "1217",
+}
+_PATCHRIGHT_VERSION = "1.41.0"
+
+
+def _materialize_install(browsers_dir: Path, dirs: list[str]) -> None:
+    browsers_dir.mkdir(parents=True, exist_ok=True)
+    for name in dirs:
+        d = browsers_dir / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "INSTALLATION_COMPLETE").write_text("")
+        (d / "DEPENDENCIES_VALIDATED").write_text("")
+
+
+def _write_metadata(path: Path, browsers_dir: Path, **overrides) -> None:
+    payload = {
+        "version": 2,
+        "runtime_id": "test-runtime",
+        "installed_at": "2026-01-01T00:00:00Z",
+        "browsers_path": str(browsers_dir),
+        "browser_name": "chromium",
+        "installer_name": "patchright",
+        "patchright_version": _PATCHRIGHT_VERSION,
+        **overrides,
+    }
+    path.write_text(json.dumps(payload))
+
+
+def _patch_targets_and_version(
+    monkeypatch, *, targets=_DEFAULT_TARGETS, version=_PATCHRIGHT_VERSION
+):
+    monkeypatch.setattr(
+        "linkedin_mcp_server.bootstrap._patchright_install_targets",
+        lambda: dict(targets) if targets else None,
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.bootstrap._patchright_pkg_version", lambda: version
+    )
+
+
+class TestBrowserSetupReady:
+    def test_false_when_metadata_absent(self, isolate_profile_dir, monkeypatch):
+        _patch_targets_and_version(monkeypatch)
+        assert browser_setup_ready() is False
+
+    def test_false_when_browsers_dir_missing(self, isolate_profile_dir, monkeypatch):
+        _patch_targets_and_version(monkeypatch)
+        meta_dir = browsers_path()
+        _write_metadata(install_metadata_path(), meta_dir)
+        assert browser_setup_ready() is False
+
+    def test_true_with_complete_install(self, isolate_profile_dir, monkeypatch):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium_headless_shell-1217"])
+        _write_metadata(install_metadata_path(), bdir)
+        assert browser_setup_ready() is True
+
+    def test_false_when_marker_missing(self, isolate_profile_dir, monkeypatch):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        bdir.mkdir(parents=True, exist_ok=True)
+        (bdir / "chromium-1217").mkdir()
+        (bdir / "chromium_headless_shell-1217").mkdir()
+        # No INSTALLATION_COMPLETE files
+        _write_metadata(install_metadata_path(), bdir)
+        assert browser_setup_ready() is False
+
+    def test_false_when_required_revision_missing(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1208", "chromium_headless_shell-1208"])
+        _write_metadata(install_metadata_path(), bdir)
+        assert browser_setup_ready() is False
+
+    def test_false_on_pkg_version_mismatch(self, isolate_profile_dir, monkeypatch):
+        _patch_targets_and_version(monkeypatch, version="1.42.0")
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium_headless_shell-1217"])
+        _write_metadata(install_metadata_path(), bdir, patchright_version="1.41.0")
+        assert browser_setup_ready() is False
+
+    def test_false_on_browsers_path_mismatch(
+        self, isolate_profile_dir, monkeypatch, tmp_path
+    ):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium_headless_shell-1217"])
+        _write_metadata(
+            install_metadata_path(), bdir, browsers_path=str(tmp_path / "elsewhere")
+        )
+        assert browser_setup_ready() is False
+
+    def test_false_on_v1_metadata(self, isolate_profile_dir, monkeypatch):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium_headless_shell-1217"])
+        _write_metadata(install_metadata_path(), bdir, version=1)
+        assert browser_setup_ready() is False
+
+    def test_false_on_corrupt_metadata(self, isolate_profile_dir, monkeypatch):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium_headless_shell-1217"])
+        bdir.mkdir(parents=True, exist_ok=True)
+        install_metadata_path().write_text("not json {{{")
+        assert browser_setup_ready() is False
+
+    def test_false_when_registry_unreadable(self, isolate_profile_dir, monkeypatch):
+        _patch_targets_and_version(monkeypatch, targets=None)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium_headless_shell-1217"])
+        _write_metadata(install_metadata_path(), bdir)
+        assert browser_setup_ready() is False
+
+    def test_true_with_stale_old_revision_alongside_current(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """Locks in: stale chromium-1208 doesn't break readiness when current 1217 is also present."""
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(
+            bdir,
+            [
+                "chromium-1208",
+                "chromium-1217",
+                "chromium_headless_shell-1208",
+                "chromium_headless_shell-1217",
+            ],
+        )
+        _write_metadata(install_metadata_path(), bdir)
+        assert browser_setup_ready() is True
+
+    def test_false_when_only_stale_revision_present(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1208", "chromium_headless_shell-1208"])
+        _write_metadata(install_metadata_path(), bdir)
+        assert browser_setup_ready() is False
+
+    def test_true_when_marker_present_but_dir_partially_corrupted(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """Documents the known gap: marker is set, but executable inside dir was deleted.
+
+        Readiness still passes; the runtime catch-site in dependencies.py is
+        the safety net that recovers from the eventual launch failure.
+        """
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium_headless_shell-1217"])
+        # Simulate partial corruption: marker stays, contents wiped.
+        (bdir / "chromium-1217" / "DEPENDENCIES_VALIDATED").unlink()
+        _write_metadata(install_metadata_path(), bdir)
+        assert browser_setup_ready() is True
+
+
+class TestPatchrightInstallTargets:
+    def _stub_registry(self, monkeypatch, payload, tmp_path):
+        registry = tmp_path / "browsers.json"
+        registry.write_text(json.dumps(payload))
+        fake_pkg_dir = tmp_path / "patchright_pkg"
+        (fake_pkg_dir / "driver" / "package").mkdir(parents=True)
+        (fake_pkg_dir / "driver" / "package" / "browsers.json").write_text(
+            json.dumps(payload)
+        )
+        # Make `Path(patchright.__file__).parent` resolve to fake_pkg_dir.
+        fake_module = MagicMock()
+        fake_module.__file__ = str(fake_pkg_dir / "__init__.py")
+        monkeypatch.setitem(__import__("sys").modules, "patchright", fake_module)
+
+    def test_resolves_chromium_pair(self, monkeypatch, tmp_path):
+        self._stub_registry(
+            monkeypatch,
+            {
+                "browsers": [
+                    {
+                        "name": "chromium",
+                        "revision": "1217",
+                        "installByDefault": True,
+                    },
+                    {
+                        "name": "chromium-headless-shell",
+                        "revision": "1217",
+                        "installByDefault": True,
+                    },
+                ]
+            },
+            tmp_path,
+        )
+        assert _patchright_install_targets() == {
+            "chromium-": "1217",
+            "chromium_headless_shell-": "1217",
+        }
+
+    def test_skips_unrelated_browsers(self, monkeypatch, tmp_path):
+        self._stub_registry(
+            monkeypatch,
+            {
+                "browsers": [
+                    {
+                        "name": "chromium",
+                        "revision": "1217",
+                        "installByDefault": True,
+                    },
+                    {
+                        "name": "chromium-headless-shell",
+                        "revision": "1217",
+                        "installByDefault": True,
+                    },
+                    {
+                        "name": "firefox",
+                        "revision": "1465",
+                        "installByDefault": True,
+                    },
+                    {
+                        "name": "webkit",
+                        "revision": "2150",
+                        "installByDefault": True,
+                    },
+                    {
+                        "name": "ffmpeg",
+                        "revision": "1011",
+                        "installByDefault": True,
+                    },
+                    {
+                        "name": "android",
+                        "revision": "1001",
+                        "installByDefault": False,
+                    },
+                ]
+            },
+            tmp_path,
+        )
+        assert _patchright_install_targets() == {
+            "chromium-": "1217",
+            "chromium_headless_shell-": "1217",
+        }
+
+    def test_returns_none_on_non_dict_payload(self, monkeypatch, tmp_path):
+        self._stub_registry(monkeypatch, ["not", "a", "dict"], tmp_path)
+        assert _patchright_install_targets() is None
+
+    def test_returns_none_on_missing_registry(self, monkeypatch, tmp_path):
+        fake_pkg_dir = tmp_path / "patchright_pkg"
+        fake_pkg_dir.mkdir()
+        # No driver/package/browsers.json → OSError
+        fake_module = MagicMock()
+        fake_module.__file__ = str(fake_pkg_dir / "__init__.py")
+        monkeypatch.setitem(__import__("sys").modules, "patchright", fake_module)
+        assert _patchright_install_targets() is None
+
+    def test_skips_install_by_default_false(self, monkeypatch, tmp_path):
+        self._stub_registry(
+            monkeypatch,
+            {
+                "browsers": [
+                    {
+                        "name": "chromium",
+                        "revision": "1217",
+                        "installByDefault": False,
+                    },
+                ]
+            },
+            tmp_path,
+        )
+        assert _patchright_install_targets() is None
+
+
+class TestInvalidateBrowserSetup:
+    def test_drops_metadata_and_resets_ready_state(self, isolate_profile_dir):
+        bdir = browsers_path()
+        bdir.mkdir(parents=True, exist_ok=True)
+        _write_metadata(install_metadata_path(), bdir)
+
+        initialize_bootstrap("managed")
+        state = get_bootstrap_state()
+        state.setup_state = SetupState.READY
+        state.setup_completed_at = "2026-01-01T00:00:00Z"
+
+        invalidate_browser_setup()
+
+        assert not install_metadata_path().exists()
+        assert state.setup_state is SetupState.IDLE
+        assert state.setup_completed_at is None
+
+    @pytest.mark.parametrize(
+        "leave_state",
+        [SetupState.IDLE, SetupState.RUNNING, SetupState.FAILED],
+    )
+    def test_leaves_non_ready_state_alone(self, isolate_profile_dir, leave_state):
+        bdir = browsers_path()
+        bdir.mkdir(parents=True, exist_ok=True)
+        _write_metadata(install_metadata_path(), bdir)
+
+        initialize_bootstrap("managed")
+        state = get_bootstrap_state()
+        state.setup_state = leave_state
+
+        invalidate_browser_setup()
+
+        assert state.setup_state is leave_state
+
+
+class TestEnsureToolReadyInvalidatesStaleReady:
+    async def test_invalidates_when_ready_state_disagrees_with_disk(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        async def fake_setup() -> None:
+            return None
+
+        # Disk says not-ready, in-memory state cached READY.
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap.browser_setup_ready", lambda: False
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._run_browser_setup", fake_setup
+        )
+
+        # Pre-existing stale metadata file the invalidator should drop.
+        bdir = browsers_path()
+        bdir.mkdir(parents=True, exist_ok=True)
+        _write_metadata(install_metadata_path(), bdir)
+
+        initialize_bootstrap("managed")
+        state = get_bootstrap_state()
+        state.setup_state = SetupState.READY
+        state.setup_completed_at = "2026-01-01T00:00:00Z"
+
+        with pytest.raises(BrowserSetupInProgressError):
+            await ensure_tool_ready_or_raise("get_person_profile")
+
+        # Invalidator must have run — metadata gone, state reset, install task spawned.
+        assert not install_metadata_path().exists()
+        assert state.setup_state is SetupState.RUNNING
+        assert state.setup_task is not None
+        await state.setup_task
+
+
+class TestConfigureBrowserEnvironment:
+    def test_honors_existing_env_var(self, isolate_profile_dir, monkeypatch, tmp_path):
+        custom = tmp_path / "shared-cache"
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(custom))
+
+        result = configure_browser_environment()
+
+        assert result == custom
+        assert os.environ["PLAYWRIGHT_BROWSERS_PATH"] == str(custom)
+
+    def test_defaults_when_env_unset(self, isolate_profile_dir, monkeypatch):
+        monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+
+        result = configure_browser_environment()
+
+        assert result == browsers_path()
+        assert os.environ["PLAYWRIGHT_BROWSERS_PATH"] == str(browsers_path())
+
+
+class TestHasInstallFor:
+    def test_true_when_marker_present(self, isolate_profile_dir):
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217"])
+        assert _has_install_for(bdir, "chromium-", "1217") is True
+
+    def test_false_when_dir_missing(self, isolate_profile_dir):
+        bdir = browsers_path()
+        bdir.mkdir(parents=True, exist_ok=True)
+        assert _has_install_for(bdir, "chromium-", "1217") is False
+
+    def test_false_when_marker_missing(self, isolate_profile_dir):
+        bdir = browsers_path()
+        bdir.mkdir(parents=True, exist_ok=True)
+        (bdir / "chromium-1217").mkdir()
+        assert _has_install_for(bdir, "chromium-", "1217") is False

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -594,6 +594,28 @@ class TestConfigureBrowserEnvironment:
         assert result == browsers_path()
         assert os.environ["PLAYWRIGHT_BROWSERS_PATH"] == str(browsers_path())
 
+    def test_expands_tilde_in_env_var(self, isolate_profile_dir, monkeypatch):
+        """A pre-set ``~``-prefixed path is expanded so readiness/metadata stay consistent."""
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "~/some-custom-browsers-cache")
+
+        result = configure_browser_environment()
+
+        assert "~" not in str(result)
+        assert result.is_absolute()
+        assert os.environ["PLAYWRIGHT_BROWSERS_PATH"] == str(result)
+
+    def test_absolutizes_relative_env_var(
+        self, isolate_profile_dir, monkeypatch, tmp_path
+    ):
+        """A relative path env var is made absolute so subsequent readiness checks don't depend on cwd."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "relative-cache")
+
+        result = configure_browser_environment()
+
+        assert result.is_absolute()
+        assert os.environ["PLAYWRIGHT_BROWSERS_PATH"] == str(result)
+
 
 class TestHasInstallFor:
     def test_true_when_marker_present(self, isolate_profile_dir):

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
-from linkedin_mcp_server.core.exceptions import AuthenticationError, RateLimitError
+from linkedin_mcp_server.core.exceptions import (
+    AuthenticationError,
+    NetworkError,
+    RateLimitError,
+)
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.exceptions import (
     AuthenticationStartedError,
@@ -100,6 +104,57 @@ class TestGetReadyExtractor:
                 await get_ready_extractor(ctx=None, tool_name="test_tool")
 
             mock_handle.assert_not_awaited()
+
+    async def test_browser_binary_missing_invalidates_and_raises_actionable(self):
+        """Patchright "Executable doesn't exist" surfaces as actionable BrowserBinaryMissingError, and metadata is dropped."""
+        err = NetworkError(
+            "Failed to start browser: BrowserType.launch_persistent_context: "
+            "Executable doesn't exist at /tmp/foo/chrome-headless-shell. "
+            "Looks like Playwright was just installed or updated. "
+            "Please run the following command to download new browsers: patchright install"
+        )
+        with (
+            patch(
+                "linkedin_mcp_server.dependencies.ensure_tool_ready_or_raise",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.get_or_create_browser",
+                new_callable=AsyncMock,
+                side_effect=err,
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.invalidate_browser_setup"
+            ) as mock_invalidate,
+        ):
+            with pytest.raises(
+                ToolError, match="Patchright Chromium browser is missing"
+            ):
+                await get_ready_extractor(ctx=None, tool_name="test_tool")
+
+            mock_invalidate.assert_called_once()
+
+    async def test_unrelated_network_error_is_not_treated_as_binary_missing(self):
+        """A generic connection error must not call invalidate_browser_setup or surface the binary-missing copy."""
+        err = NetworkError("Failed to start browser: connection reset by peer")
+        with (
+            patch(
+                "linkedin_mcp_server.dependencies.ensure_tool_ready_or_raise",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.get_or_create_browser",
+                new_callable=AsyncMock,
+                side_effect=err,
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.invalidate_browser_setup"
+            ) as mock_invalidate,
+        ):
+            with pytest.raises(ToolError, match="Network error"):
+                await get_ready_extractor(ctx=None, tool_name="test_tool")
+
+            mock_invalidate.assert_not_called()
 
     async def test_mid_scrape_auth_error_triggers_relogin(self):
         """AuthenticationError caught in tool wrapper invokes handle_auth_error."""

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -9,6 +9,7 @@ from linkedin_mcp_server.core.exceptions import (
 )
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.exceptions import (
+    BrowserBinaryMissingError,
     CredentialsNotFoundError,
     LinkedInMCPError,
     SessionExpiredError,
@@ -71,6 +72,17 @@ def test_profile_not_found_skips_issue_diagnostics(monkeypatch):
 def test_raises_tool_error_for_network_error():
     with pytest.raises(ToolError, match="Network error"):
         raise_tool_error(NetworkError("timeout"))
+
+
+def test_raises_tool_error_for_browser_binary_missing():
+    with pytest.raises(ToolError, match="Patchright Chromium browser is missing"):
+        raise_tool_error(
+            BrowserBinaryMissingError(
+                "Patchright Chromium browser is missing. "
+                "Run 'uv run patchright install chromium', "
+                "or restart the server to auto-install."
+            )
+        )
 
 
 def test_raises_tool_error_for_scraping_error():


### PR DESCRIPTION
## Summary

- Replaces the brittle metadata-only readiness check with a registry-driven check (patchright's bundled `browsers.json` + per-dir `INSTALLATION_COMPLETE` markers).
- Adds `BrowserBinaryMissingError` and an actionable "run patchright install" message in place of the misleading "Network error".
- Treats in-memory setup state as a cache invalidated by on-disk regressions, so a previously-READY server actually re-triggers install instead of looping.
- Bumps install-metadata schema to v2; v1 metadata triggers a one-time clean reinstall.
- Honors a pre-set `PLAYWRIGHT_BROWSERS_PATH` so install metadata and readiness checks agree on the effective cache path.

## Background

Patchright upgrades leave on-disk binaries stale: the new version expects a fresh chromium revision while the old one and the install metadata still linger. The server reported this as a misleading "Network error" with no guidance, and the readiness check never re-triggered install. Three intertwined bugs covered in #404:

1. `BrowserManager.start()` re-raised every patchright exception as `NetworkError`.
2. `browser_setup_ready()` returned True purely from metadata + non-empty dir, blind to revision drift.
3. The per-tool gate only kicked off setup when state was `IDLE`/`FAILED`, so a cached `READY` state blocked recovery.

## Test plan

- [x] New unit tests in `tests/test_bootstrap.py` covering readiness for every documented case (version mismatch, missing revision, stale-alongside-current, partial-corruption known gap, registry unreadable, custom `PLAYWRIGHT_BROWSERS_PATH`).
- [x] New `tests/test_dependencies.py` test asserting the binary-missing path drops metadata and surfaces the actionable error; negative test that unrelated `NetworkError`s aren't transformed.
- [x] New `tests/test_error_handler.py` mapping test for `BrowserBinaryMissingError`.
- [x] `uv run ruff check . && uv run ruff format --check . && uv run ty check`
- [x] `uv run pytest` — 422 passed.
- [x] End-to-end smoke on a real stale-v1-metadata + revision-mismatch state on this machine: install ran cleanly, metadata bumped to v2 with `patchright_version`, readiness flipped to True.

## Synthetic prompt

> Fix issue #404: patchright upgrades surface as misleading "Network error". Replace `bootstrap.browser_setup_ready()` with a check that consults patchright's bundled `browsers.json` registry, validates per-dir `INSTALLATION_COMPLETE` markers, and tracks the patchright package version in v2 install metadata. Add `BrowserBinaryMissingError` plus a consumer-side detection helper in `dependencies.py` mirroring the `LinuxBrowserDependencyError` pattern. Add `invalidate_browser_setup()` that drops metadata and resets cached `READY` -> `IDLE`, and wire it into both the lifespan and per-tool gates so on-disk regressions trigger reinstall. Fix `configure_browser_environment()` to return the effective `PLAYWRIGHT_BROWSERS_PATH`. Tests cover readiness, invalidation, and the binary-missing transform.

Resolves: #404