### PR TITLE
refactor: Remove browser warm-up before LinkedIn login

### DIFF
--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -584,7 +584,7 @@ def _move_invalid_auth_state_aside() -> None:
 
 async def _run_login_flow() -> None:
     _state.auth_state = AuthState.IN_PROGRESS
-    success = await interactive_login(get_profile_dir(), warm_up=True)
+    success = await interactive_login(get_profile_dir())
     if not success:
         raise AuthenticationBootstrapFailedError(
             "LinkedIn login was not completed. Retry the tool call to reopen the browser and continue setup."

--- a/linkedin_mcp_server/core/__init__.py
+++ b/linkedin_mcp_server/core/__init__.py
@@ -6,7 +6,6 @@ from .auth import (
     is_logged_in,
     resolve_remember_me_prompt,
     wait_for_manual_login,
-    warm_up_browser,
 )
 from .browser import BrowserManager
 from .exceptions import (
@@ -37,5 +36,4 @@ __all__ = [
     "resolve_remember_me_prompt",
     "scroll_to_bottom",
     "wait_for_manual_login",
-    "warm_up_browser",
 ]

--- a/linkedin_mcp_server/core/auth.py
+++ b/linkedin_mcp_server/core/auth.py
@@ -33,33 +33,6 @@ _REMEMBER_ME_CONTAINER_SELECTOR = "#rememberme-div"
 _REMEMBER_ME_BUTTON_SELECTOR = "#rememberme-div button"
 
 
-async def warm_up_browser(page: Page) -> None:
-    """Visit normal sites to appear more human-like before LinkedIn access."""
-    sites = [
-        "https://www.google.com",
-        "https://www.wikipedia.org",
-        "https://www.github.com",
-    ]
-
-    logger.info("Warming up browser by visiting normal sites...")
-
-    failures = 0
-    for site in sites:
-        try:
-            await page.goto(site, wait_until="domcontentloaded", timeout=10000)
-            await asyncio.sleep(1)
-            logger.debug("Visited %s", site)
-        except Exception as e:
-            failures += 1
-            logger.debug("Could not visit %s: %s", site, e)
-            continue
-
-    if failures == len(sites):
-        logger.warning("Browser warm-up failed: none of %d sites reachable", len(sites))
-    else:
-        logger.info("Browser warm-up complete")
-
-
 async def is_logged_in(page: Page) -> bool:
     """Check if currently logged in to LinkedIn.
 

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -14,16 +14,13 @@ from linkedin_mcp_server.core import (
     BrowserManager,
     resolve_remember_me_prompt,
     wait_for_manual_login,
-    warm_up_browser,
 )
 from linkedin_mcp_server.session_state import portable_cookie_path, write_source_state
 
 from linkedin_mcp_server.drivers.browser import get_profile_dir
 
 
-async def interactive_login(
-    user_data_dir: Path | None = None, warm_up: bool = True
-) -> bool:
+async def interactive_login(user_data_dir: Path | None = None) -> bool:
     """
     Open browser for manual LinkedIn login with persistent profile.
 
@@ -33,7 +30,6 @@ async def interactive_login(
 
     Args:
         user_data_dir: Path to browser profile. Defaults to config's user_data_dir.
-        warm_up: Visit normal sites first to appear more human-like (default: True)
 
     Returns:
         True if login was successful
@@ -66,11 +62,6 @@ async def interactive_login(
         viewport=viewport,
         **launch_options,
     ) as browser:
-        # Warm up browser to appear more human-like and avoid security checkpoints
-        if warm_up:
-            print("   Warming up browser (visiting normal sites first)...")
-            await warm_up_browser(browser.page)
-
         # Navigate to LinkedIn login
         await browser.page.goto("https://www.linkedin.com/login")
         # Let LinkedIn finish rendering the saved-account chooser, then retry the

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -43,7 +43,6 @@ def _patch_login_deps(
         "linkedin_mcp_server.setup.get_config", lambda: config or AppConfig()
     )
     monkeypatch.setattr("linkedin_mcp_server.setup.BrowserManager", browser_factory)
-    monkeypatch.setattr("linkedin_mcp_server.setup.warm_up_browser", AsyncMock())
     monkeypatch.setattr(
         "linkedin_mcp_server.setup.resolve_remember_me_prompt",
         AsyncMock(return_value=False),


### PR DESCRIPTION
The `--login` flow opened the browser and visited Google, Wikipedia, and GitHub before navigating to LinkedIn, meant to look more human and avoid security checkpoints. That premise does not hold. LinkedIn runs in its own origin and cannot observe visits to other origins: same-origin policy and cookie partitioning keep those cookies out of its reach, and visiting other sites does not change the browser fingerprint. The only state it altered that LinkedIn can read is in-tab `history.length`, a weak signal with no evidence LinkedIn keys on it. The real stealth comes from Patchright and the persistent profile, not from the warm-up.

It also hurt the first-run experience: a freshly opened browser loading unrelated sites looks like malware to a new user.

This removes `warm_up_browser`, its core export, and the `warm_up` parameter from `interactive_login`, plus the call site in the login flow. `interactive_login` now navigates straight to the LinkedIn login page.

`uv run pytest` passes (511 tests). `ruff check`, `ruff format --check`, and `ty check` are clean.