### PR TITLE
feat(import): match imported session to source browser user agent

### DIFF
--- a/docs/browser-import-support.md
+++ b/docs/browser-import-support.md
@@ -75,6 +75,29 @@ Before adding or trusting a browser, confirm each line:
 The fourth line is the one that bites: confirm the service against a real
 browser or against yt-dlp / HackBrowserData, never a guess.
 
+## User agent of an imported session
+
+LinkedIn ties a session token to the browser fingerprint it was minted under, so
+an imported cookie is replayed under the source browser's user agent rather than
+the runtime browser's default. Since Chromium's user-agent reduction (Chromium
+101+) the desktop UA is frozen: it varies only in the platform token and the
+engine major (minor/build/patch are always `0.0.0`). `browser_import/user_agent.py`
+reconstructs it from two on-disk inputs, no network call:
+
+- the OS platform token (frozen per platform), and
+- the Chromium major, read from `<user-data-root>/Last Version` with the
+  `Local State` `stats_version` as fallback.
+
+Only browsers whose version string leads with the Chromium engine major qualify,
+marked `chromium_versioned` in the registry: Chrome, Chromium, Edge, Arc, Brave
+(prefixes the engine major, e.g. `138.1.80.113`), and Helium. Edge appends its
+own brand token via `ua_brand_suffix` (`Edg/<major>.0.0.0`). Opera, Opera GX,
+Vivaldi, Yandex, Whale and Cốc Cốc version independently of the engine, so no UA
+is synthesized and they keep the runtime default. The UA is recorded in
+`source-state.json` (`user_agent`, absent for manual logins where the cookie is
+minted in the runtime browser itself) and every runtime replay adopts it. An
+explicit `USER_AGENT` env var or `--user-agent` flag always overrides it.
+
 ## Flat layout (Opera)
 
 Opera and Opera GX keep `Local State` at the user-data root (so the install gate

--- a/linkedin_mcp_server/browser_import/discovery.py
+++ b/linkedin_mcp_server/browser_import/discovery.py
@@ -53,6 +53,14 @@ class BrowserProfile:
 # token (``<safe_storage> Safe Storage``); it is a distinct token from both the
 # canonical key and the human label. Subpaths are relative to the per-OS base
 # directory resolved in ``_os_base_dirs``.
+#
+# ``chromium_versioned`` marks browsers whose on-disk version string leads with
+# the Chromium engine major (Chrome/Chromium/Edge/Arc report it directly, Brave
+# prefixes it, Helium tracks upstream) — the input user_agent.py needs to
+# synthesize the frozen UA for an imported session. Browsers that version
+# independently of the engine (Opera, Vivaldi, Yandex, Whale, Cốc Cốc) omit it
+# and get no synthesized UA. ``ua_brand_suffix`` is the extra brand token some
+# forks append to the frozen UA (Edge: ``Edg/<major>.0.0.0``).
 SUPPORTED_BROWSERS: dict[str, dict[str, object]] = {
     "chrome": {
         "label": "Google Chrome",
@@ -61,6 +69,7 @@ SUPPORTED_BROWSERS: dict[str, dict[str, object]] = {
         "linux_subpaths": ("google-chrome",),
         "linux_app_token": "chrome",
         "win_subpath": "Google/Chrome/User Data",
+        "chromium_versioned": True,
     },
     "chromium": {
         "label": "Chromium",
@@ -69,6 +78,7 @@ SUPPORTED_BROWSERS: dict[str, dict[str, object]] = {
         "linux_subpaths": ("chromium",),
         "linux_app_token": "chromium",
         "win_subpath": "Chromium/User Data",
+        "chromium_versioned": True,
     },
     "brave": {
         "label": "Brave",
@@ -77,6 +87,7 @@ SUPPORTED_BROWSERS: dict[str, dict[str, object]] = {
         "linux_subpaths": ("BraveSoftware/Brave-Browser",),
         "linux_app_token": "brave",
         "win_subpath": "BraveSoftware/Brave-Browser/User Data",
+        "chromium_versioned": True,
     },
     "edge": {
         "label": "Microsoft Edge",
@@ -85,6 +96,8 @@ SUPPORTED_BROWSERS: dict[str, dict[str, object]] = {
         "linux_subpaths": ("microsoft-edge",),
         "linux_app_token": "microsoft-edge",
         "win_subpath": "Microsoft/Edge/User Data",
+        "chromium_versioned": True,
+        "ua_brand_suffix": "Edg",
     },
     "arc": {
         "label": "Arc",
@@ -93,6 +106,7 @@ SUPPORTED_BROWSERS: dict[str, dict[str, object]] = {
         # Arc has no stable Linux build; omit on Linux.
         "linux_subpaths": (),
         "win_subpath": "Arc/User Data",
+        "chromium_versioned": True,
     },
     "vivaldi": {
         "label": "Vivaldi",
@@ -116,6 +130,7 @@ SUPPORTED_BROWSERS: dict[str, dict[str, object]] = {
         "mac_subpath": "net.imput.helium",
         "linux_subpaths": (),
         "win_subpath": "net.imput.helium/User Data",
+        "chromium_versioned": True,
     },
     # Standard-Chromium browsers. Paths and keychain labels cross-checked against
     # yt-dlp (yt_dlp/cookies.py) and HackBrowserData (browser/browser_darwin.go):

--- a/linkedin_mcp_server/browser_import/orchestrate.py
+++ b/linkedin_mcp_server/browser_import/orchestrate.py
@@ -36,6 +36,7 @@ from linkedin_mcp_server.browser_import.extract import (
     extract_linkedin_cookies,
     read_li_at_meta,
 )
+from linkedin_mcp_server.browser_import.user_agent import synthesize_user_agent
 from linkedin_mcp_server.common_utils import harden_linkedin_tree, secure_write_text
 
 from linkedin_mcp_server.exceptions import (
@@ -221,8 +222,14 @@ async def import_session_from_browser(
             continue
         staged_any = True
 
-        if await validate_imported_cookies(cookie_path, user_data_dir):
-            write_source_state(user_data_dir)
+        # Synthesize the source browser's UA so validation and every later
+        # runtime session replay the cookie under the fingerprint it was minted
+        # with (None keeps the runtime default; file I/O, so off the loop).
+        user_agent = await asyncio.to_thread(synthesize_user_agent, profile)
+        if await validate_imported_cookies(
+            cookie_path, user_data_dir, user_agent=user_agent
+        ):
+            write_source_state(user_data_dir, user_agent=user_agent)
             logger.info(
                 "Imported LinkedIn session from %s/%s",
                 profile.browser,

--- a/linkedin_mcp_server/browser_import/user_agent.py
+++ b/linkedin_mcp_server/browser_import/user_agent.py
@@ -1,0 +1,157 @@
+"""Synthesize the source browser's user agent for an imported session.
+
+LinkedIn associates a session token with the browser fingerprint it was minted
+under. Replaying an imported cookie under the runtime browser's own (different)
+user agent is a needless mismatch signal, so the import derives the UA the
+source browser would send and the runtime browser adopts it.
+
+This is exact, not a guess: since Chromium's user-agent reduction (Chromium
+101+), every desktop Chromium browser sends a FROZEN user agent that varies
+only in the platform token and the major version — minor/build/patch are
+always ``0.0.0`` and the OS token never changes. Reconstructing it therefore
+needs only two inputs this module can read from disk:
+
+1. the OS (the frozen platform token per ``sys.platform``), and
+2. the browser's Chromium major version, read from ``<user_data_root>/Last
+   Version`` (written by Chromium on every run) with the ``Local State``
+   ``user_experience_metrics.stability.stats_version`` as fallback.
+
+Only browsers whose version string leads with the Chromium major are eligible
+(``chromium_versioned`` in the discovery registry): Chrome, Chromium, Edge and
+Arc report the engine version directly, Brave prefixes it (``138.1.80.113`` =
+Chromium 138 + Brave 1.80.113), Helium tracks upstream. Opera, Vivaldi,
+Yandex, Whale and Cốc Cốc version independently of the engine, so no UA is
+synthesized for them and the import keeps today's behavior (runtime default).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+
+from linkedin_mcp_server.browser_import.discovery import (
+    SUPPORTED_BROWSERS,
+    BrowserProfile,
+)
+
+logger = logging.getLogger(__name__)
+
+# Frozen desktop platform tokens (unchanged since the UA reduction).
+_PLATFORM_TOKENS: dict[str, str] = {
+    "mac": "Macintosh; Intel Mac OS X 10_15_7",
+    "win": "Windows NT 10.0; Win64; x64",
+    "linux": "X11; Linux x86_64",
+}
+
+# Sanity window for a Chromium major. Chromium crossed 100 in 2022; a value
+# outside this window means the version file belongs to a browser's own
+# (non-engine) versioning scheme and must not produce a UA.
+_MIN_CHROMIUM_MAJOR = 100
+_MAX_CHROMIUM_MAJOR = 999
+
+
+def _platform_token() -> str | None:
+    if sys.platform == "darwin":
+        return _PLATFORM_TOKENS["mac"]
+    if sys.platform.startswith("win"):
+        return _PLATFORM_TOKENS["win"]
+    if sys.platform.startswith("linux"):
+        return _PLATFORM_TOKENS["linux"]
+    return None
+
+
+def _leading_int(component: str) -> int | None:
+    """The leading digits of a version component, or None when it has none."""
+    digits = ""
+    for char in component:
+        if char.isdigit():
+            digits += char
+        else:
+            break
+    return int(digits) if digits else None
+
+
+def read_engine_version(profile: BrowserProfile) -> str | None:
+    """Read the browser's version string from its user-data root.
+
+    Prefers ``Last Version`` (a bare version string Chromium rewrites on every
+    run). Falls back to ``Local State``'s
+    ``user_experience_metrics.stability.stats_version`` (same number, possibly
+    with a ``-64``/``-devel`` suffix). Returns None when neither is readable.
+    """
+    last_version = profile.user_data_root / "Last Version"
+    try:
+        text = last_version.read_text(encoding="utf-8").strip()
+        if text:
+            return text
+    except OSError:
+        pass
+
+    try:
+        payload = json.loads(profile.local_state_path.read_text(encoding="utf-8"))
+        stats = (
+            payload.get("user_experience_metrics", {})
+            .get("stability", {})
+            .get("stats_version")
+        )
+        if isinstance(stats, str) and stats.strip():
+            # "148.0.7778.179-64" -> "148.0.7778.179"
+            return stats.strip().split("-")[0]
+    except (OSError, json.JSONDecodeError, AttributeError):
+        pass
+    return None
+
+
+def chromium_major(version: str) -> int | None:
+    """The Chromium major from a version string, or None when implausible."""
+    major = _leading_int(version.split(".")[0])
+    if major is None:
+        return None
+    if not (_MIN_CHROMIUM_MAJOR <= major <= _MAX_CHROMIUM_MAJOR):
+        return None
+    return major
+
+
+def synthesize_user_agent(profile: BrowserProfile) -> str | None:
+    """Build the frozen UA string the source browser sends, or None.
+
+    None (keep the runtime default) whenever any input is missing: the browser
+    is not ``chromium_versioned``, the version files are unreadable, the major
+    is implausible, or the OS has no frozen desktop token.
+    """
+    spec = SUPPORTED_BROWSERS.get(profile.browser, {})
+    if not spec.get("chromium_versioned"):
+        return None
+
+    platform = _platform_token()
+    if platform is None:
+        return None
+
+    version = read_engine_version(profile)
+    if version is None:
+        logger.debug(
+            "No readable version for %s/%s; keeping runtime default UA",
+            profile.browser,
+            profile.profile_dir_name,
+        )
+        return None
+    major = chromium_major(version)
+    if major is None:
+        logger.debug(
+            "Implausible engine major %r for %s; keeping runtime default UA",
+            version,
+            profile.browser,
+        )
+        return None
+
+    ua = (
+        f"Mozilla/5.0 ({platform}) AppleWebKit/537.36 (KHTML, like Gecko) "
+        f"Chrome/{major}.0.0.0 Safari/537.36"
+    )
+    # Brand suffix for browsers that append their own token (currently Edge,
+    # whose fork major equals the Chromium major).
+    suffix = spec.get("ua_brand_suffix")
+    if isinstance(suffix, str) and suffix:
+        ua += f" {suffix}/{major}.0.0.0"
+    return ua

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -199,13 +199,17 @@ def _make_browser(
     *,
     launch_options: dict[str, str],
     viewport: dict[str, int],
+    user_agent: str | None = None,
 ) -> BrowserManager:
+    """Build a BrowserManager. An explicit USER_AGENT (env/CLI) always wins;
+    *user_agent* is the session's own UA (the source browser's, recorded at
+    import time) and applies only when no override is configured."""
     config = get_config()
     return BrowserManager(
         user_data_dir=profile_dir,
         headless=_headless,
         slow_mo=config.browser.slow_mo,
-        user_agent=config.browser.user_agent,
+        user_agent=config.browser.user_agent or user_agent,
         viewport=viewport,
         **launch_options,
     )
@@ -216,9 +220,13 @@ async def _authenticate_existing_profile(
     *,
     launch_options: dict[str, str],
     viewport: dict[str, int],
+    user_agent: str | None = None,
 ) -> BrowserManager:
     browser = _make_browser(
-        profile_dir, launch_options=launch_options, viewport=viewport
+        profile_dir,
+        launch_options=launch_options,
+        viewport=viewport,
+        user_agent=user_agent,
     )
     try:
         await browser.start()
@@ -233,13 +241,17 @@ async def _authenticate_existing_profile(
         raise
 
 
-async def validate_imported_cookies(cookie_path: Path, profile_dir: Path) -> bool:
+async def validate_imported_cookies(
+    cookie_path: Path, profile_dir: Path, *, user_agent: str | None = None
+) -> bool:
     """Validate freshly imported cookies against /feed/ before persisting.
 
     Starts a headless browser on *profile_dir*, injects the LinkedIn cookies
     from *cookie_path*, and proves /feed/ with the same validator login and the
     Docker bridge use (``_feed_auth_succeeds``: remember-me resolution plus
     auth-barrier detection). Used only by the browser-import CLI path.
+    *user_agent* is the source browser's synthesized UA — validating under the
+    same UA the runtime will use keeps the proof representative.
 
     A local :class:`BrowserManager` is used (never the singleton), so
     ``close_browser()``'s export-on-close is not involved and cannot shrink
@@ -252,7 +264,10 @@ async def validate_imported_cookies(cookie_path: Path, profile_dir: Path) -> boo
     secure_mkdir(profile_dir)
     harden_linkedin_tree(profile_dir)
     browser = _make_browser(
-        profile_dir, launch_options=launch_options, viewport=viewport
+        profile_dir,
+        launch_options=launch_options,
+        viewport=viewport,
+        user_agent=user_agent,
     )
     try:
         await browser.start()
@@ -284,7 +299,10 @@ async def _bridge_runtime_profile(
     secure_mkdir(profile_dir.parent)
     storage_state_path = runtime_storage_state_path(runtime_id, source_profile_dir)
     browser = _make_browser(
-        profile_dir, launch_options=launch_options, viewport=viewport
+        profile_dir,
+        launch_options=launch_options,
+        viewport=viewport,
+        user_agent=source_state.user_agent,
     )
     try:
         await browser.start()
@@ -341,6 +359,7 @@ async def _bridge_runtime_profile(
             profile_dir,
             launch_options=launch_options,
             viewport=viewport,
+            user_agent=source_state.user_agent,
         )
         try:
             await reopened.start()
@@ -429,6 +448,7 @@ async def get_or_create_browser(
             source_profile_dir,
             launch_options=launch_options,
             viewport=viewport,
+            user_agent=source_state.user_agent,
         )
         _apply_browser_settings(browser)
         _browser = browser
@@ -483,6 +503,7 @@ async def get_or_create_browser(
                 derived_profile_dir,
                 launch_options=launch_options,
                 viewport=viewport,
+                user_agent=source_state.user_agent,
             )
             _apply_browser_settings(browser)
             _browser = browser

--- a/linkedin_mcp_server/session_state.py
+++ b/linkedin_mcp_server/session_state.py
@@ -29,6 +29,11 @@ class SourceState:
     created_at: str
     profile_path: str
     cookies_path: str
+    # The user agent the session's cookies were minted under (synthesized from
+    # the source browser during import, see browser_import/user_agent.py). None
+    # for manual logins (the cookie is minted in the runtime browser itself, so
+    # its default UA already matches) and for pre-existing state files.
+    user_agent: str | None = None
 
 
 @dataclass
@@ -208,7 +213,11 @@ def load_source_state(source_profile_dir: Path | None = None) -> SourceState | N
         return None
 
 
-def write_source_state(source_profile_dir: Path | None = None) -> SourceState:
+def write_source_state(
+    source_profile_dir: Path | None = None,
+    *,
+    user_agent: str | None = None,
+) -> SourceState:
     """Write a fresh source session generation after successful login."""
     profile_dir = (
         (source_profile_dir or get_source_profile_dir()).expanduser().resolve()
@@ -220,6 +229,7 @@ def write_source_state(source_profile_dir: Path | None = None) -> SourceState:
         created_at=utcnow_iso(),
         profile_path=str(profile_dir),
         cookies_path=str(portable_cookie_path(profile_dir)),
+        user_agent=user_agent,
     )
     _write_json(source_state_path(profile_dir), asdict(state))
     return state

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -99,7 +99,14 @@ async def interactive_login(user_data_dir: Path | None = None) -> bool:
         # first successful /feed/ recovery instead of relying on browser teardown.
         if await browser.export_cookies(portable_cookie_path(user_data_dir)):
             print("   Cookies exported for Docker portability")
-            source_state = write_source_state(user_data_dir)
+            # Record the override UA the cookie was minted under (the login
+            # browser ran with config.browser.user_agent). Without this a later
+            # replay from a runtime that lacks the override would fall back to
+            # its default UA, a fingerprint mismatch. None when no override is
+            # set (the runtime default is stable across replays on that runtime).
+            source_state = write_source_state(
+                user_data_dir, user_agent=config.browser.user_agent
+            )
             print(f"   Source session generation: {source_state.login_generation}")
         else:
             print(

--- a/tests/test_browser_import_orchestrate.py
+++ b/tests/test_browser_import_orchestrate.py
@@ -158,6 +158,35 @@ async def test_import_writes_full_set_then_persists_source_state(
 
 
 @pytest.mark.asyncio
+async def test_import_persists_synthesized_user_agent(isolate_profile_dir, monkeypatch):
+    """The source browser's UA reaches validation AND source-state.json."""
+    user_data_dir = isolate_profile_dir
+    profile = _profile("chrome")
+    ua = "Mozilla/5.0 (test) Chrome/148.0.0.0"
+
+    monkeypatch.setattr(
+        orchestrate, "discover_profiles", lambda browser=None: [profile]
+    )
+    _patch_meta(monkeypatch, {profile: _meta(last_access=10.0)})
+    monkeypatch.setattr(
+        orchestrate, "extract_linkedin_cookies", lambda p: [_cookie("li_at")]
+    )
+    monkeypatch.setattr(orchestrate, "synthesize_user_agent", lambda p: ua)
+    validate = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "linkedin_mcp_server.drivers.browser.validate_imported_cookies", validate
+    )
+
+    ok = await import_session_from_browser("chrome", user_data_dir=user_data_dir)
+
+    assert ok is True
+    assert validate.await_args is not None
+    assert validate.await_args.kwargs.get("user_agent") == ua
+    state = json.loads(source_state_path(user_data_dir).read_text())
+    assert state["user_agent"] == ua
+
+
+@pytest.mark.asyncio
 async def test_import_tries_next_browser_when_first_rejected(
     isolate_profile_dir, monkeypatch
 ):

--- a/tests/test_browser_import_user_agent.py
+++ b/tests/test_browser_import_user_agent.py
@@ -1,0 +1,133 @@
+"""Tests for the imported-session user-agent synthesis (pure file I/O)."""
+
+import json
+
+import pytest
+
+from linkedin_mcp_server.browser_import import user_agent as ua_mod
+from linkedin_mcp_server.browser_import.discovery import BrowserProfile
+from linkedin_mcp_server.browser_import.user_agent import (
+    chromium_major,
+    read_engine_version,
+    synthesize_user_agent,
+)
+
+
+def _profile(tmp_path, browser="chrome"):
+    root = tmp_path / browser
+    root.mkdir(parents=True, exist_ok=True)
+    return BrowserProfile(
+        browser=browser,
+        browser_label=browser,
+        safe_storage_label="Chrome",
+        profile_dir_name="Default",
+        display_name="Personal",
+        user_data_root=root,
+        profile_path=root / "Default",
+        cookies_db=root / "Default" / "Cookies",
+        local_state_path=root / "Local State",
+    )
+
+
+def _force_platform(monkeypatch, platform):
+    monkeypatch.setattr(ua_mod.sys, "platform", platform)
+
+
+def test_chromium_major_parses_and_gates_plausibility():
+    assert chromium_major("148.0.7778.179") == 148
+    # Brave leads with the Chromium major before its own version.
+    assert chromium_major("138.1.80.113") == 138
+    # A browser-own versioning scheme (Vivaldi-style) is implausible as an
+    # engine major and must not produce a UA.
+    assert chromium_major("7.4.3684.55") is None
+    assert chromium_major("garbage") is None
+    assert chromium_major("") is None
+
+
+def test_read_engine_version_prefers_last_version(tmp_path):
+    profile = _profile(tmp_path)
+    (profile.user_data_root / "Last Version").write_text("148.0.7778.179")
+    profile.local_state_path.write_text(
+        json.dumps(
+            {"user_experience_metrics": {"stability": {"stats_version": "9.9.9.9-64"}}}
+        )
+    )
+    assert read_engine_version(profile) == "148.0.7778.179"
+
+
+def test_read_engine_version_falls_back_to_stats_version(tmp_path):
+    profile = _profile(tmp_path)
+    profile.local_state_path.write_text(
+        json.dumps(
+            {
+                "user_experience_metrics": {
+                    "stability": {"stats_version": "149.0.7827.200-64-devel"}
+                }
+            }
+        )
+    )
+    # The -64/-devel suffix is stripped to the bare version.
+    assert read_engine_version(profile) == "149.0.7827.200"
+
+
+def test_read_engine_version_none_when_unreadable(tmp_path):
+    assert read_engine_version(_profile(tmp_path)) is None
+
+
+@pytest.mark.parametrize(
+    ("platform", "token"),
+    [
+        ("darwin", "Macintosh; Intel Mac OS X 10_15_7"),
+        ("win32", "Windows NT 10.0; Win64; x64"),
+        ("linux", "X11; Linux x86_64"),
+    ],
+)
+def test_synthesize_frozen_ua_per_platform(tmp_path, monkeypatch, platform, token):
+    _force_platform(monkeypatch, platform)
+    profile = _profile(tmp_path, "chrome")
+    (profile.user_data_root / "Last Version").write_text("148.0.7778.179")
+    assert synthesize_user_agent(profile) == (
+        f"Mozilla/5.0 ({token}) AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/148.0.0.0 Safari/537.36"
+    )
+
+
+def test_synthesize_brave_uses_leading_chromium_major(tmp_path, monkeypatch):
+    _force_platform(monkeypatch, "darwin")
+    profile = _profile(tmp_path, "brave")
+    (profile.user_data_root / "Last Version").write_text("138.1.80.113")
+    ua = synthesize_user_agent(profile)
+    assert ua is not None and "Chrome/138.0.0.0" in ua
+
+
+def test_synthesize_edge_appends_brand_suffix(tmp_path, monkeypatch):
+    _force_platform(monkeypatch, "win32")
+    profile = _profile(tmp_path, "edge")
+    (profile.user_data_root / "Last Version").write_text("137.0.3296.52")
+    ua = synthesize_user_agent(profile)
+    assert ua is not None
+    assert ua.endswith("Chrome/137.0.0.0 Safari/537.36 Edg/137.0.0.0")
+
+
+def test_synthesize_none_for_non_chromium_versioned_browser(tmp_path, monkeypatch):
+    _force_platform(monkeypatch, "darwin")
+    # Opera versions independently of the engine; a UA from its own major
+    # would be wrong, so none is synthesized.
+    profile = _profile(tmp_path, "opera")
+    (profile.user_data_root / "Last Version").write_text("119.0.5497.70")
+    assert synthesize_user_agent(profile) is None
+
+
+def test_synthesize_none_when_version_missing_or_implausible(tmp_path, monkeypatch):
+    _force_platform(monkeypatch, "darwin")
+    profile = _profile(tmp_path, "chrome")
+    assert synthesize_user_agent(profile) is None  # nothing on disk
+    (profile.user_data_root / "Last Version").write_text("7.4.3684.55")
+    assert synthesize_user_agent(profile) is None  # implausible major
+
+
+def test_synthesize_none_on_unknown_platform(tmp_path, monkeypatch):
+    _force_platform(monkeypatch, "sunos5")
+    profile = _profile(tmp_path, "chrome")
+    (profile.user_data_root / "Last Version").write_text("148.0.7778.179")
+    assert synthesize_user_agent(profile) is None

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1,3 +1,5 @@
+import json
+
 from linkedin_mcp_server.session_state import (
     get_runtime_id,
     load_runtime_state,
@@ -21,8 +23,41 @@ def test_write_source_state_creates_generation(monkeypatch, isolate_profile_dir)
 
     assert state.source_runtime_id == "macos-arm64-host"
     assert state.login_generation
+    assert state.user_agent is None  # manual-login default
     assert source_state_path(isolate_profile_dir).exists()
     assert load_source_state(isolate_profile_dir) == state
+
+
+def test_source_state_round_trips_user_agent(monkeypatch, isolate_profile_dir):
+    monkeypatch.setattr(
+        "linkedin_mcp_server.session_state.get_runtime_id",
+        lambda: "macos-arm64-host",
+    )
+    ua = "Mozilla/5.0 (test) Chrome/148.0.0.0"
+
+    state = write_source_state(isolate_profile_dir, user_agent=ua)
+
+    assert state.user_agent == ua
+    assert load_source_state(isolate_profile_dir) == state
+
+
+def test_load_source_state_defaults_user_agent_for_old_files(
+    monkeypatch, isolate_profile_dir
+):
+    """A pre-existing source-state.json without user_agent still loads."""
+    monkeypatch.setattr(
+        "linkedin_mcp_server.session_state.get_runtime_id",
+        lambda: "macos-arm64-host",
+    )
+    write_source_state(isolate_profile_dir, user_agent="Mozilla/5.0 (test)")
+    payload = source_state_path(isolate_profile_dir)
+    data = json.loads(payload.read_text())
+    del data["user_agent"]
+    payload.write_text(json.dumps(data))
+
+    loaded = load_source_state(isolate_profile_dir)
+    assert loaded is not None
+    assert loaded.user_agent is None
 
 
 def test_write_runtime_state_tracks_source_generation(monkeypatch, isolate_profile_dir):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -76,10 +76,36 @@ async def test_interactive_login_writes_source_state_when_cookie_export_succeeds
     browser.export_cookies.assert_awaited_once_with(
         portable_cookie_path(tmp_path / "profile")
     )
-    write_source_state.assert_called_once_with(tmp_path / "profile")
+    # No UA override configured -> record None (runtime default is stable).
+    write_source_state.assert_called_once_with(tmp_path / "profile", user_agent=None)
     captured = capsys.readouterr()
     assert "cookies exported for docker portability" in captured.out.lower()
     assert "source session generation: gen-123" in captured.out.lower()
+
+
+@pytest.mark.asyncio
+async def test_interactive_login_records_override_user_agent(monkeypatch, tmp_path):
+    """A configured UA override is the fingerprint the manual-login cookie was
+    minted under, so it must be recorded in source-state (else a later replay
+    without the override falls back to a different UA)."""
+    browser = _make_browser(export_cookies=True)
+    write_source_state = MagicMock(
+        return_value=SimpleNamespace(login_generation="gen-1")
+    )
+    config = AppConfig()
+    config.browser.user_agent = "CustomAgent/1.0"
+
+    _patch_login_deps(
+        monkeypatch,
+        browser_factory=lambda **kwargs: _BrowserContextManager(browser),
+        config=config,
+        write_source_state=write_source_state,
+    )
+
+    assert await interactive_login(tmp_path / "profile") is True
+    write_source_state.assert_called_once_with(
+        tmp_path / "profile", user_agent="CustomAgent/1.0"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
An imported LinkedIn session cookie was replayed under the runtime browser's default user agent, which does not match the browser fingerprint the session was minted under. LinkedIn ties a session token to that fingerprint, so the mismatch is a needless security signal that can shorten the imported session's life.

Since Chromium's user-agent reduction (Chromium 101+) the desktop user agent is frozen: it varies only in the platform token and the engine major, with minor, build and patch always zero. A new browser_import/user_agent.py reconstructs it from two on-disk inputs (no network call): the OS platform token and the Chromium major read from the browser's Last Version file, with the Local State stats_version as a fallback. The synthesized UA is validated against /feed/, recorded in source-state.json, and adopted on every later runtime replay. An explicit USER_AGENT env var or --user-agent flag still overrides it, and manual logins keep the runtime default since the cookie is minted in the runtime browser itself.

Only browsers whose version string leads with the Chromium engine major qualify (a new chromium_versioned registry flag): Chrome, Chromium, Edge, Arc, Brave and Helium. Edge appends its own brand token. Opera, Opera GX, Vivaldi, Yandex, Whale and Cốc Cốc version independently of the engine, so no UA is synthesized for them and they keep today's behavior.

`uv run pytest tests` passes (794 passed, 11 skipped). ruff, ruff-format and ty pass.