### PR TITLE
feat(feed): add get_feed MCP tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Optional additional keys:
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs only)
+- `posts: [{text, url?}, ...]` (get_feed only) — per-post text blocks in feed order; `url` omitted for promoted/suggested items
 
 ## Verifying Bug Reports
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Optional additional keys:
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs only)
-- `posts: [{text, url?}, ...]` (get_feed only) — per-post text blocks in feed order; `url` omitted for promoted/suggested items
+- `references["feed"]` (get_feed only) — `kind: "feed_post"` entries may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) URLs; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
 
 ## Verifying Bug Reports
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Optional additional keys:
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs only)
-- `references["feed"]` (get_feed only) — `kind: "feed_post"` entries may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) URLs; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
+- `references["feed"]` (get_feed only) — every entry is `kind: "feed_post"`; non-post anchors (sidebar profiles, employer logos) are filtered. URLs may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) form; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
 
 ## Verifying Bug Reports
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | `search_jobs` | Search for jobs with keywords and location filters | working |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | working |
 | `get_job_details` | Get detailed information about a specific job posting | working |
+| `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `close_session` | Close browser session and clean up resources | working |
 
 <br/>

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -12,6 +12,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **People Search**: Search for people by keywords and location
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed
+- **Home Feed**: Get recent posts from the authenticated user's LinkedIn home feed
 - **Compact References**: Return typed per-section links alongside readable text without shipping full-page markdown
 
 ## Quick Start

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -347,20 +347,28 @@ def _build_feed_references(
 ) -> list[Reference]:
     """Compose feed references from DOM anchors + SDUI captures.
 
-    DOM anchors give whatever ``classify_link`` recognises (typically
-    ``feed_post`` for ``/feed/update/<urn>/`` shapes). SDUI captures
-    surface every ``/posts/<slug>`` permalink the page emitted, even
-    when no DOM anchor renders for it. We fold both into the same
-    ``feed_post`` kind, deduping on the exact URL string.
+    The feed page renders many anchors that are not post permalinks:
+    sidebar widgets, profile cards, employer logos, etc. Mixing them
+    into ``references["feed"]`` blurs the contract and competes with
+    SDUI permalinks for the per-section cap. We keep only the
+    ``feed_post`` slice from the DOM:
 
-    Note on URL shapes: ``/feed/update/<urn>/`` and ``/posts/<slug>``
-    pointing at the same underlying post will *not* collapse here —
-    ``dedupe_references`` matches exact strings. Both shapes are valid
-    LinkedIn permalinks, so consumers should treat ``feed_post`` as
-    polymorphic on URL form. URN-based equivalence is left to the
-    consumer.
+    - DOM anchors → ``feed_post`` entries with ``/feed/update/<urn>/``
+      URLs (whatever ``classify_link`` recognises).
+    - SDUI captures → ``feed_post`` entries with ``/posts/<slug>`` URLs
+      for permalinks that the DOM does not surface as an anchor.
+
+    Both are deduped on exact URL string. The two shapes pointing at
+    the same underlying post will *not* collapse — ``dedupe_references``
+    matches strings, not URNs. Both are valid LinkedIn permalinks, so
+    consumers should treat ``feed_post`` as polymorphic on URL form;
+    URN-based equivalence is left to the consumer.
     """
-    refs = build_references(raw_references, "feed")
+    refs = [
+        ref
+        for ref in build_references(raw_references, "feed")
+        if ref["kind"] == "feed_post"
+    ]
     existing = {r["url"] for r in refs}
     for sdui_url in captured_urls:
         # AGENTS.md mandates relative paths for LinkedIn references.
@@ -1018,10 +1026,19 @@ class LinkedInExtractor:
                         pending_reads, timeout=_IN_LOOP_DRAIN_TIMEOUT
                     )
                     if done:
-                        # Surface unexpected exceptions; _read() catches
-                        # the expected playwright errors but a parser bug
-                        # should not silently disappear into the loop.
-                        await asyncio.gather(*done, return_exceptions=True)
+                        # Surface unexpected exceptions. _read() catches
+                        # expected playwright errors, but a parser bug
+                        # would otherwise vanish into the loop. Log them
+                        # rather than raising so a single bad response
+                        # doesn't abort the whole scroll session.
+                        for result in await asyncio.gather(
+                            *done, return_exceptions=True
+                        ):
+                            if isinstance(result, BaseException):
+                                logger.warning(
+                                    "Unhandled error in feed _read task: %r",
+                                    result,
+                                )
                     pending_reads[:] = [t for t in pending_reads if not t.done()]
                 new_count = len(captured_urls)
                 if new_count > count:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 import json
 import logging
 import re
-import unicodedata
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import parse_qs, quote_plus, urljoin, urlparse
 
@@ -318,7 +317,6 @@ class ExtractedSection:
     text: str
     references: list[Reference]
     error: dict[str, Any] | None = None
-    posts: list[dict[str, Any]] | None = None
 
 
 _FEED_RSC_MARKER = "sduiid=com.linkedin.sdui.pagers.feed.mainFeed"
@@ -330,25 +328,10 @@ _POST_SLUG_URL_RE = re.compile(
     r"linkedin\.com(?:\\u002[fF]|/)posts(?:\\u002[fF]|/)"
     r"(?P<slug>[A-Za-z0-9_-]+?-(?:ugcPost|activity|share)-\d+-[A-Za-z0-9_-]+)"
 )
-_FEED_POST_SPLIT_RE = re.compile(r"(?:^|\n)Feed post\s*\n+")
 _FEED_DOCUMENT_URLS = {
     "https://www.linkedin.com/feed",
     "https://www.linkedin.com/feed/",
 }
-_POST_SLUG_PATH_RE = re.compile(
-    r"/posts/(?P<prefix>.+?)-(?:ugcPost|activity|share)-\d+-[A-Za-z0-9_-]+/?$"
-)
-_NON_ALNUM_RE = re.compile(r"[^a-z0-9]")
-# Minimum normalized length of a slug fingerprint before we'll try to match it
-# against a post block — guards against false positives from very short slugs.
-_MIN_FINGERPRINT_LEN = 12
-
-
-def _normalize_for_match(text: str) -> str:
-    # NFKC folds mathematical-bold / full-width / superscript characters to
-    # their ASCII equivalents, so posts styled with Unicode typography still
-    # substring-match their plain-text slugs.
-    return _NON_ALNUM_RE.sub("", unicodedata.normalize("NFKC", text).lower())
 
 
 def _is_feed_payload_response(url: str) -> bool:
@@ -358,65 +341,72 @@ def _is_feed_payload_response(url: str) -> bool:
     return url.split("?", 1)[0] in _FEED_DOCUMENT_URLS
 
 
-def _fingerprint_from_slug_url(slug_url: str) -> str | None:
-    """Derive a normalized content fingerprint from a post slug URL.
-
-    LinkedIn encodes the first several words of the post body into the slug:
-    ``/posts/<author>_<title-words>-<type>-<id>-<trk>`` (or just
-    ``/posts/<title-words>-<type>-<id>-<trk>`` for org posts). We extract the
-    title portion and strip non-alphanumerics so it substring-matches the
-    post's innerText regardless of punctuation/whitespace differences.
-    """
-    path = slug_url.split("?", 1)[0].split("#", 1)[0]
-    match = _POST_SLUG_PATH_RE.search(path)
-    if not match:
-        return None
-    prefix = match.group("prefix")
-    _, sep, title = prefix.partition("_")
-    if not sep:
-        title = prefix
-    normalized = _normalize_for_match(title)
-    return normalized if len(normalized) >= _MIN_FINGERPRINT_LEN else None
-
-
-def _build_feed_posts(
-    cleaned_text: str,
+def _build_feed_references(
+    raw_references: list[Any],
     captured_urls: list[str],
-) -> list[dict[str, Any]]:
-    """Split feed innerText into per-post blocks and attach captured permalinks.
+) -> list[Reference]:
+    """Compose feed references from DOM anchors + SDUI captures.
 
-    Matches each URL to a post by content fingerprint (first words of the
-    post body, encoded into the slug URL). Ordering between the captured-URL
-    list and the rendered DOM is not stable — posts from the initial HTML
-    document and subsequent pagination fetches interleave — so we key on
-    content instead. Promoted/suggested posts have no ``postSlugUrl`` and
-    simply receive no ``url`` field.
+    DOM anchors give whatever ``classify_link`` recognises (typically
+    ``feed_post`` for ``/feed/update/<urn>/`` shapes). SDUI captures
+    surface every ``/posts/<slug>`` permalink the page emitted, even
+    when no DOM anchor renders for it. We fold both into the same
+    ``feed_post`` kind, deduping on the exact URL string.
+
+    Note on URL shapes: ``/feed/update/<urn>/`` and ``/posts/<slug>``
+    pointing at the same underlying post will *not* collapse here —
+    ``dedupe_references`` matches exact strings. Both shapes are valid
+    LinkedIn permalinks, so consumers should treat ``feed_post`` as
+    polymorphic on URL form. URN-based equivalence is left to the
+    consumer.
     """
-    blocks = [
-        block.strip()
-        for block in _FEED_POST_SPLIT_RE.split(cleaned_text)
-        if block.strip()
-    ]
-    if blocks and not cleaned_text.lstrip().startswith("Feed post"):
-        blocks = blocks[1:]
+    refs = build_references(raw_references, "feed")
+    existing = {r["url"] for r in refs}
+    for sdui_url in captured_urls:
+        # AGENTS.md mandates relative paths for LinkedIn references.
+        # The SDUI capture carries fully-qualified URLs like
+        # https://www.linkedin.com/posts/<slug>; strip the host so the
+        # relative-path convention holds. ``classify_link`` does not
+        # currently route ``/posts/<slug>`` paths to any kind, so we
+        # bypass it for this fallback append.
+        parsed = urlparse(sdui_url)
+        if not parsed.path.startswith("/posts/"):
+            continue
+        relative = parsed.path
+        if relative in existing:
+            continue
+        refs.append({"kind": "feed_post", "url": relative, "context": "feed"})
+        existing.add(relative)
+    # Cap kept in sync with _REFERENCE_CAPS["feed"] in link_metadata.py;
+    # changing one without the other will drop or duplicate entries
+    # silently. Matches get_feed's num_posts ceiling (Field(ge=1, le=50)).
+    return dedupe_references(refs, cap=50)
 
-    url_pool: list[tuple[str, str]] = []
-    for url in captured_urls:
-        fingerprint = _fingerprint_from_slug_url(url)
-        if fingerprint:
-            url_pool.append((fingerprint, url))
 
-    posts: list[dict[str, Any]] = []
-    for block in blocks:
-        entry: dict[str, Any] = {"text": block}
-        normalized_block = _normalize_for_match(block)
-        for i, (fingerprint, url) in enumerate(url_pool):
-            if fingerprint in normalized_block:
-                entry["url"] = url
-                url_pool.pop(i)
-                break
-        posts.append(entry)
-    return posts
+async def _drain_listener_tasks(pending: list[asyncio.Task[None]]) -> None:
+    """Bounded teardown for fire-and-forget response listener tasks.
+
+    The feed scroll loop appends a read task per matching response;
+    those tasks must finish (or be cancelled) before we leave the
+    extractor or the event loop's "Task exception was never retrieved"
+    warnings will surface unrelated errors. The caps below let a stuck
+    ``resp.body()`` call burn at most three seconds of teardown budget.
+    """
+    if not pending:
+        return
+    _done, leftover = await asyncio.wait(pending, timeout=2.0)
+    for task in leftover:
+        task.cancel()
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*pending, return_exceptions=True),
+            timeout=1.0,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "SDUI feed listener tasks did not drain after cancel; leaking %d task(s)",
+            sum(1 for t in pending if not t.done()),
+        )
 
 
 class FilterValidationError(ValueError):
@@ -922,11 +912,15 @@ class LinkedInExtractor:
         """Single attempt: navigate, scroll until post count, extract."""
         url = "https://www.linkedin.com/feed/"
 
-        # Post permalinks aren't rendered in the feed DOM anymore — they only
-        # live in the SDUI pagination response (field: "postSlugUrl"). Listen
-        # for those responses during the whole scroll loop.
+        # Post permalinks live in the SDUI pagination response (field:
+        # "postSlugUrl"). The initial /feed/ HTML embeds the same data in
+        # an RSC flight payload. Listen for both during the whole scroll
+        # loop. ``seen_urls`` doubles as the locale-independent scroll
+        # progress signal, replacing the previous "Feed post" innerText
+        # marker that broke on non-English UIs.
         captured_urls: list[str] = []
         seen_urls: set[str] = set()
+        pending_reads: list[asyncio.Task[None]] = []
 
         def _handle_response(resp: Any) -> None:
             if not _is_feed_payload_response(resp.url):
@@ -946,22 +940,26 @@ class LinkedInExtractor:
                         seen_urls.add(post_url)
                         captured_urls.append(post_url)
 
-            asyncio.create_task(_read())
+            pending_reads.append(asyncio.create_task(_read()))
 
         self._page.on("response", _handle_response)
         try:
-            return await self._extract_feed_body(url, num_posts, captured_urls)
+            return await self._extract_feed_body(
+                url, num_posts, captured_urls, pending_reads
+            )
         finally:
             try:
                 self._page.remove_listener("response", _handle_response)
             except Exception:
                 pass
+            await _drain_listener_tasks(pending_reads)
 
     async def _extract_feed_body(
         self,
         url: str,
         num_posts: int,
         captured_urls: list[str],
+        pending_reads: list[asyncio.Task[None]],
     ) -> ExtractedSection:
         await self._navigate_to_page(url)
         await detect_rate_limit(self._page)
@@ -987,11 +985,11 @@ class LinkedInExtractor:
 
         # The feed has its own scroll container — window.scrollTo is a no-op.
         # mouse.wheel over the viewport center triggers the real scroll.
-        _POST_MARKER = "Feed post"
         _MAX_SCROLLS = 12
         _MAX_STALE = 3
         _BATCH_WAIT = 6.0
         _WHEEL_DELTA = 2000
+        _IN_LOOP_DRAIN_TIMEOUT = 1.0
         stale_count = 0
 
         viewport = self._page.viewport_size or {"width": 1280, "height": 720}
@@ -999,15 +997,8 @@ class LinkedInExtractor:
         await self._page.mouse.move(cx, cy)
 
         for i in range(_MAX_SCROLLS):
-            count = await self._page.evaluate(
-                """(marker) => {
-                    const main = document.querySelector('main');
-                    if (!main) return 0;
-                    return main.innerText.split(marker).length - 1;
-                }""",
-                _POST_MARKER,
-            )
-            logger.debug("Feed scroll %d: %d posts loaded", i, count)
+            count = len(captured_urls)
+            logger.debug("Feed scroll %d: %d permalinks captured", i, count)
             if count >= num_posts:
                 break
 
@@ -1016,14 +1007,23 @@ class LinkedInExtractor:
             new_count = count
             for _ in range(int(_BATCH_WAIT)):
                 await asyncio.sleep(1.0)
-                new_count = await self._page.evaluate(
-                    """(marker) => {
-                        const main = document.querySelector('main');
-                        if (!main) return 0;
-                        return main.innerText.split(marker).length - 1;
-                    }""",
-                    _POST_MARKER,
-                )
+                # Drain in-flight response reads so captured_urls reflects
+                # everything Playwright already delivered. Without this,
+                # the count comparison races: the wheel fires a network
+                # response, the listener creates a read task, and the loop
+                # sleeps and re-checks before _read() finishes appending —
+                # producing false-stale verdicts.
+                if pending_reads:
+                    done, _still = await asyncio.wait(
+                        pending_reads, timeout=_IN_LOOP_DRAIN_TIMEOUT
+                    )
+                    if done:
+                        # Surface unexpected exceptions; _read() catches
+                        # the expected playwright errors but a parser bug
+                        # should not silently disappear into the loop.
+                        await asyncio.gather(*done, return_exceptions=True)
+                    pending_reads[:] = [t for t in pending_reads if not t.done()]
+                new_count = len(captured_urls)
                 if new_count > count:
                     break
 
@@ -1032,7 +1032,7 @@ class LinkedInExtractor:
             else:
                 stale_count += 1
                 logger.debug(
-                    "Feed stale scroll %d/%d (still at %d posts)",
+                    "Feed stale scroll %d/%d (still at %d permalinks)",
                     stale_count,
                     _MAX_STALE,
                     new_count,
@@ -1040,21 +1040,6 @@ class LinkedInExtractor:
                 if stale_count >= _MAX_STALE:
                     logger.debug("Feed stopped producing new posts")
                     break
-
-        # Expand "… more" buttons via JS click (Playwright clicks time out on obscured buttons).
-        expanded = await self._page.evaluate(
-            """() => {
-                const main = document.querySelector('main');
-                if (!main) return 0;
-                const btns = Array.from(main.querySelectorAll('button'))
-                    .filter(b => /^…?\\s*(see )?more$/i.test(b.innerText.trim()));
-                btns.forEach(b => b.click());
-                return btns.length;
-            }"""
-        )
-        logger.debug("Expanded %d truncated posts", expanded)
-        if expanded:
-            await asyncio.sleep(0.5)
 
         # Give any in-flight response reads a beat to finish recording URLs.
         await asyncio.sleep(0.2)
@@ -1071,11 +1056,9 @@ class LinkedInExtractor:
             )
             return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
         cleaned = _filter_linkedin_noise_lines(truncated)
-        posts = _build_feed_posts(cleaned, captured_urls)
         return ExtractedSection(
             text=cleaned,
-            references=build_references(raw_result["references"], "feed"),
-            posts=posts,
+            references=_build_feed_references(raw_result["references"], captured_urls),
         )
 
     async def extract_page(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import json
 import logging
 import re
+import unicodedata
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import parse_qs, quote_plus, urljoin, urlparse
 
@@ -317,6 +318,105 @@ class ExtractedSection:
     text: str
     references: list[Reference]
     error: dict[str, Any] | None = None
+    posts: list[dict[str, Any]] | None = None
+
+
+_FEED_RSC_MARKER = "sduiid=com.linkedin.sdui.pagers.feed.mainFeed"
+# Matches a LinkedIn post permalink in either plain or JSON-escaped form
+# (the initial /feed/ HTML embeds the RSC flight data with \u002f for slashes,
+# while paginated responses use plain slashes). Captures the slug portion so
+# we can rebuild a canonical URL regardless of the source encoding.
+_POST_SLUG_URL_RE = re.compile(
+    r"linkedin\.com(?:\\u002[fF]|/)posts(?:\\u002[fF]|/)"
+    r"(?P<slug>[A-Za-z0-9_-]+?-(?:ugcPost|activity|share)-\d+-[A-Za-z0-9_-]+)"
+)
+_FEED_POST_SPLIT_RE = re.compile(r"(?:^|\n)Feed post\s*\n+")
+_FEED_DOCUMENT_URLS = {
+    "https://www.linkedin.com/feed",
+    "https://www.linkedin.com/feed/",
+}
+_POST_SLUG_PATH_RE = re.compile(
+    r"/posts/(?P<prefix>.+?)-(?:ugcPost|activity|share)-\d+-[A-Za-z0-9_-]+/?$"
+)
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]")
+# Minimum normalized length of a slug fingerprint before we'll try to match it
+# against a post block — guards against false positives from very short slugs.
+_MIN_FINGERPRINT_LEN = 12
+
+
+def _normalize_for_match(text: str) -> str:
+    # NFKC folds mathematical-bold / full-width / superscript characters to
+    # their ASCII equivalents, so posts styled with Unicode typography still
+    # substring-match their plain-text slugs.
+    return _NON_ALNUM_RE.sub("", unicodedata.normalize("NFKC", text).lower())
+
+
+def _is_feed_payload_response(url: str) -> bool:
+    """True if the response URL is one that carries `postSlugUrl` fields."""
+    if _FEED_RSC_MARKER in url:
+        return True
+    return url.split("?", 1)[0] in _FEED_DOCUMENT_URLS
+
+
+def _fingerprint_from_slug_url(slug_url: str) -> str | None:
+    """Derive a normalized content fingerprint from a post slug URL.
+
+    LinkedIn encodes the first several words of the post body into the slug:
+    ``/posts/<author>_<title-words>-<type>-<id>-<trk>`` (or just
+    ``/posts/<title-words>-<type>-<id>-<trk>`` for org posts). We extract the
+    title portion and strip non-alphanumerics so it substring-matches the
+    post's innerText regardless of punctuation/whitespace differences.
+    """
+    path = slug_url.split("?", 1)[0].split("#", 1)[0]
+    match = _POST_SLUG_PATH_RE.search(path)
+    if not match:
+        return None
+    prefix = match.group("prefix")
+    _, sep, title = prefix.partition("_")
+    if not sep:
+        title = prefix
+    normalized = _normalize_for_match(title)
+    return normalized if len(normalized) >= _MIN_FINGERPRINT_LEN else None
+
+
+def _build_feed_posts(
+    cleaned_text: str,
+    captured_urls: list[str],
+) -> list[dict[str, Any]]:
+    """Split feed innerText into per-post blocks and attach captured permalinks.
+
+    Matches each URL to a post by content fingerprint (first words of the
+    post body, encoded into the slug URL). Ordering between the captured-URL
+    list and the rendered DOM is not stable — posts from the initial HTML
+    document and subsequent pagination fetches interleave — so we key on
+    content instead. Promoted/suggested posts have no ``postSlugUrl`` and
+    simply receive no ``url`` field.
+    """
+    blocks = [
+        block.strip()
+        for block in _FEED_POST_SPLIT_RE.split(cleaned_text)
+        if block.strip()
+    ]
+    if blocks and not cleaned_text.lstrip().startswith("Feed post"):
+        blocks = blocks[1:]
+
+    url_pool: list[tuple[str, str]] = []
+    for url in captured_urls:
+        fingerprint = _fingerprint_from_slug_url(url)
+        if fingerprint:
+            url_pool.append((fingerprint, url))
+
+    posts: list[dict[str, Any]] = []
+    for block in blocks:
+        entry: dict[str, Any] = {"text": block}
+        normalized_block = _normalize_for_match(block)
+        for i, (fingerprint, url) in enumerate(url_pool):
+            if fingerprint in normalized_block:
+                entry["url"] = url
+                url_pool.pop(i)
+                break
+        posts.append(entry)
+    return posts
 
 
 class FilterValidationError(ValueError):
@@ -797,6 +897,186 @@ class LinkedInExtractor:
                 {"position": position},
             )
             await asyncio.sleep(pause_time)
+
+    async def extract_feed(
+        self,
+        num_posts: int = 10,
+    ) -> ExtractedSection:
+        """Scrape the LinkedIn home feed, scrolling until *num_posts* are loaded."""
+        try:
+            return await self._extract_feed_once(num_posts)
+        except LinkedInScraperException:
+            raise
+        except Exception as e:
+            logger.warning("Failed to extract feed: %s", e)
+            return ExtractedSection(
+                text="",
+                references=[],
+                error=build_issue_diagnostics(e, context="extract_feed"),
+            )
+
+    async def _extract_feed_once(
+        self,
+        num_posts: int,
+    ) -> ExtractedSection:
+        """Single attempt: navigate, scroll until post count, extract."""
+        url = "https://www.linkedin.com/feed/"
+
+        # Post permalinks aren't rendered in the feed DOM anymore — they only
+        # live in the SDUI pagination response (field: "postSlugUrl"). Listen
+        # for those responses during the whole scroll loop.
+        captured_urls: list[str] = []
+        seen_urls: set[str] = set()
+
+        def _handle_response(resp: Any) -> None:
+            if not _is_feed_payload_response(resp.url):
+                return
+
+            async def _read() -> None:
+                try:
+                    body = await resp.body()
+                except Exception:
+                    return
+                if not body:
+                    return
+                text = body.decode("utf-8", errors="replace")
+                for match in _POST_SLUG_URL_RE.finditer(text):
+                    post_url = f"https://www.linkedin.com/posts/{match.group('slug')}"
+                    if post_url not in seen_urls:
+                        seen_urls.add(post_url)
+                        captured_urls.append(post_url)
+
+            asyncio.create_task(_read())
+
+        self._page.on("response", _handle_response)
+        try:
+            return await self._extract_feed_body(url, num_posts, captured_urls)
+        finally:
+            try:
+                self._page.remove_listener("response", _handle_response)
+            except Exception:
+                pass
+
+    async def _extract_feed_body(
+        self,
+        url: str,
+        num_posts: int,
+        captured_urls: list[str],
+    ) -> ExtractedSection:
+        await self._navigate_to_page(url)
+        await detect_rate_limit(self._page)
+
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("No <main> element found on %s", url)
+
+        await handle_modal_close(self._page)
+
+        try:
+            await self._page.wait_for_function(
+                """() => {
+                    const main = document.querySelector('main');
+                    if (!main) return false;
+                    return main.innerText.length > 200;
+                }""",
+                timeout=10000,
+            )
+        except PlaywrightTimeoutError:
+            logger.debug("Feed content did not appear on %s", url)
+
+        # The feed has its own scroll container — window.scrollTo is a no-op.
+        # mouse.wheel over the viewport center triggers the real scroll.
+        _POST_MARKER = "Feed post"
+        _MAX_SCROLLS = 12
+        _MAX_STALE = 3
+        _BATCH_WAIT = 6.0
+        _WHEEL_DELTA = 2000
+        stale_count = 0
+
+        viewport = self._page.viewport_size or {"width": 1280, "height": 720}
+        cx, cy = viewport["width"] // 2, viewport["height"] // 2
+        await self._page.mouse.move(cx, cy)
+
+        for i in range(_MAX_SCROLLS):
+            count = await self._page.evaluate(
+                """(marker) => {
+                    const main = document.querySelector('main');
+                    if (!main) return 0;
+                    return main.innerText.split(marker).length - 1;
+                }""",
+                _POST_MARKER,
+            )
+            logger.debug("Feed scroll %d: %d posts loaded", i, count)
+            if count >= num_posts:
+                break
+
+            await self._page.mouse.wheel(0, _WHEEL_DELTA)
+
+            new_count = count
+            for _ in range(int(_BATCH_WAIT)):
+                await asyncio.sleep(1.0)
+                new_count = await self._page.evaluate(
+                    """(marker) => {
+                        const main = document.querySelector('main');
+                        if (!main) return 0;
+                        return main.innerText.split(marker).length - 1;
+                    }""",
+                    _POST_MARKER,
+                )
+                if new_count > count:
+                    break
+
+            if new_count > count:
+                stale_count = 0
+            else:
+                stale_count += 1
+                logger.debug(
+                    "Feed stale scroll %d/%d (still at %d posts)",
+                    stale_count,
+                    _MAX_STALE,
+                    new_count,
+                )
+                if stale_count >= _MAX_STALE:
+                    logger.debug("Feed stopped producing new posts")
+                    break
+
+        # Expand "… more" buttons via JS click (Playwright clicks time out on obscured buttons).
+        expanded = await self._page.evaluate(
+            """() => {
+                const main = document.querySelector('main');
+                if (!main) return 0;
+                const btns = Array.from(main.querySelectorAll('button'))
+                    .filter(b => /^…?\\s*(see )?more$/i.test(b.innerText.trim()));
+                btns.forEach(b => b.click());
+                return btns.length;
+            }"""
+        )
+        logger.debug("Expanded %d truncated posts", expanded)
+        if expanded:
+            await asyncio.sleep(0.5)
+
+        # Give any in-flight response reads a beat to finish recording URLs.
+        await asyncio.sleep(0.2)
+
+        raw_result = await self._extract_root_content(["main"])
+        raw = raw_result["text"]
+
+        if not raw:
+            return ExtractedSection(text="", references=[])
+        truncated = _truncate_linkedin_noise(raw)
+        if not truncated and raw.strip():
+            logger.warning(
+                "Page %s returned only LinkedIn chrome (likely rate-limited)", url
+            )
+            return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+        cleaned = _filter_linkedin_noise_lines(truncated)
+        posts = _build_feed_posts(cleaned, captured_urls)
+        return ExtractedSection(
+            text=cleaned,
+            references=build_references(raw_result["references"], "feed"),
+            posts=posts,
+        )
 
     async def extract_page(
         self,

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -101,6 +101,10 @@ _REFERENCE_CAPS = {
     "contact_info": 8,
     "inbox": 30,
     "conversation": 12,
+    # Headroom for get_feed's num_posts ceiling (Field(ge=1, le=50)).
+    # Kept in sync with the literal cap=50 in extractor._extract_feed_body
+    # where SDUI-derived /posts/<slug> permalinks are appended.
+    "feed": 50,
 }
 
 _URL_LIKE_RE = re.compile(r"^(?:https?://|/)\S+$", re.IGNORECASE)

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -102,7 +102,7 @@ _REFERENCE_CAPS = {
     "inbox": 30,
     "conversation": 12,
     # Headroom for get_feed's num_posts ceiling (Field(ge=1, le=50)).
-    # Kept in sync with the literal cap=50 in extractor._extract_feed_body
+    # Kept in sync with the literal cap=50 in extractor._build_feed_references
     # where SDUI-derived /posts/<slug> permalinks are appended.
     "feed": 50,
 }

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -23,6 +23,7 @@ from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
 from linkedin_mcp_server.tools.company import register_company_tools
+from linkedin_mcp_server.tools.feed import register_feed_tools
 from linkedin_mcp_server.tools.job import register_job_tools
 from linkedin_mcp_server.tools.messaging import register_messaging_tools
 from linkedin_mcp_server.tools.person import register_person_tools
@@ -60,6 +61,7 @@ def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> 
     register_company_tools(mcp, tool_timeout=tool_timeout)
     register_job_tools(mcp, tool_timeout=tool_timeout)
     register_messaging_tools(mcp, tool_timeout=tool_timeout)
+    register_feed_tools(mcp, tool_timeout=tool_timeout)
 
     # Register session management tool
     @mcp.tool(

--- a/linkedin_mcp_server/tools/__init__.py
+++ b/linkedin_mcp_server/tools/__init__.py
@@ -11,6 +11,7 @@ Available Tools:
 - Company tools: Company profile and information extraction
 - Job tools: Job posting details and search functionality
 - Messaging tools: Inbox, conversations, search, and sending messages
+- Feed tools: Home feed scraping
 
 Architecture:
 - FastMCP integration for MCP-compliant tool registration

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -7,11 +7,12 @@ of posts are visible in the DOM.
 """
 
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
+from pydantic import Field
 
-from linkedin_mcp_server.constants import TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
 from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
@@ -21,11 +22,13 @@ from linkedin_mcp_server.scraping.link_metadata import Reference
 logger = logging.getLogger(__name__)
 
 
-def register_feed_tools(mcp: FastMCP) -> None:
+def register_feed_tools(
+    mcp: FastMCP, *, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS
+) -> None:
     """Register feed-related tools with the MCP server."""
 
     @mcp.tool(
-        timeout=TOOL_TIMEOUT_SECONDS,
+        timeout=tool_timeout,
         title="Get Feed",
         annotations={"readOnlyHint": True, "openWorldHint": True},
         tags={"feed", "scraping"},
@@ -33,7 +36,7 @@ def register_feed_tools(mcp: FastMCP) -> None:
     )
     async def get_feed(
         ctx: Context,
-        num_posts: int = 10,
+        num_posts: Annotated[int, Field(ge=1, le=50)] = 10,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -47,15 +50,22 @@ def register_feed_tools(mcp: FastMCP) -> None:
 
         Returns:
             Dict with url, sections (name -> raw text), and optional keys:
-            - posts: list of {url, text} per post in feed order. Some posts
-              (promoted/suggested) have no url.
-            - references, section_errors.
+            - references["feed"]: list of {kind: "feed_post", url, ...}
+              entries. URLs are relative paths and may carry either
+              ``/feed/update/<urn>/`` (DOM-anchor-derived) or
+              ``/posts/<slug>`` (SDUI-derived) shape — both are valid
+              LinkedIn permalinks.
+            - section_errors: present when the feed is rate-limited or
+              extraction fails.
+
+            Truncated posts are not auto-expanded; full text for any post
+            is reachable via its permalink in references["feed"]. The LLM
+            should parse sections["feed"] for post bodies.
         """
         try:
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="get_feed"
             )
-            num_posts = max(1, min(num_posts, 50))
             logger.info("Scraping feed (num_posts=%d)", num_posts)
 
             await ctx.report_progress(
@@ -83,8 +93,6 @@ def register_feed_tools(mcp: FastMCP) -> None:
             await ctx.report_progress(progress=100, total=100, message="Complete")
 
             result: dict[str, Any] = {"url": url, "sections": sections}
-            if extracted.posts:
-                result["posts"] = extracted.posts
             if references:
                 result["references"] = references
             if section_errors:

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -1,0 +1,100 @@
+"""
+LinkedIn feed scraping tool.
+
+Fetches posts from the authenticated user's LinkedIn home feed
+using innerText extraction. Scrolls until the requested number
+of posts are visible in the DOM.
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Context, FastMCP
+
+from linkedin_mcp_server.constants import TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.core.exceptions import AuthenticationError
+from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
+from linkedin_mcp_server.error_handler import raise_tool_error
+from linkedin_mcp_server.scraping.extractor import _RATE_LIMITED_MSG
+from linkedin_mcp_server.scraping.link_metadata import Reference
+
+logger = logging.getLogger(__name__)
+
+
+def register_feed_tools(mcp: FastMCP) -> None:
+    """Register feed-related tools with the MCP server."""
+
+    @mcp.tool(
+        timeout=TOOL_TIMEOUT_SECONDS,
+        title="Get Feed",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"feed", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_feed(
+        ctx: Context,
+        num_posts: int = 10,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get posts from the authenticated user's LinkedIn feed.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+            num_posts: Number of posts to fetch (1-50, default 10).
+                       Posts are loaded in batches of ~5 as the page scrolls,
+                       so the actual count may slightly exceed the target.
+
+        Returns:
+            Dict with url, sections (name -> raw text), and optional keys:
+            - posts: list of {url, text} per post in feed order. Some posts
+              (promoted/suggested) have no url.
+            - references, section_errors.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_feed"
+            )
+            num_posts = max(1, min(num_posts, 50))
+            logger.info("Scraping feed (num_posts=%d)", num_posts)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Starting feed scrape"
+            )
+
+            extracted = await extractor.extract_feed(num_posts=num_posts)
+
+            url = "https://www.linkedin.com/feed/"
+            sections: dict[str, str] = {}
+            references: dict[str, list[Reference]] = {}
+            section_errors: dict[str, dict[str, Any]] = {}
+            if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+                sections["feed"] = extracted.text
+                if extracted.references:
+                    references["feed"] = extracted.references
+            elif extracted.text == _RATE_LIMITED_MSG:
+                section_errors["feed"] = {
+                    "error_type": "rate_limit",
+                    "error_message": extracted.text,
+                }
+            elif extracted.error:
+                section_errors["feed"] = extracted.error
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            result: dict[str, Any] = {"url": url, "sections": sections}
+            if extracted.posts:
+                result["posts"] = extracted.posts
+            if references:
+                result["references"] = references
+            if section_errors:
+                result["section_errors"] = section_errors
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_feed")
+        except Exception as e:
+            raise_tool_error(e, "get_feed")

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -1,9 +1,11 @@
 """
 LinkedIn feed scraping tool.
 
-Fetches posts from the authenticated user's LinkedIn home feed
-using innerText extraction. Scrolls until the requested number
-of posts are visible in the DOM.
+Fetches posts from the authenticated user's LinkedIn home feed using
+innerText extraction. Scrolls until the requested number of post
+permalinks have been observed in SDUI pagination responses — a
+locale-independent progress signal, since the feed DOM exposes no
+stable per-post container selector.
 """
 
 import logging

--- a/manifest.json
+++ b/manifest.json
@@ -94,6 +94,10 @@
       "description": "Send a message to a LinkedIn user with explicit confirmation and optional profile URN support"
     },
     {
+      "name": "get_feed",
+      "description": "Get recent posts from the authenticated user's LinkedIn home feed"
+    },
+    {
       "name": "close_session",
       "description": "Properly close browser session and clean up resources"
     }

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -17,7 +17,7 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _RATE_LIMITED_MSG,
-    _build_feed_posts,
+    _build_feed_references,
     _truncate_linkedin_noise,
     strip_linkedin_noise,
 )
@@ -4250,63 +4250,66 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.press.assert_awaited_once_with("Enter")
 
 
-class TestBuildFeedPosts:
-    def test_matches_urls_to_posts_by_content_fingerprint(self):
-        # URL order reversed vs DOM order — slug fingerprint matching should
-        # still pair each URL with the correct post.
-        text = (
-            "Feed post\n\nAlice\n\nMe and Charles, 7 years ago on graduation day\n\n"
-            "Feed post\n\nBob\n\nBuilding a company is almost inhuman and hard"
-        )
-        url_a = "https://www.linkedin.com/posts/alice_me-and-charles-7-years-ago-on-graduation-share-1-xx"
-        url_b = "https://www.linkedin.com/posts/building-a-company-is-almost-inhuman-and-ugcPost-2-yy"
-        posts = _build_feed_posts(text, [url_b, url_a])
-        assert posts == [
+class TestBuildFeedReferences:
+    """Tests for _build_feed_references SDUI-capture / DOM-anchor merging."""
+
+    def test_sdui_urls_become_relative_feed_post_references(self):
+        captured = [
+            "https://www.linkedin.com/posts/alice_some-slug-ugcPost-1-xx",
+            "https://www.linkedin.com/posts/bob_other-post-share-2-yy",
+        ]
+        refs = _build_feed_references([], captured)
+        assert refs == [
             {
-                "text": "Alice\n\nMe and Charles, 7 years ago on graduation day",
-                "url": url_a,
+                "kind": "feed_post",
+                "url": "/posts/alice_some-slug-ugcPost-1-xx",
+                "context": "feed",
             },
             {
-                "text": "Bob\n\nBuilding a company is almost inhuman and hard",
-                "url": url_b,
+                "kind": "feed_post",
+                "url": "/posts/bob_other-post-share-2-yy",
+                "context": "feed",
             },
         ]
 
-    def test_unmatched_post_gets_no_url(self):
-        text = "Feed post\n\nSuggested promo with no permalink"
-        posts = _build_feed_posts(text, [])
-        assert posts == [{"text": "Suggested promo with no permalink"}]
+    def test_duplicate_sdui_urls_are_deduped(self):
+        captured = [
+            "https://www.linkedin.com/posts/alice_x-ugcPost-1-xx",
+            "https://www.linkedin.com/posts/alice_x-ugcPost-1-xx",
+        ]
+        refs = _build_feed_references([], captured)
+        assert len(refs) == 1
+        assert refs[0]["url"] == "/posts/alice_x-ugcPost-1-xx"
 
-    def test_drops_preamble_before_first_marker(self):
-        text = "site chrome\nmore chrome\nFeed post\n\nreal post body here"
-        posts = _build_feed_posts(text, [])
-        assert posts == [{"text": "real post body here"}]
+    def test_dom_anchor_feed_update_passes_through(self):
+        # DOM anchors that classify_link recognises as feed_post survive
+        # the merge alongside SDUI captures.
+        raw_anchors = [
+            {
+                "href": "https://www.linkedin.com/feed/update/urn:li:activity:1234567890/",
+                "text": "View post",
+            }
+        ]
+        refs = _build_feed_references(raw_anchors, [])
+        assert any(
+            r["url"] == "/feed/update/urn:li:activity:1234567890/"
+            and r["kind"] == "feed_post"
+            for r in refs
+        )
 
-    def test_empty_text_yields_no_posts(self):
-        assert _build_feed_posts("", ["u1"]) == []
+    def test_non_posts_paths_in_sdui_capture_are_skipped(self):
+        # Defensive: only /posts/<slug> shapes count for SDUI append.
+        captured = [
+            "https://www.linkedin.com/in/someuser/",
+            "https://www.linkedin.com/posts/alice_x-ugcPost-1-xx",
+        ]
+        refs = _build_feed_references([], captured)
+        assert [r["url"] for r in refs] == ["/posts/alice_x-ugcPost-1-xx"]
 
-    def test_urls_without_matching_post_are_dropped(self):
-        text = "Feed post\n\nHello world from the only post"
-        url = "https://www.linkedin.com/posts/alice_hello-world-from-the-only-post-ugcPost-1-xx"
-        extra = "https://www.linkedin.com/posts/unrelated-slug-that-matches-nothing-ugcPost-2-yy"
-        posts = _build_feed_posts(text, [extra, url])
-        assert posts == [{"text": "Hello world from the only post", "url": url}]
-
-    def test_punctuation_differences_dont_block_match(self):
-        text = "Feed post\n\nLet's go, Paul! 15M from Benchmark."
-        url = "https://www.linkedin.com/posts/guillaumerx21_lets-go-paul-15m-from-benchmark-share-1-xx"
-        posts = _build_feed_posts(text, [url])
-        assert posts == [{"text": "Let's go, Paul! 15M from Benchmark.", "url": url}]
-
-    def test_malformed_slug_url_is_ignored(self):
-        text = "Feed post\n\nSome post"
-        posts = _build_feed_posts(text, ["https://example.com/not-a-slug-url"])
-        assert posts == [{"text": "Some post"}]
-
-    def test_unicode_bold_post_body_matches_plain_slug(self):
-        # LinkedIn posts styled with mathematical-bold Unicode (U+1D400 block)
-        # should still match their plain-text slug after NFKC normalization.
-        text = "Feed post\n\n𝐈 𝐠𝐨𝐭 𝐟𝐢𝐫𝐞𝐝 𝐟𝐫𝐨𝐦 𝐦𝐲 𝐣𝐨𝐛 because I was bad"
-        url = "https://www.linkedin.com/posts/louis_i-got-fired-from-my-job-because-i-was-bad-share-1-xx"
-        posts = _build_feed_posts(text, [url])
-        assert posts == [{"text": text.split("\n\n", 1)[1], "url": url}]
+    def test_cap_matches_num_posts_ceiling(self):
+        captured = [
+            f"https://www.linkedin.com/posts/p{i}-ugcPost-{i}-xx" for i in range(60)
+        ]
+        refs = _build_feed_references([], captured)
+        # Cap is 50, mirroring _REFERENCE_CAPS["feed"] / num_posts <= 50.
+        assert len(refs) == 50

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -17,6 +17,7 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _RATE_LIMITED_MSG,
+    _build_feed_posts,
     _truncate_linkedin_noise,
     strip_linkedin_noise,
 )
@@ -4247,3 +4248,65 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "sent"
         # Enter was pressed as fallback
         mock_keyboard.press.assert_awaited_once_with("Enter")
+
+
+class TestBuildFeedPosts:
+    def test_matches_urls_to_posts_by_content_fingerprint(self):
+        # URL order reversed vs DOM order — slug fingerprint matching should
+        # still pair each URL with the correct post.
+        text = (
+            "Feed post\n\nAlice\n\nMe and Charles, 7 years ago on graduation day\n\n"
+            "Feed post\n\nBob\n\nBuilding a company is almost inhuman and hard"
+        )
+        url_a = "https://www.linkedin.com/posts/alice_me-and-charles-7-years-ago-on-graduation-share-1-xx"
+        url_b = "https://www.linkedin.com/posts/building-a-company-is-almost-inhuman-and-ugcPost-2-yy"
+        posts = _build_feed_posts(text, [url_b, url_a])
+        assert posts == [
+            {
+                "text": "Alice\n\nMe and Charles, 7 years ago on graduation day",
+                "url": url_a,
+            },
+            {
+                "text": "Bob\n\nBuilding a company is almost inhuman and hard",
+                "url": url_b,
+            },
+        ]
+
+    def test_unmatched_post_gets_no_url(self):
+        text = "Feed post\n\nSuggested promo with no permalink"
+        posts = _build_feed_posts(text, [])
+        assert posts == [{"text": "Suggested promo with no permalink"}]
+
+    def test_drops_preamble_before_first_marker(self):
+        text = "site chrome\nmore chrome\nFeed post\n\nreal post body here"
+        posts = _build_feed_posts(text, [])
+        assert posts == [{"text": "real post body here"}]
+
+    def test_empty_text_yields_no_posts(self):
+        assert _build_feed_posts("", ["u1"]) == []
+
+    def test_urls_without_matching_post_are_dropped(self):
+        text = "Feed post\n\nHello world from the only post"
+        url = "https://www.linkedin.com/posts/alice_hello-world-from-the-only-post-ugcPost-1-xx"
+        extra = "https://www.linkedin.com/posts/unrelated-slug-that-matches-nothing-ugcPost-2-yy"
+        posts = _build_feed_posts(text, [extra, url])
+        assert posts == [{"text": "Hello world from the only post", "url": url}]
+
+    def test_punctuation_differences_dont_block_match(self):
+        text = "Feed post\n\nLet's go, Paul! 15M from Benchmark."
+        url = "https://www.linkedin.com/posts/guillaumerx21_lets-go-paul-15m-from-benchmark-share-1-xx"
+        posts = _build_feed_posts(text, [url])
+        assert posts == [{"text": "Let's go, Paul! 15M from Benchmark.", "url": url}]
+
+    def test_malformed_slug_url_is_ignored(self):
+        text = "Feed post\n\nSome post"
+        posts = _build_feed_posts(text, ["https://example.com/not-a-slug-url"])
+        assert posts == [{"text": "Some post"}]
+
+    def test_unicode_bold_post_body_matches_plain_slug(self):
+        # LinkedIn posts styled with mathematical-bold Unicode (U+1D400 block)
+        # should still match their plain-text slug after NFKC normalization.
+        text = "Feed post\n\n𝐈 𝐠𝐨𝐭 𝐟𝐢𝐫𝐞𝐝 𝐟𝐫𝐨𝐦 𝐦𝐲 𝐣𝐨𝐛 because I was bad"
+        url = "https://www.linkedin.com/posts/louis_i-got-fired-from-my-job-because-i-was-bad-share-1-xx"
+        posts = _build_feed_posts(text, [url])
+        assert posts == [{"text": text.split("\n\n", 1)[1], "url": url}]

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4313,3 +4313,42 @@ class TestBuildFeedReferences:
         refs = _build_feed_references([], captured)
         # Cap is 50, mirroring _REFERENCE_CAPS["feed"] / num_posts <= 50.
         assert len(refs) == 50
+
+    def test_non_feed_post_dom_anchors_are_filtered(self):
+        # Sidebar profile / company / external anchors must not crowd
+        # out SDUI permalinks — references["feed"] is feed_post-only.
+        raw_anchors = [
+            {
+                "href": "https://www.linkedin.com/in/sidebar-user/",
+                "text": "Sidebar User",
+            },
+            {
+                "href": "https://www.linkedin.com/company/some-corp/",
+                "text": "Some Corp",
+            },
+            {
+                "href": "https://example.com/external/",
+                "text": "External Link",
+            },
+        ]
+        refs = _build_feed_references(raw_anchors, [])
+        assert refs == []
+
+    def test_feed_post_dom_anchors_coexist_with_sdui_captures(self):
+        # The two sources fold into the same feed_post kind without
+        # collapsing across URL shapes pointing at the same post.
+        raw_anchors = [
+            {
+                "href": "https://www.linkedin.com/feed/update/urn:li:activity:111/",
+                "text": "View post",
+            }
+        ]
+        captured = ["https://www.linkedin.com/posts/alice_x-ugcPost-1-xx"]
+        refs = _build_feed_references(raw_anchors, captured)
+        urls = [r["url"] for r in refs]
+        kinds = {r["kind"] for r in refs}
+        assert urls == [
+            "/feed/update/urn:li:activity:111/",
+            "/posts/alice_x-ugcPost-1-xx",
+        ]
+        assert kinds == {"feed_post"}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -36,6 +36,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
     )
+    mock.extract_feed = AsyncMock(return_value=ExtractedSection(text="", references=[]))
     return mock
 
 
@@ -806,6 +807,111 @@ class TestMessagingTools:
             )
 
 
+class TestFeedTools:
+    async def test_get_feed_success(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_feed = AsyncMock(
+            return_value=ExtractedSection(text="Post 1\nPost 2", references=[])
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_feed")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert result["url"] == "https://www.linkedin.com/feed/"
+        assert "feed" in result["sections"]
+        assert result["sections"]["feed"] == "Post 1\nPost 2"
+        assert "posts" not in result
+
+    async def test_get_feed_includes_posts(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_feed = AsyncMock(
+            return_value=ExtractedSection(
+                text="Feed post\n\nhello\n\nFeed post\n\nworld",
+                references=[],
+                posts=[
+                    {
+                        "text": "hello",
+                        "url": "https://www.linkedin.com/posts/a_hello-ugcPost-1-xx",
+                    },
+                    {"text": "world"},
+                ],
+            )
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_feed")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert result["posts"] == [
+            {
+                "text": "hello",
+                "url": "https://www.linkedin.com/posts/a_hello-ugcPost-1-xx",
+            },
+            {"text": "world"},
+        ]
+
+    async def test_get_feed_omits_rate_limited_sentinel(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_feed = AsyncMock(
+            return_value=ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_feed")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert result["sections"] == {}
+
+    async def test_get_feed_returns_section_errors(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_feed = AsyncMock(
+            return_value=ExtractedSection(
+                text="",
+                references=[],
+                error={"issue_template_path": "/tmp/feed-issue.md"},
+            )
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_feed")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert result["sections"] == {}
+        assert "feed" in result["section_errors"]
+
+    async def test_get_feed_clamps_num_posts(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_feed = AsyncMock(
+            return_value=ExtractedSection(text="Feed content", references=[])
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_feed")
+        await tool_fn(mock_context, num_posts=100, extractor=mock_extractor)
+        mock_extractor.extract_feed.assert_called_once_with(num_posts=50)
+
+        mock_extractor.extract_feed.reset_mock()
+        await tool_fn(mock_context, num_posts=0, extractor=mock_extractor)
+        mock_extractor.extract_feed.assert_called_once_with(num_posts=1)
+
+
 class TestToolTimeouts:
     async def test_all_tools_have_global_timeout(self):
         from linkedin_mcp_server.server import create_mcp_server
@@ -853,6 +959,7 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "get_feed",
             "close_session",
         )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -826,18 +826,22 @@ class TestFeedTools:
         assert result["sections"]["feed"] == "Post 1\nPost 2"
         assert "posts" not in result
 
-    async def test_get_feed_includes_posts(self, mock_context):
+    async def test_get_feed_surfaces_references(self, mock_context):
+        """References from the extractor flow through to the tool result."""
         mock_extractor = MagicMock()
         mock_extractor.extract_feed = AsyncMock(
             return_value=ExtractedSection(
-                text="Feed post\n\nhello\n\nFeed post\n\nworld",
-                references=[],
-                posts=[
+                text="Some feed text",
+                references=[
                     {
-                        "text": "hello",
-                        "url": "https://www.linkedin.com/posts/a_hello-ugcPost-1-xx",
+                        "kind": "feed_post",
+                        "url": "/posts/alice_hello-ugcPost-1-xx",
+                        "context": "feed",
                     },
-                    {"text": "world"},
+                    {
+                        "kind": "feed_post",
+                        "url": "/feed/update/urn:li:activity:1234567890/",
+                    },
                 ],
             )
         )
@@ -849,15 +853,14 @@ class TestFeedTools:
 
         tool_fn = await get_tool_fn(mcp, "get_feed")
         result = await tool_fn(mock_context, extractor=mock_extractor)
-        assert result["posts"] == [
-            {
-                "text": "hello",
-                "url": "https://www.linkedin.com/posts/a_hello-ugcPost-1-xx",
-            },
-            {"text": "world"},
-        ]
+        assert "posts" not in result
+        assert "feed" in result["references"]
+        urls = [r["url"] for r in result["references"]["feed"]]
+        assert "/posts/alice_hello-ugcPost-1-xx" in urls
+        assert "/feed/update/urn:li:activity:1234567890/" in urls
 
-    async def test_get_feed_omits_rate_limited_sentinel(self, mock_context):
+    async def test_get_feed_rate_limited_surfaces_section_error(self, mock_context):
+        """Rate-limit sentinel becomes a typed section_errors entry."""
         mock_extractor = MagicMock()
         mock_extractor.extract_feed = AsyncMock(
             return_value=ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
@@ -870,7 +873,9 @@ class TestFeedTools:
 
         tool_fn = await get_tool_fn(mcp, "get_feed")
         result = await tool_fn(mock_context, extractor=mock_extractor)
-        assert result["sections"] == {}
+        assert "feed" not in result["sections"]
+        assert result["section_errors"]["feed"]["error_type"] == "rate_limit"
+        assert result["section_errors"]["feed"]["error_message"] == _RATE_LIMITED_MSG
 
     async def test_get_feed_returns_section_errors(self, mock_context):
         mock_extractor = MagicMock()
@@ -892,24 +897,29 @@ class TestFeedTools:
         assert result["sections"] == {}
         assert "feed" in result["section_errors"]
 
-    async def test_get_feed_clamps_num_posts(self, mock_context):
-        mock_extractor = MagicMock()
-        mock_extractor.extract_feed = AsyncMock(
-            return_value=ExtractedSection(text="Feed content", references=[])
-        )
+    async def test_get_feed_rejects_zero_num_posts(self, mock_context):
+        """Verify num_posts=0 is rejected by Field(ge=1) validation."""
+        from pydantic import ValidationError
 
         from linkedin_mcp_server.tools.feed import register_feed_tools
 
         mcp = FastMCP("test")
         register_feed_tools(mcp)
 
-        tool_fn = await get_tool_fn(mcp, "get_feed")
-        await tool_fn(mock_context, num_posts=100, extractor=mock_extractor)
-        mock_extractor.extract_feed.assert_called_once_with(num_posts=50)
+        with pytest.raises(ValidationError, match="num_posts"):
+            await mcp.call_tool("get_feed", {"num_posts": 0})
 
-        mock_extractor.extract_feed.reset_mock()
-        await tool_fn(mock_context, num_posts=0, extractor=mock_extractor)
-        mock_extractor.extract_feed.assert_called_once_with(num_posts=1)
+    async def test_get_feed_rejects_excessive_num_posts(self, mock_context):
+        """Verify num_posts=51 is rejected by Field(le=50) validation."""
+        from pydantic import ValidationError
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        with pytest.raises(ValidationError, match="num_posts"):
+            await mcp.call_tool("get_feed", {"num_posts": 51})
 
 
 class TestToolTimeouts:
@@ -932,6 +942,7 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "get_feed",
             "close_session",
         )
 


### PR DESCRIPTION
Closes #373.

Reopens the work from @hugobiais's #374. Squash-merged from `refs/pull/374/head` and rebased onto v4.11.0. Replaced the three English-text detectors (`_POST_MARKER`, `_FEED_POST_SPLIT_RE`, and the see-more button regex) with locale-independent equivalents — the live DOM probe found no stable per-post container selector (`data-id*=urn:li:activity`, `data-urn*=urn:li:activity`, `article`, `[role="article"]` all return 0), so structured `posts: [...]` is dropped and SDUI-captured permalinks surface in `references["feed"]` instead.

Other deltas from main since the original PR was authored: rebased imports off the deleted `constants.py` (now `DEFAULT_TOOL_TIMEOUT_SECONDS`), added the `tool_timeout` kwarg pattern to `register_feed_tools`, switched `num_posts` to `Annotated[int, Field(ge=1, le=50)]` so MCP validates at the boundary instead of clamping silently, and addressed the remaining Greptile P2 on the SDUI response listener — task handles are now tracked, drained in-loop with a bounded wait so the capture count is race-free, and unwound on listener removal with timeout-capped wait + cancel. `references["feed"]` entries can now carry either `/feed/update/<urn>/` or `/posts/<slug>` URLs; both are valid LinkedIn permalinks and AGENTS.md documents the duality.

Verified live against `127.0.0.1:8765`: `get_feed(num_posts=5)` returned 40 references (mix of `/posts/<slug>` from SDUI and `/feed/update/<urn>/` from DOM anchors); `get_feed(num_posts=0)` and `get_feed(num_posts=51)` both surfaced Pydantic ValidationError. `uv run pytest` passes (489 tests). `uv run pre-commit run --all-files` clean.

Credit to @hugobiais for the original implementation, careful `mouse.wheel` + `IntersectionObserver` workaround, and the SDUI permalink capture pattern that the new logic builds on.

## Synthetic prompt

> Revive PR #374 (`get_feed`) on a fresh branch from main. Squash-merge `refs/pull/374/head` with a `Co-authored-by` trailer for the original author, then layer rebase + locale + race + docs fixes as separate commits. Live-probe LinkedIn feed for stable per-post DOM container selectors first; if none survive, drop the structured `posts:` array and surface SDUI-captured permalinks via `references["feed"]` with `/posts/<slug>` shape. Replace the three locale-dependent text detectors (`_POST_MARKER`, `_FEED_POST_SPLIT_RE`, see-more regex) with locale-independent equivalents. Rebase imports onto v4.11.0, thread `tool_timeout` through `register_feed_tools`, switch `num_posts` to `Annotated[int, Field(ge=1, le=50)]`. Fix the fire-and-forget `asyncio.create_task` chain on the SDUI listener with bounded drain. Add `"feed": 50` to `_REFERENCE_CAPS`. Update tests, AGENTS.md, README, docker-hub.md, manifest.json.
