### PR TITLE
chore: Bump version to 4.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "linkedin-scraper-mcp"
-version = "4.9.5"
+version = "4.10.0"
 description = "MCP server for LinkedIn profile, company, and job scraping with Claude AI integration. Supports direct profile/company/job URL scraping with secure credential storage."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -978,7 +978,7 @@ wheels = [
 
 [[package]]
 name = "linkedin-scraper-mcp"
-version = "4.9.5"
+version = "4.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Bump version to **4.10.0** (minor — additive features + bug fix shipped in #413).

Changes since 4.9.5:
- `get_conversation` gains a 0-based `index` parameter to disambiguate participants with multiple threads
- `search_conversations` gains a `limit` parameter (1-50, default 20) and now exposes per-result thread URLs as `kind=conversation` references
- Switches messaging to URL-driven search (`?searchTerm=`) with a structural, locale-independent DOM selector and click-to-capture URL polling — fixes thread-ID discovery when participants have renamed profiles or multiple conversations (Resolves #307)

## Test plan
- [x] `uv run pytest` — 440 passed
- [x] `uv run ruff check . && uv run ty check` — clean
- [x] CI release workflow will publish 4.10.0 to PyPI and update `manifest.json` + `docker-compose.yml` automatically
