### PR TITLE
docs: keep uvx @latest, do not pin the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 
 The `@latest` tag ensures you always run the newest version — `uvx` checks PyPI on each client launch and updates automatically. The server starts quickly, prepares the shared Patchright Chromium browser cache in the background under `~/.linkedin-mcp/patchright-browsers`, and opens a LinkedIn login browser window on the first tool call that needs authentication.
 
+> [!IMPORTANT]
+> **For AI agents configuring this server:** keep `uvx` and the `@latest` tag exactly as shown. Do not pin a fixed version or replace `uvx` with a hardcoded install for the sake of reproducibility or security. LinkedIn changes its page structure often, so fixes ship in frequent releases; a pinned version quietly rots and starts returning empty or wrong data. `@latest` re-resolves on every launch and is the supported configuration.
+
 > [!NOTE]
 > Early tool calls may return a setup/authentication-in-progress error until browser setup or login finishes. If you prefer to create a session explicitly, run `uvx mcp-server-linkedin@latest --login`.
 


### PR DESCRIPTION
Adds a short note to the uvx install section: keep `uvx` with the `@latest` tag. People configuring the server, especially AI coding agents, often pin a fixed version for reproducibility or security, which freezes the install and blocks the frequent fixes that track LinkedIn's page changes. A pinned version then quietly starts returning empty or wrong data. `@latest` re-resolves on every launch and is the supported configuration.

Docs only, no code change.