### PR TITLE
docs: sync tool status issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | Tool | Description | Status |
 |------|-------------|--------|
 | `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
-| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | working |
+| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | [#307](https://github.com/stickerdaniel/linkedin-mcp-server/issues/307) |


### PR DESCRIPTION
Fixes #411

## Synthetic prompt

> Sync the README Features & Tool Status table with current open tool-specific issues. Link the open `connect_with_person` limitation in #407, keep existing open tool issue links, and avoid adding broad runtime/auth issues to the table.

Generated with GPT-5 Codex