### PR TITLE
feat(skills): add ordered triage/repro/verify workflow

### DIFF
--- a/.agents/skills/1-triage-issues/SKILL.md
+++ b/.agents/skills/1-triage-issues/SKILL.md
@@ -48,7 +48,7 @@ For every open PR, on top of its linked-issue score:
 
 - **Mergeability**: `mergeable: MERGEABLE` + `mergeStateStatus: CLEAN` + `statusCheckRollup` all green → ✓. Otherwise note what blocks (CI red, conflicts, requested changes, draft).
 - **Scope**: `additions + deletions` and `changedFiles`. Flag scope creep — does it touch unrelated files? Cross-check `gh pr diff <N> --name-only`.
-- **Locale + DOM safety audit**: do `gh pr diff <N> | grep -E '"(Connect|Follow|Message|Pending|1st|2nd|3rd)"'` — any string match on locale-dependent button text is a red flag per `CLAUDE.md → Scraping Rules → detection must be locale-independent`. Also flag class-name selectors (`.entity-result__item`) — minimal generic selectors only.
+- **Locale + DOM safety audit**: do `gh pr diff <N> | grep -E "['\"](Connect|Follow|Message|Pending|1st|2nd|3rd)['\"]"` (matches both Python-style `'Connect'` and JS/Go-style `"Connect"`). Any string match on locale-dependent button text is a red flag per `CLAUDE.md → Scraping Rules → detection must be locale-independent`. Also flag class-name selectors (`.entity-result__item`), minimal generic selectors only.
 - **One-section-one-navigation**: if the PR touches `PERSON_SECTIONS` / `COMPANY_SECTIONS` in `scraping/fields.py`, check that each entry still maps to exactly one URL.
 - **Test coverage**: does the diff add a test in `tests/test_scraping.py`? Mandatory for new tool surfaces, strongly preferred for bug fixes.
 - **Contributor audit**:

--- a/.agents/skills/1-triage-issues/SKILL.md
+++ b/.agents/skills/1-triage-issues/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: 1-triage-issues
+description: Scan all open issues and PRs in stickerdaniel/linkedin-mcp-server and rank them by urgency (severity, user impact, age, references), implementation quality (for PRs — mergeability, CI, diff scope, locale-independence, test coverage), and contributor track record (prior merged PRs, review quality, response cadence). Use when the user asks "what should I tackle first as core maintainer", "which PRs are production-ready", "triage backlog", "scan open issues", or any maintainer-prioritisation question about this repo. Outputs a ranked list with rationale per item, not a fix.
+argument-hint: '[label-or-keyword-filter]'
+---
+
+# Triage Open Issues and PRs
+
+Goal: in one pass, turn the live state of `stickerdaniel/linkedin-mcp-server` into a maintainer-grade priority list. Read-only. No checkout, no edits, no reproduction. Reproduction belongs in `/2-repro-issue`; PR verification in `/3-verify-pr-fix`.
+
+## Inputs
+
+`$ARGUMENTS` is optional. If set, treat as a label name (`bug`, `enhancement`) or freetext filter to narrow the scope. Otherwise scan everything open.
+
+## Phase 1 — Gather
+
+```bash
+REPO=stickerdaniel/linkedin-mcp-server
+
+# Issues  (gh calls the reactions field `reactionGroups`, not `reactions`)
+gh issue list --repo $REPO --state open --limit 200 \
+  --json number,title,labels,createdAt,updatedAt,author,comments,reactionGroups,body
+
+# PRs
+gh pr list --repo $REPO --state open --limit 100 \
+  --json number,title,labels,createdAt,updatedAt,author,mergeable,mergeStateStatus,statusCheckRollup,additions,deletions,changedFiles,reviewDecision,isDraft,headRepositoryOwner
+
+# Cross-link issues ↔ PRs via body references
+gh search prs --repo $REPO --state open --json number,body,title --limit 100
+```
+
+Build a map `issue_number → [referencing_pr_numbers]` by scanning PR bodies for `Closes #`, `Fixes #`, `Resolves #`, plain `#N`.
+
+If `$ARGUMENTS` is given, filter both lists down before scoring.
+
+## Phase 2 — Score each issue
+
+For every open issue, compute four signals. Cite the evidence inline so the user can audit.
+
+- **Severity** (1–5): `5` = data loss / broken-for-all-users / security; `4` = core tool unavailable (e.g. `get_person_profile` returning empty); `3` = degraded output for a subset (locale, edge-case profile); `2` = annoyance / cosmetic; `1` = question / docs. Read the body + labels (`bug`, `critical`, `security`, `regression`).
+- **Reach** (1–5): comment count, distinct commenters, `+1`/`👍` reactions, references from other issues.
+- **Age vs activity**: `createdAt` → days old; `updatedAt` → days since last activity. Stale-but-high-severity ranks higher than fresh-but-cosmetic.
+- **Has fix in flight**: did anyone open a PR (look up in cross-link map)? Is that PR ready to merge?
+
+## Phase 3 — Score each PR
+
+For every open PR, on top of its linked-issue score:
+
+- **Mergeability**: `mergeable: MERGEABLE` + `mergeStateStatus: CLEAN` + `statusCheckRollup` all green → ✓. Otherwise note what blocks (CI red, conflicts, requested changes, draft).
+- **Scope**: `additions + deletions` and `changedFiles`. Flag scope creep — does it touch unrelated files? Cross-check `gh pr diff <N> --name-only`.
+- **Locale + DOM safety audit**: do `gh pr diff <N> | grep -E '"(Connect|Follow|Message|Pending|1st|2nd|3rd)"'` — any string match on locale-dependent button text is a red flag per `CLAUDE.md → Scraping Rules → detection must be locale-independent`. Also flag class-name selectors (`.entity-result__item`) — minimal generic selectors only.
+- **One-section-one-navigation**: if the PR touches `PERSON_SECTIONS` / `COMPANY_SECTIONS` in `scraping/fields.py`, check that each entry still maps to exactly one URL.
+- **Test coverage**: does the diff add a test in `tests/test_scraping.py`? Mandatory for new tool surfaces, strongly preferred for bug fixes.
+- **Contributor audit**:
+  ```bash
+  gh search prs --repo $REPO --author <login> --state merged --json number,createdAt,mergedAt,additions,deletions --limit 20
+  gh search prs --repo $REPO --author <login> --state closed --json number,closedAt,state --limit 10
+  ```
+  Compute: prior merged PRs in this repo, average time-to-merge, ratio of merged-vs-closed-unmerged. First-time contributors are not penalised — but a contributor whose previous PRs were all closed-unmerged with maintainer pushback is a yellow flag, especially on a large diff. Cite specific PR numbers in the rationale.
+
+For very large or architecturally-loaded PRs (changes to `scraping/extractor.py`, `client/`, or session/auth code), spawn an `Explore` subagent to deep-dive how the PR integrates with the codebase and report integration risk. Use this sparingly — only for PRs over ~200 LOC or PRs touching core paths.
+
+## Phase 4 — Rank and report
+
+Two ranked tables, plus a short verdict. Imperative, no fluff.
+
+```
+## Issues — top 10
+
+| # | Issue | Severity | Reach | Age | PR? | Why this rank |
+|---|-------|----------|-------|-----|-----|---------------|
+| 1 | #366  | 4        | 8     | 12d | #366 ready | Core tool broken, contributor inactive |
+| 2 | #389  | 3        | 2     |  5d | none | Pydantic version regression, blocks installs |
+| ...
+
+## PRs — production-readiness ranking
+
+| # | PR | Linked issue | Mergeable | Scope | Locale-safe | Tests | Contributor | Verdict |
+|---|----|--------------|-----------|-------|-------------|-------|-------------|---------|
+| 1 | #386 | #385       | ✓         | +120/-40, 3 files | ✓ | ✓ | 5 prior merged | Ready — merge |
+| 2 | #366 | #365       | ✗ conflict | +800/-200, 12 files | ✗ uses "Connect" text | ✗ | 0 prior, 2 closed | Needs maintainer rewrite |
+| ...
+
+## Recommended order this week
+
+1. Merge #386 — clean fix, ready.
+2. Take over #366 via maintainer-edits — issue is core but PR has locale-issues and stalled contributor.
+3. Investigate #389 — needs reproduction first (→ `/2-repro-issue 389`).
+```
+
+End with one paragraph naming the *next concrete action* the maintainer should take, and which downstream skill applies (`/2-repro-issue <N>` to confirm bug, `/3-verify-pr-fix <N>` to test the candidate fix).
+
+## Non-negotiables
+
+- Read-only. Do not check out, do not start the MCP server, do not run scrapers. Those are downstream skills.
+- Cite evidence inline (PR/issue numbers, file paths, contributor PR history). Never assert "looks risky" without a referenceable signal.
+- Locale-dependence and DOM-class-selector usage are hard fails — flag them red regardless of how nice the PR otherwise looks.
+- Never recommend "merge as-is" for a PR that hasn't passed the locale/test/scope checks, even if the contributor is well-known.

--- a/.agents/skills/2-repro-issue/SKILL.md
+++ b/.agents/skills/2-repro-issue/SKILL.md
@@ -11,7 +11,9 @@ Goal: take an issue number, run the exact failing tool call against the real Lin
 ## Phase 1 — Read and map
 
 ```bash
-NUM="$ARGUMENTS"
+# Accept "442", "#442", or "https://github.com/.../issues/442" — extract the digits only
+NUM=$(echo "$ARGUMENTS" | sed -E 's|.*/||; s|#||g' | grep -oE '^[0-9]+' | head -1)
+[ -z "$NUM" ] && { echo "Invalid input: '$ARGUMENTS'. Pass an issue number or URL." >&2; exit 1; }
 REPO=stickerdaniel/linkedin-mcp-server
 
 gh issue view $NUM --repo $REPO --comments
@@ -58,11 +60,20 @@ echo $PORT > /tmp/repro-$NUM.port
 # Start in background
 uv run -m linkedin_mcp_server --transport streamable-http --port $PORT --log-level INFO > /tmp/repro-$NUM.log 2>&1 &
 SERVER_PID=$!
-sleep 8
-echo "Server PID: $SERVER_PID  Port: $PORT"
+echo $SERVER_PID > /tmp/repro-$NUM.pid
+
+# Wait for the port to actually start LISTENing instead of a blind sleep.
+# Cap at ~30s so a stuck startup doesn't hang the run.
+for i in $(seq 1 30); do
+  lsof -nP -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1 && break
+  kill -0 $SERVER_PID 2>/dev/null || { echo "Server died during startup. Tail of /tmp/repro-$NUM.log:" >&2; tail -20 /tmp/repro-$NUM.log >&2; exit 1; }
+  sleep 1
+done
+lsof -nP -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1 || { echo "Server never bound port $PORT after 30s" >&2; tail -20 /tmp/repro-$NUM.log >&2; exit 1; }
+echo "Server PID: $SERVER_PID  Port: $PORT  Ready"
 ```
 
-If `/tmp/repro-$NUM.log` shows login failure or browser issues, stop and report — do not try to brute-force around it.
+If `/tmp/repro-$NUM.log` shows login failure or browser issues, stop and report, do not try to brute-force around it.
 
 ## Phase 4 — Initialize MCP session
 
@@ -86,14 +97,21 @@ The `notifications/initialized` post often returns `{"error":{"code":-32602,"mes
 
 ## Phase 5 — Call the failing tool
 
-Substitute the tool name and arguments from Phase 1 verbatim. Save the full response to a stable path so `/3-verify-pr-fix` can pick it up later.
+Substitute the tool name and arguments from Phase 1 verbatim. Save the response to a stable path **and** persist the request metadata so `/3-verify-pr-fix` can replay the exact same call without guessing.
 
 ```bash
+TOOL="<TOOL>"                 # e.g. get_person_profile
+ARGS_JSON='{<ARGS>}'           # e.g. {"linkedin_username":"williamhgates","sections":"basic_info"}
+
+# Persist what we are about to call so the verifier can re-run identically
+jq -n --arg t "$TOOL" --argjson a "$ARGS_JSON" '{tool: $t, arguments: $a}' \
+  > /tmp/repro-issue-$NUM-meta.json
+
 curl -s -X POST http://127.0.0.1:$PORT/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -H "Mcp-Session-Id: $SESSION_ID" \
-  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"<TOOL>","arguments":{<ARGS>}}}' \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"$TOOL\",\"arguments\":$ARGS_JSON}}" \
   | tee /tmp/repro-issue-$NUM-main.json | head -200
 ```
 
@@ -125,8 +143,9 @@ Locate the failure in code:
 ```bash
 kill $SERVER_PID 2>/dev/null
 wait $SERVER_PID 2>/dev/null
-rm -f /tmp/repro-$NUM-headers /tmp/repro-$NUM.log /tmp/repro-$NUM.port
-# Keep /tmp/repro-issue-$NUM-main.json — /3-verify-pr-fix uses it as baseline.
+rm -f /tmp/repro-$NUM-headers /tmp/repro-$NUM.log /tmp/repro-$NUM.port /tmp/repro-$NUM.pid
+# Keep /tmp/repro-issue-$NUM-main.json (response baseline) and
+# /tmp/repro-issue-$NUM-meta.json (tool + args) — /3-verify-pr-fix uses both.
 ```
 
 Report format:

--- a/.agents/skills/2-repro-issue/SKILL.md
+++ b/.agents/skills/2-repro-issue/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: 2-repro-issue
+description: Reproduce a single LinkedIn-MCP issue locally on the current branch against the real authenticated LinkedIn session at ~/.linkedin-mcp/profile/, using the MCP streamable-http server. Captures the exact failure mode (tool output, error, missing data) and maps it back to the scraper code path. Use when the user says "reproduce #N", "investigate #N", "try #N locally", "verify the bug in #N", or pastes an issue URL from stickerdaniel/linkedin-mcp-server. Does NOT check out a PR or attempt a fix — that's /3-verify-pr-fix.
+argument-hint: '<issue-number-or-url>'
+---
+
+# Reproduce a LinkedIn-MCP Issue Locally
+
+Goal: take an issue number, run the exact failing tool call against the real LinkedIn via the local MCP server, and produce concrete evidence — output JSON, error message, partial state — that confirms or refutes the bug on the current branch. Always use the authenticated profile already at `~/.linkedin-mcp/profile/`. Never mock.
+
+## Phase 1 — Read and map
+
+```bash
+NUM="$ARGUMENTS"
+REPO=stickerdaniel/linkedin-mcp-server
+
+gh issue view $NUM --repo $REPO --comments
+```
+
+From the issue body extract:
+
+- **Which MCP tool** is affected (`get_person_profile`, `connect_with_person`, `search_jobs`, …). The issue templates ask for this explicitly.
+- **The exact arguments** that trigger the failure (username, company slug, job ID, sections list).
+- **The expected vs actual** behaviour.
+- **Any locale signal** — German UI, non-English profile name, RTL language. Locale-sensitive bugs need a deliberately diverse target.
+
+Map the tool to code so you know where to look if the repro confirms the bug:
+
+1. `linkedin_mcp_server/tools/<surface>.py` — MCP entrypoint and arg validation
+2. `linkedin_mcp_server/scraping/<feature>.py` — actual scraping (`extractor.py`, `connection.py`, `feed.py`, `inbox.py`, …)
+3. `linkedin_mcp_server/scraping/fields.py` — `PERSON_SECTIONS` / `COMPANY_SECTIONS` (each entry = one navigation)
+4. Existing test in `tests/test_scraping.py` covering the same surface
+
+State out loud before running anything: "Reproducing tool `X` with args `Y` on branch `<current>` — expecting `<failure mode from issue>`."
+
+## Phase 2 — Confirm session, branch, dependencies
+
+```bash
+git status --porcelain | head -5         # workspace must be clean
+git log -1 --oneline                     # record the SHA we're testing
+ls ~/.linkedin-mcp/profile/ | head -3    # profile must exist
+```
+
+If the workspace is dirty, ask the user before continuing — they may have local changes that affect the repro. If the profile is missing or stale, run `uv run -m linkedin_mcp_server --login` once and only once per skill invocation.
+
+## Phase 3 — Run the MCP server
+
+Always `uv run`, never `uvx` — the running server must reflect the current workspace (per `CLAUDE.md → Verifying Bug Reports`).
+
+Default port 8000 is commonly taken by other dev servers (workspace-mcp, etc.). Probe for a free port from 8765 upward instead of failing late on `address already in use`:
+
+```bash
+# Probe a free port starting at 8765
+PORT=8765
+while lsof -nP -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1; do PORT=$((PORT+1)); done
+echo $PORT > /tmp/repro-$NUM.port
+
+# Start in background
+uv run -m linkedin_mcp_server --transport streamable-http --port $PORT --log-level INFO > /tmp/repro-$NUM.log 2>&1 &
+SERVER_PID=$!
+sleep 8
+echo "Server PID: $SERVER_PID  Port: $PORT"
+```
+
+If `/tmp/repro-$NUM.log` shows login failure or browser issues, stop and report — do not try to brute-force around it.
+
+## Phase 4 — Initialize MCP session
+
+```bash
+PORT=$(cat /tmp/repro-$NUM.port)
+curl -s -D /tmp/repro-$NUM-headers -X POST http://127.0.0.1:$PORT/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"repro-issue","version":"1.0"}}}' > /dev/null
+
+SESSION_ID=$(grep -i 'Mcp-Session-Id' /tmp/repro-$NUM-headers | awk '{print $2}' | tr -d '\r')
+
+curl -s -X POST http://127.0.0.1:$PORT/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"notifications/initialized","params":{}}' > /dev/null
+```
+
+The `notifications/initialized` post often returns `{"error":{"code":-32602,"message":"Invalid request parameters"}}` and the server log shows a long pydantic ClientRequest validation dump. **This is harmless.** The session is still valid and `tools/call` works on the same `SESSION_ID`. Do not retry, do not treat as a session failure.
+
+## Phase 5 — Call the failing tool
+
+Substitute the tool name and arguments from Phase 1 verbatim. Save the full response to a stable path so `/3-verify-pr-fix` can pick it up later.
+
+```bash
+curl -s -X POST http://127.0.0.1:$PORT/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"<TOOL>","arguments":{<ARGS>}}}' \
+  | tee /tmp/repro-issue-$NUM-main.json | head -200
+```
+
+If the issue doesn't pin a concrete target, pick a stable public one:
+
+- Person tools: `williamhgates`, plus one non-English target if locale matters.
+- Company tools: `microsoft`, plus one German/EU company if locale matters.
+- Search tools: a query from the issue, else a deliberately diverse phrase.
+
+Run the call twice if the result looks flaky (network, slow render) — LinkedIn rate-limit / partial-render can mask real bugs.
+
+## Phase 6 — Classify
+
+Read `/tmp/repro-issue-$NUM-main.json` and the server log. Pick one verdict:
+
+- **Reproduced ✓** — failure matches the issue description. Note exactly what's missing/wrong (which section is empty, which reference field is null, which error is raised).
+- **Reproduced different mode ⚠** — there is a problem but it doesn't match the issue exactly. Could be a related-but-distinct bug.
+- **Not reproduced ✗** — tool returned expected data. The bug may already be fixed in an unreleased commit (check `git log --oneline -20` and last release tag) or the issue may be environment-specific (different LinkedIn account, different locale).
+- **Inconclusive** — network/rate-limit/login error, not a code-level signal.
+
+Locate the failure in code:
+
+- Grep for the tool name: `grep -rn "def <tool>" linkedin_mcp_server/`
+- Trace from tool entrypoint into the scraper module.
+- For empty-section bugs, check `scraping/fields.py` for the section's URL and verify it's correct.
+
+## Phase 7 — Report and clean up
+
+```bash
+kill $SERVER_PID 2>/dev/null
+wait $SERVER_PID 2>/dev/null
+rm -f /tmp/repro-$NUM-headers /tmp/repro-$NUM.log /tmp/repro-$NUM.port
+# Keep /tmp/repro-issue-$NUM-main.json — /3-verify-pr-fix uses it as baseline.
+```
+
+Report format:
+
+```
+**#<N>** — <one-line issue summary>
+**Branch / SHA:** <branch> @ <short-sha>
+**Tool / args:** <TOOL>(<ARGS>)
+**Verdict:** <Reproduced ✓ | Reproduced different mode ⚠ | Not reproduced ✗ | Inconclusive>
+**Evidence:** <2–4 lines of the actual tool output that proves the verdict>
+**Likely code path:** <file:line> — <one-line why>
+**Baseline saved at:** /tmp/repro-issue-<N>-main.json (used by /3-verify-pr-fix)
+**Next:** <suggest /3-verify-pr-fix N if a candidate PR exists | suggest fix sketch | suggest closing as already-fixed>
+```
+
+## Non-negotiables
+
+- Real LinkedIn against the real profile. No mocks, no fixtures.
+- `uv run`, not `uvx`. The server must reflect the workspace.
+- One run per skill invocation — don't repeatedly hammer LinkedIn.
+- Do not edit code, do not commit, do not check out a PR. This skill only reproduces and reports.
+- If the workspace is dirty, ask before continuing — local changes can hide or fake the bug.

--- a/.agents/skills/2-repro-issue/SKILL.md
+++ b/.agents/skills/2-repro-issue/SKILL.md
@@ -85,6 +85,7 @@ curl -s -D /tmp/repro-$NUM-headers -X POST http://127.0.0.1:$PORT/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"repro-issue","version":"1.0"}}}' > /dev/null
 
 SESSION_ID=$(grep -i 'Mcp-Session-Id' /tmp/repro-$NUM-headers | awk '{print $2}' | tr -d '\r')
+[ -z "$SESSION_ID" ] && { echo "MCP initialize returned no Mcp-Session-Id. Tail of /tmp/repro-$NUM.log:" >&2; tail -20 /tmp/repro-$NUM.log >&2; kill $SERVER_PID 2>/dev/null; exit 1; }
 
 curl -s -X POST http://127.0.0.1:$PORT/mcp \
   -H "Content-Type: application/json" \

--- a/.agents/skills/3-verify-pr-fix/SKILL.md
+++ b/.agents/skills/3-verify-pr-fix/SKILL.md
@@ -11,7 +11,9 @@ Goal: take a PR number, check it out cleanly, re-run the same tool call that fai
 ## Phase 1 — Resolve the PR and its linked issue
 
 ```bash
-PR="$ARGUMENTS"
+# Accept "498", "#498", or "https://github.com/.../pull/498" — extract the digits only
+PR=$(echo "$ARGUMENTS" | sed -E 's|.*/||; s|#||g' | grep -oE '^[0-9]+' | head -1)
+[ -z "$PR" ] && { echo "Invalid input: '$ARGUMENTS'. Pass a PR number or URL." >&2; exit 1; }
 REPO=stickerdaniel/linkedin-mcp-server
 
 gh pr view $PR --repo $REPO --json title,body,baseRefName,headRefName,headRepositoryOwner,mergeable,mergeStateStatus,additions,deletions,changedFiles,maintainerCanModify,statusCheckRollup
@@ -19,17 +21,26 @@ gh pr view $PR --repo $REPO --json title,body,baseRefName,headRefName,headReposi
 
 Extract the **linked issue number** from the PR body (`Closes #`, `Fixes #`, `Resolves #`, or plain `#N`). Call it `ISSUE`. If multiple, ask the user which one is the verification target.
 
-## Phase 2 — Pick up or create the baseline
+## Phase 2 — Pick up the baseline + request metadata
 
-`/2-repro-issue` writes `/tmp/repro-issue-<ISSUE>-main.json` and remembers the exact tool + args used. Check that file exists.
+`/2-repro-issue` writes two files for each issue:
+
+- `/tmp/repro-issue-<ISSUE>-main.json` — the on-main response baseline
+- `/tmp/repro-issue-<ISSUE>-meta.json` — the `{tool, arguments}` used to call it
+
+Both must exist. The meta file is how this skill replays the *exact* same call instead of guessing tool and args from the response body.
 
 ```bash
-ls -la /tmp/repro-issue-$ISSUE-main.json 2>&1
+ls -la /tmp/repro-issue-$ISSUE-main.json /tmp/repro-issue-$ISSUE-meta.json 2>&1
+[ -s /tmp/repro-issue-$ISSUE-meta.json ] || { echo "Missing or empty meta file. Re-run /2-repro-issue $ISSUE." >&2; exit 1; }
+TOOL=$(jq -r .tool /tmp/repro-issue-$ISSUE-meta.json)
+ARGS_JSON=$(jq -c .arguments /tmp/repro-issue-$ISSUE-meta.json)
+echo "Replaying: $TOOL($ARGS_JSON)"
 ```
 
-If missing, stop and tell the user: *"No baseline for #$ISSUE. Run `/2-repro-issue $ISSUE` first so we have an on-main reference to diff against."* Do not silently re-run the reproduction — `/2-repro-issue` is the canonical source of "what's the call, what's the failure mode".
+If either file is missing, stop and tell the user: *"No baseline for #$ISSUE. Run `/2-repro-issue $ISSUE` first so we have an on-main reference to diff against."* Do not silently re-run the reproduction, `/2-repro-issue` is the canonical source of "what's the call, what's the failure mode".
 
-If the baseline is older than 24 h, warn — LinkedIn DOM/data may have shifted. Offer to re-run `/2-repro-issue` first.
+If the baseline is older than 24 h, warn, LinkedIn DOM/data may have shifted. Offer to re-run `/2-repro-issue` first.
 
 ## Phase 3 — Check out the PR
 
@@ -37,8 +48,13 @@ If the baseline is older than 24 h, warn — LinkedIn DOM/data may have shifted.
 git status --porcelain | head -5     # must be clean
 git stash list | head -3             # warn if there are stashes the user may forget
 
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)   # remember where to return
-git fetch origin pull/$PR/head:pr-$PR
+# Remember where to return. `--abbrev-ref HEAD` returns the literal string "HEAD"
+# in detached state (CI worktrees, prior PR checkouts), so fall back to the SHA.
+CURRENT_REF=$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)
+
+# Force-update the local pr-$PR ref so a leftover from a failed prior run does
+# not block the fetch.
+git fetch origin "+pull/$PR/head:pr-$PR"
 git checkout pr-$PR
 
 # Scope sanity check
@@ -52,14 +68,22 @@ If `maintainerCanModify: true`, mention that to the user; it unlocks the "take o
 
 ## Phase 4 — Re-run the same MCP call on the PR branch
 
-Extract the original tool + args from the baseline JSON (`/2-repro-issue` saves the full response which includes the request envelope in the conversation). Restart the server because old workers hold the old code. Probe a free port (default 8000 is commonly taken):
+`$TOOL` and `$ARGS_JSON` came from the meta file in Phase 2. Restart the server because old workers hold the old code. Probe a free port (default 8000 is commonly taken):
 
 ```bash
 PORT=8765
 while lsof -nP -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1; do PORT=$((PORT+1)); done
 uv run -m linkedin_mcp_server --transport streamable-http --port $PORT --log-level INFO > /tmp/verify-pr-$PR.log 2>&1 &
 SERVER_PID=$!
-sleep 8
+
+# Wait for the port to actually start LISTENing (cap 30s) — a blind sleep would
+# let a startup crash silently become a "does not fix" verdict.
+for i in $(seq 1 30); do
+  lsof -nP -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1 && break
+  kill -0 $SERVER_PID 2>/dev/null || { echo "Server died during startup. Tail of /tmp/verify-pr-$PR.log:" >&2; tail -20 /tmp/verify-pr-$PR.log >&2; exit 1; }
+  sleep 1
+done
+lsof -nP -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1 || { echo "Server never bound port $PORT after 30s" >&2; tail -20 /tmp/verify-pr-$PR.log >&2; exit 1; }
 
 curl -s -D /tmp/verify-pr-$PR-headers -X POST http://127.0.0.1:$PORT/mcp \
   -H "Content-Type: application/json" \
@@ -67,21 +91,22 @@ curl -s -D /tmp/verify-pr-$PR-headers -X POST http://127.0.0.1:$PORT/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"verify-pr","version":"1.0"}}}' > /dev/null
 
 SESSION_ID=$(grep -i 'Mcp-Session-Id' /tmp/verify-pr-$PR-headers | awk '{print $2}' | tr -d '\r')
+[ -z "$SESSION_ID" ] && { echo "MCP initialize returned no Mcp-Session-Id. Tail of /tmp/verify-pr-$PR.log:" >&2; tail -20 /tmp/verify-pr-$PR.log >&2; kill $SERVER_PID 2>/dev/null; exit 1; }
 
 # notifications/initialized often replies with a pydantic validation error.
-# Harmless — same session ID still works for tools/call.
+# Harmless, same session ID still works for tools/call.
 curl -s -X POST http://127.0.0.1:$PORT/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -H "Mcp-Session-Id: $SESSION_ID" \
   -d '{"jsonrpc":"2.0","id":2,"method":"notifications/initialized","params":{}}' > /dev/null
 
-# Same tool + args as baseline:
+# Same tool + args as baseline, pulled verbatim from /tmp/repro-issue-$ISSUE-meta.json:
 curl -s -X POST http://127.0.0.1:$PORT/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -H "Mcp-Session-Id: $SESSION_ID" \
-  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"<TOOL>","arguments":{<ARGS>}}}' \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"$TOOL\",\"arguments\":$ARGS_JSON}}" \
   | tee /tmp/verify-pr-$PR.json | head -200
 
 kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null
@@ -136,10 +161,10 @@ Then one short paragraph: what the PR actually changes, why it does/doesn't addr
 ## Phase 8 — Cleanup
 
 ```bash
-git checkout "$CURRENT_BRANCH"
+git checkout "$CURRENT_REF"
 git branch -D pr-$PR 2>/dev/null
 rm -f /tmp/verify-pr-$PR.json /tmp/verify-pr-$PR-headers /tmp/verify-pr-$PR.log /tmp/pr-$PR-meta.json
-# Keep /tmp/repro-issue-$ISSUE-main.json so the user can re-verify against another PR later.
+# Keep /tmp/repro-issue-$ISSUE-main.json + meta.json so the user can re-verify against another PR later.
 ```
 
 Leave the user on the branch they started on, with a clean working tree.

--- a/.agents/skills/3-verify-pr-fix/SKILL.md
+++ b/.agents/skills/3-verify-pr-fix/SKILL.md
@@ -58,7 +58,9 @@ CURRENT_REF=$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)
 # Fetch the PR head into FETCH_HEAD only and check it out as a detached HEAD.
 # Skipping a named local branch avoids clobbering a maintainer's existing
 # `pr-$PR` work and removes the cleanup-time `git branch -D` foot-gun.
-git fetch origin "pull/$PR/head"
+# Guard the fetch: without it a network/auth failure or deleted pull ref would
+# leave a stale FETCH_HEAD and the verdict would run against the wrong commit.
+git fetch origin "pull/$PR/head" || { echo "git fetch for PR #$PR failed, aborting before checkout." >&2; exit 1; }
 PR_SHA=$(git rev-parse FETCH_HEAD)
 git checkout --detach "$PR_SHA"
 

--- a/.agents/skills/3-verify-pr-fix/SKILL.md
+++ b/.agents/skills/3-verify-pr-fix/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: 3-verify-pr-fix
+description: Check out a candidate PR locally, restart the MCP server on the PR branch, re-run the exact same MCP tool call that failed in /2-repro-issue, diff the outputs, and audit the fix for locale-independence, DOM-stability, and scope per CLAUDE.md scraping rules. Use when the user says "verify PR #N", "does this PR fix #M", "check #N locally", "test the fix in #N", or asks whether a candidate PR actually solves a previously-reproduced issue. Assumes /2-repro-issue has already captured the on-main baseline at /tmp/repro-issue-<linked>-main.json — if not, run /2-repro-issue first.
+argument-hint: '<pr-number-or-url>'
+---
+
+# Verify a Candidate PR Actually Fixes the Issue
+
+Goal: take a PR number, check it out cleanly, re-run the same tool call that failed on `main`, compare the outputs, and produce a verdict — "fixes", "fixes but with concerns", "does not fix", or "cannot run". Pair with `/2-repro-issue` (which produces the baseline). No edits, no merges, no pushes.
+
+## Phase 1 — Resolve the PR and its linked issue
+
+```bash
+PR="$ARGUMENTS"
+REPO=stickerdaniel/linkedin-mcp-server
+
+gh pr view $PR --repo $REPO --json title,body,baseRefName,headRefName,headRepositoryOwner,mergeable,mergeStateStatus,additions,deletions,changedFiles,maintainerCanModify,statusCheckRollup
+```
+
+Extract the **linked issue number** from the PR body (`Closes #`, `Fixes #`, `Resolves #`, or plain `#N`). Call it `ISSUE`. If multiple, ask the user which one is the verification target.
+
+## Phase 2 — Pick up or create the baseline
+
+`/2-repro-issue` writes `/tmp/repro-issue-<ISSUE>-main.json` and remembers the exact tool + args used. Check that file exists.
+
+```bash
+ls -la /tmp/repro-issue-$ISSUE-main.json 2>&1
+```
+
+If missing, stop and tell the user: *"No baseline for #$ISSUE. Run `/2-repro-issue $ISSUE` first so we have an on-main reference to diff against."* Do not silently re-run the reproduction — `/2-repro-issue` is the canonical source of "what's the call, what's the failure mode".
+
+If the baseline is older than 24 h, warn — LinkedIn DOM/data may have shifted. Offer to re-run `/2-repro-issue` first.
+
+## Phase 3 — Check out the PR
+
+```bash
+git status --porcelain | head -5     # must be clean
+git stash list | head -3             # warn if there are stashes the user may forget
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)   # remember where to return
+git fetch origin pull/$PR/head:pr-$PR
+git checkout pr-$PR
+
+# Scope sanity check
+gh pr view $PR --repo $REPO --json files --jq '.files[].path' | head -20
+git diff --stat $(git merge-base pr-$PR origin/main)..pr-$PR | tail -10
+```
+
+If the PR has merge conflicts with `main` (`mergeStateStatus: DIRTY`), continue anyway — local checkout still works — but note it in the verdict.
+
+If `maintainerCanModify: true`, mention that to the user; it unlocks the "take over and push a small follow-up commit" path later.
+
+## Phase 4 — Re-run the same MCP call on the PR branch
+
+Extract the original tool + args from the baseline JSON (`/2-repro-issue` saves the full response which includes the request envelope in the conversation). Restart the server because old workers hold the old code. Probe a free port (default 8000 is commonly taken):
+
+```bash
+PORT=8765
+while lsof -nP -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1; do PORT=$((PORT+1)); done
+uv run -m linkedin_mcp_server --transport streamable-http --port $PORT --log-level INFO > /tmp/verify-pr-$PR.log 2>&1 &
+SERVER_PID=$!
+sleep 8
+
+curl -s -D /tmp/verify-pr-$PR-headers -X POST http://127.0.0.1:$PORT/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"verify-pr","version":"1.0"}}}' > /dev/null
+
+SESSION_ID=$(grep -i 'Mcp-Session-Id' /tmp/verify-pr-$PR-headers | awk '{print $2}' | tr -d '\r')
+
+# notifications/initialized often replies with a pydantic validation error.
+# Harmless — same session ID still works for tools/call.
+curl -s -X POST http://127.0.0.1:$PORT/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"notifications/initialized","params":{}}' > /dev/null
+
+# Same tool + args as baseline:
+curl -s -X POST http://127.0.0.1:$PORT/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"<TOOL>","arguments":{<ARGS>}}}' \
+  | tee /tmp/verify-pr-$PR.json | head -200
+
+kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null
+```
+
+## Phase 5 — Diff and classify
+
+```bash
+diff -u /tmp/repro-issue-$ISSUE-main.json /tmp/verify-pr-$PR.json | head -200
+```
+
+Classify the PR outcome:
+
+- **Fixes cleanly ✓** — the failing field/section/error from the baseline is gone, no new failures visible, output structure matches `CLAUDE.md → Tool Return Format` (`{url, sections, ...}`).
+- **Fixes with concerns ⚠** — works on the issue's target but: (a) introduces new keys/sections not in the documented return format, (b) fails on a second target (different locale, edge case), (c) regresses an unrelated tool, (d) scope creep into unrelated files.
+- **Does not fix ✗** — same failure mode persists.
+- **Cannot run** — merge conflicts that affect runtime, dependency drift (e.g. PR pins a Python version we don't have), or unrelated breakage.
+- **Cannot verify fix (skill limitation)** — `/2-repro-issue` produced a success-baseline, not a failure-baseline (the bug only manifests under crash conditions, stdio transport, specific environments, or was already shipped-fixed). The diff therefore cannot show "before/after fix". Fall back to: (a) **regression check** — same baseline call must still succeed on PR branch, (b) **code audit** against the rules in Phase 6. Report this explicitly as a skill limitation, not as a PR weakness.
+
+For locale-sensitive bugs, run **one extra call** against a deliberately non-English target before declaring "fixes cleanly". The detection logic must not regress on a German/RTL profile.
+
+## Phase 6 — Audit the diff against CLAUDE.md scraping rules
+
+Read the actual diff, not just the file list:
+
+```bash
+git diff $(git merge-base pr-$PR origin/main)..pr-$PR
+```
+
+Hard flags (any one = downgrade from ✓ to ⚠):
+
+- **Locale-dependent detection**: any `== "Connect"`, `in ["Pending", "Follow"]`, `contains("1st")`, `aria-label="..."` with translated text. The verb is locale-dependent; attribute *presence* is not. See `CLAUDE.md → detection must be locale-independent`.
+- **LinkedIn-class-name selectors**: `.entity-result__item`, `.artdeco-button__text`, etc. Only minimal generic selectors are acceptable (`a[href*="/jobs/view/"]`).
+- **Multiple navigations behind one section**: any new entry in `PERSON_SECTIONS` / `COMPANY_SECTIONS` (`scraping/fields.py`) must map to exactly one URL.
+- **Missing tests**: bug fixes should add or update a test in `tests/test_scraping.py`. Pure-DOM fixes without test coverage are a yellow flag.
+
+## Phase 7 — Report
+
+```
+**PR #<PR>** (fixes #<ISSUE>) — <one-line PR title>
+**Mergeable:** <CLEAN | DIRTY conflicts | BLOCKED — reason>
+**Scope:** <+X/-Y, N files; flag if unrelated>
+**Verdict:** <Fixes ✓ | Fixes with concerns ⚠ | Does not fix ✗ | Cannot run | Cannot verify fix (skill limitation)>
+**Evidence:** 2–4 lines of the diff between baseline and PR-branch output that prove the verdict.
+**Audit flags:** <locale-dependent | DOM-class selectors | section-mapping violation | missing tests | none>
+**Cleaner alternative:** <other PR # | refactor sketch | none — PR is good as-is>
+**Recommended next step:** <merge | request changes citing flag X | take over via maintainer-edits (maintainerCanModify=true) | close as not-needed>
+```
+
+Then one short paragraph: what the PR actually changes, why it does/doesn't address root cause, and what the locale-independent / DOM-minimal version would look like if the verdict is ⚠ or ✗.
+
+## Phase 8 — Cleanup
+
+```bash
+git checkout "$CURRENT_BRANCH"
+git branch -D pr-$PR 2>/dev/null
+rm -f /tmp/verify-pr-$PR.json /tmp/verify-pr-$PR-headers /tmp/verify-pr-$PR.log /tmp/pr-$PR-meta.json
+# Keep /tmp/repro-issue-$ISSUE-main.json so the user can re-verify against another PR later.
+```
+
+Leave the user on the branch they started on, with a clean working tree.
+
+## Non-negotiables
+
+- Real LinkedIn, same profile, same call as the baseline. Anything else isn't a verification.
+- Restart the server after `git checkout` — running workers hold stale code.
+- Do not push, do not edit the PR, do not merge. This skill verifies and reports.
+- Locale and DOM-class flags are non-overridable: if they're present, the verdict is ⚠ at best, regardless of whether the diff "works on the target".
+- If the baseline never captured a failure (e.g. crash-only bug, stdio-only bug, env-specific bug), name it **"Cannot verify fix (skill limitation)"** and lean on code-audit + regression check. Never escalate a missing failure into a PR criticism.

--- a/.agents/skills/3-verify-pr-fix/SKILL.md
+++ b/.agents/skills/3-verify-pr-fix/SKILL.md
@@ -55,21 +55,22 @@ git stash list | head -3             # warn if there are stashes the user may fo
 # in detached state (CI worktrees, prior PR checkouts), so fall back to the SHA.
 CURRENT_REF=$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)
 
-# Force-update the local pr-$PR ref so a leftover from a failed prior run does
-# not block the fetch.
-git fetch origin "+pull/$PR/head:pr-$PR"
-git checkout pr-$PR
+# Fetch the PR head into FETCH_HEAD only and check it out as a detached HEAD.
+# Skipping a named local branch avoids clobbering a maintainer's existing
+# `pr-$PR` work and removes the cleanup-time `git branch -D` foot-gun.
+git fetch origin "pull/$PR/head"
+PR_SHA=$(git rev-parse FETCH_HEAD)
+git checkout --detach "$PR_SHA"
 
-# Any early exit after this point must still return to $CURRENT_REF and clear
-# pr-$PR + /tmp scratch files. Install a single trap so the fail-fast guards in
-# Phase 4 do not strand the user on the PR branch.
+# Any early exit after this point must still return to $CURRENT_REF + clear
+# /tmp scratch files. Install a single trap so the fail-fast guards in Phase 4
+# do not strand the user on the PR commit.
 cleanup_verify() {
   rc=$?
   trap - EXIT INT TERM
   kill $SERVER_PID 2>/dev/null
   wait $SERVER_PID 2>/dev/null
   git checkout "$CURRENT_REF" 2>/dev/null
-  git branch -D pr-$PR 2>/dev/null
   rm -f /tmp/verify-pr-$PR.json /tmp/verify-pr-$PR-headers /tmp/verify-pr-$PR.log /tmp/pr-$PR-meta.json
   exit $rc
 }
@@ -77,7 +78,7 @@ trap cleanup_verify EXIT INT TERM
 
 # Scope sanity check
 gh pr view $PR --repo $REPO --json files --jq '.files[].path' | head -20
-git diff --stat $(git merge-base pr-$PR origin/main)..pr-$PR | tail -10
+git diff --stat $(git merge-base "$PR_SHA" origin/main)..$PR_SHA | tail -10
 ```
 
 If the PR has merge conflicts with `main` (`mergeStateStatus: DIRTY`), continue anyway — local checkout still works — but note it in the verdict.
@@ -151,7 +152,7 @@ For locale-sensitive bugs, run **one extra call** against a deliberately non-Eng
 Read the actual diff, not just the file list:
 
 ```bash
-git diff $(git merge-base pr-$PR origin/main)..pr-$PR
+git diff $(git merge-base "$PR_SHA" origin/main)..$PR_SHA
 ```
 
 Hard flags (any one = downgrade from ✓ to ⚠):
@@ -180,8 +181,9 @@ Then one short paragraph: what the PR actually changes, why it does/doesn't addr
 
 ```bash
 # The EXIT trap installed in Phase 3 runs automatically — it returns to
-# $CURRENT_REF, deletes pr-$PR, and cleans up /tmp/verify-pr-$PR.* on any exit
-# (success, error, Ctrl-C). Nothing extra to do here.
+# $CURRENT_REF and cleans up /tmp/verify-pr-$PR.* on any exit (success, error,
+# Ctrl-C). No local branch was ever created (Phase 3 uses a detached HEAD on
+# FETCH_HEAD), so nothing needs deleting either.
 # Keep /tmp/repro-issue-$ISSUE-main.json + meta.json so the user can re-verify against another PR later.
 ```
 

--- a/.agents/skills/3-verify-pr-fix/SKILL.md
+++ b/.agents/skills/3-verify-pr-fix/SKILL.md
@@ -32,6 +32,9 @@ Both must exist. The meta file is how this skill replays the *exact* same call i
 
 ```bash
 ls -la /tmp/repro-issue-$ISSUE-main.json /tmp/repro-issue-$ISSUE-meta.json 2>&1
+# Both files must exist AND be non-empty. ls alone never fails the script, so
+# guard each path before we touch the PR branch or LinkedIn.
+[ -s /tmp/repro-issue-$ISSUE-main.json ] || { echo "Missing or empty response baseline. Re-run /2-repro-issue $ISSUE." >&2; exit 1; }
 [ -s /tmp/repro-issue-$ISSUE-meta.json ] || { echo "Missing or empty meta file. Re-run /2-repro-issue $ISSUE." >&2; exit 1; }
 TOOL=$(jq -r .tool /tmp/repro-issue-$ISSUE-meta.json)
 ARGS_JSON=$(jq -c .arguments /tmp/repro-issue-$ISSUE-meta.json)
@@ -56,6 +59,21 @@ CURRENT_REF=$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)
 # not block the fetch.
 git fetch origin "+pull/$PR/head:pr-$PR"
 git checkout pr-$PR
+
+# Any early exit after this point must still return to $CURRENT_REF and clear
+# pr-$PR + /tmp scratch files. Install a single trap so the fail-fast guards in
+# Phase 4 do not strand the user on the PR branch.
+cleanup_verify() {
+  rc=$?
+  trap - EXIT INT TERM
+  kill $SERVER_PID 2>/dev/null
+  wait $SERVER_PID 2>/dev/null
+  git checkout "$CURRENT_REF" 2>/dev/null
+  git branch -D pr-$PR 2>/dev/null
+  rm -f /tmp/verify-pr-$PR.json /tmp/verify-pr-$PR-headers /tmp/verify-pr-$PR.log /tmp/pr-$PR-meta.json
+  exit $rc
+}
+trap cleanup_verify EXIT INT TERM
 
 # Scope sanity check
 gh pr view $PR --repo $REPO --json files --jq '.files[].path' | head -20
@@ -161,9 +179,9 @@ Then one short paragraph: what the PR actually changes, why it does/doesn't addr
 ## Phase 8 — Cleanup
 
 ```bash
-git checkout "$CURRENT_REF"
-git branch -D pr-$PR 2>/dev/null
-rm -f /tmp/verify-pr-$PR.json /tmp/verify-pr-$PR-headers /tmp/verify-pr-$PR.log /tmp/pr-$PR-meta.json
+# The EXIT trap installed in Phase 3 runs automatically — it returns to
+# $CURRENT_REF, deletes pr-$PR, and cleans up /tmp/verify-pr-$PR.* on any exit
+# (success, error, Ctrl-C). Nothing extra to do here.
 # Keep /tmp/repro-issue-$ISSUE-main.json + meta.json so the user can re-verify against another PR later.
 ```
 

--- a/.agents/skills/triage-reviews/SKILL.md
+++ b/.agents/skills/triage-reviews/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: triage-reviews
 description: Fetch PR review comments, verify each against real code/docs, fix valid issues, commit and push
-disable-model-invocation: true
 argument-hint: '[PR number]'
 ---
 

--- a/.agents/skills/triage-reviews/SKILL.md
+++ b/.agents/skills/triage-reviews/SKILL.md
@@ -62,20 +62,21 @@ Workflow per finding:
    - Valid + unfixed: `Valid, deferred to follow-up. Reason: <why>.`
    - False positive: `False positive. <one-line evidence: file:line shows X, or doc link Y>.`
 
-2. **Resolve the thread**.
+2. **Resolve the thread only when the finding is Fixed or False positive.** `Valid + unfixed` threads must stay open so the PR view continues to surface the real bug. Resolving them would let the PR look ready while the bug is still in the code. Leave the maintainer to close those threads when they file the follow-up.
 
-GitHub's review threads can only be resolved via GraphQL (REST has no endpoint). The thread ID is a GraphQL node ID, not the REST comment ID, so fetch both together:
+GitHub's review threads can only be resolved via GraphQL (REST has no endpoint). The thread ID is a GraphQL node ID, not the REST comment ID, so fetch both together. Use `--paginate` so PRs with more than 100 threads are covered, the page size cap is per-request not total:
 
 ```bash
 PR=<pr-number>
 OWNER=<owner>
 REPO=<repo>
 
-gh api graphql -f query="
-  query {
-    repository(owner: \"$OWNER\", name: \"$REPO\") {
-      pullRequest(number: $PR) {
-        reviewThreads(first: 100) {
+gh api graphql --paginate -f query='
+  query($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100, after: $endCursor) {
+          pageInfo { hasNextPage endCursor }
           nodes {
             id
             isResolved
@@ -84,7 +85,8 @@ gh api graphql -f query="
         }
       }
     }
-  }" \
+  }' \
+  -F owner="$OWNER" -F repo="$REPO" -F pr=$PR \
   --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {threadId: .id, commentId: .comments.nodes[0].databaseId, path: .comments.nodes[0].path, line: .comments.nodes[0].line}' \
   > /tmp/triage-threads-$PR.json
 ```
@@ -96,7 +98,7 @@ Each entry now has `{threadId, commentId, path, line}`. Match it against your Ph
 gh api -X POST "/repos/$OWNER/$REPO/pulls/$PR/comments/$COMMENT_ID/replies" \
   -f body="Fixed in $SHORT_SHA. <one-line>."
 
-# Resolve the thread (GraphQL)
+# Resolve the thread (GraphQL) — Fixed and False-positive only. SKIP for Valid+unfixed.
 gh api graphql -f query="
   mutation {
     resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) {

--- a/.agents/skills/triage-reviews/SKILL.md
+++ b/.agents/skills/triage-reviews/SKILL.md
@@ -51,12 +51,72 @@ For EVERY finding, verify against real code before accepting or rejecting:
    ```
 4. Push: `gt submit` (or `git push` if not using Graphite)
 
+## Phase 3.5: Reply on each thread, then resolve it
+
+Pushing the fix isn't enough. Each inline review comment lives in its own thread that GitHub keeps showing as "Unresolved" until someone explicitly resolves it. The skill must close that loop for every Valid and False-positive finding so the PR view actually reflects what was triaged.
+
+Workflow per finding:
+
+1. **Reply on the thread** with the verdict and evidence:
+   - Valid + fixed: `Fixed in <short-sha>. <one-line what changed>.`
+   - Valid + unfixed: `Valid, deferred to follow-up. Reason: <why>.`
+   - False positive: `False positive. <one-line evidence: file:line shows X, or doc link Y>.`
+
+2. **Resolve the thread**.
+
+GitHub's review threads can only be resolved via GraphQL (REST has no endpoint). The thread ID is a GraphQL node ID, not the REST comment ID, so fetch both together:
+
+```bash
+PR=<pr-number>
+OWNER=<owner>
+REPO=<repo>
+
+gh api graphql -f query="
+  query {
+    repository(owner: \"$OWNER\", name: \"$REPO\") {
+      pullRequest(number: $PR) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            comments(first: 1) { nodes { databaseId path line body } }
+          }
+        }
+      }
+    }
+  }" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {threadId: .id, commentId: .comments.nodes[0].databaseId, path: .comments.nodes[0].path, line: .comments.nodes[0].line}' \
+  > /tmp/triage-threads-$PR.json
+```
+
+Each entry now has `{threadId, commentId, path, line}`. Match it against your Phase-2 finding map (by `path` + `line` or `commentId`). For each match:
+
+```bash
+# Post reply (REST endpoint for replies on a specific review comment)
+gh api -X POST "/repos/$OWNER/$REPO/pulls/$PR/comments/$COMMENT_ID/replies" \
+  -f body="Fixed in $SHORT_SHA. <one-line>."
+
+# Resolve the thread (GraphQL)
+gh api graphql -f query="
+  mutation {
+    resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) {
+      thread { isResolved }
+    }
+  }"
+```
+
+If the parent review left a separate top-level summary comment (Greptile's `Greptile Summary` issue-level comment, for example), leave it alone, only inline review threads need resolving.
+
+Cap: resolve only threads tied to findings you actually classified. Do not bulk-resolve unrelated threads (other reviewers, human discussion, follow-up questions that aren't from this triage round).
+
 ## Phase 4: Report
 
 Present a final summary table of ALL findings with verdicts:
 
-| # | Source | File:Line | Finding | Verdict | Reason |
-|---|--------|-----------|---------|---------|--------|
+| # | Source | File:Line | Finding | Verdict | Reason | Thread |
+|---|--------|-----------|---------|---------|--------|--------|
+
+Last column: `replied + resolved`, `replied + still open` (e.g. waiting on reviewer), or `n/a` (no inline thread, only summary). If any thread stayed open, name it explicitly so the next pass picks it up.
 
 ## Notes
 


### PR DESCRIPTION
Three ordered maintainer skills for the issue, repro, verify-PR loop, plus making `triage-reviews` auto-invocable for consistency. Each is a single focused workflow per the Anthropic skill convention, composed by sequential invocation and a shared baseline file at `/tmp/repro-issue-<N>-main.json`.

`1-triage-issues` reads open issues and PRs, ranks them by severity, reach, contributor history, and PR quality (mergeability, locale-safety, test coverage, scope). Read-only, no checkout, no server.

`2-repro-issue` starts the MCP server on the current branch, runs the failing tool call against the authenticated profile at `~/.linkedin-mcp/profile/`, classifies the outcome, saves a baseline JSON.

`3-verify-pr-fix` fetches the candidate PR, restarts the server on the PR branch, re-runs the same call, diffs against the baseline, and audits the diff against `CLAUDE.md` scraping rules. Verdicts: `fixes`, `fixes with concerns`, `does not fix`, `cannot run`, `cannot verify fix (skill limitation)`.

Real-world dry runs while authoring: `2-repro-issue 442` and `3-verify-pr-fix 385` against live LinkedIn. The `2-repro-issue 442` output drove the rescope discussion on #442.

## Synthetic prompt

> Create three composable maintainer skills under `.agents/skills/` (with `.claude/skills/` symlinks) for triage, reproduction, and PR verification, ordered by pipeline position (`1-`, `2-`, `3-`). All auto-invocable, baseline file shared via `/tmp/repro-issue-<N>-main.json`. Probe a free port from 8765 to avoid colliding with other dev MCP servers. Drop `disable-model-invocation: true` on `triage-reviews` to align with the new auto-invocable convention.

Generated with GPT-5