### PR TITLE
chore: Bump version to 4.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-linkedin"
-version = "4.15.0"
+version = "4.16.0"
 description = "MCP server that gives AI assistants like Claude access to LinkedIn profiles, companies, and job postings through the user's own browser session."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-linkedin"
-version = "4.15.0"
+version = "4.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Bumps the version to 4.16.0 to release the unreleased work on main since v4.15.0: browser session import with auto-import by default (#534, #538) and the shell-first browser install (#539, #541), plus the sponsor copy and partner README updates.

`uv version --bump minor` updated pyproject.toml and uv.lock. The release workflow updates manifest.json and docker-compose.yml on merge.