### PR TITLE
fix(messaging): resolve get_conversation via inbox

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -93,6 +93,12 @@ _SORT_BY_MAP = {"date": "DD", "relevance": "R"}
 # LinkedIn accepts "F" (1st-degree), "S" (2nd-degree), "O" (3rd-degree and beyond).
 _NETWORK_TOKENS = ("F", "S", "O")
 
+# How many inbox rows to iterate when resolving a conversation by participant
+# name. Only the matching row is clicked (see _extract_conversation_thread_refs
+# name_filter), so iterating a generous count is cheap; recent threads (the
+# common get_conversation-by-username case) sit near the top of the inbox.
+_INBOX_RESOLVE_LIMIT = 50
+
 _DIALOG_SELECTOR = 'dialog[open], [role="dialog"]'
 _DIALOG_TEXTAREA_SELECTOR = '[role="dialog"] textarea, dialog textarea'
 
@@ -2246,28 +2252,35 @@ class LinkedInExtractor:
     async def _resolve_conversation_thread_urls(self, display_name: str) -> list[str]:
         """Return all thread URLs whose participant name matches display_name.
 
-        Uses URL-driven search (`/messaging/?searchTerm=…`) plus click-to-capture
+        Enumerates the plain messaging inbox (`/messaging/`) plus click-to-capture
         because LinkedIn renders the messaging sidebar with no anchor hrefs, no
         data-thread attributes, and no embedded URNs — clicking each row and
         reading the resulting SPA URL is the only available extraction path.
+        The inbox is used rather than `?searchTerm=` because LinkedIn's
+        messaging search frequently returns "We didn't find anything" for a
+        participant whose thread is plainly present in the inbox (issue #434).
+        ``name_filter`` is passed to the enumerator so only the matching row is
+        clicked — clicking a row may mark it read, so unrelated threads stay
+        untouched.
 
         Matches by case-insensitive equality on the cleaned participant name
         derived from the row's aria-label, which tolerates duplicate threads
         with the same participant. Browser locale is forced to en-US so the
         verb prefix strips reliably; in any other locale the comparison fails
         cleanly with "Could not find a conversation" rather than returning
-        a wrong-thread match.
+        a wrong-thread match. Threads buried below the scrolled rows are not
+        found by name; open those via ``thread_id``.
         """
-        search_url = (
-            f"https://www.linkedin.com/messaging/?searchTerm={quote_plus(display_name)}"
-        )
-        await self._navigate_to_page(search_url)
+        await self._navigate_to_page("https://www.linkedin.com/messaging/")
         await detect_rate_limit(self._page)
+        await self._wait_for_main_text(log_context="Messaging inbox")
         await handle_modal_close(self._page)
-        await self._wait_for_main_text(log_context="Messaging search results")
+        await self._scroll_main_scrollable_region(
+            position="bottom", attempts=2, pause_time=0.5
+        )
 
         refs = await self._extract_conversation_thread_refs(
-            limit=None, context="search"
+            limit=_INBOX_RESOLVE_LIMIT, context="inbox", name_filter=display_name
         )
         target_name = display_name.strip().lower()
         urls: list[str] = []
@@ -2932,7 +2945,7 @@ class LinkedInExtractor:
         )
 
     async def _extract_conversation_thread_refs(
-        self, limit: int | None, context: str
+        self, limit: int | None, context: str, *, name_filter: str | None = None
     ) -> list[Reference]:
         """Click each visible conversation item and capture the thread URL.
 
@@ -2945,6 +2958,12 @@ class LinkedInExtractor:
         ``data-thread-id`` attributes, and no embedded URNs — clicking each
         row and reading the SPA URL is the only reliable extraction path.
         Pass ``limit=None`` to capture every visible row.
+
+        When ``name_filter`` is provided, every row's aria-label is still read
+        but only rows whose cleaned participant name equals it (case-insensitive)
+        are clicked; non-matching rows are skipped without clicking. Clicking a
+        row may mark it as read, so the filter keeps the read-marking side effect
+        scoped to the requested participant when resolving by username.
         """
         # The conversation list mounts after main text settles, so wait
         # explicitly for at least one label rather than relying on
@@ -2981,17 +3000,28 @@ class LinkedInExtractor:
         # The aria-label value flows through unmodified — Python strips any
         # known locale prefix to derive a clean participant name for refs.
         conversations: list[dict[str, str]] = await self._page.evaluate(
-            """async ({ limit }) => {
+            """async ({ limit, nameFilter }) => {
                 const labels = Array.from(document.querySelectorAll(
                     'main li label[aria-label]'
                 ));
                 const cap = (limit == null)
                     ? labels.length
                     : Math.min(labels.length, limit);
+                // Normalize the optional participant filter the same way the
+                // Python prefix-strip does (en-US "Select conversation with"
+                // verb, collapsed whitespace) so the JS-side comparison
+                // matches. Only the matching row is clicked — clicking marks a
+                // row read, so unrelated threads must not be clicked.
+                const wanted = (nameFilter || '')
+                    .replace(/\\s+/g, ' ').trim().toLowerCase();
                 const results = [];
                 for (let i = 0; i < cap; i++) {
                     const label = labels[i];
                     const ariaLabel = label.getAttribute('aria-label') || '';
+                    const rowName = ariaLabel
+                        .replace(/^Select conversation with\\s+/i, '')
+                        .replace(/\\s+/g, ' ').trim().toLowerCase();
+                    if (wanted && rowName !== wanted) continue;
                     const clickTarget = label.closest('li')
                         ?.querySelector('div[class*="listitem__link"]');
                     if (!clickTarget) continue;
@@ -3016,7 +3046,7 @@ class LinkedInExtractor:
                 }
                 return results;
             }""",
-            {"limit": limit},
+            {"limit": limit, "nameFilter": name_filter},
         )
         refs: list[Reference] = []
         for conv in conversations:
@@ -3058,9 +3088,9 @@ class LinkedInExtractor:
         ``search_conversations`` to enumerate thread IDs first if disambiguation
         by index is impractical.
 
-        Side effect when looked up by username: resolution searches LinkedIn's
-        messaging inbox for the participant's display name and click-visits
-        every matching row to capture its thread ID (no anchor hrefs or
+        Side effect when looked up by username: resolution enumerates the
+        messaging inbox and click-visits only the row(s) matching the
+        participant's display name to capture the thread ID (no anchor hrefs or
         thread-id attributes exist in the sidebar). Each visit selects the row
         in the LinkedIn UI and may mark it as read. Pass ``thread_id`` directly
         to skip this enumeration.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2265,6 +2265,12 @@ class LinkedInExtractor:
         a wrong-thread match. If the inbox scan finds nothing (a thread buried
         below the scrolled rows), it falls back to the `?searchTerm=` search as
         a last resort.
+
+        For a participant with multiple threads, the returned set — and thus
+        ``index`` selection in the caller — covers the threads visible in the
+        scanned inbox; the search fallback only runs when the inbox scan is
+        empty. Open a buried duplicate thread directly via ``thread_id``
+        (enumerate IDs with ``search_conversations``).
         """
         target_name = display_name.strip().lower()
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -93,12 +93,6 @@ _SORT_BY_MAP = {"date": "DD", "relevance": "R"}
 # LinkedIn accepts "F" (1st-degree), "S" (2nd-degree), "O" (3rd-degree and beyond).
 _NETWORK_TOKENS = ("F", "S", "O")
 
-# How many inbox rows to iterate when resolving a conversation by participant
-# name. Only the matching row is clicked (see _extract_conversation_thread_refs
-# name_filter), so iterating a generous count is cheap; recent threads (the
-# common get_conversation-by-username case) sit near the top of the inbox.
-_INBOX_RESOLVE_LIMIT = 50
-
 _DIALOG_SELECTOR = 'dialog[open], [role="dialog"]'
 _DIALOG_TEXTAREA_SELECTOR = '[role="dialog"] textarea, dialog textarea'
 
@@ -2268,9 +2262,23 @@ class LinkedInExtractor:
         with the same participant. Browser locale is forced to en-US so the
         verb prefix strips reliably; in any other locale the comparison fails
         cleanly with "Could not find a conversation" rather than returning
-        a wrong-thread match. Threads buried below the scrolled rows are not
-        found by name; open those via ``thread_id``.
+        a wrong-thread match. If the inbox scan finds nothing (a thread buried
+        below the scrolled rows), it falls back to the `?searchTerm=` search as
+        a last resort.
         """
+        target_name = display_name.strip().lower()
+
+        def _match(refs: list[Reference]) -> list[str]:
+            # name_filter already gated the clicks; this enforces the same
+            # exact-equality match Python-side and tolerates duplicate threads.
+            return [
+                f"https://www.linkedin.com{ref['url']}"
+                for ref in refs
+                if (ref.get("text") or "").strip().lower() == target_name
+            ]
+
+        # Primary path: enumerate the plain inbox. Reliable for the recent
+        # threads that the verify-after-send workflow needs (issue #434).
         await self._navigate_to_page("https://www.linkedin.com/messaging/")
         await detect_rate_limit(self._page)
         await self._wait_for_main_text(log_context="Messaging inbox")
@@ -2278,18 +2286,29 @@ class LinkedInExtractor:
         await self._scroll_main_scrollable_region(
             position="bottom", attempts=2, pause_time=0.5
         )
-
-        refs = await self._extract_conversation_thread_refs(
-            limit=_INBOX_RESOLVE_LIMIT, context="inbox", name_filter=display_name
+        urls = _match(
+            await self._extract_conversation_thread_refs(
+                limit=None, context="inbox", name_filter=display_name
+            )
         )
-        target_name = display_name.strip().lower()
-        urls: list[str] = []
-        for ref in refs:
-            ref_text = (ref.get("text") or "").strip().lower()
-            if not ref_text or ref_text != target_name:
-                continue
-            urls.append(f"https://www.linkedin.com{ref['url']}")
-        return urls
+        if urls:
+            return urls
+
+        # Fallback: LinkedIn's messaging search. Unreliable (often returns
+        # "We didn't find anything" even for present threads, see #434), so it
+        # runs only when the inbox scan came up empty — e.g. a thread buried
+        # below the scrolled inbox window.
+        await self._navigate_to_page(
+            f"https://www.linkedin.com/messaging/?searchTerm={quote_plus(display_name)}"
+        )
+        await detect_rate_limit(self._page)
+        await handle_modal_close(self._page)
+        await self._wait_for_main_text(log_context="Messaging search results")
+        return _match(
+            await self._extract_conversation_thread_refs(
+                limit=None, context="search", name_filter=display_name
+            )
+        )
 
     async def _open_conversation_by_username(
         self, linkedin_username: str, index: int = 0

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,6 +1,6 @@
 """Tests for the LinkedInExtractor scraping engine."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -3921,9 +3921,9 @@ class TestStripSelectConversationPrefix:
 
 
 class TestResolveConversationThreadUrls:
-    async def test_url_driven_search_and_exact_aria_match(self, mock_page):
-        """_resolve_conversation_thread_urls drives search via URL parameter
-        and matches participant by exact aria-label rather than substring."""
+    async def test_inbox_enumeration_and_exact_aria_match(self, mock_page):
+        """_resolve_conversation_thread_urls enumerates the plain inbox and
+        matches participant by exact aria-label rather than substring."""
         extractor = LinkedInExtractor(mock_page)
         nav_mock = AsyncMock()
         thread_refs = [
@@ -3958,6 +3958,9 @@ class TestResolveConversationThreadUrls:
             ),
             patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
             patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
                 extractor,
                 "_extract_conversation_thread_refs",
                 new_callable=AsyncMock,
@@ -3966,13 +3969,67 @@ class TestResolveConversationThreadUrls:
         ):
             urls = await extractor._resolve_conversation_thread_urls("Jacki McMahan")
 
-        nav_mock.assert_awaited_once_with(
-            "https://www.linkedin.com/messaging/?searchTerm=Jacki+McMahan"
-        )
+        nav_mock.assert_awaited_once_with("https://www.linkedin.com/messaging/")
         assert urls == [
             "https://www.linkedin.com/messaging/thread/2-aaa/",
             "https://www.linkedin.com/messaging/thread/2-ccc/",
         ]
+
+    async def test_resolver_passes_name_filter_to_enumerator(self, mock_page):
+        """_resolve_conversation_thread_urls scopes the click side effect by
+        forwarding name_filter so only the participant's row is clicked."""
+        extractor = LinkedInExtractor(mock_page)
+        refs_mock = AsyncMock(
+            return_value=[
+                {
+                    "kind": "conversation",
+                    "url": "/messaging/thread/2-aaa/",
+                    "text": "Jacki McMahan",
+                    "context": "inbox",
+                },
+            ]
+        )
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(extractor, "_extract_conversation_thread_refs", refs_mock),
+        ):
+            urls = await extractor._resolve_conversation_thread_urls("Jacki McMahan")
+
+        refs_mock.assert_awaited_once_with(
+            limit=ANY, context="inbox", name_filter="Jacki McMahan"
+        )
+        assert urls == ["https://www.linkedin.com/messaging/thread/2-aaa/"]
+
+    async def test_extract_refs_threads_name_filter_into_evaluate(self, mock_page):
+        """_extract_conversation_thread_refs forwards name_filter into the
+        in-browser click loop so non-matching rows are never clicked."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_selector = AsyncMock()
+        captured: dict[str, object] = {}
+
+        async def fake_evaluate(_js: str, arg: dict | None = None) -> list:
+            captured["arg"] = arg
+            return []
+
+        mock_page.evaluate = fake_evaluate
+
+        await extractor._extract_conversation_thread_refs(
+            limit=50, context="inbox", name_filter="Jacki McMahan"
+        )
+
+        assert captured["arg"] == {"limit": 50, "nameFilter": "Jacki McMahan"}
 
 
 class TestSearchConversations:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4012,6 +4012,52 @@ class TestResolveConversationThreadUrls:
         )
         assert urls == ["https://www.linkedin.com/messaging/thread/2-aaa/"]
 
+    async def test_resolver_falls_back_to_search_when_inbox_empty(self, mock_page):
+        """When the inbox scan finds no match, resolution falls back to the
+        messaging search for threads buried below the inbox window."""
+        extractor = LinkedInExtractor(mock_page)
+        nav_mock = AsyncMock()
+        # First call (inbox) finds nothing; second call (search) finds the thread.
+        refs_mock = AsyncMock(
+            side_effect=[
+                [],
+                [
+                    {
+                        "kind": "conversation",
+                        "url": "/messaging/thread/2-ddd/",
+                        "text": "Jacki McMahan",
+                        "context": "search",
+                    },
+                ],
+            ]
+        )
+        with (
+            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(extractor, "_extract_conversation_thread_refs", refs_mock),
+        ):
+            urls = await extractor._resolve_conversation_thread_urls("Jacki McMahan")
+
+        assert nav_mock.await_args_list[0].args == (
+            "https://www.linkedin.com/messaging/",
+        )
+        assert nav_mock.await_args_list[1].args == (
+            "https://www.linkedin.com/messaging/?searchTerm=Jacki+McMahan",
+        )
+        assert refs_mock.await_count == 2
+        assert urls == ["https://www.linkedin.com/messaging/thread/2-ddd/"]
+
     async def test_extract_refs_threads_name_filter_into_evaluate(self, mock_page):
         """_extract_conversation_thread_refs forwards name_filter into the
         in-browser click loop so non-matching rows are never clicked."""


### PR DESCRIPTION
Closes #434

`get_conversation(linkedin_username=...)` raised "Could not find a conversation" even when the thread existed and was fully readable by `thread_id`. This broke the verify-after-send workflow (send_message then get_conversation), leaving no programmatic way to confirm what landed.

The username-to-thread resolver navigated to `/messaging/?searchTerm={display_name}` and enumerated the search results. LinkedIn's messaging search returns "We didn't find anything" for the exact display name even when the identical thread is the top row of the plain inbox, so resolution found nothing. The issue's hypotheses (recency lag, InMail routing, name mismatch) don't hold: the thread was hours old, 1st-degree, and the inbox row's aria-label matched the profile name exactly.

The resolver now enumerates the plain inbox (`/messaging/`) the same way `get_inbox` already does, and passes a `name_filter` to the row enumerator so only the row matching the participant is clicked. Clicking a row can mark it read, so the filter keeps that side effect scoped to the requested participant instead of touching every recent thread. The exact-name match and multi-thread `index` selection are unchanged, and `get_inbox`/`search_conversations` are unaffected (the new parameter defaults to off).

`uv run pytest` passes (510 tests, including updated and new coverage for the inbox resolver). Verified live against a real account: `get_conversation` by username now returns the thread it previously couldn't find, and `get_inbox` still enumerates unchanged.
