### PR TITLE
feat(jobs): add optional file output to job tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_companies` | Search for companies on LinkedIn by keywords | working |
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter | working |
-| `search_jobs` | Search for jobs with keywords and location filters; optional `output_mode`/`output_path` to save results to a file instead of (or alongside) returning them | working |
+| `search_jobs` | Search for jobs with keywords and location filters; optional `output_mode`/`output_path` saves under `~/.linkedin-mcp/exports` instead of (or alongside) returning results | working |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | working |
-| `get_job_details` | Get detailed information about a specific job posting; optional `output_mode`/`output_path` to save the posting to a file instead of (or alongside) returning it | working |
+| `get_job_details` | Get detailed job posting information; optional `output_mode`/`output_path` saves under `~/.linkedin-mcp/exports` instead of (or alongside) returning it | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `close_session` | Close browser session and clean up resources | working |
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_companies` | Search for companies on LinkedIn by keywords | working |
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter | working |
-| `search_jobs` | Search for jobs with keywords and location filters | working |
+| `search_jobs` | Search for jobs with keywords and location filters; optional `output_mode`/`output_path` to save results to a file instead of (or alongside) returning them | working |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | working |
-| `get_job_details` | Get detailed information about a specific job posting | working |
+| `get_job_details` | Get detailed information about a specific job posting; optional `output_mode`/`output_path` to save the posting to a file instead of (or alongside) returning it | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `close_session` | Close browser session and clean up resources | working |
 

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -12,8 +12,8 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Company Profiles**: Extract comprehensive company data, including the LinkedIn company URN id (used by LinkedIn's people-search `currentCompany` URL facet)
 - **Company Employees**: List employees at a company with optional keyword filtering
 - **Company Search**: Search for companies by keyword
-- **Job Details**: Retrieve job posting information, optionally saved to a file via `output_mode`/`output_path`
-- **Job Search**: Search for jobs with keywords and location filters, optionally saved to a file via `output_mode`/`output_path`
+- **Job Details**: Retrieve job posting information, optionally saved under `~/.linkedin-mcp/exports` via `output_mode`/`output_path`
+- **Job Search**: Search for jobs with keywords and location filters, optionally saved under `~/.linkedin-mcp/exports` via `output_mode`/`output_path`
 - **People Search**: Search for people by keywords and location
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -12,8 +12,8 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Company Profiles**: Extract comprehensive company data, including the LinkedIn company URN id (used by LinkedIn's people-search `currentCompany` URL facet)
 - **Company Employees**: List employees at a company with optional keyword filtering
 - **Company Search**: Search for companies by keyword
-- **Job Details**: Retrieve job posting information
-- **Job Search**: Search for jobs with keywords and location filters
+- **Job Details**: Retrieve job posting information, optionally saved to a file via `output_mode`/`output_path`
+- **Job Search**: Search for jobs with keywords and location filters, optionally saved to a file via `output_mode`/`output_path`
 - **People Search**: Search for people by keywords and location
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed

--- a/linkedin_mcp_server/common_utils.py
+++ b/linkedin_mcp_server/common_utils.py
@@ -96,7 +96,11 @@ def _render_result_text(result: dict[str, Any]) -> str:
 
 def _resolve_export_path(output_path: str) -> Path:
     """Resolve *output_path* inside the dedicated LinkedIn MCP export directory."""
-    export_root = (Path.home() / ".linkedin-mcp" / "exports").resolve()
+    export_root_path = Path.home().resolve() / ".linkedin-mcp" / "exports"
+    export_root = export_root_path.resolve()
+    if export_root != export_root_path:
+        raise ValueError("LinkedIn MCP export directory must not be a symlink")
+
     requested = Path(output_path).expanduser()
     path = (requested if requested.is_absolute() else export_root / requested).resolve()
     if not path.is_relative_to(export_root):

--- a/linkedin_mcp_server/common_utils.py
+++ b/linkedin_mcp_server/common_utils.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import os
 import stat
 from datetime import UTC, datetime
 from pathlib import Path
 import re
 import tempfile
+from typing import Any, Literal
 
 _PRIVATE_DIR_MODE = 0o700
 
@@ -76,3 +78,53 @@ def secure_write_text(path: Path, content: str, mode: int = 0o600) -> None:
     except BaseException:
         os.unlink(tmp)
         raise
+
+
+def _render_result_text(result: dict[str, Any]) -> str:
+    """Render a tool result dict as readable plain text for .txt/.md dumps."""
+    parts: list[str] = []
+    url = result.get("url")
+    if url:
+        parts.append(f"URL: {url}")
+    for name, text in (result.get("sections") or {}).items():
+        parts.append(f"\n## {name}\n{text}")
+    job_ids = result.get("job_ids")
+    if job_ids:
+        parts.append("\nJOB_IDS: " + ", ".join(job_ids))
+    return "\n".join(parts) + "\n"
+
+
+def apply_output_mode(
+    result: dict[str, Any],
+    output_path: str | None,
+    output_mode: Literal["display", "file", "both"],
+) -> dict[str, Any]:
+    """Optionally persist *result* to disk and shape what is returned to the caller.
+
+    - ``display`` (default): return the full result, write nothing.
+    - ``file``: write to *output_path*, return a compact confirmation only.
+    - ``both``: write to *output_path* and return the full result.
+
+    File format follows the extension: ``.json`` dumps the full dict, anything
+    else writes a readable text rendering of url/sections/job_ids.
+    """
+    if output_mode == "display":
+        return result
+    if not output_path:
+        raise ValueError("output_path is required when output_mode is 'file' or 'both'")
+
+    path = Path(output_path).expanduser()
+    if path.suffix == ".json":
+        secure_write_text(path, json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        secure_write_text(path, _render_result_text(result))
+
+    if output_mode == "both":
+        return result
+    confirmation: dict[str, Any] = {"saved_path": str(path)}
+    if "url" in result:
+        confirmation["url"] = result["url"]
+    if "job_ids" in result:
+        confirmation["job_ids"] = result["job_ids"]
+    confirmation["sections"] = sorted((result.get("sections") or {}).keys())
+    return confirmation

--- a/linkedin_mcp_server/common_utils.py
+++ b/linkedin_mcp_server/common_utils.py
@@ -141,5 +141,5 @@ def apply_output_mode(
         confirmation["url"] = result["url"]
     if "job_ids" in result:
         confirmation["job_ids"] = result["job_ids"]
-    confirmation["sections"] = sorted((result.get("sections") or {}).keys())
+    confirmation["section_names"] = sorted((result.get("sections") or {}).keys())
     return confirmation

--- a/linkedin_mcp_server/common_utils.py
+++ b/linkedin_mcp_server/common_utils.py
@@ -94,6 +94,19 @@ def _render_result_text(result: dict[str, Any]) -> str:
     return "\n".join(parts) + "\n"
 
 
+def _resolve_export_path(output_path: str) -> Path:
+    """Resolve *output_path* inside the dedicated LinkedIn MCP export directory."""
+    export_root = (Path.home() / ".linkedin-mcp" / "exports").resolve()
+    requested = Path(output_path).expanduser()
+    path = (requested if requested.is_absolute() else export_root / requested).resolve()
+    if not path.is_relative_to(export_root):
+        raise ValueError(
+            "output_path must be inside the LinkedIn MCP export directory "
+            f"({export_root})"
+        )
+    return path
+
+
 def apply_output_mode(
     result: dict[str, Any],
     output_path: str | None,
@@ -103,24 +116,26 @@ def apply_output_mode(
 
     - ``display`` (default): return the full result, write nothing.
     - ``file``: write to *output_path*, return a compact confirmation only.
-    - ``both``: write to *output_path* and return the full result.
+    - ``both``: write to *output_path* and return the full result plus saved path.
 
-    File format follows the extension: ``.json`` dumps the full dict, anything
-    else writes a readable text rendering of url/sections/job_ids.
+    Relative paths resolve under ``~/.linkedin-mcp/exports``. Absolute paths
+    must also stay inside that directory. File format follows the extension:
+    ``.json`` dumps the full dict; anything else writes a readable text rendering
+    of url/sections/job_ids.
     """
     if output_mode == "display":
         return result
     if not output_path:
         raise ValueError("output_path is required when output_mode is 'file' or 'both'")
 
-    path = Path(output_path).expanduser()
+    path = _resolve_export_path(output_path)
     if path.suffix == ".json":
         secure_write_text(path, json.dumps(result, ensure_ascii=False, indent=2))
     else:
         secure_write_text(path, _render_result_text(result))
 
     if output_mode == "both":
-        return result
+        return {**result, "saved_path": str(path)}
     confirmation: dict[str, Any] = {"saved_path": str(path)}
     if "url" in result:
         confirmation["url"] = result["url"]

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -5,11 +5,12 @@ Uses innerText extraction for resilient job data capture.
 """
 
 import logging
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context, FastMCP
 from pydantic import Field
 
+from linkedin_mcp_server.common_utils import apply_output_mode
 from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
 from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
@@ -33,6 +34,8 @@ def register_job_tools(
     async def get_job_details(
         job_id: str,
         ctx: Context,
+        output_path: str | None = None,
+        output_mode: Literal["display", "file", "both"] = "display",
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -41,6 +44,12 @@ def register_job_tools(
         Args:
             job_id: LinkedIn job ID (e.g., "4252026496", "3856789012")
             ctx: FastMCP context for progress reporting
+            output_path: Where to save the result when output_mode is file/both.
+                Extension drives format: .json dumps the full dict, anything
+                else writes a readable text rendering.
+            output_mode: 'display' (default) returns content and writes nothing;
+                'file' writes to output_path and returns a compact confirmation;
+                'both' writes to output_path and returns the full content.
 
         Returns:
             Dict with url, sections (name -> raw text), and optional references.
@@ -60,7 +69,7 @@ def register_job_tools(
 
             await ctx.report_progress(progress=100, total=100, message="Complete")
 
-            return result
+            return apply_output_mode(result, output_path, output_mode)
 
         except AuthenticationError as e:
             try:
@@ -88,6 +97,8 @@ def register_job_tools(
         work_type: str | None = None,
         easy_apply: bool = False,
         sort_by: str | None = None,
+        output_path: str | None = None,
+        output_mode: Literal["display", "file", "both"] = "display",
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -106,6 +117,12 @@ def register_job_tools(
             work_type: Filter by work type, comma-separated (on_site, remote, hybrid)
             easy_apply: Only show Easy Apply jobs (default false)
             sort_by: Sort results (date, relevance)
+            output_path: Where to save the result when output_mode is file/both.
+                Extension drives format: .json dumps the full dict, anything
+                else writes a readable text rendering.
+            output_mode: 'display' (default) returns content and writes nothing;
+                'file' writes to output_path and returns a compact confirmation
+                (url + job_ids + section names); 'both' writes and returns full.
 
         Returns:
             Dict with url, sections (name -> raw text), job_ids (list of
@@ -140,7 +157,7 @@ def register_job_tools(
 
             await ctx.report_progress(progress=100, total=100, message="Complete")
 
-            return result
+            return apply_output_mode(result, output_path, output_mode)
 
         except AuthenticationError as e:
             try:

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -30,7 +30,7 @@ def register_job_tools(
         annotations={
             "readOnlyHint": False,
             "destructiveHint": True,
-            "idempotentHint": True,
+            "idempotentHint": False,
             "openWorldHint": True,
         },
         tags={"job", "scraping"},
@@ -91,7 +91,7 @@ def register_job_tools(
         annotations={
             "readOnlyHint": False,
             "destructiveHint": True,
-            "idempotentHint": True,
+            "idempotentHint": False,
             "openWorldHint": True,
         },
         tags={"job", "search"},

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -27,7 +27,12 @@ def register_job_tools(
     @mcp.tool(
         timeout=tool_timeout,
         title="Get Job Details",
-        annotations={"readOnlyHint": True, "openWorldHint": True},
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
         tags={"job", "scraping"},
         exclude_args=["extractor"],
     )
@@ -44,12 +49,13 @@ def register_job_tools(
         Args:
             job_id: LinkedIn job ID (e.g., "4252026496", "3856789012")
             ctx: FastMCP context for progress reporting
-            output_path: Where to save the result when output_mode is file/both.
-                Extension drives format: .json dumps the full dict, anything
-                else writes a readable text rendering.
+            output_path: Export path for file/both mode. Relative paths resolve
+                under ~/.linkedin-mcp/exports; absolute paths must remain inside
+                that directory. Extension drives format: .json dumps the full
+                dict; anything else writes a readable text rendering.
             output_mode: 'display' (default) returns content and writes nothing;
                 'file' writes to output_path and returns a compact confirmation;
-                'both' writes to output_path and returns the full content.
+                'both' writes and returns the full content plus saved_path.
 
         Returns:
             Dict with url, sections (name -> raw text), and optional references.
@@ -82,7 +88,12 @@ def register_job_tools(
     @mcp.tool(
         timeout=tool_timeout,
         title="Search Jobs",
-        annotations={"readOnlyHint": True, "openWorldHint": True},
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
         tags={"job", "search"},
         exclude_args=["extractor"],
     )
@@ -117,12 +128,13 @@ def register_job_tools(
             work_type: Filter by work type, comma-separated (on_site, remote, hybrid)
             easy_apply: Only show Easy Apply jobs (default false)
             sort_by: Sort results (date, relevance)
-            output_path: Where to save the result when output_mode is file/both.
-                Extension drives format: .json dumps the full dict, anything
-                else writes a readable text rendering.
+            output_path: Export path for file/both mode. Relative paths resolve
+                under ~/.linkedin-mcp/exports; absolute paths must remain inside
+                that directory. Extension drives format: .json dumps the full
+                dict; anything else writes a readable text rendering.
             output_mode: 'display' (default) returns content and writes nothing;
-                'file' writes to output_path and returns a compact confirmation
-                (url + job_ids + section names); 'both' writes and returns full.
+                'file' writes and returns a compact confirmation (url + job_ids
+                + section names); 'both' returns full content plus saved_path.
 
         Returns:
             Dict with url, sections (name -> raw text), job_ids (list of

--- a/manifest.json
+++ b/manifest.json
@@ -77,11 +77,11 @@
     },
     {
       "name": "get_job_details",
-      "description": "Retrieve specific job posting details using LinkedIn job IDs, with optional output_mode/output_path to save the result to a file"
+      "description": "Retrieve job details by LinkedIn job ID, with optional output_mode/output_path exports restricted to ~/.linkedin-mcp/exports"
     },
     {
       "name": "search_jobs",
-      "description": "Search for jobs with filters like keywords and location, with optional output_mode/output_path to save results to a file"
+      "description": "Search jobs by keywords and location, with optional output_mode/output_path exports restricted to ~/.linkedin-mcp/exports"
     },
     {
       "name": "search_people",

--- a/manifest.json
+++ b/manifest.json
@@ -77,11 +77,11 @@
     },
     {
       "name": "get_job_details",
-      "description": "Retrieve specific job posting details using LinkedIn job IDs"
+      "description": "Retrieve specific job posting details using LinkedIn job IDs, with optional output_mode/output_path to save the result to a file"
     },
     {
       "name": "search_jobs",
-      "description": "Search for jobs with filters like keywords and location"
+      "description": "Search for jobs with filters like keywords and location, with optional output_mode/output_path to save results to a file"
     },
     {
       "name": "search_people",

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -1,0 +1,77 @@
+"""Tests for linkedin_mcp_server.common_utils output helpers."""
+
+import json
+
+import pytest
+
+from linkedin_mcp_server.common_utils import apply_output_mode
+
+
+def _sample_result() -> dict:
+    return {
+        "url": "https://www.linkedin.com/jobs/view/12345/",
+        "sections": {"job_posting": "Software Engineer\nGreat opportunity"},
+        "job_ids": ["12345", "67890"],
+    }
+
+
+class TestApplyOutputMode:
+    def test_display_returns_full_result_and_writes_nothing(self, tmp_path):
+        result = _sample_result()
+        target = tmp_path / "out.json"
+
+        returned = apply_output_mode(result, str(target), "display")
+
+        assert returned is result
+        assert not target.exists()
+
+    def test_file_writes_json_and_returns_confirmation(self, tmp_path):
+        result = _sample_result()
+        target = tmp_path / "job.json"
+
+        returned = apply_output_mode(result, str(target), "file")
+
+        # Confirmation carries section names, not the full sections payload.
+        assert returned["saved_path"] == str(target)
+        assert returned["url"] == result["url"]
+        assert returned["job_ids"] == result["job_ids"]
+        assert returned["sections"] == ["job_posting"]
+        assert returned["sections"] != result["sections"]
+
+        on_disk = json.loads(target.read_text())
+        assert on_disk == result
+
+    def test_file_writes_text_for_non_json_extension(self, tmp_path):
+        result = _sample_result()
+        target = tmp_path / "job.md"
+
+        apply_output_mode(result, str(target), "file")
+
+        body = target.read_text()
+        assert "URL: https://www.linkedin.com/jobs/view/12345/" in body
+        assert "## job_posting" in body
+        assert "Software Engineer" in body
+        assert "JOB_IDS: 12345, 67890" in body
+
+    def test_both_writes_file_and_returns_full_result(self, tmp_path):
+        result = _sample_result()
+        target = tmp_path / "job.json"
+
+        returned = apply_output_mode(result, str(target), "both")
+
+        assert returned is result
+        assert json.loads(target.read_text()) == result
+
+    def test_file_mode_requires_output_path(self):
+        with pytest.raises(ValueError, match="output_path is required"):
+            apply_output_mode(_sample_result(), None, "file")
+
+    def test_expands_user_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = _sample_result()
+
+        returned = apply_output_mode(result, "~/saved-job.json", "file")
+
+        written = tmp_path / "saved-job.json"
+        assert written.exists()
+        assert returned["saved_path"] == str(written)

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -16,6 +16,17 @@ def _sample_result() -> dict:
 
 
 class TestApplyOutputMode:
+    def test_rejects_absolute_path_outside_export_root(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        target = tmp_path / "outside" / "job.json"
+
+        with pytest.raises(
+            ValueError, match="inside the LinkedIn MCP export directory"
+        ):
+            apply_output_mode(_sample_result(), str(target), "file")
+
+        assert not target.exists()
+
     def test_display_returns_full_result_and_writes_nothing(self, tmp_path):
         result = _sample_result()
         target = tmp_path / "out.json"
@@ -25,11 +36,12 @@ class TestApplyOutputMode:
         assert returned is result
         assert not target.exists()
 
-    def test_file_writes_json_and_returns_confirmation(self, tmp_path):
+    def test_file_writes_json_and_returns_confirmation(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
         result = _sample_result()
-        target = tmp_path / "job.json"
+        target = tmp_path / ".linkedin-mcp" / "exports" / "job.json"
 
-        returned = apply_output_mode(result, str(target), "file")
+        returned = apply_output_mode(result, "job.json", "file")
 
         # Confirmation carries section names, not the full sections payload.
         assert returned["saved_path"] == str(target)
@@ -41,11 +53,12 @@ class TestApplyOutputMode:
         on_disk = json.loads(target.read_text())
         assert on_disk == result
 
-    def test_file_writes_text_for_non_json_extension(self, tmp_path):
+    def test_file_writes_text_for_non_json_extension(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
         result = _sample_result()
-        target = tmp_path / "job.md"
+        target = tmp_path / ".linkedin-mcp" / "exports" / "job.md"
 
-        apply_output_mode(result, str(target), "file")
+        apply_output_mode(result, "job.md", "file")
 
         body = target.read_text()
         assert "URL: https://www.linkedin.com/jobs/view/12345/" in body
@@ -53,25 +66,55 @@ class TestApplyOutputMode:
         assert "Software Engineer" in body
         assert "JOB_IDS: 12345, 67890" in body
 
-    def test_both_writes_file_and_returns_full_result(self, tmp_path):
+    def test_both_writes_file_and_returns_full_result_with_path(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path))
         result = _sample_result()
-        target = tmp_path / "job.json"
+        target = tmp_path / ".linkedin-mcp" / "exports" / "job.json"
 
-        returned = apply_output_mode(result, str(target), "both")
+        returned = apply_output_mode(result, "job.json", "both")
 
-        assert returned is result
+        assert returned == {**result, "saved_path": str(target)}
+        assert "saved_path" not in result
         assert json.loads(target.read_text()) == result
 
     def test_file_mode_requires_output_path(self):
         with pytest.raises(ValueError, match="output_path is required"):
             apply_output_mode(_sample_result(), None, "file")
 
-    def test_expands_user_home(self, tmp_path, monkeypatch):
+    def test_accepts_absolute_path_inside_export_root(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         result = _sample_result()
+        written = tmp_path / ".linkedin-mcp" / "exports" / "saved-job.json"
 
-        returned = apply_output_mode(result, "~/saved-job.json", "file")
+        returned = apply_output_mode(result, str(written), "file")
 
-        written = tmp_path / "saved-job.json"
         assert written.exists()
-        assert returned["saved_path"] == str(written)
+        assert returned["saved_path"] == str(written.resolve())
+
+    def test_rejects_parent_traversal_from_export_root(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        escaped = tmp_path / ".linkedin-mcp" / "outside.json"
+
+        with pytest.raises(
+            ValueError, match="inside the LinkedIn MCP export directory"
+        ):
+            apply_output_mode(_sample_result(), "../outside.json", "file")
+
+        assert not escaped.exists()
+
+    def test_rejects_symlink_escape_from_export_root(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        export_root = tmp_path / ".linkedin-mcp" / "exports"
+        outside = tmp_path / "outside"
+        export_root.mkdir(parents=True)
+        outside.mkdir()
+        (export_root / "escape").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(
+            ValueError, match="inside the LinkedIn MCP export directory"
+        ):
+            apply_output_mode(_sample_result(), "escape/job.json", "file")
+
+        assert not (outside / "job.json").exists()

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -43,12 +43,13 @@ class TestApplyOutputMode:
 
         returned = apply_output_mode(result, "job.json", "file")
 
-        # Confirmation carries section names, not the full sections payload.
+        # Confirmation carries section names without changing the standard
+        # mapping type of the optional `sections` response field.
         assert returned["saved_path"] == str(target)
         assert returned["url"] == result["url"]
         assert returned["job_ids"] == result["job_ids"]
-        assert returned["sections"] == ["job_posting"]
-        assert returned["sections"] != result["sections"]
+        assert returned["section_names"] == ["job_posting"]
+        assert "sections" not in returned
 
         on_disk = json.loads(target.read_text())
         assert on_disk == result

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -119,3 +119,16 @@ class TestApplyOutputMode:
             apply_output_mode(_sample_result(), "escape/job.json", "file")
 
         assert not (outside / "job.json").exists()
+
+    def test_rejects_symlinked_export_root(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        linkedin_dir = tmp_path / ".linkedin-mcp"
+        outside = tmp_path / "outside"
+        linkedin_dir.mkdir()
+        outside.mkdir()
+        (linkedin_dir / "exports").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="export directory must not be a symlink"):
+            apply_output_mode(_sample_result(), "job.json", "file")
+
+        assert not (outside / "job.json").exists()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -605,7 +605,7 @@ class TestCompanyTools:
 
 
 class TestJobTools:
-    async def test_file_capable_job_tools_are_not_annotated_read_only(self):
+    async def test_file_capable_job_tools_have_conservative_annotations(self):
         from linkedin_mcp_server.tools.job import register_job_tools
 
         mcp = FastMCP("test")
@@ -616,6 +616,9 @@ class TestJobTools:
             assert tool is not None
             assert tool.annotations is not None
             assert tool.annotations.readOnlyHint is False
+            assert tool.annotations.destructiveHint is True
+            assert tool.annotations.idempotentHint is False
+            assert tool.annotations.openWorldHint is True
 
     async def test_get_job_details(self, mock_context):
         expected = {
@@ -680,8 +683,9 @@ class TestJobTools:
         )
 
         assert result["saved_path"] == str(target)
-        # Confirmation lists section names, not the full text payload.
-        assert result["sections"] == ["job_posting"]
+        # Confirmation lists section names without changing the `sections` type.
+        assert result["section_names"] == ["job_posting"]
+        assert "sections" not in result
         assert target.exists()
 
     async def test_search_jobs_default_mode_returns_content(self, mock_context):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -605,6 +605,18 @@ class TestCompanyTools:
 
 
 class TestJobTools:
+    async def test_file_capable_job_tools_are_not_annotated_read_only(self):
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        for tool_name in ("get_job_details", "search_jobs"):
+            tool = await mcp.get_tool(tool_name)
+            assert tool is not None
+            assert tool.annotations is not None
+            assert tool.annotations.readOnlyHint is False
+
     async def test_get_job_details(self, mock_context):
         expected = {
             "url": "https://www.linkedin.com/jobs/view/12345/",
@@ -641,8 +653,11 @@ class TestJobTools:
         assert "search_results" in result["sections"]
         assert "pages_visited" not in result
 
-    async def test_get_job_details_writes_file(self, mock_context, tmp_path):
+    async def test_get_job_details_writes_file(
+        self, mock_context, tmp_path, monkeypatch
+    ):
         """output_mode='file' persists the result and returns a confirmation."""
+        monkeypatch.setenv("HOME", str(tmp_path))
         expected = {
             "url": "https://www.linkedin.com/jobs/view/12345/",
             "sections": {"job_posting": "Software Engineer"},
@@ -654,12 +669,12 @@ class TestJobTools:
         mcp = FastMCP("test")
         register_job_tools(mcp)
 
-        target = tmp_path / "job.json"
+        target = tmp_path / ".linkedin-mcp" / "exports" / "job.json"
         tool_fn = await get_tool_fn(mcp, "get_job_details")
         result = await tool_fn(
             "12345",
             mock_context,
-            output_path=str(target),
+            output_path="job.json",
             output_mode="file",
             extractor=mock_extractor,
         )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -641,6 +641,53 @@ class TestJobTools:
         assert "search_results" in result["sections"]
         assert "pages_visited" not in result
 
+    async def test_get_job_details_writes_file(self, mock_context, tmp_path):
+        """output_mode='file' persists the result and returns a confirmation."""
+        expected = {
+            "url": "https://www.linkedin.com/jobs/view/12345/",
+            "sections": {"job_posting": "Software Engineer"},
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        target = tmp_path / "job.json"
+        tool_fn = await get_tool_fn(mcp, "get_job_details")
+        result = await tool_fn(
+            "12345",
+            mock_context,
+            output_path=str(target),
+            output_mode="file",
+            extractor=mock_extractor,
+        )
+
+        assert result["saved_path"] == str(target)
+        # Confirmation lists section names, not the full text payload.
+        assert result["sections"] == ["job_posting"]
+        assert target.exists()
+
+    async def test_search_jobs_default_mode_returns_content(self, mock_context):
+        """The default output_mode keeps the existing display behaviour."""
+        expected = {
+            "url": "https://www.linkedin.com/jobs/search/?keywords=python",
+            "sections": {"search_results": "Job 1\nJob 2"},
+            "job_ids": ["1", "2"],
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "search_jobs")
+        result = await tool_fn("python", mock_context, extractor=mock_extractor)
+        assert "search_results" in result["sections"]
+        assert "saved_path" not in result
+
 
 class TestGetSidebarProfilesTool:
     async def test_get_sidebar_profiles_success(self, mock_context):


### PR DESCRIPTION
## Summary

Adds an optional file-output mode to the two job tools so results can be written to disk instead of (or alongside) being returned to the MCP client. Implements #518.

Job results are large; fanning an agent over many postings and returning every full payload into the model context burns the window fast. With `output_mode="file"` the tool persists the result and returns only a compact confirmation, so an agent can scrape many jobs without flooding context, hand the files to a downstream step (CV tailoring, scoring, human review), and keep a local record.

**What's in scope**

- Two new optional parameters on `get_job_details` and `search_jobs`:
  - `output_mode: "display" | "file" | "both"` — default `"display"`, which is the existing behaviour unchanged.
  - `output_path: str | None` — required when mode is `file`/`both`. Relative paths resolve under `~/.linkedin-mcp/exports`; absolute paths must remain inside that directory. The extension drives the format: `.json` dumps the full result dict; any other extension writes readable text.
- New `apply_output_mode(result, output_path, output_mode)` in `common_utils.py`, reusing the existing atomic `secure_write_text` helper (`0o600`). Path traversal, absolute escapes, symlinked subdirectories, and a symlinked export root are rejected before writing.
- In `file` mode the tool returns a compact confirmation (`saved_path`, `url`, `job_ids`, `section_names`) instead of the full payload; `both` writes and returns the full result plus `saved_path`.
- MCP annotations conservatively declare both tools mutating, destructive, non-idempotent, and open-world because file modes can overwrite exports and repeated scrapes can change.
- Tests cover display/file/both, JSON/text rendering, missing path, relative and allowed absolute paths, traversal/symlink escapes, response contracts, annotations, and tool-level pass-through.
- Docs: README tool table, `docs/docker-hub.md`, `manifest.json`.

**Intentionally out of scope**

- Only the two job tools are wired up. `apply_output_mode` is generic and can wrap other tools later if there's appetite, but this PR keeps the surface small and reviewable.
- No change to the default return contract — `display` callers see identical behaviour.

## Testing

- `uv run pytest`: 818 passed, 1 macOS-keychain-only skip.
- `uv run ruff check .`, `uv run ruff format --check .`, and `uv run ty check`: clean.
- `uv run pre-commit run --all-files`: clean.
- GitHub CI and Greptile Review: green.

## Synthetic prompt

> Add optional `display`/`file`/`both` output modes to `get_job_details` and `search_jobs`. Sandbox all writes to `~/.linkedin-mcp/exports`, rejecting traversal, absolute and symlink escapes while reusing atomic owner-only writes. Keep display unchanged; make file mode return a compact confirmation with `section_names`; make both return full content plus `saved_path`; annotate both tools conservatively as mutating, destructive, non-idempotent, and open-world. Add regression tests and update README, Docker docs, and manifest.

Generated with Claude Opus 4.7

Closes #518

