### PR TITLE
docs(readme): sync tool status

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Through this LinkedIn MCP server, AI assistants like Claude can connect to your 
 | `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) [#432](https://github.com/stickerdaniel/linkedin-mcp-server/issues/432) [#448](https://github.com/stickerdaniel/linkedin-mcp-server/issues/448) [#454](https://github.com/stickerdaniel/linkedin-mcp-server/issues/454) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
-| `get_conversation` | Read a specific messaging conversation by username or thread ID | [#434](https://github.com/stickerdaniel/linkedin-mcp-server/issues/434) [#442](https://github.com/stickerdaniel/linkedin-mcp-server/issues/442) |
+| `get_conversation` | Read a specific messaging conversation by username or thread ID | [#442](https://github.com/stickerdaniel/linkedin-mcp-server/issues/442) |
 | `search_conversations` | Search messages by keyword | working |
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet | working |


### PR DESCRIPTION
Closes #479.

## Summary

- Remove closed issue #434 from the README Features & Tool Status row for `get_conversation`.
- Keep open issue #442 as the current `get_conversation` status.

## Verification

- pre-commit hooks from `gt create` passed for the README-only change.

## Synthetic prompt

> Sync the README Features & Tool Status table with current GitHub issues by removing closed get_conversation issue #434 while keeping open issue #442 linked. Create a docs issue and reference it from the PR so it closes on merge.

Generated with GPT-5 Codex.