### PR TITLE
fix(person): detect and accept incoming requests

### DIFF
--- a/linkedin_mcp_server/scraping/connection.py
+++ b/linkedin_mcp_server/scraping/connection.py
@@ -13,11 +13,12 @@ Per ``AGENTS.md`` Scraping Rules, classification logic relies on URL
 patterns and attribute *presence* — never on the values of locale-dependent
 text labels like "Connect", "Follow", or "1st".
 
-The single text-based fallback that remains is incoming-request detection
-(Accept/Ignore present in the top-card text). LinkedIn does not expose a
-distinctive URL or attribute for this state. Per the same rules, that
-fallback lives behind an explicit per-locale label table that is trivial
-to extend.
+Incoming-request detection is primarily structural: the Accept/Ignore
+action row is fingerprinted by attribute presence and element counts
+(see :attr:`ActionSignals.has_incoming_action_row`). LinkedIn exposes no
+URL for this state, so a text-based fallback (Accept/Ignore present in
+the top-card text) is retained behind an explicit per-locale label table
+for DOM variants the fingerprint does not cover.
 """
 
 from __future__ import annotations
@@ -38,12 +39,15 @@ ConnectionState = Literal[
 
 
 # Per AGENTS.md Scraping Rules: text-only signals must live behind an
-# explicit per-locale table. This table covers incoming-request detection
-# only — the one state without a structural URL/attribute signal we have
-# verified against the live DOM. Extend with additional ("xx", (a, b))
-# entries once the labels are confirmed against a real profile.
+# explicit per-locale table. This table is the incoming-request fallback
+# for DOM variants the structural action-row fingerprint does not match.
+# Extend with additional ("xx", (a, b)) entries once the labels are
+# confirmed against a real profile.
 INCOMING_REQUEST_LABELS: dict[str, tuple[str, str]] = {
     "en": ("Accept", "Ignore"),
+    # Verified live 2026-06-11 against two German-locale incoming-request
+    # profiles.
+    "de": ("Annehmen", "Ignorieren"),
 }
 
 
@@ -99,6 +103,19 @@ class ActionSignals:
     locale-dependent and not read; presence-on-an-``<a>`` is the
     locale-independent Pending signal."""
 
+    has_incoming_action_row: bool
+    """The top-card action row matches the incoming-request fingerprint:
+    exactly three ``<button>``s in the smallest multi-button container
+    around a ``button[aria-expanded]`` — two with ``aria-label``
+    (Accept, Ignore) preceding one unlabeled expander (More) — and the
+    container holds no compose anchor, no invite anchor, and no labeled
+    ``<a>``. All checks are attribute presence and structural counts per
+    the AGENTS.md Scraping Rules; no label values are read. Verified
+    live 2026-06-11 against two German-locale incoming-request profiles.
+    Computed independently of the compose-anchor action-root walk, which
+    finds no top-card root on incoming profiles (they have no Message
+    button) and would otherwise mis-anchor on sidebar cards."""
+
 
 def detect_connection_state(
     profile_text: str,
@@ -110,27 +127,34 @@ def detect_connection_state(
 
     1. ``self_profile`` — edit-intro anchor (URL).
     2. ``connectable`` — vanityName invite anchor (URL).
-    3. ``pending`` — labeled action ``<a>`` in the action root (the
+    3. ``incoming_request`` — structural action-row fingerprint. Must
+       precede the pending check: incoming profiles have no Message
+       button in the top card, so the compose-anchor action-root walk
+       mis-anchors on sidebar cards whose labeled anchors would
+       otherwise satisfy the pending signal.
+    4. ``pending`` — labeled action ``<a>`` in the action root (the
        Pending control LinkedIn renders for invitations awaiting
        response).
-    4. ``incoming_request`` — locale-table text fallback. The one
-       AGENTS.md-sanctioned text-based signal; extend
+    5. ``incoming_request`` — locale-table text fallback for DOM
+       variants the fingerprint does not match; extend
        :data:`INCOMING_REQUEST_LABELS` to add locales.
-    5. ``already_connected`` — compose anchor present in action root and
+    6. ``already_connected`` — compose anchor present in action root and
        no labeled action button. (1st-degree connections render Message
        as the primary action; there is no Follow/Connect button.)
-    6. ``follow_only`` — compose anchor present in action root and at
+    7. ``follow_only`` — compose anchor present in action root and at
        least one labeled action ``<button>`` (Follow / Save in Sales
        Navigator), but no invite anchor anywhere. The
        ``connect_with_person`` write-gate prevents the deeplink from
        firing on this state.
-    7. ``unavailable`` — fallthrough (e.g. profile pages where the
+    8. ``unavailable`` — fallthrough (e.g. profile pages where the
        action area could not be located at all).
     """
     if signals.has_edit_intro_anchor:
         return "self_profile"
     if signals.has_invite_anchor:
         return "connectable"
+    if signals.has_incoming_action_row:
+        return "incoming_request"
     if signals.has_labeled_action_anchor:
         return "pending"
     if _has_incoming_request_text(profile_text):

--- a/linkedin_mcp_server/scraping/connection.py
+++ b/linkedin_mcp_server/scraping/connection.py
@@ -11,19 +11,15 @@ ARIA attributes it sets do not depend on UI language. Detection here uses:
 
 Per ``AGENTS.md`` Scraping Rules, classification logic relies on URL
 patterns and attribute *presence* — never on the values of locale-dependent
-text labels like "Connect", "Follow", or "1st".
-
-Incoming-request detection is primarily structural: the Accept/Ignore
-action row is fingerprinted by attribute presence and element counts
-(see :attr:`ActionSignals.has_incoming_action_row`). LinkedIn exposes no
-URL for this state, so a text-based fallback (Accept/Ignore present in
-the top-card text) is retained behind an explicit per-locale label table
-for DOM variants the fingerprint does not cover.
+text labels like "Connect", "Follow", or "1st". Incoming-request detection
+is fully structural: the Accept/Ignore action row is fingerprinted by
+attribute presence, element counts, and DOM order
+(see :attr:`ActionSignals.has_incoming_action_row`), so no text labels are
+read for any state.
 """
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from typing import Literal
 
@@ -36,28 +32,6 @@ ConnectionState = Literal[
     "self_profile",
     "unavailable",
 ]
-
-
-# Per AGENTS.md Scraping Rules: text-only signals must live behind an
-# explicit per-locale table. This table is the incoming-request fallback
-# for DOM variants the structural action-row fingerprint does not match.
-# Extend with additional ("xx", (a, b)) entries once the labels are
-# confirmed against a real profile.
-INCOMING_REQUEST_LABELS: dict[str, tuple[str, str]] = {
-    "en": ("Accept", "Ignore"),
-    # Verified live 2026-06-11 against two German-locale incoming-request
-    # profiles.
-    "de": ("Annehmen", "Ignorieren"),
-}
-
-
-# Bound the text scan to the top-card region. The previous implementation
-# cut at the first occurrence of "About"/"Experience"/"Education" — but
-# those sentinel words are themselves locale-dependent, so a fixed
-# character budget is the locale-clean replacement. ~600 chars is enough
-# to comfortably cover name, headline, location, and the action-button
-# row in every locale we have observed.
-_TOP_CARD_CHAR_BUDGET = 600
 
 
 @dataclass(frozen=True)
@@ -117,11 +91,8 @@ class ActionSignals:
     button) and would otherwise mis-anchor on sidebar cards."""
 
 
-def detect_connection_state(
-    profile_text: str,
-    signals: ActionSignals,
-) -> ConnectionState:
-    """Determine the relationship state for a profile.
+def detect_connection_state(signals: ActionSignals) -> ConnectionState:
+    """Determine the relationship state for a profile from structural signals.
 
     Resolution order:
 
@@ -135,18 +106,15 @@ def detect_connection_state(
     4. ``pending`` — labeled action ``<a>`` in the action root (the
        Pending control LinkedIn renders for invitations awaiting
        response).
-    5. ``incoming_request`` — locale-table text fallback for DOM
-       variants the fingerprint does not match; extend
-       :data:`INCOMING_REQUEST_LABELS` to add locales.
-    6. ``already_connected`` — compose anchor present in action root and
+    5. ``already_connected`` — compose anchor present in action root and
        no labeled action button. (1st-degree connections render Message
        as the primary action; there is no Follow/Connect button.)
-    7. ``follow_only`` — compose anchor present in action root and at
+    6. ``follow_only`` — compose anchor present in action root and at
        least one labeled action ``<button>`` (Follow / Save in Sales
        Navigator), but no invite anchor anywhere. The
        ``connect_with_person`` write-gate prevents the deeplink from
        firing on this state.
-    8. ``unavailable`` — fallthrough (e.g. profile pages where the
+    7. ``unavailable`` — fallthrough (e.g. profile pages where the
        action area could not be located at all).
     """
     if signals.has_edit_intro_anchor:
@@ -157,44 +125,8 @@ def detect_connection_state(
         return "incoming_request"
     if signals.has_labeled_action_anchor:
         return "pending"
-    if _has_incoming_request_text(profile_text):
-        return "incoming_request"
     if signals.has_compose_anchor_in_action_root:
         if signals.has_labeled_action_button:
             return "follow_only"
         return "already_connected"
     return "unavailable"
-
-
-def _has_incoming_request_text(profile_text: str) -> bool:
-    """Return True if any locale's Accept+Ignore label pair appears in the
-    bounded top-card prefix of ``profile_text``.
-
-    This is the single text-based detector retained from the previous
-    implementation. Per AGENTS.md it is gated behind an explicit locale
-    table; new languages are added by appending to
-    :data:`INCOMING_REQUEST_LABELS`. The character budget keeps the scan
-    inside the top-card region without depending on locale-dependent
-    section sentinels.
-
-    Each label is matched with newline boundaries — LinkedIn renders
-    each action button on its own line in the top-card text, and
-    line-bounded matching prevents false positives from the same
-    substring appearing inside a name or headline (e.g. "Ignored" or
-    "Acceptance Speech" would not match "Ignore" / "Accept").
-    """
-    if not profile_text:
-        return False
-    head = profile_text[:_TOP_CARD_CHAR_BUDGET]
-    for accept, ignore in INCOMING_REQUEST_LABELS.values():
-        if _label_present(head, accept) and _label_present(head, ignore):
-            return True
-    return False
-
-
-def _label_present(head: str, label: str) -> bool:
-    """Return True if ``label`` appears as a complete, line-bounded token
-    inside ``head``. Allows the label to start at the beginning of the
-    head and to end at the end of the head."""
-    pattern = re.compile(r"(?:^|\n)" + re.escape(label) + r"(?:\n|$)")
-    return pattern.search(head) is not None

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -173,13 +173,21 @@ function findActionRoot(main) {
 # expander candidates because cover-video profiles render the player's
 # expander before the top-card row in DOM order.
 #
+# The search is scoped to the top card — the first <section> of <main>
+# (falling back to main's first child, then main). Profile pages render
+# the action row in the top card; feed, "people also viewed", and other
+# widgets live in later sections. Without the scope an unrelated widget
+# elsewhere in main with the same button shape could be misclassified and
+# its first labeled button clicked.
+#
 # Inlined into _ACTION_SIGNALS_JS and _CLICK_INCOMING_ACCEPT_JS so a
 # single change to the fingerprint propagates to both call sites.
 _FIND_INCOMING_ACTION_ROW_FN_JS = r"""
 function findIncomingActionRow(main) {
-  for (const expander of main.querySelectorAll('button[aria-expanded]')) {
+  const scope = main.querySelector('section') || main.firstElementChild || main;
+  for (const expander of scope.querySelectorAll('button[aria-expanded]')) {
     let el = expander.parentElement;
-    while (el && el !== main) {
+    while (el && el !== scope && el !== main) {
       if (el.querySelectorAll('button').length >= 2) {
         const buttons = el.querySelectorAll('button');
         const labeled = el.querySelectorAll('button[aria-label]');
@@ -2001,10 +2009,7 @@ class LinkedInExtractor:
         whether the user-visible Connect button is in the action bar
         or buried under the More menu.
         """
-        from linkedin_mcp_server.scraping.connection import (
-            INCOMING_REQUEST_LABELS,
-            detect_connection_state,
-        )
+        from linkedin_mcp_server.scraping.connection import detect_connection_state
 
         url = f"https://www.linkedin.com/in/{username}/"
 
@@ -2044,17 +2049,14 @@ class LinkedInExtractor:
             )
 
         if state == "incoming_request":
-            # Structural click first (fingerprinted row, first labeled
-            # button). The locale-table text click remains as fallback for
-            # DOM variants where detection fired via the text table but
-            # the fingerprint does not match; exact-match filtering in
-            # click_button_by_text cannot hit the Ignore label.
+            # Accept clicks the first labeled button in the fingerprinted
+            # row. There is deliberately no locale-text fallback: clicking
+            # a button matched by exact text anywhere in the page risks
+            # hitting the wrong control (or the Ignore button in another
+            # locale), and accepting/ignoring is irreversible. When the
+            # fingerprint does not match we report send_failed rather than
+            # guess.
             clicked = await self._click_incoming_accept()
-            if not clicked:
-                for accept_label, _ignore_label in INCOMING_REQUEST_LABELS.values():
-                    if await self.click_button_by_text(accept_label, scope="main"):
-                        clicked = True
-                        break
             if not clicked:
                 return _connection_result(
                     url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -150,6 +150,62 @@ function findActionRoot(main) {
 }
 """
 
+# Shared JS function that fingerprints the incoming-request action row.
+# Incoming-request profiles render no Message button in the top card, so
+# findActionRoot (compose-anchor walk) cannot locate their action row and
+# would mis-anchor on sidebar mutual-connection cards instead. This walk
+# anchors on button[aria-expanded] (the More button) and validates the
+# smallest multi-button ancestor against the fingerprint verified live
+# 2026-06-11 on two German-locale incoming-request profiles:
+#
+#   [button aria-label (Accept)] [button aria-label (Ignore)]
+#   [button aria-expanded, no aria-label (More)]
+#
+# All checks are attribute presence and structural counts per the
+# AGENTS.md Scraping Rules — no label values are read. Every guard kills
+# a known false positive: total-button-count === 3 and labeled === 2
+# exclude video-player control bars (play/mute/captions all carry
+# aria-label); the unlabeled-expander check excludes player settings
+# expanders (the profile More button never carries aria-label); the
+# DOM-order guard excludes bars with trailing labeled buttons; the
+# compose/invite/labeled-anchor exclusions kill follow_only, pending,
+# connected top cards and sidebar cards. The scan continues over ALL
+# expander candidates because cover-video profiles render the player's
+# expander before the top-card row in DOM order.
+#
+# Inlined into _ACTION_SIGNALS_JS and _CLICK_INCOMING_ACCEPT_JS so a
+# single change to the fingerprint propagates to both call sites.
+_FIND_INCOMING_ACTION_ROW_FN_JS = r"""
+function findIncomingActionRow(main) {
+  for (const expander of main.querySelectorAll('button[aria-expanded]')) {
+    let el = expander.parentElement;
+    while (el && el !== main) {
+      if (el.querySelectorAll('button').length >= 2) {
+        const buttons = el.querySelectorAll('button');
+        const labeled = el.querySelectorAll('button[aria-label]');
+        const expanders = el.querySelectorAll('button[aria-expanded]');
+        if (
+          buttons.length === 3 &&
+          labeled.length === 2 &&
+          expanders.length === 1 &&
+          !expanders[0].hasAttribute('aria-label') &&
+          expanders[0].compareDocumentPosition(labeled[1]) &
+            Node.DOCUMENT_POSITION_PRECEDING &&
+          !el.querySelector('a[href*="/messaging/compose/"]') &&
+          !el.querySelector('a[href*="/preload/custom-invite/"]') &&
+          !el.querySelector('a[aria-label]')
+        ) {
+          return el;
+        }
+        break;
+      }
+      el = el.parentElement;
+    }
+  }
+  return null;
+}
+"""
+
 # Locale-independent connection-state probe. Returns four booleans;
 # per AGENTS.md Scraping Rules, every signal is based on URL patterns
 # or ARIA-attribute *presence* — never on label text values.
@@ -172,6 +228,11 @@ function findActionRoot(main) {
 #   back to the profile URL) carrying aria-label like "Pending, click to
 #   withdraw…". The Message anchor has only aria-disabled, so a labeled
 #   anchor is the locale-independent Pending signal.
+# - hasIncomingActionRow: the incoming-request fingerprint matched (see
+#   _FIND_INCOMING_ACTION_ROW_FN_JS). Computed independently of
+#   findActionRoot, which cannot locate the top-card row on incoming
+#   profiles (no compose anchor there) and would mis-anchor on sidebar
+#   cards.
 #
 # The username is CSS-escaped before interpolation into attribute
 # selectors to defend against malformed inputs containing characters
@@ -181,6 +242,7 @@ _ACTION_SIGNALS_JS = (
 ((username) => {
 """
     + _FIND_ACTION_ROOT_FN_JS
+    + _FIND_INCOMING_ACTION_ROW_FN_JS
     + r"""
   const main = document.querySelector('main');
   if (!main) return null;
@@ -220,6 +282,7 @@ _ACTION_SIGNALS_JS = (
     hasEditIntro,
     hasLabeledActionButton,
     hasLabeledActionAnchor,
+    hasIncomingActionRow: !!findIncomingActionRow(main),
   };
 })
 """
@@ -244,6 +307,28 @@ _OPEN_MORE_BUTTON_JS = (
   const moreBtn = actionRoot.querySelector('button[aria-expanded]');
   if (!moreBtn) return false;
   moreBtn.click();
+  return true;
+})
+"""
+)
+
+# Click Accept on an incoming-request profile. Accept is the FIRST labeled
+# button in the fingerprinted row — primary actions render first in
+# top-card action rows (Connect/Message lead on other profile states; the
+# inverse of dialogs, where the primary button renders last). Clicking the
+# second button would silently and irreversibly Ignore the request, so the
+# click only fires when the full fingerprint matched.
+_CLICK_INCOMING_ACCEPT_JS = (
+    r"""
+(() => {
+"""
+    + _FIND_INCOMING_ACTION_ROW_FN_JS
+    + r"""
+  const main = document.querySelector('main');
+  if (!main) return false;
+  const row = findIncomingActionRow(main);
+  if (!row) return false;
+  row.querySelectorAll('button[aria-label]')[0].click();
   return true;
 })
 """
@@ -971,6 +1056,23 @@ class LinkedInExtractor:
             logger.debug("More menu did not appear after click")
             return False
 
+    async def _click_incoming_accept(self) -> bool:
+        """Click Accept on an incoming-request profile, locale-independently.
+
+        Delegates to ``_CLICK_INCOMING_ACCEPT_JS``: the click fires only
+        when the full incoming-row fingerprint matches, and it targets the
+        FIRST labeled button (Accept renders before Ignore — primary
+        actions lead in top-card rows). Clicking the second button would
+        silently and irreversibly Ignore the request; the strict
+        fingerprint plus the caller's verify-after-click are the
+        mitigations. Returns True iff the click landed.
+        """
+        try:
+            return bool(await self._page.evaluate(_CLICK_INCOMING_ACCEPT_JS))
+        except Exception:
+            logger.debug("Incoming accept click via JS failed", exc_info=True)
+            return False
+
     async def _locator_is_visible(self, selector: str, *, timeout: int = 2000) -> bool:
         """Return whether the first matching locator is visible."""
         locator = self._page.locator(selector)
@@ -1693,6 +1795,7 @@ class LinkedInExtractor:
                 has_edit_intro_anchor=False,
                 has_labeled_action_button=False,
                 has_labeled_action_anchor=False,
+                has_incoming_action_row=False,
             )
         return ActionSignals(
             has_invite_anchor=bool(data.get("hasInvite")),
@@ -1700,6 +1803,7 @@ class LinkedInExtractor:
             has_edit_intro_anchor=bool(data.get("hasEditIntro")),
             has_labeled_action_button=bool(data.get("hasLabeledActionButton")),
             has_labeled_action_anchor=bool(data.get("hasLabeledActionAnchor")),
+            has_incoming_action_row=bool(data.get("hasIncomingActionRow")),
         )
 
     async def _submit_invite_dialog(
@@ -1897,7 +2001,10 @@ class LinkedInExtractor:
         whether the user-visible Connect button is in the action bar
         or buried under the More menu.
         """
-        from linkedin_mcp_server.scraping.connection import detect_connection_state
+        from linkedin_mcp_server.scraping.connection import (
+            INCOMING_REQUEST_LABELS,
+            detect_connection_state,
+        )
 
         url = f"https://www.linkedin.com/in/{username}/"
 
@@ -1937,11 +2044,17 @@ class LinkedInExtractor:
             )
 
         if state == "incoming_request":
-            # TODO(locale): replace text-based Accept click with a
-            # structural identifier — needs a live probe against a real
-            # incoming-request profile (we have none to test against).
-            # Tracked as a documented escape-hatch per AGENTS.md.
-            clicked = await self.click_button_by_text("Accept", scope="main")
+            # Structural click first (fingerprinted row, first labeled
+            # button). The locale-table text click remains as fallback for
+            # DOM variants where detection fired via the text table but
+            # the fingerprint does not match; exact-match filtering in
+            # click_button_by_text cannot hit the Ignore label.
+            clicked = await self._click_incoming_accept()
+            if not clicked:
+                for accept_label, _ignore_label in INCOMING_REQUEST_LABELS.values():
+                    if await self.click_button_by_text(accept_label, scope="main"):
+                        clicked = True
+                        break
             if not clicked:
                 return _connection_result(
                     url,
@@ -1949,10 +2062,23 @@ class LinkedInExtractor:
                     "Could not find or click the Accept button.",
                     profile=page_text,
                 )
-            verified = await self.scrape_person(username, {"main_profile"})
-            verified_text = verified.get("sections", {}).get("main_profile", "")
-            verified_signals = await self._read_action_signals(username)
-            verified_state = detect_connection_state(verified_text, verified_signals)
+            # LinkedIn propagates the accepted state asynchronously; an
+            # immediate re-read can still render the old top card and
+            # would report send_failed for a successful accept (observed
+            # live 2026-06-11). Verify with one settle retry.
+            verified_text = ""
+            verified_state = None
+            for attempt in range(2):
+                if attempt:
+                    await asyncio.sleep(3.0)
+                verified = await self.scrape_person(username, {"main_profile"})
+                verified_text = verified.get("sections", {}).get("main_profile", "")
+                verified_signals = await self._read_action_signals(username)
+                verified_state = detect_connection_state(
+                    verified_text, verified_signals
+                )
+                if verified_state == "already_connected":
+                    break
             if verified_state != "already_connected":
                 return _connection_result(
                     url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -185,6 +185,7 @@ function findActionRoot(main) {
 _FIND_INCOMING_ACTION_ROW_FN_JS = r"""
 function findIncomingActionRow(main) {
   const scope = main.querySelector('section') || main.firstElementChild || main;
+  const matches = [];
   for (const expander of scope.querySelectorAll('button[aria-expanded]')) {
     let el = expander.parentElement;
     while (el && el !== scope && el !== main) {
@@ -203,14 +204,17 @@ function findIncomingActionRow(main) {
           !el.querySelector('a[href*="/preload/custom-invite/"]') &&
           !el.querySelector('a[aria-label]')
         ) {
-          return el;
+          matches.push(el);
         }
         break;
       }
       el = el.parentElement;
     }
   }
-  return null;
+  // Require a unique match: a profile's top card has exactly one action
+  // row. Ambiguity (two rows matching the shape) is treated as no match so
+  // the irreversible Accept click never fires on a guessed control.
+  return matches.length === 1 ? matches[0] : null;
 }
 """
 
@@ -2021,7 +2025,7 @@ class LinkedInExtractor:
             )
 
         signals = await self._read_action_signals(username)
-        state = detect_connection_state(page_text, signals)
+        state = detect_connection_state(signals)
         logger.info(
             "Connection signals for %s: state=%s signals=%s", username, state, signals
         )
@@ -2076,9 +2080,7 @@ class LinkedInExtractor:
                 verified = await self.scrape_person(username, {"main_profile"})
                 verified_text = verified.get("sections", {}).get("main_profile", "")
                 verified_signals = await self._read_action_signals(username)
-                verified_state = detect_connection_state(
-                    verified_text, verified_signals
-                )
+                verified_state = detect_connection_state(verified_signals)
                 if verified_state == "already_connected":
                     break
             if verified_state != "already_connected":
@@ -2172,7 +2174,7 @@ class LinkedInExtractor:
         verified = await self.scrape_person(username, {"main_profile"})
         verified_text = verified.get("sections", {}).get("main_profile", "")
         verified_signals = await self._read_action_signals(username)
-        verified_state = detect_connection_state(verified_text, verified_signals)
+        verified_state = detect_connection_state(verified_signals)
 
         if verified_signals.has_invite_anchor:
             return _connection_result(

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ testpaths = tests
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 addopts = -v --strict-markers -ra
+markers =
+    browser_dom: evaluates extractor JS against a real chromium DOM; skipped when no browser is installed

--- a/tests/test_action_signals_dom.py
+++ b/tests/test_action_signals_dom.py
@@ -27,9 +27,11 @@ from linkedin_mcp_server.scraping.extractor import (
 pytestmark = pytest.mark.browser_dom
 
 
-INCOMING_TOP_CARD = """
-<div class="topcard">
-  <h1>Eric Langlouis</h1>
+# Each constant is a full <section>. The top card is always the first
+# section of <main>; the fingerprint is scoped there, so sidebar and feed
+# widgets live in later sections and must never match.
+
+INCOMING_ACTION_ROW = """
   <div class="actions">
     <button type="button" aria-label="Kontaktanfrage von Eric Langlouis annehmen"
       onclick="document.body.setAttribute('data-clicked','accept')">Annehmen</button>
@@ -37,11 +39,37 @@ INCOMING_TOP_CARD = """
       onclick="document.body.setAttribute('data-clicked','ignore')">Ignorieren</button>
     <button type="button" aria-expanded="false">Mehr</button>
   </div>
-</div>
 """
 
-SIDEBAR_CARDS = """
-<aside class="sidebar">
+INCOMING_TOP_CARD = f"""
+<section class="topcard">
+  <h1>Eric Langlouis</h1>
+  {INCOMING_ACTION_ROW}
+</section>
+"""
+
+VIDEO_PLAYER_BAR = """
+  <div class="player">
+    <button type="button" aria-label="Abspielen">▶</button>
+    <button type="button" aria-label="Stummschalten">🔇</button>
+    <button type="button" aria-label="Untertitel">CC</button>
+    <button type="button" aria-label="Vollbild">⛶</button>
+    <button type="button" aria-expanded="false" aria-label="Einstellungen">⚙</button>
+  </div>
+"""
+
+# Cover-video profile: the player's expander renders before the action row
+# within the same top card. The scan must skip it and still find the row.
+INCOMING_TOP_CARD_WITH_COVER = f"""
+<section class="topcard">
+  <h1>Eric Langlouis</h1>
+  {VIDEO_PLAYER_BAR}
+  {INCOMING_ACTION_ROW}
+</section>
+"""
+
+SIDEBAR_SECTION = """
+<section class="sidebar">
   <div class="card">
     <a href="https://www.linkedin.com/in/julien-f/">Julien</a>
     <a href="/messaging/compose/?profileUrn=urn%3Ali%3Afsd_profile%3AAAA"
@@ -53,43 +81,46 @@ SIDEBAR_CARDS = """
       aria-label="Rahul als Kontakt einladen">Vernetzen</a>
   </div>
   <button type="button">Mehr anzeigen</button>
-</aside>
+</section>
 """
 
-VIDEO_PLAYER_BAR = """
-<div class="player">
-  <button type="button" aria-label="Abspielen">▶</button>
-  <button type="button" aria-label="Stummschalten">🔇</button>
-  <button type="button" aria-label="Untertitel">CC</button>
-  <button type="button" aria-label="Vollbild">⛶</button>
-  <button type="button" aria-expanded="false" aria-label="Einstellungen">⚙</button>
-</div>
+# A widget elsewhere in main with the exact incoming-row shape (two labeled
+# buttons + one unlabeled expander). It must NOT match because it lives in a
+# later section, outside the scoped top card.
+UNRELATED_MATCHING_WIDGET = """
+<section class="feed">
+  <div class="actions">
+    <button type="button" aria-label="Gefällt mir">A</button>
+    <button type="button" aria-label="Kommentieren">B</button>
+    <button type="button" aria-expanded="false">Mehr</button>
+  </div>
+</section>
 """
 
 CONNECTED_TOP_CARD = """
-<div class="topcard">
+<section class="topcard">
   <h1>Fadi Al Eliwi</h1>
   <div class="actions">
     <a href="/messaging/compose/?profileUrn=urn%3Ali%3Afsd_profile%3ABBB"
       aria-disabled="false">Nachricht</a>
     <button type="button" aria-expanded="false">Mehr</button>
   </div>
-</div>
+</section>
 """
 
 FOLLOW_ONLY_TOP_CARD = """
-<div class="topcard">
+<section class="topcard">
   <h1>Verena</h1>
   <div class="actions">
     <button type="button" aria-label="Verena folgen">Folgen</button>
     <a href="/messaging/compose/?profileUrn=urn%3Ali%3Afsd_profile%3ACCC">Nachricht</a>
     <button type="button" aria-expanded="false">Mehr</button>
   </div>
-</div>
+</section>
 """
 
 PENDING_TOP_CARD = """
-<div class="topcard">
+<section class="topcard">
   <h1>Florian</h1>
   <div class="actions">
     <a href="/messaging/compose/?profileUrn=urn%3Ali%3Afsd_profile%3ADDD">Nachricht</a>
@@ -97,42 +128,49 @@ PENDING_TOP_CARD = """
       aria-label="Ausstehend, klicken zum Zurückziehen">Ausstehend</a>
     <button type="button" aria-expanded="false">Mehr</button>
   </div>
-</div>
+</section>
 """
 
 EXPANDER_FIRST_BAR = """
-<div class="hostile">
+<section class="hostile">
   <button type="button" aria-expanded="false">⚙</button>
   <button type="button" aria-label="Aktion A">A</button>
   <button type="button" aria-label="Aktion B">B</button>
-</div>
+</section>
 """
 
 EXTRA_BUTTON_ROW = """
-<div class="hostile">
+<section class="hostile">
   <button type="button" aria-label="Aktion A">A</button>
   <button type="button" aria-label="Aktion B">B</button>
   <button type="button" aria-expanded="false">Mehr</button>
   <button type="button">Extra</button>
-</div>
+</section>
 """
 
 
-def _page_html(*fragments: str) -> str:
-    return f"<html><body><main>{''.join(fragments)}</main></body></html>"
+def _page_html(*sections: str) -> str:
+    return f"<html><body><main>{''.join(sections)}</main></body></html>"
 
 
 @pytest.fixture
 async def dom_page():
-    """Real chromium page, or skip when no browser is installed."""
-    try:
-        async with async_playwright() as p:
+    """Real chromium page, or skip when no browser is installed.
+
+    Only launch/setup is guarded by the skip — the ``yield`` is outside it
+    so an assertion failure or JS error in a test body is never swallowed
+    into a skip.
+    """
+    async with async_playwright() as p:
+        try:
             browser = await p.chromium.launch(headless=True)
             page = await browser.new_page()
+        except Exception as exc:  # browser binary missing
+            pytest.skip(f"chromium unavailable: {exc}")
+        try:
             yield page
+        finally:
             await browser.close()
-    except Exception as exc:  # browser binary missing
-        pytest.skip(f"chromium unavailable: {exc}")
 
 
 async def _signals(page, html: str) -> dict:
@@ -142,7 +180,7 @@ async def _signals(page, html: str) -> dict:
 
 class TestIncomingActionRowFingerprint:
     async def test_incoming_row_detected_next_to_sidebar_cards(self, dom_page):
-        data = await _signals(dom_page, _page_html(INCOMING_TOP_CARD, SIDEBAR_CARDS))
+        data = await _signals(dom_page, _page_html(INCOMING_TOP_CARD, SIDEBAR_SECTION))
         assert data["hasIncomingActionRow"] is True
 
     async def test_video_player_bar_not_detected(self, dom_page):
@@ -157,9 +195,18 @@ class TestIncomingActionRowFingerprint:
 
     async def test_preceding_nonmatching_expander_does_not_abort_scan(self, dom_page):
         # Cover-video layout: the player's expander renders before the
-        # top-card row in DOM order; the scan must continue past it.
-        data = await _signals(dom_page, _page_html(VIDEO_PLAYER_BAR, INCOMING_TOP_CARD))
+        # action row inside the same top card; the scan must continue past
+        # it and still find the row.
+        data = await _signals(dom_page, _page_html(INCOMING_TOP_CARD_WITH_COVER))
         assert data["hasIncomingActionRow"] is True
+
+    async def test_matching_widget_outside_top_card_not_detected(self, dom_page):
+        # F1 regression: a widget with the exact incoming-row shape in a
+        # later section must not match — the scan is scoped to the top card.
+        data = await _signals(
+            dom_page, _page_html(CONNECTED_TOP_CARD, UNRELATED_MATCHING_WIDGET)
+        )
+        assert data["hasIncomingActionRow"] is False
 
     async def test_extra_unlabeled_button_fails_count_guard(self, dom_page):
         data = await _signals(dom_page, _page_html(EXTRA_BUTTON_ROW))
@@ -174,13 +221,13 @@ class TestIncomingActionRowFingerprint:
         assert data["hasIncomingActionRow"] is False
 
     async def test_connected_row_not_detected(self, dom_page):
-        data = await _signals(dom_page, _page_html(CONNECTED_TOP_CARD, SIDEBAR_CARDS))
+        data = await _signals(dom_page, _page_html(CONNECTED_TOP_CARD, SIDEBAR_SECTION))
         assert data["hasIncomingActionRow"] is False
 
 
 class TestClickIncomingAccept:
     async def test_clicks_first_labeled_button_only(self, dom_page):
-        await dom_page.set_content(_page_html(INCOMING_TOP_CARD, SIDEBAR_CARDS))
+        await dom_page.set_content(_page_html(INCOMING_TOP_CARD, SIDEBAR_SECTION))
         clicked = await dom_page.evaluate(_CLICK_INCOMING_ACCEPT_JS)
         assert clicked is True
         # Patchright evaluates in an isolated world; page-world variables

--- a/tests/test_action_signals_dom.py
+++ b/tests/test_action_signals_dom.py
@@ -1,0 +1,195 @@
+# tests/test_action_signals_dom.py
+"""Browser-DOM tests for the incoming-request action-row fingerprint.
+
+The unit suite mocks ``page.evaluate``, so the JS in ``_ACTION_SIGNALS_JS``
+and ``_CLICK_INCOMING_ACCEPT_JS`` never executes there. These tests run the
+real JS against synthetic HTML in headless chromium. Fixtures use German
+labels throughout: the fingerprint must classify without reading any label
+text. Skipped automatically when chromium is not installed (CI installs no
+browser; run locally after ``uv run patchright install chromium``).
+
+Fixture structure mirrors the live DOM dumps of two incoming-request
+profiles (2026-06-11): three buttons sharing one parent, Accept and Ignore
+carrying aria-label, More carrying aria-expanded without aria-label, plus
+sidebar cards with labeled compose anchors and other-user invite anchors.
+"""
+
+from __future__ import annotations
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.scraping.extractor import (
+    _ACTION_SIGNALS_JS,
+    _CLICK_INCOMING_ACCEPT_JS,
+)
+
+pytestmark = pytest.mark.browser_dom
+
+
+INCOMING_TOP_CARD = """
+<div class="topcard">
+  <h1>Eric Langlouis</h1>
+  <div class="actions">
+    <button type="button" aria-label="Kontaktanfrage von Eric Langlouis annehmen"
+      onclick="document.body.setAttribute('data-clicked','accept')">Annehmen</button>
+    <button type="button" aria-label="Kontaktanfrage von Eric Langlouis ignorieren"
+      onclick="document.body.setAttribute('data-clicked','ignore')">Ignorieren</button>
+    <button type="button" aria-expanded="false">Mehr</button>
+  </div>
+</div>
+"""
+
+SIDEBAR_CARDS = """
+<aside class="sidebar">
+  <div class="card">
+    <a href="https://www.linkedin.com/in/julien-f/">Julien</a>
+    <a href="/messaging/compose/?profileUrn=urn%3Ali%3Afsd_profile%3AAAA"
+      aria-label="Nachricht an Julien senden">Nachricht</a>
+  </div>
+  <div class="card">
+    <a href="https://www.linkedin.com/in/rahul-g/">Rahul</a>
+    <a href="/preload/custom-invite/?vanityName=rahul-g"
+      aria-label="Rahul als Kontakt einladen">Vernetzen</a>
+  </div>
+  <button type="button">Mehr anzeigen</button>
+</aside>
+"""
+
+VIDEO_PLAYER_BAR = """
+<div class="player">
+  <button type="button" aria-label="Abspielen">▶</button>
+  <button type="button" aria-label="Stummschalten">🔇</button>
+  <button type="button" aria-label="Untertitel">CC</button>
+  <button type="button" aria-label="Vollbild">⛶</button>
+  <button type="button" aria-expanded="false" aria-label="Einstellungen">⚙</button>
+</div>
+"""
+
+CONNECTED_TOP_CARD = """
+<div class="topcard">
+  <h1>Fadi Al Eliwi</h1>
+  <div class="actions">
+    <a href="/messaging/compose/?profileUrn=urn%3Ali%3Afsd_profile%3ABBB"
+      aria-disabled="false">Nachricht</a>
+    <button type="button" aria-expanded="false">Mehr</button>
+  </div>
+</div>
+"""
+
+FOLLOW_ONLY_TOP_CARD = """
+<div class="topcard">
+  <h1>Verena</h1>
+  <div class="actions">
+    <button type="button" aria-label="Verena folgen">Folgen</button>
+    <a href="/messaging/compose/?profileUrn=urn%3Ali%3Afsd_profile%3ACCC">Nachricht</a>
+    <button type="button" aria-expanded="false">Mehr</button>
+  </div>
+</div>
+"""
+
+PENDING_TOP_CARD = """
+<div class="topcard">
+  <h1>Florian</h1>
+  <div class="actions">
+    <a href="/messaging/compose/?profileUrn=urn%3Ali%3Afsd_profile%3ADDD">Nachricht</a>
+    <a href="https://www.linkedin.com/in/florian/"
+      aria-label="Ausstehend, klicken zum Zurückziehen">Ausstehend</a>
+    <button type="button" aria-expanded="false">Mehr</button>
+  </div>
+</div>
+"""
+
+EXPANDER_FIRST_BAR = """
+<div class="hostile">
+  <button type="button" aria-expanded="false">⚙</button>
+  <button type="button" aria-label="Aktion A">A</button>
+  <button type="button" aria-label="Aktion B">B</button>
+</div>
+"""
+
+EXTRA_BUTTON_ROW = """
+<div class="hostile">
+  <button type="button" aria-label="Aktion A">A</button>
+  <button type="button" aria-label="Aktion B">B</button>
+  <button type="button" aria-expanded="false">Mehr</button>
+  <button type="button">Extra</button>
+</div>
+"""
+
+
+def _page_html(*fragments: str) -> str:
+    return f"<html><body><main>{''.join(fragments)}</main></body></html>"
+
+
+@pytest.fixture
+async def dom_page():
+    """Real chromium page, or skip when no browser is installed."""
+    try:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(headless=True)
+            page = await browser.new_page()
+            yield page
+            await browser.close()
+    except Exception as exc:  # browser binary missing
+        pytest.skip(f"chromium unavailable: {exc}")
+
+
+async def _signals(page, html: str) -> dict:
+    await page.set_content(html)
+    return await page.evaluate(_ACTION_SIGNALS_JS, "testuser")
+
+
+class TestIncomingActionRowFingerprint:
+    async def test_incoming_row_detected_next_to_sidebar_cards(self, dom_page):
+        data = await _signals(dom_page, _page_html(INCOMING_TOP_CARD, SIDEBAR_CARDS))
+        assert data["hasIncomingActionRow"] is True
+
+    async def test_video_player_bar_not_detected(self, dom_page):
+        data = await _signals(
+            dom_page, _page_html(CONNECTED_TOP_CARD, VIDEO_PLAYER_BAR)
+        )
+        assert data["hasIncomingActionRow"] is False
+
+    async def test_expander_first_order_guard(self, dom_page):
+        data = await _signals(dom_page, _page_html(EXPANDER_FIRST_BAR))
+        assert data["hasIncomingActionRow"] is False
+
+    async def test_preceding_nonmatching_expander_does_not_abort_scan(self, dom_page):
+        # Cover-video layout: the player's expander renders before the
+        # top-card row in DOM order; the scan must continue past it.
+        data = await _signals(dom_page, _page_html(VIDEO_PLAYER_BAR, INCOMING_TOP_CARD))
+        assert data["hasIncomingActionRow"] is True
+
+    async def test_extra_unlabeled_button_fails_count_guard(self, dom_page):
+        data = await _signals(dom_page, _page_html(EXTRA_BUTTON_ROW))
+        assert data["hasIncomingActionRow"] is False
+
+    async def test_follow_only_row_not_detected(self, dom_page):
+        data = await _signals(dom_page, _page_html(FOLLOW_ONLY_TOP_CARD))
+        assert data["hasIncomingActionRow"] is False
+
+    async def test_pending_row_not_detected(self, dom_page):
+        data = await _signals(dom_page, _page_html(PENDING_TOP_CARD))
+        assert data["hasIncomingActionRow"] is False
+
+    async def test_connected_row_not_detected(self, dom_page):
+        data = await _signals(dom_page, _page_html(CONNECTED_TOP_CARD, SIDEBAR_CARDS))
+        assert data["hasIncomingActionRow"] is False
+
+
+class TestClickIncomingAccept:
+    async def test_clicks_first_labeled_button_only(self, dom_page):
+        await dom_page.set_content(_page_html(INCOMING_TOP_CARD, SIDEBAR_CARDS))
+        clicked = await dom_page.evaluate(_CLICK_INCOMING_ACCEPT_JS)
+        assert clicked is True
+        # Patchright evaluates in an isolated world; page-world variables
+        # are invisible there, but the DOM is shared — the inline onclick
+        # records the click as a body attribute.
+        recorded = await dom_page.evaluate("document.body.getAttribute('data-clicked')")
+        assert recorded == "accept"
+
+    async def test_no_click_without_fingerprint_match(self, dom_page):
+        await dom_page.set_content(_page_html(FOLLOW_ONLY_TOP_CARD, VIDEO_PLAYER_BAR))
+        clicked = await dom_page.evaluate(_CLICK_INCOMING_ACCEPT_JS)
+        assert clicked is False

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1583,49 +1583,9 @@ class TestConnectWithPerson:
         mock_nav.assert_not_awaited()
         mock_submit.assert_not_awaited()
 
-    async def test_incoming_request_accept_falls_back_to_text_click(self, mock_page):
-        """Detection fired via the text table on a DOM variant without the
-        fingerprinted row; the click falls back to the locale table."""
-        extractor = LinkedInExtractor(mock_page)
-        pre = "Aklasur\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore\nAbout\n"
-        post = "Aklasur\n\n· 1st\n\nDhaka\n\nMessage\nMore\nAbout\n"
-
-        with (
-            patch.object(
-                extractor,
-                "scrape_person",
-                self._mock_scrape(pre, follow_up_text=post),
-            ),
-            patch.object(
-                extractor,
-                "_read_action_signals",
-                new_callable=AsyncMock,
-                side_effect=[self._signals(), self._signals(compose=True)],
-            ),
-            patch.object(
-                extractor,
-                "_click_incoming_accept",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch.object(
-                extractor,
-                "click_button_by_text",
-                new_callable=AsyncMock,
-                return_value=True,
-            ) as mock_click,
-        ):
-            result = await extractor.connect_with_person("testuser")
-
-        assert result["status"] == "accepted"
-        from linkedin_mcp_server.scraping.connection import INCOMING_REQUEST_LABELS
-
-        accept_labels = {accept for accept, _ in INCOMING_REQUEST_LABELS.values()}
-        assert mock_click.await_args is not None
-        assert mock_click.await_args.args[0] in accept_labels
-
     async def test_incoming_request_send_failed_when_click_fails(self, mock_page):
-        """Neither the structural nor the text-table click landed."""
+        """Structural accept click did not land; no locale-text guessing —
+        report send_failed without navigating or clicking by text."""
         extractor = LinkedInExtractor(mock_page)
         pre = "Eric\n\n· 2.\n\nAachen\n\nAnnehmen\nIgnorieren\nMehr\nInfo\n"
 
@@ -1651,8 +1611,8 @@ class TestConnectWithPerson:
                 extractor,
                 "click_button_by_text",
                 new_callable=AsyncMock,
-                return_value=False,
-            ),
+                return_value=True,
+            ) as mock_text_click,
             patch.object(
                 extractor,
                 "_navigate_to_page",
@@ -1663,6 +1623,8 @@ class TestConnectWithPerson:
 
         assert result["status"] == "send_failed"
         mock_nav.assert_not_awaited()
+        # No text-based clicking on the destructive accept path.
+        mock_text_click.assert_not_awaited()
 
     async def test_incoming_request_send_failed_when_no_first_degree(self, mock_page):
         """Accept clicked but profile never transitions to 1st-degree."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -861,6 +861,7 @@ class TestDetectConnectionState:
         edit: bool = False,
         labeled_action: bool = False,
         labeled_anchor: bool = False,
+        incoming_row: bool = False,
     ) -> ActionSignals:
         return ActionSignals(
             has_invite_anchor=invite,
@@ -868,6 +869,7 @@ class TestDetectConnectionState:
             has_edit_intro_anchor=edit,
             has_labeled_action_button=labeled_action,
             has_labeled_action_anchor=labeled_anchor,
+            has_incoming_action_row=incoming_row,
         )
 
     def test_self_profile(self):
@@ -920,10 +922,56 @@ class TestDetectConnectionState:
             == "pending"
         )
 
+    def test_incoming_request_via_structural_row(self):
+        # The structural fingerprint alone decides — empty text proves no
+        # label values are consulted (locale-independent).
+        assert (
+            detect_connection_state("", self._signals(incoming_row=True))
+            == "incoming_request"
+        )
+
+    def test_incoming_structural_beats_pending_misclassification(self):
+        # Regression for the sidebar mis-anchor: on incoming profiles the
+        # compose-anchor action-root walk lands on sidebar cards and
+        # produces garbage signals (compose, labeled button, labeled
+        # anchor all True). The structural incoming signal must win over
+        # the pending check those garbage signals would trigger.
+        text = "Eric Langlouis\n\n· 2.\n\nAachen\n\nAnnehmen\nIgnorieren\nMehr"
+        assert (
+            detect_connection_state(
+                text,
+                self._signals(
+                    incoming_row=True,
+                    compose_in_root=True,
+                    labeled_action=True,
+                    labeled_anchor=True,
+                ),
+            )
+            == "incoming_request"
+        )
+
+    def test_connectable_takes_priority_over_incoming_row(self):
+        assert (
+            detect_connection_state("", self._signals(invite=True, incoming_row=True))
+            == "connectable"
+        )
+
+    def test_self_profile_takes_priority_over_incoming_row(self):
+        assert (
+            detect_connection_state("", self._signals(edit=True, incoming_row=True))
+            == "self_profile"
+        )
+
     def test_incoming_request_via_text_fallback_en(self):
         # Locale-table fallback per AGENTS.md — Accept+Ignore (en) appear
         # within the top-card prefix.
         text = "Aklasur Rahman\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore"
+        assert detect_connection_state(text, self._signals()) == "incoming_request"
+
+    def test_incoming_request_via_text_fallback_de(self):
+        # German labels from the locale table; signals all False simulates
+        # a DOM variant the structural fingerprint does not match.
+        text = "BOMMINA SRIRAM\n\n· 2.\n\nHyderabad\n\nAnnehmen\nIgnorieren\nMehr"
         assert detect_connection_state(text, self._signals()) == "incoming_request"
 
     def test_incoming_request_text_outside_top_card_ignored(self):
@@ -990,6 +1038,7 @@ class TestConnectWithPerson:
         edit: bool = False,
         labeled_action: bool = False,
         labeled_anchor: bool = False,
+        incoming_row: bool = False,
     ) -> ActionSignals:
         return ActionSignals(
             has_invite_anchor=invite,
@@ -997,6 +1046,7 @@ class TestConnectWithPerson:
             has_edit_intro_anchor=edit,
             has_labeled_action_button=labeled_action,
             has_labeled_action_anchor=labeled_anchor,
+            has_incoming_action_row=incoming_row,
         )
 
     async def test_connectable_navigates_deeplink_and_verifies(self, mock_page):
@@ -1489,6 +1539,53 @@ class TestConnectWithPerson:
         mock_submit.assert_not_awaited()
 
     async def test_returns_incoming_request_accepted(self, mock_page):
+        """Structural detection + structural accept click, German locale."""
+        extractor = LinkedInExtractor(mock_page)
+        pre = "Eric\n\n· 2.\n\nAachen\n\nAnnehmen\nIgnorieren\nMehr\nInfo\n"
+        post = "Eric\n\n· 1.\n\nAachen\n\nNachricht\nMehr\nInfo\n"
+
+        with (
+            patch.object(
+                extractor,
+                "scrape_person",
+                self._mock_scrape(pre, follow_up_text=post),
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                side_effect=[
+                    self._signals(incoming_row=True),
+                    self._signals(compose=True),
+                ],
+            ),
+            patch.object(
+                extractor,
+                "_click_incoming_accept",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_accept,
+            patch.object(
+                extractor,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+            ) as mock_nav,
+            patch.object(
+                extractor,
+                "_submit_invite_dialog",
+                new_callable=AsyncMock,
+            ) as mock_submit,
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+        assert result["status"] == "accepted"
+        mock_accept.assert_awaited_once()
+        mock_nav.assert_not_awaited()
+        mock_submit.assert_not_awaited()
+
+    async def test_incoming_request_accept_falls_back_to_text_click(self, mock_page):
+        """Detection fired via the text table on a DOM variant without the
+        fingerprinted row; the click falls back to the locale table."""
         extractor = LinkedInExtractor(mock_page)
         pre = "Aklasur\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore\nAbout\n"
         post = "Aklasur\n\n· 1st\n\nDhaka\n\nMessage\nMore\nAbout\n"
@@ -1507,6 +1604,12 @@ class TestConnectWithPerson:
             ),
             patch.object(
                 extractor,
+                "_click_incoming_accept",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                extractor,
                 "click_button_by_text",
                 new_callable=AsyncMock,
                 return_value=True,
@@ -1515,35 +1618,135 @@ class TestConnectWithPerson:
             result = await extractor.connect_with_person("testuser")
 
         assert result["status"] == "accepted"
-        mock_click.assert_awaited_once_with("Accept", scope="main")
+        from linkedin_mcp_server.scraping.connection import INCOMING_REQUEST_LABELS
 
-    async def test_incoming_request_send_failed_when_no_first_degree(self, mock_page):
-        """Accept clicked but profile never transitions to 1st-degree."""
+        accept_labels = {accept for accept, _ in INCOMING_REQUEST_LABELS.values()}
+        assert mock_click.await_args is not None
+        assert mock_click.await_args.args[0] in accept_labels
+
+    async def test_incoming_request_send_failed_when_click_fails(self, mock_page):
+        """Neither the structural nor the text-table click landed."""
         extractor = LinkedInExtractor(mock_page)
-        pre = "Aklasur\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore\nAbout\n"
+        pre = "Eric\n\n· 2.\n\nAachen\n\nAnnehmen\nIgnorieren\nMehr\nInfo\n"
 
         with (
             patch.object(
                 extractor,
                 "scrape_person",
-                self._mock_scrape(pre, follow_up_text=pre),
+                self._mock_scrape(pre),
             ),
             patch.object(
                 extractor,
                 "_read_action_signals",
                 new_callable=AsyncMock,
-                side_effect=[self._signals(), self._signals()],
+                return_value=self._signals(incoming_row=True),
+            ),
+            patch.object(
+                extractor,
+                "_click_incoming_accept",
+                new_callable=AsyncMock,
+                return_value=False,
             ),
             patch.object(
                 extractor,
                 "click_button_by_text",
                 new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                extractor,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+            ) as mock_nav,
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+        assert result["status"] == "send_failed"
+        mock_nav.assert_not_awaited()
+
+    async def test_incoming_request_send_failed_when_no_first_degree(self, mock_page):
+        """Accept clicked but profile never transitions to 1st-degree."""
+        extractor = LinkedInExtractor(mock_page)
+        pre = "Eric\n\n· 2.\n\nAachen\n\nAnnehmen\nIgnorieren\nMehr\nInfo\n"
+
+        with (
+            patch.object(
+                extractor,
+                "scrape_person",
+                AsyncMock(
+                    return_value={
+                        "url": "https://www.linkedin.com/in/testuser/",
+                        "sections": {"main_profile": pre},
+                    }
+                ),
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                return_value=self._signals(incoming_row=True),
+            ),
+            patch.object(
+                extractor,
+                "_click_incoming_accept",
+                new_callable=AsyncMock,
                 return_value=True,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
             ),
         ):
             result = await extractor.connect_with_person("testuser")
 
         assert result["status"] == "send_failed"
+
+    async def test_incoming_request_accepted_on_settle_retry(self, mock_page):
+        """The first post-click read still renders the old top card;
+        the settle retry sees the 1st-degree state and reports accepted."""
+        extractor = LinkedInExtractor(mock_page)
+        pre = "Eric\n\n· 2.\n\nAachen\n\nAnnehmen\nIgnorieren\nMehr\nInfo\n"
+        post = "Eric\n\n· 1.\n\nAachen\n\nNachricht\nMehr\nInfo\n"
+        page = {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "sections": {"main_profile": pre},
+        }
+        page_post = {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "sections": {"main_profile": post},
+        }
+
+        with (
+            patch.object(
+                extractor,
+                "scrape_person",
+                AsyncMock(side_effect=[page, page, page_post]),
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                side_effect=[
+                    self._signals(incoming_row=True),
+                    self._signals(incoming_row=True),
+                    self._signals(compose=True),
+                ],
+            ),
+            patch.object(
+                extractor,
+                "_click_incoming_accept",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep,
+        ):
+            result = await extractor.connect_with_person("testuser")
+
+        assert result["status"] == "accepted"
+        mock_sleep.assert_awaited_once()
 
     async def test_returns_unavailable_when_no_signals_and_text(self, mock_page):
         """No structural signals, no actionable text → connect_unavailable."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -845,13 +845,9 @@ class TestScrapePersonUrls:
 class TestDetectConnectionState:
     """Tests for locale-independent connection-state detection.
 
-    All states except incoming_request are decided purely from the
-    structural ActionSignals; profile_text is passed empty for those.
-    Incoming-request is the one AGENTS.md-sanctioned text fallback,
-    so its test passes both signals (all False) and a profile_text
-    containing Accept/Ignore labels. The two priority-ordering tests
-    intentionally pass non-empty text to verify that URL/attribute
-    signals win over text fallbacks regardless of what's in the text.
+    Every state is decided purely from the structural ActionSignals; no
+    profile text is read for any state, including incoming_request (whose
+    Accept/Ignore action row is fingerprinted by ``has_incoming_action_row``).
     """
 
     @staticmethod
@@ -873,17 +869,17 @@ class TestDetectConnectionState:
         )
 
     def test_self_profile(self):
-        assert detect_connection_state("", self._signals(edit=True)) == "self_profile"
+        assert detect_connection_state(self._signals(edit=True)) == "self_profile"
 
     def test_connectable(self):
-        assert detect_connection_state("", self._signals(invite=True)) == "connectable"
+        assert detect_connection_state(self._signals(invite=True)) == "connectable"
 
     def test_already_connected(self):
         # 1st-degree: Message anchor in action root, but no Follow/Connect/Pending
         # button (no aria-label on any action-root button).
         assert (
             detect_connection_state(
-                "", self._signals(compose_in_root=True, labeled_action=False)
+                self._signals(compose_in_root=True, labeled_action=False)
             )
             == "already_connected"
         )
@@ -894,7 +890,7 @@ class TestDetectConnectionState:
         # anchor.
         assert (
             detect_connection_state(
-                "", self._signals(compose_in_root=True, labeled_action=True)
+                self._signals(compose_in_root=True, labeled_action=True)
             )
             == "follow_only"
         )
@@ -904,8 +900,7 @@ class TestDetectConnectionState:
         # the action root — distinct from Follow's <button aria-label=...>.
         assert (
             detect_connection_state(
-                "",
-                self._signals(compose_in_root=True, labeled_anchor=True),
+                self._signals(compose_in_root=True, labeled_anchor=True)
             )
             == "pending"
         )
@@ -916,17 +911,14 @@ class TestDetectConnectionState:
         # fallthrough that would otherwise apply.
         assert (
             detect_connection_state(
-                "",
-                self._signals(compose_in_root=True, labeled_anchor=True),
+                self._signals(compose_in_root=True, labeled_anchor=True)
             )
             == "pending"
         )
 
     def test_incoming_request_via_structural_row(self):
-        # The structural fingerprint alone decides — empty text proves no
-        # label values are consulted (locale-independent).
         assert (
-            detect_connection_state("", self._signals(incoming_row=True))
+            detect_connection_state(self._signals(incoming_row=True))
             == "incoming_request"
         )
 
@@ -936,77 +928,37 @@ class TestDetectConnectionState:
         # produces garbage signals (compose, labeled button, labeled
         # anchor all True). The structural incoming signal must win over
         # the pending check those garbage signals would trigger.
-        text = "Eric Langlouis\n\n· 2.\n\nAachen\n\nAnnehmen\nIgnorieren\nMehr"
         assert (
             detect_connection_state(
-                text,
                 self._signals(
                     incoming_row=True,
                     compose_in_root=True,
                     labeled_action=True,
                     labeled_anchor=True,
-                ),
+                )
             )
             == "incoming_request"
         )
 
     def test_connectable_takes_priority_over_incoming_row(self):
         assert (
-            detect_connection_state("", self._signals(invite=True, incoming_row=True))
+            detect_connection_state(self._signals(invite=True, incoming_row=True))
             == "connectable"
         )
 
     def test_self_profile_takes_priority_over_incoming_row(self):
         assert (
-            detect_connection_state("", self._signals(edit=True, incoming_row=True))
+            detect_connection_state(self._signals(edit=True, incoming_row=True))
             == "self_profile"
         )
 
-    def test_incoming_request_via_text_fallback_en(self):
-        # Locale-table fallback per AGENTS.md — Accept+Ignore (en) appear
-        # within the top-card prefix.
-        text = "Aklasur Rahman\n\n--\n\nDhaka\n\nAccept\nIgnore\nMore"
-        assert detect_connection_state(text, self._signals()) == "incoming_request"
+    def test_unavailable_when_no_signals(self):
+        assert detect_connection_state(self._signals()) == "unavailable"
 
-    def test_incoming_request_via_text_fallback_de(self):
-        # German labels from the locale table; signals all False simulates
-        # a DOM variant the structural fingerprint does not match.
-        text = "BOMMINA SRIRAM\n\n· 2.\n\nHyderabad\n\nAnnehmen\nIgnorieren\nMehr"
-        assert detect_connection_state(text, self._signals()) == "incoming_request"
-
-    def test_incoming_request_text_outside_top_card_ignored(self):
-        # Accept/Ignore far past the 600-char top-card budget must not match.
-        prefix = "X" * 700
-        text = prefix + "\nAccept\nIgnore\n"
-        assert detect_connection_state(text, self._signals()) == "unavailable"
-
-    def test_incoming_request_takes_priority_over_already_connected(self):
-        # If the profile somehow has both compose anchor and Accept/Ignore
-        # labels (edge case), incoming_request wins per resolution order.
-        text = "Aklasur\n\nAccept\nIgnore\nMore"
-        assert (
-            detect_connection_state(text, self._signals(compose_in_root=True))
-            == "incoming_request"
-        )
-
-    def test_connectable_takes_priority_over_text_signals(self):
-        # vanityName invite anchor wins even if the page also has
-        # text that would otherwise match a fallback.
-        text = "Jane\n\nAccept\nIgnore\n"
-        assert (
-            detect_connection_state(text, self._signals(invite=True)) == "connectable"
-        )
-
-    def test_unavailable_when_no_signals_or_text(self):
-        assert detect_connection_state("", self._signals()) == "unavailable"
-
-    def test_unavailable_when_compose_missing_and_no_text(self):
+    def test_unavailable_when_compose_missing(self):
         # Restricted profile: no compose anchor, no labels, no invite.
         assert (
-            detect_connection_state(
-                "Some name\n\nFollow\n", self._signals(labeled_action=True)
-            )
-            == "unavailable"
+            detect_connection_state(self._signals(labeled_action=True)) == "unavailable"
         )
 
 


### PR DESCRIPTION
Closes #504

`connect_with_person` could not handle profiles with an open incoming connection request. Incoming profiles render no Message button in the top card, so the compose-anchor action-root walk anchored on sidebar mutual-connection cards instead; their labeled anchors satisfied the pending signal and the incoming-request check was never reached. Detection and the Accept click were also bound to English text labels, so non-English sessions (verified live on a German session) always returned `pending`.

Detection is now fully structural and language-agnostic. A new signal fingerprints the Accept/Ignore action row, scoped to the top card (the first section of `main`): exactly three buttons in the smallest multi-button container around an unlabeled `button[aria-expanded]`, two of them carrying `aria-label` and preceding the expander, with no compose anchor, no invite anchor and no labeled anchor in the row. The match must be unique within that scope. All checks are attribute presence, counts and DOM order per the AGENTS.md scraping rules; no label text is read for any state. This signal is checked before the pending signal, so the sidebar mis-anchor no longer wins.

The Accept click targets the first labeled button in that row and only fires when the fingerprint matched, since clicking the second button would irreversibly ignore the request. There is deliberately no text-based fallback for either detection or the click: guessing a control by exact label text risks the wrong locale or an unrelated button on an irreversible action. The accepted state is verified with one settle retry because LinkedIn propagates it asynchronously; without the retry a successful accept could be reported as `send_failed`.

A new browser-DOM test module runs the real extractor JS against synthetic German fixtures in headless chromium, covering the live-replica incoming row plus hostile cases (video-player bars, expander-first ordering, extra buttons, a matching widget in a later section, follow-only, pending, connected). It auto-skips when no browser is installed, so CI is unaffected.

`uv run pytest` passes (544 tests, including 11 browser-DOM tests locally). `uv run ruff check .`, `uv run ruff format --check .` and `uv run ty check` are clean. Verified live against real LinkedIn: a read-only classification matrix over 10 profiles covering all seven connection states classifies every profile correctly with the new signal False on all non-incoming profiles, and an end-to-end `connect_with_person` against a real German-locale incoming request clicked Accept structurally and the profile transitioned to 1st-degree.

## Synthetic prompt

> connect_with_person misclassifies incoming-request profiles as pending (sidebar compose anchors poison the action-root signals) and its Accept detection/click is English-only. Replace it with a fully structural, locale-independent fingerprint of the Accept/Ignore action row (attribute presence, counts, DOM order, scoped to the top card and unique), checked before the pending signal, click the first labeled button only when it matches with no text fallback, verify the accepted state with a settle retry, and cover the fingerprint with real-DOM chromium tests plus unit tests.