### PR TITLE
fix(search_people): accept JSON-stringified network arrays from MCP clients

### DIFF
--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -5,6 +5,7 @@ Uses innerText extraction for resilient profile data capture
 with configurable section selection.
 """
 
+import json
 import logging
 from typing import Annotated, Any
 
@@ -112,7 +113,7 @@ def register_person_tools(
         keywords: str,
         ctx: Context,
         location: str | None = None,
-        network: list[str] | None = None,
+        network: str | list[str] | None = None,
         current_company: str | None = None,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
@@ -126,6 +127,9 @@ def register_person_tools(
             network: Optional connection-degree filter. Each element is one of
                 "F" (1st-degree), "S" (2nd-degree), "O" (3rd-degree and beyond).
                 Example: ["F"] to only return 1st-degree connections.
+                Accepts either a list or a JSON-encoded string (e.g. '["F"]')
+                for compatibility with MCP clients that serialize array
+                arguments to strings.
             current_company: Optional current-employer filter. LinkedIn's
                 currentCompany facet only filters on the numeric company URN id
                 (e.g. "1115" for SAP); plain company names are accepted by the
@@ -139,6 +143,20 @@ def register_person_tools(
             Dict with url, sections (name -> raw text), and optional references.
             The LLM should parse the raw text to extract individual people and their profiles.
         """
+        # Some MCP clients serialize array arguments whose JSON Schema has no
+        # top-level "type" (the anyOf[array, null] rendering of `list[str] |
+        # None`) into a JSON string before dispatch, so ["F"] can arrive as
+        # the string '["F"]'. Accept and normalize that to a list.
+        if isinstance(network, str):
+            raw = network.strip()
+            if not raw:
+                network = None
+            else:
+                try:
+                    parsed = json.loads(raw)
+                except ValueError:
+                    parsed = raw
+                network = parsed if isinstance(parsed, list) else [str(parsed)]
         try:
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="search_people"


### PR DESCRIPTION
## Summary
Some MCP clients serialize array-typed tool arguments whose JSON Schema has no top-level `type` (the `anyOf: [array, null]` rendering of `list[str] | None`) into a JSON string before dispatch. As a result, `search_people`'s `network` argument arrives as the string `'["F"]'` instead of the array `["F"]`, and pydantic rejects it:

    Input should be a valid list [type=list_type, input_value='["F"]', input_type=str]

This makes the 1st/2nd/3rd-degree connection filter unusable from affected clients (observed with Claude Desktop / "Cowork"). Clients that send a native array (e.g. the MCP Inspector) are unaffected.

## Change
- `network` now accepts `str | list[str] | None`.
- A string value is normalized to a list (JSON-decoded when possible; otherwise treated as a single token like `"F"`). Native lists pass through unchanged.
- The advertised schema becomes `anyOf: [string, array<string>, null]`, so the stringified value also passes validation.

## Testing
- `network=["F"]` -> `["F"]` (unchanged)
- `network='["F"]'` (stringified) -> `["F"]`
- `network='["F","S"]'` -> `["F","S"]`
- `network="F"` (bare token) -> `["F"]`
- `ruff check` / `ruff format` clean.

Co-Authored-By: Oz <oz-agent@warp.dev>
