### PR TITLE
fix(auth): stop discarding valid sessions (2FA race + transient network errors)

### DIFF
--- a/linkedin_mcp_server/core/auth.py
+++ b/linkedin_mcp_server/core/auth.py
@@ -92,6 +92,25 @@ async def is_logged_in(page: Page) -> bool:
         raise
 
 
+async def has_auth_cookie(page: Page) -> bool:
+    """Return True only once the ``li_at`` session cookie has been issued.
+
+    ``li_at`` is the authoritative signal that LinkedIn has *fully* authenticated
+    the session — it is set only after every challenge (password, 2FA, app
+    verification, captcha) clears. Nav chrome can flash on screen during the 2FA
+    handshake before ``li_at`` exists, so relying on :func:`is_logged_in` alone
+    lets the login loop return — and the browser close — mid-2FA, persisting a
+    half-baked session that later fails ``/feed/`` validation. Gating on this
+    cookie closes that race.
+    """
+    try:
+        cookies = await page.context.cookies()
+    except Exception:
+        logger.warning("Could not read cookies while checking login completion")
+        return False
+    return any(c.get("name") == "li_at" and c.get("value") for c in cookies)
+
+
 async def detect_auth_barrier(page: Page) -> str | None:
     """Detect LinkedIn auth/account-picker barriers on the current page."""
     return await _detect_auth_barrier(page, include_body_text=True)
@@ -258,7 +277,11 @@ async def wait_for_manual_login(page: Page, timeout: int = 300000) -> None:
                 )
             continue
 
-        if await is_logged_in(page):
+        # Require the authoritative li_at cookie, not just logged-in-looking
+        # chrome. During app/2FA verification LinkedIn can render nav elements
+        # before li_at is issued; returning then would close the browser
+        # mid-challenge and persist an unusable session. See has_auth_cookie.
+        if await is_logged_in(page) and await has_auth_cookie(page):
             logger.info("Manual login completed successfully")
             return
 

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -14,6 +14,7 @@ from linkedin_mcp_server.common_utils import secure_mkdir
 from linkedin_mcp_server.core import (
     AuthenticationError,
     BrowserManager,
+    NetworkError,
     detect_auth_barrier_quick,
     detect_rate_limit,
     is_logged_in,
@@ -124,12 +125,47 @@ async def _log_feed_failure_context(
     )
 
 
+# Chrome/patchright network-layer failures that mean "couldn't reach LinkedIn",
+# NOT "the session is invalid". Treating these as auth failures wrongly discards
+# a perfectly good logged-in session on a transient DNS/connectivity blip.
+_TRANSIENT_NETWORK_ERROR_MARKERS = (
+    "err_name_not_resolved",
+    "err_internet_disconnected",
+    "err_network_changed",
+    "err_connection_reset",
+    "err_connection_closed",
+    "err_connection_refused",
+    "err_connection_timed_out",
+    "err_connection_aborted",
+    "err_timed_out",
+    "err_address_unreachable",
+    "err_network_access_denied",
+    "err_proxy_connection_failed",
+    "err_socket_not_connected",
+    "err_empty_response",
+    "err_ssl_protocol_error",
+)
+
+
+def _is_transient_network_error(exc: Exception) -> bool:
+    """True if the exception is a network-layer failure, not an auth failure."""
+    message = str(exc).lower()
+    return any(marker in message for marker in _TRANSIENT_NETWORK_ERROR_MARKERS)
+
+
 async def _feed_auth_succeeds(
     browser: BrowserManager,
     *,
     allow_remember_me: bool = True,
 ) -> bool:
-    """Validate that /feed/ loads without an auth barrier."""
+    """Validate that /feed/ loads without an auth barrier.
+
+    Raises:
+        NetworkError: If ``/feed/`` could not be reached due to a transient
+            network/DNS failure. The caller must treat this as "could not
+            verify right now" and surface a retriable error — NOT as an expired
+            session, which would quarantine valid auth state and force re-login.
+    """
     try:
         await browser.page.goto(
             "https://www.linkedin.com/feed/",
@@ -177,6 +213,14 @@ async def _feed_auth_succeeds(
             extra={"error": f"{type(exc).__name__}: {exc}"},
         )
         await _log_feed_failure_context(browser, str(exc), exc)
+        if _is_transient_network_error(exc):
+            # Could not reach LinkedIn — do NOT discard the session. Surface a
+            # retriable error so valid auth state survives the network blip.
+            raise NetworkError(
+                "Could not reach LinkedIn to verify the session "
+                f"({type(exc).__name__}). This looks like a temporary network "
+                "issue, not an expired login. Retry the tool in a moment."
+            ) from exc
         return False
 
 

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -79,13 +79,23 @@ async def interactive_login(user_data_dir: Path | None = None) -> bool:
         # Wait for persistent context to flush cookies to disk
         await asyncio.sleep(2)
 
-        # Verify session cookie was persisted
+        # Verify the li_at session cookie was persisted. wait_for_manual_login
+        # already gates on it, so this is a defensive backstop: if it is still
+        # absent, refuse to export a half-baked session (which would later fail
+        # /feed/ validation and be quarantined). Returning False reopens the
+        # login browser on the next tool call instead of poisoning the profile.
         cookies = await browser.context.cookies()
         li_at = [c for c in cookies if c["name"] == "li_at"]
         if not li_at:
-            print("   Warning: Session cookie not found. Login may not have persisted.")
-            print("   Waiting longer for cookie propagation...")
             await asyncio.sleep(5)
+            cookies = await browser.context.cookies()
+            li_at = [c for c in cookies if c["name"] == "li_at"]
+        if not li_at:
+            print(
+                "   Error: Session cookie (li_at) never appeared — login did not "
+                "complete. Not exporting. Retry the tool to reopen the browser."
+            )
+            return False
 
         # Export source-session cookies for the one-time foreign-runtime bridge.
         # Docker now checkpoint-commits its own derived runtime profile after the

--- a/tests/test_browser_driver.py
+++ b/tests/test_browser_driver.py
@@ -6,8 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.core import NetworkError
 from linkedin_mcp_server.drivers.browser import (
     _feed_auth_succeeds,
+    _is_transient_network_error,
     get_or_create_browser,
     reset_browser_for_testing,
 )
@@ -233,6 +235,46 @@ async def test_feed_auth_records_single_post_recovery_trace():
     steps = [call.args[1] for call in record_page_trace.await_args_list]
     assert "feed-after-remember-me-error-recovery" in steps
     assert "feed-navigation-error-before-remember-me-retry" not in steps
+
+
+def test_is_transient_network_error_detects_dns_and_connectivity():
+    assert _is_transient_network_error(
+        Exception("Page.goto: net::ERR_NAME_NOT_RESOLVED at https://...")
+    )
+    assert _is_transient_network_error(Exception("net::ERR_INTERNET_DISCONNECTED"))
+    assert _is_transient_network_error(Exception("net::ERR_CONNECTION_RESET"))
+    # An auth barrier / redirect is NOT a network error — must stay quarantinable.
+    assert not _is_transient_network_error(Exception("net::ERR_TOO_MANY_REDIRECTS"))
+    assert not _is_transient_network_error(Exception("auth barrier URL: /login"))
+
+
+@pytest.mark.asyncio
+async def test_feed_auth_raises_network_error_on_dns_failure():
+    """A DNS/connectivity failure must raise NetworkError, not return False.
+
+    Returning False is read by callers as "session invalid" and quarantines a
+    valid login. NetworkError is surfaced as retriable and preserves the session.
+    """
+    browser = _make_mock_browser()
+    browser.page.goto = AsyncMock(
+        side_effect=Exception(
+            "Page.goto: net::ERR_NAME_NOT_RESOLVED at https://www.linkedin.com/feed/"
+        )
+    )
+
+    with (
+        patch(
+            "linkedin_mcp_server.drivers.browser.resolve_remember_me_prompt",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "linkedin_mcp_server.drivers.browser.record_page_trace",
+            new_callable=AsyncMock,
+        ),
+    ):
+        with pytest.raises(NetworkError):
+            await _feed_auth_succeeds(browser)
 
 
 @pytest.mark.asyncio

--- a/tests/test_core_auth.py
+++ b/tests/test_core_auth.py
@@ -8,6 +8,7 @@ from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.core.auth import (
     detect_auth_barrier,
     detect_auth_barrier_quick,
+    has_auth_cookie,
     is_logged_in,
     resolve_remember_me_prompt,
     wait_for_manual_login,
@@ -210,10 +211,65 @@ async def test_wait_for_manual_login_clicks_saved_account(monkeypatch):
         "linkedin_mcp_server.core.auth.resolve_remember_me_prompt", fake_resolve
     )
     monkeypatch.setattr("linkedin_mcp_server.core.auth.is_logged_in", fake_is_logged_in)
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.has_auth_cookie", AsyncMock(return_value=True)
+    )
 
     await wait_for_manual_login(page, timeout=1000)
 
     assert clicked["value"] is True
+
+
+@pytest.mark.asyncio
+async def test_has_auth_cookie_detects_li_at():
+    page = MagicMock()
+    page.context.cookies = AsyncMock(
+        return_value=[{"name": "li_at", "value": "AQED..."}]
+    )
+    assert await has_auth_cookie(page) is True
+
+
+@pytest.mark.asyncio
+async def test_has_auth_cookie_false_without_li_at():
+    page = MagicMock()
+    # Nav chrome can be present mid-2FA, but li_at is not yet issued.
+    page.context.cookies = AsyncMock(
+        return_value=[{"name": "lidc", "value": "x"}, {"name": "li_at", "value": ""}]
+    )
+    assert await has_auth_cookie(page) is False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_waits_until_li_at_present(monkeypatch):
+    """Logged-in-looking chrome alone must not end the wait — li_at must exist."""
+    page = MagicMock()
+    cookie_ready = {"value": False}
+
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.resolve_remember_me_prompt",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.is_logged_in", AsyncMock(return_value=True)
+    )
+
+    async def fake_has_cookie(_page):
+        # First poll: nav present but li_at not yet issued (mid-2FA).
+        # Second poll: li_at has landed.
+        if not cookie_ready["value"]:
+            cookie_ready["value"] = True
+            return False
+        return True
+
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.has_auth_cookie", fake_has_cookie
+    )
+    monkeypatch.setattr("linkedin_mcp_server.core.auth.asyncio.sleep", AsyncMock())
+
+    await wait_for_manual_login(page, timeout=10000)
+
+    # Returned only after li_at appeared (second poll), proving the gate held.
+    assert cookie_ready["value"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

Two related auth-resilience fixes. Both address the same failure class: **a valid, logged-in session getting thrown away**, forcing a needless re-login.

### 1. Gate manual login on the `li_at` cookie (`57d1330`)
`wait_for_manual_login` returned on the first `is_logged_in()` success, which passes as soon as nav chrome renders. During app/2FA verification LinkedIn flashes feed-like chrome **before** issuing the `li_at` session cookie, so the loop returned and the persistent-context browser closed **mid-2FA**. `interactive_login` then only *warned* on a missing `li_at` and exported the half-baked session anyway, which later failed `/feed/` validation and was quarantined as "session expired".

- New `has_auth_cookie()` in `core/auth.py`; the wait loop now requires `is_logged_in() AND li_at present`. `li_at` is set only after every challenge (password, 2FA, app, captcha) clears, so it's the authoritative completion signal.
- `setup.py` now refuses to export a session without `li_at` (returns `False` → reopens login next call) instead of persisting an unusable profile.

### 2. Don't discard the session on transient network errors (`484b511`)
Startup/feed validation treated **any** `/feed/` navigation failure as an expired session: `_feed_auth_succeeds` caught everything and returned `False`, which the caller converts to `AuthenticationError`, triggering quarantine + forced re-login. A momentary DNS blip (`net::ERR_NAME_NOT_RESOLVED`) thus threw away a perfectly valid session — cookies intact, `li_at` present.

- Detect Chrome network-layer errors (DNS, connectivity, reset, timeout, SSL, etc.) and raise `NetworkError` instead of returning `False`.
- `NetworkError` is not an `AuthenticationError`, so `dependencies.get_ready_extractor` surfaces it as a retriable "network error, try again" **without** quarantining auth state. Genuine auth barriers (redirect to `/login`, account picker) still return `False` and quarantine as before.

Both reproduced live on macOS: the 2FA race closed the browser before `li_at`, and a real DNS blip during startup `/feed/` validation quarantined a valid session.

## Tests
`+5` tests (`has_auth_cookie` detection, the `li_at` wait gate, transient-error detection, and `_feed_auth_succeeds` raising `NetworkError` on DNS failure vs. quarantinable auth barriers). Full suite green: `uv run pytest` — 45 passed across the touched modules; `ruff` + `ty` clean.

## Synthetic prompt

> The LinkedIn MCP keeps forcing re-login even though a valid session was saved. Find and fix the root causes: (1) the manual-login wait returns on logged-in-looking chrome before the `li_at` cookie exists, closing the browser mid-2FA and persisting a half-baked session; gate completion on `li_at` and refuse to export without it. (2) `/feed/` startup validation treats transient network/DNS errors (`net::ERR_NAME_NOT_RESOLVED` etc.) as an expired session and quarantines valid auth state; distinguish network-layer failures and raise `NetworkError` (retriable) instead of returning `False`, while genuine auth barriers still quarantine. Add tests; keep ruff/ty/pytest green.

Generated with Claude Opus 4.8 (Claude Code)
