### PR TITLE
docs: Require locale-independent scraping detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **One section = one navigation.** Each entry in `PERSON_SECTIONS` / `COMPANY_SECTIONS` (`scraping/fields.py`) maps to exactly one page navigation. Never combine multiple URLs behind a single section.
 - **Minimize DOM dependence.** Prefer innerText and URL navigation over DOM selectors. When DOM access is unavoidable, use minimal generic selectors (`a[href*="/jobs/view/"]`) — never class names tied to LinkedIn's layout.
+- **Detection must be locale-independent.** Classification logic — connection state, action availability, button identity — must rely on URL patterns (`/preload/custom-invite/?vanityName=USER`, `/in/USER/edit/intro/`, `/messaging/compose/`), attribute *presence* (`aria-label` exists, `aria-expanded` exists, `aria-disabled` exists), or structural counts — never on text values like "Connect", "Follow", "Message", "1st", "Pending". The verb in an `aria-label` is locale-dependent; whether the attribute exists is not. Where text is genuinely the only signal, guard it behind an explicit per-locale table and document the limitation in code.
 
 ## Tool Return Format
 


### PR DESCRIPTION
## Summary

Adds a third bullet to `AGENTS.md` Scraping Rules: classification logic must rely on URL patterns, attribute *presence* (not values), or structural counts — never on text labels like "Connect", "Follow", "1st", or "Pending". Where text matching is genuinely the only signal, it must live behind an explicit per-locale table.

This is a foundational rule landing first; PR #409 (stacked on top) is the first implementation that follows it.

## Test plan

- [x] No code changes — docs only

## Synthetic prompt

> Add a third bullet to AGENTS.md Scraping Rules requiring all detection logic (connection state, action availability, button identity) to rely on URL patterns, ARIA-attribute presence, or structural counts — never on text values. Where text matching is genuinely the only signal, gate it behind an explicit per-locale table and document the limitation in code.