### PR TITLE
feat(send_message): add thread_id support ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | working |
 | `search_conversations` | Search messages by keyword | working |
-| `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) [#483](https://github.com/stickerdaniel/linkedin-mcp-server/issues/483) |
+| `send_message` | Send a message to a LinkedIn user or reply to an existing thread via `thread_id` (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_companies` | Search for companies on LinkedIn by keywords | working |

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3718,6 +3718,7 @@ class LinkedInExtractor:
             thread_url,
             "sent",
             "Reply sent.",
+            recipient_selected=True,
             sent=True,
         )
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3621,6 +3621,108 @@ class LinkedInExtractor:
             references=references,
         )
 
+    async def _reply_in_thread(
+        self,
+        thread_id: str,
+        message: str,
+        *,
+        confirm_send: bool,
+    ) -> dict[str, Any]:
+        """Reply to an existing messaging thread by thread ID.
+
+        Navigates to the thread page and uses the inline reply input at the
+        bottom, avoiding the compose overlay that creates a new DM thread.
+
+        Args:
+            thread_id: LinkedIn messaging thread ID.
+            message: The message text to send.
+            confirm_send: Must be True to actually send (False does a dry run).
+        """
+        thread_url = f"https://www.linkedin.com/messaging/thread/{thread_id}/"
+        await self._navigate_to_page(thread_url)
+        await detect_rate_limit(self._page)
+
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("Thread page did not load for thread_id=%s", thread_id)
+            return self._message_action_result(
+                thread_url,
+                "send_failed",
+                "Thread page did not load.",
+            )
+
+        await handle_modal_close(self._page)
+
+        compose_box = await self._resolve_message_compose_box()
+        if compose_box is None:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                thread_url,
+                "composer_unavailable",
+                "LinkedIn did not expose a usable reply composer on the thread page.",
+            )
+
+        if not confirm_send:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                thread_url,
+                "confirmation_required",
+                "Set confirm_send=true to send the message.",
+            )
+
+        focused = await self._page.evaluate(
+            """() => {
+                const el = document.querySelector(
+                    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
+                    + 'div[role="textbox"][contenteditable="true"]'
+                );
+                if (!el) return false;
+                el.focus();
+                return true;
+            }"""
+        )
+        if not focused:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                thread_url,
+                "compose_interact_failed",
+                "Could not focus reply compose box via JavaScript.",
+            )
+        await asyncio.sleep(0.1)
+        await self._page.keyboard.type(message, delay=15)
+        await asyncio.sleep(0.3)
+
+        await asyncio.sleep(1.0)
+        sent_via_js = await self._page.evaluate(
+            """() => {
+                const btn = Array.from(document.querySelectorAll(
+                    'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
+                    + 'button[data-control-name="send"]'
+                )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
+                if (!btn) return false;
+                btn.click();
+                return true;
+            }"""
+        )
+        if not sent_via_js:
+            await self._page.keyboard.press("Enter")
+
+        if not await self._message_text_visible(message):
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                thread_url,
+                "send_unavailable",
+                "LinkedIn did not confirm that the reply was sent.",
+            )
+
+        return self._message_action_result(
+            thread_url,
+            "sent",
+            "Reply sent.",
+            sent=True,
+        )
+
     async def send_message(
         self,
         linkedin_username: str,
@@ -3628,16 +3730,35 @@ class LinkedInExtractor:
         *,
         confirm_send: bool,
         profile_urn: str | None = None,
+        thread_id: str | None = None,
     ) -> dict[str, Any]:
         """Send a message to a LinkedIn user with explicit confirmation gating.
 
+        When ``thread_id`` is provided, the tool replies to the existing
+        messaging thread instead of opening a new compose overlay. When
+        ``thread_id`` is not provided, the tool navigates to the recipient's
+        profile and opens the compose overlay as before.
+
         Args:
-            linkedin_username: LinkedIn username of the recipient.
+            linkedin_username: LinkedIn username of the recipient. Ignored when
+                ``thread_id`` is provided.
             message: The message text to send.
             confirm_send: Must be True to actually send (False does a dry run).
             profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
                 compose URL directly, bypassing the Message-button lookup.
+                Ignored when ``thread_id`` is provided.
+            thread_id: Optional LinkedIn messaging thread ID. When provided the
+                tool replies inline to the existing thread instead of creating
+                a new compose overlay. Use ``get_conversation`` or
+                ``search_conversations`` to obtain thread IDs.
         """
+        if thread_id:
+            return await self._reply_in_thread(
+                thread_id,
+                message,
+                confirm_send=confirm_send,
+            )
+
         profile_url = f"https://www.linkedin.com/in/{linkedin_username}/"
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3656,7 +3656,6 @@ class LinkedInExtractor:
 
         compose_box = await self._resolve_message_compose_box()
         if compose_box is None:
-            await self._dismiss_message_ui()
             return self._message_action_result(
                 thread_url,
                 "composer_unavailable",
@@ -3664,7 +3663,6 @@ class LinkedInExtractor:
             )
 
         if not confirm_send:
-            await self._dismiss_message_ui()
             return self._message_action_result(
                 thread_url,
                 "confirmation_required",
@@ -3682,7 +3680,6 @@ class LinkedInExtractor:
             }"""
         )
         if not focused:
-            await self._dismiss_message_ui()
             return self._message_action_result(
                 thread_url,
                 "compose_interact_failed",
@@ -3707,7 +3704,6 @@ class LinkedInExtractor:
             await self._page.keyboard.press("Enter")
 
         if not await self._message_text_visible(message):
-            await self._dismiss_message_ui()
             return self._message_action_result(
                 thread_url,
                 "send_unavailable",

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3674,8 +3674,7 @@ class LinkedInExtractor:
         focused = await self._page.evaluate(
             """() => {
                 const el = document.querySelector(
-                    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
-                    + 'div[role="textbox"][contenteditable="true"]'
+                    'div[role="textbox"][contenteditable="true"]'
                 );
                 if (!el) return false;
                 el.focus();
@@ -3697,8 +3696,7 @@ class LinkedInExtractor:
         sent_via_js = await self._page.evaluate(
             """() => {
                 const btn = Array.from(document.querySelectorAll(
-                    'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
-                    + 'button[data-control-name="send"]'
+                    'button[type="submit"], button[data-control-name="send"]'
                 )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
                 if (!btn) return false;
                 btn.click();

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -217,24 +217,35 @@ def register_messaging_tools(
         confirm_send: bool,
         ctx: Context,
         profile_urn: str | None = None,
+        thread_id: str | None = None,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
-        Send a message to a LinkedIn user.
+        Send a message to a LinkedIn user or reply to an existing thread.
+
+        When ``thread_id`` is provided, the tool replies inline to the existing
+        messaging thread — use this to reply to InMail/recruiter conversations.
+        When ``thread_id`` is omitted, the tool opens a new compose overlay to
+        send a direct message to the specified user (which may create a separate
+        DM instead of replying to an existing thread — see issue #483).
 
         The recipient must be directly messageable from the profile page. This is a
         write operation when confirm_send is True.
 
         Args:
-            linkedin_username: LinkedIn username of the recipient
+            linkedin_username: LinkedIn username of the recipient. Ignored when
+                thread_id is provided.
             message: The message text to send
             confirm_send: Must be True to send the message
             ctx: FastMCP context for progress reporting
             profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
                 compose URL directly. Providing this bypasses the Message-button
                 lookup and is more reliable when available. Obtain via
-                get_person_profile. Note: inbox may not always show all
-                messages; use search_conversations as a fallback.
+                get_person_profile. Ignored when thread_id is provided.
+            thread_id: Optional LinkedIn messaging thread ID. When provided, the
+                tool replies inline to the existing thread instead of creating a
+                new compose overlay. Obtain thread IDs via get_conversation or
+                search_conversations.
 
         Returns:
             Dict with url, status, message, recipient_selected, and sent.
@@ -244,9 +255,10 @@ def register_messaging_tools(
                 ctx, tool_name="send_message"
             )
             logger.info(
-                "Sending message to %s (confirm_send=%s)",
+                "Sending message to %s (confirm_send=%s, thread_id=%s)",
                 linkedin_username,
                 confirm_send,
+                thread_id,
             )
 
             await ctx.report_progress(progress=0, total=100, message="Sending message")
@@ -256,6 +268,7 @@ def register_messaging_tools(
                 message,
                 confirm_send=confirm_send,
                 profile_urn=profile_urn,
+                thread_id=thread_id,
             )
 
             await ctx.report_progress(progress=100, total=100, message="Complete")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -824,6 +824,40 @@ class TestMessagingTools:
             thread_id=None,
         )
 
+    async def test_send_message_with_thread_id(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123/",
+            "status": "sent",
+            "message": "Reply sent.",
+            "recipient_selected": True,
+            "sent": True,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "send_message")
+        result = await tool_fn(
+            "testuser",
+            "Hello!",
+            True,
+            mock_context,
+            thread_id="2-abc123",
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "sent"
+        mock_extractor.send_message.assert_awaited_once_with(
+            "testuser",
+            "Hello!",
+            confirm_send=True,
+            profile_urn=None,
+            thread_id="2-abc123",
+        )
+
     async def test_send_message_error(self, mock_context):
         from fastmcp.exceptions import ToolError
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -787,7 +787,7 @@ class TestMessagingTools:
         assert result["status"] == "sent"
         assert result["sent"] is True
         mock_extractor.send_message.assert_awaited_once_with(
-            "testuser", "Hello!", confirm_send=True, profile_urn=None
+            "testuser", "Hello!", confirm_send=True, profile_urn=None, thread_id=None
         )
 
     async def test_send_message_with_profile_urn(self, mock_context):
@@ -817,7 +817,11 @@ class TestMessagingTools:
 
         assert result["status"] == "sent"
         mock_extractor.send_message.assert_awaited_once_with(
-            "testuser", "Hello!", confirm_send=True, profile_urn="ACoAAB1IelEB"
+            "testuser",
+            "Hello!",
+            confirm_send=True,
+            profile_urn="ACoAAB1IelEB",
+            thread_id=None,
         )
 
     async def test_send_message_error(self, mock_context):


### PR DESCRIPTION
…reads
When thread_id is provided, send_message navigates to the thread page and uses the inline reply composer instead of creating a new compose overlay. Fixes #483.