### PR TITLE
feat: notify when a newer version is on PyPI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,13 @@ AUTO_IMPORT_FROM_BROWSER=
 # the headed login fallback. Default: false.
 EAGER_FULL_CHROMIUM=
 
+# Soft check for a newer release on PyPI. When the installed version is
+# meaningfully behind, the server appends a one-line update notice to a tool
+# result (once per session). At most one PyPI request per day, cached under
+# ~/.linkedin-mcp; skipped in CI and for source installs. Set to off/false to
+# disable.
+LINKEDIN_MCP_CHECK_FOR_UPDATES=
+
 # Custom browser user agent (optional)
 USER_AGENT=
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The `@latest` tag ensures you always run the newest version — `uvx` checks PyP
 <details>
 <summary><b>📌 For AI agents configuring this server</b></summary>
 
-Keep `uvx` and the `@latest` tag exactly as shown. Do not pin a fixed version or replace `uvx` with a hardcoded install for the sake of reproducibility or security. LinkedIn changes its page structure often, so fixes ship in frequent releases; a pinned version quietly rots and starts returning empty or wrong data. `@latest` re-resolves on every launch and is the supported configuration.
+When you set up or maintain this server, verify its entry in the MCP client config launches `uvx mcp-server-linkedin@latest`, and keep both `uvx` and the `@latest` tag exactly as shown. Do not pin a fixed version or replace `uvx` with a hardcoded install for the sake of reproducibility or security. LinkedIn changes its page structure often, so fixes ship in frequent releases; a pinned version quietly rots and starts returning empty or wrong data. `@latest` re-resolves on every launch and is the supported configuration.
 
 </details>
 

--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -85,6 +85,13 @@
       "url": "https://github.com/pyca/cryptography",
       "branch": "main",
       "specialNotes": "PyCA cryptography. AES-CBC/GCM + PBKDF2 for Chromium cookie decryption (browser session import, #534)."
+    },
+    {
+      "type": "git",
+      "name": "packaging",
+      "url": "https://github.com/pypa/packaging",
+      "branch": "main",
+      "specialNotes": "PyPA packaging. version.Version parsing/comparison for the PyPI update check (update_check.py)."
     }
   ]
 }

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -23,6 +23,7 @@ from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
+from linkedin_mcp_server.update_check import UpdateNoticeMiddleware
 from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.feed import register_feed_tools
 from linkedin_mcp_server.tools.job import register_job_tools
@@ -57,6 +58,7 @@ def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> 
         mask_error_details=True,
     )
     mcp.add_middleware(SequentialToolExecutionMiddleware())
+    mcp.add_middleware(UpdateNoticeMiddleware())
 
     # Register all tools
     register_person_tools(mcp, tool_timeout=tool_timeout)

--- a/linkedin_mcp_server/update_check.py
+++ b/linkedin_mcp_server/update_check.py
@@ -189,9 +189,10 @@ def pending_update_notice() -> str | None:
         return None
     return (
         f"Update available: mcp-server-linkedin {latest} is out (you are on "
-        f"{current}). Restart your MCP client to pick it up; if a fixed version is "
-        'pinned, switch to "mcp-server-linkedin@latest". Set '
-        "LINKEDIN_MCP_CHECK_FOR_UPDATES=off to silence this."
+        f"{current}). Check this server's entry in the MCP client config: it should "
+        'run "uvx mcp-server-linkedin@latest". If it pins a fixed version or drops '
+        "@latest, update the config so new releases install automatically, then "
+        "restart the client. Set LINKEDIN_MCP_CHECK_FOR_UPDATES=off to silence this."
     )
 
 

--- a/linkedin_mcp_server/update_check.py
+++ b/linkedin_mcp_server/update_check.py
@@ -34,6 +34,9 @@ from linkedin_mcp_server import __version__
 logger = logging.getLogger(__name__)
 
 _PYPI_URL = "https://pypi.org/pypi/mcp-server-linkedin/json"
+_LATEST_RELEASE_URL = (
+    "https://github.com/stickerdaniel/linkedin-mcp-server/releases/latest"
+)
 _CACHE_PATH = Path.home() / ".linkedin-mcp" / "update-check.json"
 _CACHE_TTL_SECONDS = 24 * 60 * 60
 _REQUEST_TIMEOUT_SECONDS = 2.0
@@ -174,28 +177,43 @@ def _is_meaningfully_behind(current: Version, latest: Version) -> bool:
     return (latest.micro - current.micro) >= 2
 
 
-def _update_action() -> str:
-    """Method-specific instruction for getting onto the latest release.
+def _runtime_kind() -> str:
+    """Best-effort install method: ``docker``, ``mcpb``, or ``managed`` (uvx/local).
 
-    Only Docker is reliably detectable at runtime; uvx, a local ``uv run``, and a
-    Claude Desktop bundle all report as the managed runtime, so the managed branch
-    covers both the uvx-config and the bundle-reinstall paths.
+    Docker is detected from the runtime policy. A Claude Desktop bundle is otherwise
+    indistinguishable from uvx, so the bundle build sets ``LINKEDIN_MCP_RUNTIME=mcpb``
+    in its manifest; everything else is treated as the uvx/local managed case.
     """
     try:
         from linkedin_mcp_server.bootstrap import RuntimePolicy, get_runtime_policy
 
         if get_runtime_policy() == RuntimePolicy.DOCKER:
-            return (
-                "You are running in Docker: pull the newest image tag and recreate "
-                "the container."
-            )
-    except Exception:  # noqa: BLE001 - fall back to the managed guidance
+            return "docker"
+    except Exception:  # noqa: BLE001 - fall back to env / managed detection
         logger.debug("Could not resolve runtime policy", exc_info=True)
+    if os.environ.get("LINKEDIN_MCP_RUNTIME", "").strip().lower() == "mcpb":
+        return "mcpb"
+    return "managed"
+
+
+def _update_action() -> str:
+    """Method-specific instruction for getting onto the latest release."""
+    kind = _runtime_kind()
+    if kind == "docker":
+        return (
+            "You are running in Docker: pull the newest image tag and recreate the "
+            "container."
+        )
+    if kind == "mcpb":
+        return (
+            "You are running the Claude Desktop bundle, which does not auto-update. "
+            f"Download the latest .mcpb from {_LATEST_RELEASE_URL} and reinstall it "
+            "in Claude Desktop."
+        )
     return (
-        "If this server is configured via uvx, make sure the entry runs "
-        '"uvx mcp-server-linkedin@latest" rather than a pinned version, then restart '
-        "the client. If you installed it as a Claude Desktop bundle (.mcpb), install "
-        "the latest bundle."
+        "Check this server's entry in the MCP client config: it should run "
+        '"uvx mcp-server-linkedin@latest" rather than a pinned version. If it pins a '
+        "version or drops @latest, fix it and restart the client."
     )
 
 

--- a/linkedin_mcp_server/update_check.py
+++ b/linkedin_mcp_server/update_check.py
@@ -174,6 +174,31 @@ def _is_meaningfully_behind(current: Version, latest: Version) -> bool:
     return (latest.micro - current.micro) >= 2
 
 
+def _update_action() -> str:
+    """Method-specific instruction for getting onto the latest release.
+
+    Only Docker is reliably detectable at runtime; uvx, a local ``uv run``, and a
+    Claude Desktop bundle all report as the managed runtime, so the managed branch
+    covers both the uvx-config and the bundle-reinstall paths.
+    """
+    try:
+        from linkedin_mcp_server.bootstrap import RuntimePolicy, get_runtime_policy
+
+        if get_runtime_policy() == RuntimePolicy.DOCKER:
+            return (
+                "You are running in Docker: pull the newest image tag and recreate "
+                "the container."
+            )
+    except Exception:  # noqa: BLE001 - fall back to the managed guidance
+        logger.debug("Could not resolve runtime policy", exc_info=True)
+    return (
+        "If this server is configured via uvx, make sure the entry runs "
+        '"uvx mcp-server-linkedin@latest" rather than a pinned version, then restart '
+        "the client. If you installed it as a Claude Desktop bundle (.mcpb), install "
+        "the latest bundle."
+    )
+
+
 def pending_update_notice() -> str | None:
     """A one-line notice when the installed version is meaningfully behind, else None."""
     if _latest_known is None:
@@ -189,10 +214,8 @@ def pending_update_notice() -> str | None:
         return None
     return (
         f"Update available: mcp-server-linkedin {latest} is out (you are on "
-        f"{current}). Check this server's entry in the MCP client config: it should "
-        'run "uvx mcp-server-linkedin@latest". If it pins a fixed version or drops '
-        "@latest, update the config so new releases install automatically, then "
-        "restart the client. Set LINKEDIN_MCP_CHECK_FOR_UPDATES=off to silence this."
+        f"{current}). {_update_action()} Set LINKEDIN_MCP_CHECK_FOR_UPDATES=off to "
+        "silence this."
     )
 
 

--- a/linkedin_mcp_server/update_check.py
+++ b/linkedin_mcp_server/update_check.py
@@ -232,8 +232,7 @@ def pending_update_notice() -> str | None:
         return None
     return (
         f"Update available: mcp-server-linkedin {latest} is out (you are on "
-        f"{current}). {_update_action()} Set LINKEDIN_MCP_CHECK_FOR_UPDATES=off to "
-        "silence this."
+        f"{current}). {_update_action()}"
     )
 
 

--- a/linkedin_mcp_server/update_check.py
+++ b/linkedin_mcp_server/update_check.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import time
+from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from urllib.request import Request, urlopen
 
@@ -42,12 +43,32 @@ _DISABLED_VALUES = {"0", "false", "off", "no"}
 _latest_known: str | None = None
 
 
+def _is_editable_install() -> bool:
+    """True for an editable/source checkout (PEP 610 direct_url.json, editable)."""
+    for name in ("mcp-server-linkedin", "linkedin-scraper-mcp"):
+        try:
+            text = distribution(name).read_text("direct_url.json")
+        except PackageNotFoundError:
+            continue
+        if not text:
+            continue
+        try:
+            info = json.loads(text)
+        except ValueError:
+            continue
+        if info.get("dir_info", {}).get("editable"):
+            return True
+    return False
+
+
 def _check_disabled() -> bool:
     """Whether the network check should be skipped entirely."""
     value = os.environ.get("LINKEDIN_MCP_CHECK_FOR_UPDATES", "").strip().lower()
     if value in _DISABLED_VALUES:
         return True
     if os.environ.get("CI"):
+        return True
+    if _is_editable_install():
         return True
     try:
         # Source / dev builds (the 0.0.0.dev fallback and PEP 440 dev releases

--- a/linkedin_mcp_server/update_check.py
+++ b/linkedin_mcp_server/update_check.py
@@ -46,20 +46,20 @@ _DISABLED_VALUES = {"0", "false", "off", "no"}
 _latest_known: str | None = None
 
 
-def _is_editable_install() -> bool:
-    """True for an editable/source checkout (PEP 610 direct_url.json, editable)."""
+def _is_source_install() -> bool:
+    """True for any non-index install: local path, editable, or VCS.
+
+    PEP 610 writes ``direct_url.json`` only for installs that did not come from a
+    package index, so its mere presence marks a source/editable/VCS checkout. Index
+    installs from PyPI (uvx, pip, pipx, including pinned versions) have no such file
+    and remain the audience for the update nudge.
+    """
     for name in ("mcp-server-linkedin", "linkedin-scraper-mcp"):
         try:
             text = distribution(name).read_text("direct_url.json")
         except PackageNotFoundError:
             continue
-        if not text:
-            continue
-        try:
-            info = json.loads(text)
-        except ValueError:
-            continue
-        if info.get("dir_info", {}).get("editable"):
+        if text:
             return True
     return False
 
@@ -71,7 +71,7 @@ def _check_disabled() -> bool:
         return True
     if os.environ.get("CI"):
         return True
-    if _is_editable_install():
+    if _is_source_install():
         return True
     try:
         # Source / dev builds (the 0.0.0.dev fallback and PEP 440 dev releases

--- a/linkedin_mcp_server/update_check.py
+++ b/linkedin_mcp_server/update_check.py
@@ -1,0 +1,179 @@
+"""Background check for a newer release on PyPI, surfaced as a tool-result notice.
+
+Most users install via ``uvx mcp-server-linkedin@latest``, which re-resolves PyPI
+on every client launch, so they are already current. This is defense-in-depth for
+the minority that pin a fixed version, run a stale Docker tag, or are offline: it
+polls the PyPI JSON API at most once a day, caches the answer under
+``~/.linkedin-mcp``, and appends a single gentle notice to a tool result when the
+installed version is meaningfully behind. Set ``LINKEDIN_MCP_CHECK_FOR_UPDATES=off``
+to disable; it is skipped automatically in CI and for source/dev installs.
+
+The notice is added as an extra text content block so the model relays it. It never
+touches the structured tool output, so the documented ``{url, sections}`` shape is
+unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+import mcp.types as mt
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import ToolResult
+from packaging.version import InvalidVersion, Version
+
+from linkedin_mcp_server import __version__
+
+logger = logging.getLogger(__name__)
+
+_PYPI_URL = "https://pypi.org/pypi/mcp-server-linkedin/json"
+_CACHE_PATH = Path.home() / ".linkedin-mcp" / "update-check.json"
+_CACHE_TTL_SECONDS = 24 * 60 * 60
+_REQUEST_TIMEOUT_SECONDS = 2.0
+_DEV_VERSION = "0.0.0.dev"
+_DISABLED_VALUES = {"0", "false", "off", "no"}
+
+# Latest version learned this process. None until the background check resolves.
+_latest_known: str | None = None
+
+
+def _check_disabled() -> bool:
+    """Whether the network check should be skipped entirely."""
+    value = os.environ.get("LINKEDIN_MCP_CHECK_FOR_UPDATES", "").strip().lower()
+    if value in _DISABLED_VALUES:
+        return True
+    if os.environ.get("CI"):
+        return True
+    if __version__ == _DEV_VERSION:
+        return True
+    return False
+
+
+def _read_cache() -> tuple[float, str] | None:
+    try:
+        data = json.loads(_CACHE_PATH.read_text())
+        return float(data["checked_at"]), str(data["latest"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+
+
+def _write_cache(latest: str) -> None:
+    try:
+        _CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _CACHE_PATH.write_text(
+            json.dumps({"checked_at": time.time(), "latest": latest})
+        )
+    except OSError:
+        logger.debug("Could not write update-check cache", exc_info=True)
+
+
+def _fetch_latest_from_pypi() -> str | None:
+    request = Request(
+        _PYPI_URL,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": f"mcp-server-linkedin/{__version__}",
+        },
+    )
+    try:
+        with urlopen(request, timeout=_REQUEST_TIMEOUT_SECONDS) as response:
+            data = json.loads(response.read().decode("utf-8"))
+        return str(data["info"]["version"])
+    except Exception:  # noqa: BLE001 - never let a version check break a tool call
+        logger.debug("PyPI update check failed", exc_info=True)
+        return None
+
+
+async def refresh_latest_version() -> None:
+    """Populate ``_latest_known`` from cache or a throttled PyPI request.
+
+    Fire-and-forget: any failure falls back to the stale cache or leaves the
+    notice silent. Never raises.
+    """
+    global _latest_known
+    if _check_disabled():
+        return
+
+    cached = _read_cache()
+    if cached is not None and (time.time() - cached[0]) < _CACHE_TTL_SECONDS:
+        _latest_known = cached[1]
+        return
+
+    latest = await asyncio.to_thread(_fetch_latest_from_pypi)
+    if latest is None:
+        if cached is not None:  # fail open to whatever we last knew
+            _latest_known = cached[1]
+        return
+
+    _write_cache(latest)
+    _latest_known = latest
+
+
+def _is_meaningfully_behind(current: Version, latest: Version) -> bool:
+    """True for a minor/major bump, or two-plus patch releases on the same line.
+
+    A single fresh patch is ignored so ``@latest`` users mid-refresh are not nagged.
+    """
+    if latest <= current:
+        return False
+    if (latest.major, latest.minor) > (current.major, current.minor):
+        return True
+    return (latest.micro - current.micro) >= 2
+
+
+def pending_update_notice() -> str | None:
+    """A one-line notice when the installed version is meaningfully behind, else None."""
+    if _latest_known is None or __version__ == _DEV_VERSION:
+        return None
+    try:
+        current = Version(__version__)
+        latest = Version(_latest_known)
+    except InvalidVersion:
+        return None
+    if current.is_devrelease or latest.is_prerelease:
+        return None
+    if not _is_meaningfully_behind(current, latest):
+        return None
+    return (
+        f"Update available: mcp-server-linkedin {latest} is out (you are on "
+        f"{current}). Restart your MCP client to pick it up; if a fixed version is "
+        'pinned, switch to "mcp-server-linkedin@latest". Set '
+        "LINKEDIN_MCP_CHECK_FOR_UPDATES=off to silence this."
+    )
+
+
+class UpdateNoticeMiddleware(Middleware):
+    """Kick off the update check once and append the notice to a tool result once."""
+
+    def __init__(self) -> None:
+        self._kicked = False
+        self._notified = False
+        self._task: asyncio.Task[None] | None = None
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        if not self._kicked:
+            self._kicked = True
+            # Retain a reference so the task is not garbage-collected mid-flight.
+            self._task = asyncio.create_task(refresh_latest_version())
+
+        result = await call_next(context)
+
+        if not self._notified:
+            notice = pending_update_notice()
+            if notice is not None:
+                self._notified = True
+                result.content = [
+                    *result.content,
+                    mt.TextContent(type="text", text=notice),
+                ]
+        return result

--- a/linkedin_mcp_server/update_check.py
+++ b/linkedin_mcp_server/update_check.py
@@ -36,10 +36,9 @@ _PYPI_URL = "https://pypi.org/pypi/mcp-server-linkedin/json"
 _CACHE_PATH = Path.home() / ".linkedin-mcp" / "update-check.json"
 _CACHE_TTL_SECONDS = 24 * 60 * 60
 _REQUEST_TIMEOUT_SECONDS = 2.0
-_DEV_VERSION = "0.0.0.dev"
 _DISABLED_VALUES = {"0", "false", "off", "no"}
 
-# Latest version learned this process. None until the background check resolves.
+# Latest version learned this process. None until the check resolves.
 _latest_known: str | None = None
 
 
@@ -50,7 +49,12 @@ def _check_disabled() -> bool:
         return True
     if os.environ.get("CI"):
         return True
-    if __version__ == _DEV_VERSION:
+    try:
+        # Source / dev builds (the 0.0.0.dev fallback and PEP 440 dev releases
+        # like 4.17.0.dev1) should never poll PyPI.
+        if Version(__version__).is_devrelease:
+            return True
+    except InvalidVersion:
         return True
     return False
 
@@ -90,6 +94,27 @@ def _fetch_latest_from_pypi() -> str | None:
         return None
 
 
+def _fresh_cached_latest() -> str | None:
+    cached = _read_cache()
+    if cached is not None and (time.time() - cached[0]) < _CACHE_TTL_SECONDS:
+        return cached[1]
+    return None
+
+
+def prime_from_cache() -> None:
+    """Synchronously seed ``_latest_known`` from a fresh cache (no network).
+
+    Lets a single fast tool call still surface a notice when an earlier session
+    already wrote the cache, instead of waiting on the background task.
+    """
+    global _latest_known
+    if _check_disabled():
+        return
+    fresh = _fresh_cached_latest()
+    if fresh is not None:
+        _latest_known = fresh
+
+
 async def refresh_latest_version() -> None:
     """Populate ``_latest_known`` from cache or a throttled PyPI request.
 
@@ -100,13 +125,14 @@ async def refresh_latest_version() -> None:
     if _check_disabled():
         return
 
-    cached = _read_cache()
-    if cached is not None and (time.time() - cached[0]) < _CACHE_TTL_SECONDS:
-        _latest_known = cached[1]
+    fresh = _fresh_cached_latest()
+    if fresh is not None:
+        _latest_known = fresh
         return
 
     latest = await asyncio.to_thread(_fetch_latest_from_pypi)
     if latest is None:
+        cached = _read_cache()
         if cached is not None:  # fail open to whatever we last knew
             _latest_known = cached[1]
         return
@@ -129,7 +155,7 @@ def _is_meaningfully_behind(current: Version, latest: Version) -> bool:
 
 def pending_update_notice() -> str | None:
     """A one-line notice when the installed version is meaningfully behind, else None."""
-    if _latest_known is None or __version__ == _DEV_VERSION:
+    if _latest_known is None:
         return None
     try:
         current = Version(__version__)
@@ -163,6 +189,9 @@ class UpdateNoticeMiddleware(Middleware):
     ) -> ToolResult:
         if not self._kicked:
             self._kicked = True
+            # Seed from a fresh cache synchronously so even a single fast call can
+            # surface the notice, then refresh over the network in the background.
+            prime_from_cache()
             # Retain a reference so the task is not garbage-collected mid-flight.
             self._task = asyncio.create_task(refresh_latest_version())
 

--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,10 @@
         "${__dirname}",
         "-m",
         "linkedin_mcp_server"
-      ]
+      ],
+      "env": {
+        "LINKEDIN_MCP_RUNTIME": "mcpb"
+      }
     }
   },
   "tools": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "cryptography>=48.0.1",
     "fastmcp>=3.0.0",
     "inquirer>=3.4.0",
+    "packaging>=26.2",
     "patchright>=1.40.0",
     "python-dotenv>=1.1.1",
 ]

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,134 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import mcp.types as mt
+from fastmcp.tools import ToolResult
+
+from linkedin_mcp_server import update_check
+from linkedin_mcp_server.update_check import (
+    UpdateNoticeMiddleware,
+    pending_update_notice,
+    refresh_latest_version,
+)
+
+
+class TestPendingUpdateNotice:
+    def test_notice_on_minor_bump(self, monkeypatch):
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", "4.18.0")
+
+        notice = pending_update_notice()
+
+        assert notice is not None
+        assert "4.18.0" in notice
+        assert "4.16.1" in notice
+
+    def test_notice_on_two_patches_behind(self, monkeypatch):
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", "4.16.3")
+
+        assert pending_update_notice() is not None
+
+    def test_no_notice_for_single_patch(self, monkeypatch):
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", "4.16.2")
+
+        assert pending_update_notice() is None
+
+    def test_no_notice_when_current(self, monkeypatch):
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", "4.16.1")
+
+        assert pending_update_notice() is None
+
+    def test_no_notice_for_prerelease_latest(self, monkeypatch):
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", "4.18.0rc1")
+
+        assert pending_update_notice() is None
+
+    def test_no_notice_for_dev_install(self, monkeypatch):
+        monkeypatch.setattr(update_check, "__version__", "0.0.0.dev")
+        monkeypatch.setattr(update_check, "_latest_known", "9.9.9")
+
+        assert pending_update_notice() is None
+
+    def test_no_notice_when_latest_unknown(self, monkeypatch):
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", None)
+
+        assert pending_update_notice() is None
+
+
+class TestRefreshLatestVersion:
+    async def test_disabled_skips_network(self, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_MCP_CHECK_FOR_UPDATES", "off")
+        monkeypatch.setattr(update_check, "_latest_known", None)
+        fetch = MagicMock()
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", fetch)
+
+        await refresh_latest_version()
+
+        fetch.assert_not_called()
+        assert update_check._latest_known is None
+
+    async def test_fetches_and_caches_when_stale(self, monkeypatch):
+        monkeypatch.delenv("LINKEDIN_MCP_CHECK_FOR_UPDATES", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", None)
+        monkeypatch.setattr(update_check, "_read_cache", lambda: None)
+        written = {}
+        monkeypatch.setattr(
+            update_check, "_write_cache", lambda latest: written.update(latest=latest)
+        )
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", lambda: "4.18.0")
+
+        await refresh_latest_version()
+
+        assert update_check._latest_known == "4.18.0"
+        assert written == {"latest": "4.18.0"}
+
+    async def test_fresh_cache_skips_network(self, monkeypatch):
+        import time
+
+        monkeypatch.delenv("LINKEDIN_MCP_CHECK_FOR_UPDATES", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", None)
+        monkeypatch.setattr(
+            update_check, "_read_cache", lambda: (time.time(), "4.17.0")
+        )
+        fetch = MagicMock()
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", fetch)
+
+        await refresh_latest_version()
+
+        fetch.assert_not_called()
+        assert update_check._latest_known == "4.17.0"
+
+
+class TestUpdateNoticeMiddleware:
+    async def test_appends_notice_once(self, monkeypatch):
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", "4.18.0")
+
+        async def _noop() -> None:
+            return None
+
+        monkeypatch.setattr(update_check, "refresh_latest_version", _noop)
+
+        middleware = UpdateNoticeMiddleware()
+
+        def fresh_result() -> ToolResult:
+            return ToolResult(content=[mt.TextContent(type="text", text="payload")])
+
+        call_next = AsyncMock(side_effect=lambda _ctx: fresh_result())
+
+        first = await middleware.on_call_tool(MagicMock(), call_next)
+        assert len(first.content) == 2
+        assert isinstance(first.content[-1], mt.TextContent)
+        assert "4.18.0" in first.content[-1].text
+
+        # A second call must not nag again.
+        second = await middleware.on_call_tool(MagicMock(), call_next)
+        assert len(second.content) == 1

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -4,7 +4,7 @@ import mcp.types as mt
 import pytest
 from fastmcp.tools import ToolResult
 
-from linkedin_mcp_server import update_check
+from linkedin_mcp_server import bootstrap, update_check
 from linkedin_mcp_server.update_check import (
     UpdateNoticeMiddleware,
     _check_disabled,
@@ -22,17 +22,34 @@ def _not_editable(monkeypatch):
 
 
 class TestPendingUpdateNotice:
-    def test_notice_on_minor_bump(self, monkeypatch):
+    def test_notice_on_minor_bump_managed(self, monkeypatch):
         monkeypatch.setattr(update_check, "__version__", "4.16.1")
         monkeypatch.setattr(update_check, "_latest_known", "4.18.0")
+        monkeypatch.setattr(
+            bootstrap, "get_runtime_policy", lambda: bootstrap.RuntimePolicy.MANAGED
+        )
 
         notice = pending_update_notice()
 
         assert notice is not None
         assert "4.18.0" in notice
         assert "4.16.1" in notice
+        # Managed runtime covers both the uvx-config and bundle-reinstall paths.
         assert "uvx mcp-server-linkedin@latest" in notice
-        assert "config" in notice
+        assert ".mcpb" in notice
+
+    def test_notice_for_docker_targets_the_image(self, monkeypatch):
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", "4.18.0")
+        monkeypatch.setattr(
+            bootstrap, "get_runtime_policy", lambda: bootstrap.RuntimePolicy.DOCKER
+        )
+
+        notice = pending_update_notice()
+
+        assert notice is not None
+        assert "Docker" in notice
+        assert "uvx" not in notice
 
     def test_notice_on_two_patches_behind(self, monkeypatch):
         monkeypatch.setattr(update_check, "__version__", "4.16.1")

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -6,7 +6,9 @@ from fastmcp.tools import ToolResult
 from linkedin_mcp_server import update_check
 from linkedin_mcp_server.update_check import (
     UpdateNoticeMiddleware,
+    _check_disabled,
     pending_update_notice,
+    prime_from_cache,
     refresh_latest_version,
 )
 
@@ -71,6 +73,21 @@ class TestRefreshLatestVersion:
         fetch.assert_not_called()
         assert update_check._latest_known is None
 
+    async def test_pep440_dev_release_does_not_poll(self, monkeypatch):
+        # A real installed dev build, not just the 0.0.0.dev fallback.
+        monkeypatch.delenv("LINKEDIN_MCP_CHECK_FOR_UPDATES", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(update_check, "__version__", "4.17.0.dev1")
+        monkeypatch.setattr(update_check, "_latest_known", None)
+        fetch = MagicMock()
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", fetch)
+
+        assert _check_disabled() is True
+        await refresh_latest_version()
+
+        fetch.assert_not_called()
+        assert update_check._latest_known is None
+
     async def test_fetches_and_caches_when_stale(self, monkeypatch):
         monkeypatch.delenv("LINKEDIN_MCP_CHECK_FOR_UPDATES", raising=False)
         monkeypatch.delenv("CI", raising=False)
@@ -107,10 +124,28 @@ class TestRefreshLatestVersion:
         assert update_check._latest_known == "4.17.0"
 
 
+class TestPrimeFromCache:
+    def test_seeds_latest_from_fresh_cache(self, monkeypatch):
+        import time
+
+        monkeypatch.delenv("LINKEDIN_MCP_CHECK_FOR_UPDATES", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", None)
+        monkeypatch.setattr(
+            update_check, "_read_cache", lambda: (time.time(), "4.18.0")
+        )
+
+        prime_from_cache()
+
+        assert update_check._latest_known == "4.18.0"
+
+
 class TestUpdateNoticeMiddleware:
     async def test_appends_notice_once(self, monkeypatch):
         monkeypatch.setattr(update_check, "__version__", "4.16.1")
         monkeypatch.setattr(update_check, "_latest_known", "4.18.0")
+        monkeypatch.setattr(update_check, "prime_from_cache", lambda: None)
 
         async def _noop() -> None:
             return None

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -22,21 +22,21 @@ def _not_editable(monkeypatch):
 
 
 class TestPendingUpdateNotice:
-    def test_notice_on_minor_bump_managed(self, monkeypatch):
+    def test_notice_managed_points_at_uvx_config(self, monkeypatch):
         monkeypatch.setattr(update_check, "__version__", "4.16.1")
         monkeypatch.setattr(update_check, "_latest_known", "4.18.0")
         monkeypatch.setattr(
             bootstrap, "get_runtime_policy", lambda: bootstrap.RuntimePolicy.MANAGED
         )
+        monkeypatch.delenv("LINKEDIN_MCP_RUNTIME", raising=False)
 
         notice = pending_update_notice()
 
         assert notice is not None
         assert "4.18.0" in notice
         assert "4.16.1" in notice
-        # Managed runtime covers both the uvx-config and bundle-reinstall paths.
         assert "uvx mcp-server-linkedin@latest" in notice
-        assert ".mcpb" in notice
+        assert ".mcpb" not in notice
 
     def test_notice_for_docker_targets_the_image(self, monkeypatch):
         monkeypatch.setattr(update_check, "__version__", "4.16.1")
@@ -49,6 +49,21 @@ class TestPendingUpdateNotice:
 
         assert notice is not None
         assert "Docker" in notice
+        assert "uvx" not in notice
+
+    def test_notice_for_mcpb_links_latest_release(self, monkeypatch):
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_latest_known", "4.18.0")
+        monkeypatch.setattr(
+            bootstrap, "get_runtime_policy", lambda: bootstrap.RuntimePolicy.MANAGED
+        )
+        monkeypatch.setenv("LINKEDIN_MCP_RUNTIME", "mcpb")
+
+        notice = pending_update_notice()
+
+        assert notice is not None
+        assert "releases/latest" in notice
+        assert ".mcpb" in notice
         assert "uvx" not in notice
 
     def test_notice_on_two_patches_behind(self, monkeypatch):

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -31,6 +31,8 @@ class TestPendingUpdateNotice:
         assert notice is not None
         assert "4.18.0" in notice
         assert "4.16.1" in notice
+        assert "uvx mcp-server-linkedin@latest" in notice
+        assert "config" in notice
 
     def test_notice_on_two_patches_behind(self, monkeypatch):
         monkeypatch.setattr(update_check, "__version__", "4.16.1")

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -15,10 +15,10 @@ from linkedin_mcp_server.update_check import (
 
 
 @pytest.fixture(autouse=True)
-def _not_editable(monkeypatch):
+def _not_source(monkeypatch):
     # Keep tests deterministic regardless of how the package under test is
-    # installed; a pip -e checkout would otherwise disable the network path.
-    monkeypatch.setattr(update_check, "_is_editable_install", lambda: False)
+    # installed; a source/editable checkout would otherwise disable the network path.
+    monkeypatch.setattr(update_check, "_is_source_install", lambda: False)
 
 
 class TestPendingUpdateNotice:
@@ -130,11 +130,11 @@ class TestRefreshLatestVersion:
         fetch.assert_not_called()
         assert update_check._latest_known is None
 
-    async def test_editable_install_does_not_poll(self, monkeypatch):
+    async def test_source_install_does_not_poll(self, monkeypatch):
         monkeypatch.delenv("LINKEDIN_MCP_CHECK_FOR_UPDATES", raising=False)
         monkeypatch.delenv("CI", raising=False)
         monkeypatch.setattr(update_check, "__version__", "4.16.1")
-        monkeypatch.setattr(update_check, "_is_editable_install", lambda: True)
+        monkeypatch.setattr(update_check, "_is_source_install", lambda: True)
         monkeypatch.setattr(update_check, "_latest_known", None)
         fetch = MagicMock()
         monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", fetch)

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import mcp.types as mt
+import pytest
 from fastmcp.tools import ToolResult
 
 from linkedin_mcp_server import update_check
@@ -11,6 +12,13 @@ from linkedin_mcp_server.update_check import (
     prime_from_cache,
     refresh_latest_version,
 )
+
+
+@pytest.fixture(autouse=True)
+def _not_editable(monkeypatch):
+    # Keep tests deterministic regardless of how the package under test is
+    # installed; a pip -e checkout would otherwise disable the network path.
+    monkeypatch.setattr(update_check, "_is_editable_install", lambda: False)
 
 
 class TestPendingUpdateNotice:
@@ -78,6 +86,21 @@ class TestRefreshLatestVersion:
         monkeypatch.delenv("LINKEDIN_MCP_CHECK_FOR_UPDATES", raising=False)
         monkeypatch.delenv("CI", raising=False)
         monkeypatch.setattr(update_check, "__version__", "4.17.0.dev1")
+        monkeypatch.setattr(update_check, "_latest_known", None)
+        fetch = MagicMock()
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", fetch)
+
+        assert _check_disabled() is True
+        await refresh_latest_version()
+
+        fetch.assert_not_called()
+        assert update_check._latest_known is None
+
+    async def test_editable_install_does_not_poll(self, monkeypatch):
+        monkeypatch.delenv("LINKEDIN_MCP_CHECK_FOR_UPDATES", raising=False)
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setattr(update_check, "__version__", "4.16.1")
+        monkeypatch.setattr(update_check, "_is_editable_install", lambda: True)
         monkeypatch.setattr(update_check, "_latest_known", None)
         fetch = MagicMock()
         monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", fetch)

--- a/uv.lock
+++ b/uv.lock
@@ -1046,6 +1046,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastmcp" },
     { name = "inquirer" },
+    { name = "packaging" },
     { name = "patchright" },
     { name = "python-dotenv" },
 ]
@@ -1067,6 +1068,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "fastmcp", specifier = ">=3.0.0" },
     { name = "inquirer", specifier = ">=3.4.0" },
+    { name = "packaging", specifier = ">=26.2" },
     { name = "patchright", specifier = ">=1.40.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
 ]


### PR DESCRIPTION
Most users install via `uvx mcp-server-linkedin@latest` and stay current automatically, but anyone who pins a fixed version, runs a stale Docker tag, or installs without `@latest` can silently fall behind and miss the fixes that track LinkedIn's frequent page changes. Nothing in the server told them.

Adds a background check against the PyPI JSON API (`info.version`), throttled to at most one request per day and cached under `~/.linkedin-mcp`. When the installed version is meaningfully behind (a minor or major bump, or two or more patch releases), a middleware appends a single one-line update notice to a tool result so the model relays it. It fires once per session, never touches the structured `{url, sections}` output, fails open on any network error, skips prereleases and source/dev installs, and is suppressed in CI. Set `LINKEDIN_MCP_CHECK_FOR_UPDATES=off` to disable.

`uv run pytest` passes (774 existing plus new update-check tests); ruff and ty clean.