### PR TITLE
feat(scraping): surface company URN id in get_company_profile references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ All scraping tools return: `{url, sections: {name: raw_text}}`.
 
 Optional additional keys:
 
-- `references: {section_name: [{kind, url, text?, context?}]}` — LinkedIn URLs are relative paths
+- `references: {section_name: [{kind, url, text?, context?, value?}]}` — LinkedIn URLs are relative paths; `value` carries non-URL identifiers (e.g. company URN id for `kind: "company_urn"`)
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs only)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ for section_name, (suffix, is_overlay) in PERSON_SECTIONS.items():
 ```python
 {"url": str, "sections": {name: raw_text}}
 # Optional compact link metadata:
-{"url": str, "sections": {name: raw_text}, "references": {section: [{kind, url, text?, context?}, ...]}}
+{"url": str, "sections": {name: raw_text}, "references": {section: [{kind, url, text?, context?, value?}, ...]}}
 # When unknown section names are provided:
 {"url": str, "sections": {name: raw_text}, "unknown_sections": [name, ...]}
 # search_jobs also returns:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | working |
 | `search_conversations` | Search messages by keyword | working |
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) | working |
-| `get_company_profile` | Extract company information with explicit section selection (posts, jobs) | working |
+| `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references include a `company_urn` entry usable as `search_people` `current_company` filter value | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_jobs` | Search for jobs with keywords and location filters | working |
 | `search_people` | Search for people by keywords and location | working |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | working |
 | `search_conversations` | Search messages by keyword | working |
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) | working |
-| `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references include a `company_urn` entry usable as `search_people` `current_company` filter value | working |
+| `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_jobs` | Search for jobs with keywords and location filters | working |
 | `search_people` | Search for people by keywords and location | working |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -6,7 +6,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 
 - **Profile Access**: Get detailed LinkedIn profile information including experience, education, skills, projects, certifications, and more
 - **Profile Connections**: Send connection requests or accept incoming ones, with optional notes
-- **Company Profiles**: Extract comprehensive company data, including the company URN id usable as a people-search filter
+- **Company Profiles**: Extract comprehensive company data, including the LinkedIn company URN id (used by LinkedIn's people-search `currentCompany` URL facet)
 - **Job Details**: Retrieve job posting information
 - **Job Search**: Search for jobs with keywords and location filters
 - **People Search**: Search for people by keywords and location

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -6,7 +6,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 
 - **Profile Access**: Get detailed LinkedIn profile information including experience, education, skills, projects, certifications, and more
 - **Profile Connections**: Send connection requests or accept incoming ones, with optional notes
-- **Company Profiles**: Extract comprehensive company data
+- **Company Profiles**: Extract comprehensive company data, including the company URN id usable as a people-search filter
 - **Job Details**: Retrieve job posting information
 - **Job Search**: Search for jobs with keywords and location filters
 - **People Search**: Search for people by keywords and location

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -117,7 +117,11 @@ _FEED_PATH_RE = re.compile(r"^/feed/update/([^/?#]+)")
 _MESSAGING_THREAD_PATH_RE = re.compile(r"^/messaging/thread/([^/?#]+)")
 _MAX_REDIRECT_UNWRAP_DEPTH = 5
 
-_FIRST_URN_RE = re.compile(r'\["(\d+)"')
+# Accept both quoted-string and bare-integer JSON list elements, e.g.
+# ``["1115","2573558"]`` (the form LinkedIn currently emits — verified live)
+# and ``[1115,2573558]`` (also valid JSON). Optional surrounding quote keeps
+# the matcher resilient if LinkedIn ever drops the string-typing.
+_FIRST_URN_RE = re.compile(r'\[\s*"?(\d+)"?')
 
 
 def _first_company_urn_from_query(query: str) -> str | None:
@@ -188,6 +192,11 @@ def normalize_reference(
         "url": normalized_url,
     }
     if kind == "company_urn":
+        # ``classify_link`` already extracted the urn while building the
+        # canonical url. Re-parsing here keeps that classifier internal —
+        # callers of ``normalize_reference`` shouldn't have to know the
+        # url shape — and is cheap (the canonical url has a fixed
+        # single-id form, so ``parse_qs`` is O(1) here).
         urn_id = _first_company_urn_from_query(urlparse(normalized_url).query)
         if urn_id:
             reference["value"] = urn_id

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -9,6 +9,7 @@ from urllib.parse import parse_qs, unquote, urlparse, urlunparse
 ReferenceKind = Literal[
     "person",
     "company",
+    "company_urn",
     "job",
     "feed_post",
     "article",
@@ -26,6 +27,7 @@ class Reference(TypedDict):
     url: Required[str]
     text: NotRequired[str]
     context: NotRequired[str]
+    value: NotRequired[str]
 
 
 class RawReference(TypedDict, total=False):
@@ -115,6 +117,23 @@ _FEED_PATH_RE = re.compile(r"^/feed/update/([^/?#]+)")
 _MESSAGING_THREAD_PATH_RE = re.compile(r"^/messaging/thread/([^/?#]+)")
 _MAX_REDIRECT_UNWRAP_DEPTH = 5
 
+_FIRST_URN_RE = re.compile(r'\["(\d+)"')
+
+
+def _first_company_urn_from_query(query: str) -> str | None:
+    """Pull the first numeric id from a ``currentCompany`` people-search facet.
+
+    LinkedIn's people-search canned-search anchors carry the company URN
+    in the ``currentCompany`` query param as a JSON list, e.g.
+    ``currentCompany=["1115","2573558"]`` (percent-encoded in the href).
+    The first id is the parent company; subsequent ids are subsidiaries.
+    """
+    values = parse_qs(query).get("currentCompany")
+    if not values:
+        return None
+    match = _FIRST_URN_RE.match(values[0])
+    return match.group(1) if match else None
+
 
 def build_references(
     raw_references: list[RawReference],
@@ -150,8 +169,16 @@ def normalize_reference(
         return None
     kind, normalized_url = kind_url
 
-    text = choose_reference_text(raw, kind)
-    if text is None and kind not in {"feed_post", "external", "conversation"}:
+    if kind == "company_urn":
+        text = None
+    else:
+        text = choose_reference_text(raw, kind)
+    if text is None and kind not in {
+        "feed_post",
+        "external",
+        "conversation",
+        "company_urn",
+    }:
         return None
 
     context = derive_context(section_name, raw, kind)
@@ -160,6 +187,10 @@ def normalize_reference(
         "kind": kind,
         "url": normalized_url,
     }
+    if kind == "company_urn":
+        urn_id = _first_company_urn_from_query(urlparse(normalized_url).query)
+        if urn_id:
+            reference["value"] = urn_id
     if text:
         reference["text"] = text
     if context:
@@ -206,6 +237,18 @@ def classify_link(href: str) -> tuple[ReferenceKind, str] | None:
         return "external", urlunparse(
             (parsed.scheme, parsed.netloc, parsed.path or "/", "", "", "")
         )
+
+    # The "See all employees on LinkedIn" canned-search anchor carries the
+    # company URN id, which is the only value LinkedIn's currentCompany
+    # people-search facet actually filters on. Match before the chrome
+    # check below, which would otherwise drop every /search/results path.
+    if path.rstrip("/") == "/search/results/people":
+        urn_id = _first_company_urn_from_query(parsed.query)
+        if urn_id:
+            return (
+                "company_urn",
+                f"/search/results/people/?currentCompany=%5B%22{urn_id}%22%5D",
+            )
 
     if _is_linkedin_chrome(path):
         return None

--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -57,10 +57,13 @@ def register_company_tools(
             Includes unknown_sections list when unrecognised names are passed.
             The LLM should parse the raw text in each section.
 
-            When the about section is included, references["about"] contains
-            a {kind: "company_urn", value: "<numeric-id>"} entry. Pass that
-            value to search_people's current_company parameter; LinkedIn
-            silently ignores plain-text company names.
+            When the about section is included, references["about"] may
+            include a {kind: "company_urn", value: "<numeric-id>"} entry —
+            present whenever the page exposes the "See all employees" link
+            (typically all but the smallest companies). The value is the
+            numeric id LinkedIn's people-search uses in its currentCompany
+            URL facet; plain-text company names are silently ignored by
+            that facet.
         """
         try:
             extractor = extractor or await get_ready_extractor(

--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -56,6 +56,11 @@ def register_company_tools(
             Dict with url, sections (name -> raw text), and optional references.
             Includes unknown_sections list when unrecognised names are passed.
             The LLM should parse the raw text in each section.
+
+            When the about section is included, references["about"] contains
+            a {kind: "company_urn", value: "<numeric-id>"} entry. Pass that
+            value to search_people's current_company parameter; LinkedIn
+            silently ignores plain-text company names.
         """
         try:
             extractor = extractor or await get_ready_extractor(

--- a/manifest.json
+++ b/manifest.json
@@ -59,7 +59,7 @@
     },
     {
       "name": "get_company_profile",
-      "description": "Extract comprehensive company information and details"
+      "description": "Extract comprehensive company information and details. References include a company_urn entry usable as the search_people current_company filter value."
     },
     {
       "name": "get_company_posts",

--- a/manifest.json
+++ b/manifest.json
@@ -59,7 +59,7 @@
     },
     {
       "name": "get_company_profile",
-      "description": "Extract comprehensive company information and details. References include a company_urn entry usable as the search_people current_company filter value."
+      "description": "Extract comprehensive company information and details. About-section references may include a company_urn entry carrying the numeric id LinkedIn's people-search uses in its currentCompany URL facet."
     },
     {
       "name": "get_company_posts",

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -524,6 +524,105 @@ class TestBuildReferences:
             }
         ]
 
+    def test_company_urn_single_id_anchor(self):
+        """Anthropic-style: single id in the currentCompany list."""
+        references = build_references(
+            [
+                {
+                    "href": "https://www.linkedin.com/search/results/people/"
+                    "?currentCompany=%5B%2274126343%22%5D"
+                    "&origin=COMPANY_PAGE_CANNED_SEARCH",
+                    "text": "501-1K employees",
+                }
+            ],
+            "about",
+        )
+
+        assert references == [
+            {
+                "kind": "company_urn",
+                "url": "/search/results/people/?currentCompany=%5B%2274126343%22%5D",
+                "value": "74126343",
+                "context": "top card",
+            }
+        ]
+
+    def test_company_urn_multi_id_anchor_uses_first_id(self):
+        """SAP-style: parent + subsidiaries; the first id is the parent company."""
+        references = build_references(
+            [
+                {
+                    "href": "https://www.linkedin.com/search/results/people/"
+                    "?currentCompany=%5B%221115%22%2C%222573558%22%2C%222818%22%5D"
+                    "&origin=COMPANY_PAGE_CANNED_SEARCH",
+                    "text": "143,150 associated members",
+                }
+            ],
+            "about",
+        )
+
+        assert references == [
+            {
+                "kind": "company_urn",
+                "url": "/search/results/people/?currentCompany=%5B%221115%22%5D",
+                "value": "1115",
+                "context": "top card",
+            }
+        ]
+
+    def test_company_urn_suppresses_anchor_text(self):
+        """Anchor text like '10K+ employees' is not user-meaningful for a URN
+        reference; callers should key off ``value``."""
+        references = build_references(
+            [
+                {
+                    "href": "https://www.linkedin.com/search/results/people/"
+                    "?currentCompany=%5B%221115%22%5D",
+                    "text": "10K+ employees",
+                }
+            ],
+            "about",
+        )
+
+        assert len(references) == 1
+        assert references[0]["kind"] == "company_urn"
+        assert references[0]["value"] == "1115"
+        assert "text" not in references[0]
+
+    def test_company_urn_lowercase_percent_escapes(self):
+        """``parse_qs`` decodes percent-escapes regardless of case, so
+        lowercase variants must still classify and extract the same id."""
+        references = build_references(
+            [
+                {
+                    "href": "https://www.linkedin.com/search/results/people/"
+                    "?currentCompany=%5b%221115%22%5d",
+                    "text": "10K+ employees",
+                }
+            ],
+            "about",
+        )
+
+        assert len(references) == 1
+        assert references[0]["kind"] == "company_urn"
+        assert references[0]["value"] == "1115"
+
+    def test_plain_people_search_still_dropped(self):
+        """A people-search href without ``currentCompany`` is page chrome
+        and stays excluded — preserves existing behaviour."""
+        references = build_references(
+            [
+                {
+                    "href": "https://www.linkedin.com/search/results/people/"
+                    "?keywords=engineer",
+                    "text": "engineer",
+                }
+            ],
+            "about",
+        )
+
+        assert references == []
+
 
 class TestClassifyLink:
     def test_messaging_thread_url(self):

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -589,6 +589,24 @@ class TestBuildReferences:
         assert references[0]["value"] == "1115"
         assert "text" not in references[0]
 
+    def test_company_urn_accepts_unquoted_json_integers(self):
+        """Defensive: LinkedIn currently serialises ids as quoted strings,
+        but plain JSON integers are also valid and should still classify."""
+        references = build_references(
+            [
+                {
+                    "href": "https://www.linkedin.com/search/results/people/"
+                    "?currentCompany=%5B1115%5D",
+                    "text": "10K+ employees",
+                }
+            ],
+            "about",
+        )
+
+        assert len(references) == 1
+        assert references[0]["kind"] == "company_urn"
+        assert references[0]["value"] == "1115"
+
     def test_company_urn_lowercase_percent_escapes(self):
         """``parse_qs`` decodes percent-escapes regardless of case, so
         lowercase variants must still classify and extract the same id."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1607,6 +1607,70 @@ class TestScrapeCompany:
         assert "about" not in result["sections"]
         assert result["sections"]["posts"] == "Posts text"
 
+    async def test_scrape_company_extracts_company_urn(self, mock_page):
+        """End-to-end: a canned-search anchor on the company about page
+        produces a ``company_urn`` reference with the parent-company id.
+
+        Stubs ``_extract_root_content`` (rather than ``extract_page``) so
+        the real ``build_references`` pipeline runs against raw anchor
+        data, mirroring what the JS crawler emits live.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        raw_root = {
+            "source": "root",
+            "text": "About SAP\nCompany overview",
+            "references": [
+                {
+                    "href": "https://www.linkedin.com/search/results/people/"
+                    "?currentCompany=%5B%221115%22%5D"
+                    "&origin=COMPANY_PAGE_CANNED_SEARCH",
+                    "text": "10K+ employees",
+                    "aria_label": "",
+                    "title": "",
+                    "heading": "",
+                    "in_article": False,
+                    "in_nav": False,
+                    "in_footer": False,
+                }
+            ],
+        }
+        with (
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value=raw_root,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_company("sap", {"about"})
+
+        urns = [
+            ref for ref in result["references"]["about"] if ref["kind"] == "company_urn"
+        ]
+        assert len(urns) == 1
+        assert urns[0]["value"] == "1115"
+        assert urns[0]["url"] == (
+            "/search/results/people/?currentCompany=%5B%221115%22%5D"
+        )
+        assert "text" not in urns[0]
+
 
 class TestScrapeJob:
     async def test_scrape_job(self, mock_page):


### PR DESCRIPTION
Adds a new company_urn reference kind so callers (and LLMs) can pass the
numeric LinkedIn company id to search_people.current_company. LinkedIn
silently ignores plain-text names on that facet, so the URN is the only
value that actually filters.

Extracts the URN from the canned-search "See all employees" anchor that
LinkedIn embeds on every company page (verified live on /company/sap/about/
and /company/anthropicresearch/about/). The first id in the
currentCompany list is the parent company; subsidiaries follow.

Schema additions kept minimal: ReferenceKind gains "company_urn",
Reference TypedDict gains optional value: str. Anchor text like "10K+
employees" is suppressed for this kind so callers key off value.

Resolves #430.