### PR TITLE
fix(scraping): treat company posts pages as activity feeds

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1154,8 +1154,12 @@ class LinkedInExtractor:
         # Dismiss any modals blocking content
         await handle_modal_close(self._page)
 
-        # Activity feed pages lazy-load post content after the tab header
-        is_activity = "/recent-activity/" in url
+        # Activity feed pages lazy-load post content after the tab header.
+        # Company posts pages (/company/<slug>/posts/) lazy-load the same way
+        # but don't carry a /recent-activity/ path, so match them too.
+        is_activity = "/recent-activity/" in url or (
+            "/company/" in url and url.rstrip("/").endswith("/posts")
+        )
         if is_activity:
             try:
                 await self._page.wait_for_function(

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2500,6 +2500,47 @@ class TestActivityFeedExtraction:
         assert kwargs["max_scrolls"] == 10
         assert len(result.text) > 200
 
+    async def test_company_posts_page_waits_for_content_and_uses_slow_scroll(
+        self, mock_page
+    ):
+        """Company posts URLs get the same lazy-load wait and scroll budget
+        as person activity pages, even though they lack /recent-activity/."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Post content " * 50,
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/company/microsoft/posts/",
+                section_name="posts",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        mock_scroll.assert_awaited_once()
+        _, kwargs = mock_scroll.call_args
+        assert kwargs["pause_time"] == 1.0
+        assert kwargs["max_scrolls"] == 10
+        assert len(result.text) > 200
+
     async def test_non_activity_non_details_page_skips_wait_and_uses_fast_scroll(
         self, mock_page
     ):


### PR DESCRIPTION
Company posts pages (/company/<slug>/posts/) lazy-load content the same way person /recent-activity/ pages do, but lacked the content-ready wait and 10-scroll budget since is_activity only matched /recent-activity/. Extend detection so company post scraping loads as many posts as person activity scraping does.

https://claude.ai/code/session_012sXhsoKXZuFbHLtsEeYPks