### PR TITLE
chore: Bump version to 4.16.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-linkedin"
-version = "4.16.0"
+version = "4.16.1"
 description = "MCP server that gives AI assistants like Claude access to LinkedIn profiles, companies, and job postings through the user's own browser session."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-linkedin"
-version = "4.16.0"
+version = "4.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Patch release. Ships the changes already on main since 4.16.0:

- fix(setup): the browser setup-in-progress message now tells agents the server handles the download and not to run `patchright install` or restart the server, just wait and retry (#547).
- chore: unify the server name on `mcp-server-linkedin` (#545).

The release workflow updates `manifest.json` and `docker-compose.yml` automatically on merge.
