### PR TITLE
fix(messaging): expose per-thread refs in search and add index for multi-thread participants

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2541,6 +2541,13 @@ class LinkedInExtractor:
         InMail. Ignored when ``thread_id`` is provided. Use
         ``search_conversations`` to enumerate thread IDs first if disambiguation
         by index is impractical.
+
+        Side effect when looked up by username: resolution searches LinkedIn's
+        messaging inbox for the participant's display name and click-visits
+        every matching row to capture its thread ID (no anchor hrefs or
+        thread-id attributes exist in the sidebar). Each visit selects the row
+        in the LinkedIn UI and may mark it as read. Pass ``thread_id`` directly
+        to skip this enumeration.
         """
         if not linkedin_username and not thread_id:
             raise LinkedInScraperException(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1831,102 +1831,51 @@ class LinkedInExtractor:
         match = re.search(r"/messaging/thread/([^/?#]+)/", url)
         return match.group(1) if match else None
 
-    async def _resolve_conversation_thread_url(self, search_query: str) -> str | None:
-        """Search the messaging inbox and return the matching thread URL."""
-        await self._navigate_to_page("https://www.linkedin.com/messaging/")
+    async def _resolve_conversation_thread_urls(self, display_name: str) -> list[str]:
+        """Return all thread URLs whose participant aria-label matches display_name.
+
+        Uses URL-driven search (`/messaging/?searchTerm=…`) plus click-to-capture
+        because LinkedIn renders the messaging sidebar with no anchor hrefs, no
+        data-thread attributes, and no embedded URNs — clicking each row and
+        reading the resulting SPA URL is the only available extraction path.
+
+        Matching is by exact ``aria-label == "Select conversation with <name>"``,
+        which is locale-independent and tolerates duplicate threads with the
+        same participant.
+        """
+        search_url = (
+            f"https://www.linkedin.com/messaging/?searchTerm={quote_plus(display_name)}"
+        )
+        await self._navigate_to_page(search_url)
         await detect_rate_limit(self._page)
         await handle_modal_close(self._page)
-        await self._wait_for_main_text(log_context="Messaging inbox")
-        # LinkedIn auto-redirects /messaging/ to the most recent thread;
-        # capture the baseline *after* the SPA settles so we can distinguish
-        # between the auto-opened thread and a search-selected one.
-        baseline_thread_id = self._extract_thread_id(self._page.url)
-
-        search_input = self._page.get_by_role("searchbox")
-        await search_input.wait_for()
-        await search_input.click()
-        await self._page.keyboard.type(search_query, delay=30)
-        await asyncio.sleep(1.0)
-        await self._page.keyboard.press("Enter")
-        await asyncio.sleep(1.5)
         await self._wait_for_main_text(log_context="Messaging search results")
 
-        match_result = await self._page.evaluate(
-            """({ searchQuery }) => {
-                const normalize = value =>
-                    (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
-                const target = normalize(searchQuery);
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
-                    );
-                const resolveThreadHref = element => {
-                    if (!element) return null;
-                    const threadSelector = 'a[href*="/messaging/thread/"]';
-                    const candidates = [
-                        element.matches?.(threadSelector) ? element : null,
-                        element.querySelector?.(threadSelector) || null,
-                        element.closest?.(threadSelector) || null,
-                    ].filter(Boolean);
-                    const threadLink = candidates.find(candidate => isVisible(candidate));
-                    return threadLink?.href || threadLink?.getAttribute('href') || null;
-                };
-
-                const matchingAnchor = Array.from(
-                    document.querySelectorAll('main a[href*="/messaging/thread/"]')
-                ).find(anchor => {
-                    if (!isVisible(anchor)) return false;
-                    const container =
-                        anchor.closest('[role="listitem"], li') ||
-                        anchor.parentElement ||
-                        anchor;
-                    const text = normalize(container.innerText || container.textContent);
-                    return text.includes(target);
-                });
-                if (matchingAnchor) {
-                    matchingAnchor.click();
-                    return {
-                        clicked: true,
-                        href: resolveThreadHref(matchingAnchor),
-                    };
-                }
-
-                const matchingRow = Array.from(
-                    document.querySelectorAll('main [role="listitem"], main li')
-                ).find(row => {
-                    if (!isVisible(row)) return false;
-                    const text = normalize(row.innerText || row.textContent);
-                    return text.includes(target);
-                });
-                if (matchingRow) {
-                    const interactionTarget =
-                        matchingRow.querySelector(
-                            '[tabindex="0"], button, [role="button"], a'
-                        ) || matchingRow;
-                    interactionTarget.click();
-                    return {
-                        clicked: true,
-                        href: resolveThreadHref(matchingRow),
-                    };
-                }
-
-                return { clicked: false, href: null };
-            }""",
-            {"searchQuery": search_query},
+        refs = await self._extract_conversation_thread_refs(
+            limit=None, context="search"
         )
-        if not isinstance(match_result, dict) or not match_result.get("clicked"):
-            return None
+        target_aria = f"Select conversation with {display_name}".strip().lower()
+        urls: list[str] = []
+        for ref in refs:
+            ref_text = (ref.get("text") or "").strip().lower()
+            if not ref_text:
+                continue
+            if f"select conversation with {ref_text}" != target_aria:
+                continue
+            urls.append(f"https://www.linkedin.com{ref['url']}")
+        return urls
 
-        await asyncio.sleep(1.0)
-        current_thread_id = self._extract_thread_id(self._page.url)
-        if current_thread_id and current_thread_id != baseline_thread_id:
-            return self._page.url
-        href = match_result.get("href")
-        return href if isinstance(href, str) and href else None
+    async def _open_conversation_by_username(
+        self, linkedin_username: str, index: int = 0
+    ) -> None:
+        """Open the ``index``-th conversation thread for the named participant.
 
-    async def _open_conversation_by_username(self, linkedin_username: str) -> None:
-        """Open a conversation by resolving the profile name, then searching inbox."""
+        ``index`` is 0-based and orders threads as the search-results sidebar
+        renders them (LinkedIn surfaces newest activity first).
+        """
+        if index < 0:
+            raise LinkedInScraperException(f"index must be non-negative (got {index}).")
+
         profile_url = f"https://www.linkedin.com/in/{linkedin_username}/"
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
@@ -1944,13 +1893,18 @@ class LinkedInExtractor:
             )
 
         try:
-            thread_url = await self._resolve_conversation_thread_url(display_name)
-            if not thread_url:
+            thread_urls = await self._resolve_conversation_thread_urls(display_name)
+            if not thread_urls:
                 raise LinkedInScraperException(
                     f"Could not find a conversation for {linkedin_username}."
                 )
+            if index >= len(thread_urls):
+                raise LinkedInScraperException(
+                    f"index {index} out of range: only {len(thread_urls)} "
+                    f"thread(s) exist for {linkedin_username}."
+                )
 
-            await self._navigate_to_page(thread_url)
+            await self._navigate_to_page(thread_urls[index])
         except PlaywrightTimeoutError as exc:
             raise LinkedInScraperException("Messaging search input not found.") from exc
 
@@ -2445,7 +2399,9 @@ class LinkedInExtractor:
         # LinkedIn's conversation sidebar uses JS click handlers instead of
         # <a> tags, so anchor extraction cannot capture thread IDs.  Click each
         # conversation item and read the resulting SPA URL to build references.
-        conversation_refs = await self._extract_conversation_thread_refs(limit)
+        conversation_refs = await self._extract_conversation_thread_refs(
+            limit=limit, context="inbox"
+        )
         if conversation_refs:
             references = dedupe_references(conversation_refs + references)
 
@@ -2456,25 +2412,58 @@ class LinkedInExtractor:
             references=references,
         )
 
-    async def _extract_conversation_thread_refs(self, limit: int) -> list[Reference]:
-        """Click each inbox conversation item and capture the thread URL.
+    async def _extract_conversation_thread_refs(
+        self, limit: int | None, context: str
+    ) -> list[Reference]:
+        """Click each visible conversation item and capture the thread URL.
 
-        LinkedIn's conversation sidebar renders ``<li>`` items with JS click
-        handlers — no ``<a href>`` tags — so the only reliable way to obtain
-        thread IDs is to click each item and read the SPA URL change.
+        Works for both the inbox sidebar and the URL-driven search-results
+        sidebar (`/messaging/?searchTerm=…`), since LinkedIn uses the same
+        ``label[aria-label^="Select conversation"]`` markup for both.
+
+        LinkedIn renders the sidebar with no ``<a href>`` tags, no
+        ``data-thread-id`` attributes, and no embedded URNs — clicking each
+        row and reading the SPA URL is the only reliable extraction path.
+        Pass ``limit=None`` to capture every visible row.
         """
+        # The conversation list mounts after main text settles, so wait
+        # explicitly for at least one label rather than relying on
+        # _wait_for_main_text alone (which only checks chrome text). LinkedIn
+        # routinely takes several seconds to hydrate the messaging sidebar
+        # after a navigation; an empty sidebar (zero matches) returns on
+        # timeout.
+        # The <label> for each conversation row sits inside an Ember-managed
+        # form and is reliably attached but not always considered "visible"
+        # by Playwright's default visibility heuristic — wait on attachment,
+        # which is the only state we actually need to query the DOM.
+        try:
+            await self._page.wait_for_selector(
+                'main label[aria-label^="Select conversation"]',
+                state="attached",
+                timeout=10000,
+            )
+        except PlaywrightTimeoutError:
+            logger.debug(
+                "conversation labels did not appear within 10s (context=%s)",
+                context,
+            )
+            return []
+
         # The Ember click handler lives on an inner div; the <li> and <label>
         # don't trigger SPA navigation.  No role/aria attributes exist on the
         # clickable element, so class-name selectors are unavoidable here.
-        # Participant names are extracted from the <label aria-label> instead
-        # of innerText to avoid layout-dependent parsing.
+        # Participant names come from the <label aria-label> instead of
+        # innerText to avoid layout-dependent parsing.
         conversations: list[dict[str, str]] = await self._page.evaluate(
             """async ({ limit }) => {
                 const labels = Array.from(document.querySelectorAll(
                     'main label[aria-label^="Select conversation"]'
                 ));
+                const cap = (limit == null)
+                    ? labels.length
+                    : Math.min(labels.length, limit);
                 const results = [];
-                for (let i = 0; i < Math.min(labels.length, limit); i++) {
+                for (let i = 0; i < cap; i++) {
                     const label = labels[i];
                     const ariaLabel = label.getAttribute('aria-label') || '';
                     const name = ariaLabel
@@ -2482,9 +2471,19 @@ class LinkedInExtractor:
                     const clickTarget = label.closest('li')
                         ?.querySelector('div[class*="listitem__link"]');
                     if (!clickTarget) continue;
+                    const before = location.href;
                     clickTarget.click();
-                    await new Promise(r => setTimeout(r, 300));
-                    const match = location.href.match(
+                    // Poll for the SPA URL to settle on the thread route. The
+                    // Ember click handler can take a moment to bind after the
+                    // label mounts, and a fixed sleep races the initial click.
+                    let after = before;
+                    for (let waits = 0; waits < 12; waits++) {
+                        await new Promise(r => setTimeout(r, 100));
+                        after = location.href;
+                        if (after !== before
+                            && /\\/messaging\\/thread\\//.test(after)) break;
+                    }
+                    const match = after.match(
                         /\\/messaging\\/thread\\/([^/?#]+)/
                     );
                     if (match) {
@@ -2500,7 +2499,7 @@ class LinkedInExtractor:
             ref: Reference = {
                 "kind": "conversation",
                 "url": f"/messaging/thread/{conv['threadId']}/",
-                "context": "inbox",
+                "context": context,
             }
             if conv.get("name"):
                 ref["text"] = conv["name"]
@@ -2511,8 +2510,16 @@ class LinkedInExtractor:
         self,
         linkedin_username: str | None = None,
         thread_id: str | None = None,
+        index: int = 0,
     ) -> dict[str, Any]:
-        """Read a specific messaging conversation by thread ID or username."""
+        """Read a specific messaging conversation by thread ID or username.
+
+        ``index`` (0-based) selects which thread to open when a participant has
+        multiple conversation threads — e.g. an organic 1-on-1 plus a separate
+        InMail. Ignored when ``thread_id`` is provided. Use
+        ``search_conversations`` to enumerate thread IDs first if disambiguation
+        by index is impractical.
+        """
         if not linkedin_username and not thread_id:
             raise LinkedInScraperException(
                 "Provide at least one of linkedin_username or thread_id"
@@ -2523,7 +2530,9 @@ class LinkedInExtractor:
                 f"https://www.linkedin.com/messaging/thread/{thread_id}/"
             )
         else:
-            await self._open_conversation_by_username(linkedin_username or "")
+            await self._open_conversation_by_username(
+                linkedin_username or "", index=index
+            )
 
         await detect_rate_limit(self._page)
         await self._wait_for_main_text(log_context="Conversation")
@@ -2548,32 +2557,41 @@ class LinkedInExtractor:
         )
 
     async def search_conversations(self, keywords: str) -> dict[str, Any]:
-        """Search messages by keyword."""
-        await self._navigate_to_page("https://www.linkedin.com/messaging/")
+        """Search messages by keyword.
+
+        Uses LinkedIn's ``?searchTerm=`` URL parameter to drive the search
+        rather than typing into the searchbox — the URL form is reliable
+        regardless of how soon the messaging SPA mounts its searchbox role,
+        and (critically) preserves the search filter across click-to-capture
+        navigations so per-thread refs can be enumerated.
+        """
+        search_url = (
+            f"https://www.linkedin.com/messaging/?searchTerm={quote_plus(keywords)}"
+        )
+        await self._navigate_to_page(search_url)
         await detect_rate_limit(self._page)
         await handle_modal_close(self._page)
-
-        try:
-            search_input = self._page.get_by_role("searchbox")
-            await search_input.wait_for()
-            await search_input.click()
-            await self._page.keyboard.type(keywords, delay=30)
-            await asyncio.sleep(1.0)
-            await self._page.keyboard.press("Enter")
-            await asyncio.sleep(1.5)
-        except PlaywrightTimeoutError:
-            logger.warning("Messaging search input not found")
-
         await self._wait_for_main_text(log_context="Messaging search")
 
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
         cleaned = strip_linkedin_noise(raw) if raw else ""
-        references = (
+        references: list[Reference] = (
             build_references(raw_result["references"], "search_results")
             if cleaned
             else []
         )
+
+        # Same click-to-capture path as get_inbox: LinkedIn's search sidebar
+        # has no anchor hrefs or thread-id attributes, so the only way to
+        # surface per-result thread IDs is to click each row and read the SPA
+        # URL. URL-driven search keeps the filter active across clicks.
+        conversation_refs = await self._extract_conversation_thread_refs(
+            limit=None, context="search_results"
+        )
+        if conversation_refs:
+            references = dedupe_references(conversation_refs + references)
+
         return self._single_section_result(
             self._page.url,
             "search_results",

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1832,16 +1832,19 @@ class LinkedInExtractor:
         return match.group(1) if match else None
 
     async def _resolve_conversation_thread_urls(self, display_name: str) -> list[str]:
-        """Return all thread URLs whose participant aria-label matches display_name.
+        """Return all thread URLs whose participant name matches display_name.
 
         Uses URL-driven search (`/messaging/?searchTerm=…`) plus click-to-capture
         because LinkedIn renders the messaging sidebar with no anchor hrefs, no
         data-thread attributes, and no embedded URNs — clicking each row and
         reading the resulting SPA URL is the only available extraction path.
 
-        Matching is by exact ``aria-label == "Select conversation with <name>"``,
-        which is locale-independent and tolerates duplicate threads with the
-        same participant.
+        Matches by case-insensitive equality on the cleaned participant name
+        derived from the row's aria-label, which tolerates duplicate threads
+        with the same participant. Browser locale is forced to en-US so the
+        verb prefix strips reliably; in any other locale the comparison fails
+        cleanly with "Could not find a conversation" rather than returning
+        a wrong-thread match.
         """
         search_url = (
             f"https://www.linkedin.com/messaging/?searchTerm={quote_plus(display_name)}"
@@ -1854,13 +1857,11 @@ class LinkedInExtractor:
         refs = await self._extract_conversation_thread_refs(
             limit=None, context="search"
         )
-        target_aria = f"Select conversation with {display_name}".strip().lower()
+        target_name = display_name.strip().lower()
         urls: list[str] = []
         for ref in refs:
             ref_text = (ref.get("text") or "").strip().lower()
-            if not ref_text:
-                continue
-            if f"select conversation with {ref_text}" != target_aria:
+            if not ref_text or ref_text != target_name:
                 continue
             urls.append(f"https://www.linkedin.com{ref['url']}")
         return urls
@@ -1906,7 +1907,9 @@ class LinkedInExtractor:
 
             await self._navigate_to_page(thread_urls[index])
         except PlaywrightTimeoutError as exc:
-            raise LinkedInScraperException("Messaging search input not found.") from exc
+            raise LinkedInScraperException(
+                "Messaging search results did not load in time."
+            ) from exc
 
     async def scrape_company(
         self,
@@ -2418,8 +2421,9 @@ class LinkedInExtractor:
         """Click each visible conversation item and capture the thread URL.
 
         Works for both the inbox sidebar and the URL-driven search-results
-        sidebar (`/messaging/?searchTerm=…`), since LinkedIn uses the same
-        ``label[aria-label^="Select conversation"]`` markup for both.
+        sidebar (`/messaging/?searchTerm=…`), which share the same DOM shape:
+        each conversation row is an ``<li>`` containing a ``<label>`` with an
+        ``aria-label`` attribute carrying the participant name.
 
         LinkedIn renders the sidebar with no ``<a href>`` tags, no
         ``data-thread-id`` attributes, and no embedded URNs — clicking each
@@ -2432,13 +2436,19 @@ class LinkedInExtractor:
         # routinely takes several seconds to hydrate the messaging sidebar
         # after a navigation; an empty sidebar (zero matches) returns on
         # timeout.
-        # The <label> for each conversation row sits inside an Ember-managed
-        # form and is reliably attached but not always considered "visible"
-        # by Playwright's default visibility heuristic — wait on attachment,
-        # which is the only state we actually need to query the DOM.
+        #
+        # Selector is structural (`main li label[aria-label]`) rather than
+        # text-prefix-based (`aria-label^="Select conversation"`) so it
+        # survives any LinkedIn locale — the verb in the aria-label is
+        # locale-dependent, the attribute's presence inside a list-item label
+        # is not.
+        #
+        # Wait on `state="attached"` instead of the default `visible`:
+        # Ember-managed labels are reliably attached but Playwright's
+        # visibility heuristic doesn't always consider them visible.
         try:
             await self._page.wait_for_selector(
-                'main label[aria-label^="Select conversation"]',
+                "main li label[aria-label]",
                 state="attached",
                 timeout=10000,
             )
@@ -2452,12 +2462,12 @@ class LinkedInExtractor:
         # The Ember click handler lives on an inner div; the <li> and <label>
         # don't trigger SPA navigation.  No role/aria attributes exist on the
         # clickable element, so class-name selectors are unavoidable here.
-        # Participant names come from the <label aria-label> instead of
-        # innerText to avoid layout-dependent parsing.
+        # The aria-label value flows through unmodified — Python strips any
+        # known locale prefix to derive a clean participant name for refs.
         conversations: list[dict[str, str]] = await self._page.evaluate(
             """async ({ limit }) => {
                 const labels = Array.from(document.querySelectorAll(
-                    'main label[aria-label^="Select conversation"]'
+                    'main li label[aria-label]'
                 ));
                 const cap = (limit == null)
                     ? labels.length
@@ -2466,8 +2476,6 @@ class LinkedInExtractor:
                 for (let i = 0; i < cap; i++) {
                     const label = labels[i];
                     const ariaLabel = label.getAttribute('aria-label') || '';
-                    const name = ariaLabel
-                        .replace(/^Select conversation with\\s*/i, '').trim();
                     const clickTarget = label.closest('li')
                         ?.querySelector('div[class*="listitem__link"]');
                     if (!clickTarget) continue;
@@ -2487,7 +2495,7 @@ class LinkedInExtractor:
                         /\\/messaging\\/thread\\/([^/?#]+)/
                     );
                     if (match) {
-                        results.push({ name, threadId: match[1] });
+                        results.push({ ariaLabel, threadId: match[1] });
                     }
                 }
                 return results;
@@ -2501,10 +2509,24 @@ class LinkedInExtractor:
                 "url": f"/messaging/thread/{conv['threadId']}/",
                 "context": context,
             }
-            if conv.get("name"):
-                ref["text"] = conv["name"]
+            name = self._strip_select_conversation_prefix(conv.get("ariaLabel", ""))
+            if name:
+                ref["text"] = name
             refs.append(ref)
         return refs
+
+    # Best-effort prefix strip for the en-US "Select conversation with " verb.
+    # Browser locale is forced to en-US (see BrowserManager) so this normally
+    # succeeds; the regex falls through silently for any other locale, in
+    # which case the full aria-label flows into the ref's text field rather
+    # than a stripped name.
+    _SELECT_CONVERSATION_PREFIX_RE = re.compile(
+        r"^Select conversation with\s+", re.IGNORECASE
+    )
+
+    @classmethod
+    def _strip_select_conversation_prefix(cls, aria_label: str) -> str:
+        return cls._SELECT_CONVERSATION_PREFIX_RE.sub("", aria_label).strip()
 
     async def get_conversation(
         self,
@@ -2556,7 +2578,9 @@ class LinkedInExtractor:
             references=references,
         )
 
-    async def search_conversations(self, keywords: str) -> dict[str, Any]:
+    async def search_conversations(
+        self, keywords: str, limit: int = 20
+    ) -> dict[str, Any]:
         """Search messages by keyword.
 
         Uses LinkedIn's ``?searchTerm=`` URL parameter to drive the search
@@ -2564,6 +2588,10 @@ class LinkedInExtractor:
         regardless of how soon the messaging SPA mounts its searchbox role,
         and (critically) preserves the search filter across click-to-capture
         navigations so per-thread refs can be enumerated.
+
+        ``limit`` caps how many search-result rows the click-to-capture loop
+        visits. Each visit selects the row in LinkedIn's UI (and may mark it
+        as read), so a low cap is preferable for noisy queries.
         """
         search_url = (
             f"https://www.linkedin.com/messaging/?searchTerm={quote_plus(keywords)}"
@@ -2587,7 +2615,7 @@ class LinkedInExtractor:
         # surface per-result thread IDs is to click each row and read the SPA
         # URL. URL-driven search keeps the filter active across clicks.
         conversation_refs = await self._extract_conversation_thread_refs(
-            limit=None, context="search_results"
+            limit=limit, context="search_results"
         )
         if conversation_refs:
             references = dedupe_references(conversation_refs + references)

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -152,6 +152,7 @@ def register_messaging_tools(mcp: FastMCP) -> None:
     async def search_conversations(
         keywords: str,
         ctx: Context,
+        limit: Annotated[int, Field(ge=1, le=50)] = 20,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -160,6 +161,10 @@ def register_messaging_tools(mcp: FastMCP) -> None:
         Args:
             keywords: Search keywords to filter conversations
             ctx: FastMCP context for progress reporting
+            limit: Maximum number of search-result rows to enumerate as
+                conversation references (1-50, default 20). Each enumeration
+                selects the row in LinkedIn's UI and may mark it as read, so
+                a low cap is preferable for noisy queries.
 
         Returns:
             Dict with url, sections (search_results -> raw text), and optional references.
@@ -168,13 +173,15 @@ def register_messaging_tools(mcp: FastMCP) -> None:
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="search_conversations"
             )
-            logger.info("Searching conversations: keywords='%s'", keywords)
+            logger.info(
+                "Searching conversations: keywords='%s', limit=%d", keywords, limit
+            )
 
             await ctx.report_progress(
                 progress=0, total=100, message="Searching messages"
             )
 
-            result = await extractor.search_conversations(keywords)
+            result = await extractor.search_conversations(keywords, limit=limit)
 
             await ctx.report_progress(progress=100, total=100, message="Complete")
 

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -89,6 +89,13 @@ def register_messaging_tools(mcp: FastMCP) -> None:
 
         Provide either linkedin_username or thread_id to identify the conversation.
 
+        When looked up by linkedin_username, resolution searches the messaging
+        inbox for the participant's display name and click-visits every
+        matching row to capture its thread ID — LinkedIn's sidebar has no
+        anchor hrefs or thread-id attributes, so this is the only available
+        path. Each visit selects the row in the LinkedIn UI and may mark it
+        as read. Pass thread_id directly to skip this enumeration.
+
         Args:
             ctx: FastMCP context for progress reporting
             linkedin_username: LinkedIn username of the conversation participant

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -81,6 +81,7 @@ def register_messaging_tools(mcp: FastMCP) -> None:
         ctx: Context,
         linkedin_username: str | None = None,
         thread_id: str | None = None,
+        index: Annotated[int, Field(ge=0)] = 0,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -92,6 +93,10 @@ def register_messaging_tools(mcp: FastMCP) -> None:
             ctx: FastMCP context for progress reporting
             linkedin_username: LinkedIn username of the conversation participant
             thread_id: LinkedIn messaging thread ID
+            index: 0-based selector for which thread to open when the
+                participant has multiple threads (e.g. an organic 1-on-1 plus
+                an InMail). Ignored when thread_id is provided. To enumerate
+                thread IDs first, call search_conversations.
 
         Returns:
             Dict with url, sections (conversation -> raw text), and optional references.
@@ -109,9 +114,10 @@ def register_messaging_tools(mcp: FastMCP) -> None:
                 ctx, tool_name="get_conversation"
             )
             logger.info(
-                "Fetching conversation: username=%s, thread_id=%s",
+                "Fetching conversation: username=%s, thread_id=%s, index=%d",
                 linkedin_username,
                 thread_id,
+                index,
             )
 
             await ctx.report_progress(
@@ -121,6 +127,7 @@ def register_messaging_tools(mcp: FastMCP) -> None:
             result = await extractor.get_conversation(
                 linkedin_username=linkedin_username,
                 thread_id=thread_id,
+                index=index,
             )
 
             await ctx.report_progress(progress=100, total=100, message="Complete")

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3470,6 +3470,38 @@ class TestGetConversation:
                 await extractor.get_conversation(linkedin_username="jacki-old")
 
 
+class TestStripSelectConversationPrefix:
+    def test_strips_en_us_prefix(self):
+        """Best-effort strip removes the en-US 'Select conversation with ' prefix."""
+        assert (
+            LinkedInExtractor._strip_select_conversation_prefix(
+                "Select conversation with Jacki McMahan"
+            )
+            == "Jacki McMahan"
+        )
+
+    def test_case_insensitive(self):
+        assert (
+            LinkedInExtractor._strip_select_conversation_prefix(
+                "select conversation with jacki mcmahan"
+            )
+            == "jacki mcmahan"
+        )
+
+    def test_returns_full_aria_when_prefix_absent(self):
+        """In a non-en-US locale the verb prefix won't match; return as-is so
+        downstream matching can endsWith / endswith on the participant name."""
+        assert (
+            LinkedInExtractor._strip_select_conversation_prefix(
+                "Konversation auswählen mit Jacki McMahan"
+            )
+            == "Konversation auswählen mit Jacki McMahan"
+        )
+
+    def test_empty_input(self):
+        assert LinkedInExtractor._strip_select_conversation_prefix("") == ""
+
+
 class TestResolveConversationThreadUrls:
     async def test_url_driven_search_and_exact_aria_match(self, mock_page):
         """_resolve_conversation_thread_urls drives search via URL parameter
@@ -3625,7 +3657,7 @@ class TestSearchConversations:
         ):
             result = await extractor.search_conversations("Jacki")
 
-        mock_refs.assert_awaited_once_with(limit=None, context="search_results")
+        mock_refs.assert_awaited_once_with(limit=20, context="search_results")
         refs = result["references"]["search_results"]
         assert len(refs) == 2
         assert {ref["url"] for ref in refs} == {

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3289,20 +3289,126 @@ class TestGetConversation:
         with pytest.raises(LinkedInScraperException):
             await extractor.get_conversation()
 
-
-class TestSearchConversations:
-    async def test_returns_search_results(self, mock_page):
-        """search_conversations returns search_results section."""
+    async def test_by_username_default_index_picks_first_thread(self, mock_page):
+        """get_conversation by username opens the 0th matching thread by default."""
         extractor = LinkedInExtractor(mock_page)
-        mock_searchbox = AsyncMock()
-        mock_searchbox.wait_for = AsyncMock()
-        mock_searchbox.click = AsyncMock()
-        mock_page.get_by_role = MagicMock(return_value=mock_searchbox)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
+        nav_mock = AsyncMock()
+        mock_page.wait_for_selector = AsyncMock()
+        with (
+            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor,
+                "_read_profile_display_name",
+                new_callable=AsyncMock,
+                return_value="Jacki McMahan",
+            ),
+            patch.object(
+                extractor,
+                "_resolve_conversation_thread_urls",
+                new_callable=AsyncMock,
+                return_value=[
+                    "https://www.linkedin.com/messaging/thread/2-newer/",
+                    "https://www.linkedin.com/messaging/thread/2-older/",
+                ],
+            ),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={"text": "msg", "references": []},
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                return_value="msg",
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.build_references",
+                return_value=[],
+            ),
+        ):
+            await extractor.get_conversation(linkedin_username="jacki-old")
 
+        target_calls = [
+            c.args[0]
+            for c in nav_mock.call_args_list
+            if c.args and "/messaging/thread/" in c.args[0]
+        ]
+        assert target_calls == ["https://www.linkedin.com/messaging/thread/2-newer/"]
+
+    async def test_by_username_index_picks_specified_thread(self, mock_page):
+        """get_conversation by username + index opens the i-th matching thread."""
+        extractor = LinkedInExtractor(mock_page)
+        nav_mock = AsyncMock()
+        mock_page.wait_for_selector = AsyncMock()
+        with (
+            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor,
+                "_read_profile_display_name",
+                new_callable=AsyncMock,
+                return_value="Jacki McMahan",
+            ),
+            patch.object(
+                extractor,
+                "_resolve_conversation_thread_urls",
+                new_callable=AsyncMock,
+                return_value=[
+                    "https://www.linkedin.com/messaging/thread/2-newer/",
+                    "https://www.linkedin.com/messaging/thread/2-older/",
+                ],
+            ),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={"text": "msg", "references": []},
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                return_value="msg",
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.build_references",
+                return_value=[],
+            ),
+        ):
+            await extractor.get_conversation(linkedin_username="jacki-old", index=1)
+
+        target_calls = [
+            c.args[0]
+            for c in nav_mock.call_args_list
+            if c.args and "/messaging/thread/" in c.args[0]
+        ]
+        assert target_calls == ["https://www.linkedin.com/messaging/thread/2-older/"]
+
+    async def test_by_username_index_out_of_range_raises(self, mock_page):
+        """get_conversation raises when index exceeds the number of threads."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_selector = AsyncMock()
         with (
             patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
             patch(
@@ -3313,11 +3419,129 @@ class TestSearchConversations:
                 "linkedin_mcp_server.scraping.extractor.handle_modal_close",
                 new_callable=AsyncMock,
             ),
-            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor,
+                "_read_profile_display_name",
+                new_callable=AsyncMock,
+                return_value="Jacki McMahan",
+            ),
+            patch.object(
+                extractor,
+                "_resolve_conversation_thread_urls",
+                new_callable=AsyncMock,
+                return_value=[
+                    "https://www.linkedin.com/messaging/thread/2-only/",
+                ],
+            ),
+        ):
+            with pytest.raises(LinkedInScraperException, match="out of range"):
+                await extractor.get_conversation(linkedin_username="jacki-old", index=5)
+
+    async def test_by_username_no_threads_raises_could_not_find(self, mock_page):
+        """get_conversation raises 'Could not find a conversation' when none exist."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_selector = AsyncMock()
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
             patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
             ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_read_profile_display_name",
+                new_callable=AsyncMock,
+                return_value="Jacki McMahan",
+            ),
+            patch.object(
+                extractor,
+                "_resolve_conversation_thread_urls",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            with pytest.raises(
+                LinkedInScraperException, match="Could not find a conversation"
+            ):
+                await extractor.get_conversation(linkedin_username="jacki-old")
+
+
+class TestResolveConversationThreadUrls:
+    async def test_url_driven_search_and_exact_aria_match(self, mock_page):
+        """_resolve_conversation_thread_urls drives search via URL parameter
+        and matches participant by exact aria-label rather than substring."""
+        extractor = LinkedInExtractor(mock_page)
+        nav_mock = AsyncMock()
+        thread_refs = [
+            {
+                "kind": "conversation",
+                "url": "/messaging/thread/2-aaa/",
+                "text": "Jacki McMahan",  # exact match
+                "context": "search",
+            },
+            {
+                "kind": "conversation",
+                "url": "/messaging/thread/2-bbb/",
+                "text": "Jacki McMahan-Group",  # extra suffix → not exact
+                "context": "search",
+            },
+            {
+                "kind": "conversation",
+                "url": "/messaging/thread/2-ccc/",
+                "text": "Jacki McMahan",  # second exact match (multi-thread case)
+                "context": "search",
+            },
+        ]
+        with (
+            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor,
+                "_extract_conversation_thread_refs",
+                new_callable=AsyncMock,
+                return_value=thread_refs,
+            ),
+        ):
+            urls = await extractor._resolve_conversation_thread_urls("Jacki McMahan")
+
+        nav_mock.assert_awaited_once_with(
+            "https://www.linkedin.com/messaging/?searchTerm=Jacki+McMahan"
+        )
+        assert urls == [
+            "https://www.linkedin.com/messaging/thread/2-aaa/",
+            "https://www.linkedin.com/messaging/thread/2-ccc/",
+        ]
+
+
+class TestSearchConversations:
+    async def test_returns_search_results(self, mock_page):
+        """search_conversations returns search_results section."""
+        extractor = LinkedInExtractor(mock_page)
+        nav_mock = AsyncMock()
+
+        with (
+            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
             patch.object(
                 extractor,
                 "_extract_root_content",
@@ -3332,11 +3556,82 @@ class TestSearchConversations:
                 "linkedin_mcp_server.scraping.extractor.build_references",
                 return_value=[],
             ),
+            patch.object(
+                extractor,
+                "_extract_conversation_thread_refs",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
         ):
-            result = await extractor.search_conversations("hello")
+            result = await extractor.search_conversations("hello world")
 
         assert "search_results" in result["sections"]
         assert "Result 1" in result["sections"]["search_results"]
+        # Search must be driven by the searchTerm URL parameter, not by typing
+        # into the searchbox -- the URL form is reliable across SPA mounts and
+        # preserves the search filter across click-to-capture navigations.
+        nav_mock.assert_awaited_once_with(
+            "https://www.linkedin.com/messaging/?searchTerm=hello+world"
+        )
+
+    async def test_includes_conversation_thread_refs(self, mock_page):
+        """search_conversations exposes per-result thread URLs as references."""
+        extractor = LinkedInExtractor(mock_page)
+        thread_refs = [
+            {
+                "kind": "conversation",
+                "url": "/messaging/thread/2-abc/",
+                "text": "Jacki McMahan",
+                "context": "search_results",
+            },
+            {
+                "kind": "conversation",
+                "url": "/messaging/thread/2-def/",
+                "text": "Jacki McMahan",
+                "context": "search_results",
+            },
+        ]
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={"text": "Jacki McMahan\nJacki McMahan", "references": []},
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                return_value="Jacki McMahan\nJacki McMahan",
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.build_references",
+                return_value=[],
+            ),
+            patch.object(
+                extractor,
+                "_extract_conversation_thread_refs",
+                new_callable=AsyncMock,
+                return_value=thread_refs,
+            ) as mock_refs,
+        ):
+            result = await extractor.search_conversations("Jacki")
+
+        mock_refs.assert_awaited_once_with(limit=None, context="search_results")
+        refs = result["references"]["search_results"]
+        assert len(refs) == 2
+        assert {ref["url"] for ref in refs} == {
+            "/messaging/thread/2-abc/",
+            "/messaging/thread/2-def/",
+        }
 
 
 class TestSendMessage:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -653,7 +653,7 @@ class TestMessagingTools:
         result = await tool_fn("hello", mock_context, extractor=mock_extractor)
 
         assert result["sections"]["search_results"] == "Result 1\nResult 2"
-        mock_extractor.search_conversations.assert_awaited_once_with("hello")
+        mock_extractor.search_conversations.assert_awaited_once_with("hello", limit=20)
 
     async def test_send_message_success(self, mock_context):
         expected = {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -634,7 +634,7 @@ class TestMessagingTools:
 
         assert result["sections"]["conversation"] == "Hello!\nHi there!"
         mock_extractor.get_conversation.assert_awaited_once_with(
-            linkedin_username="testuser", thread_id=None
+            linkedin_username="testuser", thread_id=None, index=0
         )
 
     async def test_search_conversations_success(self, mock_context):


### PR DESCRIPTION
## Summary

LinkedIn renders the messaging sidebar with no anchor `href`s, no `data-thread-*` attributes, and no embedded URNs (verified via DOM probe), so callers had no way to discover thread IDs from search results and could not reach an older thread when one participant has multiple conversations. Issue #307 reports this as: search shows both threads, but `get_conversation(linkedin_username=...)` returns "Could not find a conversation" and the thread ID copied out of the search URL points to the wrong (auto-loaded most-recent) thread.

- `search_conversations` now drives search via the `?searchTerm=` URL parameter (no more flaky searchbox typing) and click-to-captures per-result thread URLs as `kind=conversation` references — same shape `get_inbox` already uses.
- `_resolve_conversation_thread_urls` returns every thread whose participant `aria-label` matches the profile display name *exactly*, replacing the substring matcher that broke on cached old names after a profile rename.
- `get_conversation` accepts a 0-based `index` parameter to disambiguate when one participant has multiple threads; out-of-range raises with the actual count.
- The shared click-to-capture helper waits on label `state="attached"` instead of the default `visible` (Ember-managed labels never satisfy Playwright's visibility heuristic) and polls for the SPA URL change instead of a fixed 300 ms sleep that raced LinkedIn's click-handler binding — both fixed long-standing flakes seen with `get_inbox`.

Resolves: #307

## Test plan

- [x] `uv run pytest` — 436 passed
- [x] `uv run ruff check .` and `uv run ty check` — clean
- [x] Live verification against LinkedIn:
  - `search_conversations(keywords="Daniel")` → 11 conversation refs, each with a unique thread URL (was 0 before, plus a "search input not found" warning)
  - `get_conversation(linkedin_username="fadi-eliwi")` → loads correct thread with default `index=0`
  - `get_conversation(linkedin_username="fadi-eliwi", index=99)` → raises `index 99 out of range: only 1 thread(s) exist for fadi-eliwi.`
