### PR TITLE
chore(btca): Migrate from btca CLI to btca-local skill

### DIFF
--- a/.agents/skills/btca-local/SKILL.md
+++ b/.agents/skills/btca-local/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: btca-local
+description: Invoke this skill when the user says "use btca"
+---
+
+# BTCA Local
+
+BTCA Local, aka "The Better Context App Local" is a simple app defined as a skill file. The purpose of this app is to search git repos cloned onto this machine.
+
+## the BTCA Search Workflow
+
+<guidelines>
+    <guideline>
+        if the user includes a direct like to a github repo, always load and reference that
+    </guideline>
+    <guideline>
+        if the user doesn't include any specific links/repos they want you to use, do your best to guess based on the context provided
+    </guideline>
+    <guideline>
+        always include links/citations in your answers explaining what you found
+    </guideline>
+    <guideline>
+        include very clear and complete code snippets. don't leave out stuff like imports, that's important context
+    </guideline>
+    <guideline>
+        when answering use lots of bulleted/numbered lists to keep things readable and clear
+    </guideline>
+</guidelines>
+
+<workflow>
+    <step name="work dir setup">
+        use ~/.btca/agent/sandbox as the place where you clone/search repos
+    </step>
+    <step name="load">
+        if the repo(s) are already in the work dir ~/.btca/agent/sandbox update them, otherwise clone them. clone the main branch by default, unless the user asks for something else
+    </step>
+    <step name="search">
+        search the repo for the information you need. make sure to follow the guidelines
+    </step>
+<workflow>
+
+<end_goal>
+a clear, concise answer to the question with code examples
+</end_goal>
+
+## Startup Cases:
+
+This skill can be invoked in a couple different ways, and your behavior should reflect that:
+
+### user invoked without extra context/question
+
+this is the "app startup" state, almost as if a terminal app was booted up.
+
+Your job is to search the working directory ~/.btca/agent/sandbox at the top level, just to get a list of all the repos that have been previously cloned
+
+Then you should simply output the following markdown (filling in the existing repos):
+
+```md
+# BTCA Local
+
+_use your coding agent to search any git repo locally_
+
+Previously searched:
+
+- repo 1
+- ...
+
+Give me a question and the link to a git repo to get started!
+(we can also clean out or pre-load some resources to this list...)
+```
+
+### you invoked because of user's prompt
+
+in this case, your job is to answer/execute the users prompt faithfully, just while also using the btca search workflow when needed to better execute your task
+
+### user invoked while also giving a prompt/questions
+
+this one's simple, simply answer the users prompt with the btca search workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,10 +109,6 @@ gh api repos/{owner}/{repo}/issues/{pr}/comments   # follow-up reviews
 
 ## btca
 
-When you need up-to-date information about technologies used in this project, use btca to query source repositories directly.
+When you need up-to-date information about technologies used in this project, use the `btca-local` skill to search the actual source repos. `btca.config.jsonc` is the resource registry; every resource is pre-cloned at `~/.btca/agent/sandbox/<resourceName>` (e.g. `fastmcp`, `playwrightPython`). "Use btca with `<resource>` resource" means: search that clone.
 
-```bash
-btca resources                           # list available resources
-btca ask -r <resource> -q "<question>"
-btca ask -r fastmcp -r playwright -q "How do I set up browser context with FastMCP tools?"
-```
+**New dependencies:** When adding a new dependency, always add its repo to `btca.config.jsonc` (verify the default branch first: `gh api repos/OWNER/REPO --jq '.default_branch'`) and clone it into the sandbox. Resource names are shared across projects in the sandbox, so pick a name that identifies the repo unambiguously (`playwrightPython`, not `playwright`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,6 @@ gh api repos/{owner}/{repo}/issues/{pr}/comments   # follow-up reviews
 
 ## btca
 
-When you need up-to-date information about technologies used in this project, use the `btca-local` skill to search the actual source repos. `btca.config.jsonc` is the resource registry; every resource is pre-cloned at `~/.btca/agent/sandbox/<resourceName>` (e.g. `fastmcp`, `playwrightPython`). "Use btca with `<resource>` resource" means: search that clone.
+When you need up-to-date information about technologies used in this project, use the `btca-local` skill to search the actual source repos. `btca.config.jsonc` is the resource registry; every resource is pre-cloned at `~/.btca/agent/sandbox/<resourceName>` (e.g. `fastmcp`, `playwrightPython`). "Use btca with `<resource>` resource" means: search that clone. If a resource is missing from the sandbox, clone it with the url and branch from the manifest (the skill's "clone main by default" does not apply to registered resources).
 
 **New dependencies:** When adding a new dependency, always add its repo to `btca.config.jsonc` (verify the default branch first: `gh api repos/OWNER/REPO --jq '.default_branch'`) and clone it into the sandbox. Resource names are shared across projects in the sandbox, so pick a name that identifies the repo unambiguously (`playwrightPython`, not `playwright`).

--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -1,6 +1,7 @@
 {
-  "$schema": "https://btca.dev/btca.schema.json",
-  "providerTimeoutMs": 300000,
+  // Resource manifest for the btca-local skill: repos pre-cloned into
+  // ~/.btca/agent/sandbox/<name>. The sandbox is shared across projects,
+  // so resource names must identify the repo unambiguously.
   "resources": [
     {
       "type": "git",
@@ -11,7 +12,7 @@
     },
     {
       "type": "git",
-      "name": "playwright",
+      "name": "playwrightPython",
       "url": "https://github.com/microsoft/playwright-python",
       "branch": "main",
       "specialNotes": "Playwright Python bindings for browser automation."
@@ -48,7 +49,7 @@
       "type": "git",
       "name": "inquirer",
       "url": "https://github.com/magmax/python-inquirer",
-      "branch": "master",
+      "branch": "main",
       "specialNotes": "Python library for CLI interactive prompts."
     },
     {
@@ -78,7 +79,5 @@
       "url": "https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-python",
       "branch": "main"
     }
-  ],
-  "model": "gpt-5.4-mini",
-  "provider": "openai"
+  ]
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "btca-local": {
+      "source": "davis7dotsh/better-context",
+      "sourceType": "github",
+      "skillPath": "skills/btca-local/SKILL.md",
+      "computedHash": "1888cc18192c3e0356fd8a4333b5e8ea60524f920a8dbc9c203c39d7e8de7e56"
+    }
+  }
+}


### PR DESCRIPTION
The project documented btca usage through the btca CLI (`btca ask -r <resource> -q "<question>"`). Upstream replaced the local app with a skill, so those commands no longer exist and the AGENTS.md instructions were dead.

This installs the `btca-local` skill (`.agents/skills/btca-local`, tracked in `skills-lock.json`) and updates the AGENTS.md btca section to the skill approach: every resource is pre-cloned as a shallow clone at `~/.btca/agent/sandbox/<resourceName>`, named after its entry in `btca.config.jsonc`. The config file is reduced to a pure resource manifest; the CLI-only fields (`$schema`, `providerTimeoutMs`, `model`, `provider`) are removed. The `playwright` resource is renamed to `playwrightPython` because the sandbox is shared across projects and the name collided with `microsoft/playwright`. The `inquirer` entry pinned branch `master`, which no longer exists on `magmax/python-inquirer`; it now pins `main`.

All 11 manifest resources clone successfully into the sandbox and the trimmed config parses.