### PR TITLE
fix(scraping): Strip conversation page chrome

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -482,6 +482,11 @@ class _MessagingChromeTable:
     composer_companions: tuple[str, ...]
 
 
+# How far below a composer-label candidate a companion control may sit and
+# still count as the same block. The observed block spans 6 lines; the slack
+# covers extra controls LinkedIn injects (e.g. "Press Enter to Send").
+_COMPOSER_COMPANION_WINDOW = 8
+
 _MESSAGING_CHROME_STRINGS: dict[str, _MessagingChromeTable] = {
     "en": _MessagingChromeTable(
         sidebar_end="Load more conversations",
@@ -516,15 +521,18 @@ def strip_conversation_chrome(text: str, locale: str = "en") -> str:
     lines = text.splitlines()
 
     # End boundary: the last composer-label line, accepted only when another
-    # composer control follows it. A message that merely quotes the label has
-    # no trailing controls and falls through to the missing-marker fallback.
+    # composer control follows within the next few lines. The real composer
+    # block is contiguous (label + controls observed within 6 lines), so a
+    # nearby companion confirms chrome, while a message that merely quotes
+    # the label — or mentions a control text much later — falls through to
+    # the missing-marker fallback.
     end = len(lines)
     for i in range(len(lines) - 1, -1, -1):
         if lines[i].strip() != table.composer_start:
             continue
         if any(
             lines[j].strip().startswith(table.composer_companions)
-            for j in range(i + 1, len(lines))
+            for j in range(i + 1, min(i + 1 + _COMPOSER_COMPANION_WINDOW, len(lines)))
         ):
             end = i
         break

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -464,15 +464,37 @@ def _truncate_linkedin_noise(text: str) -> str:
 # Rules). BrowserManager forces the context locale to en-US (core/browser.py),
 # so the "en" entry is the operative one; a locale without a table entry
 # passes through unstripped.
-_MESSAGING_CHROME_STRINGS: dict[str, dict[str, str]] = {
-    "en": {
-        # Screen-reader label on the options dropdown; appears once per
-        # sidebar entry and once in the opened thread's header, so the last
-        # occurrence before the composer marks the end of the page chrome.
-        "thread_header_prefix": "Open the options list in your conversation with",
-        # First control of the trailing message-composer block.
-        "composer_start": "Maximize compose field",
-    },
+@dataclass(frozen=True)
+class _MessagingChromeTable:
+    # Sidebar pagination control; the last line of the inbox sidebar. Pins
+    # the thread header so quoted UI text inside messages can't move the
+    # start boundary.
+    sidebar_end: str
+    # Screen-reader label on the options dropdown; appears once per sidebar
+    # entry and once in the opened thread's header. The thread's own line is
+    # the first occurrence after ``sidebar_end``.
+    thread_header_prefix: str
+    # First control of the trailing message-composer block.
+    composer_start: str
+    # Other controls of the composer block. At least one must follow a
+    # ``composer_start`` candidate to confirm it is the real composer rather
+    # than a message quoting the label.
+    composer_companions: tuple[str, ...]
+
+
+_MESSAGING_CHROME_STRINGS: dict[str, _MessagingChromeTable] = {
+    "en": _MessagingChromeTable(
+        sidebar_end="Load more conversations",
+        thread_header_prefix="Open the options list in your conversation with",
+        composer_start="Maximize compose field",
+        composer_companions=(
+            "Attach an image to your conversation with",
+            "Attach a file to your conversation with",
+            "Open GIF Keyboard",
+            "Open Emoji Keyboard",
+            "Open send options",
+        ),
+    ),
 }
 
 
@@ -482,9 +504,10 @@ def strip_conversation_chrome(text: str, locale: str = "en") -> str:
     A conversation page's innerText embeds the thread between three chrome
     blocks: the messaging header, the inbox sidebar (which previews *other*
     conversations), and the trailing message composer. Drops everything
-    through the last thread-header line and everything from the last
-    composer line onward. Each boundary independently falls back to keeping
-    the text when its marker is absent (unknown locale, layout change).
+    through the thread-header line and everything from the composer onward.
+    Each boundary independently falls back to keeping the text when its
+    marker is absent (unknown locale, layout change), so a failed match
+    leaks chrome rather than dropping messages.
     """
     table = _MESSAGING_CHROME_STRINGS.get(locale)
     if table is None:
@@ -492,19 +515,44 @@ def strip_conversation_chrome(text: str, locale: str = "en") -> str:
 
     lines = text.splitlines()
 
-    # Last exact composer line wins so a message that merely quotes the
-    # string can't truncate the thread early.
+    # End boundary: the last composer-label line, accepted only when another
+    # composer control follows it. A message that merely quotes the label has
+    # no trailing controls and falls through to the missing-marker fallback.
     end = len(lines)
     for i in range(len(lines) - 1, -1, -1):
-        if lines[i].strip() == table["composer_start"]:
+        if lines[i].strip() != table.composer_start:
+            continue
+        if any(
+            lines[j].strip().startswith(table.composer_companions)
+            for j in range(i + 1, len(lines))
+        ):
             end = i
-            break
+        break
 
+    # Start boundary: the sidebar's pagination line, when present, pins the
+    # real thread header as the first options line after it; quoted UI text
+    # inside messages can no longer pull the boundary into the thread. The
+    # sidebar omits the pagination control when there are few conversations —
+    # then fall back to the last options line before the composer.
     start = 0
-    for i in range(end - 1, -1, -1):
-        if lines[i].strip().startswith(table["thread_header_prefix"]):
-            start = i + 1
-            break
+    sidebar_end = next(
+        (i for i in range(end) if lines[i].strip() == table.sidebar_end), None
+    )
+    if sidebar_end is not None:
+        header = next(
+            (
+                i
+                for i in range(sidebar_end + 1, end)
+                if lines[i].strip().startswith(table.thread_header_prefix)
+            ),
+            None,
+        )
+        start = (header + 1) if header is not None else sidebar_end + 1
+    else:
+        for i in range(end - 1, -1, -1):
+            if lines[i].strip().startswith(table.thread_header_prefix):
+                start = i + 1
+                break
 
     return "\n".join(lines[start:end]).strip()
 
@@ -3195,8 +3243,11 @@ class LinkedInExtractor:
 
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
-        cleaned = strip_linkedin_noise(raw) if raw else ""
-        cleaned = strip_conversation_chrome(cleaned) if cleaned else ""
+        # Conversation chrome first: a sidebar preview containing a generic
+        # noise marker would otherwise truncate the page before the thread
+        # markers are ever seen.
+        cleaned = strip_conversation_chrome(raw) if raw else ""
+        cleaned = strip_linkedin_noise(cleaned) if cleaned else ""
         references = (
             build_references(raw_result["references"], "conversation")
             if cleaned

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -457,6 +457,58 @@ def _truncate_linkedin_noise(text: str) -> str:
     return text[:earliest].strip()
 
 
+# Messaging-page chrome around an opened conversation thread. innerText on
+# /messaging/thread/ pages carries no URL or attribute signal separating the
+# inbox sidebar from the thread, so the boundaries are matched on visible
+# strings — guarded by an explicit per-locale table (CLAUDE.md → Scraping
+# Rules). BrowserManager forces the context locale to en-US (core/browser.py),
+# so the "en" entry is the operative one; a locale without a table entry
+# passes through unstripped.
+_MESSAGING_CHROME_STRINGS: dict[str, dict[str, str]] = {
+    "en": {
+        # Screen-reader label on the options dropdown; appears once per
+        # sidebar entry and once in the opened thread's header, so the last
+        # occurrence before the composer marks the end of the page chrome.
+        "thread_header_prefix": "Open the options list in your conversation with",
+        # First control of the trailing message-composer block.
+        "composer_start": "Maximize compose field",
+    },
+}
+
+
+def strip_conversation_chrome(text: str, locale: str = "en") -> str:
+    """Trim messaging chrome around an opened conversation thread.
+
+    A conversation page's innerText embeds the thread between three chrome
+    blocks: the messaging header, the inbox sidebar (which previews *other*
+    conversations), and the trailing message composer. Drops everything
+    through the last thread-header line and everything from the last
+    composer line onward. Each boundary independently falls back to keeping
+    the text when its marker is absent (unknown locale, layout change).
+    """
+    table = _MESSAGING_CHROME_STRINGS.get(locale)
+    if table is None:
+        return text
+
+    lines = text.splitlines()
+
+    # Last exact composer line wins so a message that merely quotes the
+    # string can't truncate the thread early.
+    end = len(lines)
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip() == table["composer_start"]:
+            end = i
+            break
+
+    start = 0
+    for i in range(end - 1, -1, -1):
+        if lines[i].strip().startswith(table["thread_header_prefix"]):
+            start = i + 1
+            break
+
+    return "\n".join(lines[start:end]).strip()
+
+
 class LinkedInExtractor:
     """Extracts LinkedIn page content via navigate-scroll-innerText pattern."""
 
@@ -3144,6 +3196,7 @@ class LinkedInExtractor:
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
         cleaned = strip_linkedin_noise(raw) if raw else ""
+        cleaned = strip_conversation_chrome(cleaned) if cleaned else ""
         references = (
             build_references(raw_result["references"], "conversation")
             if cleaned

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -478,8 +478,11 @@ class _MessagingChromeTable:
     composer_start: str
     # Other controls of the composer block. At least one must follow a
     # ``composer_start`` candidate to confirm it is the real composer rather
-    # than a message quoting the label.
-    composer_companions: tuple[str, ...]
+    # than a message quoting the label. Standalone controls match exactly so
+    # quoted control text with a commentary suffix can't confirm; only
+    # controls that embed the participant name match by prefix.
+    composer_companions_exact: tuple[str, ...]
+    composer_companion_prefixes: tuple[str, ...]
 
 
 # How far below a composer-label candidate a companion control may sit and
@@ -492,12 +495,14 @@ _MESSAGING_CHROME_STRINGS: dict[str, _MessagingChromeTable] = {
         sidebar_end="Load more conversations",
         thread_header_prefix="Open the options list in your conversation with",
         composer_start="Maximize compose field",
-        composer_companions=(
-            "Attach an image to your conversation with",
-            "Attach a file to your conversation with",
+        composer_companions_exact=(
             "Open GIF Keyboard",
             "Open Emoji Keyboard",
             "Open send options",
+        ),
+        composer_companion_prefixes=(
+            "Attach an image to your conversation with",
+            "Attach a file to your conversation with",
         ),
     ),
 }
@@ -520,18 +525,26 @@ def strip_conversation_chrome(text: str, locale: str = "en") -> str:
 
     lines = text.splitlines()
 
+    def is_companion(idx: int) -> bool:
+        candidate = lines[idx].strip()
+        return candidate in table.composer_companions_exact or candidate.startswith(
+            table.composer_companion_prefixes
+        )
+
     # End boundary: the last composer-label line, accepted only when another
     # composer control follows within the next few lines. The real composer
     # block is contiguous (label + controls observed within 6 lines), so a
     # nearby companion confirms chrome, while a message that merely quotes
-    # the label — or mentions a control text much later — falls through to
-    # the missing-marker fallback.
+    # the label — or mentions a control text elsewhere — falls through to
+    # the missing-marker fallback. A verbatim multi-line reproduction of the
+    # block inside a message remains indistinguishable from the block itself;
+    # that ambiguity is inherent to text-only stripping.
     end = len(lines)
     for i in range(len(lines) - 1, -1, -1):
         if lines[i].strip() != table.composer_start:
             continue
         if any(
-            lines[j].strip().startswith(table.composer_companions)
+            is_companion(j)
             for j in range(i + 1, min(i + 1 + _COMPOSER_COMPANION_WINDOW, len(lines)))
         ):
             end = i

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -476,13 +476,13 @@ class _MessagingChromeTable:
     thread_header_prefix: str
     # First control of the trailing message-composer block.
     composer_start: str
-    # Other controls of the composer block. At least one must follow a
-    # ``composer_start`` candidate to confirm it is the real composer rather
-    # than a message quoting the label. Standalone controls match exactly so
-    # quoted control text with a commentary suffix can't confirm; only
-    # controls that embed the participant name match by prefix.
-    composer_companions_exact: tuple[str, ...]
-    composer_companion_prefixes: tuple[str, ...]
+    # Standalone controls of the composer block, matched exactly. At least
+    # one must follow a ``composer_start`` candidate to confirm it is the
+    # real composer rather than a message quoting the label. Controls whose
+    # text embeds the participant name (the Attach lines) are deliberately
+    # excluded: they would need prefix matching, and any prefix match lets
+    # quoted control text with a suffix confirm a false boundary.
+    composer_companions: tuple[str, ...]
 
 
 # How far below a composer-label candidate a companion control may sit and
@@ -495,14 +495,10 @@ _MESSAGING_CHROME_STRINGS: dict[str, _MessagingChromeTable] = {
         sidebar_end="Load more conversations",
         thread_header_prefix="Open the options list in your conversation with",
         composer_start="Maximize compose field",
-        composer_companions_exact=(
+        composer_companions=(
             "Open GIF Keyboard",
             "Open Emoji Keyboard",
             "Open send options",
-        ),
-        composer_companion_prefixes=(
-            "Attach an image to your conversation with",
-            "Attach a file to your conversation with",
         ),
     ),
 }
@@ -525,17 +521,11 @@ def strip_conversation_chrome(text: str, locale: str = "en") -> str:
 
     lines = text.splitlines()
 
-    def is_companion(idx: int) -> bool:
-        candidate = lines[idx].strip()
-        return candidate in table.composer_companions_exact or candidate.startswith(
-            table.composer_companion_prefixes
-        )
-
-    # End boundary: the last composer-label line, accepted only when another
-    # composer control follows within the next few lines. The real composer
-    # block is contiguous (label + controls observed within 6 lines), so a
-    # nearby companion confirms chrome, while a message that merely quotes
-    # the label — or mentions a control text elsewhere — falls through to
+    # End boundary: the last composer-label line, accepted only when an
+    # exact companion control follows within the next few lines. The real
+    # composer block is contiguous (label + controls observed within 6
+    # lines), so a nearby companion confirms chrome, while a message that
+    # quotes the label — or control text with any suffix — falls through to
     # the missing-marker fallback. A verbatim multi-line reproduction of the
     # block inside a message remains indistinguishable from the block itself;
     # that ambiguity is inherent to text-only stripping.
@@ -544,7 +534,7 @@ def strip_conversation_chrome(text: str, locale: str = "en") -> str:
         if lines[i].strip() != table.composer_start:
             continue
         if any(
-            is_companion(j)
+            lines[j].strip() in table.composer_companions
             for j in range(i + 1, min(i + 1 + _COMPOSER_COMPANION_WINDOW, len(lines)))
         ):
             end = i

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2522,6 +2522,15 @@ class TestStripConversationChrome:
             == "Maximize compose field\nis the label I keep seeing"
         )
 
+    def test_distant_companion_text_does_not_confirm_composer(self):
+        filler = "\n".join(f"message {n}" for n in range(10))
+        text = (
+            "Maximize compose field\n"
+            + filler
+            + "\nOpen send options is what I clicked"
+        )
+        assert strip_conversation_chrome(text) == text
+
     def test_quoted_composer_without_companions_does_not_truncate(self):
         text = (
             "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -19,6 +19,7 @@ from linkedin_mcp_server.scraping.extractor import (
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
+    strip_conversation_chrome,
     strip_linkedin_noise,
 )
 from linkedin_mcp_server.scraping.link_metadata import Reference
@@ -2457,6 +2458,79 @@ class TestStripLinkedInNoise:
         assert strip_linkedin_noise(text) == "Feed post number 1\nActual post content"
 
 
+class TestStripConversationChrome:
+    THREAD = (
+        "MAY 25\n"
+        "Grace Hopper sent the following message at 5:27 PM\n"
+        "Grace Hopper  5:27 PM\n"
+        "\n"
+        "Hello!"
+    )
+    PAGE = (
+        "Messaging\n"
+        "Search messages\n"
+        "Compose a new message\n"
+        "Inbox\n"
+        "Attention screen reader users, messaging items continuously update.\n"
+        "Ada Lovelace\n"
+        "Jun 8\n"
+        "Ada: Preview belonging to a different conversation\n"
+        ". Press return to go to conversation details\n"
+        "Open the options list in your conversation with Ada Lovelace and Grace Hopper\n"
+        "Status is reachable\n"
+        "Load more conversations\n"
+        "Grace Hopper\n"
+        "Status is online\n"
+        "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
+        + THREAD
+        + "\n"
+        "Maximize compose field\n"
+        "Attach an image to your conversation with Grace Hopper\n"
+        "Open GIF Keyboard\n"
+        "Send"
+    )
+
+    def test_strips_sidebar_and_composer(self):
+        assert strip_conversation_chrome(self.PAGE) == self.THREAD
+
+    def test_other_conversation_previews_removed(self):
+        assert "different conversation" not in strip_conversation_chrome(self.PAGE)
+        assert "Ada Lovelace" not in strip_conversation_chrome(self.PAGE)
+
+    def test_missing_composer_strips_only_leading_chrome(self):
+        text = (
+            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
+            + self.THREAD
+        )
+        assert strip_conversation_chrome(text) == self.THREAD
+
+    def test_missing_thread_header_strips_only_composer(self):
+        text = self.THREAD + "\nMaximize compose field\nSend"
+        assert strip_conversation_chrome(text) == self.THREAD
+
+    def test_quoted_composer_string_in_message_survives(self):
+        text = (
+            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
+            "Maximize compose field\n"
+            "is the label I keep seeing\n"
+            "Maximize compose field\n"
+            "Send"
+        )
+        assert (
+            strip_conversation_chrome(text)
+            == "Maximize compose field\nis the label I keep seeing"
+        )
+
+    def test_unknown_locale_returns_unchanged(self):
+        assert strip_conversation_chrome(self.PAGE, locale="de") == self.PAGE
+
+    def test_no_markers_returns_stripped_text(self):
+        assert strip_conversation_chrome("Hello!\nHi there!") == "Hello!\nHi there!"
+
+    def test_empty_string(self):
+        assert strip_conversation_chrome("") == ""
+
+
 class TestActivityFeedExtraction:
     """Tests for activity page detection and wait behavior in _extract_page_once."""
 
@@ -3700,6 +3774,45 @@ class TestGetConversation:
             "https://www.linkedin.com/messaging/thread/abc123/"
         )
         assert result["sections"]["conversation"] == "Hello!\nHi there!"
+
+    async def test_strips_conversation_page_chrome(self, mock_page):
+        """get_conversation trims sidebar and composer chrome from the thread."""
+        raw = (
+            "Ada: Preview belonging to a different conversation\n"
+            "Open the options list in your conversation with Ada and Grace\n"
+            "Hello!\n"
+            "Maximize compose field\n"
+            "Send"
+        )
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={"text": raw, "references": []},
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.build_references",
+                return_value=[],
+            ),
+        ):
+            result = await extractor.get_conversation(thread_id="abc123")
+
+        assert result["sections"]["conversation"] == "Hello!"
 
     async def test_raises_when_no_identifier(self, mock_page):
         """get_conversation raises LinkedInScraperException with no args."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2487,7 +2487,8 @@ class TestStripConversationChrome:
         "Maximize compose field\n"
         "Attach an image to your conversation with Grace Hopper\n"
         "Open GIF Keyboard\n"
-        "Send"
+        "Send\n"
+        "Open send options"
     )
 
     def test_strips_sidebar_and_composer(self):
@@ -2505,7 +2506,7 @@ class TestStripConversationChrome:
         assert strip_conversation_chrome(text) == self.THREAD
 
     def test_missing_thread_header_strips_only_composer(self):
-        text = self.THREAD + "\nMaximize compose field\nSend"
+        text = self.THREAD + "\nMaximize compose field\nOpen send options"
         assert strip_conversation_chrome(text) == self.THREAD
 
     def test_quoted_composer_string_in_message_survives(self):
@@ -2514,12 +2515,48 @@ class TestStripConversationChrome:
             "Maximize compose field\n"
             "is the label I keep seeing\n"
             "Maximize compose field\n"
-            "Send"
+            "Open send options"
         )
         assert (
             strip_conversation_chrome(text)
             == "Maximize compose field\nis the label I keep seeing"
         )
+
+    def test_quoted_composer_without_companions_does_not_truncate(self):
+        text = (
+            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
+            "Hello!\n"
+            "Maximize compose field\n"
+            "is what the button says"
+        )
+        assert (
+            strip_conversation_chrome(text)
+            == "Hello!\nMaximize compose field\nis what the button says"
+        )
+
+    def test_quoted_thread_header_in_message_keeps_earlier_messages(self):
+        text = (
+            "Load more conversations\n"
+            "Grace Hopper\n"
+            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
+            "Hello!\n"
+            "Open the options list in your conversation with is a label I quoted\n"
+            "Bye!\n"
+            "Maximize compose field\n"
+            "Open send options"
+        )
+        assert strip_conversation_chrome(text) == (
+            "Hello!\n"
+            "Open the options list in your conversation with is a label I quoted\n"
+            "Bye!"
+        )
+
+    def test_sidebar_end_without_thread_header_still_strips_sidebar(self):
+        text = (
+            "Ada: Preview belonging to a different conversation\n"
+            "Load more conversations\n" + self.THREAD
+        )
+        assert strip_conversation_chrome(text) == self.THREAD
 
     def test_unknown_locale_returns_unchanged(self):
         assert strip_conversation_chrome(self.PAGE, locale="de") == self.PAGE
@@ -3782,7 +3819,7 @@ class TestGetConversation:
             "Open the options list in your conversation with Ada and Grace\n"
             "Hello!\n"
             "Maximize compose field\n"
-            "Send"
+            "Open send options"
         )
         extractor = LinkedInExtractor(mock_page)
         with (

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2522,6 +2522,10 @@ class TestStripConversationChrome:
             == "Maximize compose field\nis the label I keep seeing"
         )
 
+    def test_quoted_companion_with_suffix_does_not_confirm_composer(self):
+        text = "Hello!\nMaximize compose field\nOpen send options is what I clicked"
+        assert strip_conversation_chrome(text) == text
+
     def test_distant_companion_text_does_not_confirm_composer(self):
         filler = "\n".join(f"message {n}" for n in range(10))
         text = (

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2526,6 +2526,14 @@ class TestStripConversationChrome:
         text = "Hello!\nMaximize compose field\nOpen send options is what I clicked"
         assert strip_conversation_chrome(text) == text
 
+    def test_quoted_attach_text_does_not_confirm_composer(self):
+        text = (
+            "Hello!\n"
+            "Maximize compose field\n"
+            "Attach an image to your conversation with Grace is the label I clicked"
+        )
+        assert strip_conversation_chrome(text) == text
+
     def test_distant_companion_text_does_not_confirm_composer(self):
         filler = "\n".join(f"message {n}" for n in range(10))
         text = (


### PR DESCRIPTION
Closes #442

`get_conversation` returned the entire messaging page innerText. Besides the opened thread, that included the messaging header, the full inbox sidebar with message previews of unrelated conversations, and the trailing compose controls (`Maximize compose field` through `Open send options`). On a real thread this was 167 lines of which only 54 belonged to the conversation, and the sidebar previews leak content from other people's chats into every tool response.

The fix trims both chrome blocks with a stop-string pass over the text, no DOM selectors. The thread starts after the last `Open the options list in your conversation with` line (the options dropdown label that follows both the sidebar entries and the thread header) and ends before the last `Maximize compose field` line. Both strings sit in an explicit per-locale table per the scraping rules; the browser context locale is forced to en-US in `core/browser.py`, so the `en` entry is the operative one and any other locale passes through unchanged. Each boundary falls back independently when its marker is missing.

The encoding corruption mentioned in the issue discussion (`100€` shown as `100â¬`) turned out to be a display artifact on my side: the captured response bytes on disk are valid UTF-8, so there is nothing to fix server-side.

Verified against a captured real conversation page: 5490 chars reduced to 1678, output starts at the first message group and contains no sidebar or composer strings. `uv run pytest` passes (520 tests), `uv run ruff check .` and `uv run ty check` are clean.

## Synthetic prompt

> get_conversation returns the whole messaging page text including the inbox sidebar (with previews of other conversations) and the trailing compose-field controls. Strip both so only the opened thread remains, text-only without DOM selectors, with the boundary strings in a per-locale table per the CLAUDE.md scraping rules. Add unit tests and an extractor-level test.
