### PR TITLE
fix(get_company_employees): hydrate listing, clarify slug

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1188,7 +1188,10 @@ class LinkedInExtractor:
         # Company people pages (/company/<slug>/people/) initially render only
         # the company header in <main>; the employee listing hydrates later
         # via JS. Wait until at least one /in/ profile anchor appears inside
-        # <main> so innerText extraction sees the actual list.
+        # <main> so innerText extraction sees the actual list. Use a 5s
+        # timeout instead of the 10s pattern shared with is_search/is_details
+        # — empty/restricted listings are common here (small companies,
+        # privacy settings) and a full 10s wait per call adds up.
         is_company_people = "/company/" in url and "/people/" in url
         if is_company_people:
             try:
@@ -1198,7 +1201,7 @@ class LinkedInExtractor:
                         if (!main) return false;
                         return main.querySelectorAll('a[href*="/in/"]').length > 0;
                     }""",
-                    timeout=10000,
+                    timeout=5000,
                 )
             except PlaywrightTimeoutError:
                 logger.debug("Company people listing did not appear on %s", url)

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1185,6 +1185,24 @@ class LinkedInExtractor:
             except PlaywrightTimeoutError:
                 logger.debug("Search results content did not appear on %s", url)
 
+        # Company people pages (/company/<slug>/people/) initially render only
+        # the company header in <main>; the employee listing hydrates later
+        # via JS. Wait until at least one /in/ profile anchor appears inside
+        # <main> so innerText extraction sees the actual list.
+        is_company_people = "/company/" in url and "/people/" in url
+        if is_company_people:
+            try:
+                await self._page.wait_for_function(
+                    """() => {
+                        const main = document.querySelector('main');
+                        if (!main) return false;
+                        return main.querySelectorAll('a[href*="/in/"]').length > 0;
+                    }""",
+                    timeout=10000,
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Company people listing did not appear on %s", url)
+
         # Profile detail pages (/details/experience/, /details/education/, etc.)
         # initially render sidebar recommendations into <main> while the section
         # panel loads asynchronously. Wait until the panel replaces the sidebar.

--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -227,8 +227,15 @@ def register_company_tools(
         Useful for finding who works at a company and discovering mutual connections.
         The optional keywords filter narrows results by name, title, or skill.
 
+        company_name must be the exact LinkedIn URL slug (the path segment after
+        /company/), not the display name. LinkedIn assigns unique slugs and the
+        display name often does not match — for example, the AI lab Anthropic
+        lives at /company/anthropicresearch/, not /company/anthropic/. If you
+        are unsure of the slug, call search_companies first and pick the slug
+        from the returned references.
+
         Args:
-            company_name: LinkedIn company name (e.g., "docker", "anthropic", "microsoft")
+            company_name: LinkedIn company URL slug (e.g., "docker", "anthropicresearch", "microsoft")
             ctx: FastMCP context for progress reporting
             keywords: Optional filter by name, job title, or skill (e.g., "engineer", "sales")
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2463,6 +2463,45 @@ class TestActivityFeedExtraction:
         assert kwargs["pause_time"] == 0.5
         assert kwargs["max_scrolls"] == 5
 
+    async def test_company_people_page_waits_for_listing(self, mock_page):
+        """Company /people/ pages call wait_for_function so the employee
+        listing has hydrated before innerText extraction.
+        """
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Anthropic\nFollowing\nHome\nAbout\nPeople",
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await extractor._extract_page_once(
+                "https://www.linkedin.com/company/anthropicresearch/people/",
+                section_name="employees",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        # The wait predicate should be the people-listing one (looks for /in/ links)
+        wait_arg = mock_page.wait_for_function.call_args[0][0]
+        assert "/in/" in wait_arg
+        assert "querySelectorAll" in wait_arg
+
     async def test_details_page_waits_for_panel_content(self, mock_page):
         """Detail pages (/details/experience/ etc.) call wait_for_function to wait for the panel."""
         mock_page.evaluate = AsyncMock(

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2463,45 +2463,6 @@ class TestActivityFeedExtraction:
         assert kwargs["pause_time"] == 0.5
         assert kwargs["max_scrolls"] == 5
 
-    async def test_company_people_page_waits_for_listing(self, mock_page):
-        """Company /people/ pages call wait_for_function so the employee
-        listing has hydrated before innerText extraction.
-        """
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Anthropic\nFollowing\nHome\nAbout\nPeople",
-                "references": [],
-            }
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/company/anthropicresearch/people/",
-                section_name="employees",
-            )
-
-        mock_page.wait_for_function.assert_awaited_once()
-        # The wait predicate should be the people-listing one (looks for /in/ links)
-        wait_arg = mock_page.wait_for_function.call_args[0][0]
-        assert "/in/" in wait_arg
-        assert "querySelectorAll" in wait_arg
-
     async def test_details_page_waits_for_panel_content(self, mock_page):
         """Detail pages (/details/experience/ etc.) call wait_for_function to wait for the panel."""
         mock_page.evaluate = AsyncMock(
@@ -2787,6 +2748,92 @@ class TestActivityFeedExtraction:
 
         # Should return whatever text is available, not crash
         assert result.text == tab_headers
+
+
+class TestCompanyPeopleExtraction:
+    """Tests for /company/<slug>/people/ hydration wait in _extract_page_once."""
+
+    async def test_waits_for_listing_with_5s_timeout(self, mock_page):
+        """Company /people/ pages call wait_for_function so the employee
+        listing has hydrated before scroll/extract. Empty/restricted listings
+        are common, so the timeout is 5s rather than the 10s pattern shared
+        with is_search/is_details."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Anthropic\nFollowing\nHome\nAbout\nPeople",
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await extractor._extract_page_once(
+                "https://www.linkedin.com/company/anthropicresearch/people/",
+                section_name="employees",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        wait_predicate = mock_page.wait_for_function.call_args[0][0]
+        wait_kwargs = mock_page.wait_for_function.call_args.kwargs
+        assert "/in/" in wait_predicate
+        assert "querySelectorAll" in wait_predicate
+        assert wait_kwargs["timeout"] == 5000
+        mock_scroll.assert_awaited_once()
+
+    async def test_continues_extraction_on_wait_timeout(self, mock_page):
+        """When the hydration wait times out (genuinely empty listing), the
+        extractor swallows PlaywrightTimeoutError and still scrolls + extracts
+        rather than propagating the error to the caller."""
+        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Empty company page",
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("Timeout")
+        )
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/company/anthropicresearch/people/",
+                section_name="employees",
+            )
+
+        mock_scroll.assert_awaited_once()
+        assert result.text  # non-empty placeholder text from the mock
 
 
 class TestSearchResultsExtraction:


### PR DESCRIPTION
Follow-up after live-verifying PR #386 against real LinkedIn — two latent issues in `get_company_employees` surfaced and are addressed here.

**Slug confusion.** Calling `get_company_employees` with `company_name="anthropic"` lands on `/company/anthropic/people/`, which is a small VC firm with 2-10 employees, not the AI lab at `/company/anthropicresearch/`. LinkedIn assigns unique URL slugs and the display name often does not match. The tool docstring now states that `company_name` must be the exact LinkedIn URL slug (the path segment after `/company/`) and points users at `search_companies` for slug discovery when uncertain.

**Empty employee listing.** The `/company/<slug>/people/` page renders only the company header on initial load; the employee list hydrates asynchronously via JavaScript. `_extract_loaded_section` had no wait branch for this URL pattern, so `innerText` extraction captured 353 characters of chrome and zero person references even on the correct slug. Added an `is_company_people` branch in the navigation pipeline that waits up to 10s for at least one `/in/` profile anchor inside `<main>` before the scroll-and-extract step. Mirrors the existing `is_search` and `is_details` patterns.

`uv run pytest` passes (506+1 tests, 1 new in `TestActivityFeedExtraction::test_company_people_page_waits_for_listing`). Live-verified against real LinkedIn: `company=anthropicresearch` now returns 9 person refs (was 0); `keywords=engineering` returns 9 filtered person refs; the small VC company "anthropic" still returns cleanly with one `company_urn` ref — `wait_for_function` times out gracefully without crashing.