### PR TITLE
feat(post): comment_on_post tool + activity URNs in posts references

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 
 | Tool | Description | Status |
 |------|-------------|--------|
-| `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
+| `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts). The `posts` section surfaces each post's permalink in `references.posts` (kind `feed_post`) so callers can chain to `comment_on_post`. | working |
 | `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | working |
 | `search_conversations` | Search messages by keyword | working |
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) | working |
+| `comment_on_post` | Post a top-level comment on a feed post (requires confirmation) | working |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs) | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_jobs` | Search for jobs with keywords and location filters | working |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -12,6 +12,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **People Search**: Search for people by keywords and location
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed
+- **Post Engagement**: Post top-level comments on feed posts (requires explicit confirmation)
 - **Compact References**: Return typed per-section links alongside readable text without shipping full-page markdown
 
 ## Quick Start

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -380,6 +380,55 @@ class LinkedInExtractor:
             "sent": sent,
         }
 
+    @staticmethod
+    def _post_action_result(
+        url: str,
+        status: str,
+        message: str,
+        *,
+        posted: bool = False,
+        comment_visible: bool = False,
+    ) -> dict[str, Any]:
+        """Build a structured response for the comment_on_post tool."""
+        return {
+            "url": url,
+            "status": status,
+            "message": message,
+            "posted": posted,
+            "comment_visible": comment_visible,
+        }
+
+    @staticmethod
+    def _normalize_activity_url(post_url: str) -> str | None:
+        """Normalize a post reference to a canonical feed-update URL.
+
+        LinkedIn exposes a feed post under several shapes: the canonical
+        ``/feed/update/urn:li:activity:{id}/`` URL, the share-style
+        ``/posts/<slug>-activity-{id}-<sig>/`` permalink, the bare URN, or
+        the bare numeric activity id. All carry the same activity id; this
+        helper extracts it and returns the canonical detail URL so
+        ``post_comment`` always navigates to a single shape regardless of
+        what the caller passed in.
+
+        Returns ``None`` when no activity id can be extracted.
+        """
+        # urn:li:activity:NUMBERS pattern (handles both bare URNs and the
+        # full /feed/update/ shape that embeds the URN).
+        m = re.search(r"urn:li:activity:(\d+)", post_url)
+        if m:
+            return f"https://www.linkedin.com/feed/update/urn:li:activity:{m.group(1)}/"
+        # /posts/<slug>-activity-{id}-<sig>/ share permalinks.
+        m = re.search(r"-activity-(\d+)-", post_url)
+        if m:
+            return f"https://www.linkedin.com/feed/update/urn:li:activity:{m.group(1)}/"
+        # Bare numeric id. LinkedIn activity ids are 19 digits today; gate
+        # on >=15 to tolerate future width while rejecting ambiguous short
+        # numerics that are clearly not activity ids.
+        stripped = post_url.strip()
+        if re.fullmatch(r"\d{15,}", stripped):
+            return f"https://www.linkedin.com/feed/update/urn:li:activity:{stripped}/"
+        return None
+
     async def _log_navigation_failure(
         self,
         target_url: str,
@@ -931,9 +980,30 @@ class LinkedInExtractor:
             )
             return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
         cleaned = _filter_linkedin_noise_lines(truncated)
+
+        # Activity feed pages render the post timestamp/permalink as a
+        # <button>, not an <a>, so _extract_root_content (which only collects
+        # anchor hrefs) misses the URN that identifies each post. Harvest
+        # data-urn / data-id attributes from post wrappers and synthesize
+        # references with the canonical /feed/update/urn:li:activity:{id}/
+        # URL — these flow through the same build_references pipeline and
+        # dedupe against any share-permalink anchors that classify_link picks
+        # up via _SHARE_POST_PATH_RE.
+        #
+        # Order matters: prepend the wrapper-derived URN refs so they win the
+        # per-section reference cap over generic anchors (post attachments,
+        # author mentions, lnkd.in shortlinks). The post permalink is the
+        # canonical identifier callers need to chain into comment_on_post —
+        # losing it to a cap that fills with post-attachment anchors would
+        # defeat the purpose of harvesting.
+        references_raw: list[Any] = []
+        if is_activity:
+            references_raw.extend(await self._harvest_activity_urns())
+        references_raw.extend(raw_result["references"])
+
         return ExtractedSection(
             text=cleaned,
-            references=build_references(raw_result["references"], section_name),
+            references=build_references(references_raw, section_name),
         )
 
     async def _extract_overlay(
@@ -2838,6 +2908,324 @@ class LinkedInExtractor:
             recipient_selected=recipient_selected,
             sent=True,
         )
+
+    async def post_comment(
+        self,
+        post_url: str,
+        comment_text: str,
+        *,
+        confirm_post: bool,
+    ) -> dict[str, Any]:
+        """Post a top-level comment on a LinkedIn feed post.
+
+        Mirrors the confirmation-gated, JS-driven write pattern of
+        :meth:`send_message`. patchright's actionability checks block
+        normal ``.click()`` and ``.type()`` calls on the React-driven
+        comment composer, so focusing and submitting both go through
+        ``page.evaluate()``.
+
+        Locale-independence: the composer and submit button selectors
+        layer an ``aria-label`` hint on top of a plain
+        ``[role=textbox][contenteditable=true]`` / ``button[type=submit]``
+        fallback, so detection works regardless of the LinkedIn UI
+        language. Activity URL navigation is purely structural — no
+        text labels are read.
+
+        Args:
+            post_url: A feed post URL or activity reference. Accepts the
+                ``/feed/update/urn:li:activity:{id}/`` URL, the share-style
+                ``/posts/<slug>-activity-{id}-<sig>/`` permalink, a bare
+                ``urn:li:activity:{id}`` URN, or the bare numeric id.
+            comment_text: The comment body to post.
+            confirm_post: Must be True to actually submit (False does a
+                dry run that locates the composer and returns
+                ``confirmation_required`` without typing).
+        """
+        canonical_url = self._normalize_activity_url(post_url)
+        if not canonical_url:
+            return self._post_action_result(
+                post_url,
+                "post_unavailable",
+                "Could not extract a LinkedIn activity id from the provided URL.",
+            )
+
+        await self._navigate_to_page(canonical_url)
+        await detect_rate_limit(self._page)
+
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("Post detail page did not load for %s", canonical_url)
+
+        await handle_modal_close(self._page)
+
+        # The post detail page hydrates the comment composer asynchronously
+        # — `wait_for_selector("main")` returns long before the Tiptap
+        # editor (`<div role="textbox" contenteditable="true">`) appears in
+        # the DOM. Wait explicitly for any contenteditable textbox to mount
+        # so the focus/type evaluate below has something to act on.
+        # Selector kept structural (role + contenteditable presence) so it
+        # works regardless of UI locale.
+        try:
+            await self._page.wait_for_selector(
+                'div[role="textbox"][contenteditable="true"]',
+                timeout=10000,
+                state="visible",
+            )
+        except PlaywrightTimeoutError:
+            logger.debug(
+                "Comment composer did not hydrate within timeout on %s",
+                canonical_url,
+            )
+
+        # Locate and focus the comment composer. Locale-independent
+        # strategy mirroring send_message (extractor.py:2780-2790):
+        # aria-label hint first, generic [role=textbox][contenteditable]
+        # fallback so the German "Kommentar verfassen" / French
+        # "Ajouter un commentaire" cases still resolve. We pick the first
+        # *visible* match (offsetWidth/offsetHeight/getClientRects) to
+        # skip hidden composer skeletons LinkedIn renders for related
+        # posts in side rails.
+        composer_focused = await self._page.evaluate(
+            """() => {
+                const sel = 'div[role="textbox"][contenteditable="true"][aria-label*="comment" i],'
+                    + 'div[role="textbox"][contenteditable="true"]';
+                const el = Array.from(document.querySelectorAll(sel))
+                    .find(node => node.offsetWidth || node.offsetHeight || node.getClientRects().length);
+                if (!el) return false;
+                el.focus();
+                return true;
+            }"""
+        )
+        if not composer_focused:
+            return self._post_action_result(
+                self._page.url,
+                "composer_unavailable",
+                "LinkedIn did not expose a usable comment composer on this post.",
+            )
+
+        if not confirm_post:
+            return self._post_action_result(
+                self._page.url,
+                "confirmation_required",
+                "Set confirm_post=true to submit the comment.",
+            )
+
+        # patchright quirk: same as send_message — type via the keyboard
+        # against the focused element. delay=15 lets React fire the
+        # input/keyup events that enable the submit button.
+        await asyncio.sleep(0.1)
+        await self._page.keyboard.type(comment_text, delay=15)
+        await asyncio.sleep(0.5)
+
+        # Submit. LinkedIn's current React UI renders the submit control
+        # as `<button type="button" componentkey="…commentButtonSection…">`
+        # with the visible label inside nested <span>s and *no*
+        # aria-label and *no* data-control-name. The componentkey
+        # attribute is part of LinkedIn's React component identity and
+        # is locale-independent, so we anchor on its substring match.
+        # The legacy aria-label / type="submit" / data-control-name
+        # selectors stay as fallbacks for older renderings.
+        #
+        # React handlers need a full mousedown → mouseup → click event
+        # sequence to fire reliably; a bare `btn.click()` sometimes
+        # registers as a synthetic event but skips the parent handlers
+        # that gate the actual submit. Dispatching the three events
+        # explicitly via MouseEvent matches what a real cursor produces.
+        # Final fallback is the documented Ctrl+Enter LinkedIn
+        # comment-submit shortcut, which works irrespective of locale.
+        click_diag = await self._page.evaluate(
+            """() => {
+                // querySelectorAll returns in document order, so a
+                // broad-but-low-priority match (overflow menus with the
+                // word 'post' in their aria-label) can outrank the
+                // submit button if we naively .find() the first match.
+                // Collect all candidates, then sort so the most
+                // specific signal (componentkey containing
+                // 'commentButtonSection') wins. The aria-label
+                // 'Comment' clause stays as a fallback for older
+                // LinkedIn renderings; the broader aria-label='Post'
+                // clause is dropped because LinkedIn renders the
+                // overall post overflow as 'Open control menu for post
+                // by NAME', which substring-matches 'post' and is the
+                // wrong target.
+                const candidates = Array.from(document.querySelectorAll(
+                    'button[componentkey*="commentButtonSection"],'
+                    + 'button[type="submit"][data-control-name*="comment" i],'
+                    + 'button[aria-label="Comment"],'
+                    + 'button[aria-label="Kommentieren"],'
+                    + 'button[aria-label="Commenter"]'
+                )).filter(b =>
+                    !b.disabled
+                    && (b.offsetWidth || b.offsetHeight || b.getClientRects().length)
+                );
+                candidates.sort((a, b) => {
+                    const ak = (a.getAttribute('componentkey') || '')
+                        .includes('commentButtonSection') ? 0 : 1;
+                    const bk = (b.getAttribute('componentkey') || '')
+                        .includes('commentButtonSection') ? 0 : 1;
+                    return ak - bk;
+                });
+                const btn = candidates[0];
+                if (!btn) return { clicked: false, reason: 'no_candidate', count: candidates.length };
+                const rect = btn.getBoundingClientRect();
+                const opts = {
+                    bubbles: true,
+                    cancelable: true,
+                    view: window,
+                    button: 0,
+                    clientX: rect.left + rect.width / 2,
+                    clientY: rect.top + rect.height / 2,
+                };
+                ['mousedown', 'mouseup', 'click'].forEach((type) => {
+                    btn.dispatchEvent(new MouseEvent(type, opts));
+                });
+                return {
+                    clicked: true,
+                    component_key: btn.getAttribute('componentkey'),
+                    aria_label: btn.getAttribute('aria-label'),
+                    type: btn.getAttribute('type'),
+                };
+            }"""
+        )
+        logger.info("comment_on_post submit click diag: %s", click_diag)
+        if not click_diag.get("clicked"):
+            # Fallback: documented LinkedIn comment-submit shortcut.
+            await self._page.keyboard.down("Control")
+            await self._page.keyboard.press("Enter")
+            await self._page.keyboard.up("Control")
+
+        # Verify-after-action. Two-stage check, because
+        # `body.innerText.includes(comment_text)` alone is a false
+        # positive: the typed text already sits in the contenteditable
+        # composer's DOM and contributes to body.innerText whether or
+        # not the submit actually landed. The reliable structural signal
+        # is the composer *emptying* — LinkedIn clears the Tiptap editor
+        # only after the comment is accepted server-side. We poll for
+        # that, then assert the comment text is still visible elsewhere
+        # on the page (i.e. in the comments thread).
+        composer_cleared = await self._wait_for_composer_clear()
+        body_visible = await self._message_text_visible(comment_text)
+        if not composer_cleared:
+            return self._post_action_result(
+                self._page.url,
+                "post_unverified",
+                "Comment submitted but the composer did not clear — LinkedIn may have rejected the post.",
+                posted=False,
+                comment_visible=False,
+            )
+        if not body_visible:
+            return self._post_action_result(
+                self._page.url,
+                "post_unverified",
+                "Composer cleared but the comment text was not visible in the comments thread.",
+                posted=True,
+                comment_visible=False,
+            )
+
+        return self._post_action_result(
+            self._page.url,
+            "posted",
+            "Comment posted.",
+            posted=True,
+            comment_visible=True,
+        )
+
+    async def _wait_for_composer_clear(self) -> bool:
+        """Wait until the comment composer's contenteditable becomes empty.
+
+        Used as the structural success signal after submitting a comment:
+        LinkedIn clears the Tiptap composer only when the comment has been
+        accepted server-side. Returns True if the composer is empty (or
+        has gone away entirely) within the page's default timeout, False
+        on timeout — which means submit silently failed.
+        """
+        try:
+            await self._page.wait_for_function(
+                """() => {
+                    const el = document.querySelector(
+                        'div[role="textbox"][contenteditable="true"][aria-label*="comment" i],'
+                        + 'div[role="textbox"][contenteditable="true"]'
+                    );
+                    if (!el) return true;
+                    const text = (el.innerText || '').trim();
+                    // Tiptap renders an empty editor with a placeholder
+                    // <p data-placeholder="..." class="is-empty"><br></p>,
+                    // so .innerText is an empty string when cleared.
+                    return text === '';
+                }"""
+            )
+            return True
+        except PlaywrightTimeoutError:
+            return False
+
+    async def _harvest_activity_urns(self) -> list[dict[str, Any]]:
+        """Collect post URNs from activity-feed post wrappers.
+
+        On `/recent-activity/all/` pages, LinkedIn renders each post's
+        timestamp/permalink as a ``<button>`` rather than an ``<a>``, so
+        :meth:`_extract_root_content` (which only collects anchor hrefs)
+        cannot see the URN that identifies the post. Each post wrapper,
+        however, carries a ``data-urn="urn:li:activity:NNN"`` (or
+        ``data-id`` on older variants) attribute that survives across
+        locales and layout tweaks.
+
+        This helper walks those wrappers and returns synthesized raw
+        references with the canonical ``/feed/update/urn:li:activity:NNN/``
+        permalink as ``href`` so they flow through the standard
+        :func:`build_references` pipeline. Anchor-derived references that
+        ``classify_link`` rewrites from ``/posts/<slug>-activity-NNN-XXX/``
+        share permalinks share the same canonical URL, so
+        :func:`dedupe_references` collapses any overlap.
+
+        Per ``AGENTS.md`` Scraping Rules: detection here uses attribute
+        *presence* and a stable URN prefix — never locale-dependent text.
+        """
+        raw_urns = await self._page.evaluate(
+            """() => {
+                const seen = new Set();
+                const out = [];
+                const els = document.querySelectorAll(
+                    '[data-urn^="urn:li:activity:"],'
+                    + '[data-id^="urn:li:activity:"]'
+                );
+                for (const el of els) {
+                    const urn = el.getAttribute('data-urn')
+                        || el.getAttribute('data-id');
+                    if (!urn || seen.has(urn)) continue;
+                    seen.add(urn);
+                    const text = (el.innerText || '')
+                        .replace(/\\s+/g, ' ')
+                        .trim()
+                        .slice(0, 120);
+                    out.push({ urn, text });
+                }
+                return out;
+            }"""
+        )
+
+        synthetic: list[dict[str, Any]] = []
+        if not isinstance(raw_urns, list):
+            return synthetic
+        for entry in raw_urns:
+            if not isinstance(entry, dict):
+                continue
+            urn = entry.get("urn", "") or ""
+            if not isinstance(urn, str) or not urn.startswith("urn:li:activity:"):
+                continue
+            synthetic.append(
+                {
+                    "href": f"https://www.linkedin.com/feed/update/{urn}/",
+                    "text": entry.get("text", ""),
+                    "aria_label": "",
+                    "title": "",
+                    "heading": "",
+                    "in_article": True,
+                    "in_nav": False,
+                    "in_footer": False,
+                }
+            )
+        return synthetic
 
     async def _extract_root_content(
         self,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -88,6 +88,28 @@ _WORK_TYPE_MAP = {"on_site": "1", "remote": "2", "hybrid": "3"}
 
 _SORT_BY_MAP = {"date": "DD", "relevance": "R"}
 
+
+# Per AGENTS.md Scraping Rules, text-only signals must live behind an
+# explicit per-locale table. The submit button on the post-detail
+# comment composer is rendered in current LinkedIn UIs as
+# `<button componentkey="…commentButtonSection…">` with no aria-label
+# and no data-control-name — that componentkey selector is the primary,
+# locale-independent path and what `post_comment` matches first.
+# This table is the second-line fallback for older renderings (or
+# layouts where the componentkey hasn't rolled out for a locale yet).
+# Extend by appending entries verified against a real account; locales
+# not listed here fall through to the documented Ctrl+Enter
+# composer-submit shortcut, which works regardless of UI language.
+#
+# Known unsupported (would benefit from entries here): Spanish
+# ("Comentar"), Portuguese ("Comentar"), Dutch ("Reageren"),
+# Italian ("Commenta"), Polish ("Skomentuj").
+_COMMENT_SUBMIT_LABELS_BY_LOCALE: dict[str, str] = {
+    "en": "Comment",
+    "de": "Kommentieren",
+    "fr": "Commenter",
+}
+
 _DIALOG_SELECTOR = 'dialog[open], [role="dialog"]'
 _DIALOG_TEXTAREA_SELECTOR = '[role="dialog"] textarea, dialog textarea'
 
@@ -412,18 +434,22 @@ class LinkedInExtractor:
 
         Returns ``None`` when no activity id can be extracted.
         """
+        # All branches use the same >=15-digit floor as
+        # _SHARE_POST_PATH_RE in scraping/link_metadata.py — LinkedIn
+        # activity ids are 19 digits today; the floor tolerates future
+        # width while rejecting ambiguous short numerics in URLs that
+        # happen to contain unrelated -activity-NN- segments.
+
         # urn:li:activity:NUMBERS pattern (handles both bare URNs and the
         # full /feed/update/ shape that embeds the URN).
-        m = re.search(r"urn:li:activity:(\d+)", post_url)
+        m = re.search(r"urn:li:activity:(\d{15,})", post_url)
         if m:
             return f"https://www.linkedin.com/feed/update/urn:li:activity:{m.group(1)}/"
         # /posts/<slug>-activity-{id}-<sig>/ share permalinks.
-        m = re.search(r"-activity-(\d+)-", post_url)
+        m = re.search(r"-activity-(\d{15,})-", post_url)
         if m:
             return f"https://www.linkedin.com/feed/update/urn:li:activity:{m.group(1)}/"
-        # Bare numeric id. LinkedIn activity ids are 19 digits today; gate
-        # on >=15 to tolerate future width while rejecting ambiguous short
-        # numerics that are clearly not activity ids.
+        # Bare numeric id.
         stripped = post_url.strip()
         if re.fullmatch(r"\d{15,}", stripped):
             return f"https://www.linkedin.com/feed/update/urn:li:activity:{stripped}/"
@@ -3024,8 +3050,9 @@ class LinkedInExtractor:
         # aria-label and *no* data-control-name. The componentkey
         # attribute is part of LinkedIn's React component identity and
         # is locale-independent, so we anchor on its substring match.
-        # The legacy aria-label / type="submit" / data-control-name
-        # selectors stay as fallbacks for older renderings.
+        # The aria-label fallbacks come from the explicit per-locale
+        # table _COMMENT_SUBMIT_LABELS_BY_LOCALE (per AGENTS.md scraping
+        # rules — text-only signals must live behind an explicit table).
         #
         # React handlers need a full mousedown → mouseup → click event
         # sequence to fire reliably; a bare `btn.click()` sometimes
@@ -3035,30 +3062,31 @@ class LinkedInExtractor:
         # Final fallback is the documented Ctrl+Enter LinkedIn
         # comment-submit shortcut, which works irrespective of locale.
         click_diag = await self._page.evaluate(
-            """() => {
+            """({ labels }) => {
                 // querySelectorAll returns in document order, so a
                 // broad-but-low-priority match (overflow menus with the
                 // word 'post' in their aria-label) can outrank the
                 // submit button if we naively .find() the first match.
                 // Collect all candidates, then sort so the most
                 // specific signal (componentkey containing
-                // 'commentButtonSection') wins. The aria-label
-                // 'Comment' clause stays as a fallback for older
-                // LinkedIn renderings; the broader aria-label='Post'
-                // clause is dropped because LinkedIn renders the
-                // overall post overflow as 'Open control menu for post
-                // by NAME', which substring-matches 'post' and is the
-                // wrong target.
-                const candidates = Array.from(document.querySelectorAll(
-                    'button[componentkey*="commentButtonSection"],'
-                    + 'button[type="submit"][data-control-name*="comment" i],'
-                    + 'button[aria-label="Comment"],'
-                    + 'button[aria-label="Kommentieren"],'
-                    + 'button[aria-label="Commenter"]'
-                )).filter(b =>
-                    !b.disabled
-                    && (b.offsetWidth || b.offsetHeight || b.getClientRects().length)
-                );
+                // 'commentButtonSection') wins. The aria-label clauses
+                // stay as fallbacks for older LinkedIn renderings,
+                // sourced from the per-locale table on the Python side
+                // — broader aria-label substring matches were dropped
+                // because LinkedIn renders the post overflow as
+                // 'Open control menu for post by NAME', which would
+                // substring-match 'post' and click the wrong target.
+                const labelSelectors = labels
+                    .map(label => `button[aria-label="${label}"]`)
+                    .join(',');
+                const sel = 'button[componentkey*="commentButtonSection"],'
+                    + 'button[type="submit"][data-control-name*="comment" i]'
+                    + (labelSelectors ? ',' + labelSelectors : '');
+                const candidates = Array.from(document.querySelectorAll(sel))
+                    .filter(b =>
+                        !b.disabled
+                        && (b.offsetWidth || b.offsetHeight || b.getClientRects().length)
+                    );
                 candidates.sort((a, b) => {
                     const ak = (a.getAttribute('componentkey') || '')
                         .includes('commentButtonSection') ? 0 : 1;
@@ -3086,7 +3114,8 @@ class LinkedInExtractor:
                     aria_label: btn.getAttribute('aria-label'),
                     type: btn.getAttribute('type'),
                 };
-            }"""
+            }""",
+            arg={"labels": list(_COMMENT_SUBMIT_LABELS_BY_LOCALE.values())},
         )
         logger.info("comment_on_post submit click diag: %s", click_diag)
         if not click_diag.get("clicked"):

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -112,6 +112,14 @@ _JOB_PATH_RE = re.compile(r"^/jobs/view/(\d+)")
 _NEWSLETTER_PATH_RE = re.compile(r"^/newsletters/([^/?#]+)")
 _PULSE_PATH_RE = re.compile(r"^/pulse/([^/?#]+)")
 _FEED_PATH_RE = re.compile(r"^/feed/update/([^/?#]+)")
+# Share-style post permalinks LinkedIn renders on /recent-activity/all/ pages
+# alongside the /feed/update/ form. Shape:
+#   /posts/<slug>-activity-<19-digit-id>-<short-sig>/
+# The 15+ digit floor avoids matching unrelated /posts/<slug>-... URLs that
+# happen to contain shorter numeric segments. Both LinkedIn shapes carry the
+# same activity id, so we canonicalize to /feed/update/urn:li:activity:{id}/
+# and emit kind="feed_post" to fold into the existing reference pipeline.
+_SHARE_POST_PATH_RE = re.compile(r"^/posts/[^/?#]*-activity-(\d{15,})-[^/?#]+/?$")
 _MESSAGING_THREAD_PATH_RE = re.compile(r"^/messaging/thread/([^/?#]+)")
 _MAX_REDIRECT_UNWRAP_DEPTH = 5
 
@@ -234,6 +242,12 @@ def classify_link(href: str) -> tuple[ReferenceKind, str] | None:
 
     if match := _FEED_PATH_RE.match(path):
         return "feed_post", f"/feed/update/{match.group(1)}/"
+
+    if match := _SHARE_POST_PATH_RE.match(path):
+        return (
+            "feed_post",
+            f"/feed/update/urn:li:activity:{match.group(1)}/",
+        )
 
     if match := _MESSAGING_THREAD_PATH_RE.match(path):
         return "conversation", f"/messaging/thread/{match.group(1)}/"

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -26,6 +26,7 @@ from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.job import register_job_tools
 from linkedin_mcp_server.tools.messaging import register_messaging_tools
 from linkedin_mcp_server.tools.person import register_person_tools
+from linkedin_mcp_server.tools.post import register_post_tools
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,7 @@ def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> 
     register_company_tools(mcp, tool_timeout=tool_timeout)
     register_job_tools(mcp, tool_timeout=tool_timeout)
     register_messaging_tools(mcp, tool_timeout=tool_timeout)
+    register_post_tools(mcp, tool_timeout=tool_timeout)
 
     # Register session management tool
     @mcp.tool(

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -1,0 +1,85 @@
+"""LinkedIn feed post engagement tools."""
+
+import logging
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.core.exceptions import AuthenticationError
+from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
+from linkedin_mcp_server.error_handler import raise_tool_error
+
+logger = logging.getLogger(__name__)
+
+
+def register_post_tools(
+    mcp: FastMCP, *, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS
+) -> None:
+    """Register feed-post engagement tools with the MCP server."""
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Comment on Post",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"feed", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def comment_on_post(
+        post_url: str,
+        comment_text: Annotated[str, Field(min_length=1, max_length=1500)],
+        confirm_post: bool,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Post a top-level comment on a LinkedIn feed post.
+
+        This is a write operation when confirm_post is True. With
+        confirm_post=False the composer is located but no comment is
+        submitted, returning status="confirmation_required" — useful for
+        dry-run pre-flight checks before issuing the real call.
+
+        Args:
+            post_url: A feed post URL or activity reference. Accepts the
+                full /feed/update/urn:li:activity:{id}/ URL, the
+                /posts/<slug>-activity-{id}-<sig>/ permalink, a bare
+                urn:li:activity:{id} URN, or the bare numeric id.
+            comment_text: The comment body (1-1500 characters, plain text).
+            confirm_post: Must be True to actually submit the comment.
+            ctx: FastMCP context for progress reporting.
+
+        Returns:
+            Dict with url, status, message, posted, comment_visible.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="comment_on_post"
+            )
+            logger.info(
+                "Posting comment on %s (confirm_post=%s, length=%d)",
+                post_url,
+                confirm_post,
+                len(comment_text),
+            )
+
+            await ctx.report_progress(progress=0, total=100, message="Posting comment")
+
+            result = await extractor.post_comment(
+                post_url,
+                comment_text,
+                confirm_post=confirm_post,
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "comment_on_post")
+        except Exception as e:
+            raise_tool_error(e, "comment_on_post")  # NoReturn

--- a/manifest.json
+++ b/manifest.json
@@ -94,6 +94,10 @@
       "description": "Send a message to a LinkedIn user with explicit confirmation and optional profile URN support"
     },
     {
+      "name": "comment_on_post",
+      "description": "Post a top-level comment on a LinkedIn feed post with explicit confirmation"
+    },
+    {
       "name": "close_session",
       "description": "Properly close browser session and clean up resources"
     }

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -578,3 +578,75 @@ class TestClassifyLink:
         assert len(references) == 1
         assert references[0]["kind"] == "conversation"
         assert references[0]["url"] == "/messaging/thread/2-xyz/"
+
+
+class TestClassifyShareActivityPermalink:
+    """Share-style /posts/<slug>-activity-<id>-<sig>/ canonicalize to feed_post."""
+
+    _CANONICAL = "/feed/update/urn:li:activity:7000000000000000000/"
+
+    def test_share_permalink_classifies_as_feed_post(self):
+        result = classify_link(
+            "https://www.linkedin.com/posts/"
+            "someone-12345_topic-thoughts-activity-7000000000000000000-AbCd/"
+        )
+        assert result == ("feed_post", self._CANONICAL)
+
+    def test_share_permalink_with_query_string(self):
+        result = classify_link(
+            "https://www.linkedin.com/posts/"
+            "alice-bob_topic-activity-7000000000000000000-XYZ/"
+            "?utm_source=share"
+        )
+        assert result == ("feed_post", self._CANONICAL)
+
+    def test_share_permalink_minimal_slug(self):
+        """A bare slug (no underscores or hashtags) still matches."""
+        result = classify_link(
+            "https://www.linkedin.com/posts/foo-activity-7000000000000000000-XYZ/"
+        )
+        assert result == ("feed_post", self._CANONICAL)
+
+    def test_short_id_rejected(self):
+        """IDs below the 15-digit floor are not treated as activity ids."""
+        result = classify_link("https://www.linkedin.com/posts/foo-activity-12345-XYZ/")
+        assert result is None
+
+    def test_signature_required(self):
+        """The trailing -<sig> segment is required to match."""
+        # The URL ends after the digits (no trailing -<sig>) — should not
+        # match the share-permalink shape.
+        result = classify_link(
+            "https://www.linkedin.com/posts/foo-activity-7000000000000000000/"
+        )
+        assert result is None
+
+    def test_unrelated_posts_url_rejected(self):
+        """A /posts/<slug>/ without -activity-<id>- doesn't match."""
+        result = classify_link("https://www.linkedin.com/posts/some-article-headline/")
+        assert result is None
+
+    def test_share_and_canonical_dedupe(self):
+        """Anchor with share permalink + anchor with /feed/update/ collapse to one."""
+        references = build_references(
+            [
+                {
+                    "href": (
+                        "https://www.linkedin.com/posts/"
+                        "alice_topic-activity-7000000000000000000-XYZ/"
+                    ),
+                    "text": "Alice's post",
+                },
+                {
+                    "href": (
+                        "https://www.linkedin.com/feed/update/"
+                        "urn:li:activity:7000000000000000000/"
+                    ),
+                    "text": "",
+                },
+            ],
+            "posts",
+        )
+        assert len(references) == 1
+        assert references[0]["kind"] == "feed_post"
+        assert references[0]["url"] == self._CANONICAL

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2287,6 +2287,22 @@ class TestNormalizeActivityUrl:
         # activity id.
         assert LinkedInExtractor._normalize_activity_url("12345678901234") is None
 
+    def test_short_id_in_share_permalink_rejected(self):
+        # Share permalink shape with a sub-15-digit numeric segment —
+        # gated by the >=15-digit floor so the helper does not silently
+        # canonicalize a bogus URL into a real-looking feed-update URL.
+        assert (
+            LinkedInExtractor._normalize_activity_url(
+                "https://www.linkedin.com/posts/user-news-activity-123-sig/"
+            )
+            is None
+        )
+
+    def test_short_id_in_urn_rejected(self):
+        # Same floor applied to the urn:li:activity:NN shape so a
+        # malformed URN cannot squeeze through.
+        assert LinkedInExtractor._normalize_activity_url("urn:li:activity:123") is None
+
     def test_unrelated_url_rejected(self):
         assert (
             LinkedInExtractor._normalize_activity_url(
@@ -2838,8 +2854,17 @@ class TestActivityUrnExtraction:
         assert len(feed_post_refs) == 1
         assert feed_post_refs[0]["url"] == self._CANONICAL_URL
 
-    async def test_harvest_helper_filters_invalid_urns_and_dedupes(self, mock_page):
-        """_harvest_activity_urns drops non-activity URNs and dedupes within itself."""
+    async def test_harvest_helper_filters_invalid_urns(self, mock_page):
+        """_harvest_activity_urns drops non-activity / empty / missing URNs.
+
+        Note: the helper itself does *not* dedupe duplicate URNs. The
+        JS-side seen-set in the live evaluate prevents duplicates at the
+        DOM level, but if the JS were to return repeats the Python
+        helper passes them through. Cross-source dedup (e.g. URN entries
+        from this helper vs. share-permalink anchors in the same page)
+        happens downstream in `dedupe_references` via the canonical
+        URL — not here.
+        """
         mock_page.evaluate = AsyncMock(
             return_value=[
                 # Valid activity URN.
@@ -2847,9 +2872,9 @@ class TestActivityUrnExtraction:
                     "urn": "urn:li:activity:7000000000000000000",
                     "text": "Alice's post",
                 },
-                # Duplicate of the first — JS-side seen-set should prevent
-                # this in practice, but the Python side defensively dedupes
-                # too via dict-key on the synthesized href in build_references.
+                # Duplicate URN — passed through unchanged by the helper
+                # (the JS seen-set normally prevents this; if it didn't,
+                # `dedupe_references` collapses by canonical URL later).
                 {
                     "urn": "urn:li:activity:7000000000000000000",
                     "text": "duplicate",
@@ -2869,7 +2894,9 @@ class TestActivityUrnExtraction:
 
         result = await extractor._harvest_activity_urns()
 
-        assert len(result) == 2  # Two activity URNs survive (one is a dup).
+        # Two activity URNs survive; the duplicate is intentionally
+        # *not* collapsed at this layer — see docstring.
+        assert len(result) == 2
         for entry in result:
             assert entry["href"] == (
                 "https://www.linkedin.com/feed/update/"

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2235,6 +2235,73 @@ class TestStripLinkedInNoise:
         assert strip_linkedin_noise(text) == "Feed post number 1\nActual post content"
 
 
+class TestNormalizeActivityUrl:
+    """Pure-function tests for LinkedInExtractor._normalize_activity_url."""
+
+    _CANONICAL = (
+        "https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000000/"
+    )
+
+    def test_full_feed_update_url(self):
+        url = (
+            "https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000000/"
+        )
+        assert LinkedInExtractor._normalize_activity_url(url) == self._CANONICAL
+
+    def test_feed_update_url_with_trailing_query(self):
+        url = (
+            "https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000000/"
+            "?utm_source=share"
+        )
+        assert LinkedInExtractor._normalize_activity_url(url) == self._CANONICAL
+
+    def test_share_permalink(self):
+        url = (
+            "https://www.linkedin.com/posts/"
+            "someone-12345_topic-thoughts-activity-7000000000000000000-AbCd/"
+        )
+        assert LinkedInExtractor._normalize_activity_url(url) == self._CANONICAL
+
+    def test_bare_urn(self):
+        assert (
+            LinkedInExtractor._normalize_activity_url(
+                "urn:li:activity:7000000000000000000"
+            )
+            == self._CANONICAL
+        )
+
+    def test_bare_numeric_id(self):
+        assert (
+            LinkedInExtractor._normalize_activity_url("7000000000000000000")
+            == self._CANONICAL
+        )
+
+    def test_bare_numeric_id_with_whitespace(self):
+        assert (
+            LinkedInExtractor._normalize_activity_url("  7000000000000000000  ")
+            == self._CANONICAL
+        )
+
+    def test_short_numeric_rejected(self):
+        # 14 digits — below the 15-digit floor, ambiguous and not an
+        # activity id.
+        assert LinkedInExtractor._normalize_activity_url("12345678901234") is None
+
+    def test_unrelated_url_rejected(self):
+        assert (
+            LinkedInExtractor._normalize_activity_url(
+                "https://www.linkedin.com/in/williamhgates/"
+            )
+            is None
+        )
+
+    def test_empty_string_rejected(self):
+        assert LinkedInExtractor._normalize_activity_url("") is None
+
+    def test_garbage_rejected(self):
+        assert LinkedInExtractor._normalize_activity_url("not a url") is None
+
+
 class TestActivityFeedExtraction:
     """Tests for activity page detection and wait behavior in _extract_page_once."""
 
@@ -2598,6 +2665,218 @@ class TestActivityFeedExtraction:
 
         # Should return whatever text is available, not crash
         assert result.text == tab_headers
+
+
+class TestActivityUrnExtraction:
+    """Tests for activity-feed URN harvesting from data-urn / data-id wrappers."""
+
+    _CANONICAL_URL = "/feed/update/urn:li:activity:7000000000000000000/"
+
+    async def test_urn_harvest_runs_on_activity_pages(self, mock_page):
+        """An activity URL triggers _harvest_activity_urns and emits feed_post refs."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Post content " * 50,
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+
+        synthesized_ref = {
+            "href": (
+                "https://www.linkedin.com/feed/update/"
+                "urn:li:activity:7000000000000000000/"
+            ),
+            "text": "Hendrik's post about Claude Code search",
+            "aria_label": "",
+            "title": "",
+            "heading": "",
+            "in_article": True,
+            "in_nav": False,
+            "in_footer": False,
+        }
+
+        with (
+            patch.object(
+                extractor,
+                "_harvest_activity_urns",
+                new_callable=AsyncMock,
+            ) as mock_harvest,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            mock_harvest.return_value = [synthesized_ref]
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/in/billgates/recent-activity/all/",
+                section_name="posts",
+            )
+            mock_harvest.assert_awaited_once()
+
+        feed_post_refs = [r for r in result.references if r["kind"] == "feed_post"]
+        assert len(feed_post_refs) == 1
+        assert feed_post_refs[0]["url"] == self._CANONICAL_URL
+        assert feed_post_refs[0]["text"] == "Hendrik's post about Claude Code search"
+
+    async def test_urn_harvest_skipped_on_non_activity_pages(self, mock_page):
+        """Non-activity sections (main_profile, experience, …) skip the harvest."""
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": "Profile text", "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+
+        with (
+            patch.object(
+                extractor,
+                "_harvest_activity_urns",
+                new_callable=AsyncMock,
+            ) as mock_harvest,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            mock_harvest.return_value = []
+            await extractor._extract_page_once(
+                "https://www.linkedin.com/in/billgates/",
+                section_name="main_profile",
+            )
+            mock_harvest.assert_not_awaited()
+
+    async def test_urn_harvest_dedupes_against_share_permalink_anchors(self, mock_page):
+        """A share-permalink anchor and a data-urn wrapper for the same post collapse."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Post content " * 50,
+                # Anchor-derived: a share permalink that classify_link rewrites
+                # to /feed/update/urn:li:activity:NNN/ via _SHARE_POST_PATH_RE.
+                "references": [
+                    {
+                        "href": (
+                            "https://www.linkedin.com/posts/"
+                            "alice_topic-activity-7000000000000000000-XYZ/"
+                        ),
+                        "text": "Alice's post",
+                        "aria_label": "",
+                        "title": "",
+                        "heading": "",
+                        "in_article": True,
+                        "in_nav": False,
+                        "in_footer": False,
+                    }
+                ],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+
+        wrapper_ref = {
+            "href": (
+                "https://www.linkedin.com/feed/update/"
+                "urn:li:activity:7000000000000000000/"
+            ),
+            "text": "Alice's post (from wrapper)",
+            "aria_label": "",
+            "title": "",
+            "heading": "",
+            "in_article": True,
+            "in_nav": False,
+            "in_footer": False,
+        }
+
+        with (
+            patch.object(
+                extractor,
+                "_harvest_activity_urns",
+                new_callable=AsyncMock,
+            ) as mock_harvest,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            mock_harvest.return_value = [wrapper_ref]
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/in/alice/recent-activity/all/",
+                section_name="posts",
+            )
+
+        feed_post_refs = [r for r in result.references if r["kind"] == "feed_post"]
+        # dedupe_references collapses by canonical URL — exactly one survives.
+        assert len(feed_post_refs) == 1
+        assert feed_post_refs[0]["url"] == self._CANONICAL_URL
+
+    async def test_harvest_helper_filters_invalid_urns_and_dedupes(self, mock_page):
+        """_harvest_activity_urns drops non-activity URNs and dedupes within itself."""
+        mock_page.evaluate = AsyncMock(
+            return_value=[
+                # Valid activity URN.
+                {
+                    "urn": "urn:li:activity:7000000000000000000",
+                    "text": "Alice's post",
+                },
+                # Duplicate of the first — JS-side seen-set should prevent
+                # this in practice, but the Python side defensively dedupes
+                # too via dict-key on the synthesized href in build_references.
+                {
+                    "urn": "urn:li:activity:7000000000000000000",
+                    "text": "duplicate",
+                },
+                # Wrong URN type — must be filtered out.
+                {
+                    "urn": "urn:li:share:1234567890",
+                    "text": "share-not-activity",
+                },
+                # Empty URN — filtered.
+                {"urn": "", "text": "empty"},
+                # Missing urn key entirely — filtered.
+                {"text": "no urn key"},
+            ]
+        )
+        extractor = LinkedInExtractor(mock_page)
+
+        result = await extractor._harvest_activity_urns()
+
+        assert len(result) == 2  # Two activity URNs survive (one is a dup).
+        for entry in result:
+            assert entry["href"] == (
+                "https://www.linkedin.com/feed/update/"
+                "urn:li:activity:7000000000000000000/"
+            )
+            assert entry["in_nav"] is False
+            assert entry["in_footer"] is False
 
 
 class TestSearchResultsExtraction:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -33,6 +33,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.get_conversation = AsyncMock(return_value=scrape_result)
     mock.search_conversations = AsyncMock(return_value=scrape_result)
     mock.send_message = AsyncMock(return_value=scrape_result)
+    mock.post_comment = AsyncMock(return_value=scrape_result)
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
     )
@@ -739,6 +740,123 @@ class TestMessagingTools:
             )
 
 
+class TestPostTool:
+    async def test_comment_on_post_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000000/",
+            "status": "posted",
+            "message": "Comment posted.",
+            "posted": True,
+            "comment_visible": True,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "comment_on_post")
+        result = await tool_fn(
+            "urn:li:activity:7000000000000000000",
+            "Great point!",
+            True,
+            mock_context,
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "posted"
+        assert result["posted"] is True
+        assert result["comment_visible"] is True
+        mock_extractor.post_comment.assert_awaited_once_with(
+            "urn:li:activity:7000000000000000000",
+            "Great point!",
+            confirm_post=True,
+        )
+
+    async def test_comment_on_post_dry_run(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000000/",
+            "status": "confirmation_required",
+            "message": "Set confirm_post=true to submit the comment.",
+            "posted": False,
+            "comment_visible": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "comment_on_post")
+        result = await tool_fn(
+            "https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000000/",
+            "Great point!",
+            False,
+            mock_context,
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "confirmation_required"
+        assert result["posted"] is False
+        mock_extractor.post_comment.assert_awaited_once_with(
+            "https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000000/",
+            "Great point!",
+            confirm_post=False,
+        )
+
+    async def test_comment_on_post_composer_unavailable(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000000/",
+            "status": "composer_unavailable",
+            "message": "LinkedIn did not expose a usable comment composer on this post.",
+            "posted": False,
+            "comment_visible": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "comment_on_post")
+        result = await tool_fn(
+            "urn:li:activity:7000000000000000000",
+            "Great point!",
+            True,
+            mock_context,
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "composer_unavailable"
+        assert result["posted"] is False
+
+    async def test_comment_on_post_error(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.exceptions import SessionExpiredError
+
+        mock_extractor = MagicMock()
+        mock_extractor.post_comment = AsyncMock(side_effect=SessionExpiredError())
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "comment_on_post")
+        with pytest.raises(ToolError, match="Session expired"):
+            await tool_fn(
+                "urn:li:activity:7000000000000000000",
+                "Great point!",
+                True,
+                mock_context,
+                extractor=mock_extractor,
+            )
+
+
 class TestToolTimeouts:
     async def test_all_tools_have_global_timeout(self):
         from linkedin_mcp_server.server import create_mcp_server
@@ -759,6 +877,7 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "comment_on_post",
             "close_session",
         )
 


### PR DESCRIPTION
## Summary

Adds the engagement-loop pair upstream is missing in v4.10.1: callers can chain `get_person_profile(sections=["posts"])` → `comment_on_post` end-to-end without external URL discovery.

- **`comment_on_post`** — write tool mirroring `send_message`'s confirmation gate. `confirm_post=False` does a dry run that locates the composer; `confirm_post=True` types and submits.
- **Activity URNs in `posts` references** — `classify_link` now recognises share-style `/posts/<slug>-activity-<id>-<sig>/` permalinks, and a `data-urn` harvest in the `is_activity` branch picks up the URNs that the recent-activity DOM exposes only on post wrappers (timestamps render as `<button>`, not `<a>`, so anchor-only references missed them). Both surface as `feed_post` references with the canonical `/feed/update/urn:li:activity:NNN/` URL.

End-to-end live-tested against a German LinkedIn account: `get_person_profile(<user>, sections=posts)` returned 12 `feed_post` URNs; `comment_on_post(<urn>, <text>, confirm_post=true)` posted, composer cleared, comment visible in thread.

## Why bundled

`comment_on_post` is dead weight without a way to discover post URLs programmatically; the URN harvest is the missing other half. Happy to split into two PRs if preferred.

## Design highlights

**Locale-independence** (per `AGENTS.md` Scraping Rules)
- Composer detection: `[role=textbox][contenteditable=true]` + aria-label hint with structural fallback.
- Submit-button detection: `componentkey*="commentButtonSection"` (LinkedIn's React component identity, locale-independent), with exact-match aria-label fallbacks (`"Comment"` / `"Kommentieren"` / `"Commenter"`) for older renderings.
- URN harvest: `[data-urn^="urn:li:activity:"]` + `[data-id^="urn:li:activity:"]` — attribute presence + URN prefix.
- Share permalink regex: `^/posts/[^/?#]*-activity-(\d{15,})-[^/?#]+/?$`.

**Reliability lessons baked in**
- The Tiptap composer hydrates async; `wait_for_selector` lets it mount before the focus/type evaluate.
- Submit click uses a full `mousedown → mouseup → click` `MouseEvent` sequence; bare `btn.click()` registers but skips React parent gates that gate the actual submit.
- Verify-after-action is two-stage: composer-empty (the reliable structural success signal — LinkedIn clears Tiptap only on server-accept) **then** body-text-visible. The composer-clear stage eliminates the false positive where typed-but-unsubmitted text matches `body.innerText.includes(comment)`.
- Candidate buttons re-ranked so `componentkey` matches always win — an earlier draft used `aria-label*="Post"` and substring-matched `"Open control menu for post by NAME"`, clicking the post overflow menu instead of the comment submit.
- Harvest entries prepended (not appended) so URNs win the per-section reference cap over generic post-attachment anchors.

## Verification

- `uv run pytest --cov` — 486 passing (461 baseline + 25 new). New classes:
  - `TestPostTool` — happy path, dry-run, composer-unavailable, error.
  - `TestNormalizeActivityUrl` — URL normalisation across all four input shapes.
  - `TestClassifyShareActivityPermalink` — share-permalink regex + dedup with `/feed/update/` form.
  - `TestActivityUrnExtraction` — wrapper harvest, non-activity-section skip, dedup with anchor-derived refs, helper-level filtering.
  - `comment_on_post` added to `TestToolTimeouts.test_all_tools_have_global_timeout`.
- `uv run ruff check . && uv run ruff format --check . && uv run ty check && uv run pre-commit run --all-files` — clean.
- Live E2E confirmed on a real post (German UI).

## Synthetic prompt

> Add a comment_on_post MCP tool to linkedin-mcp-server v4.10.1 that mirrors send_message's confirmation-gated, JS-driven write pattern, with locale-independent composer + componentkey-anchored submit detection. Surface activity URNs in get_person_profile(posts) section so callers can chain into comment_on_post — both via a /posts/<slug>-activity-<id>-<sig>/ regex in classify_link and a data-urn wrapper harvest inside the is_activity branch of _extract_page_once. Tests, docs, manifest.

Generated with Claude Opus 4.7 (1M context)