### PR TITLE
feat(job): add get_saved_jobs tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Optional additional keys:
 - `references: {section_name: [{kind, url, text?, context?, value?}]}` — LinkedIn URLs are relative paths; `value` carries non-URL identifiers (e.g. company URN id for `kind: "company_urn"`)
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
-- `job_ids: [id, ...]` (search_jobs only)
+- `job_ids: [id, ...]` (search_jobs and get_saved_jobs)
 - `references["feed"]` (get_feed only) — every entry is `kind: "feed_post"`; non-post anchors (sidebar profiles, employer logos) are filtered. URLs may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) form; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
 
 ## Verifying Bug Reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ for section_name, (suffix, is_overlay) in PERSON_SECTIONS.items():
 {"url": str, "sections": {name: raw_text}, "references": {section: [{kind, url, text?, context?, value?}, ...]}}
 # When unknown section names are provided:
 {"url": str, "sections": {name: raw_text}, "unknown_sections": [name, ...]}
-# search_jobs also returns:
+# search_jobs and get_saved_jobs also return:
 {"url": str, "sections": {name: raw_text}, "job_ids": [id, ...]}
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `search_companies` | Search for companies on LinkedIn by keywords | working |
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter | working |
 | `search_jobs` | Search for jobs with keywords and location filters | working |
+| `get_saved_jobs` | List job postings saved by the authenticated user | working |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | [#526](https://github.com/stickerdaniel/linkedin-mcp-server/issues/526) |
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -14,6 +14,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Company Search**: Search for companies by keyword
 - **Job Details**: Retrieve job posting information
 - **Job Search**: Search for jobs with keywords and location filters
+- **Saved Jobs**: List job postings saved by the authenticated user
 - **People Search**: Search for people by keywords and location
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed

--- a/linkedin_mcp_server/error_diagnostics.py
+++ b/linkedin_mcp_server/error_diagnostics.py
@@ -404,6 +404,8 @@ def _tool_name_for_context(payload: dict[str, Any]) -> str | None:
             return "search_people"
         if "/jobs/search" in target_url:
             return "search_jobs"
+    if context in {"extract_saved_jobs_page", "get_saved_jobs"}:
+        return "get_saved_jobs"
 
     return None
 

--- a/linkedin_mcp_server/error_diagnostics.py
+++ b/linkedin_mcp_server/error_diagnostics.py
@@ -389,6 +389,7 @@ def _tool_name_for_context(payload: dict[str, Any]) -> str | None:
         "get_company_posts",
         "get_job_details",
         "search_jobs",
+        "get_saved_jobs",
         "search_people",
         "close_session",
     }:
@@ -404,7 +405,7 @@ def _tool_name_for_context(payload: dict[str, Any]) -> str | None:
             return "search_people"
         if "/jobs/search" in target_url:
             return "search_jobs"
-    if context in {"extract_saved_jobs_page", "get_saved_jobs"}:
+    if context == "extract_saved_jobs_page":
         return "get_saved_jobs"
 
     return None

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3337,10 +3337,11 @@ class LinkedInExtractor:
         NOTE: This is a deliberate DOM exception, mirroring
         ``_get_total_search_pages``. The my-items pager exposes no page count
         in ``innerText`` and no stable attribute to count, so a design-system
-        class is the only reachable signal. The button labels are bare digits,
-        which stay identical across locales. Gracefully returns ``None`` if
-        LinkedIn renames the class — pagination then falls back to
-        ``max_pages`` and the no-new-ids early stop.
+        class is the only reachable signal. The labels are numerals rather
+        than words, so no locale table is needed. A renamed class, or a locale
+        serving non-ASCII numerals that ``parseInt`` cannot read, both yield
+        ``None`` — pagination then falls back to ``max_pages`` and the
+        no-new-ids early stop.
         """
         value = await self._page.evaluate(
             """() => {

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -58,6 +58,8 @@ _RATE_LIMITED_MSG = "[Rate limited] LinkedIn blocked this section. Try again lat
 # LinkedIn shows 25 results per page
 _PAGE_SIZE = 25
 
+_SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
+
 # Normalization maps for job search filters
 _DATE_POSTED_MAP = {
     "past_hour": "r3600",
@@ -3234,6 +3236,226 @@ class LinkedInExtractor:
         if page_references:
             result["references"] = {
                 "search_results": dedupe_references(page_references, cap=15)
+            }
+        if section_errors:
+            result["section_errors"] = section_errors
+        return result
+
+    async def _extract_saved_jobs_page(
+        self,
+        url: str,
+        section_name: str,
+    ) -> ExtractedSection:
+        """Extract innerText from a saved-jobs page with soft rate-limit retry."""
+        try:
+            result = await self._extract_saved_jobs_page_once(url, section_name)
+            if result.text != _RATE_LIMITED_MSG:
+                return result
+
+            logger.info(
+                "Retrying saved jobs page %s after %.0fs backoff",
+                url,
+                _RATE_LIMIT_RETRY_DELAY,
+            )
+            await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
+            result = await self._extract_saved_jobs_page_once(url, section_name)
+            if result.text == _RATE_LIMITED_MSG:
+                logger.warning(
+                    "Saved jobs page %s still rate-limited after retry", url
+                )
+            return result
+
+        except LinkedInScraperException:
+            raise
+        except Exception as e:
+            logger.warning("Failed to extract saved jobs page %s: %s", url, e)
+            return ExtractedSection(
+                text="",
+                references=[],
+                error=build_issue_diagnostics(
+                    e,
+                    context="extract_saved_jobs_page",
+                    target_url=url,
+                    section_name=section_name,
+                ),
+            )
+
+    async def _extract_saved_jobs_page_once(
+        self,
+        url: str,
+        section_name: str,
+    ) -> ExtractedSection:
+        """Single attempt: navigate, scroll list, and extract innerText."""
+        await self._navigate_to_page(url)
+        await detect_rate_limit(self._page)
+
+        main_found = True
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("No <main> element found on %s", url)
+            main_found = False
+
+        await handle_modal_close(self._page)
+        if main_found:
+            await scroll_to_bottom(self._page, pause_time=0.5, max_scrolls=5)
+
+        raw_result = await self._extract_root_content(["main"])
+        raw = raw_result["text"]
+        if raw_result["source"] == "body":
+            logger.debug("No <main> at evaluation time on %s, using body fallback", url)
+        elif not main_found:
+            logger.debug(
+                "<main> appeared after wait timeout on %s, scroll was skipped",
+                url,
+            )
+
+        if not raw:
+            return ExtractedSection(text="", references=[])
+        truncated = _truncate_linkedin_noise(raw)
+        if not truncated and raw.strip():
+            logger.warning(
+                "Saved jobs page %s returned only LinkedIn chrome (likely rate-limited)",
+                url,
+            )
+            return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+        cleaned = _filter_linkedin_noise_lines(truncated)
+        return ExtractedSection(
+            text=cleaned,
+            references=build_references(raw_result["references"], section_name),
+        )
+
+    async def _get_total_list_pages(self) -> int | None:
+        """Read last page number from artdeco pagination buttons.
+
+        Parses numeric page labels from ``ul.artdeco-pagination__pages`` so
+        pagination works on locale-independent my-items list pages. Returns
+        ``None`` when pagination is absent or unparseable.
+        """
+        value = await self._page.evaluate(
+            """() => {
+                const buttons = document.querySelectorAll(
+                    'ul.artdeco-pagination__pages li button'
+                );
+                if (!buttons.length) return null;
+                const nums = [...buttons]
+                    .map((b) => parseInt(b.textContent.trim(), 10))
+                    .filter((n) => !Number.isNaN(n));
+                return nums.length ? Math.max(...nums) : null;
+            }"""
+        )
+        return int(value) if value is not None else None
+
+    async def get_saved_jobs(self, max_pages: int = 3) -> dict[str, Any]:
+        """List the authenticated user's saved job postings.
+
+        Navigates to ``/my-items/saved-jobs/``, extracts innerText and job IDs
+        from each page, and paginates with ``?start=`` offsets (25 per step).
+
+        Args:
+            max_pages: Maximum pages to load (1-10, default 3)
+
+        Returns:
+            {url, sections: {saved_jobs: text}, job_ids: [str]}
+        """
+        base_url = _SAVED_JOBS_URL
+        all_job_ids: list[str] = []
+        seen_ids: set[str] = set()
+        page_texts: list[str] = []
+        page_references: list[Reference] = []
+        section_errors: dict[str, dict[str, Any]] = {}
+        total_pages: int | None = None
+        total_pages_queried = False
+
+        for page_num in range(max_pages):
+            if total_pages is not None and page_num >= total_pages:
+                logger.debug("All %d saved-jobs pages fetched, stopping", total_pages)
+                break
+
+            if page_num > 0:
+                await asyncio.sleep(_NAV_DELAY)
+
+            url = (
+                base_url
+                if page_num == 0
+                else f"{base_url}?start={page_num * _PAGE_SIZE}"
+            )
+
+            try:
+                extracted = await self._extract_saved_jobs_page(
+                    url, section_name="saved_jobs"
+                )
+
+                if not extracted.text or extracted.text == _RATE_LIMITED_MSG:
+                    if extracted.error:
+                        section_errors["saved_jobs"] = extracted.error
+                    break
+
+                if not total_pages_queried:
+                    total_pages_queried = True
+                    try:
+                        total_pages = await self._get_total_list_pages()
+                    except Exception as e:
+                        logger.debug("Could not read saved-jobs page count: %s", e)
+                    else:
+                        if total_pages is not None:
+                            logger.debug(
+                                "LinkedIn reports %d saved-jobs pages", total_pages
+                            )
+
+                if "/my-items/saved-jobs" not in self._page.url:
+                    logger.debug(
+                        "Unexpected page URL after saved-jobs extraction: %s — "
+                        "skipping job ID extraction",
+                        self._page.url,
+                    )
+                    page_texts.append(extracted.text)
+                    if extracted.references:
+                        page_references.extend(extracted.references)
+                    break
+
+                page_ids = await self._extract_job_ids()
+                new_ids = [jid for jid in page_ids if jid not in seen_ids]
+
+                if not new_ids:
+                    page_texts.append(extracted.text)
+                    if extracted.references:
+                        page_references.extend(extracted.references)
+                    logger.debug(
+                        "No new saved job IDs on page %d, stopping", page_num + 1
+                    )
+                    break
+
+                for jid in new_ids:
+                    seen_ids.add(jid)
+                    all_job_ids.append(jid)
+
+                page_texts.append(extracted.text)
+                if extracted.references:
+                    page_references.extend(extracted.references)
+
+            except LinkedInScraperException:
+                raise
+            except Exception as e:
+                logger.warning("Error on saved jobs page %d: %s", page_num + 1, e)
+                section_errors["saved_jobs"] = build_issue_diagnostics(
+                    e,
+                    context="get_saved_jobs",
+                    target_url=url,
+                    section_name="saved_jobs",
+                )
+                break
+
+        result: dict[str, Any] = {
+            "url": base_url,
+            "sections": {"saved_jobs": "\n---\n".join(page_texts)}
+            if page_texts
+            else {},
+            "job_ids": all_job_ids,
+        }
+        if page_references:
+            result["references"] = {
+                "saved_jobs": dedupe_references(page_references, cap=15)
             }
         if section_errors:
             result["section_errors"] = section_errors

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3331,9 +3331,16 @@ class LinkedInExtractor:
     async def _get_total_list_pages(self) -> int | None:
         """Read last page number from artdeco pagination buttons.
 
-        Parses numeric page labels from ``ul.artdeco-pagination__pages`` so
-        pagination works on locale-independent my-items list pages. Returns
-        ``None`` when pagination is absent or unparseable.
+        Parses numeric page labels from ``ul.artdeco-pagination__pages``.
+        Returns ``None`` when pagination is absent or unparseable.
+
+        NOTE: This is a deliberate DOM exception, mirroring
+        ``_get_total_search_pages``. The my-items pager exposes no page count
+        in ``innerText`` and no stable attribute to count, so a design-system
+        class is the only reachable signal. The button labels are bare digits,
+        which stay identical across locales. Gracefully returns ``None`` if
+        LinkedIn renames the class — pagination then falls back to
+        ``max_pages`` and the no-new-ids early stop.
         """
         value = await self._page.evaluate(
             """() => {

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3260,9 +3260,7 @@ class LinkedInExtractor:
             await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
             result = await self._extract_saved_jobs_page_once(url, section_name)
             if result.text == _RATE_LIMITED_MSG:
-                logger.warning(
-                    "Saved jobs page %s still rate-limited after retry", url
-                )
+                logger.warning("Saved jobs page %s still rate-limited after retry", url)
             return result
 
         except LinkedInScraperException:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -60,6 +60,11 @@ _PAGE_SIZE = 25
 
 _SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
 
+# The my-items lists page in 10s, unlike job search. Verified live: ?start=10
+# returns the 11th saved job, while ?start=25 lands past the end of a two-page
+# list and yields nothing.
+_SAVED_JOBS_PAGE_SIZE = 10
+
 # Normalization maps for job search filters
 _DATE_POSTED_MAP = {
     "past_hour": "r3600",
@@ -3348,7 +3353,7 @@ class LinkedInExtractor:
         """List the authenticated user's saved job postings.
 
         Navigates to ``/my-items/saved-jobs/``, extracts innerText and job IDs
-        from each page, and paginates with ``?start=`` offsets (25 per step).
+        from each page, and paginates with ``?start=`` offsets (10 per step).
 
         Args:
             max_pages: Maximum pages to load (1-10, default 3)
@@ -3376,7 +3381,7 @@ class LinkedInExtractor:
             url = (
                 base_url
                 if page_num == 0
-                else f"{base_url}?start={page_num * _PAGE_SIZE}"
+                else f"{base_url}?start={page_num * _SAVED_JOBS_PAGE_SIZE}"
             )
 
             try:

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -149,3 +149,52 @@ def register_job_tools(
                 raise_tool_error(relogin_exc, "search_jobs")
         except Exception as e:
             raise_tool_error(e, "search_jobs")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Get Saved Jobs",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"job", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_saved_jobs(
+        ctx: Context,
+        max_pages: Annotated[int, Field(ge=1, le=10)] = 3,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        List job postings saved by the authenticated LinkedIn user.
+
+        Returns job_ids that can be passed to get_job_details for full info.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+            max_pages: Maximum number of saved-jobs pages to load (1-10, default 3)
+
+        Returns:
+            Dict with url, sections (name -> raw text), job_ids (list of
+            numeric job ID strings usable with get_job_details), and optional references.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_saved_jobs"
+            )
+            logger.info("Fetching saved jobs (max_pages=%d)", max_pages)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Loading saved jobs"
+            )
+
+            result = await extractor.get_saved_jobs(max_pages=max_pages)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_saved_jobs")
+        except Exception as e:
+            raise_tool_error(e, "get_saved_jobs")  # NoReturn

--- a/manifest.json
+++ b/manifest.json
@@ -84,6 +84,10 @@
       "description": "Search for jobs with filters like keywords and location"
     },
     {
+      "name": "get_saved_jobs",
+      "description": "List job postings saved by the authenticated LinkedIn user"
+    },
+    {
       "name": "search_people",
       "description": "Search for people on LinkedIn by keywords, location, connection degree (1st/2nd/3rd), and current company"
     },

--- a/tests/test_error_diagnostics.py
+++ b/tests/test_error_diagnostics.py
@@ -5,6 +5,7 @@ import pytest
 from linkedin_mcp_server.error_diagnostics import (
     _installation_method_lines,
     _installation_method_summary,
+    _tool_name_for_context,
     build_issue_diagnostics,
     format_tool_error_with_diagnostics,
 )
@@ -224,6 +225,18 @@ def test_build_issue_diagnostics_marks_inferred_tool_and_container_runtime(
     assert "`~/.linkedin-mcp` mounted into `/home/pwuser/.linkedin-mcp`" in issue_body
     assert "- [x] Docker" in issue_body
     assert "- Tool: search_jobs" in issue_body
+
+
+@pytest.mark.parametrize(
+    ("context", "expected"),
+    [
+        ("get_saved_jobs", "get_saved_jobs"),
+        ("extract_saved_jobs_page", "get_saved_jobs"),
+    ],
+)
+def test_saved_jobs_contexts_resolve_to_the_tool(context: str, expected: str) -> None:
+    """A saved-jobs failure names the tool the user called, not the helper."""
+    assert _tool_name_for_context({"context": context}) == expected
 
 
 def test_installation_method_lines_marks_managed_runtime() -> None:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2599,6 +2599,115 @@ class TestSearchJobs:
         assert result["sections"] == {}
         mock_ids.assert_not_awaited()
 
+
+class TestGetSavedJobs:
+    """Tests for get_saved_jobs with job ID extraction and pagination."""
+
+    @pytest.fixture(autouse=True)
+    def _set_saved_jobs_url(self, mock_page):
+        mock_page.url = "https://www.linkedin.com/my-items/saved-jobs/"
+
+    async def test_returns_job_ids(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Saved Job 1\nSaved Job 2"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111", "222"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=1)
+
+        assert result["job_ids"] == ["111", "222"]
+        assert "saved_jobs" in result["sections"]
+        assert result["url"] == "https://www.linkedin.com/my-items/saved-jobs/"
+
+    async def test_pagination_uses_start_offset(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        id_pages = iter([["100", "200"], ["300"]])
+        urls_visited: list[str] = []
+
+        async def mock_extract(url, *args, **kwargs):
+            urls_visited.append(url)
+            return extracted("page text")
+
+        with (
+            patch.object(
+                extractor, "_extract_saved_jobs_page", side_effect=mock_extract
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                side_effect=lambda: next(id_pages),
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=2)
+
+        assert result["job_ids"] == ["100", "200", "300"]
+        assert len(urls_visited) == 2
+        assert urls_visited[1].endswith("?start=25")
+
+    async def test_early_stop_no_new_ids(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        id_pages = iter([["100"], ["100"]])
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                side_effect=lambda: next(id_pages),
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=5)
+
+        assert result["job_ids"] == ["100"]
+
+
+class TestSearchPeople:
     async def test_search_people_omits_orphaned_references(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         with patch.object(

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2688,7 +2688,7 @@ class TestGetSavedJobs:
                 "_extract_saved_jobs_page",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
-            ),
+            ) as mock_extract,
             patch.object(
                 extractor,
                 "_extract_job_ids",
@@ -2709,6 +2709,122 @@ class TestGetSavedJobs:
             result = await extractor.get_saved_jobs(max_pages=5)
 
         assert result["job_ids"] == ["100"]
+        # Stops on the repeat page rather than exhausting max_pages
+        assert mock_extract.await_count == 2
+
+    async def test_stops_at_total_pages(self, mock_page):
+        """The pager's page count caps pagination below max_pages."""
+        extractor = LinkedInExtractor(mock_page)
+        id_pages = iter([["100"], ["200"], ["300"]])
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_extract,
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                side_effect=lambda: next(id_pages),
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=2,
+            ) as mock_total_pages,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=10)
+
+        # Both pages the pager reports, and no more.
+        assert mock_extract.await_count == 2
+        assert mock_total_pages.await_count == 1
+        assert result["job_ids"] == ["100", "200"]
+
+    async def test_rate_limited_page_keeps_earlier_pages(self, mock_page):
+        """A rate-limited later page stops pagination without losing page 1.
+
+        Matches the sibling behaviour of ``search_jobs``: the sentinel page
+        contributes no text, and a soft rate limit is not reported as a
+        section error (it is not a scraper bug).
+        """
+        extractor = LinkedInExtractor(mock_page)
+        pages = iter([extracted("first page"), extracted(_RATE_LIMITED_MSG)])
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                side_effect=lambda *a, **kw: next(pages),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["100"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=3)
+
+        assert result["job_ids"] == ["100"]
+        # The blocked page contributes nothing; page 1 survives intact.
+        assert result["sections"]["saved_jobs"] == "first page"
+        assert "section_errors" not in result
+
+    async def test_url_redirect_skips_id_extraction(self, mock_page):
+        """A redirect away from the list captures the landing page, no IDs.
+
+        Mirrors ``search_jobs``: the text is kept deliberately so the caller
+        can see what LinkedIn served instead (e.g. a login wall).
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.url = "https://www.linkedin.com/uas/login"
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Login page content"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["999"],
+            ) as mock_ids,
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=2)
+
+        # Never mine IDs off a page that is not the saved-jobs list.
+        mock_ids.assert_not_awaited()
+        assert result["job_ids"] == []
+        assert result["sections"]["saved_jobs"] == "Login page content"
 
 
 class TestSearchPeople:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2639,6 +2639,75 @@ class TestGetSavedJobs:
         assert "saved_jobs" in result["sections"]
         assert result["url"] == "https://www.linkedin.com/my-items/saved-jobs/"
 
+    async def test_returns_references(self, mock_page):
+        """References are keyed by the section name, per the return contract."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=extracted(
+                    "Job 1",
+                    [{"kind": "job", "url": "/jobs/view/111/", "text": "Job 1"}],
+                ),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=1)
+
+        assert result["references"] == {
+            "saved_jobs": [{"kind": "job", "url": "/jobs/view/111/", "text": "Job 1"}]
+        }
+
+    async def test_page_texts_joined_with_separator(self, mock_page):
+        """Multi-page text is joined so the caller can tell pages apart."""
+        extractor = LinkedInExtractor(mock_page)
+        texts = iter([extracted("page one"), extracted("page two")])
+        id_pages = iter([["100"], ["200"]])
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                side_effect=lambda *a, **kw: next(texts),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                side_effect=lambda: next(id_pages),
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=2,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=2)
+
+        assert result["sections"]["saved_jobs"] == "page one\n---\npage two"
+
     async def test_pagination_uses_start_offset(self, mock_page):
         """The my-items list pages in 10s, not the 25 used by job search."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2640,8 +2640,9 @@ class TestGetSavedJobs:
         assert result["url"] == "https://www.linkedin.com/my-items/saved-jobs/"
 
     async def test_pagination_uses_start_offset(self, mock_page):
+        """The my-items list pages in 10s, not the 25 used by job search."""
         extractor = LinkedInExtractor(mock_page)
-        id_pages = iter([["100", "200"], ["300"]])
+        id_pages = iter([["100", "200"], ["300"], ["400"]])
         urls_visited: list[str] = []
 
         async def mock_extract(url, *args, **kwargs):
@@ -2669,11 +2670,14 @@ class TestGetSavedJobs:
                 new_callable=AsyncMock,
             ),
         ):
-            result = await extractor.get_saved_jobs(max_pages=2)
+            result = await extractor.get_saved_jobs(max_pages=3)
 
-        assert result["job_ids"] == ["100", "200", "300"]
-        assert len(urls_visited) == 2
-        assert urls_visited[1].endswith("?start=25")
+        assert result["job_ids"] == ["100", "200", "300", "400"]
+        assert urls_visited == [
+            "https://www.linkedin.com/my-items/saved-jobs/",
+            "https://www.linkedin.com/my-items/saved-jobs/?start=10",
+            "https://www.linkedin.com/my-items/saved-jobs/?start=20",
+        ]
 
     async def test_early_stop_no_new_ids(self, mock_page):
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -27,6 +27,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.scrape_company = AsyncMock(return_value=scrape_result)
     mock.scrape_job = AsyncMock(return_value=scrape_result)
     mock.search_jobs = AsyncMock(return_value=scrape_result)
+    mock.get_saved_jobs = AsyncMock(return_value=scrape_result)
     mock.search_people = AsyncMock(return_value=scrape_result)
     mock.get_sidebar_profiles = AsyncMock(return_value=scrape_result)
     mock.get_inbox = AsyncMock(return_value=scrape_result)
@@ -641,6 +642,25 @@ class TestJobTools:
         assert "search_results" in result["sections"]
         assert "pages_visited" not in result
 
+    async def test_get_saved_jobs(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/my-items/saved-jobs/",
+            "sections": {"saved_jobs": "Saved Job 1\nSaved Job 2"},
+            "job_ids": ["111", "222"],
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_saved_jobs")
+        result = await tool_fn(mock_context, max_pages=2, extractor=mock_extractor)
+        assert "saved_jobs" in result["sections"]
+        assert result["job_ids"] == ["111", "222"]
+        mock_extractor.get_saved_jobs.assert_awaited_once_with(max_pages=2)
+
 
 class TestGetSidebarProfilesTool:
     async def test_get_sidebar_profiles_success(self, mock_context):
@@ -1167,6 +1187,7 @@ class TestToolTimeouts:
             "get_company_posts",
             "get_job_details",
             "search_jobs",
+            "get_saved_jobs",
             "get_inbox",
             "get_conversation",
             "search_conversations",
@@ -1198,6 +1219,7 @@ class TestToolTimeouts:
             "get_company_employees",
             "get_job_details",
             "search_jobs",
+            "get_saved_jobs",
             "get_inbox",
             "get_conversation",
             "search_conversations",


### PR DESCRIPTION
## Summary

- Adds `get_saved_jobs` MCP tool to list job postings saved by the authenticated user at `/my-items/saved-jobs/`
- Returns `{url, sections: {saved_jobs}, job_ids, references?}` compatible with existing `get_job_details`
- Supports pagination via `max_pages` (1–10, default 3) using `?start=` offsets
- Locale-independent extraction: innerText + `a[href*="/jobs/view/"]` job ID parsing

Closes #522

## Synthetic prompt

> Add `get_saved_jobs` tool following the `search_jobs` pattern: navigate to `/my-items/saved-jobs/`, extract innerText and job IDs with pagination, register in `tools/job.py`, add tests and update README, docker-hub.md, and manifest.json.

## Test plan

- [x] `uv run pytest tests/test_scraping.py::TestGetSavedJobs`
- [x] `uv run pytest tests/test_tools.py::TestJobTools::test_get_saved_jobs`
- [x] Live verification against authenticated session (`get_saved_jobs(max_pages=2)` returned 20 job IDs across 2 pages)
- [x] Maintainer review on non-English LinkedIn locale (extraction is locale-independent by design)