### PR TITLE
docs(readme): sync tool status issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 |------|-------------|--------|
 | `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
 | `get_my_profile` | Get the authenticated user's own LinkedIn profile (same sections as get_person_profile) | working |
-| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) |
+| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) [#432](https://github.com/stickerdaniel/linkedin-mcp-server/issues/432) [#448](https://github.com/stickerdaniel/linkedin-mcp-server/issues/448) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
-| `get_conversation` | Read a specific messaging conversation by username or thread ID | working |
+| `get_conversation` | Read a specific messaging conversation by username or thread ID | [#434](https://github.com/stickerdaniel/linkedin-mcp-server/issues/434) |
 | `search_conversations` | Search messages by keyword | working |
-| `send_message` | Send a message to a LinkedIn user (requires confirmation) | working |
+| `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_companies` | Search for companies on LinkedIn by keywords | working |


### PR DESCRIPTION
## Summary

Updates the README Features & Tool Status table so listed tools with current tool-specific bugs link to their open issues instead of showing `working`.

Reflected issues:
- `connect_with_person`: #407, #432, #448
- `get_conversation`: #434
- `send_message`: #433, #441

Broad runtime/setup issues and feature requests remain excluded from the table.

Closes #438

## Testing

- Pre-commit hooks run during commit; README-only change, Python tests not run.

## Synthetic prompt

> Sync the README Features & Tool Status table with currently open tool-specific GitHub issues. Keep unaffected tools marked `working`; for affected tools, replace the status with linked issue numbers. Exclude broad runtime/setup issues and feature requests. Reference the docs tracking issue so it closes on merge.

Generated with GPT-5 Codex
