### PR TITLE
docs(tools): Clarify employees vs search roles

### DIFF
--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -222,14 +222,20 @@ def register_company_tools(
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
-        List employees at a company from the LinkedIn /people/ page.
+        List employees at a company from the LinkedIn /people/ page, including
+        the demographics aggregate that this view exposes: where employees
+        live, where they studied, and a function breakdown (Engineering, Sales,
+        Operations, etc.). The demographics are unique to this tool.
 
-        Useful for finding who works at a company and discovering mutual connections.
+        For filtered search by network degree (1st/2nd/3rd) or location, prefer
+        search_people with current_company set to the company URN id. That path
+        also returns more result pages than the /people/ tab.
+
         The optional keywords filter narrows results by name, title, or skill.
 
         company_name must be the exact LinkedIn URL slug (the path segment after
         /company/), not the display name. LinkedIn assigns unique slugs and the
-        display name often does not match — for example, the AI lab Anthropic
+        display name often does not match. For example, the AI lab Anthropic
         lives at /company/anthropicresearch/, not /company/anthropic/. If you
         are unsure of the slug, call search_companies first and pick the slug
         from the returned references.

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -131,7 +131,9 @@ def register_person_tools(
                 (e.g. "1115" for SAP); plain company names are accepted by the
                 URL but ignored by LinkedIn and return the unfiltered result
                 set. Look up a company's URN via get_company_profile -- it is
-                exposed under references["about"].
+                exposed under references["about"]. For company-wide employee
+                demographics (location/education/function breakdown) plus a
+                slug-based lookup, use get_company_employees instead.
 
         Returns:
             Dict with url, sections (name -> raw text), and optional references.


### PR DESCRIPTION
Tool descriptions for `get_company_employees` and `search_people` overlap in scope, leaving LLM clients without a clear signal for which to call. A live diff across three companies (Anthropic, Docker, Helicone) showed 100% profile overlap on the first 10 results, with `search_people` exposing more result pages while `get_company_employees` uniquely surfaces a demographics aggregate (location, education, function breakdown) from the `/people/` tab.

Sharpened `get_company_employees` to lead with the demographics value and to explicitly point at `search_people` for filtered-by-network or location queries. Added a reciprocal pointer in the `search_people` `current_company` param doc back to `get_company_employees` for demographics plus slug-based lookup. Docstring-only change, no code or tests touched. `uv run ruff check .` and `uv run ruff format --check .` pass on both files.

## Synthetic prompt

> Sharpen the get_company_employees tool docstring to lead with its unique demographics aggregate (location/education/function breakdown) and explicitly point to search_people for filtered search by network degree or location; add a reciprocal cross-reference in search_people current_company param doc.