### PR TITLE
fix(messaging): dismiss stale message overlay before send_message

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3167,6 +3167,10 @@ class LinkedInExtractor:
             profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
                 compose URL directly, bypassing the Message-button lookup.
         """
+        # Clear any floating message overlay from previous tools/calls
+        # that might intercept the compose box or block page interactions.
+        await self._dismiss_message_ui()
+
         profile_url = f"https://www.linkedin.com/in/{linkedin_username}/"
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3167,10 +3167,6 @@ class LinkedInExtractor:
             profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
                 compose URL directly, bypassing the Message-button lookup.
         """
-        # Clear any floating message overlay from previous tools/calls
-        # that might intercept the compose box or block page interactions.
-        await self._dismiss_message_ui()
-
         profile_url = f"https://www.linkedin.com/in/{linkedin_username}/"
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
@@ -3181,6 +3177,9 @@ class LinkedInExtractor:
             logger.debug("Profile page did not load for %s", linkedin_username)
 
         await handle_modal_close(self._page)
+        # Clear any floating message overlay from previous tool calls
+        # that might intercept the compose box or block interactions.
+        await self._dismiss_message_ui()
         display_name = await self._read_profile_display_name()
         if profile_urn:
             # Build the full compose URL that LinkedIn's own Message button

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4094,10 +4094,10 @@ class TestSendMessage:
         # Track call order
         calls = []
 
-        async def mock_nav(*args, **kwargs):
+        def mock_nav(*args, **kwargs):
             calls.append("nav")
 
-        async def mock_dismiss(*args, **kwargs):
+        def mock_dismiss(*args, **kwargs):
             calls.append("dismiss")
 
         nav_mock.side_effect = mock_nav
@@ -4147,8 +4147,7 @@ class TestSendMessage:
         ):
             await extractor.send_message("testuser", "Hello!", confirm_send=False)
 
-        assert calls[0] == "nav"
-        assert calls[1] == "dismiss"
+        assert calls == ["nav", "dismiss", "nav", "dismiss"]
 
     async def test_dry_run_returns_confirmation_required(self, mock_page):
         """send_message with confirm_send=False returns confirmation_required status."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4085,6 +4085,71 @@ class TestSearchConversations:
 
 
 class TestSendMessage:
+    async def test_dismisses_stale_overlay_before_navigating(self, mock_page):
+        """send_message calls _dismiss_message_ui before navigating to profile."""
+        extractor = LinkedInExtractor(mock_page)
+        nav_mock = AsyncMock()
+        dismiss_mock = AsyncMock()
+
+        # Track call order
+        calls = []
+
+        async def mock_nav(*args, **kwargs):
+            calls.append("nav")
+
+        async def mock_dismiss(*args, **kwargs):
+            calls.append("dismiss")
+
+        nav_mock.side_effect = mock_nav
+        dismiss_mock.side_effect = mock_dismiss
+
+        with (
+            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch.object(extractor, "_dismiss_message_ui", dismiss_mock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_read_profile_display_name",
+                new_callable=AsyncMock,
+                return_value="Test User",
+            ),
+            patch.object(
+                extractor,
+                "_resolve_message_compose_href",
+                new_callable=AsyncMock,
+                return_value="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+            ),
+            patch.object(
+                extractor,
+                "_wait_for_message_surface",
+                new_callable=AsyncMock,
+                return_value="composer",
+            ),
+            patch.object(
+                extractor,
+                "_resolve_message_compose_box",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                extractor,
+                "_compose_page_matches_recipient",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await extractor.send_message("testuser", "Hello!", confirm_send=False)
+
+        assert calls[0] == "dismiss"
+        assert calls[1] == "nav"
+
     async def test_dry_run_returns_confirmation_required(self, mock_page):
         """send_message with confirm_send=False returns confirmation_required status."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4147,8 +4147,8 @@ class TestSendMessage:
         ):
             await extractor.send_message("testuser", "Hello!", confirm_send=False)
 
-        assert calls[0] == "dismiss"
-        assert calls[1] == "nav"
+        assert calls[0] == "nav"
+        assert calls[1] == "dismiss"
 
     async def test_dry_run_returns_confirmation_required(self, mock_page):
         """send_message with confirm_send=False returns confirmation_required status."""


### PR DESCRIPTION
Fixes #433. Calls _dismiss_message_ui at the beginning of send_message to prevent stale overlays from causing composer_unavailable.