### PR TITLE
fix(person): dismiss composer overlay to prevent dialog collision

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1758,7 +1758,7 @@ class LinkedInExtractor:
             f"?vanityName={quote_plus(username)}"
         )
         # Issue 432: Clear any message composer overlay which might overlap the invite dialog
-        await self._dismiss_message_ui()
+        await self._dismiss_message_ui(fast=True)
         await self._navigate_to_page(invite_url)
 
         submitted, note_sent = await self._submit_invite_dialog(note)
@@ -2238,12 +2238,25 @@ class LinkedInExtractor:
         except PlaywrightTimeoutError:
             return False
 
-    async def _dismiss_message_ui(self) -> None:
-        """Best-effort dismissal for the profile messaging UI."""
-        if not await self._locator_is_visible(_MESSAGING_CLOSE_SELECTOR, timeout=750):
+    async def _dismiss_message_ui(self, fast: bool = False) -> None:
+        """Best-effort dismissal for the profile messaging UI.
+
+        Args:
+            fast: If True, uses a 0ms timeout for the initial visibility check
+                so it doesn't block the caller when no overlay is present.
+        """
+        # Prefix with aside to avoid matching generic page-level toasts/modals
+        # which might share common "Close" / "Dismiss" labels.
+        selector = ", ".join(
+            f"aside {s.strip()}"
+            for s in _MESSAGING_CLOSE_SELECTOR.split(",")
+            if s.strip()
+        )
+        timeout = 0 if fast else 750
+        if not await self._locator_is_visible(selector, timeout=timeout):
             return
         try:
-            await self._click_first(_MESSAGING_CLOSE_SELECTOR, timeout=1500)
+            await self._click_first(selector, timeout=1500)
             await asyncio.sleep(0.5)
         except Exception:
             logger.debug("Could not dismiss LinkedIn messaging UI", exc_info=True)

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -736,10 +736,19 @@ class LinkedInExtractor:
         """Return whether a dialog is currently open (structural check)."""
         locator = self._page.locator(_DIALOG_SELECTOR)
         try:
-            if await locator.count() == 0:
+            count = await locator.count()
+            if count == 0:
                 return False
-            await locator.first.wait_for(state="visible", timeout=timeout)
-            return True
+
+            # Filter out composer overlays (they have [role="dialog"] but shouldn't count as modal dialogs)
+            for i in range(count):
+                el = locator.nth(i)
+                if await el.is_visible(timeout=timeout):
+                    # Check if it contains the messaging close button
+                    if await el.locator(_MESSAGING_CLOSE_SELECTOR).count() > 0:
+                        continue
+                    return True
+            return False
         except Exception:
             return False
 
@@ -1748,6 +1757,8 @@ class LinkedInExtractor:
             "https://www.linkedin.com/preload/custom-invite/"
             f"?vanityName={quote_plus(username)}"
         )
+        # Issue 432: Clear any message composer overlay which might overlap the invite dialog
+        await self._dismiss_message_ui()
         await self._navigate_to_page(invite_url)
 
         submitted, note_sent = await self._submit_invite_dialog(note)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -998,6 +998,58 @@ class TestConnectWithPerson:
             has_labeled_action_anchor=labeled_anchor,
         )
 
+    async def test_dismisses_composer_overlay_before_invite(self, mock_page):
+        """connect_with_person dismisses any composer overlay before navigating to invite."""
+        extractor = LinkedInExtractor(mock_page)
+
+        # Track call order
+        calls = []
+
+        async def mock_nav(*args, **kwargs):
+            calls.append("nav")
+
+        async def mock_dismiss(*args, **kwargs):
+            calls.append("dismiss")
+
+        with (
+            patch.object(
+                extractor,
+                "scrape_person",
+                self._mock_scrape("Profile", follow_up_text="Profile"),
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                side_effect=[self._signals(invite=True), self._signals()],
+            ),
+            patch.object(
+                extractor,
+                "_dismiss_message_ui",
+                new_callable=AsyncMock,
+                side_effect=mock_dismiss,
+            ),
+            patch.object(
+                extractor,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+                side_effect=mock_nav,
+            ),
+            patch.object(
+                extractor, "_dialog_is_open", new_callable=AsyncMock, return_value=True
+            ),
+            patch.object(
+                extractor,
+                "_submit_invite_dialog",
+                new_callable=AsyncMock,
+                return_value=(True, False),
+            ),
+        ):
+            await extractor.connect_with_person("testuser")
+
+        assert calls[0] == "dismiss"
+        assert calls[1] == "nav"
+
     async def test_connectable_navigates_deeplink_and_verifies(self, mock_page):
         """Connect via deeplink: dialog opens, submit succeeds, anchor disappears."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1005,10 +1005,10 @@ class TestConnectWithPerson:
         # Track call order
         calls = []
 
-        async def mock_nav(*args, **kwargs):
+        def mock_nav(*args, **kwargs):
             calls.append("nav")
 
-        async def mock_dismiss(*args, **kwargs):
+        def mock_dismiss(*args, **kwargs):
             calls.append("dismiss")
 
         with (
@@ -1028,7 +1028,7 @@ class TestConnectWithPerson:
                 "_dismiss_message_ui",
                 new_callable=AsyncMock,
                 side_effect=mock_dismiss,
-            ),
+            ) as mock_dismiss_call,
             patch.object(
                 extractor,
                 "_navigate_to_page",
@@ -1047,8 +1047,8 @@ class TestConnectWithPerson:
         ):
             await extractor.connect_with_person("testuser")
 
-        assert calls[0] == "dismiss"
-        assert calls[1] == "nav"
+        assert calls == ["dismiss", "nav"]
+        mock_dismiss_call.assert_awaited_once_with(fast=True)
 
     async def test_connectable_navigates_deeplink_and_verifies(self, mock_page):
         """Connect via deeplink: dialog opens, submit succeeds, anchor disappears."""


### PR DESCRIPTION
Fixes #432. Calls _dismiss_message_ui before navigating to the connect deeplink to prevent the composer overlay from intercepting the dialog.