### PR TITLE
fix(setup): warn agents off manual browser install

### DIFF
--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -587,7 +587,13 @@ async def ensure_tool_ready_or_raise(
                 message=f"{tool_name}: Patchright Chromium browser setup still in progress",
             )
         raise BrowserSetupInProgressError(
-            "LinkedIn setup is not complete yet. The Patchright Chromium browser is still downloading in the background. Retry this tool in a few minutes."
+            "LinkedIn setup is not complete yet: the server is downloading the "
+            "Patchright Chromium browser in the background and will use it "
+            "automatically once ready. Do not install the browser yourself (no "
+            "`patchright install` or `uv run patchright install`), and do not "
+            "restart the server. A manual install only fights the background one "
+            "for the same lock and slows it down. Just wait and call this tool "
+            "again in a minute or two."
         )
 
     if _auth_ready():


### PR DESCRIPTION
Closes #546

During a fresh managed-runtime setup, the first tool call returns a setup-in-progress error while the Patchright Chromium browser downloads in the background. The message only said the browser was downloading and to retry, so a shell-capable agent (for example Claude Code) would run `patchright install` itself to speed things up. That manual install contends with the server's background install for patchright's global lock, so it does not help and can stall both.

The message now states that the server is handling the download and will use the browser automatically once ready, and tells the agent not to install the browser itself (`patchright install` / `uv run patchright install`) or restart the server, just wait and retry. Only the guidance text changes; the setup behavior is unchanged.

`uv run ruff check .`, `uv run ty check`, and `uv run pytest tests/test_bootstrap.py` (97 passed) pass. The bootstrap tests assert the `BrowserSetupInProgressError` type, not its text, so the wording change is safe.
