### PR TITLE
feat(network): add get_pending_invitations tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | [#434](https://github.com/stickerdaniel/linkedin-mcp-server/issues/434) |
 | `search_conversations` | Search messages by keyword | working |
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) |
+| `get_pending_invitations` | List pending network invitations (received or sent) from `/mynetwork/invitation-manager/` | working |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_companies` | Search for companies on LinkedIn by keywords | working |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | working |
 | `search_conversations` | Search messages by keyword | working |
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) [#483](https://github.com/stickerdaniel/linkedin-mcp-server/issues/483) [#560](https://github.com/stickerdaniel/linkedin-mcp-server/issues/560) |
+| `get_pending_invitations` | List pending network invitations (received or sent) from `/mynetwork/invitation-manager/` | working |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_companies` | Search for companies on LinkedIn by keywords | working |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -9,6 +9,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Profile Access**: Get detailed LinkedIn profile information including experience, education, skills, projects, certifications, and more
 - **Own Profile**: Fetch the authenticated user's own profile to give agents self-context
 - **Profile Connections**: Send connection requests or accept incoming ones, with optional notes
+- **Network Invitations**: List pending network invitations (received or sent) from `/mynetwork/invitation-manager/`
 - **Company Profiles**: Extract comprehensive company data, including the LinkedIn company URN id (used by LinkedIn's people-search `currentCompany` URL facet)
 - **Company Employees**: List employees at a company with optional keyword filtering
 - **Company Search**: Search for companies by keyword

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -7,6 +7,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Profile Access**: Get detailed LinkedIn profile information including experience, education, skills, projects, certifications, and more
 - **Own Profile**: Fetch the authenticated user's own profile to give agents self-context
 - **Profile Connections**: Send connection requests or accept incoming ones, with optional notes
+- **Network Invitations**: List pending network invitations (received or sent) from `/mynetwork/invitation-manager/`
 - **Company Profiles**: Extract comprehensive company data, including the LinkedIn company URN id (used by LinkedIn's people-search `currentCompany` URL facet)
 - **Company Employees**: List employees at a company with optional keyword filtering
 - **Company Search**: Search for companies by keyword

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3359,9 +3359,16 @@ class LinkedInExtractor:
         no accept/ignore/withdraw side effects.
 
         Truncated invitation notes are auto-expanded before extraction by
-        clicking inline ``aria-expanded="false"`` toggles, so the returned
-        section text contains the full invite body rather than the
-        "... see more" preview LinkedIn renders by default.
+        clicking the inline ``data-testid="expandable-text-button"`` toggles
+        that are not already in the expanded state, so the returned section
+        text contains the full invite body rather than the "... see more"
+        preview LinkedIn renders by default.
+
+        ``limit`` controls how many inviter ``references`` are returned and
+        how many scroll passes pre-load the list. The ``sections`` text
+        always reflects whatever was rendered when extraction ran — typically
+        rounded up to LinkedIn's screenful (~10 cards), so the visible
+        section text may include slightly more invitations than ``limit``.
         """
         url = f"https://www.linkedin.com/mynetwork/invitation-manager/{kind}/"
         await self._navigate_to_page(url)
@@ -3382,7 +3389,9 @@ class LinkedInExtractor:
         raw = raw_result["text"]
         cleaned = strip_linkedin_noise(raw) if raw else ""
         references: list[Reference] = (
-            build_references(raw_result["references"], "invitations") if cleaned else []
+            build_references(raw_result["references"], "invitations")[:limit]
+            if cleaned
+            else []
         )
 
         return self._single_section_result(
@@ -3417,6 +3426,14 @@ class LinkedInExtractor:
         re-clicks them — without the marker the post-click "collapse"
         button (same testid, different visible verb) would be re-toggled
         and silently re-truncate notes the first pass just expanded.
+
+        The selector additionally excludes ``aria-expanded="true"`` so any
+        notes LinkedIn happens to render pre-expanded on initial load are
+        left alone instead of being toggled closed by the first pass.
+        Collapsed toggles ship without an ``aria-expanded`` attribute at
+        all on this surface, so the ``:not([aria-expanded="true"])`` filter
+        is the conservative shape: it matches both the unset and the
+        explicit ``"false"`` states while skipping the expanded ones.
         """
         try:
             for _ in range(2):
@@ -3434,7 +3451,9 @@ class LinkedInExtractor:
                             document.head.appendChild(styleNode);
                         }
                         const buttons = Array.from(document.querySelectorAll(
-                            'main [data-testid="expandable-text-button"]:not([data-mcp-clicked])'
+                            'main [data-testid="expandable-text-button"]'
+                            + ':not([aria-expanded="true"])'
+                            + ':not([data-mcp-clicked])'
                         ));
                         let count = 0;
                         for (const btn of buttons) {

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3357,6 +3357,11 @@ class LinkedInExtractor:
         optional ``references["invitations"]``) so the consumer can read
         invite text and follow inviter/invitee profile links. Read-only:
         no accept/ignore/withdraw side effects.
+
+        Truncated invitation notes are auto-expanded before extraction by
+        clicking inline ``aria-expanded="false"`` toggles, so the returned
+        section text contains the full invite body rather than the
+        "... see more" preview LinkedIn renders by default.
         """
         url = f"https://www.linkedin.com/mynetwork/invitation-manager/{kind}/"
         await self._navigate_to_page(url)
@@ -3371,6 +3376,8 @@ class LinkedInExtractor:
             position="bottom", attempts=scrolls, pause_time=0.5
         )
 
+        await self._expand_invitation_note_toggles()
+
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
         cleaned = strip_linkedin_noise(raw) if raw else ""
@@ -3384,6 +3391,75 @@ class LinkedInExtractor:
             cleaned,
             references=references,
         )
+
+    async def _expand_invitation_note_toggles(self) -> None:
+        """Click inline expand toggles on invitation cards to reveal full notes.
+
+        LinkedIn truncates invitation notes longer than ~5 lines and renders
+        an inline ``<button data-testid="expandable-text-button">`` inside
+        a ``<span data-testid="expandable-text-box">``. The testid attribute
+        is the locale-independent signal — the visible verb ("see more" /
+        "pokaż więcej" / "voir plus") varies by locale and is unreliable.
+
+        The button ships with inline ``pointer-events: none`` and
+        ``aria-hidden="true"``, which blocks Playwright's standard
+        ``.click()`` from delivering the event to the React handler. We
+        therefore (a) inject a one-shot stylesheet re-enabling pointer
+        events on these specific testid'd nodes and (b) dispatch a
+        synthetic bubbling MouseEvent so the handler fires. The injected
+        style is scoped narrowly enough that it does not affect any other
+        element on the page.
+
+        Each dispatched click can cause LinkedIn to lazy-load further
+        invitation cards with their own collapsed notes, so we run a second
+        pass to pick up the newly-mounted toggles. Already-clicked buttons
+        are tagged with ``data-mcp-clicked="1"`` so the second pass never
+        re-clicks them — without the marker the post-click "collapse"
+        button (same testid, different visible verb) would be re-toggled
+        and silently re-truncate notes the first pass just expanded.
+        """
+        try:
+            for _ in range(2):
+                dispatched = await self._page.evaluate(
+                    """async () => {
+                        if (!document.getElementById('__linkedin_mcp_expand_style')) {
+                            const styleNode = document.createElement('style');
+                            styleNode.id = '__linkedin_mcp_expand_style';
+                            styleNode.textContent = `
+                                [data-testid="expandable-text-button"],
+                                [data-testid="expandable-text-box"] {
+                                    pointer-events: auto !important;
+                                }
+                            `;
+                            document.head.appendChild(styleNode);
+                        }
+                        const buttons = Array.from(document.querySelectorAll(
+                            'main [data-testid="expandable-text-button"]:not([data-mcp-clicked])'
+                        ));
+                        let count = 0;
+                        for (const btn of buttons) {
+                            try {
+                                btn.dataset.mcpClicked = '1';
+                                btn.dispatchEvent(new MouseEvent('click', {
+                                    bubbles: true,
+                                    cancelable: true,
+                                    view: window,
+                                }));
+                                count++;
+                            } catch (e) {
+                                /* ignore individual dispatch failures */
+                            }
+                        }
+                        // Let React render the expanded note bodies before
+                        // the caller extracts innerText.
+                        await new Promise(r => setTimeout(r, 400));
+                        return count;
+                    }"""
+                )
+                if not dispatched:
+                    break
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Failed to expand invitation note toggles: %s", exc)
 
     async def _extract_root_content(
         self,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3345,6 +3345,46 @@ class LinkedInExtractor:
             sent=True,
         )
 
+    async def get_pending_invitations(
+        self,
+        limit: int = 20,
+        kind: Literal["received", "sent"] = "received",
+    ) -> dict[str, Any]:
+        """List pending LinkedIn network invitations (received or sent).
+
+        Mirrors ``/mynetwork/invitation-manager/{received|sent}/``. Returns
+        the standard single-section payload (``sections["invitations"]`` +
+        optional ``references["invitations"]``) so the consumer can read
+        invite text and follow inviter/invitee profile links. Read-only:
+        no accept/ignore/withdraw side effects.
+        """
+        url = f"https://www.linkedin.com/mynetwork/invitation-manager/{kind}/"
+        await self._navigate_to_page(url)
+        await detect_rate_limit(self._page)
+        await self._wait_for_main_text(log_context=f"Invitations ({kind})")
+        await handle_modal_close(self._page)
+
+        # Invitations paginate as the list scrolls, ~10 cards per screenful,
+        # so reuse the same heuristic as get_inbox.
+        scrolls = max(1, limit // 10)
+        await self._scroll_main_scrollable_region(
+            position="bottom", attempts=scrolls, pause_time=0.5
+        )
+
+        raw_result = await self._extract_root_content(["main"])
+        raw = raw_result["text"]
+        cleaned = strip_linkedin_noise(raw) if raw else ""
+        references: list[Reference] = (
+            build_references(raw_result["references"], "invitations") if cleaned else []
+        )
+
+        return self._single_section_result(
+            url,
+            "invitations",
+            cleaned,
+            references=references,
+        )
+
     async def _extract_root_content(
         self,
         selectors: list[str],

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3840,9 +3840,16 @@ class LinkedInExtractor:
         no accept/ignore/withdraw side effects.
 
         Truncated invitation notes are auto-expanded before extraction by
-        clicking inline ``aria-expanded="false"`` toggles, so the returned
-        section text contains the full invite body rather than the
-        "... see more" preview LinkedIn renders by default.
+        clicking the inline ``data-testid="expandable-text-button"`` toggles
+        that are not already in the expanded state, so the returned section
+        text contains the full invite body rather than the "... see more"
+        preview LinkedIn renders by default.
+
+        ``limit`` controls how many inviter ``references`` are returned and
+        how many scroll passes pre-load the list. The ``sections`` text
+        always reflects whatever was rendered when extraction ran — typically
+        rounded up to LinkedIn's screenful (~10 cards), so the visible
+        section text may include slightly more invitations than ``limit``.
         """
         url = f"https://www.linkedin.com/mynetwork/invitation-manager/{kind}/"
         await self._navigate_to_page(url)
@@ -3863,7 +3870,9 @@ class LinkedInExtractor:
         raw = raw_result["text"]
         cleaned = strip_linkedin_noise(raw) if raw else ""
         references: list[Reference] = (
-            build_references(raw_result["references"], "invitations") if cleaned else []
+            build_references(raw_result["references"], "invitations")[:limit]
+            if cleaned
+            else []
         )
 
         return self._single_section_result(
@@ -3898,6 +3907,14 @@ class LinkedInExtractor:
         re-clicks them — without the marker the post-click "collapse"
         button (same testid, different visible verb) would be re-toggled
         and silently re-truncate notes the first pass just expanded.
+
+        The selector additionally excludes ``aria-expanded="true"`` so any
+        notes LinkedIn happens to render pre-expanded on initial load are
+        left alone instead of being toggled closed by the first pass.
+        Collapsed toggles ship without an ``aria-expanded`` attribute at
+        all on this surface, so the ``:not([aria-expanded="true"])`` filter
+        is the conservative shape: it matches both the unset and the
+        explicit ``"false"`` states while skipping the expanded ones.
         """
         try:
             for _ in range(2):
@@ -3915,7 +3932,9 @@ class LinkedInExtractor:
                             document.head.appendChild(styleNode);
                         }
                         const buttons = Array.from(document.querySelectorAll(
-                            'main [data-testid="expandable-text-button"]:not([data-mcp-clicked])'
+                            'main [data-testid="expandable-text-button"]'
+                            + ':not([aria-expanded="true"])'
+                            + ':not([data-mcp-clicked])'
                         ));
                         let count = 0;
                         for (const btn of buttons) {

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3838,6 +3838,11 @@ class LinkedInExtractor:
         optional ``references["invitations"]``) so the consumer can read
         invite text and follow inviter/invitee profile links. Read-only:
         no accept/ignore/withdraw side effects.
+
+        Truncated invitation notes are auto-expanded before extraction by
+        clicking inline ``aria-expanded="false"`` toggles, so the returned
+        section text contains the full invite body rather than the
+        "... see more" preview LinkedIn renders by default.
         """
         url = f"https://www.linkedin.com/mynetwork/invitation-manager/{kind}/"
         await self._navigate_to_page(url)
@@ -3852,6 +3857,8 @@ class LinkedInExtractor:
             position="bottom", attempts=scrolls, pause_time=0.5
         )
 
+        await self._expand_invitation_note_toggles()
+
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
         cleaned = strip_linkedin_noise(raw) if raw else ""
@@ -3865,6 +3872,75 @@ class LinkedInExtractor:
             cleaned,
             references=references,
         )
+
+    async def _expand_invitation_note_toggles(self) -> None:
+        """Click inline expand toggles on invitation cards to reveal full notes.
+
+        LinkedIn truncates invitation notes longer than ~5 lines and renders
+        an inline ``<button data-testid="expandable-text-button">`` inside
+        a ``<span data-testid="expandable-text-box">``. The testid attribute
+        is the locale-independent signal — the visible verb ("see more" /
+        "pokaż więcej" / "voir plus") varies by locale and is unreliable.
+
+        The button ships with inline ``pointer-events: none`` and
+        ``aria-hidden="true"``, which blocks Playwright's standard
+        ``.click()`` from delivering the event to the React handler. We
+        therefore (a) inject a one-shot stylesheet re-enabling pointer
+        events on these specific testid'd nodes and (b) dispatch a
+        synthetic bubbling MouseEvent so the handler fires. The injected
+        style is scoped narrowly enough that it does not affect any other
+        element on the page.
+
+        Each dispatched click can cause LinkedIn to lazy-load further
+        invitation cards with their own collapsed notes, so we run a second
+        pass to pick up the newly-mounted toggles. Already-clicked buttons
+        are tagged with ``data-mcp-clicked="1"`` so the second pass never
+        re-clicks them — without the marker the post-click "collapse"
+        button (same testid, different visible verb) would be re-toggled
+        and silently re-truncate notes the first pass just expanded.
+        """
+        try:
+            for _ in range(2):
+                dispatched = await self._page.evaluate(
+                    """async () => {
+                        if (!document.getElementById('__linkedin_mcp_expand_style')) {
+                            const styleNode = document.createElement('style');
+                            styleNode.id = '__linkedin_mcp_expand_style';
+                            styleNode.textContent = `
+                                [data-testid="expandable-text-button"],
+                                [data-testid="expandable-text-box"] {
+                                    pointer-events: auto !important;
+                                }
+                            `;
+                            document.head.appendChild(styleNode);
+                        }
+                        const buttons = Array.from(document.querySelectorAll(
+                            'main [data-testid="expandable-text-button"]:not([data-mcp-clicked])'
+                        ));
+                        let count = 0;
+                        for (const btn of buttons) {
+                            try {
+                                btn.dataset.mcpClicked = '1';
+                                btn.dispatchEvent(new MouseEvent('click', {
+                                    bubbles: true,
+                                    cancelable: true,
+                                    view: window,
+                                }));
+                                count++;
+                            } catch (e) {
+                                /* ignore individual dispatch failures */
+                            }
+                        }
+                        // Let React render the expanded note bodies before
+                        // the caller extracts innerText.
+                        await new Promise(r => setTimeout(r, 400));
+                        return count;
+                    }"""
+                )
+                if not dispatched:
+                    break
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Failed to expand invitation note toggles: %s", exc)
 
     async def _extract_root_content(
         self,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3848,7 +3848,8 @@ class LinkedInExtractor:
         ``limit`` controls how many inviter ``references`` are returned and
         how many scroll passes pre-load the list. The ``sections`` text is
         trimmed at the first omitted invitation's profile label when possible,
-        keeping the readable text aligned with the returned references.
+        with a blank-line card-boundary fallback for visible cards that do not
+        produce distinct usable profile references.
         """
         url = f"https://www.linkedin.com/mynetwork/invitation-manager/{kind}/"
         await self._navigate_to_page(url)
@@ -3898,12 +3899,14 @@ class LinkedInExtractor:
 
         LinkedIn lazy-loads invitations in screenfuls, so even ``limit=1`` can
         render several cards before extraction. The profile references preserve
-        DOM order, and each invitation card includes the inviter/invitee profile
-        label in its readable text. Cutting before the first omitted reference
-        keeps ``sections["invitations"]`` aligned with the sliced references
-        without relying on LinkedIn layout class names.
+        DOM order, and each invitation card usually includes the inviter/invitee
+        profile label in its readable text. Cutting before the first omitted
+        reference keeps ``sections["invitations"]`` aligned with the sliced
+        references when that signal is available. If later visible cards do not
+        produce usable references, fall back to the blank line separation that
+        LinkedIn's readable text emits between invitation cards.
         """
-        if limit < 1 or len(references) <= limit or not text:
+        if limit < 1 or not text:
             return text
 
         search_from = 0
@@ -3915,14 +3918,49 @@ class LinkedInExtractor:
             if index >= 0:
                 search_from = index + len(label)
 
-        next_label = references[limit].get("text")
-        if not next_label:
+        if len(references) > limit:
+            next_label = references[limit].get("text")
+            if next_label:
+                next_index = text.find(next_label, search_from)
+                if next_index > 0:
+                    return text[:next_index].rstrip()
+
+        return LinkedInExtractor._trim_invitation_text_to_block_limit(
+            text,
+            references,
+            limit,
+        )
+
+    @staticmethod
+    def _trim_invitation_text_to_block_limit(
+        text: str,
+        references: list[Reference],
+        limit: int,
+    ) -> str:
+        """Fallback trim using blank-line card boundaries after first reference."""
+        first_label = next(
+            (
+                reference.get("text")
+                for reference in references
+                if reference.get("text")
+            ),
+            None,
+        )
+        if not first_label:
             return text
 
-        next_index = text.find(next_label, search_from)
-        if next_index <= 0:
+        first_index = text.find(first_label)
+        if first_index < 0:
             return text
-        return text[:next_index].rstrip()
+
+        prefix = text[:first_index]
+        card_text = text[first_index:].strip()
+        blocks = [
+            block.strip() for block in re.split(r"\n\s*\n", card_text) if block.strip()
+        ]
+        if len(blocks) <= limit:
+            return text
+        return (prefix + "\n\n".join(blocks[:limit])).rstrip()
 
     async def _received_invitation_count_is_zero(self) -> bool:
         """Return True when the received invitation counter is explicitly zero.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3826,6 +3826,46 @@ class LinkedInExtractor:
             sent=True,
         )
 
+    async def get_pending_invitations(
+        self,
+        limit: int = 20,
+        kind: Literal["received", "sent"] = "received",
+    ) -> dict[str, Any]:
+        """List pending LinkedIn network invitations (received or sent).
+
+        Mirrors ``/mynetwork/invitation-manager/{received|sent}/``. Returns
+        the standard single-section payload (``sections["invitations"]`` +
+        optional ``references["invitations"]``) so the consumer can read
+        invite text and follow inviter/invitee profile links. Read-only:
+        no accept/ignore/withdraw side effects.
+        """
+        url = f"https://www.linkedin.com/mynetwork/invitation-manager/{kind}/"
+        await self._navigate_to_page(url)
+        await detect_rate_limit(self._page)
+        await self._wait_for_main_text(log_context=f"Invitations ({kind})")
+        await handle_modal_close(self._page)
+
+        # Invitations paginate as the list scrolls, ~10 cards per screenful,
+        # so reuse the same heuristic as get_inbox.
+        scrolls = max(1, limit // 10)
+        await self._scroll_main_scrollable_region(
+            position="bottom", attempts=scrolls, pause_time=0.5
+        )
+
+        raw_result = await self._extract_root_content(["main"])
+        raw = raw_result["text"]
+        cleaned = strip_linkedin_noise(raw) if raw else ""
+        references: list[Reference] = (
+            build_references(raw_result["references"], "invitations") if cleaned else []
+        )
+
+        return self._single_section_result(
+            url,
+            "invitations",
+            cleaned,
+            references=references,
+        )
+
     async def _extract_root_content(
         self,
         selectors: list[str],

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3939,15 +3939,15 @@ class LinkedInExtractor:
                         let count = 0;
                         for (const btn of buttons) {
                             try {
-                                btn.dataset.mcpClicked = '1';
                                 btn.dispatchEvent(new MouseEvent('click', {
                                     bubbles: true,
                                     cancelable: true,
                                     view: window,
                                 }));
+                                btn.dataset.mcpClicked = '1';
                                 count++;
                             } catch (e) {
-                                /* ignore individual dispatch failures */
+                                /* leave unmarked so a later pass can retry */
                             }
                         }
                         // Let React render the expanded note bodies before

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3866,6 +3866,9 @@ class LinkedInExtractor:
 
         await self._expand_invitation_note_toggles()
 
+        if kind == "received" and await self._received_invitation_count_is_zero():
+            return self._single_section_result(url, "invitations", "", references=[])
+
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
         cleaned = strip_linkedin_noise(raw) if raw else ""
@@ -3881,6 +3884,38 @@ class LinkedInExtractor:
             cleaned,
             references=references,
         )
+
+    async def _received_invitation_count_is_zero(self) -> bool:
+        """Return True when the received invitation counter is explicitly zero.
+
+        The received manager can render unrelated "people you may know"
+        recommendations below the empty state. Anchors in that block are not
+        pending invitations, so if LinkedIn exposes the selected ALL-count tab
+        as zero we return an empty single-section result instead of scraping
+        the recommendation cards.
+
+        DOM dependency: the count itself is visible text, but the selected tab
+        is located through locale-independent structural signals: current link
+        state plus the stable ``/invitation-manager/received/ALL`` URL.
+        """
+        try:
+            return bool(
+                await self._page.evaluate(
+                    r"""() => {
+                        const currentAll = document.querySelector(
+                            'main a[aria-current="true"]'
+                            + '[href*="/mynetwork/invitation-manager/received/ALL"]'
+                        );
+                        if (!currentAll) return false;
+                        const text = currentAll.innerText || currentAll.textContent || '';
+                        const match = text.match(/\((\d+)\)/);
+                        return match ? Number(match[1]) === 0 : false;
+                    }"""
+                )
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Failed to read received invitation count: %s", exc)
+            return False
 
     async def _expand_invitation_note_toggles(self) -> None:
         """Click inline expand toggles on invitation cards to reveal full notes.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3846,10 +3846,9 @@ class LinkedInExtractor:
         preview LinkedIn renders by default.
 
         ``limit`` controls how many inviter ``references`` are returned and
-        how many scroll passes pre-load the list. The ``sections`` text
-        always reflects whatever was rendered when extraction ran — typically
-        rounded up to LinkedIn's screenful (~10 cards), so the visible
-        section text may include slightly more invitations than ``limit``.
+        how many scroll passes pre-load the list. The ``sections`` text is
+        trimmed at the first omitted invitation's profile label when possible,
+        keeping the readable text aligned with the returned references.
         """
         url = f"https://www.linkedin.com/mynetwork/invitation-manager/{kind}/"
         await self._navigate_to_page(url)
@@ -3872,10 +3871,14 @@ class LinkedInExtractor:
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
         cleaned = strip_linkedin_noise(raw) if raw else ""
-        references: list[Reference] = (
-            build_references(raw_result["references"], "invitations")[:limit]
-            if cleaned
-            else []
+        all_references: list[Reference] = (
+            build_references(raw_result["references"], "invitations") if cleaned else []
+        )
+        references = all_references[:limit]
+        cleaned = self._trim_invitation_text_to_limit(
+            cleaned,
+            all_references,
+            limit,
         )
 
         return self._single_section_result(
@@ -3884,6 +3887,42 @@ class LinkedInExtractor:
             cleaned,
             references=references,
         )
+
+    @staticmethod
+    def _trim_invitation_text_to_limit(
+        text: str,
+        references: list[Reference],
+        limit: int,
+    ) -> str:
+        """Trim invitation text at the first omitted profile label.
+
+        LinkedIn lazy-loads invitations in screenfuls, so even ``limit=1`` can
+        render several cards before extraction. The profile references preserve
+        DOM order, and each invitation card includes the inviter/invitee profile
+        label in its readable text. Cutting before the first omitted reference
+        keeps ``sections["invitations"]`` aligned with the sliced references
+        without relying on LinkedIn layout class names.
+        """
+        if limit < 1 or len(references) <= limit or not text:
+            return text
+
+        search_from = 0
+        for reference in references[:limit]:
+            label = reference.get("text")
+            if not label:
+                continue
+            index = text.find(label, search_from)
+            if index >= 0:
+                search_from = index + len(label)
+
+        next_label = references[limit].get("text")
+        if not next_label:
+            return text
+
+        next_index = text.find(next_label, search_from)
+        if next_index <= 0:
+            return text
+        return text[:next_index].rstrip()
 
     async def _received_invitation_count_is_zero(self) -> bool:
         """Return True when the received invitation counter is explicitly zero.

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -105,6 +105,11 @@ _REFERENCE_CAPS = {
     # Kept in sync with the literal cap=50 in extractor._build_feed_references
     # where SDUI-derived /posts/<slug> permalinks are appended.
     "feed": 50,
+    # Headroom for get_pending_invitations' limit ceiling (Field(ge=1, le=100)).
+    # The extractor trims to the per-call limit before returning, so this cap
+    # only governs the upper bound of how many inviter profiles can survive
+    # the dedupe pass — the request-level limit is the operative ceiling.
+    "invitations": 100,
 }
 
 _URL_LIKE_RE = re.compile(r"^(?:https?://|/)\S+$", re.IGNORECASE)

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -26,6 +26,7 @@ from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.feed import register_feed_tools
 from linkedin_mcp_server.tools.job import register_job_tools
 from linkedin_mcp_server.tools.messaging import register_messaging_tools
+from linkedin_mcp_server.tools.network import register_network_tools
 from linkedin_mcp_server.tools.person import register_person_tools
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,7 @@ def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> 
     register_company_tools(mcp, tool_timeout=tool_timeout)
     register_job_tools(mcp, tool_timeout=tool_timeout)
     register_messaging_tools(mcp, tool_timeout=tool_timeout)
+    register_network_tools(mcp, tool_timeout=tool_timeout)
     register_feed_tools(mcp, tool_timeout=tool_timeout)
 
     # Register session management tool

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -28,6 +28,7 @@ from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.feed import register_feed_tools
 from linkedin_mcp_server.tools.job import register_job_tools
 from linkedin_mcp_server.tools.messaging import register_messaging_tools
+from linkedin_mcp_server.tools.network import register_network_tools
 from linkedin_mcp_server.tools.person import register_person_tools
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,7 @@ def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> 
     register_company_tools(mcp, tool_timeout=tool_timeout)
     register_job_tools(mcp, tool_timeout=tool_timeout)
     register_messaging_tools(mcp, tool_timeout=tool_timeout)
+    register_network_tools(mcp, tool_timeout=tool_timeout)
     register_feed_tools(mcp, tool_timeout=tool_timeout)
 
     # Register session management tool

--- a/linkedin_mcp_server/tools/network.py
+++ b/linkedin_mcp_server/tools/network.py
@@ -1,0 +1,83 @@
+"""
+LinkedIn network tools.
+
+Provides read-only access to pending network invitations (received or
+sent) from ``/mynetwork/invitation-manager/``. Accept, ignore, and
+withdraw actions are intentionally not exposed.
+"""
+
+import logging
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.core.exceptions import AuthenticationError
+from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
+from linkedin_mcp_server.error_handler import raise_tool_error
+
+logger = logging.getLogger(__name__)
+
+
+def register_network_tools(
+    mcp: FastMCP, *, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS
+) -> None:
+    """Register all network-related tools with the MCP server."""
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Get Pending Invitations",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"network", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_pending_invitations(
+        ctx: Context,
+        limit: Annotated[int, Field(ge=1, le=100)] = 20,
+        kind: Literal["received", "sent"] = "received",
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        List pending LinkedIn network invitations (received or sent).
+
+        Reads ``/mynetwork/invitation-manager/{received|sent}/`` and returns
+        the page's visible text plus references to inviter/invitee profiles.
+        Read-only — accepting, ignoring, or withdrawing invitations is not
+        exposed.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+            limit: Maximum number of invitations to load (1-100, default 20).
+                Invitations load in batches of ~10 as the list scrolls, so
+                the actual count may slightly exceed the target.
+            kind: "received" (default) for incoming invitations, "sent" for
+                outgoing ones awaiting the recipient's response.
+
+        Returns:
+            Dict with url, sections (invitations -> raw text), and optional
+            references.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_pending_invitations"
+            )
+            logger.info("Fetching pending invitations (kind=%s, limit=%d)", kind, limit)
+
+            await ctx.report_progress(
+                progress=0, total=100, message=f"Loading {kind} invitations"
+            )
+
+            result = await extractor.get_pending_invitations(limit=limit, kind=kind)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_pending_invitations")
+        except Exception as e:
+            raise_tool_error(e, "get_pending_invitations")  # NoReturn

--- a/linkedin_mcp_server/tools/network.py
+++ b/linkedin_mcp_server/tools/network.py
@@ -48,9 +48,9 @@ def register_network_tools(
 
         Args:
             ctx: FastMCP context for progress reporting
-            limit: Maximum number of invitations to load (1-100, default 20).
-                Invitations load in batches of ~10 as the list scrolls, so
-                the actual count may slightly exceed the target.
+            limit: Maximum number of invitations to return (1-100, default 20).
+                References are capped exactly; readable text is trimmed at the
+                first omitted invitation when LinkedIn renders extra cards.
             kind: "received" (default) for incoming invitations, "sent" for
                 outgoing ones awaiting the recipient's response.
 

--- a/manifest.json
+++ b/manifest.json
@@ -106,6 +106,10 @@
       "description": "Send a message to a LinkedIn user with explicit confirmation and optional profile URN support"
     },
     {
+      "name": "get_pending_invitations",
+      "description": "List pending LinkedIn network invitations (received or sent) from /mynetwork/invitation-manager/"
+    },
+    {
       "name": "get_feed",
       "description": "Get recent posts from the authenticated user's LinkedIn home feed"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -104,6 +104,10 @@
       "description": "Send a message to a LinkedIn user with explicit confirmation and optional profile URN support"
     },
     {
+      "name": "get_pending_invitations",
+      "description": "List pending LinkedIn network invitations (received or sent) from /mynetwork/invitation-manager/"
+    },
+    {
       "name": "get_feed",
       "description": "Get recent posts from the authenticated user's LinkedIn home feed"
     },

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5316,6 +5316,32 @@ class TestGetPendingInvitations:
         assert result["sections"]["invitations"] == "User 0\nInvited you to connect"
         assert len(result["references"]["invitations"]) == 1
 
+    async def test_text_trimmed_to_limit_when_next_card_has_no_reference(
+        self, mock_page
+    ):
+        """The text limit must still hold when later visible cards do not
+        produce distinct usable profile references."""
+        raw_references = [
+            {"href": "https://www.linkedin.com/in/user-0/", "text": "User 0"}
+        ]
+        raw_text = (
+            "User 0\nInvited you to connect\n\n"
+            "Someone without a usable profile link\nInvited you to connect"
+        )
+        extractor = LinkedInExtractor(mock_page)
+
+        with ExitStack() as stack:
+            for ctx in self._patch_invitation_helpers(
+                extractor,
+                raw_references,
+                raw_text=raw_text,
+            ):
+                stack.enter_context(ctx)
+            result = await extractor.get_pending_invitations(limit=1)
+
+        assert result["sections"]["invitations"] == "User 0\nInvited you to connect"
+        assert len(result["references"]["invitations"]) == 1
+
     async def test_sent_kind_navigates_to_sent_page(self, mock_page):
         """kind='sent' targets the sent invitation-manager surface."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,5 +1,6 @@
 """Tests for the LinkedInExtractor scraping engine."""
 
+from contextlib import ExitStack
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
@@ -5214,3 +5215,94 @@ class TestBuildFeedReferences:
             "/posts/alice_x-ugcPost-1-xx",
         ]
         assert kinds == {"feed_post"}
+
+
+class TestGetPendingInvitations:
+    """Extractor-level tests for get_pending_invitations.
+
+    These lock the two non-obvious guarantees that earlier review feedback
+    introduced: the per-call ``limit`` trims the returned references, and the
+    note-expansion selector never touches an already-expanded toggle.
+    """
+
+    def _patch_invitation_helpers(self, extractor, raw_references):
+        """Context managers that stub the navigation/scroll/extract helpers so
+        the test exercises only the limit/cap/reference logic. Mirrors the
+        ``patch.object`` style used elsewhere in this module."""
+        return (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor, "_expand_invitation_note_toggles", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={
+                    "source": "main",
+                    "text": "Pending invitations text",
+                    "references": raw_references,
+                },
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        )
+
+    async def test_references_trimmed_to_limit(self, mock_page):
+        """References must not exceed the requested limit even when the page
+        renders more invitation cards than asked for."""
+        # 30 distinct inviter profile anchors — all classify as person refs.
+        raw_references = [
+            {"href": f"https://www.linkedin.com/in/user-{i}/", "text": f"User {i}"}
+            for i in range(30)
+        ]
+        extractor = LinkedInExtractor(mock_page)
+
+        with ExitStack() as stack:
+            for ctx in self._patch_invitation_helpers(extractor, raw_references):
+                stack.enter_context(ctx)
+            result = await extractor.get_pending_invitations(limit=5)
+
+        invitations = result["references"]["invitations"]
+        assert len(invitations) == 5
+        assert all(ref["kind"] == "person" for ref in invitations)
+        assert result["url"].endswith("/invitation-manager/received/")
+
+    async def test_sent_kind_navigates_to_sent_page(self, mock_page):
+        """kind='sent' targets the sent invitation-manager surface."""
+        extractor = LinkedInExtractor(mock_page)
+
+        with ExitStack() as stack:
+            for ctx in self._patch_invitation_helpers(extractor, []):
+                stack.enter_context(ctx)
+            result = await extractor.get_pending_invitations(limit=3, kind="sent")
+
+        assert result["url"].endswith("/invitation-manager/sent/")
+
+    async def test_expand_selector_skips_expanded_and_clicked(self, mock_page):
+        """The expand-toggle selector must be locale-independent (testid-based)
+        and skip both already-expanded and already-clicked toggles, so a pass
+        can never re-collapse a note it previously revealed."""
+        mock_page.evaluate = AsyncMock(return_value=0)
+        extractor = LinkedInExtractor(mock_page)
+
+        await extractor._expand_invitation_note_toggles()
+
+        assert mock_page.evaluate.await_count >= 1
+        js = mock_page.evaluate.await_args_list[0].args[0]
+        # locale-independent structural selector, not a visible verb
+        assert '[data-testid="expandable-text-button"]' in js
+        # the two regression guards from review feedback
+        assert ':not([aria-expanded="true"])' in js
+        assert ":not([data-mcp-clicked])" in js

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5225,7 +5225,12 @@ class TestGetPendingInvitations:
     note-expansion selector never touches an already-expanded toggle.
     """
 
-    def _patch_invitation_helpers(self, extractor, raw_references):
+    def _patch_invitation_helpers(
+        self,
+        extractor,
+        raw_references,
+        raw_text="Pending invitations text",
+    ):
         """Context managers that stub the navigation/scroll/extract helpers so
         the test exercises only the limit/cap/reference logic. Mirrors the
         ``patch.object`` style used elsewhere in this module."""
@@ -5250,7 +5255,7 @@ class TestGetPendingInvitations:
                 new_callable=AsyncMock,
                 return_value={
                     "source": "main",
-                    "text": "Pending invitations text",
+                    "text": raw_text,
                     "references": raw_references,
                 },
             ),
@@ -5284,6 +5289,32 @@ class TestGetPendingInvitations:
         assert len(invitations) == 5
         assert all(ref["kind"] == "person" for ref in invitations)
         assert result["url"].endswith("/invitation-manager/received/")
+
+    async def test_text_trimmed_to_limit_reference_boundary(self, mock_page):
+        """Returned section text should stop before the first omitted card so
+        text and references describe the same invitation count."""
+        raw_references = [
+            {"href": f"https://www.linkedin.com/in/user-{i}/", "text": f"User {i}"}
+            for i in range(3)
+        ]
+        raw_text = (
+            "User 0\nInvited you to connect\n\n"
+            "User 1\nInvited you to connect\n\n"
+            "User 2\nInvited you to connect"
+        )
+        extractor = LinkedInExtractor(mock_page)
+
+        with ExitStack() as stack:
+            for ctx in self._patch_invitation_helpers(
+                extractor,
+                raw_references,
+                raw_text=raw_text,
+            ):
+                stack.enter_context(ctx)
+            result = await extractor.get_pending_invitations(limit=1)
+
+        assert result["sections"]["invitations"] == "User 0\nInvited you to connect"
+        assert len(result["references"]["invitations"]) == 1
 
     async def test_sent_kind_navigates_to_sent_page(self, mock_page):
         """kind='sent' targets the sent invitation-manager surface."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5240,6 +5240,12 @@ class TestGetPendingInvitations:
             ),
             patch.object(
                 extractor,
+                "_received_invitation_count_is_zero",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                extractor,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value={
@@ -5289,6 +5295,47 @@ class TestGetPendingInvitations:
             result = await extractor.get_pending_invitations(limit=3, kind="sent")
 
         assert result["url"].endswith("/invitation-manager/sent/")
+
+    async def test_received_zero_count_omits_recommendations(self, mock_page):
+        """When the selected received-count tab is zero, do not return
+        unrelated "people you may know" recommendations as invitations."""
+        extractor = LinkedInExtractor(mock_page)
+
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor, "_expand_invitation_note_toggles", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor,
+                "_received_invitation_count_is_zero",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                extractor, "_extract_root_content", new_callable=AsyncMock
+            ) as extract_root,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor.get_pending_invitations(limit=1)
+
+        assert result == {
+            "url": "https://www.linkedin.com/mynetwork/invitation-manager/received/",
+            "sections": {},
+        }
+        extract_root.assert_not_awaited()
 
     async def test_expand_selector_skips_expanded_and_clicked(self, mock_page):
         """The expand-toggle selector must be locale-independent (testid-based)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5306,3 +5306,5 @@ class TestGetPendingInvitations:
         # the two regression guards from review feedback
         assert ':not([aria-expanded="true"])' in js
         assert ":not([data-mcp-clicked])" in js
+        # mark only after dispatch succeeds so a failed click can be retried
+        assert js.index("btn.dispatchEvent") < js.index("btn.dataset.mcpClicked")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -33,6 +33,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.get_conversation = AsyncMock(return_value=scrape_result)
     mock.search_conversations = AsyncMock(return_value=scrape_result)
     mock.send_message = AsyncMock(return_value=scrape_result)
+    mock.get_pending_invitations = AsyncMock(return_value=scrape_result)
     mock.get_my_profile = AsyncMock(return_value=scrape_result)
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.get_company_employees = AsyncMock(return_value=scrape_result)
@@ -1117,6 +1118,74 @@ class TestFeedTools:
             await mcp.call_tool("get_feed", {"num_posts": 51})
 
 
+class TestNetworkTools:
+    async def test_get_pending_invitations_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/mynetwork/invitation-manager/received/",
+            "sections": {"invitations": "Alice Smith\nBob Jones"},
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.network import register_network_tools
+
+        mcp = FastMCP("test")
+        register_network_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_pending_invitations")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+
+        assert result["sections"]["invitations"] == "Alice Smith\nBob Jones"
+        mock_extractor.get_pending_invitations.assert_awaited_once_with(
+            limit=20, kind="received"
+        )
+
+    async def test_get_pending_invitations_sent_kind(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/mynetwork/invitation-manager/sent/",
+            "sections": {"invitations": "Sent to Carol"},
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.network import register_network_tools
+
+        mcp = FastMCP("test")
+        register_network_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_pending_invitations")
+        result = await tool_fn(
+            mock_context, limit=5, kind="sent", extractor=mock_extractor
+        )
+
+        assert result["url"].endswith("/sent/")
+        mock_extractor.get_pending_invitations.assert_awaited_once_with(
+            limit=5, kind="sent"
+        )
+
+    async def test_get_pending_invitations_rejects_invalid_kind(self):
+        """kind must be one of the Literal values."""
+        from pydantic import ValidationError
+
+        from linkedin_mcp_server.tools.network import register_network_tools
+
+        mcp = FastMCP("test")
+        register_network_tools(mcp)
+
+        with pytest.raises(ValidationError):
+            await mcp.call_tool("get_pending_invitations", {"kind": "archived"})
+
+    async def test_get_pending_invitations_rejects_excessive_limit(self):
+        """Verify limit=101 is rejected by Field(le=100) validation."""
+        from pydantic import ValidationError
+
+        from linkedin_mcp_server.tools.network import register_network_tools
+
+        mcp = FastMCP("test")
+        register_network_tools(mcp)
+
+        with pytest.raises(ValidationError, match="limit"):
+            await mcp.call_tool("get_pending_invitations", {"limit": 101})
+
+
 class TestToolTimeouts:
     async def test_all_tools_have_global_timeout(self):
         from linkedin_mcp_server.server import create_mcp_server
@@ -1137,6 +1206,7 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "get_pending_invitations",
             "get_feed",
             "close_session",
         )
@@ -1168,6 +1238,7 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "get_pending_invitations",
             "get_feed",
             "close_session",
         )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -33,6 +33,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.get_conversation = AsyncMock(return_value=scrape_result)
     mock.search_conversations = AsyncMock(return_value=scrape_result)
     mock.send_message = AsyncMock(return_value=scrape_result)
+    mock.get_pending_invitations = AsyncMock(return_value=scrape_result)
     mock.get_my_profile = AsyncMock(return_value=scrape_result)
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.get_company_employees = AsyncMock(return_value=scrape_result)
@@ -1151,6 +1152,74 @@ class TestFeedTools:
             await mcp.call_tool("get_feed", {"num_posts": 51})
 
 
+class TestNetworkTools:
+    async def test_get_pending_invitations_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/mynetwork/invitation-manager/received/",
+            "sections": {"invitations": "Alice Smith\nBob Jones"},
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.network import register_network_tools
+
+        mcp = FastMCP("test")
+        register_network_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_pending_invitations")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+
+        assert result["sections"]["invitations"] == "Alice Smith\nBob Jones"
+        mock_extractor.get_pending_invitations.assert_awaited_once_with(
+            limit=20, kind="received"
+        )
+
+    async def test_get_pending_invitations_sent_kind(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/mynetwork/invitation-manager/sent/",
+            "sections": {"invitations": "Sent to Carol"},
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.network import register_network_tools
+
+        mcp = FastMCP("test")
+        register_network_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_pending_invitations")
+        result = await tool_fn(
+            mock_context, limit=5, kind="sent", extractor=mock_extractor
+        )
+
+        assert result["url"].endswith("/sent/")
+        mock_extractor.get_pending_invitations.assert_awaited_once_with(
+            limit=5, kind="sent"
+        )
+
+    async def test_get_pending_invitations_rejects_invalid_kind(self):
+        """kind must be one of the Literal values."""
+        from pydantic import ValidationError
+
+        from linkedin_mcp_server.tools.network import register_network_tools
+
+        mcp = FastMCP("test")
+        register_network_tools(mcp)
+
+        with pytest.raises(ValidationError):
+            await mcp.call_tool("get_pending_invitations", {"kind": "archived"})
+
+    async def test_get_pending_invitations_rejects_excessive_limit(self):
+        """Verify limit=101 is rejected by Field(le=100) validation."""
+        from pydantic import ValidationError
+
+        from linkedin_mcp_server.tools.network import register_network_tools
+
+        mcp = FastMCP("test")
+        register_network_tools(mcp)
+
+        with pytest.raises(ValidationError, match="limit"):
+            await mcp.call_tool("get_pending_invitations", {"limit": 101})
+
+
 class TestToolTimeouts:
     async def test_all_tools_have_global_timeout(self):
         from linkedin_mcp_server.server import create_mcp_server
@@ -1171,6 +1240,7 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "get_pending_invitations",
             "get_feed",
             "close_session",
         )
@@ -1202,6 +1272,7 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "get_pending_invitations",
             "get_feed",
             "close_session",
         )


### PR DESCRIPTION
## Summary

Adds a new read-only MCP tool `get_pending_invitations` for listing pending LinkedIn network invitations (received or sent). This fills the gap noted in #446 — recruiter "Invite + note" messages live in `/mynetwork/invitation-manager/` and never reach `get_inbox` until accepted, so an agent assisting with inbound triage cannot see them today.

**What's in scope**

- New tool exposed via `tools/network.py::register_network_tools` with signature `get_pending_invitations(ctx, limit=20, kind="received"|"sent")`.
- New extractor method `LinkedInExtractor.get_pending_invitations(limit, kind)` that follows the `get_inbox` template line-for-line: `_navigate_to_page` -> `detect_rate_limit` -> `_wait_for_main_text` -> `handle_modal_close` -> `_scroll_main_scrollable_region` -> `_expand_invitation_note_toggles` -> `_extract_root_content(["main"])` -> `strip_linkedin_noise` -> `build_references` -> `_single_section_result`.
- Auto-expansion of truncated invitation notes via the new `_expand_invitation_note_toggles` helper. Uses the locale-independent `data-testid="expandable-text-button"` selector, injects a scoped one-shot stylesheet to re-enable `pointer-events` (LinkedIn ships these buttons with inline `pointer-events: none`), and dispatches a synthetic bubbling MouseEvent so the React handler fires. A button is tagged with `data-mcp-clicked` only **after** a successful dispatch, so a click that throws is left unmarked and retried on the second pass; the selector also skips `aria-expanded="true"` so an already-expanded note is never toggled closed.
- Empty-state handling for `kind="received"`: when the selected ALL-count tab reads zero, the method returns an empty single-section result instead of scraping the unrelated "people you may know" recommendation cards LinkedIn renders below the empty invitations list. The zero check is locale-independent — it locates the selected tab via `aria-current="true"` + the stable `/invitation-manager/received/ALL` URL, and only the digit count is read as text (guarded behind that structural selector, documented in the helper docstring).
- Per-call `limit` bounds the returned references (`build_references(...)[:limit]`), and `_REFERENCE_CAPS["invitations"]` is set to 100 to match the tool's `Field(le=100)` ceiling so larger invitation lists are not silently truncated at the default cap of 12.
- Registration in `server.py::create_mcp_server()`.
- Tests: `TestNetworkTools` in `tests/test_tools.py` (happy path, `sent` kind, invalid kind rejection, limit-bound rejection; `_make_mock_extractor` extended; tool added to both timeout-coverage tuples) plus `TestGetPendingInvitations` in `tests/test_scraping.py` (extractor-level regression coverage: `[:limit]` reference trimming, the `sent` navigation target, the `aria-expanded="true"` / `data-mcp-clicked` skip guards, and the zero-count empty-state path).
- README tool table, `docs/docker-hub.md` features list, and `manifest.json` tools array all updated.

**Intentionally out of scope**

- Accept / ignore / withdraw actions are deferred to a follow-up PR if this lands. Keeping the surface area read-only here both shrinks the diff and avoids exposing destructive operations on a surface that hasn't been exercised yet.
- No new entry in `fields.py` — this is a one-page tool, not a sectioned scraper, matching `get_feed` / `get_inbox`.

## Testing

- `uv run pytest`: 551 passed locally. One pre-existing failure in `test_browser_security.py::test_harden_linkedin_tree_noop_outside_linkedin` reproduces on `main` before this branch with `umask=002`; it's environmental and unrelated.
- `uv run ruff check .`: clean. `uv run ty check`: clean. `uv run pre-commit run --all-files`: all hooks pass.
- Live verified end-to-end via `get_pending_invitations` (read-only) on a real account in two states:
  - non-empty `kind="received"`: result shape conforms to `{url, sections, references}`; the section text contained inviter blocks with every truncated invitation note auto-expanded (`text` matched the collapse verb N times, the expand verb 0 times); references carried `kind: "person"` entries with `/in/USERNAME/` URLs, sliced to `limit`.
  - zero `kind="received"`: returns `sections: {}` with no references, confirming the "people you may know" recommendation cards are not surfaced as invitations.

## Synthetic prompt

> Add a read-only `get_pending_invitations` MCP tool that lists pending LinkedIn network invitations (received or sent) by navigating to `/mynetwork/invitation-manager/{kind}/`, mirroring the existing `get_inbox` extractor pattern. Before extracting, auto-expand truncated invitation notes by dispatching a synthetic click on each `data-testid="expandable-text-button"` (inject a scoped `pointer-events` stylesheet override, mark each button `data-mcp-clicked` only after a successful dispatch so failed clicks retry, and skip `aria-expanded="true"` so expanded notes are never re-collapsed). Bound returned references to the per-call `limit` and add an `invitations` entry to `_REFERENCE_CAPS`. For `kind="received"`, when the selected ALL-count tab reads zero, return an empty result instead of scraping the "people you may know" recommendations, locating the tab via the locale-independent `aria-current="true"` + `/received/ALL` URL signal. Wire it through `tools/network.py` and `server.py::create_mcp_server()`, add `TestNetworkTools` in `tests/test_tools.py` and `TestGetPendingInvitations` in `tests/test_scraping.py`, and update README, `docs/docker-hub.md`, and `manifest.json`. Accept/ignore/withdraw actions are intentionally out of scope.

Generated with Claude Opus 4.7 and GPT-5.5

Closes #446
