### PR TITLE
docs(readme): update tool status

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 |------|-------------|--------|
 | `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
 | `get_my_profile` | Get the authenticated user's own LinkedIn profile (same sections as get_person_profile) | working |
-| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) [#432](https://github.com/stickerdaniel/linkedin-mcp-server/issues/432) [#448](https://github.com/stickerdaniel/linkedin-mcp-server/issues/448) |
+| `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) [#432](https://github.com/stickerdaniel/linkedin-mcp-server/issues/432) [#448](https://github.com/stickerdaniel/linkedin-mcp-server/issues/448) [#454](https://github.com/stickerdaniel/linkedin-mcp-server/issues/454) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | [#434](https://github.com/stickerdaniel/linkedin-mcp-server/issues/434) |


### PR DESCRIPTION
## Summary

- Add missing #454 to the `connect_with_person` status row in README.md.

Fixes #469

## Testing

- Not run; docs-only README status update.

## Synthetic prompt

> Update the README Features & Tool Status table so the `connect_with_person` row links open issue #454 alongside the existing tool-specific bug references. Create and reference a docs issue for the mismatch.

Generated with GPT-5 Codex