### PR TITLE
fix(connect): locale-independent state detection and More-menu retry

### DIFF
--- a/linkedin_mcp_server/scraping/connection.py
+++ b/linkedin_mcp_server/scraping/connection.py
@@ -1,15 +1,23 @@
-"""Connection state detection from structural DOM signals.
+"""Locale-independent connection-state detection from action-area DOM signals.
 
-LinkedIn translates every visible label, but the URLs it links to do not
-get translated. The action area at the top of a profile page exposes the
-relationship state through anchor hrefs: a Connect button is always an
-``<a href="/preload/custom-invite/?vanityName=...">``; the Message button
-on a 1st-degree connection is always ``<a href="/messaging/compose/...">``.
-Editing your own profile exposes ``<a href=".../edit/intro/">``.
+LinkedIn translates every visible label, but the URLs it links to and the
+ARIA attributes it sets do not depend on UI language. Detection here uses:
 
-These hrefs work as language-independent signals. Text-based fallbacks
-remain available for the niche states (Pending and incoming requests)
-where no anchor reliably exposes the state.
+* ``/in/USER/edit/intro/`` anchor → self profile
+* ``/preload/custom-invite/?vanityName=USER`` anchor → connectable
+* ``/messaging/compose/`` anchor presence inside the top-card action root,
+  combined with attribute-presence checks on action buttons
+  (``aria-label`` set vs. unset on ``<button>``s) → 1st-degree vs. follow-only
+
+Per ``AGENTS.md`` Scraping Rules, classification logic relies on URL
+patterns and attribute *presence* — never on the values of locale-dependent
+text labels like "Connect", "Follow", or "1st".
+
+The single text-based fallback that remains is incoming-request detection
+(Accept/Ignore present in the top-card text). LinkedIn does not expose a
+distinctive URL or attribute for this state. Per the same rules, that
+fallback lives behind an explicit per-locale label table that is trivial
+to extend.
 """
 
 from __future__ import annotations
@@ -29,85 +37,140 @@ ConnectionState = Literal[
 ]
 
 
+# Per AGENTS.md Scraping Rules: text-only signals must live behind an
+# explicit per-locale table. This table covers incoming-request detection
+# only — the one state without a structural URL/attribute signal we have
+# verified against the live DOM. Extend with additional ("xx", (a, b))
+# entries once the labels are confirmed against a real profile.
+INCOMING_REQUEST_LABELS: dict[str, tuple[str, str]] = {
+    "en": ("Accept", "Ignore"),
+}
+
+
+# Bound the text scan to the top-card region. The previous implementation
+# cut at the first occurrence of "About"/"Experience"/"Education" — but
+# those sentinel words are themselves locale-dependent, so a fixed
+# character budget is the locale-clean replacement. ~600 chars is enough
+# to comfortably cover name, headline, location, and the action-button
+# row in every locale we have observed.
+_TOP_CARD_CHAR_BUDGET = 600
+
+
 @dataclass(frozen=True)
 class ActionSignals:
-    """Structural signals read from the profile action area.
+    """Structural signals read from the top-card action area.
 
-    Each flag corresponds to the presence of a specific anchor href in the
-    top of the page. None of them depend on visible text, so detection works
-    in any locale.
+    All fields are locale-independent: each is the result of either a URL
+    pattern match or the *presence* (not value) of an ARIA attribute.
+    Detection downstream never reads the contents of an aria-label —
+    only whether it is set on a button — so the verb portion of labels
+    like "Follow {Name}" or "Folgen {Name}" is irrelevant.
     """
 
     has_invite_anchor: bool
-    has_compose_anchor: bool
+    """``a[href*="/preload/custom-invite/?vanityName={user}"]`` exists in
+    ``document`` (covers both the in-DOM action area and portal-rendered
+    More-menu overlays). vanityName scoping prevents false positives from
+    Connect anchors targeting other profiles on the page."""
+
+    has_compose_anchor_in_action_root: bool
+    """``a[href*="/messaging/compose/"]`` exists *inside* the action root
+    found by walking up from any compose anchor in ``<main>``. This is the
+    Message anchor in the top-card action button row."""
+
     has_edit_intro_anchor: bool
+    """``a[href*="/in/{user}/edit/intro/"]`` exists in ``<main>``. Only
+    rendered when viewing your own profile."""
+
+    has_labeled_action_button: bool
+    """At least one ``<button>`` with an ``aria-label`` attribute exists
+    inside the action root. Primary action ``<button>``s (Follow,
+    Connect, Save in Sales Navigator) carry ``aria-label`` for screen
+    readers. The profile More button uses ``aria-expanded`` instead and
+    is not counted here. Absence of any labeled button means there is no
+    primary action ``<button>`` targeting this person."""
+
+    has_labeled_action_anchor: bool
+    """At least one ``<a>`` with an ``aria-label`` attribute exists
+    inside the action root. LinkedIn renders the Pending state as an
+    ``<a>`` (linking to the profile URL) with an ``aria-label`` like
+    "Pending, click to withdraw invitation sent to {Name}", whereas the
+    Message anchor carries only ``aria-disabled``. The label *value* is
+    locale-dependent and not read; presence-on-an-``<a>`` is the
+    locale-independent Pending signal."""
 
 
 def detect_connection_state(
     profile_text: str,
-    signals: ActionSignals | None = None,
+    signals: ActionSignals,
 ) -> ConnectionState:
     """Determine the relationship state for a profile.
 
-    Structural signals (URL hrefs) take priority. Text fallbacks only handle
-    the rare states (Pending, incoming requests) that are not exposed via a
-    distinctive anchor. The text checks remain English-only and can be
-    extended without changing the structural happy path.
-    """
-    if signals is not None:
-        if signals.has_edit_intro_anchor:
-            return "self_profile"
-        if signals.has_invite_anchor:
-            return "connectable"
+    Resolution order:
 
-    # Text fallbacks for states without a unique anchor href
+    1. ``self_profile`` — edit-intro anchor (URL).
+    2. ``connectable`` — vanityName invite anchor (URL).
+    3. ``pending`` — labeled action ``<a>`` in the action root (the
+       Pending control LinkedIn renders for invitations awaiting
+       response).
+    4. ``incoming_request`` — locale-table text fallback. The one
+       AGENTS.md-sanctioned text-based signal; extend
+       :data:`INCOMING_REQUEST_LABELS` to add locales.
+    5. ``already_connected`` — compose anchor present in action root and
+       no labeled action button. (1st-degree connections render Message
+       as the primary action; there is no Follow/Connect button.)
+    6. ``follow_only`` — compose anchor present in action root and at
+       least one labeled action ``<button>`` (Follow / Save in Sales
+       Navigator), but no invite anchor anywhere. The
+       ``connect_with_person`` write-gate prevents the deeplink from
+       firing on this state.
+    7. ``unavailable`` — fallthrough (e.g. profile pages where the
+       action area could not be located at all).
+    """
+    if signals.has_edit_intro_anchor:
+        return "self_profile"
+    if signals.has_invite_anchor:
+        return "connectable"
+    if signals.has_labeled_action_anchor:
+        return "pending"
     if _has_incoming_request_text(profile_text):
         return "incoming_request"
-    if _has_pending_text(profile_text):
-        return "pending"
-
-    if signals is not None and signals.has_compose_anchor:
+    if signals.has_compose_anchor_in_action_root:
+        if signals.has_labeled_action_button:
+            return "follow_only"
         return "already_connected"
-
-    if profile_text and "· 1st" in profile_text[:300]:
-        return "already_connected"
-
-    # No structural or text marker matched. Fall back to text-only inspection
-    # so an unmatched profile can resolve to follow_only or unavailable based
-    # on the action area instead of being silently lumped into follow_only.
-    return _detect_from_text_only(profile_text)
-
-
-_ACTION_AREA_END = re.compile(
-    r"^(?:About|Highlights|Featured|Activity|Experience|Education)\n",
-    re.MULTILINE,
-)
-
-
-def _action_area(profile_text: str) -> str:
-    match = _ACTION_AREA_END.search(profile_text)
-    if match:
-        return profile_text[: match.start()]
-    return profile_text[:500]
-
-
-def _has_pending_text(profile_text: str) -> bool:
-    area = _action_area(profile_text)
-    return "\nPending\n" in area or area.endswith("\nPending")
+    return "unavailable"
 
 
 def _has_incoming_request_text(profile_text: str) -> bool:
-    area = _action_area(profile_text)
-    return "\nAccept\n" in area and "\nIgnore\n" in area
+    """Return True if any locale's Accept+Ignore label pair appears in the
+    bounded top-card prefix of ``profile_text``.
+
+    This is the single text-based detector retained from the previous
+    implementation. Per AGENTS.md it is gated behind an explicit locale
+    table; new languages are added by appending to
+    :data:`INCOMING_REQUEST_LABELS`. The character budget keeps the scan
+    inside the top-card region without depending on locale-dependent
+    section sentinels.
+
+    Each label is matched with newline boundaries — LinkedIn renders
+    each action button on its own line in the top-card text, and
+    line-bounded matching prevents false positives from the same
+    substring appearing inside a name or headline (e.g. "Ignored" or
+    "Acceptance Speech" would not match "Ignore" / "Accept").
+    """
+    if not profile_text:
+        return False
+    head = profile_text[:_TOP_CARD_CHAR_BUDGET]
+    for accept, ignore in INCOMING_REQUEST_LABELS.values():
+        if _label_present(head, accept) and _label_present(head, ignore):
+            return True
+    return False
 
 
-def _detect_from_text_only(profile_text: str) -> ConnectionState:
-    """Fallback when DOM signals are unavailable (e.g. unit tests)."""
-    if profile_text and "· 1st" in profile_text[:300]:
-        return "already_connected"
-    area = _action_area(profile_text)
-    if "\nConnect\n" in area or area.endswith("\nConnect"):
-        return "connectable"
-    if "\nFollow\n" in area or area.endswith("\nFollow"):
-        return "follow_only"
-    return "unavailable"
+def _label_present(head: str, label: str) -> bool:
+    """Return True if ``label`` appears as a complete, line-bounded token
+    inside ``head``. Allows the label to start at the beginning of the
+    head and to end at the end of the head."""
+    pattern = re.compile(r"(?:^|\n)" + re.escape(label) + r"(?:\n|$)")
+    return pattern.search(head) is not None

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -117,6 +117,130 @@ _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Close"]'
 )
 
+# Shared JS function that walks up from any /messaging/compose/ anchor
+# inside <main> to find the smallest ancestor that satisfies the
+# action-root predicate (>=2 interactive children, >=1 button). This is
+# the top-card action row regardless of LinkedIn's class names.
+#
+# Inlined into both _ACTION_SIGNALS_JS and _OPEN_MORE_BUTTON_JS so a
+# single change to the heuristic propagates to both call sites.
+_FIND_ACTION_ROOT_FN_JS = r"""
+function findActionRoot(main) {
+  const composeAnchors = main.querySelectorAll('a[href*="/messaging/compose/"]');
+  for (const a of composeAnchors) {
+    let el = a.parentElement;
+    while (el && el !== main) {
+      const interactive = el.querySelectorAll('button, a').length;
+      const buttons = el.querySelectorAll('button').length;
+      if (interactive >= 2 && buttons >= 1) {
+        return el;
+      }
+      el = el.parentElement;
+    }
+  }
+  return null;
+}
+"""
+
+# Locale-independent connection-state probe. Returns four booleans;
+# per AGENTS.md Scraping Rules, every signal is based on URL patterns
+# or ARIA-attribute *presence* — never on label text values.
+#
+# - hasInvite: vanityName-scoped invite anchor anywhere in document.
+#   Searches document (not main) so a post-More-menu reread sees
+#   portal-rendered menu items. The vanityName parameter is unique to
+#   the target user, so document-wide search has no false-positive risk.
+# - hasComposeInActionRoot: any /messaging/compose/ anchor exists inside
+#   the action root. Scoped to main (not document) to avoid the More
+#   menu's "Send profile in a message" anchor, which is a compose URL
+#   but lives outside the action area.
+# - hasEditIntro: edit-intro URL exists, only rendered on own profile.
+# - hasLabeledActionButton: at least one <button[aria-label]> inside the
+#   action root. Primary action buttons (Follow / Connect /
+#   Save in Sales Navigator) carry aria-label for screen readers; the
+#   profile More button uses aria-expanded instead and is not counted.
+# - hasLabeledActionAnchor: at least one <a[aria-label]> inside the
+#   action root. LinkedIn renders the Pending state as an anchor (linking
+#   back to the profile URL) carrying aria-label like "Pending, click to
+#   withdraw…". The Message anchor has only aria-disabled, so a labeled
+#   anchor is the locale-independent Pending signal.
+#
+# The username is CSS-escaped before interpolation into attribute
+# selectors to defend against malformed inputs containing characters
+# that would otherwise break the selector syntax (quotes, brackets).
+_ACTION_SIGNALS_JS = (
+    r"""
+((username) => {
+"""
+    + _FIND_ACTION_ROOT_FN_JS
+    + r"""
+  const main = document.querySelector('main');
+  if (!main) return null;
+
+  const safe = CSS.escape(username);
+  const inviteSel = `a[href*="/preload/custom-invite/?vanityName=${safe}"]`;
+  const editSel = `a[href*="/in/${safe}/edit/intro/"]`;
+
+  const hasInvite = !!document.querySelector(inviteSel);
+  const hasEditIntro = !!main.querySelector(editSel);
+
+  const actionRoot = findActionRoot(main);
+
+  let hasComposeInActionRoot = false;
+  let hasLabeledActionButton = false;
+  let hasLabeledActionAnchor = false;
+  if (actionRoot) {
+    hasComposeInActionRoot =
+      !!actionRoot.querySelector('a[href*="/messaging/compose/"]');
+    for (const b of actionRoot.querySelectorAll('button')) {
+      if (b.hasAttribute('aria-label')) {
+        hasLabeledActionButton = true;
+        break;
+      }
+    }
+    for (const a of actionRoot.querySelectorAll('a')) {
+      if (a.hasAttribute('aria-label')) {
+        hasLabeledActionAnchor = true;
+        break;
+      }
+    }
+  }
+
+  return {
+    hasInvite,
+    hasComposeInActionRoot,
+    hasEditIntro,
+    hasLabeledActionButton,
+    hasLabeledActionAnchor,
+  };
+})
+"""
+)
+
+# Open the profile's More button, located inside the action root via the
+# aria-expanded attribute. The aria-expanded attribute uniquely identifies
+# the menu opener without text labels (the More button has no aria-label,
+# while Follow/Connect/Pending buttons do — the inverse pattern). Returns
+# true iff the click landed; the caller waits for [role='menu'] visibility
+# before re-scanning signals.
+_OPEN_MORE_BUTTON_JS = (
+    r"""
+(() => {
+"""
+    + _FIND_ACTION_ROOT_FN_JS
+    + r"""
+  const main = document.querySelector('main');
+  if (!main) return false;
+  const actionRoot = findActionRoot(main);
+  if (!actionRoot) return false;
+  const moreBtn = actionRoot.querySelector('button[aria-expanded]');
+  if (!moreBtn) return false;
+  moreBtn.click();
+  return true;
+})
+"""
+)
+
 
 def _connection_result(
     url: str,
@@ -537,36 +661,33 @@ class LinkedInExtractor:
             pass
 
     async def _open_more_menu(self) -> bool:
-        """Open the profile's More (three-dot) menu and check for Connect.
+        """Open the profile's More (three-dot) menu in a locale-independent way.
 
-        Uses ``aria-label`` to find the More button (language-independent)
-        and ``[role="menu"]`` to detect the opened menu (structural).
-        Returns True if the menu opened and contains a Connect option.
+        Locates the More button structurally as ``actionRoot
+        button[aria-expanded]`` — the action-root walk discriminates the
+        profile More button from any other More-labelled buttons elsewhere
+        on the page (notably the video-player More on profiles with
+        background videos), and ``aria-expanded`` distinguishes the menu
+        opener from primary action buttons (which carry ``aria-label``
+        instead). Returns True iff the click landed and a ``[role='menu']``
+        became visible. The caller is expected to follow up with
+        ``_read_action_signals`` to scan the now-rendered menu items for
+        the vanityName invite anchor; this helper does not classify menu
+        contents itself.
         """
-        more_btn = self._page.locator("main button[aria-label*='More']")
         try:
-            if await more_btn.count() == 0:
-                return False
-            await more_btn.first.click()
+            clicked = await self._page.evaluate(_OPEN_MORE_BUTTON_JS)
         except Exception:
-            logger.debug("Could not click More button", exc_info=True)
+            logger.debug("More button click via JS failed", exc_info=True)
             return False
-
+        if not clicked:
+            return False
         try:
             await self._page.wait_for_selector("[role='menu']", timeout=3000)
+            return True
         except PlaywrightTimeoutError:
-            logger.debug("More menu did not appear")
+            logger.debug("More menu did not appear after click")
             return False
-
-        # Check if Connect is in the menu
-        menu_connect = (
-            self._page.locator("[role='menu']")
-            .locator("button, a, li, [role='menuitem'], [role='button']")
-            .filter(has_text=re.compile(r"^Connect$"))
-        )
-        count = await menu_connect.count()
-        logger.debug("More menu Connect matches: %d", count)
-        return count > 0
 
     async def _locator_is_visible(self, selector: str, *, timeout: int = 2000) -> bool:
         """Return whether the first matching locator is visible."""
@@ -990,42 +1111,35 @@ class LinkedInExtractor:
 
         return result
 
-    async def _read_action_signals(self) -> ActionSignals:
-        """Read structural anchor signals from the top of the profile page.
+    async def _read_action_signals(self, username: str) -> ActionSignals:
+        """Read locale-independent structural signals for a profile's
+        relationship state.
 
-        LinkedIn translates labels but not URLs, so the action area's hrefs
-        are the only locale-independent signal of relationship state.
+        Detection uses URL patterns and ARIA attribute presence only — never
+        text values — per the AGENTS.md Scraping Rules. The vanityName invite
+        anchor is searched document-wide because LinkedIn renders the More
+        menu's contents in a portal-mounted ``[role='menu']`` outside ``<main>``;
+        the URL is uniquely scoped to the target user, so document-wide
+        search introduces no false positives. The compose anchor used for
+        action-root discovery is scoped to ``<main>`` to avoid the
+        portal-rendered "Send profile in a message" anchor that appears
+        inside the More menu after click.
         """
-        data = await self._page.evaluate(
-            """() => {
-                const main = document.querySelector('main');
-                if (!main) return null;
-                const links = Array.from(main.querySelectorAll('a[href]')).filter(
-                    (a) => {
-                        const r = a.getBoundingClientRect();
-                        return r.top < 600 && r.width > 20 && r.height > 12;
-                    }
-                );
-                const hrefs = links.map((a) => a.getAttribute('href') || '');
-                return {
-                    hasInvite: hrefs.some(
-                        (h) => h.includes('/preload/custom-invite/')
-                    ),
-                    hasCompose: hrefs.some(
-                        (h) => h.includes('/messaging/compose/')
-                    ),
-                    hasEditIntro: hrefs.some(
-                        (h) => h.includes('/edit/intro/')
-                    ),
-                };
-            }"""
-        )
+        data = await self._page.evaluate(_ACTION_SIGNALS_JS, username)
         if not isinstance(data, dict):
-            return ActionSignals(False, False, False)
+            return ActionSignals(
+                has_invite_anchor=False,
+                has_compose_anchor_in_action_root=False,
+                has_edit_intro_anchor=False,
+                has_labeled_action_button=False,
+                has_labeled_action_anchor=False,
+            )
         return ActionSignals(
             has_invite_anchor=bool(data.get("hasInvite")),
-            has_compose_anchor=bool(data.get("hasCompose")),
+            has_compose_anchor_in_action_root=bool(data.get("hasComposeInActionRoot")),
             has_edit_intro_anchor=bool(data.get("hasEditIntro")),
+            has_labeled_action_button=bool(data.get("hasLabeledActionButton")),
+            has_labeled_action_anchor=bool(data.get("hasLabeledActionAnchor")),
         )
 
     async def _submit_invite_dialog(self, note: str | None) -> tuple[bool, bool]:
@@ -1104,13 +1218,16 @@ class LinkedInExtractor:
     ) -> dict[str, Any]:
         """Send a LinkedIn connection request or accept an incoming one.
 
-        Detection uses structural anchor hrefs read from the top-card area
-        (Connect, Message, Edit). Sending uses LinkedIn's
-        ``/preload/custom-invite/`` deeplink so no Connect button click is
-        required. The dialog is submitted via positional button indexing.
-        Success is only reported once a fresh re-read of the profile no
-        longer exposes a Connect anchor (or shows a 1st-degree marker for
-        accepted requests).
+        Detection is locale-independent: classification uses URL patterns
+        (vanityName invite anchor, edit-intro anchor) and ARIA-attribute
+        presence on top-card buttons (`aria-label` for primary actions,
+        `aria-expanded` for the More-menu opener). The deeplink-submit
+        path is gated strictly on `has_invite_anchor=True` *after* the
+        optional More-menu retry, so Pending and follow-only profiles
+        cannot trigger a write. Sending itself uses the
+        ``/preload/custom-invite/?vanityName=`` deeplink, which works
+        whether the user-visible Connect button is in the action bar
+        or buried under the More menu.
         """
         from linkedin_mcp_server.scraping.connection import detect_connection_state
 
@@ -1123,7 +1240,7 @@ class LinkedInExtractor:
                 url, "unavailable", "Could not read profile page."
             )
 
-        signals = await self._read_action_signals()
+        signals = await self._read_action_signals(username)
         state = detect_connection_state(page_text, signals)
         logger.info(
             "Connection signals for %s: state=%s signals=%s", username, state, signals
@@ -1152,9 +1269,10 @@ class LinkedInExtractor:
             )
 
         if state == "incoming_request":
-            # Accept is rendered inline on the profile (no modal). The
-            # button text is locale-dependent but no anchor exposes the
-            # accept action; we accept this English-only fallback.
+            # TODO(locale): replace text-based Accept click with a
+            # structural identifier — needs a live probe against a real
+            # incoming-request profile (we have none to test against).
+            # Tracked as a documented escape-hatch per AGENTS.md.
             clicked = await self.click_button_by_text("Accept", scope="main")
             if not clicked:
                 return _connection_result(
@@ -1165,7 +1283,7 @@ class LinkedInExtractor:
                 )
             verified = await self.scrape_person(username, {"main_profile"})
             verified_text = verified.get("sections", {}).get("main_profile", "")
-            verified_signals = await self._read_action_signals()
+            verified_signals = await self._read_action_signals(username)
             verified_state = detect_connection_state(verified_text, verified_signals)
             if verified_state != "already_connected":
                 return _connection_result(
@@ -1181,7 +1299,32 @@ class LinkedInExtractor:
                 profile=verified_text,
             )
 
-        if state not in {"connectable", "follow_only"}:
+        # Follow-only profiles may have Connect hidden under the More menu
+        # (high-follower / creator-mode profiles). Try opening it and
+        # re-reading signals; if the vanityName invite anchor surfaces in
+        # the menu, we can proceed with the deeplink. (The
+        # has_invite_anchor=False guard is implicit: detect_connection_state
+        # only returns "follow_only" after the has_invite_anchor branch
+        # has already failed, so reaching this branch already implies it.)
+        if state == "follow_only":
+            opened = await self._open_more_menu()
+            if opened:
+                signals = await self._read_action_signals(username)
+                # Close the menu before any subsequent navigation so it
+                # doesn't intercept the upcoming page transition.
+                try:
+                    await self._page.keyboard.press("Escape")
+                except Exception:
+                    logger.debug("Escape after More-menu reread failed", exc_info=True)
+                logger.info("Post-More signals for %s: signals=%s", username, signals)
+
+        # Write-gate: the deeplink fires only when we have a vanityName
+        # invite anchor at this point. A `follow_only` outcome with no
+        # invite anchor (Pending profile, restricted profile, or
+        # genuinely follow-only) returns connect_unavailable without
+        # navigating to the invite URL — protects against accidental
+        # re-invitation of Pending profiles.
+        if not signals.has_invite_anchor:
             return _connection_result(
                 url,
                 "connect_unavailable",
@@ -1189,10 +1332,6 @@ class LinkedInExtractor:
                 profile=page_text,
             )
 
-        # Connectable / follow_only: drive the invite via the deeplink.
-        # The URL pattern matches LinkedIn's own Connect anchor href, so it
-        # works regardless of locale or whether the visible button is behind
-        # the More menu.
         invite_url = (
             "https://www.linkedin.com/preload/custom-invite/"
             f"?vanityName={quote_plus(username)}"
@@ -1210,7 +1349,7 @@ class LinkedInExtractor:
 
         verified = await self.scrape_person(username, {"main_profile"})
         verified_text = verified.get("sections", {}).get("main_profile", "")
-        verified_signals = await self._read_action_signals()
+        verified_signals = await self._read_action_signals(username)
         verified_state = detect_connection_state(verified_text, verified_signals)
 
         if verified_signals.has_invite_anchor:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -11,7 +11,6 @@ from linkedin_mcp_server.core.exceptions import (
 )
 from linkedin_mcp_server.scraping.connection import (
     ActionSignals,
-    _action_area,
     detect_connection_state,
 )
 from linkedin_mcp_server.scraping.extractor import (
@@ -842,52 +841,123 @@ class TestScrapePersonUrls:
 
 
 class TestDetectConnectionState:
-    """Tests for connection state detection from profile text."""
+    """Tests for locale-independent connection-state detection.
 
-    def test_already_connected(self):
-        text = "Collin Pfeifer\n\n· 1st\n\nAI Engineer\n\nMessage\nMore"
-        assert detect_connection_state(text) == "already_connected"
+    All states except incoming_request are decided purely from the
+    structural ActionSignals; profile_text is passed empty for those.
+    Incoming-request is the one AGENTS.md-sanctioned text fallback,
+    so its test passes both signals (all False) and a profile_text
+    containing Accept/Ignore labels. The two priority-ordering tests
+    intentionally pass non-empty text to verify that URL/attribute
+    signals win over text fallbacks regardless of what's in the text.
+    """
 
-    def test_pending(self):
-        text = "Marinus Prey\n\n· 2nd\n\nStudent\n\nMessage\nPending\nMore"
-        assert detect_connection_state(text) == "pending"
+    @staticmethod
+    def _signals(
+        invite: bool = False,
+        compose_in_root: bool = False,
+        edit: bool = False,
+        labeled_action: bool = False,
+        labeled_anchor: bool = False,
+    ) -> ActionSignals:
+        return ActionSignals(
+            has_invite_anchor=invite,
+            has_compose_anchor_in_action_root=compose_in_root,
+            has_edit_intro_anchor=edit,
+            has_labeled_action_button=labeled_action,
+            has_labeled_action_anchor=labeled_anchor,
+        )
 
-    def test_incoming_request(self):
-        text = "Aklasur Rahman\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore"
-        assert detect_connection_state(text) == "incoming_request"
+    def test_self_profile(self):
+        assert detect_connection_state("", self._signals(edit=True)) == "self_profile"
 
     def test_connectable(self):
-        text = "Jane Doe\n\n· 3rd\n\nEngineer\n\nConnect\nMore"
-        assert detect_connection_state(text) == "connectable"
+        assert detect_connection_state("", self._signals(invite=True)) == "connectable"
+
+    def test_already_connected(self):
+        # 1st-degree: Message anchor in action root, but no Follow/Connect/Pending
+        # button (no aria-label on any action-root button).
+        assert (
+            detect_connection_state(
+                "", self._signals(compose_in_root=True, labeled_action=False)
+            )
+            == "already_connected"
+        )
 
     def test_follow_only(self):
-        text = "Public Figure\n\n· 3rd+\n\nCEO\n\nFollow\nMore"
-        assert detect_connection_state(text) == "follow_only"
-
-    def test_unavailable(self):
-        text = "Unknown Person\n\nSome text here"
-        assert detect_connection_state(text) == "unavailable"
-
-    def test_follow_in_interests_not_matched(self):
-        """Follow in the Interests section should not cause a false positive."""
-        text = (
-            "Jane Doe\n\n· 2nd\n\nEngineer\n\nConnect\nMore\n"
-            "About\n\nSome bio\n\nInterests\n\n"
-            "Elon Musk\n101,000 followers\nFollow"
+        # No invite anchor anywhere, but a primary action <button> (Follow
+        # / Save in Sales Navigator) is present alongside the Message
+        # anchor.
+        assert (
+            detect_connection_state(
+                "", self._signals(compose_in_root=True, labeled_action=True)
+            )
+            == "follow_only"
         )
-        assert detect_connection_state(text) == "connectable"
 
-    def test_action_area_cuts_at_about(self):
-        text = "Name\n\nConnect\nMore\nAbout\n\nFollow\nConnect"
-        area = _action_area(text)
-        assert "About" not in area
-        assert "Follow" not in area
+    def test_pending_via_labeled_anchor(self):
+        # Pending is rendered as <a aria-label="Pending, click to ..."> in
+        # the action root — distinct from Follow's <button aria-label=...>.
+        assert (
+            detect_connection_state(
+                "",
+                self._signals(compose_in_root=True, labeled_anchor=True),
+            )
+            == "pending"
+        )
 
-    def test_action_area_cuts_at_highlights(self):
-        text = "Name\n\nMessage\nPending\nMore\nHighlights\n\nFollow"
-        area = _action_area(text)
-        assert "Follow" not in area
-        assert "Pending" in area
+    def test_pending_takes_priority_over_already_connected(self):
+        # If the labeled anchor is present alongside compose-in-root with
+        # no labeled button, pending wins over the already_connected
+        # fallthrough that would otherwise apply.
+        assert (
+            detect_connection_state(
+                "",
+                self._signals(compose_in_root=True, labeled_anchor=True),
+            )
+            == "pending"
+        )
+
+    def test_incoming_request_via_text_fallback_en(self):
+        # Locale-table fallback per AGENTS.md — Accept+Ignore (en) appear
+        # within the top-card prefix.
+        text = "Aklasur Rahman\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore"
+        assert detect_connection_state(text, self._signals()) == "incoming_request"
+
+    def test_incoming_request_text_outside_top_card_ignored(self):
+        # Accept/Ignore far past the 600-char top-card budget must not match.
+        prefix = "X" * 700
+        text = prefix + "\nAccept\nIgnore\n"
+        assert detect_connection_state(text, self._signals()) == "unavailable"
+
+    def test_incoming_request_takes_priority_over_already_connected(self):
+        # If the profile somehow has both compose anchor and Accept/Ignore
+        # labels (edge case), incoming_request wins per resolution order.
+        text = "Aklasur\n\nAccept\nIgnore\nMore"
+        assert (
+            detect_connection_state(text, self._signals(compose_in_root=True))
+            == "incoming_request"
+        )
+
+    def test_connectable_takes_priority_over_text_signals(self):
+        # vanityName invite anchor wins even if the page also has
+        # text that would otherwise match a fallback.
+        text = "Jane\n\nAccept\nIgnore\n"
+        assert (
+            detect_connection_state(text, self._signals(invite=True)) == "connectable"
+        )
+
+    def test_unavailable_when_no_signals_or_text(self):
+        assert detect_connection_state("", self._signals()) == "unavailable"
+
+    def test_unavailable_when_compose_missing_and_no_text(self):
+        # Restricted profile: no compose anchor, no labels, no invite.
+        assert (
+            detect_connection_state(
+                "Some name\n\nFollow\n", self._signals(labeled_action=True)
+            )
+            == "unavailable"
+        )
 
 
 class TestConnectWithPerson:
@@ -913,12 +983,18 @@ class TestConnectWithPerson:
 
     @staticmethod
     def _signals(
-        invite: bool = False, compose: bool = False, edit: bool = False
+        invite: bool = False,
+        compose: bool = False,
+        edit: bool = False,
+        labeled_action: bool = False,
+        labeled_anchor: bool = False,
     ) -> ActionSignals:
         return ActionSignals(
             has_invite_anchor=invite,
-            has_compose_anchor=compose,
+            has_compose_anchor_in_action_root=compose,
             has_edit_intro_anchor=edit,
+            has_labeled_action_button=labeled_action,
+            has_labeled_action_anchor=labeled_anchor,
         )
 
     async def test_connectable_navigates_deeplink_and_verifies(self, mock_page):
@@ -1055,9 +1131,72 @@ class TestConnectWithPerson:
         assert result["status"] == "connect_unavailable"
         assert "own profile" in result["message"]
 
-    async def test_returns_pending(self, mock_page):
+    async def test_connect_via_more_menu(self, mock_page):
+        """Follow-primary profile with Connect under More: detection sees
+        no invite anchor initially, _open_more_menu surfaces it, deeplink
+        fires."""
         extractor = LinkedInExtractor(mock_page)
-        text = "Marinus\n\n· 2nd\n\nStudent\n\nMessage\nPending\nMore\nAbout\n"
+        # Pre-More: Follow primary, Connect hidden under the More dropdown.
+        pre = "Christian\n\n· 2nd\n\nFounder\n\nFollow\nMessage\nMore\n"
+        post = "Christian\n\n· 2nd\n\nFounder\n\nMessage\nPending\nMore\n"
+
+        with (
+            patch.object(
+                extractor,
+                "scrape_person",
+                self._mock_scrape(pre, follow_up_text=post),
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                # 1st: follow_only (compose+labeled, no invite).
+                # 2nd: post-More reread reveals invite anchor.
+                # 3rd: post-deeplink verification — invite anchor gone.
+                side_effect=[
+                    self._signals(compose=True, labeled_action=True),
+                    self._signals(invite=True, compose=True, labeled_action=True),
+                    self._signals(),
+                ],
+            ),
+            patch.object(
+                extractor,
+                "_open_more_menu",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_open_more,
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as mock_nav,
+            patch.object(
+                extractor,
+                "_dialog_is_open",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                extractor,
+                "_click_dialog_primary_button",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+        assert result["status"] == "connected"
+        mock_open_more.assert_awaited_once()
+        # Deeplink fired exactly once.
+        assert mock_nav.await_count == 1
+        await_args = mock_nav.await_args
+        assert await_args is not None
+        assert "preload/custom-invite" in await_args.args[0]
+
+    async def test_follow_only_after_more_does_not_send(self, mock_page):
+        """Pending or genuinely follow-only profile: invite anchor never
+        appears even after More-menu open. Critical write-gate guardrail —
+        no deeplink fires, no connection request goes out."""
+        extractor = LinkedInExtractor(mock_page)
+        text = "Public Figure\n\n· 3rd+\n\nCEO\n\nFollow\nMessage\nMore\n"
 
         with (
             patch.object(extractor, "scrape_person", self._mock_scrape(text)),
@@ -1065,12 +1204,95 @@ class TestConnectWithPerson:
                 extractor,
                 "_read_action_signals",
                 new_callable=AsyncMock,
-                return_value=self._signals(),
+                # Both reads (initial + post-More) show no invite anchor.
+                side_effect=[
+                    self._signals(compose=True, labeled_action=True),
+                    self._signals(compose=True, labeled_action=True),
+                ],
             ),
+            patch.object(
+                extractor,
+                "_open_more_menu",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_open_more,
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as mock_nav,
+            patch.object(
+                extractor, "_submit_invite_dialog", new_callable=AsyncMock
+            ) as mock_submit,
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+        assert result["status"] == "connect_unavailable"
+        assert result.get("note_sent") is False or "note_sent" not in result
+        mock_open_more.assert_awaited_once()
+        # Critical: deeplink must NOT fire and dialog must NOT be submitted.
+        mock_nav.assert_not_awaited()
+        mock_submit.assert_not_awaited()
+
+    async def test_more_menu_unavailable_does_not_send(self, mock_page):
+        """Action root present but no More button (unusual but possible):
+        _open_more_menu returns False, no retry, no deeplink fires."""
+        extractor = LinkedInExtractor(mock_page)
+        text = "Public Figure\n\n· 3rd+\n\nCEO\n\nFollow\nMessage\n"
+
+        with (
+            patch.object(extractor, "scrape_person", self._mock_scrape(text)),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                return_value=self._signals(compose=True, labeled_action=True),
+            ),
+            patch.object(
+                extractor,
+                "_open_more_menu",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as mock_nav,
+            patch.object(
+                extractor, "_submit_invite_dialog", new_callable=AsyncMock
+            ) as mock_submit,
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+        assert result["status"] == "connect_unavailable"
+        mock_nav.assert_not_awaited()
+        mock_submit.assert_not_awaited()
+
+    async def test_returns_pending(self, mock_page):
+        """Profile with a pending invitation: detected via labeled <a> in
+        the action root. Returns status='pending' without firing the
+        deeplink (LinkedIn would only show 'already invited' anyway)."""
+        extractor = LinkedInExtractor(mock_page)
+        text = "Frank\n\n· 3rd\n\nFounder\n\nMessage\nPending\nMore\n"
+
+        with (
+            patch.object(extractor, "scrape_person", self._mock_scrape(text)),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                return_value=self._signals(compose=True, labeled_anchor=True),
+            ),
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as mock_nav,
+            patch.object(
+                extractor, "_submit_invite_dialog", new_callable=AsyncMock
+            ) as mock_submit,
         ):
             result = await extractor.connect_with_person("testuser")
 
         assert result["status"] == "pending"
+        # No write-path side effects.
+        mock_nav.assert_not_awaited()
+        mock_submit.assert_not_awaited()
 
     async def test_returns_incoming_request_accepted(self, mock_page):
         extractor = LinkedInExtractor(mock_page)


### PR DESCRIPTION
## Summary

Resolves #406. The previous flow returned `already_connected` for any profile that exposes a `/messaging/compose/` anchor — which LinkedIn renders for every non-self profile with Open Profile, Premium messaging, or follow-relationship messaging eligibility. Live testing confirmed this misclassified 2nd- and 3rd-degree profiles. Issue #406 (Connect under More menu) was filed against the same root defect: detection short-circuited before the More-menu fallback could run.

This PR rewrites the connection-state detection to be fully locale-independent (URL patterns + ARIA-attribute presence) per the rule landed in #408, fixes the broken More-menu helper, adds a write-gate so follow-only profiles cannot trigger an accidental deeplink dispatch, and detects the Pending state via a structurally-distinct signal so Pending profiles return `status="pending"` cleanly without write-path side effects.

**Stacked on:** #408 (the AGENTS.md rule that this PR implements).

## Changes

**`linkedin_mcp_server/scraping/connection.py`** — rewritten:
- `ActionSignals` fields: `has_invite_anchor` (vanityName-scoped, document-wide), `has_compose_anchor_in_action_root` (scoped to top-card action row), `has_edit_intro_anchor`, `has_labeled_action_button` (any `<button[aria-label]>` in action root), `has_labeled_action_anchor` (any `<a[aria-label]>` in action root — the structural Pending signal).
- `detect_connection_state` resolves: self → connectable → pending → incoming → already_connected → follow_only → unavailable.
- One text-based fallback retained for `incoming_request` (no URL/attribute signal exists today), gated behind `INCOMING_REQUEST_LABELS: dict[str, tuple[str, str]]` and bounded to the first 600 chars of profile text via line-anchored regex (`(?:^|\n)…(?:\n|$)`). English-only entries to start; new languages append tuples.

**`linkedin_mcp_server/scraping/extractor.py`**:
- `_read_action_signals(username)`: vanityName invite anchor searched document-wide (covers portal-rendered More-menu items); compose anchor + action-root walk scoped to `<main>` to avoid the More menu's "Send profile in a message" anchor. Username is `CSS.escape`'d before interpolation into selectors.
- Action-root discovery extracted to a shared `_FIND_ACTION_ROOT_FN_JS` snippet, inlined into both `_ACTION_SIGNALS_JS` and `_OPEN_MORE_BUTTON_JS` so future heuristic tweaks propagate to both call sites.
- `_open_more_menu`: replaced broken `main button[aria-label*='More']` selector (matched video-player More buttons on profiles with background videos) with `actionRoot button[aria-expanded]` — distinguishes the menu opener from primary action buttons (which carry `aria-label` instead).
- `connect_with_person`: opens the More menu only when initial signals classify as `follow_only`; closes the menu via Escape before navigation. **Critical write-gate**: deeplink dispatch fires only when `has_invite_anchor=True` at the moment of dispatch. Follow-only profiles return `connect_unavailable` instead of accidentally re-inviting. Pending profiles return `status="pending"` directly.
- `incoming_request` accept path keeps the existing English-only `click_button_by_text("Accept")` with a TODO marker — needs a live probe against a real incoming-request profile before a structural replacement can be verified.

## Test plan

### Unit tests (430/430 passing)

- [x] `tests/test_scraping.py::TestDetectConnectionState` rewritten — 12 tests covering all seven states plus locale-table boundary guards and resolution-priority assertions (incoming, pending, connectable all take priority over weaker signals).
- [x] `tests/test_scraping.py::TestConnectWithPerson` extended:
  - `test_connect_via_more_menu` — success path: follow-primary profile with Connect under More opens menu, surfaces invite anchor, deeplink fires.
  - `test_follow_only_after_more_does_not_send` — write-gate guardrail: follow-only profile, More opens but no invite anchor surfaces, **deeplink does NOT fire**.
  - `test_more_menu_unavailable_does_not_send` — no More button at all, deeplink does NOT fire.
  - `test_returns_pending` — Pending profile (labeled anchor in action root) returns `status="pending"` without touching the deeplink or dialog.
- [x] `uv run ty check`: all checks passed.
- [x] `uv run ruff check . && uv run ruff format .`: all checks passed.

### Live verification (against real LinkedIn)

Tested per the verification matrix in the plan:

| Profile | Pre-fix | Post-fix | Path exercised |
|---|---|---|---|
| `stickerdaniel` (self) | `self_profile` ✓ | `self_profile` ✓ | edit-intro anchor |
| `len-seitter` (1st-degree) | `already_connected` ✓ (right answer, wrong reason) | `already_connected` via locale-independent rule (compose-in-action-root + no labeled action button + no labeled anchor) | new attribute-presence rule |
| `verenapausder` (2nd, 208k followers, inline Connect anchor at top=642 — outside old viewport filter) | `already_connected` ❌ | detection: `connectable` ✓ — invite anchor pre-rendered | direct deeplink path |
| `christianreber` (2nd, 21k followers, Connect under More) | `already_connected` ❌ | detection: `follow_only` → More opens → re-read → `connectable` ✓ | full More-menu retry |
| `frankthelen` (3rd) | `already_connected` ❌ | First test: `follow_only` → More → `connectable` → deeplink → **invite sent** ✓. After invite stayed standing: re-tested → `pending` (via labeled-anchor signal, no deeplink fired) ✓ | end-to-end + Pending |

`frankthelen` proved both the More-menu deeplink chain works AND the Pending detection avoids re-firing the deeplink on subsequent calls. `verenapausder` and `christianreber` reached the deeplink path correctly but failed at the dialog-submit step — LinkedIn requires a personalized note for high-follower / creator-mode profiles before enabling Send. **This is a separate pre-existing issue, tracked as #407.**

The standing `frankthelen` invite is left in place (real human, valid connection request).

## Synthetic prompt

> Make connect_with_person's connection-state detection locale-independent. Replace text-based 1st-vs-follow detection with URL patterns and attribute presence: vanityName invite anchor, edit-intro anchor, action-root buttons identified by aria-label/aria-expanded/aria-disabled presence (not values). Detect Pending via the locale-independent labeled-anchor signal — LinkedIn renders Pending as `<a aria-label="Pending, click to withdraw …">` while Follow renders as `<button aria-label="Follow {Name}">`. Fix the broken More-menu fallback (the previous selector matched video-player More buttons), extract the shared action-root discovery JS, CSS.escape the username before interpolation into selectors, and gate the invite-deeplink write strictly on has_invite_anchor=True after the optional More-menu reread. Keep the existing Accept/Ignore text fallback for incoming-request detection as the one documented locale escape-hatch behind a per-locale label table with line-anchored regex matching. Update tests in tests/test_scraping.py and add the locale-independence rule to AGENTS.md Scraping Rules.