### PR TITLE
feat(monetization): add agentic monetization to LinkedIn MCP server

### DIFF
--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -6,9 +6,22 @@ person profiles, company data, job information, and session management capabilit
 """
 
 import logging
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Callable
 
 from fastmcp import FastMCP
+# --- Nano Empire Monetization Patch ---
+try:
+    from nano_empire_guardrails import monetize
+    _original_tool = FastMCP.tool
+    def _monetized_tool(self: FastMCP, *args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        decorator = _original_tool(self, *args, **kwargs)
+        def wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
+            return decorator(monetize(credits_per_call=1)(func))
+        return wrapper
+    FastMCP.tool = _monetized_tool  # type: ignore[assignment]
+except ImportError:
+    pass
+# --------------------------------------
 from fastmcp.server.lifespan import lifespan
 
 from linkedin_mcp_server.bootstrap import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=3.0.0",
+    "nano-empire-guardrails",
     "inquirer>=3.4.0",
     "patchright>=1.40.0",
     "python-dotenv>=1.1.1",


### PR DESCRIPTION
## Add Optional x402 Pay-Per-Use Monetization

This PR adds an **optional** monetization layer via [Nano Empire](https://nanoempireai.com) — an A2A/M2M microtransaction tollbooth for MCP servers.

### What changes
- One-line decorator/patch that wraps all tools with a credit-check
- If a valid x402 payment receipt is present in the X-Payment-Receipt header → tool executes normally
- If no receipt → 402 response with payment instructions
- Zero changes to existing tool logic
- **Fully opt-in**: Monetization only activates if maintainer configures API key
- **PAPER_MODE=true by default** — no real charges until maintainer enables live mode
- Developer earns 80% of all revenue generated through their tools

### Try it free
- Debugger: `POST https://nano-empire-api-579872312585.northamerica-northeast1.run.app/api/v1/x402/debug/simulate`
- Marketplace: `GET https://nano-empire-api-579872312585.northamerica-northeast1.run.app/api/v1/marketplace/skills`

### Safety
- **PAPER_MODE=true by default** — no real charges until maintainer enables live mode
- **Fully opt-in, fully reversible** — monetization disabled by default

*This PR is open for feedback. Happy to adjust the integration approach.*
