### PR TITLE
fix(person): try connect deeplink fallback for follow_only profiles

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1730,26 +1730,23 @@ class LinkedInExtractor:
                     logger.debug("Escape after More-menu reread failed", exc_info=True)
                 logger.info("Post-More signals for %s: signals=%s", username, signals)
 
+        # Write-gate: the deeplink fires when we have a vanityName invite anchor,
+        # or when we detected a Connect button but couldn't find the anchor (Issue #454).
+        # A profile with neither returns connect_unavailable without navigating to
+        # the invite URL — protecting against accidental re-invitation of Pending profiles.
+        if not signals.has_invite_anchor and not signals.has_labeled_action_button:
+            return _connection_result(
+                url,
+                "connect_unavailable",
+                "LinkedIn did not expose a usable Connect action for this profile.",
+                profile=page_text,
+            )
+
         invite_url = (
             "https://www.linkedin.com/preload/custom-invite/"
             f"?vanityName={quote_plus(username)}"
         )
-
-        # Write-gate: Try to find the vanityName invite anchor. If missing,
-        # (e.g. because Connect is rendered as a <button> instead of an <a>,
-        # see Issue #454), fallback to probing the deeplink URL directly.
-        if not signals.has_invite_anchor:
-            logger.info("No invite anchor for %s, probing deeplink fallback", username)
-            await self._navigate_to_page(invite_url)
-            if not await self._dialog_is_open(timeout=5000):
-                return _connection_result(
-                    url,
-                    "connect_unavailable",
-                    "LinkedIn did not expose a usable Connect action for this profile.",
-                    profile=page_text,
-                )
-        else:
-            await self._navigate_to_page(invite_url)
+        await self._navigate_to_page(invite_url)
 
         submitted, note_sent = await self._submit_invite_dialog(note)
         if not submitted:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1730,25 +1730,26 @@ class LinkedInExtractor:
                     logger.debug("Escape after More-menu reread failed", exc_info=True)
                 logger.info("Post-More signals for %s: signals=%s", username, signals)
 
-        # Write-gate: the deeplink fires only when we have a vanityName
-        # invite anchor at this point. A `follow_only` outcome with no
-        # invite anchor (Pending profile, restricted profile, or
-        # genuinely follow-only) returns connect_unavailable without
-        # navigating to the invite URL — protects against accidental
-        # re-invitation of Pending profiles.
-        if not signals.has_invite_anchor:
-            return _connection_result(
-                url,
-                "connect_unavailable",
-                "LinkedIn did not expose a usable Connect action for this profile.",
-                profile=page_text,
-            )
-
         invite_url = (
             "https://www.linkedin.com/preload/custom-invite/"
             f"?vanityName={quote_plus(username)}"
         )
-        await self._navigate_to_page(invite_url)
+
+        # Write-gate: Try to find the vanityName invite anchor. If missing,
+        # (e.g. because Connect is rendered as a <button> instead of an <a>,
+        # see Issue #454), fallback to probing the deeplink URL directly.
+        if not signals.has_invite_anchor:
+            logger.info("No invite anchor for %s, probing deeplink fallback", username)
+            await self._navigate_to_page(invite_url)
+            if not await self._dialog_is_open(timeout=5000):
+                return _connection_result(
+                    url,
+                    "connect_unavailable",
+                    "LinkedIn did not expose a usable Connect action for this profile.",
+                    profile=page_text,
+                )
+        else:
+            await self._navigate_to_page(invite_url)
 
         submitted, note_sent = await self._submit_invite_dialog(note)
         if not submitted:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -131,9 +131,9 @@ _MESSAGING_CLOSE_SELECTOR = (
 # single change to the heuristic propagates to both call sites.
 _FIND_ACTION_ROOT_FN_JS = r"""
 function findActionRoot(main) {
-  const composeAnchors = main.querySelectorAll('a[href*="/messaging/compose/"]');
-  for (const a of composeAnchors) {
-    let el = a.parentElement;
+  const candidates = main.querySelectorAll('button, a[href*="/messaging/compose/"]');
+  for (const c of candidates) {
+    let el = c.parentElement;
     while (el && el !== main) {
       const interactive = el.querySelectorAll('button, a').length;
       const buttons = el.querySelectorAll('button').length;

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1730,17 +1730,18 @@ class LinkedInExtractor:
                     logger.debug("Escape after More-menu reread failed", exc_info=True)
                 logger.info("Post-More signals for %s: signals=%s", username, signals)
 
-        # Write-gate: the deeplink fires when we have a vanityName invite anchor,
-        # or when we detected a Connect button but couldn't find the anchor (Issue #454).
-        # A profile with neither returns connect_unavailable without navigating to
-        # the invite URL — protecting against accidental re-invitation of Pending profiles.
-        if not signals.has_invite_anchor and not signals.has_labeled_action_button:
-            return _connection_result(
-                url,
-                "connect_unavailable",
-                "LinkedIn did not expose a usable Connect action for this profile.",
-                profile=page_text,
-            )
+        # Write-gate: the deeplink fires when we have a vanityName invite anchor.
+        # Fallback (Issue #454): If we didn't find an invite anchor but the state
+        # is "unavailable" and there is a primary button, it might be a hidden Connect button.
+        # We strictly prevent probing for follow_only or pending states to preserve guardrails.
+        if not signals.has_invite_anchor:
+            if state != "unavailable" or not signals.has_labeled_action_button:
+                return _connection_result(
+                    url,
+                    "connect_unavailable",
+                    "LinkedIn did not expose a usable Connect action for this profile.",
+                    profile=page_text,
+                )
 
         invite_url = (
             "https://www.linkedin.com/preload/custom-invite/"

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1002,9 +1002,6 @@ class TestConnectWithPerson:
         """connect_with_person probes deeplink even if has_invite_anchor is False."""
         extractor = LinkedInExtractor(mock_page)
 
-        async def mock_dialog(*args, **kwargs):
-            return True
-
         with (
             patch.object(
                 extractor,
@@ -1023,12 +1020,6 @@ class TestConnectWithPerson:
             patch.object(
                 extractor, "_navigate_to_page", new_callable=AsyncMock
             ) as mock_nav,
-            patch.object(
-                extractor,
-                "_dialog_is_open",
-                new_callable=AsyncMock,
-                side_effect=mock_dialog,
-            ),
             patch.object(
                 extractor,
                 "_submit_invite_dialog",

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -998,6 +998,52 @@ class TestConnectWithPerson:
             has_labeled_action_anchor=labeled_anchor,
         )
 
+    async def test_connect_with_person_fallback_deeplink_probe(self, mock_page):
+        """connect_with_person probes deeplink even if has_invite_anchor is False."""
+        extractor = LinkedInExtractor(mock_page)
+
+        async def mock_dialog(*args, **kwargs):
+            return True
+
+        with (
+            patch.object(
+                extractor,
+                "scrape_person",
+                self._mock_scrape("Profile", follow_up_text="Profile"),
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                side_effect=[self._signals(labeled_action=True), self._signals()],
+            ),
+            patch.object(
+                extractor, "_open_more_menu", new_callable=AsyncMock, return_value=True
+            ),
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as mock_nav,
+            patch.object(
+                extractor,
+                "_dialog_is_open",
+                new_callable=AsyncMock,
+                side_effect=mock_dialog,
+            ),
+            patch.object(
+                extractor,
+                "_submit_invite_dialog",
+                new_callable=AsyncMock,
+                return_value=(True, False),
+            ),
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+            assert result["status"] == "connected"
+            # It navigated to the invite deeplink despite has_invite_anchor=False
+            mock_nav.assert_any_call(
+                "https://www.linkedin.com/preload/custom-invite/?vanityName=testuser"
+            )
+
     async def test_connectable_navigates_deeplink_and_verifies(self, mock_page):
         """Connect via deeplink: dialog opens, submit succeeds, anchor disappears."""
         extractor = LinkedInExtractor(mock_page)


### PR DESCRIPTION
Fixes #454. Removes strict has_invite_anchor requirement and probes deeplink to detect Connect buttons hidden inside standard button elements.