### PR TITLE
fix(job): expand collapsed job description by clicking 'See more' button

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1526,11 +1526,19 @@ class LinkedInExtractor:
                     break
 
         if is_job:
+            # Expand the collapsed job description by clicking the "See more" button.
+            # Uses a text-based selector scoped to <main> — no class names tied to
+            # LinkedIn's CSS bundle (per project scraping rules in CLAUDE.md).
+            button = self._page.locator("main button").filter(
+                has_text=re.compile(r"^See more\b", re.IGNORECASE)
+            )
             try:
-                button = self._page.locator("button.show-more-less-html__button--more")
-                if await button.count() > 0 and await button.first.is_visible():
-                    await button.first.click(timeout=3000)
-                    await asyncio.sleep(0.5)
+                if await button.count() > 0:
+                    target = button.first
+                    await target.scroll_into_view_if_needed(timeout=2000)
+                    if await target.is_visible():
+                        await target.click(timeout=3000)
+                        await asyncio.sleep(0.5)
             except Exception as e:
                 logger.debug("Job description 'See more' click failed: %s", e)
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1483,6 +1483,7 @@ class LinkedInExtractor:
         # panel loads asynchronously. Wait until the panel replaces the sidebar.
         # The sidebar placeholder starts with "Load more" or "More profiles for you".
         is_details = "/details/" in url
+        is_job = "/jobs/view/" in url
         if is_details:
             try:
                 await self._page.wait_for_function(
@@ -1523,6 +1524,15 @@ class LinkedInExtractor:
                 except Exception as e:
                     logger.debug("Show more click failed: %s", e)
                     break
+
+        if is_job:
+            try:
+                button = self._page.locator("button.show-more-less-html__button--more")
+                if await button.count() > 0 and await button.first.is_visible():
+                    await button.first.click(timeout=3000)
+                    await asyncio.sleep(0.5)
+            except Exception as e:
+                logger.debug("Job description 'See more' click failed: %s", e)
 
         # Scroll to trigger lazy loading
         if is_activity:


### PR DESCRIPTION
## Problem

LinkedIn job detail pages (`/jobs/view/`) render the job description inside a collapsed element hidden with `overflow-hidden`. A 'See more' button must be clicked before `innerText` is called — otherwise only the visible page chrome is captured ('Apply', 'Save', 'Try Premium') instead of the actual job description text.

The existing `is_details` flag in `_extract_loaded_section` handles `/details/` pages, but `/jobs/view/` pages are not handled.

## Fix

Add an `is_job` flag for `/jobs/view/` URLs and click `button.show-more-less-html__button--more` before text extraction.

```python
is_job = "/jobs/view/" in url

if is_job:
    try:
        button = self._page.locator("button.show-more-less-html__button--more")
        if await button.count() > 0 and await button.first.is_visible():
            await button.first.click(timeout=3000)
            await asyncio.sleep(0.5)
    except Exception as e:
        logger.debug("Job description 'See more' click failed: %s", e)
```

## Impact

Without this fix, `get_job_details` returns boilerplate UI text instead of the actual job description, making language detection, skill matching, and scoring unreliable for any downstream consumer of this tool.