### PR TITLE
docs(readme): mark conversation tool working

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
-| `get_conversation` | Read a specific messaging conversation by username or thread ID | [#307](https://github.com/stickerdaniel/linkedin-mcp-server/issues/307) |
+| `get_conversation` | Read a specific messaging conversation by username or thread ID | working |
 | `search_conversations` | Search messages by keyword | working |
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) | working |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs) | working |


### PR DESCRIPTION
## Summary

- sync the README Features & Tool Status table after #307 was closed by merged PR #413
- mark `get_conversation` as `working` again
- leave `connect_with_person` linked to the still-open tool-specific issue #407

Closes #416

## Validation

- `git diff --check`
- `uv run pre-commit run --files README.md`

## Synthetic prompt

> Sync the README Features & Tool Status table with current GitHub issues by marking `get_conversation` as working because its linked issue #307 is closed as fixed, while leaving still-open tool-specific issue #407 linked for `connect_with_person`. File a docs issue for the mismatch and close it from the PR.

Generated with GPT-5 Codex