### PR TITLE
fix(server): advertise our version in serverInfo

### DIFF
--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -11,6 +11,7 @@ from typing import Any, AsyncIterator
 from fastmcp import FastMCP
 from fastmcp.server.lifespan import lifespan
 
+from linkedin_mcp_server import __version__
 from linkedin_mcp_server.bootstrap import (
     get_runtime_policy,
     initialize_bootstrap,
@@ -51,6 +52,7 @@ def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> 
     """Create and configure the MCP server with all LinkedIn tools."""
     mcp = FastMCP(
         "mcp-server-linkedin",
+        version=__version__,
         lifespan=browser_lifespan,
         mask_error_details=True,
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,6 +5,7 @@ import mcp.types as mt
 from fastmcp import FastMCP
 from fastmcp.server.middleware import MiddlewareContext
 
+from linkedin_mcp_server import __version__
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
@@ -87,3 +88,12 @@ class TestSequentialToolExecutionMiddleware:
                 ),
             ]
         )
+
+
+class TestServerVersion:
+    def test_create_mcp_server_advertises_package_version(self):
+        # Without an explicit version=, FastMCP advertises its own library
+        # version in serverInfo instead of ours.
+        mcp = create_mcp_server()
+
+        assert mcp.version == __version__


### PR DESCRIPTION
`create_mcp_server()` constructs `FastMCP(...)` without a `version=`, so FastMCP falls back to advertising its own library version in `serverInfo.version` during the initialize handshake instead of the package version. Clients and the MCP registry's latest-version comparison saw the wrong number (FastMCP's version, not ours).

Passes `version=__version__` so the server reports the installed `mcp-server-linkedin` version. Adds a regression test.

`uv run pytest tests/test_server.py` passes; ruff and ty clean.