### PR TITLE
feat: add support for remote browser connections via CDP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,13 @@ VIEWPORT=1280x720
 # Custom Chrome/Chromium executable path (optional)
 # Use this if Chrome is installed in a non-standard location
 CHROME_PATH=
+
+# Remote browser over CDP (optional, e.g. browser-use)
+# When set, the server connects to this CDP endpoint instead of launching a
+# local Chrome. The LinkedIn session/profile is managed on the remote browser
+# (you must be logged in there). CDP_URL is accepted as an alias for CDP_ENDPOINT.
+CDP_ENDPOINT=
+# Reuse one remote CDP browser across all tool calls (only disconnect on shutdown).
+# Default (false) is ephemeral: each tool call uses a fresh connection and
+# closes the remote browser when the call completes. Options: true/false
+CDP_PERSISTENT=false

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The `@latest` tag ensures you always run the newest version — `uvx` checks PyP
 - `--tool-timeout SECONDS` - Per-tool MCP execution timeout in seconds (default: 180.0). Increase further for heavy scrapes / cold-start Chromium / slow networks.
 - `--user-data-dir PATH` - Path to persistent browser profile directory (default: ~/.linkedin-mcp/profile)
 - `--chrome-path PATH` - Path to Chrome/Chromium executable (for custom browser installations)
+- `--cdp-endpoint URL` - Connect to a remote browser over CDP (e.g. browser-use) instead of launching a local Chrome. The LinkedIn session is managed on the remote browser. Also `CDP_ENDPOINT` / `CDP_URL`.
+- `--cdp-persistent` - Reuse one remote CDP browser across all tool calls (only disconnect on shutdown). Without this flag (default), each tool call uses a fresh connection and the remote browser is closed when the call completes. Also `CDP_PERSISTENT`.
 
 **Basic Usage Examples:**
 
@@ -279,6 +281,8 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 - `--tool-timeout SECONDS` - Per-tool MCP execution timeout in seconds (default: 180.0). Increase further for heavy scrapes / cold-start Chromium / slow networks.
 - `--user-data-dir PATH` - Path to persistent browser profile directory (default: ~/.linkedin-mcp/profile)
 - `--chrome-path PATH` - Path to Chrome/Chromium executable (rarely needed in Docker)
+- `--cdp-endpoint URL` - Connect to a remote browser over CDP (e.g. browser-use) instead of launching a local Chrome. The LinkedIn session is managed on the remote browser. Also `CDP_ENDPOINT` / `CDP_URL`.
+- `--cdp-persistent` - Reuse one remote CDP browser across all tool calls (only disconnect on shutdown). Without this flag (default), each tool call uses a fresh connection and the remote browser is closed when the call completes. Also `CDP_PERSISTENT`.
 
 > [!NOTE]
 > `--login` and `--no-headless` are not available in Docker (no display server). Use the [uvx setup](#-uvx-setup-recommended---universal) to create profiles.
@@ -389,6 +393,8 @@ The local server uses the same managed-runtime flow as MCPB and `uvx`: it prepar
 - `--user-agent STRING` - Custom browser user agent
 - `--viewport WxH` - Browser viewport size (default: 1280x720)
 - `--chrome-path PATH` - Path to Chrome/Chromium executable (for custom browser installations)
+- `--cdp-endpoint URL` - Connect to a remote browser over CDP (e.g. browser-use) instead of launching a local Chrome. The LinkedIn session is managed on the remote browser. Also `CDP_ENDPOINT` / `CDP_URL`.
+- `--cdp-persistent` - Reuse one remote CDP browser across all tool calls (only disconnect on shutdown). Without this flag (default), each tool call uses a fresh connection and the remote browser is closed when the call completes. Also `CDP_PERSISTENT`.
 - `--help` - Show help
 
 > **Note:** Most CLI options have environment variable equivalents. See `.env.example` for details.
@@ -451,6 +457,17 @@ uv run -m linkedin_mcp_server --transport streamable-http --host 127.0.0.1 --por
 
 - If Chrome is installed in a non-standard location, use `--chrome-path /path/to/chrome`
 - Can also set via environment variable: `CHROME_PATH=/path/to/chrome`
+
+**Remote browser over CDP (e.g. browser-use):**
+
+- Connect to an existing browser instead of launching a local Chrome:
+  `uv run -m linkedin_mcp_server --transport streamable-http --cdp-endpoint http://127.0.0.1:9222`
+  (or `CDP_ENDPOINT` / `CDP_URL`).
+- The LinkedIn session/profile is managed entirely on the remote browser. **You must be logged in to LinkedIn there** — the server does not create a local profile and does not run `--login` (it trusts the remote session and validates it with a `/feed/` check). If the remote browser is not authenticated, tools return an actionable error.
+- No local Patchright Chromium download is needed in this mode.
+- **Session lifecycle:** by default (non-persistent) the connection is **ephemeral** — each tool call connects, does its work, and then **closes the remote browser** (via the CDP `Browser.close` command). This means your CDP provider should hand out a fresh browser per connection. With `--cdp-persistent` (or `CDP_PERSISTENT=true`), one remote browser is reused across all tool calls and is only disconnected (left running) on shutdown / `close_session`.
+- `--status` connects over CDP and reports whether the remote LinkedIn session is valid without terminating the remote browser (it never closes it, even in non-persistent mode).
+- Limitation: the remote context's locale cannot be forced to `en-US`. Detection logic is locale-independent by design, but keep the remote browser in a supported language if you hit edge cases.
 
 </details>
 

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -73,6 +73,8 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 | `SLOW_MO` | `0` | Delay between browser actions in ms (debugging) |
 | `VIEWPORT` | `1280x720` | Browser viewport size as WIDTHxHEIGHT |
 | `CHROME_PATH` | - | Path to Chrome/Chromium executable (rarely needed in Docker) |
+| `CDP_ENDPOINT` | - | Connect to a remote browser over CDP (e.g. browser-use) instead of launching a local Chrome. The LinkedIn session is managed on the remote browser. `CDP_URL` is accepted as an alias. |
+| `CDP_PERSISTENT` | `false` | Reuse one remote CDP browser across all tool calls (only disconnect on shutdown). Default (false) is ephemeral: each tool call uses a fresh connection and closes the remote browser when done. |
 | `LINKEDIN_EXPERIMENTAL_PERSIST_DERIVED_SESSION` | `false` | Experimental: reuse checkpointed derived Linux runtime profiles across Docker restarts instead of fresh-bridging each startup |
 | `LINKEDIN_TRACE_MODE` | `on_error` | Trace/log retention mode: `on_error` keeps ephemeral artifacts only when a failure occurs, `always` keeps every run, `off` disables trace persistence |
 

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -19,6 +19,7 @@ from fastmcp import Context
 
 from linkedin_mcp_server.authentication import get_authentication_source
 from linkedin_mcp_server.common_utils import secure_mkdir, secure_write_text, utcnow_iso
+from linkedin_mcp_server.config import get_config
 from linkedin_mcp_server.drivers.browser import get_profile_dir
 from linkedin_mcp_server.exceptions import (
     AuthenticationBootstrapFailedError,
@@ -59,6 +60,7 @@ _REGISTRY_NAME_TO_DIR_PREFIX = {
 class RuntimePolicy(str, Enum):
     MANAGED = "managed"
     DOCKER = "docker"
+    CDP = "cdp"
 
 
 class SetupState(str, Enum):
@@ -114,6 +116,8 @@ def get_runtime_policy() -> RuntimePolicy:
     """Return the active bootstrap runtime policy."""
     if _state.runtime_policy is not None:
         return _state.runtime_policy
+    if get_config().browser.cdp_enabled:
+        return RuntimePolicy.CDP
     return (
         RuntimePolicy.DOCKER
         if get_runtime_id().endswith("-container")
@@ -386,6 +390,12 @@ async def ensure_tool_ready_or_raise(
     """Gate scrape/search tools on browser setup and authentication readiness."""
     initialize_bootstrap()
     await _refresh_background_task_state()
+
+    if get_runtime_policy() == RuntimePolicy.CDP:
+        # No local Chromium install and no local auth artifacts: the remote
+        # browser manages the profile/session. Validation happens when the
+        # driver connects over CDP and runs the /feed/ check.
+        return
 
     if get_runtime_policy() == RuntimePolicy.DOCKER:
         _raise_if_docker_auth_missing()

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -117,10 +117,58 @@ def get_profile_and_exit() -> None:
     version = get_version()
     logger.info(f"LinkedIn MCP Server v{version} - Session Creation mode")
 
+    if config.browser.cdp_enabled:
+        print("ℹ️  CDP mode is enabled (--cdp-endpoint / CDP_ENDPOINT).")
+        print("   LinkedIn login is managed on the remote browser (e.g. browser-use).")
+        print("   No local profile is created. Log in there, then start the server.")
+        sys.exit(0)
+
     user_data_dir = config.browser.user_data_dir
     success = run_profile_creation(user_data_dir)
 
     sys.exit(0 if success else 1)
+
+
+def _cdp_status_and_exit() -> None:
+    """Validate the remote CDP LinkedIn session and exit.
+
+    A status check must never terminate the remote browser, so persistence is
+    forced for the duration of the check (close only disconnects).
+    """
+    config = get_config()
+    # Forcing persistence guarantees both the success path and the connect
+    # failure path (which closes the browser) only disconnect from the remote.
+    config.browser.cdp_persistent = True
+
+    print(f"CDP endpoint: {config.browser.cdp_endpoint}")
+
+    async def check_session() -> bool:
+        try:
+            set_headless(True)
+            browser = await get_or_create_browser()
+            return browser.is_authenticated
+        except AuthenticationError:
+            return False
+        except Exception as e:
+            logger.exception(f"Unexpected error checking CDP session: {e}")
+            raise
+        finally:
+            await close_browser()
+
+    try:
+        valid = asyncio.run(check_session())
+    except Exception as e:
+        print(f"❌ Could not validate remote CDP session: {e}")
+        print("   Check the CDP endpoint and that the remote browser is reachable.")
+        sys.exit(1)
+
+    if valid:
+        print("✅ Remote CDP session is valid (LinkedIn authenticated)")
+        sys.exit(0)
+
+    print("❌ Remote CDP session is not authenticated with LinkedIn")
+    print("   Log in to LinkedIn in the remote browser (e.g. browser-use), then retry")
+    sys.exit(1)
 
 
 def profile_info_and_exit() -> None:
@@ -134,6 +182,10 @@ def profile_info_and_exit() -> None:
 
     version = get_version()
     logger.info(f"LinkedIn MCP Server v{version} - Session Info mode")
+
+    if config.browser.cdp_enabled:
+        _cdp_status_and_exit()
+        return
 
     profile_dir = get_profile_dir()
     cookies_path = portable_cookie_path(profile_dir)
@@ -293,7 +345,10 @@ def main() -> None:
 
         # Ensure browser is installed for CLI modes that need it.
         # Normal server startup uses async background setup instead.
-        if config.server.login or config.server.status:
+        # CDP mode connects to a remote browser, so no local Chromium is needed.
+        if (config.server.login or config.server.status) and not (
+            config.browser.cdp_enabled
+        ):
             ensure_browser_installed()
 
         # Handle --login flag

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -64,6 +64,9 @@ class EnvironmentKeys:
     CHROME_PATH = "CHROME_PATH"
     USER_DATA_DIR = "USER_DATA_DIR"
     TOOL_TIMEOUT = "TOOL_TIMEOUT"
+    CDP_ENDPOINT = "CDP_ENDPOINT"
+    CDP_URL = "CDP_URL"
+    CDP_PERSISTENT = "CDP_PERSISTENT"
 
 
 def is_interactive_environment() -> bool:
@@ -181,6 +184,21 @@ def load_from_env(config: AppConfig) -> AppConfig:
     if chrome_path_env := os.environ.get(EnvironmentKeys.CHROME_PATH):
         config.browser.chrome_path = chrome_path_env
 
+    # Remote CDP endpoint (CDP_ENDPOINT preferred, CDP_URL accepted as alias)
+    cdp_endpoint_env = os.environ.get(EnvironmentKeys.CDP_ENDPOINT) or os.environ.get(
+        EnvironmentKeys.CDP_URL
+    )
+    if cdp_endpoint_env:
+        config.browser.cdp_endpoint = cdp_endpoint_env.strip()
+
+    # Persist the remote CDP browser across server shutdown
+    if cdp_persistent_env := os.environ.get(EnvironmentKeys.CDP_PERSISTENT):
+        cdp_persistent_value = _normalize_env(cdp_persistent_env)
+        if cdp_persistent_value in TRUTHY_VALUES:
+            config.browser.cdp_persistent = True
+        elif cdp_persistent_value in FALSY_VALUES:
+            config.browser.cdp_persistent = False
+
     return config
 
 
@@ -278,6 +296,27 @@ def load_from_args(config: AppConfig) -> AppConfig:
         help="Path to Chrome/Chromium executable (for custom browser installations)",
     )
 
+    parser.add_argument(
+        "--cdp-endpoint",
+        type=str,
+        default=None,
+        metavar="URL",
+        help=(
+            "Connect to a remote browser over CDP (e.g. browser-use) instead of "
+            "launching a local Chrome. The LinkedIn session is managed on the "
+            "remote side. Example: http://127.0.0.1:9222"
+        ),
+    )
+
+    parser.add_argument(
+        "--cdp-persistent",
+        action="store_true",
+        help=(
+            "Keep the remote CDP browser running on shutdown (only disconnect). "
+            "Without this flag the remote browser is closed."
+        ),
+    )
+
     # Session management
     parser.add_argument(
         "--login",
@@ -353,6 +392,12 @@ def load_from_args(config: AppConfig) -> AppConfig:
 
     if args.chrome_path:
         config.browser.chrome_path = args.chrome_path
+
+    if args.cdp_endpoint:
+        config.browser.cdp_endpoint = args.cdp_endpoint.strip()
+
+    if args.cdp_persistent:
+        config.browser.cdp_persistent = True
 
     # Session management
     if args.login:

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -20,6 +20,9 @@ class ConfigurationError(Exception):
     """Raised when configuration validation fails."""
 
 
+_CDP_ENDPOINT_SCHEMES = ("ws://", "wss://", "http://", "https://")
+
+
 @dataclass
 class BrowserConfig:
     """Configuration for browser settings."""
@@ -32,6 +35,18 @@ class BrowserConfig:
     default_timeout: int = 5000  # Milliseconds for page operations
     chrome_path: str | None = None  # Path to Chrome/Chromium executable
     user_data_dir: str = "~/.linkedin-mcp/profile"  # Persistent browser profile
+    # Remote Chrome DevTools Protocol endpoint (e.g. browser-use). When set, the
+    # server connects to this browser instead of launching a local Chrome and
+    # trusts the LinkedIn session managed on the remote side.
+    cdp_endpoint: str | None = None
+    # When True, closing only disconnects from the CDP endpoint and leaves the
+    # remote browser running. When False (default) the remote browser is closed.
+    cdp_persistent: bool = False
+
+    @property
+    def cdp_enabled(self) -> bool:
+        """Whether the server should connect over CDP instead of launching Chrome."""
+        return bool(self.cdp_endpoint)
 
     def validate(self) -> None:
         """Validate browser configuration values."""
@@ -57,6 +72,13 @@ class BrowserConfig:
                 raise ConfigurationError(
                     f"chrome_path '{self.chrome_path}' is not a file"
                 )
+        if self.cdp_endpoint and not self.cdp_endpoint.startswith(
+            _CDP_ENDPOINT_SCHEMES
+        ):
+            raise ConfigurationError(
+                f"cdp_endpoint '{self.cdp_endpoint}' must start with one of "
+                f"{', '.join(_CDP_ENDPOINT_SCHEMES)}"
+            )
 
 
 @dataclass

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from patchright.async_api import (
+    Browser,
     BrowserContext,
     Page,
     Playwright,
@@ -51,6 +52,11 @@ class BrowserManager:
     Session persistence is handled automatically by the persistent browser
     context -- all cookies, localStorage, and session state are retained in
     the ``user_data_dir`` between runs.
+
+    When ``cdp_endpoint`` is provided, the manager connects to a remote browser
+    over the Chrome DevTools Protocol (e.g. browser-use) instead of launching a
+    local Chrome. In that mode the LinkedIn session/profile is managed entirely
+    on the remote side and ``user_data_dir`` is unused.
     """
 
     def __init__(
@@ -60,6 +66,8 @@ class BrowserManager:
         slow_mo: int = 0,
         viewport: dict[str, int] | None = None,
         user_agent: str | None = None,
+        cdp_endpoint: str | None = None,
+        cdp_persistent: bool = False,
         **launch_options: Any,
     ):
         self.user_data_dir = str(Path(user_data_dir).expanduser())
@@ -67,12 +75,20 @@ class BrowserManager:
         self.slow_mo = slow_mo
         self.viewport = viewport or {"width": 1280, "height": 720}
         self.user_agent = user_agent
+        self.cdp_endpoint = cdp_endpoint
+        self.cdp_persistent = cdp_persistent
         self.launch_options = launch_options
 
         self._playwright: Playwright | None = None
+        self._browser: Browser | None = None
         self._context: BrowserContext | None = None
         self._page: Page | None = None
         self._is_authenticated = False
+
+    @property
+    def is_cdp(self) -> bool:
+        """Whether this manager connects to a remote browser over CDP."""
+        return self.cdp_endpoint is not None
 
     async def __aenter__(self) -> "BrowserManager":
         await self.start()
@@ -84,41 +100,16 @@ class BrowserManager:
         await self.close()
 
     async def start(self) -> None:
-        """Start Patchright and launch persistent browser context."""
+        """Start Patchright and launch persistent context or connect over CDP."""
         if self._context is not None:
             raise RuntimeError("Browser already started. Call close() first.")
         try:
             self._playwright = await async_playwright().start()
 
-            secure_mkdir(Path(self.user_data_dir))
-            _harden_linkedin_tree(Path(self.user_data_dir))
-
-            context_options: dict[str, Any] = {
-                "headless": self.headless,
-                "slow_mo": self.slow_mo,
-                "viewport": self.viewport,
-                **self.launch_options,
-                "locale": "en-US",
-            }
-
-            if self.user_agent:
-                context_options["user_agent"] = self.user_agent
-
-            self._context = await self._playwright.chromium.launch_persistent_context(
-                self.user_data_dir,
-                **context_options,
-            )
-
-            logger.info(
-                "Persistent browser launched (headless=%s, user_data_dir=%s)",
-                self.headless,
-                self.user_data_dir,
-            )
-
-            if self._context.pages:
-                self._page = self._context.pages[0]
+            if self.is_cdp:
+                await self._start_over_cdp()
             else:
-                self._page = await self._context.new_page()
+                await self._start_persistent_context()
 
             logger.info("Browser context and page ready")
 
@@ -126,18 +117,102 @@ class BrowserManager:
             await self.close()
             raise NetworkError(f"Failed to start browser: {e}") from e
 
+    async def _start_persistent_context(self) -> None:
+        """Launch a local persistent browser context backed by ``user_data_dir``."""
+        assert self._playwright is not None
+
+        secure_mkdir(Path(self.user_data_dir))
+        _harden_linkedin_tree(Path(self.user_data_dir))
+
+        context_options: dict[str, Any] = {
+            "headless": self.headless,
+            "slow_mo": self.slow_mo,
+            "viewport": self.viewport,
+            **self.launch_options,
+            "locale": "en-US",
+        }
+
+        if self.user_agent:
+            context_options["user_agent"] = self.user_agent
+
+        self._context = await self._playwright.chromium.launch_persistent_context(
+            self.user_data_dir,
+            **context_options,
+        )
+
+        logger.info(
+            "Persistent browser launched (headless=%s, user_data_dir=%s)",
+            self.headless,
+            self.user_data_dir,
+        )
+
+        if self._context.pages:
+            self._page = self._context.pages[0]
+        else:
+            self._page = await self._context.new_page()
+
+    async def _start_over_cdp(self) -> None:
+        """Connect to a remote browser over CDP and reuse its context/page.
+
+        The remote browser (e.g. browser-use) owns the user data dir, profile,
+        and LinkedIn session, so no local profile is created and context-level
+        options (viewport, user_agent, locale) cannot be applied to the existing
+        remote context.
+        """
+        assert self._playwright is not None
+        assert self.cdp_endpoint is not None
+
+        self._browser = await self._playwright.chromium.connect_over_cdp(
+            self.cdp_endpoint,
+            slow_mo=self.slow_mo,
+        )
+
+        if self._browser.contexts:
+            self._context = self._browser.contexts[0]
+        else:
+            self._context = await self._browser.new_context()
+
+        if self._context.pages:
+            self._page = self._context.pages[0]
+        else:
+            self._page = await self._context.new_page()
+
+        logger.info(
+            "Connected to remote browser over CDP (endpoint=%s, persistent=%s)",
+            self.cdp_endpoint,
+            self.cdp_persistent,
+        )
+        if self.viewport or self.user_agent:
+            logger.debug(
+                "Ignoring viewport/user_agent on CDP connection: the remote "
+                "context configuration cannot be overridden"
+            )
+
     async def close(self) -> None:
-        """Close persistent context and cleanup resources."""
+        """Close (or disconnect from) the browser and cleanup resources.
+
+        In CDP mode the context belongs to the remote browser, so it is never
+        closed directly. When ``cdp_persistent`` is set we only stop the local
+        playwright connection (disconnect) and leave the remote browser running;
+        otherwise we close the remote browser before stopping playwright.
+        """
         context = self._context
+        browser = self._browser
         playwright = self._playwright
+        is_cdp = self.is_cdp
+        cdp_persistent = self.cdp_persistent
         self._context = None
+        self._browser = None
         self._page = None
         self._playwright = None
 
-        if context is None and playwright is None:
+        if context is None and browser is None and playwright is None:
             return
 
-        if context is not None:
+        if is_cdp:
+            if not cdp_persistent and browser is not None:
+                await self._close_remote_cdp_browser(browser)
+        elif context is not None:
             try:
                 await context.close()
             except Exception as exc:
@@ -149,7 +224,33 @@ class BrowserManager:
             except Exception as exc:
                 logger.error("Error stopping playwright: %s", exc)
 
-        logger.info("Browser closed")
+        if is_cdp and cdp_persistent:
+            logger.info("Disconnected from remote CDP browser (left running)")
+        else:
+            logger.info("Browser closed")
+
+    @staticmethod
+    async def _close_remote_cdp_browser(browser: Browser) -> None:
+        """Terminate the remote browser reached over CDP.
+
+        Over a CDP connection ``browser.close()`` only disconnects the client --
+        the remote browser keeps running. Issuing the CDP ``Browser.close``
+        command actually shuts the remote browser down. If the command cannot be
+        sent we fall back to disconnecting so we never leak the connection.
+        """
+        try:
+            session = await browser.new_browser_cdp_session()
+            await session.send("Browser.close")
+        except Exception as exc:
+            logger.warning(
+                "CDP Browser.close did not complete cleanly (%s); "
+                "disconnecting instead",
+                exc,
+            )
+            try:
+                await browser.close()
+            except Exception:
+                logger.debug("Fallback browser.close() failed", exc_info=True)
 
     @property
     def page(self) -> Page:

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -21,6 +21,7 @@ from linkedin_mcp_server.drivers.browser import (
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.exceptions import (
     BrowserBinaryMissingError,
+    CDPSessionUnauthenticatedError,
     DockerHostLoginRequiredError,
     LinuxBrowserDependencyError,
 )
@@ -57,8 +58,21 @@ async def handle_auth_error(
     """Close the stale browser and trigger interactive re-login.
 
     In Docker mode a GUI browser cannot be opened, so we raise
-    ``DockerHostLoginRequiredError`` for a consistent user message.
+    ``DockerHostLoginRequiredError`` for a consistent user message. In CDP mode
+    the session is managed on the remote browser, so we cannot open an
+    interactive login and raise ``CDPSessionUnauthenticatedError`` instead.
     """
+    if get_runtime_policy() == RuntimePolicy.CDP:
+        try:
+            await close_browser()
+        except Exception as close_exc:
+            logger.warning("Failed to close stale CDP browser (ignored): %s", close_exc)
+        raise CDPSessionUnauthenticatedError(
+            "No valid LinkedIn session is available on the remote CDP browser. "
+            "Log in to LinkedIn in the remote browser (e.g. browser-use), "
+            "then retry this tool."
+        ) from error
+
     if get_runtime_policy() == RuntimePolicy.DOCKER:
         raise DockerHostLoginRequiredError(
             "No valid LinkedIn session is available in Docker. "

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -9,6 +9,7 @@ automatic profile persistence.
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
 from linkedin_mcp_server.common_utils import secure_mkdir
 from linkedin_mcp_server.core import (
@@ -180,23 +181,28 @@ async def _feed_auth_succeeds(
         return False
 
 
-def _launch_options() -> tuple[dict[str, str], dict[str, int]]:
+def _launch_options() -> tuple[dict[str, Any], dict[str, int]]:
     config = get_config()
     viewport = {
         "width": config.browser.viewport_width,
         "height": config.browser.viewport_height,
     }
-    launch_options: dict[str, str] = {}
+    launch_options: dict[str, Any] = {}
     if config.browser.chrome_path:
         launch_options["executable_path"] = config.browser.chrome_path
         logger.info("Using custom Chrome path: %s", config.browser.chrome_path)
     return launch_options, viewport
 
 
+def _cdp_enabled() -> bool:
+    """Return whether the server should connect over CDP instead of launching Chrome."""
+    return get_config().browser.cdp_enabled
+
+
 def _make_browser(
     profile_dir: Path,
     *,
-    launch_options: dict[str, str],
+    launch_options: dict[str, Any],
     viewport: dict[str, int],
 ) -> BrowserManager:
     config = get_config()
@@ -210,10 +216,49 @@ def _make_browser(
     )
 
 
+def _make_cdp_browser() -> BrowserManager:
+    """Create a BrowserManager that connects to a remote browser over CDP."""
+    config = get_config()
+    return BrowserManager(
+        headless=_headless,
+        slow_mo=config.browser.slow_mo,
+        user_agent=config.browser.user_agent,
+        viewport={
+            "width": config.browser.viewport_width,
+            "height": config.browser.viewport_height,
+        },
+        cdp_endpoint=config.browser.cdp_endpoint,
+        cdp_persistent=config.browser.cdp_persistent,
+    )
+
+
+async def _connect_cdp_browser() -> BrowserManager:
+    """Connect to the remote CDP browser and validate the LinkedIn session.
+
+    The remote browser (e.g. browser-use) manages the profile and LinkedIn
+    session, so no local profile/cookie bridge applies. Authentication is
+    confirmed solely by the /feed/ check against the remote page.
+    """
+    browser = _make_cdp_browser()
+    try:
+        await browser.start()
+        if not await _feed_auth_succeeds(browser):
+            raise AuthenticationError(
+                "Remote CDP browser is not authenticated with LinkedIn. "
+                "Log in to LinkedIn in the remote browser (e.g. browser-use) "
+                "and retry."
+            )
+        browser.is_authenticated = True
+        return browser
+    except Exception:
+        await browser.close()
+        raise
+
+
 async def _authenticate_existing_profile(
     profile_dir: Path,
     *,
-    launch_options: dict[str, str],
+    launch_options: dict[str, Any],
     viewport: dict[str, int],
 ) -> BrowserManager:
     browser = _make_browser(
@@ -238,7 +283,7 @@ async def _bridge_runtime_profile(
     cookie_path: Path,
     source_state: SourceState,
     runtime_id: str,
-    launch_options: dict[str, str],
+    launch_options: dict[str, Any],
     viewport: dict[str, int],
     persist_runtime: bool,
 ) -> BrowserManager:
@@ -366,6 +411,14 @@ async def get_or_create_browser(
         _headless = headless
 
     if _browser is not None:
+        return _browser
+
+    if _cdp_enabled():
+        logger.info("Connecting over CDP (profile managed on the remote browser)")
+        browser = await _connect_cdp_browser()
+        _apply_browser_settings(browser)
+        _browser = browser
+        _browser_cookie_export_path = None
         return _browser
 
     launch_options, viewport = _launch_options()
@@ -504,6 +557,19 @@ async def close_browser() -> None:
             logger.debug("Cookie export on close skipped", exc_info=True)
     await browser.close()
     logger.info("Browser closed")
+
+
+async def close_browser_after_tool_if_ephemeral() -> None:
+    """Close the browser after a tool call when the CDP session is ephemeral.
+
+    In non-persistent CDP mode the remote browser is not reused across tool
+    calls: each call connects fresh and the remote browser is terminated when
+    the call completes. In all other modes (local persistent Chrome, or
+    persistent CDP) the browser is kept for reuse and this is a no-op.
+    """
+    config = get_config().browser
+    if config.cdp_enabled and not config.cdp_persistent:
+        await close_browser()
 
 
 def get_profile_dir() -> Path:

--- a/linkedin_mcp_server/error_handler.py
+++ b/linkedin_mcp_server/error_handler.py
@@ -28,6 +28,7 @@ from linkedin_mcp_server.exceptions import (
     BrowserBinaryMissingError,
     BrowserSetupFailedError,
     BrowserSetupInProgressError,
+    CDPSessionUnauthenticatedError,
     CredentialsNotFoundError,
     DockerHostLoginRequiredError,
     LinuxBrowserDependencyError,
@@ -108,6 +109,10 @@ def raise_tool_error(exception: Exception, context: str = "") -> NoReturn:
 
     elif isinstance(exception, DockerHostLoginRequiredError):
         logger.warning("Docker host login required%s: %s", ctx, exception)
+        raise ToolError(str(exception)) from exception
+
+    elif isinstance(exception, CDPSessionUnauthenticatedError):
+        logger.warning("CDP session unauthenticated%s: %s", ctx, exception)
         raise ToolError(str(exception)) from exception
 
     elif isinstance(exception, LinuxBrowserDependencyError):

--- a/linkedin_mcp_server/exceptions.py
+++ b/linkedin_mcp_server/exceptions.py
@@ -55,6 +55,10 @@ class DockerHostLoginRequiredError(LinkedInMCPError):
     """Docker runtime requires host-side login creation."""
 
 
+class CDPSessionUnauthenticatedError(LinkedInMCPError):
+    """Remote CDP browser has no authenticated LinkedIn session."""
+
+
 class LinuxBrowserDependencyError(LinkedInMCPError):
     """Linux host dependencies required for Chromium are missing."""
 

--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -70,3 +70,24 @@ class SequentialToolExecutionMiddleware(Middleware):
                     tool_name,
                     hold_seconds,
                 )
+                await self._close_ephemeral_cdp_browser(tool_name)
+
+    @staticmethod
+    async def _close_ephemeral_cdp_browser(tool_name: str) -> None:
+        """Tear down the remote browser after the call in ephemeral CDP mode.
+
+        Imported lazily to keep this middleware import-light and avoid pulling
+        the browser driver into modules that only need request serialization.
+        """
+        from linkedin_mcp_server.drivers.browser import (
+            close_browser_after_tool_if_ephemeral,
+        )
+
+        try:
+            await close_browser_after_tool_if_ephemeral()
+        except Exception as exc:
+            logger.warning(
+                "Failed to close ephemeral CDP browser after tool '%s': %s",
+                tool_name,
+                exc,
+            )

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -21,9 +21,11 @@ from linkedin_mcp_server.bootstrap import (
     invalidate_auth_and_trigger_relogin,
     invalidate_browser_setup,
     reset_bootstrap_for_testing,
+    RuntimePolicy,
     SetupState,
     start_background_browser_setup_if_needed,
 )
+from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.exceptions import (
     AuthenticationInProgressError,
     AuthenticationStartedError,
@@ -146,6 +148,30 @@ class TestBootstrap:
     def test_runtime_policy_uses_initialized_value(self):
         initialize_bootstrap("managed")
         assert get_runtime_policy() == "managed"
+
+    def test_runtime_policy_cdp_when_endpoint_set(self, monkeypatch):
+        config = AppConfig()
+        config.browser.cdp_endpoint = "http://127.0.0.1:9222"
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
+        assert get_runtime_policy() == RuntimePolicy.CDP
+
+    async def test_cdp_bypasses_setup_and_auth_gating(self, monkeypatch):
+        config = AppConfig()
+        config.browser.cdp_endpoint = "http://127.0.0.1:9222"
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
+        # browser_setup_ready / _auth_ready must never be consulted in CDP mode.
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap.browser_setup_ready",
+            lambda: pytest.fail("browser setup should not be checked in CDP mode"),
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._auth_ready",
+            lambda: pytest.fail("auth should not be checked in CDP mode"),
+        )
+
+        # Returns without raising and without requiring local setup or auth.
+        await ensure_tool_ready_or_raise("get_person_profile")
+        assert get_runtime_policy() == RuntimePolicy.CDP
 
 
 def _make_auth_ready(profile_dir):

--- a/tests/test_browser_driver.py
+++ b/tests/test_browser_driver.py
@@ -121,6 +121,125 @@ async def test_get_or_create_browser_requires_source_state():
 
 
 @pytest.mark.asyncio
+async def test_cdp_mode_bypasses_source_state_and_validates_feed(monkeypatch):
+    config = AppConfig()
+    config.browser.cdp_endpoint = "http://127.0.0.1:9222"
+    monkeypatch.setattr(
+        "linkedin_mcp_server.drivers.browser.get_config", lambda: config
+    )
+    cdp_browser = _make_mock_browser()
+
+    with (
+        patch(
+            "linkedin_mcp_server.drivers.browser.BrowserManager",
+            return_value=cdp_browser,
+        ) as ctor,
+        patch(
+            "linkedin_mcp_server.drivers.browser.detect_auth_barrier_quick",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        result = await get_or_create_browser()
+
+    assert result is cdp_browser
+    assert cdp_browser.is_authenticated is True
+    # No local profile artifacts read; constructed with the CDP endpoint.
+    assert ctor.call_args.kwargs["cdp_endpoint"] == "http://127.0.0.1:9222"
+    assert "user_data_dir" not in ctor.call_args.kwargs
+    cdp_browser.import_cookies.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cdp_mode_feed_check_failure_raises_and_closes(monkeypatch):
+    from linkedin_mcp_server.core import AuthenticationError
+
+    config = AppConfig()
+    config.browser.cdp_endpoint = "http://127.0.0.1:9222"
+    monkeypatch.setattr(
+        "linkedin_mcp_server.drivers.browser.get_config", lambda: config
+    )
+    cdp_browser = _make_mock_browser()
+
+    with (
+        patch(
+            "linkedin_mcp_server.drivers.browser.BrowserManager",
+            return_value=cdp_browser,
+        ),
+        patch(
+            "linkedin_mcp_server.drivers.browser.detect_auth_barrier_quick",
+            new_callable=AsyncMock,
+            return_value="login title: linkedin login",
+        ),
+        pytest.raises(AuthenticationError, match="Remote CDP browser"),
+    ):
+        await get_or_create_browser()
+
+    cdp_browser.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_cdp_closes_browser_after_tool(monkeypatch):
+    config = AppConfig()
+    config.browser.cdp_endpoint = "http://127.0.0.1:9222"
+    config.browser.cdp_persistent = False
+    monkeypatch.setattr(
+        "linkedin_mcp_server.drivers.browser.get_config", lambda: config
+    )
+    from linkedin_mcp_server.drivers.browser import (
+        close_browser_after_tool_if_ephemeral,
+    )
+
+    with patch(
+        "linkedin_mcp_server.drivers.browser.close_browser",
+        new_callable=AsyncMock,
+    ) as mock_close:
+        await close_browser_after_tool_if_ephemeral()
+
+    mock_close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_persistent_cdp_keeps_browser_after_tool(monkeypatch):
+    config = AppConfig()
+    config.browser.cdp_endpoint = "http://127.0.0.1:9222"
+    config.browser.cdp_persistent = True
+    monkeypatch.setattr(
+        "linkedin_mcp_server.drivers.browser.get_config", lambda: config
+    )
+    from linkedin_mcp_server.drivers.browser import (
+        close_browser_after_tool_if_ephemeral,
+    )
+
+    with patch(
+        "linkedin_mcp_server.drivers.browser.close_browser",
+        new_callable=AsyncMock,
+    ) as mock_close:
+        await close_browser_after_tool_if_ephemeral()
+
+    mock_close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_local_mode_keeps_browser_after_tool(monkeypatch):
+    config = AppConfig()  # no cdp_endpoint -> local persistent Chrome
+    monkeypatch.setattr(
+        "linkedin_mcp_server.drivers.browser.get_config", lambda: config
+    )
+    from linkedin_mcp_server.drivers.browser import (
+        close_browser_after_tool_if_ephemeral,
+    )
+
+    with patch(
+        "linkedin_mcp_server.drivers.browser.close_browser",
+        new_callable=AsyncMock,
+    ) as mock_close:
+        await close_browser_after_tool_if_ephemeral()
+
+    mock_close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_same_runtime_uses_source_profile(tmp_path):
     _write_source_state(tmp_path, runtime_id="macos-arm64-host")
     source_browser = _make_mock_browser()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,35 @@ class TestBrowserConfig:
         with pytest.raises(ConfigurationError):
             BrowserConfig(slow_mo=-1).validate()
 
+    def test_cdp_defaults(self):
+        config = BrowserConfig()
+        assert config.cdp_endpoint is None
+        assert config.cdp_persistent is False
+        assert config.cdp_enabled is False
+
+    def test_cdp_enabled_when_endpoint_set(self):
+        config = BrowserConfig(cdp_endpoint="http://127.0.0.1:9222")
+        assert config.cdp_enabled is True
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "ws://127.0.0.1:9222/devtools/browser/abc",
+            "wss://example.com/cdp",
+            "http://127.0.0.1:9222",
+            "https://example.com:9222",
+        ],
+    )
+    def test_validate_accepts_valid_cdp_endpoint(self, endpoint):
+        BrowserConfig(cdp_endpoint=endpoint).validate()  # No error
+
+    @pytest.mark.parametrize(
+        "endpoint", ["127.0.0.1:9222", "tcp://127.0.0.1:9222", "localhost"]
+    )
+    def test_validate_rejects_invalid_cdp_endpoint(self, endpoint):
+        with pytest.raises(ConfigurationError, match="cdp_endpoint"):
+            BrowserConfig(cdp_endpoint=endpoint).validate()
+
 
 class TestServerConfig:
     def test_defaults(self):
@@ -261,3 +290,61 @@ class TestLoaders:
 
         config = load_from_env(AppConfig())
         assert config.browser.user_data_dir == "/custom/profile"
+
+    def test_load_from_env_cdp_endpoint(self, monkeypatch):
+        monkeypatch.delenv("CDP_URL", raising=False)
+        monkeypatch.setenv("CDP_ENDPOINT", "http://127.0.0.1:9222")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.cdp_endpoint == "http://127.0.0.1:9222"
+        assert config.browser.cdp_enabled is True
+
+    def test_load_from_env_cdp_url_alias(self, monkeypatch):
+        monkeypatch.delenv("CDP_ENDPOINT", raising=False)
+        monkeypatch.setenv("CDP_URL", "ws://127.0.0.1:9222/devtools/browser/x")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.cdp_endpoint == "ws://127.0.0.1:9222/devtools/browser/x"
+
+    def test_load_from_env_cdp_endpoint_preferred_over_url(self, monkeypatch):
+        monkeypatch.setenv("CDP_ENDPOINT", "http://primary:9222")
+        monkeypatch.setenv("CDP_URL", "http://alias:9222")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.cdp_endpoint == "http://primary:9222"
+
+    def test_load_from_env_cdp_persistent_true(self, monkeypatch):
+        monkeypatch.setenv("CDP_PERSISTENT", "true")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.cdp_persistent is True
+
+    def test_load_from_env_cdp_persistent_false_alias(self, monkeypatch):
+        monkeypatch.setenv("CDP_PERSISTENT", "off")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.cdp_persistent is False
+
+    def test_load_from_args_cdp_endpoint_and_persistent(self, monkeypatch):
+        monkeypatch.delenv("CDP_ENDPOINT", raising=False)
+        monkeypatch.delenv("CDP_URL", raising=False)
+        monkeypatch.delenv("CDP_PERSISTENT", raising=False)
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "linkedin-mcp-server",
+                "--cdp-endpoint",
+                "http://127.0.0.1:9222",
+                "--cdp-persistent",
+            ],
+        )
+        from linkedin_mcp_server.config.loaders import load_from_args
+
+        config = load_from_args(AppConfig())
+        assert config.browser.cdp_endpoint == "http://127.0.0.1:9222"
+        assert config.browser.cdp_persistent is True

--- a/tests/test_core_browser.py
+++ b/tests/test_core_browser.py
@@ -161,3 +161,147 @@ async def test_close_is_idempotent_and_resets_state(tmp_path):
     assert browser._context is None
     assert browser._page is None
     assert browser._playwright is None
+
+
+def _make_cdp_playwright(existing_context=None, existing_page=None):
+    """Build a fake playwright whose chromium.connect_over_cdp returns a Browser."""
+    page = existing_page or MagicMock()
+    context = existing_context or MagicMock()
+    context.pages = [page] if existing_page is not None else []
+    context.new_page = AsyncMock(return_value=page)
+    remote_browser = MagicMock()
+    remote_browser.contexts = [context] if existing_context is not None else []
+    remote_browser.new_context = AsyncMock(return_value=context)
+    remote_browser.close = AsyncMock()
+    chromium = MagicMock()
+    chromium.connect_over_cdp = AsyncMock(return_value=remote_browser)
+    playwright = MagicMock()
+    playwright.chromium = chromium
+    playwright.stop = AsyncMock()
+    return playwright, remote_browser, context, page
+
+
+@pytest.mark.asyncio
+async def test_start_over_cdp_reuses_existing_context_and_page(monkeypatch):
+    page = MagicMock()
+    context = MagicMock()
+    playwright, remote_browser, context, page = _make_cdp_playwright(
+        existing_context=context, existing_page=page
+    )
+
+    starter = MagicMock()
+    starter.start = AsyncMock(return_value=playwright)
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.browser.async_playwright", lambda: starter
+    )
+
+    browser = BrowserManager(cdp_endpoint="http://127.0.0.1:9222", slow_mo=7)
+    await browser.start()
+
+    chromium = playwright.chromium
+    chromium.connect_over_cdp.assert_awaited_once_with(
+        "http://127.0.0.1:9222", slow_mo=7
+    )
+    remote_browser.new_context.assert_not_awaited()
+    context.new_page.assert_not_awaited()
+    assert browser._browser is remote_browser
+    assert browser._context is context
+    assert browser._page is page
+    assert browser.is_cdp is True
+
+
+@pytest.mark.asyncio
+async def test_start_over_cdp_creates_context_and_page_when_missing(monkeypatch):
+    playwright, remote_browser, context, page = _make_cdp_playwright()
+
+    starter = MagicMock()
+    starter.start = AsyncMock(return_value=playwright)
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.browser.async_playwright", lambda: starter
+    )
+
+    browser = BrowserManager(cdp_endpoint="ws://remote/cdp")
+    await browser.start()
+
+    remote_browser.new_context.assert_awaited_once()
+    context.new_page.assert_awaited_once()
+    assert browser._page is page
+
+
+@pytest.mark.asyncio
+async def test_cdp_close_non_persistent_sends_browser_close_command():
+    browser = BrowserManager(cdp_endpoint="http://127.0.0.1:9222")
+    session = MagicMock()
+    session.send = AsyncMock()
+    remote_browser = MagicMock()
+    remote_browser.new_browser_cdp_session = AsyncMock(return_value=session)
+    remote_browser.close = AsyncMock()
+    context = MagicMock()
+    context.close = AsyncMock()
+    playwright = MagicMock()
+    playwright.stop = AsyncMock()
+    browser._browser = remote_browser
+    browser._context = context
+    browser._page = MagicMock()
+    browser._playwright = playwright
+
+    await browser.close()
+
+    # The remote browser is terminated via the CDP Browser.close command, not
+    # via browser.close() (which would only disconnect the client).
+    remote_browser.new_browser_cdp_session.assert_awaited_once()
+    session.send.assert_awaited_once_with("Browser.close")
+    remote_browser.close.assert_not_awaited()
+    context.close.assert_not_awaited()
+    playwright.stop.assert_awaited_once()
+    assert browser._browser is None
+    assert browser._context is None
+
+
+@pytest.mark.asyncio
+async def test_cdp_close_non_persistent_falls_back_to_disconnect_on_error():
+    browser = BrowserManager(cdp_endpoint="http://127.0.0.1:9222")
+    remote_browser = MagicMock()
+    remote_browser.new_browser_cdp_session = AsyncMock(
+        side_effect=RuntimeError("no cdp session")
+    )
+    remote_browser.close = AsyncMock()
+    playwright = MagicMock()
+    playwright.stop = AsyncMock()
+    browser._browser = remote_browser
+    browser._context = MagicMock()
+    browser._page = MagicMock()
+    browser._playwright = playwright
+
+    await browser.close()
+
+    remote_browser.new_browser_cdp_session.assert_awaited_once()
+    remote_browser.close.assert_awaited_once()
+    playwright.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cdp_close_persistent_only_disconnects():
+    browser = BrowserManager(cdp_endpoint="http://127.0.0.1:9222", cdp_persistent=True)
+    session = MagicMock()
+    session.send = AsyncMock()
+    remote_browser = MagicMock()
+    remote_browser.new_browser_cdp_session = AsyncMock(return_value=session)
+    remote_browser.close = AsyncMock()
+    context = MagicMock()
+    context.close = AsyncMock()
+    playwright = MagicMock()
+    playwright.stop = AsyncMock()
+    browser._browser = remote_browser
+    browser._context = context
+    browser._page = MagicMock()
+    browser._playwright = playwright
+
+    await browser.close()
+
+    remote_browser.new_browser_cdp_session.assert_not_awaited()
+    remote_browser.close.assert_not_awaited()
+    session.send.assert_not_awaited()
+    context.close.assert_not_awaited()
+    playwright.stop.assert_awaited_once()
+    assert browser._browser is None

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -13,6 +13,7 @@ from linkedin_mcp_server.core.exceptions import (
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.exceptions import (
     AuthenticationStartedError,
+    CDPSessionUnauthenticatedError,
     DockerHostLoginRequiredError,
 )
 
@@ -53,6 +54,32 @@ class TestHandleAuthError:
                 await handle_auth_error(
                     AuthenticationError("Session expired"), ctx=None
                 )
+
+    async def test_cdp_raises_unauthenticated_without_relogin(self):
+        """On CDP runtime, raise CDPSessionUnauthenticatedError, never relogin."""
+        from linkedin_mcp_server.bootstrap import RuntimePolicy
+
+        with (
+            patch(
+                "linkedin_mcp_server.dependencies.get_runtime_policy",
+                return_value=RuntimePolicy.CDP,
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.close_browser",
+                new_callable=AsyncMock,
+            ) as mock_close,
+            patch(
+                "linkedin_mcp_server.dependencies.invalidate_auth_and_trigger_relogin",
+                new_callable=AsyncMock,
+            ) as mock_relogin,
+        ):
+            with pytest.raises(CDPSessionUnauthenticatedError, match="remote"):
+                await handle_auth_error(
+                    AuthenticationError("Session expired"), ctx=None
+                )
+
+            mock_close.assert_awaited_once()
+            mock_relogin.assert_not_awaited()
 
 
 class TestGetReadyExtractor:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,14 +1,30 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import mcp.types as mt
+import pytest
 from fastmcp import FastMCP
 from fastmcp.server.middleware import MiddlewareContext
 
+from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
 from linkedin_mcp_server.server import create_mcp_server
+
+
+@pytest.fixture(autouse=True)
+def _stub_browser_config(monkeypatch):
+    """Give the middleware teardown a clean local config.
+
+    The middleware closes the browser after each tool call in ephemeral CDP
+    mode by reading ``get_config()``. Under pytest the config singleton is reset
+    between tests, so without this stub it would re-parse pytest's argv. A plain
+    AppConfig (no CDP endpoint) makes the teardown a safe no-op.
+    """
+    monkeypatch.setattr(
+        "linkedin_mcp_server.drivers.browser.get_config", lambda: AppConfig()
+    )
 
 
 class TestSequentialToolExecutionMiddleware:
@@ -87,3 +103,38 @@ class TestSequentialToolExecutionMiddleware:
                 ),
             ]
         )
+
+    async def test_on_call_tool_closes_ephemeral_cdp_browser(self):
+        middleware = SequentialToolExecutionMiddleware()
+        call_next = AsyncMock(return_value=MagicMock())
+        context = MiddlewareContext(
+            message=mt.CallToolRequestParams(name="get_person_profile", arguments={}),
+            method="tools/call",
+            fastmcp_context=None,
+        )
+
+        with patch(
+            "linkedin_mcp_server.drivers.browser.close_browser_after_tool_if_ephemeral",
+            new_callable=AsyncMock,
+        ) as mock_teardown:
+            await middleware.on_call_tool(context, call_next)
+
+        mock_teardown.assert_awaited_once()
+
+    async def test_on_call_tool_closes_ephemeral_cdp_browser_even_on_error(self):
+        middleware = SequentialToolExecutionMiddleware()
+        call_next = AsyncMock(side_effect=RuntimeError("boom"))
+        context = MiddlewareContext(
+            message=mt.CallToolRequestParams(name="get_person_profile", arguments={}),
+            method="tools/call",
+            fastmcp_context=None,
+        )
+
+        with patch(
+            "linkedin_mcp_server.drivers.browser.close_browser_after_tool_if_ephemeral",
+            new_callable=AsyncMock,
+        ) as mock_teardown:
+            with pytest.raises(RuntimeError, match="boom"):
+                await middleware.on_call_tool(context, call_next)
+
+        mock_teardown.assert_awaited_once()


### PR DESCRIPTION
- Introduced `CDP_ENDPOINT` and `CDP_PERSISTENT` configuration options in `.env.example` and updated documentation to reflect these changes.
- Implemented logic in the server to connect to a remote browser over the Chrome DevTools Protocol (CDP), allowing LinkedIn sessions to be managed remotely.
- Updated the `BrowserManager` to handle both local and CDP connections, including session validation and management.
- Added tests to ensure proper functionality of CDP mode, including session validation and browser lifecycle management.
- Enhanced error handling for unauthenticated CDP sessions.