### PR TITLE
chore: unify server naming on mcp-server-linkedin

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 ```json
 {
   "mcpServers": {
-    "linkedin": {
+    "mcp-server-linkedin": {
       "command": "uvx",
       "args": ["mcp-server-linkedin@latest"],
       "env": { "UV_HTTP_TIMEOUT": "300" }
@@ -262,7 +262,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 ```json
 {
   "mcpServers": {
-    "linkedin": {
+    "mcp-server-linkedin": {
       "command": "docker",
       "args": [
         "run", "--rm", "-i",
@@ -434,7 +434,7 @@ uv run -m linkedin_mcp_server --transport streamable-http --host 127.0.0.1 --por
 ```json
 {
   "mcpServers": {
-    "linkedin": {
+    "mcp-server-linkedin": {
       "command": "uv",
       "args": ["--directory", "/path/to/linkedin-mcp-server", "run", "-m", "linkedin_mcp_server"]
     }

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -39,7 +39,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 ```json
 {
   "mcpServers": {
-    "linkedin": {
+    "mcp-server-linkedin": {
       "command": "docker",
       "args": [
         "run", "--rm", "-i",
@@ -86,7 +86,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 ```json
 {
   "mcpServers": {
-    "linkedin": {
+    "mcp-server-linkedin": {
       "command": "docker",
       "args": [
         "run", "-i", "--rm",

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -50,7 +50,7 @@ async def browser_lifespan(app: FastMCP) -> AsyncIterator[dict[str, Any]]:
 def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> FastMCP:
     """Create and configure the MCP server with all LinkedIn tools."""
     mcp = FastMCP(
-        "linkedin_scraper",
+        "mcp-server-linkedin",
         lifespan=browser_lifespan,
         mask_error_details=True,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ Changelog = "https://github.com/stickerdaniel/linkedin-mcp-server/releases"
 
 [project.scripts]
 mcp-server-linkedin = "linkedin_mcp_server.cli_main:main"
-linkedin-mcp-server = "linkedin_mcp_server.cli_main:main"
 
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]


### PR DESCRIPTION
Unifies the server name across every surface a user types, sees, or installs onto the canonical `mcp-server-linkedin` / "MCP Server for LinkedIn".

- Server identity: `FastMCP("linkedin_scraper")` becomes `FastMCP("mcp-server-linkedin")`, dropping "scraper" and matching the package and title.
- Console scripts: keep only `mcp-server-linkedin`; the legacy `linkedin-mcp-server` alias is removed. `uvx mcp-server-linkedin` is unchanged, so the documented install path is unaffected.
- Setup examples in README and Docker Hub docs use `mcp-server-linkedin` as the MCP config-server key instead of the bare `linkedin`.

Repository slug, Docker image, and bundle name stay `linkedin-mcp-server`.

`ruff check`, `ruff format --check`, `ty check`, and `pytest` pass (762 passed, 11 skipped).