### PR TITLE
feat(tools): add tool get_saved_jobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Optional additional keys:
 - `references: {section_name: [{kind, url, text?, context?}]}` — LinkedIn URLs are relative paths
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
-- `job_ids: [id, ...]` (search_jobs only)
+- `job_ids: [id, ...]` (search_jobs, get_saved_jobs)
 
 ## Verifying Bug Reports
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | `search_jobs` | Search for jobs with keywords and location filters | working |
 | `search_people` | Search for people by keywords and location | working |
 | `get_job_details` | Get detailed information about a specific job posting | working |
+| `get_saved_jobs` | List the user's saved jobs from the LinkedIn job tracker (returns job IDs usable with `get_job_details`) | working |
 | `close_session` | Close browser session and clean up resources | working |
 
 <br/>

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2097,6 +2097,19 @@ class LinkedInExtractor:
     ) -> ExtractedSection:
         """Single attempt to navigate, scroll sidebar, and extract innerText."""
         await self._navigate_to_page(url)
+        return await self._extract_search_page_static(url, section_name)
+
+    async def _extract_search_page_static(
+        self,
+        url: str,
+        section_name: str,
+    ) -> ExtractedSection:
+        """Extract from the currently loaded search-style page without navigating.
+
+        Used by click-based pagination flows (e.g. /jobs-tracker/) where the
+        URL stays the same and content updates in place. ``url`` is only used
+        for logging context.
+        """
         await detect_rate_limit(self._page)
 
         main_found = True
@@ -2337,6 +2350,149 @@ class LinkedInExtractor:
         if page_references:
             result["references"] = {
                 "search_results": dedupe_references(page_references, cap=15)
+            }
+        if section_errors:
+            result["section_errors"] = section_errors
+        return result
+
+    async def _advance_saved_jobs_page(self, target_index: int) -> bool:
+        """Click the saved-jobs "next" pagination button, then wait for the
+        target page indicator to become active.
+
+        ``/jobs-tracker/`` paginates client-side: the URL stays the same and
+        content updates in place, so URL-based pagination is impossible.
+
+        Detection is locale-independent — we use the ``data-testid`` suffix
+        (``-visible``/``-hidden``) on the next button and ``aria-current="true"``
+        on the target indicator. Returns ``False`` if no next button is
+        visible (we're on the last page) or if the indicator never updates.
+        """
+        next_visible = self._page.locator(
+            '[data-testid="pagination-controls-next-button-visible"]'
+        )
+        if await next_visible.count() == 0:
+            return False
+
+        try:
+            await next_visible.first.click()
+        except Exception as e:
+            logger.debug("Could not click saved-jobs next button: %s", e)
+            return False
+
+        target = self._page.locator(
+            f'[data-testid="pagination-indicator-{target_index}"][aria-current="true"]'
+        )
+        try:
+            await target.wait_for(state="attached", timeout=10000)
+        except PlaywrightTimeoutError:
+            logger.debug(
+                "Saved-jobs indicator %d never became aria-current",
+                target_index,
+            )
+            return False
+        return True
+
+    async def scrape_saved_jobs(self, max_pages: int = 3) -> dict[str, Any]:
+        """Scrape the user's saved jobs from /jobs-tracker/ with pagination.
+
+        Extracts job IDs from ``a[href*="/jobs/view/"]`` links and paginates
+        by clicking the next button (``data-testid=pagination-controls-next-
+        button-visible``). The page has no ``Page X of Y`` text element, so
+        we stop when the next button disappears, when a page yields no new
+        IDs, or when ``max_pages`` is hit.
+
+        Args:
+            max_pages: Maximum pages to load (1-10, default 3)
+
+        Returns:
+            {url, sections: {saved_jobs: text}, job_ids: [str]}
+        """
+        base_url = "https://www.linkedin.com/jobs-tracker/"
+        all_job_ids: list[str] = []
+        seen_ids: set[str] = set()
+        page_texts: list[str] = []
+        page_references: list[Reference] = []
+        section_errors: dict[str, dict[str, Any]] = {}
+
+        for page_num in range(max_pages):
+            try:
+                if page_num == 0:
+                    extracted = await self._extract_search_page(
+                        base_url, section_name="saved_jobs"
+                    )
+                else:
+                    await asyncio.sleep(_NAV_DELAY)
+                    advanced = await self._advance_saved_jobs_page(page_num)
+                    if not advanced:
+                        logger.debug(
+                            "No more saved-jobs pages after page %d, stopping",
+                            page_num,
+                        )
+                        break
+                    extracted = await self._extract_search_page_static(
+                        self._page.url, section_name="saved_jobs"
+                    )
+
+                if not extracted.text or extracted.text == _RATE_LIMITED_MSG:
+                    if extracted.error:
+                        section_errors["saved_jobs"] = extracted.error
+                    break
+
+                if not self._page.url.startswith(
+                    "https://www.linkedin.com/jobs-tracker/"
+                ):
+                    logger.debug(
+                        "Unexpected page URL after extraction: %s — "
+                        "skipping job ID extraction",
+                        self._page.url,
+                    )
+                    page_texts.append(extracted.text)
+                    if extracted.references:
+                        page_references.extend(extracted.references)
+                    break
+
+                page_ids = await self._extract_job_ids()
+                new_ids = [jid for jid in page_ids if jid not in seen_ids]
+
+                if not new_ids:
+                    page_texts.append(extracted.text)
+                    if extracted.references:
+                        page_references.extend(extracted.references)
+                    logger.debug(
+                        "No new saved-job IDs on page %d, stopping", page_num + 1
+                    )
+                    break
+
+                for jid in new_ids:
+                    seen_ids.add(jid)
+                    all_job_ids.append(jid)
+
+                page_texts.append(extracted.text)
+                if extracted.references:
+                    page_references.extend(extracted.references)
+
+            except LinkedInScraperException:
+                raise
+            except Exception as e:
+                logger.warning("Error on saved-jobs page %d: %s", page_num + 1, e)
+                section_errors["saved_jobs"] = build_issue_diagnostics(
+                    e,
+                    context="scrape_saved_jobs",
+                    target_url=self._page.url,
+                    section_name="saved_jobs",
+                )
+                break
+
+        result: dict[str, Any] = {
+            "url": base_url,
+            "sections": {"saved_jobs": "\n---\n".join(page_texts)}
+            if page_texts
+            else {},
+            "job_ids": all_job_ids,
+        }
+        if page_references:
+            result["references"] = {
+                "saved_jobs": dedupe_references(page_references, cap=15)
             }
         if section_errors:
             result["section_errors"] = section_errors

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -149,3 +149,53 @@ def register_job_tools(
                 raise_tool_error(relogin_exc, "search_jobs")
         except Exception as e:
             raise_tool_error(e, "search_jobs")  # NoReturn
+
+    @mcp.tool(
+        timeout=TOOL_TIMEOUT_SECONDS,
+        title="Get Saved Jobs",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"job", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_saved_jobs(
+        ctx: Context,
+        max_pages: Annotated[int, Field(ge=1, le=10)] = 3,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get the user's saved jobs from https://www.linkedin.com/jobs-tracker/.
+
+        Returns job_ids that can be passed to get_job_details for full info,
+        along with the raw page text under sections["saved_jobs"].
+
+        Args:
+            ctx: FastMCP context for progress reporting
+            max_pages: Maximum number of result pages to load (1-10, default 3)
+
+        Returns:
+            Dict with url, sections (name -> raw text), job_ids (list of
+            numeric job ID strings usable with get_job_details), and optional references.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_saved_jobs"
+            )
+            logger.info("Scraping saved jobs: max_pages=%d", max_pages)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Starting saved jobs scrape"
+            )
+
+            result = await extractor.scrape_saved_jobs(max_pages=max_pages)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_saved_jobs")
+        except Exception as e:
+            raise_tool_error(e, "get_saved_jobs")  # NoReturn

--- a/manifest.json
+++ b/manifest.json
@@ -74,6 +74,10 @@
       "description": "Search for jobs with filters like keywords and location"
     },
     {
+      "name": "get_saved_jobs",
+      "description": "List the user's saved jobs from the LinkedIn job tracker (returns job IDs usable with get_job_details)"
+    },
+    {
       "name": "search_people",
       "description": "Search for people on LinkedIn by keywords and location"
     },

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2164,6 +2164,283 @@ class TestSearchJobs:
         assert "references" not in result
 
 
+class TestScrapeSavedJobs:
+    """Tests for scrape_saved_jobs (jobs-tracker page)."""
+
+    @pytest.fixture(autouse=True)
+    def _set_tracker_url(self, mock_page):
+        mock_page.url = "https://www.linkedin.com/jobs-tracker/"
+
+    async def test_returns_job_ids(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Saved 1\nSaved 2"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111", "222"],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_saved_jobs(max_pages=1)
+
+        assert result["url"] == "https://www.linkedin.com/jobs-tracker/"
+        assert result["job_ids"] == ["111", "222"]
+        assert "saved_jobs" in result["sections"]
+
+    async def test_returns_references(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted(
+                    "Saved 1",
+                    [{"kind": "job", "url": "/jobs/view/111/", "text": "Job 111"}],
+                ),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111"],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_saved_jobs(max_pages=1)
+
+        assert result["references"] == {
+            "saved_jobs": [{"kind": "job", "url": "/jobs/view/111/", "text": "Job 111"}]
+        }
+
+    async def test_pagination_clicks_next_button(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        id_pages = iter([["100", "200"], ["300", "400"]])
+
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Page 1 text"),
+            ) as mock_extract_initial,
+            patch.object(
+                extractor,
+                "_extract_search_page_static",
+                new_callable=AsyncMock,
+                return_value=extracted("Page 2 text"),
+            ) as mock_extract_static,
+            patch.object(
+                extractor,
+                "_advance_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_advance,
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                side_effect=lambda: next(id_pages),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_saved_jobs(max_pages=2)
+
+        assert result["job_ids"] == ["100", "200", "300", "400"]
+        mock_extract_initial.assert_awaited_once()
+        mock_advance.assert_awaited_once_with(1)
+        mock_extract_static.assert_awaited_once()
+
+    async def test_pagination_stops_when_next_button_hidden(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Page 1 text"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_search_page_static",
+                new_callable=AsyncMock,
+                return_value=extracted("never reached"),
+            ) as mock_extract_static,
+            patch.object(
+                extractor,
+                "_advance_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as mock_advance,
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["100", "200"],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_saved_jobs(max_pages=5)
+
+        assert result["job_ids"] == ["100", "200"]
+        mock_advance.assert_awaited_once_with(1)
+        mock_extract_static.assert_not_awaited()
+
+    async def test_early_stop_no_new_ids(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        id_pages = iter([["100", "200"], ["100", "200"]])
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_extract_initial,
+            patch.object(
+                extractor,
+                "_extract_search_page_static",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_extract_static,
+            patch.object(
+                extractor,
+                "_advance_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                side_effect=lambda: next(id_pages),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_saved_jobs(max_pages=5)
+
+        assert result["job_ids"] == ["100", "200"]
+        assert mock_extract_initial.await_count == 1
+        assert mock_extract_static.await_count == 1
+
+    async def test_rate_limited_skips_ids_and_text(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted(_RATE_LIMITED_MSG),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["100"],
+            ) as mock_ids,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_saved_jobs(max_pages=1)
+
+        assert result["job_ids"] == []
+        assert result["sections"] == {}
+        mock_ids.assert_not_awaited()
+
+    async def test_url_redirect_skips_id_extraction(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.url = "https://www.linkedin.com/uas/login"
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Login page content"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_ids,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_saved_jobs(max_pages=2)
+
+        mock_ids.assert_not_awaited()
+        assert result["job_ids"] == []
+        assert result["sections"]["saved_jobs"] == "Login page content"
+
+
+class TestAdvanceSavedJobsPage:
+    """Tests for _advance_saved_jobs_page click-based pagination helper."""
+
+    async def test_returns_false_when_next_button_hidden(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        next_locator = MagicMock()
+        next_locator.count = AsyncMock(return_value=0)
+        mock_page.locator = MagicMock(return_value=next_locator)
+
+        result = await extractor._advance_saved_jobs_page(1)
+
+        assert result is False
+        mock_page.locator.assert_called_once_with(
+            '[data-testid="pagination-controls-next-button-visible"]'
+        )
+
+    async def test_clicks_and_waits_for_indicator(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        next_locator = MagicMock()
+        next_locator.count = AsyncMock(return_value=1)
+        next_first = MagicMock()
+        next_first.click = AsyncMock()
+        next_locator.first = next_first
+
+        indicator_locator = MagicMock()
+        indicator_locator.wait_for = AsyncMock()
+
+        def locator_side_effect(selector):
+            if "next-button-visible" in selector:
+                return next_locator
+            if "pagination-indicator-1" in selector and "aria-current" in selector:
+                return indicator_locator
+            raise AssertionError(f"unexpected selector: {selector}")
+
+        mock_page.locator = MagicMock(side_effect=locator_side_effect)
+
+        result = await extractor._advance_saved_jobs_page(1)
+
+        assert result is True
+        next_first.click.assert_awaited_once()
+        indicator_locator.wait_for.assert_awaited_once()
+
+
 class TestStripLinkedInNoise:
     def test_strips_footer(self):
         text = "Bill Gates\nChair, Gates Foundation\n\nAbout\nAccessibility\nTalent Solutions\nCareers"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -27,6 +27,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.scrape_company = AsyncMock(return_value=scrape_result)
     mock.scrape_job = AsyncMock(return_value=scrape_result)
     mock.search_jobs = AsyncMock(return_value=scrape_result)
+    mock.scrape_saved_jobs = AsyncMock(return_value=scrape_result)
     mock.search_people = AsyncMock(return_value=scrape_result)
     mock.get_sidebar_profiles = AsyncMock(return_value=scrape_result)
     mock.get_inbox = AsyncMock(return_value=scrape_result)
@@ -535,6 +536,25 @@ class TestJobTools:
         )
         assert "search_results" in result["sections"]
         assert "pages_visited" not in result
+
+    async def test_get_saved_jobs(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/jobs-tracker/",
+            "sections": {"saved_jobs": "Saved 1\nSaved 2"},
+            "job_ids": ["111", "222"],
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_saved_jobs")
+        result = await tool_fn(mock_context, max_pages=2, extractor=mock_extractor)
+        assert "saved_jobs" in result["sections"]
+        assert result["job_ids"] == ["111", "222"]
+        mock_extractor.scrape_saved_jobs.assert_awaited_once_with(max_pages=2)
 
 
 class TestGetSidebarProfilesTool:


### PR DESCRIPTION
Hello, I'm referring to this issue to inspect saved jobs: 
https://github.com/stickerdaniel/linkedin-mcp-server/issues/364

I've tested this on a job tracker with 26 entries and 3 pages. 
It works well together with `get_job_details`. 

## Summary

Adds a new `get_saved_jobs` MCP tool that scrapes the user's saved jobs from `https://www.linkedin.com/jobs-tracker/` and returns LinkedIn job IDs alongside the raw page text, with support for click-based pagination across multiple tracker pages.

Closes #364.

## What's new

- **New tool `get_saved_jobs`** (`linkedin_mcp_server/tools/job.py`)
  - Returns the standard scraping payload: `{url, sections: {saved_jobs: text}, job_ids: [...], references?, section_errors?}`
  - `max_pages` parameter (1–10, default 3) to bound the work
  - Job IDs returned are directly usable with `get_job_details`
  - Reports progress and reuses the project's standard `AuthenticationError` / `handle_auth_error` flow

- **Scraper support** (`linkedin_mcp_server/scraping/extractor.py`)
  - `scrape_saved_jobs(max_pages)` orchestrates the multi-page scrape: extract → advance → re-extract, with deduping across pages, an "unexpected URL" guard (e.g. login redirect), and graceful early-stop when no new IDs appear or rate limiting is detected.
  - `_advance_saved_jobs_page(target_index)` performs locale-independent click pagination: `/jobs-tracker/` is a client-side SPA where the URL never changes, so URL-based pagination is impossible.
  - `_extract_search_page_static(url, section_name)` was split out of `_extract_search_page_once` so click-pagination flows can re-extract the in-place updated page without re-navigating.

## Locale-independent pagination

Per the repo's scraping rules (CLAUDE.md), all detection avoids LinkedIn's translated UI text:

- Next button: `[data-testid="pagination-controls-next-button-visible"]` (the `-visible` / `-hidden` suffix is the locale-independent state signal)
- Active page indicator: `[data-testid="pagination-indicator-{n}"][aria-current="true"]`

No class names, no button-text matching.

## Tests

- `tests/test_scraping.py`: new `TestScrapeSavedJobs` and `TestAdvanceSavedJobsPage` classes cover the happy path, references propagation, multi-page click pagination, early-stop when the next button is hidden, early-stop when no new IDs appear, rate-limit handling, and login-redirect handling.
- `tests/test_tools.py`: registers and exercises the new MCP tool, asserts payload shape, and verifies `scrape_saved_jobs` is awaited with the expected `max_pages`.

## Docs

- `README.md`: new tool listed in the working-tools table.
- `manifest.json`: `get_saved_jobs` entry added.

## Test plan

- [x] `uv run pytest tests/test_scraping.py::TestScrapeSavedJobs tests/test_scraping.py::TestAdvanceSavedJobsPage tests/test_tools.py -q` passes
- [x] `uv run ruff check . && uv run ruff format --check . && uv run ty check` clean
- [x] Live verification against LinkedIn with `uv run -m linkedin_mcp_server --transport streamable-http --log-level DEBUG`, calling `get_saved_jobs` with `max_pages=1`, `max_pages=3`, and a value larger than the actual saved-job pages — confirm IDs accumulate, dedupe across pages, and the loop terminates cleanly.
- [x] One ID from the response round-trips through `get_job_details` successfully.

## Synthetic prompt

> Add a new `get_saved_jobs` MCP tool that scrapes `https://www.linkedin.com/jobs-tracker/` and returns the standard `{url, sections, job_ids, references?}` payload, following the `search_jobs` pattern. The tracker page is a client-side SPA (URL never changes between pages), so implement click-based pagination using `data-testid="pagination-controls-next-button-visible"` for the next button and `data-testid="pagination-indicator-N"` with `aria-current="true"` for the active-page signal — no text matching, per the locale-independence rule. Add a `max_pages` parameter (1–10, default 3) and dedupe job IDs across pages. Split the existing search-page extractor so click-pagination flows can re-extract the in-place updated page without navigating. Update README, manifest, and tests.

Generated with Claude Opus 4.7