### PR TITLE
fix(bootstrap): show browser download progress

### DIFF
--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -81,6 +81,13 @@
     },
     {
       "type": "git",
+      "name": "rich",
+      "url": "https://github.com/Textualize/rich",
+      "branch": "main",
+      "specialNotes": "Terminal rendering. Used for the browser-install progress bar; the bar glyph is hardcoded in progress_bar.py."
+    },
+    {
+      "type": "git",
       "name": "pythonCryptography",
       "url": "https://github.com/pyca/cryptography",
       "branch": "main",

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
+from collections import deque
+from collections.abc import AsyncIterator, Callable, Iterator
+import contextlib
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from enum import Enum
 import functools
 import importlib.metadata
@@ -12,12 +15,27 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 import stat
 import sys
-from collections.abc import Callable
-from typing import NoReturn
+import time
+from typing import Any, NoReturn
 
 from fastmcp import Context
+from rich.console import Console
+from rich.markup import escape
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+    TimeRemainingColumn,
+    TransferSpeedColumn,
+)
+from rich.spinner import Spinner
+from rich.theme import Theme
 
 from linkedin_mcp_server.common_utils import secure_mkdir, secure_write_text, utcnow_iso
 from linkedin_mcp_server.config import get_config
@@ -89,6 +107,101 @@ _FULL_DIR_PREFIX = "chromium-"
 _CACHE_REPORT_MARKER = ".linkedin-mcp-cache-report.json"
 _CACHE_REPORT_LOCK = ".linkedin-mcp-cache-report.lock"
 _CACHE_REPORT_SCHEMA = 1
+
+#: How much of the installer's output a failure message may quote. Patchright
+#: embeds a whole non-200 response body in one error, and retries five times, so
+#: an authenticated mirror answering with a page rather than a browser can emit
+#: arbitrarily much. The tail is what says why it failed. Bounded by characters
+#: as well as by count, because a fragment can itself be 64 KiB: two hundred of
+#: those would put 12 MiB into an exception message and into ``last_error``.
+_MAX_RETAINED_LINES = 200
+_MAX_RETAINED_CHARS = 64 * 1024
+#: Read size for the installer's pipe.
+_READ_CHUNK = 64 * 1024
+#: A run of output this long with no newline in it is emitted as one line rather
+#: than buffered further. Bounds memory for output that never terminates a line.
+_MAX_LINE_CHARS = 64 * 1024
+#: Any userinfo in a URL, not only the ``user:password`` form. Patchright prints
+#: the download URL it resolved, and ``PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST`` may
+#: carry credentials for an internal mirror. A bare ``//TOKEN@host`` is as much
+#: a secret as a pair, and so are ``//TOKEN:@host`` and ``//:TOKEN@host``, which
+#: a pattern requiring both halves lets through. Greedy to the *last* ``@``: a
+#: password may contain one, and stopping at the first leaves the rest of it in
+#: the line. Backslashes too, which Node normalises to slashes before
+#: authenticating, so ``https:\\user:pw@host`` is a working credential.
+_CREDENTIALS_IN_URL = re.compile(r"[/\\]{2}[^/\\\s]*@")
+#: The query of any URL. A mirror can carry its credential there as easily as
+#: in the userinfo, patchright pastes its download path onto whatever
+#: ``PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST`` names, and no list of parameter names
+#: is ever complete: ``?token=``, ``?auth_token=``, ``?x-api-key=`` and
+#: ``?X-Amz-Signature=`` are all in use. So the whole query goes, and the part
+#: that identifies the mirror stays. Stopping at an apostrophe as well as at
+#: whitespace, because the run would otherwise reach past the quote that closes
+#: a response body and swallow the ``'. URL: `` that ends it, which is what
+#: ``_installer_lines`` looks for. A query holding a literal apostrophe is not
+#: something patchright constructs.
+_QUERY_IN_URL = re.compile(r"(?i)(\bhttps?:[/\\]{2}[^\s?']*)\?[^\s']*")
+#: C0 and C1 controls and escape sequences. The eight-bit C1 forms do the same
+#: work as their ESC pairs on terminals that accept them, so U+009B followed by
+#: "2J" clears a screen exactly as "\x1b[2J" does. Patchright quotes a whole non-200 response
+#: body, and a body can carry the sequence that clears a terminal or renames
+#: its window. rich strips these from what it renders; the debug log writes
+#: straight to a stream and would not.
+_TERMINAL_CONTROLS = re.compile(
+    r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b\[[0-9;?]*[a-zA-Z]|[\x00-\x08\x0b-\x1f\x7f\x80-\x9f]"
+)
+#: ``Download failed: server returned code 403 body '…'. URL: …``, patchright's
+#: one message that quotes what a server sent it (``coreBundle.js``, in
+#: ``downloadFile``; every other download error carries a status code, a size
+#: or a URL). Whatever is between those two markers is a stranger's bytes on a
+#: developer's terminal, so it is dropped rather than sanitised: it is where the
+#: escape sequences, the reflected credentials, the markup and the absurd
+#: numbers all came from, and none of it says anything the status code does not.
+#: The body is not one line: ``content += chunk`` collects an HTML error page
+#: with its newlines intact, so the closing marker can arrive thousands of lines
+#: later.
+_RESPONSE_BODY_OPENS = re.compile(r"server returned code \d{1,3} body '")
+_RESPONSE_BODY_CLOSES = "'. URL: "
+#: The closing marker as patchright writes it: the marker, the download URL,
+#: end of line. Anchored, because the body between the markers is a stranger's
+#: bytes and can hold the marker itself: measured against a refusing mirror,
+#: the real closer starts a line of its own and its URL runs to the end of it,
+#: so a marker with prose behind it is the body talking and the drop stays
+#: open. This narrows the forgery to a body line that ends in a URL-shaped
+#: token; it cannot close it, because the grammar is ambiguous at the source.
+#: What the drop is *for* does not rest on that: the escape sequences are
+#: stripped, the credentials redacted, the markup disabled and the line length
+#: capped whether or not a body is recognised as one.
+_RESPONSE_BODY_CLOSED = re.compile(r"'\. URL: \S*\Z")
+#: One short of the marker, which is the most of it that a forced cut can leave
+#: on the far side of a fragment boundary.
+_CLOSER_CARRY = len(_RESPONSE_BODY_CLOSES) - 1
+_OMITTED_BODY = "<response body omitted>"
+
+#: ``|■■■■    |  30% of 187.2 MiB``: the progress line patchright writes when
+#: its stdout is a pipe, which is always the case here. The digit counts are the
+#: guard: patchright's error output carries a whole response body, and a
+#: progress-shaped line from one raised ``OverflowError`` on a 400-digit size
+#: and hit Python's 4300-digit integer limit on a long percentage. Bounded here,
+#: neither can be constructed.
+_PATCHRIGHT_PERCENT = re.compile(r"\|\s*(\d{1,3})%\s+of\s+([\d.]{1,15})\s*([KMG]i?B)")
+#: ``Downloading Chrome for Testing 149.0.7827.55 (…) from https://…``
+_PATCHRIGHT_DOWNLOAD = re.compile(r"^Downloading (.+?) from ")
+#: ``Chrome for Testing 149.0.7827.55 (…) downloaded to /…/chromium-1228``. The
+#: only completion signal there is when no percentage was ever reported.
+_PATCHRIGHT_DONE = re.compile(r" downloaded to ")
+_BINARY_UNITS = {"KiB": 1024, "MiB": 1024**2, "GiB": 1024**3}
+#: LinkedIn's dark-mode blue, for the bar and the spinner alike. The brand blue
+#: #0A66C2 is meant for light backgrounds and reads muted on a dark terminal,
+#: which is where this runs. Only honoured where the terminal advertises
+#: truecolor; rich approximates it to the nearest ANSI colour otherwise.
+_PROGRESS_STYLE = "#70B5F9"
+#: Everything non-ASCII this draws. The bar downgrades itself to "-" wherever
+#: the console encoding is not utf (``ConsoleOptions.ascii_only``); the spinner
+#: does not, and its braille goes into ``write`` as it is. Read off the spinner
+#: rather than copied, so a rich release that redraws "dots" is measured here
+#: instead of assumed.
+_BAR_GLYPHS = "".join(Spinner("dots").frames)
 
 
 class RuntimePolicy(str, Enum):
@@ -582,10 +695,13 @@ async def _run_patchright_install(
     processes reaching this at once queue on the same browsers path rather than
     corrupting it.
 
-    Subprocess output is streamed to the logger in real-time so users see
-    download progress when running with ``--log-level DEBUG``.  When a
-    *line_callback* is provided (e.g. ``print`` in CLI mode) each line is
-    forwarded to it as well.
+    Output is streamed line by line to ``logger.debug`` as it arrives, so a
+    download that used to run behind a blank line reports its progress under
+    ``--log-level DEBUG`` (#533). ``stderr`` is folded into ``stdout`` so the
+    two interleave in the order patchright wrote them, and the collected lines
+    become the failure message when the installer exits non-zero. A
+    *line_callback* (``print`` for the CLI modes) receives each line too, so
+    those modes show progress regardless of the log level.
     """
     proc = await asyncio.create_subprocess_exec(
         sys.executable,
@@ -597,22 +713,662 @@ async def _run_patchright_install(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     )
-    lines: list[str] = []
-    stdout_stream = proc.stdout
-    assert stdout_stream is not None
-    async for raw in stdout_stream:
-        text = raw.decode("utf-8", errors="replace").rstrip()
-        if text:
-            logger.debug("patchright: %s", text)
+    assert proc.stdout is not None
+    lines: deque[str] = deque()
+    retained = 0
+    try:
+        async for raw in _installer_lines(proc.stdout):
+            text = raw
+            if not text:
+                continue
+            if line_callback is None:
+                # The background path has nothing else to show it in. On the
+                # CLI path the bar is the display, and logging each line too
+                # would print every percentage permanently above it.
+                logger.debug("patchright: %s", text)
             lines.append(text)
+            retained += len(text)
+            # A running total, because summing the deque per line is quadratic
+            # in the output: measured, a multi-megabyte error body spent
+            # seconds of CPU inside this bound while the point of it was to be
+            # cheap. One line always survives, so a failure still quotes
+            # something.
+            while len(lines) > 1 and (
+                len(lines) > _MAX_RETAINED_LINES or retained > _MAX_RETAINED_CHARS
+            ):
+                retained -= len(lines.popleft())
             if line_callback is not None:
                 line_callback(text)
-    await proc.wait()
+        await proc.wait()
+    except BaseException:
+        # Cancellation included, which is how shutdown and a failed peer reach
+        # here. Reaps what this call started rather than leaving a process
+        # behind for the lifetime of the server; the Node processes under it
+        # survive, which ``_stop_installer`` records and this cannot fix.
+        _stop_installer(proc)
+        raise
     if proc.returncode != 0:
-        output = "\n".join(lines)
         raise BrowserSetupFailedError(
-            output or "Patchright Chromium browser setup failed."
+            "\n".join(lines) or "Patchright Chromium browser setup failed."
         )
+
+
+def _finish(progress: Progress, task: TaskID | None) -> None:
+    """Drive a task to completion, including one that never had a total."""
+    if task is None:
+        return
+    active = next((t for t in progress.tasks if t.id == task), None)
+    if active is None or active.finished:
+        return
+    total = active.total if active.total is not None else max(active.completed, 1)
+    progress.update(task, total=total, completed=total)
+
+
+def _parsed_total(found: re.Match[str] | None) -> int | None:
+    """The download size a progress line names, or None if it names none.
+
+    Patchright's current format always reports binary units and a plain decimal,
+    but its error output can carry anything, and this runs inside a render
+    callback where an exception costs the remaining retries. So an unknown unit
+    or an unparseable number is treated as "not a progress line" and printed.
+    """
+    if found is None:
+        return None
+    unit = _BINARY_UNITS.get(found.group(3))
+    if unit is None:
+        return None
+    try:
+        return int(float(found.group(2)) * unit)
+    except ValueError:
+        return None
+
+
+def _writes_to_the_terminal(stream: object) -> bool:
+    """Whether this stream ends up on the screen. Never raises."""
+    isatty = getattr(stream, "isatty", None)
+    if not callable(isatty):
+        return False
+    try:
+        return bool(isatty())
+    except Exception:
+        return False
+
+
+def _device_of(stream: object) -> tuple[int, int] | None:
+    """Where this stream physically writes, or None if it cannot say.
+
+    ``(0, 0)`` is *cannot say* rather than a device. Windows only fills these
+    two in for a handle on disk: ``_Py_fstat_noraise`` zeroes the struct and
+    then sets ``st_mode`` alone for ``FILE_TYPE_PIPE`` and ``FILE_TYPE_CHAR``
+    (``Python/fileutils.c``, unchanged across the supported range). Two
+    unrelated pipes would otherwise answer identically, and so would a console
+    and a pipe, which is the pairing a redirect actually produces.
+    """
+    fileno = getattr(stream, "fileno", None)
+    if not callable(fileno):
+        return None
+    try:
+        status = os.fstat(fileno())
+    except Exception:
+        return None
+    if status.st_dev == 0 and status.st_ino == 0:
+        return None
+    return (status.st_dev, status.st_ino)
+
+
+def _same_destination(one: object, other: object) -> bool:
+    """Whether two streams end up in the same place. Never raises.
+
+    The device and inode rather than the descriptor number: stdout and stderr
+    on a terminal are two descriptors on one device, and ``>log 2>&1`` is two
+    descriptors on one file. Two *different* files answer differently, which is
+    the case that must not be treated as a collision.
+
+    One identity and one unknown is *not* the same place. Falling back to the
+    terminal guess there would answer yes for a wrapper that hides its
+    descriptor while writing to a second pane. This direction is the cheap one
+    to get wrong: a false no draws a log record through the bar, a false yes
+    takes it out of the destination the operator chose.
+    """
+    if one is other:
+        return True
+    first, second = _device_of(one), _device_of(other)
+    if first is None and second is None:
+        # Neither can name a device, which in practice means an in-memory
+        # stream or a wrapper that hides the descriptor. Two streams that both
+        # claim a terminal are the same terminal often enough to keep the old
+        # answer here.
+        return _writes_to_the_terminal(one) and _writes_to_the_terminal(other)
+    # Identity against unknown is never equal, which `None` gives for free.
+    #
+    # Two *names* for one terminal are missed by this and stay missed: a
+    # handler reopened through `/dev/tty` shares the screen with the pty slave
+    # under it and carries a different inode (measured on macOS). Widening the
+    # rule to same-device-and-both-a-terminal would close that and would also
+    # merge two genuinely different ptys, which is the losing direction above.
+    return first == second
+
+
+@contextlib.contextmanager
+def _log_handlers_follow_the_live_region(
+    before: tuple[object, object],
+    destination: object,
+) -> Iterator[None]:
+    """Let stream log handlers follow the streams rich redirects.
+
+    rich swaps ``sys.stdout`` and ``sys.stderr`` for proxies while a live region
+    is up, so anything written lands above the bar instead of through it. A
+    ``StreamHandler`` built earlier holds the stream object it was given and
+    never sees the swap, so a record emitted while the bar is live is drawn into
+    the middle of it. Measured in a pty: without this the record and the bar
+    ended up on the same physical line.
+
+    *before* is what the two streams were just before the swap, which is what
+    the handlers can be holding. Comparing against ``sys.__stderr__`` instead
+    would only match when nothing else had wrapped it: and something usually
+    has: pytest captures it, and the detached owner points it at the daemon log.
+
+    *destination* is where the bar is drawn, and a handler only moves if it
+    writes there too. Asking ``isatty`` instead was wrong in both directions
+    once ``FORCE_COLOR`` or ``TTY_COMPATIBLE`` is set, which is how CI runners
+    keep colour through a redirect: rich then draws into a file, so under
+    ``>build.log 2>&1`` a handler that answers False stayed put and wrote its
+    records into the middle of a rendered frame (measured), while with
+    ``2>errors.log`` on a terminal a handler that answers True would be moved
+    and its records taken out of the file the operator chose.
+
+    Only handlers on those two streams move, so a file handler keeps its file.
+    Restored on the way out, because the proxies stop working once the live
+    region is gone.
+    """
+    old_stdout, old_stderr = before
+    moved: list[tuple[logging.StreamHandler[Any], object, object]] = []
+    for candidate in logging.getLogger().handlers:
+        if not isinstance(candidate, logging.StreamHandler):
+            continue
+        # Re-bound because the isinstance narrowing leaves the stream type
+        # unsolved, and `setStream` is declared against it.
+        handler: logging.StreamHandler[Any] = candidate
+        if handler.stream is old_stderr:
+            proxy = sys.stderr
+        elif handler.stream is old_stdout:
+            proxy = sys.stdout
+        else:
+            continue
+        # Only a handler writing where the bar is drawn can collide with it.
+        # Both proxies write through the progress console, so moving one that
+        # writes somewhere else would take its records out of the destination
+        # the operator chose and put them where the bar is.
+        if not _same_destination(handler.stream, destination):
+            continue
+        # `setStream` rather than the attribute: it takes the handler's lock
+        # and flushes what is still buffered, so a record being emitted from
+        # another thread is not split across the two streams. It answers None
+        # when there was nothing to change, which is the case where rich left
+        # the stream alone because something had already wrapped it.
+        replaced = handler.setStream(proxy)
+        if replaced is not None:
+            moved.append((handler, replaced, proxy))
+    try:
+        yield
+    finally:
+        for handler, stream, proxy in moved:
+            # Only if the handler is still where it was put. A host that
+            # reconfigured logging during the download chose the newer stream,
+            # and restoring over it would discard that choice and can leave
+            # records pointed at a stream closed along with the old config.
+            if handler.stream is proxy:
+                handler.setStream(stream)
+
+
+def _print_whatever_the_stream_takes(line: str) -> None:
+    """Print a line, replacing anything the stream cannot encode."""
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    try:
+        try:
+            print(line, flush=True)
+        except UnicodeEncodeError:
+            print(line.encode(encoding, "replace").decode(encoding), flush=True)
+    except (OSError, ValueError):
+        # A closed or broken stdout is not a reason to fail an install, and the
+        # replacement attempt can meet the same closed pipe as the first.
+        # ``ValueError`` because that is what a closed ``TextIOBase`` raises:
+        # only a real pipe answers with ``BrokenPipeError``, and a stdout
+        # already closed by the host answers "I/O operation on closed file".
+        pass
+
+
+def _bar_is_encodable() -> bool:
+    """Whether the glyphs rich draws survive this stdout's encoding.
+
+    rich does not consult the encoding before rendering, and it does not fall
+    back either: the bar's U+2501 and the spinner's braille go straight into
+    ``write`` and raise ``UnicodeEncodeError`` from inside the live region.
+    That leaves the read loop, kills the installer, and reports an encoding
+    error in place of a browser. ``PYTHONIOENCODING=ascii`` on a real terminal
+    is enough to reach it, so the answer decides between the bar and the lines.
+    """
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    try:
+        _BAR_GLYPHS.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
+
+
+class _ConsoleThatGoesQuiet(Console):
+    """A console that falls silent on a closed pipe instead of exiting.
+
+    rich's default ``on_broken_pipe`` points ``sys.stdout`` at ``os.devnull``
+    and raises ``SystemExit(1)``. Piping ``--install-browser`` into ``head``
+    reaches it whenever the bar is drawn at all, which ``FORCE_COLOR=1`` or
+    ``TTY_COMPATIBLE=1`` arranges for a redirected stdout: measured, exit code
+    1 with an empty stderr, mid-download, with the archive half unpacked. Going
+    quiet leaves the install running, which is the same answer the plain-line
+    path already gives a stream that will not take a line.
+    """
+
+    def on_broken_pipe(self) -> None:
+        self.quiet = True
+
+    def _check_buffer(self) -> None:
+        """Go quiet for the other ways a stream stops taking bytes, too.
+
+        rich catches ``BrokenPipeError`` here and nothing else, so a stdout the
+        host has closed (``ValueError``) or a pseudo-terminal whose other end
+        detached (``OSError`` EIO) raises out of the bar's own refresh:
+        measured against rich 15.0.0, both escape ``Console.print``. From there
+        it leaves the read loop, kills the installer and reports a failed
+        install for a browser already unpacked on disk. ``BrokenPipeError`` is
+        an ``OSError``, so the base class has taken it before this sees it.
+        """
+        try:
+            super()._check_buffer()
+        except (OSError, ValueError):
+            self.on_broken_pipe()
+            del self._buffer[:]
+
+
+@contextlib.contextmanager
+def _cli_progress() -> Iterator[Callable[[str], None]]:
+    """A live progress bar for a terminal, plain lines for anything else.
+
+    Patchright writes to a pipe here, so it picks its newline-delimited
+    progress: one line per ten percent, eleven lines per download. That reads
+    fine in a log and poorly on a terminal, where eleven lines are one bar drawn
+    eleven times. This reads the percentage back out and draws it once.
+
+    Only for a terminal. Redirected output keeps the lines themselves, because a
+    bar redrawn in place is noise in a file, and the background path never
+    reaches here at all: its output goes to a debug log.
+
+    Anything that does not parse as progress is printed unchanged, so a change
+    in patchright's format costs the bar and never the message.
+    """
+    try:
+        console = _ConsoleThatGoesQuiet(
+            # rich's defaults give the three fields three different colours :
+            # magenta, red, blue: which reads as noise beside a single-colour
+            # bar. TransferSpeedColumn hardcodes its style name rather than
+            # taking one, so the theme is the only place all three can be set.
+            theme=Theme(
+                {
+                    "progress.percentage": _PROGRESS_STYLE,
+                    "progress.data.speed": "grey58",
+                    "progress.remaining": "grey58",
+                }
+            )
+        )
+        there_is_a_screen = console.is_terminal and not console.is_dumb_terminal
+    except OSError:
+        # A stream whose ``isatty`` raises instead of answering, which a
+        # detached pseudo-terminal does with ``EIO``. rich guards that call for
+        # ``ValueError`` alone (measured in 15.0.0), so an ``OSError`` comes
+        # back out here. Not knowing whether there is a terminal is exactly the
+        # plain-line case; raising would take the browser install with it.
+        yield _print_whatever_the_stream_takes
+        return
+
+    if not there_is_a_screen or not _bar_is_encodable():
+        # Whether there is a terminal at all is rich's judgement rather than
+        # ``sys.stdout``'s, because where rich will not draw it does not fall
+        # back either: ``Live.refresh`` renders through ``elif not
+        # self._started``, which is to say once, on the way out. A dumb
+        # terminal (``TERM=dumb`` or ``unknown``, common on CI consoles) passes
+        # ``isatty`` and would then show nothing at all for the whole download,
+        # which is the silence this change removes. What the stream can encode
+        # is the one part rich does not decide, and it is asked separately.
+        #
+        # Not bare ``print`` on the way out: patchright draws its own bar with
+        # U+25A0, and an ascii stream raises ``UnicodeEncodeError`` on it.
+        # Raising here would leave the read loop, kill the installer, and
+        # report an encoding error in place of the download. Reporting is never
+        # worth that.
+        yield _print_whatever_the_stream_takes
+        return
+
+    progress = Progress(
+        SpinnerColumn(style=_PROGRESS_STYLE),
+        TextColumn("[white]{task.description}"),
+        BarColumn(
+            bar_width=24,
+            complete_style=_PROGRESS_STYLE,
+            finished_style=_PROGRESS_STYLE,
+            # The pulse is what shows while no percentage has arrived, which
+            # is the whole of a chunked download and the whole of a failing
+            # one. Left alone it shimmers in rich's magenta beside a blue bar.
+            pulse_style=_PROGRESS_STYLE,
+        ),
+        TaskProgressColumn(),
+        TransferSpeedColumn(),
+        TimeRemainingColumn(),
+        # rich's default 30s averaging window is deliberate here. Shortening it
+        # to 10s makes a stall show up sooner, and costs far more than it buys:
+        # rich drops samples older than the window before adding the next one,
+        # so once one of patchright's ten-percent steps takes longer than the
+        # window, a single sample is left, the elapsed span is zero, and both
+        # the rate and the estimate become unavailable for the whole download.
+        # Measured against the sample interval: at 6.6 MB/s a step takes 2.7s
+        # and either window works; at 1.0 MB/s it takes 17.9s and only the 30s
+        # window still reports anything. The slow connection is the one that
+        # needs an estimate most.
+        console=console,
+        # rich redirects both streams while the bar is up, so that a direct
+        # write lands above it rather than through it. Right for a stream that
+        # shares the bar's screen and wrong for one that does not: under
+        # ``2>errors.log`` rich would take a `sys.stderr.write` out of the file
+        # the operator named and print it on the terminal instead, and leave a
+        # handler built during the download pointed there afterwards. Same
+        # question as the log handlers below, asked once, before rich swaps the
+        # streams and the answer stops being available.
+        redirect_stderr=_same_destination(sys.stderr, console.file),
+    )
+    described = "Installing browser"
+    # Created before a single line arrives. Patchright can be silent for the
+    # whole download: `npm_config_loglevel=warn` suppresses its announcements
+    # and a chunked response suppresses its percentages, and it waits up to ten
+    # minutes on the registry lock without saying anything either. A bar that
+    # only appears once a line is recognised leaves all of those blank.
+    task: TaskID | None = progress.add_task(described, total=None)
+
+    def report(line: str) -> None:
+        nonlocal task, described
+        started = _PATCHRIGHT_DOWNLOAD.match(line)
+        if started:
+            # Patchright fetches ffmpeg after the browser, and retries a failed
+            # download up to five times, announcing each attempt the same way.
+            # A finished bar stays as a record; an unfinished one belonged to an
+            # attempt that died, and leaving it would spin at 40% forever
+            # beside its own retry.
+            announced = started.group(1).split(" (")[0]
+            placeholder = next(
+                (t for t in progress.tasks if t.id == task and t.completed == 0),
+                None,
+            )
+            if (
+                task is not None
+                and placeholder is not None
+                and placeholder.total is None
+            ):
+                # Still the bar this context opened with. Name it rather than
+                # stacking a second one beside it.
+                progress.update(task, description=escape(announced))
+                described = announced
+                return
+            if task is not None:
+                active = next((t for t in progress.tasks if t.id == task), None)
+                # Unfinished means the attempt died. Finished under the same
+                # name means a retry after patchright reported 100% and then
+                # failed to unpack, which it does on a corrupt archive: five of
+                # those would leave four completed bars for one browser.
+                same_artifact = active is not None and active.description == escape(
+                    announced
+                )
+                if active is not None and (not active.finished or same_artifact):
+                    with contextlib.suppress(KeyError):
+                        progress.remove_task(task)
+            # Escaped where it is used: the column renders the description as
+            # markup, so an error body announcing "Downloading [/red] from …"
+            # would raise out of the render callback and take patchright's
+            # remaining retries with it.
+            described = announced
+            # Started here rather than at the first percentage. A mirror
+            # serving the archive with ``Transfer-Encoding: chunked`` makes
+            # patchright suppress progress altogether: its reporter is guarded
+            # by ``if (!chunked && reportProgress)``: so a bar created on the
+            # first percentage would never appear, and the download would run
+            # behind the silence this change exists to remove. Without a total
+            # rich pulses, and the total is filled in if a percentage arrives.
+            task = progress.add_task(escape(described), total=None)
+            return
+
+        if _PATCHRIGHT_DONE.search(line):
+            # The archive is in place. Without percentages this is the only
+            # thing that says so, and a bar left pulsing would read as a
+            # download that never ended.
+            _finish(progress, task)
+            progress.console.print(line, highlight=False, markup=False)
+            return
+        found = _PATCHRIGHT_PERCENT.search(line)
+        total = _parsed_total(found)
+        if total is None:
+            # markup=False: the installer's text is data, not rich markup. An
+            # error body containing "[/red]" would otherwise raise MarkupError
+            # from inside the render callback, which aborts patchright's
+            # remaining retries and reports rich instead of the download.
+            progress.console.print(line, highlight=False, markup=False)
+            return
+        percent = int(found.group(1)) if found else 0
+        active = next((t for t in progress.tasks if t.id == task), None)
+        going_backwards = (
+            active is not None
+            and active.total is not None
+            and int(total * percent / 100) < active.completed
+        )
+        if (
+            going_backwards
+            and task is not None
+            and active is not None
+            and (not active.finished or active.total == total)
+        ):
+            # An unfinished bar going backwards is the same artifact starting
+            # over, which patchright does up to five times. Reuse it, or five
+            # abandoned bars pile up for one download.
+            #
+            # A *finished* one going backwards to the same total is the same
+            # thing seen without its announcements, which a raised npm log
+            # level suppresses: ``logPolitely`` is silent from "warn" up while
+            # the percentages keep coming. Patchright reports 100% before it
+            # unpacks, so a corrupt archive finishes the bar and then retries,
+            # and without this the failure ends under five completed bars. The
+            # total is what tells the two apart: a retry re-downloads the same
+            # bytes, and the next artifact is a different archive.
+            progress.reset(task, total=total, description=active.description)
+        elif task is None or going_backwards:
+            # Backwards from a finished bar with a different total is the next
+            # artifact, whose announcement never arrived for the same reason.
+            task = progress.add_task(escape(described), total=total)
+        elif task is not None:
+            progress.update(task, total=total)
+        # Bytes rather than percent, so the rate and the estimate have
+        # something to divide. Both are as coarse as the ten-percent steps
+        # patchright reports, which is honest: it is what the installer says.
+        progress.update(task, completed=int(total * percent / 100))
+
+    # Captured before entering, because that is what the handlers can be
+    # holding; inside, rich has already replaced both. The console's own file
+    # is read here for the same reason, though it unwraps the proxy either way.
+    streams_before = (sys.stdout, sys.stderr)
+    drawn_on = console.file
+    with progress, _log_handlers_follow_the_live_region(streams_before, drawn_on):
+        yield report
+        # Reached only when the caller left without raising, so the install
+        # succeeded. It can succeed in silence: patchright prints nothing at
+        # all when every browser is already on disk and only the metadata was
+        # stale, and the bar this context opens would then pulse under
+        # "Browser installed." as its last frame.
+        _finish(progress, task)
+
+
+def _stop_installer(proc: asyncio.subprocess.Process) -> None:
+    """Kill the installer process. Never raises.
+
+    This reaches ``python -m patchright`` and nothing below it. Measured: the
+    wrapper runs a Node CLI which runs a second Node process for the download,
+    and after the wrapper is killed both were still alive, still downloading,
+    and still refreshing the cache lock's heartbeat. So a cancelled install can
+    keep the lock until it finishes on its own, and an install started in the
+    meantime queues behind it.
+
+    That is what ``main`` already did, and it is left alone deliberately.
+    Reaching the whole tree means giving the installer its own session, which
+    is a session the terminal's signals no longer reach; that was tried here
+    and cost a crash on Windows, a race against the spawn, and a terminal left
+    without its cursor. Closing this properly is worth its own change.
+    """
+    with contextlib.suppress(ProcessLookupError, OSError):
+        proc.kill()
+
+
+def _safe_to_print(text: str) -> str:
+    """Text with its terminal controls and its URL credentials taken out.
+
+    Controls go first. A credential can be reassembled out of the fragments an
+    escape sequence separates, so redacting before stripping would leave
+    ``//us\x1b[0mer:pw@host`` unmatched and then hand the stripper a whole
+    credential to put back together.
+
+    What survives here is the download URL patchright echoes, with its userinfo
+    and its query replaced. A credential the operator put in the *path* of
+    ``PLAYWRIGHT_DOWNLOAD_HOST`` still prints: the path is also where the
+    browser build lives, and blanking it would take the diagnostic with it.
+    """
+    text = _TERMINAL_CONTROLS.sub("", text)
+    text = _CREDENTIALS_IN_URL.sub("//***@", text)
+    return _QUERY_IN_URL.sub(r"\1?***", text)
+
+
+async def _installer_lines(stream: asyncio.StreamReader) -> AsyncIterator[str]:
+    """The installer's lines, with any quoted response body dropped.
+
+    A body is the one part of this output a stranger writes, and patchright
+    prints it verbatim, five times, once per retry. Dropping it here rather
+    than defending against it downstream is what keeps the rest of this file
+    honest: the escape sequences, the reflected credentials, the markup that
+    would raise out of a render callback and the 400-digit sizes were all the
+    same bytes arriving through the same quotes.
+
+    Stateful across lines, because the body carries its own newlines and the
+    marker that ends it can be thousands of lines further on. While a body is
+    open every line is dropped whole, which also bounds what a mirror can make
+    this process hold.
+    """
+    eliding = False
+    carry = ""
+    async for line in _split_installer_output(stream):
+        if eliding:
+            # The cut in ``_split_installer_output`` falls wherever the cap
+            # does, including inside the marker, and half a marker on each side
+            # of it would leave this open for the rest of the install: the URL,
+            # the stack trace and every later retry dropped with the body.
+            joined = carry + line
+            found = _RESPONSE_BODY_CLOSED.search(joined)
+            if found is None:
+                carry = joined[-_CLOSER_CARRY:]
+                continue
+            eliding = False
+            carry = ""
+            # Resume at the marker: what follows it is patchright's own text.
+            # Anything the match takes from the carry is marker, not body.
+            line = joined[found.start() :]
+        kept: list[str] = []
+        # Scanning forward from ``pos`` rather than over the result: the marker
+        # stays in what is kept, so a search from the front would find the same
+        # opener again and never terminate.
+        pos = 0
+        while True:
+            opened = _RESPONSE_BODY_OPENS.search(line, pos)
+            if opened is None:
+                kept.append(line[pos:])
+                break
+            kept.append(line[pos : opened.end()])
+            kept.append(_OMITTED_BODY)
+            found = _RESPONSE_BODY_CLOSED.search(line, opened.end())
+            if found is None:
+                eliding = True
+                carry = line[-_CLOSER_CARRY:]
+                break
+            pos = found.start()
+        # Yielded even when empty, so what a caller sees is still the line
+        # structure the installer wrote.
+        yield "".join(kept)
+
+
+async def _split_installer_output(stream: asyncio.StreamReader) -> AsyncIterator[str]:
+    """The installer's output, split into lines, with no limit on line length.
+
+    Deliberately not ``async for line in stream``. That reads through
+    ``readline``, which raises ``ValueError`` once a single line passes the
+    reader's 64 KiB limit: mid-download, out of the loop, and with the child
+    still running and unreaped. Patchright puts an entire non-200 response body
+    into one error line, so a captive portal or a mirror answering with minified
+    HTML reaches that limit, and the server would report an asyncio error
+    instead of the download failure. Measured: a 70 000-byte line raises
+    ``Separator is found, but chunk is longer than limit`` and leaves the child
+    alive.
+    """
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    buffer = ""
+    while True:
+        chunk = await stream.read(_READ_CHUNK)
+        if not chunk:
+            break
+        buffer += decoder.decode(chunk)
+        # Sanitised here, on the buffer, while a credential is still whole. Per
+        # fragment it would be too late: the cut below is a split point like
+        # any other, and half a URL matches no pattern. Together with the tail
+        # held back, any userinfo shorter than that tail is either redacted
+        # before anything is emitted or still sitting in the buffer when the
+        # rest of it arrives.
+        buffer = _safe_to_print(buffer)
+        while True:
+            end = buffer.find("\n")
+            if 0 <= end <= _MAX_LINE_CHARS:
+                # rstrip here, where the line genuinely ends. A forced fragment
+                # below ends where the cap fell, and trimming there would eat
+                # whitespace the installer wrote.
+                line, buffer = buffer[:end].rstrip(), buffer[end + 1 :]
+                yield line
+                continue
+            if len(buffer) <= _MAX_LINE_CHARS:
+                break
+            # Past the cap with no newline in reach: emit a bounded piece and
+            # keep going. Checking the newline first is what a size check alone
+            # got wrong: two reads under the read size could still meet as one
+            # fragment of twice the cap.
+            #
+            # A credential whole in the buffer was redacted above, before any
+            # of this. One whose "@" has not been read yet is split by the cut
+            # and prints in halves, and no window held back here changes that:
+            # the buffer is over the cap by definition, so holding the opener
+            # back only moves the same fragment one iteration later. Which no
+            # longer has an author: the only output patchright produced without
+            # newlines was the quoted response body, and that is dropped.
+            #
+            # A URL cut in half here loses its scheme with the near fragment,
+            # and the query the far one completes then matches no pattern: a
+            # token split across two reads at the cut printed whole, measured.
+            # Cutting at the last space instead would keep tokens together and
+            # cannot be done from here: the opener ends in one, so preferring a
+            # space splits *that* marker instead, systematically rather than by
+            # coincidence, and the body it opens then prints in full. Both ends
+            # want the same thing, which is a splitter that knows where the
+            # markers are, and that is its own change.
+            yield buffer[:_MAX_LINE_CHARS]
+            buffer = buffer[_MAX_LINE_CHARS:]
+    buffer += decoder.decode(b"", final=True)
+    if buffer:
+        yield buffer.rstrip()
 
 
 def _write_install_metadata(
@@ -661,10 +1417,21 @@ async def _run_browser_setup(
     browser_dir = configure_browser_environment()
     secure_mkdir(browser_dir)
 
+    # Timed here, right where the download runs, rather than at the state
+    # reconciliation that flips this to READY: that reconciliation happens on
+    # the next tool or auth call, which can arrive minutes after the install
+    # actually finished, and would report the idle gap as setup time.
+    started = time.monotonic()
     await _run_patchright_install("--no-shell", line_callback=line_callback)
     _write_install_metadata(
         browser_dir,
         {_SHELL_DIR_PREFIX: False, _FULL_DIR_PREFIX: True},
+    )
+    # After the metadata, which is what makes the browser count as installed.
+    # Before it, a failing write would follow "setup completed" with a failure.
+    logger.info(
+        "Patchright Chromium browser setup completed in %.0fs",
+        time.monotonic() - started,
     )
     # After the installer, because that is the moment a bump has just added a
     # revision beside the old one and patchright has already had its chance to
@@ -702,13 +1469,21 @@ def ensure_browser_installed() -> None:
     if browser_ready():
         _report_retained_browser_revisions()
         return
-    print("   Installing Patchright Chromium browser...")
+    # Through the helper, not ``print``: these three sit on the same stdout the
+    # bar does, so ``--install-browser | head`` reaches them with the pipe
+    # already gone. Measured: a *successful* install then ended in a
+    # ``BrokenPipeError`` traceback, and a failed one raised it in place of the
+    # ``BrowserSetupFailedError`` that says what went wrong. The helper also
+    # carries the encoding fallback, which the cross mark below needs on an
+    # ascii terminal for the same reason.
+    _print_whatever_the_stream_takes("   Installing Patchright Chromium browser...")
     try:
-        asyncio.run(_ensure_browser_installed(line_callback=print))
+        with _cli_progress() as report:
+            asyncio.run(_ensure_browser_installed(line_callback=report))
     except Exception as exc:
-        print(f"   ❌ Browser installation failed: {exc}")
+        _print_whatever_the_stream_takes(f"   ❌ Browser installation failed: {exc}")
         raise
-    print("   Browser installed.")
+    _print_whatever_the_stream_takes("   Browser installed.")
 
 
 def _safe_task_done(task: asyncio.Task[None] | None) -> bool:
@@ -733,21 +1508,6 @@ async def _refresh_background_task_state() -> None:
         else:
             _state.setup_state = SetupState.READY
             _state.setup_completed_at = utcnow_iso()
-            elapsed = "unknown"
-            if _state.setup_started_at:
-                try:
-                    started = datetime.fromisoformat(
-                        _state.setup_started_at.replace("Z", "+00:00")
-                    )
-                    elapsed = (
-                        f"{(datetime.now(timezone.utc) - started).total_seconds():.0f}s"
-                    )
-                except (ValueError, TypeError):
-                    pass
-            logger.info(
-                "Patchright Chromium browser setup completed in %s",
-                elapsed,
-            )
 
     if _safe_task_done(_state.login_task):
         task = _state.login_task

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
 import functools
 import importlib.metadata
@@ -13,6 +14,7 @@ import os
 from pathlib import Path
 import stat
 import sys
+from collections.abc import Callable
 from typing import NoReturn
 
 from fastmcp import Context
@@ -571,12 +573,19 @@ def _start_browser_setup_task_locked() -> None:
     _state.setup_task = asyncio.create_task(_run_browser_setup(), name="browser-setup")
 
 
-async def _run_patchright_install(extra_arg: str) -> None:
+async def _run_patchright_install(
+    extra_arg: str, *, line_callback: Callable[[str], None] | None = None
+) -> None:
     """Run one ``patchright install chromium`` stage with the given flag.
 
     The patchright registry lock serializes concurrent installs, so two
     processes reaching this at once queue on the same browsers path rather than
     corrupting it.
+
+    Subprocess output is streamed to the logger in real-time so users see
+    download progress when running with ``--log-level DEBUG``.  When a
+    *line_callback* is provided (e.g. ``print`` in CLI mode) each line is
+    forwarded to it as well.
     """
     proc = await asyncio.create_subprocess_exec(
         sys.executable,
@@ -586,13 +595,21 @@ async def _run_patchright_install(extra_arg: str) -> None:
         "chromium",
         extra_arg,
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
     )
-    stdout, stderr = await proc.communicate()
+    lines: list[str] = []
+    stdout_stream = proc.stdout
+    assert stdout_stream is not None
+    async for raw in stdout_stream:
+        text = raw.decode("utf-8", errors="replace").rstrip()
+        if text:
+            logger.debug("patchright: %s", text)
+            lines.append(text)
+            if line_callback is not None:
+                line_callback(text)
+    await proc.wait()
     if proc.returncode != 0:
-        output = "\n".join(
-            text for text in (stderr.decode().strip(), stdout.decode().strip()) if text
-        )
+        output = "\n".join(lines)
         raise BrowserSetupFailedError(
             output or "Patchright Chromium browser setup failed."
         )
@@ -618,7 +635,9 @@ def _write_install_metadata(
     )
 
 
-async def _run_browser_setup() -> None:
+async def _run_browser_setup(
+    *, line_callback: Callable[[str], None] | None = None
+) -> None:
     """Install full Chrome for Testing, in one stage.
 
     The two-stage shell-first arrangement existed to make the headless path
@@ -642,7 +661,7 @@ async def _run_browser_setup() -> None:
     browser_dir = configure_browser_environment()
     secure_mkdir(browser_dir)
 
-    await _run_patchright_install("--no-shell")
+    await _run_patchright_install("--no-shell", line_callback=line_callback)
     _write_install_metadata(
         browser_dir,
         {_SHELL_DIR_PREFIX: False, _FULL_DIR_PREFIX: True},
@@ -654,11 +673,13 @@ async def _run_browser_setup() -> None:
     _schedule_retained_browser_revision_report()
 
 
-async def _ensure_browser_installed() -> None:
+async def _ensure_browser_installed(
+    *, line_callback: Callable[[str], None] | None = None
+) -> None:
     """Install the browser on demand. A no-op once it is present."""
     if browser_ready():
         return
-    await _run_browser_setup()
+    await _run_browser_setup(line_callback=line_callback)
 
 
 def ensure_browser_installed() -> None:
@@ -683,7 +704,7 @@ def ensure_browser_installed() -> None:
         return
     print("   Installing Patchright Chromium browser...")
     try:
-        asyncio.run(_ensure_browser_installed())
+        asyncio.run(_ensure_browser_installed(line_callback=print))
     except Exception as exc:
         print(f"   ❌ Browser installation failed: {exc}")
         raise
@@ -712,6 +733,21 @@ async def _refresh_background_task_state() -> None:
         else:
             _state.setup_state = SetupState.READY
             _state.setup_completed_at = utcnow_iso()
+            elapsed = "unknown"
+            if _state.setup_started_at:
+                try:
+                    started = datetime.fromisoformat(
+                        _state.setup_started_at.rstrip("Z")
+                    )
+                    elapsed = (
+                        f"{(datetime.now(timezone.utc) - started).total_seconds():.0f}s"
+                    )
+                except (ValueError, TypeError):
+                    pass
+            logger.info(
+                "Patchright Chromium browser setup completed in %s",
+                elapsed,
+            )
 
     if _safe_task_done(_state.login_task):
         task = _state.login_task

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -737,7 +737,7 @@ async def _refresh_background_task_state() -> None:
             if _state.setup_started_at:
                 try:
                     started = datetime.fromisoformat(
-                        _state.setup_started_at.rstrip("Z")
+                        _state.setup_started_at.replace("Z", "+00:00")
                     )
                     elapsed = (
                         f"{(datetime.now(timezone.utc) - started).total_seconds():.0f}s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "packaging>=26.2",
     "patchright>=1.55.0",
     "python-dotenv>=1.1.1",
+    "rich>=15.0.0",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 
@@ -189,3 +191,46 @@ def mock_context():
     ctx = MagicMock()
     ctx.report_progress = AsyncMock()
     return ctx
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Fail a test that leaves ``sys.stdout`` or ``sys.stderr`` unusable.
+
+    A test that closes one of them breaks every test that runs after it in the
+    same process, and the traceback lands on the innocent one. The failure
+    reads as unrelated: ``uvicorn`` asks ``sys.stdout.isatty()`` while building
+    its log config, so a closed stream surfaces as ``Unable to configure
+    formatter 'default'`` in a daemon test.
+
+    Under pytest's own capturing every test gets a fresh ``sys.stdout``, which
+    repairs the damage before anything can trip over it. CI runs with ``-s``,
+    where nothing repairs it, so this class of defect passes locally and fails
+    there. The usual cause is ``capsys`` in the signature of a test that also
+    monkeypatches ``sys.stdout``: ``capsys`` installs the object that
+    ``monkeypatch`` then records as the one to restore, tears down first, and
+    closes it, so the undo reinstalls a closed stream.
+
+    Checked on the teardown report rather than in a fixture, because a fixture
+    cannot see what the teardown of another fixture did after it, and reported
+    against the test that caused it rather than raised from a hook, which would
+    abort the whole session as an internal error.
+    """
+    report = yield
+    if call.when != "teardown" or report.get_result().failed:
+        return
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name)
+        try:
+            stream.write("")
+            stream.flush()
+        except Exception as exc:  # noqa: BLE001 - any failure is the same defect
+            result = report.get_result()
+            result.outcome = "failed"
+            result.longrepr = (
+                f"{item.nodeid} left sys.{name} unusable "
+                f"({type(exc).__name__}: {exc}). Every later test in this "
+                f"process would print into it. A `capsys` argument on a test "
+                f"that also monkeypatches sys.{name} is the usual cause."
+            )
+            return

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -923,7 +923,7 @@ class TestRetainedRevisionReportCallSites:
         )
         monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
 
-        async def fake_install(extra_arg: str) -> None:
+        async def fake_install(extra_arg: str, **kwargs: object) -> None:
             return None
 
         monkeypatch.setattr(
@@ -1072,7 +1072,7 @@ class TestTwoStageInstall:
         """Replace the patchright subprocess with a recorder of the install flags."""
         calls: list[str] = []
 
-        async def fake_install(extra_arg: str) -> None:
+        async def fake_install(extra_arg: str, **kwargs: object) -> None:
             calls.append(extra_arg)
 
         monkeypatch.setattr(
@@ -1124,7 +1124,7 @@ class TestTwoStageInstall:
         )
         monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
 
-        async def fake_install(extra_arg: str) -> None:
+        async def fake_install(extra_arg: str, **kwargs: object) -> None:
             raise BrowserSetupFailedError("network down")
 
         monkeypatch.setattr(
@@ -1185,7 +1185,7 @@ class TestEnsureBrowserInstalledSkipsCustomChrome:
 
         called = {"value": 0}
 
-        async def fake_install() -> None:
+        async def fake_install(**kwargs: object) -> None:
             called["value"] += 1
 
         monkeypatch.setattr(
@@ -1208,7 +1208,7 @@ class TestEnsureBrowserInstalledSkipsCustomChrome:
 
         called = {"value": 0}
 
-        async def fake_install() -> None:
+        async def fake_install(**kwargs: object) -> None:
             called["value"] += 1
 
         monkeypatch.setattr(
@@ -1238,7 +1238,7 @@ class TestEnsureBrowserInstalled:
     def _stub(self, monkeypatch):
         calls = {"value": 0}
 
-        async def fake_install() -> None:
+        async def fake_install(**kwargs: object) -> None:
             calls["value"] += 1
 
         monkeypatch.setattr(
@@ -1289,7 +1289,7 @@ class TestLoginInstallBackstop:
     def _stub(self, monkeypatch, *, custom_chrome: bool):
         order: list[str] = []
 
-        async def fake_full() -> None:
+        async def fake_full(**kwargs: object) -> None:
             order.append("full")
 
         async def fake_login(_profile_dir, *, superseded_by=None) -> bool:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,11 +1,14 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+import io
 import json
 import logging
 import os
 from pathlib import Path
+import sys
 import threading
 from types import SimpleNamespace
+from typing import IO, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -923,7 +926,7 @@ class TestRetainedRevisionReportCallSites:
         )
         monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
 
-        async def fake_install(extra_arg: str, **kwargs: object) -> None:
+        async def fake_install(extra_arg: str, **_kwargs: object) -> None:
             return None
 
         monkeypatch.setattr(
@@ -1072,7 +1075,7 @@ class TestTwoStageInstall:
         """Replace the patchright subprocess with a recorder of the install flags."""
         calls: list[str] = []
 
-        async def fake_install(extra_arg: str, **kwargs: object) -> None:
+        async def fake_install(extra_arg: str, **_kwargs: object) -> None:
             calls.append(extra_arg)
 
         monkeypatch.setattr(
@@ -1124,7 +1127,7 @@ class TestTwoStageInstall:
         )
         monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
 
-        async def fake_install(extra_arg: str, **kwargs: object) -> None:
+        async def fake_install(extra_arg: str, **_kwargs: object) -> None:
             raise BrowserSetupFailedError("network down")
 
         monkeypatch.setattr(
@@ -1163,6 +1166,1872 @@ class TestTwoStageInstall:
         assert calls == ["--no-shell"]
 
 
+class _StdoutThatIsGone(io.StringIO):
+    """A stdout whose every write meets a reader that has already left.
+
+    What ``--install-browser | head`` leaves behind once head has printed its
+    ten lines and exited.
+    """
+
+    encoding = "utf-8"
+
+    def isatty(self) -> bool:
+        return False
+
+    def write(self, text: str) -> int:
+        raise BrokenPipeError(32, "Broken pipe")
+
+
+class _FakeStdout:
+    """Serves pre-canned byte chunks through ``read()``, like a real pipe.
+
+    Records ``exhausted`` once it has answered with b"" so the process can
+    assert its pipe was fully drained before ``wait()``.
+    """
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._pending = list(chunks)
+        self.exhausted = False
+
+    async def read(self, n: int = -1) -> bytes:
+        """At most *n* bytes, like a real StreamReader: never the whole line."""
+        while self._pending and not self._pending[0]:
+            self._pending.pop(0)
+        if not self._pending:
+            self.exhausted = True
+            return b""
+        head = self._pending[0]
+        if n is not None and 0 <= n < len(head):
+            self._pending[0] = head[n:]
+            return head[:n]
+        self._pending.pop(0)
+        return head
+
+
+class _FakeProc:
+    """A running process: ``returncode`` stays None until ``wait()`` reaps it."""
+
+    def __init__(self, chunks: list[bytes], returncode: int) -> None:
+        self.stdout = _FakeStdout(chunks)
+        self.returncode: int | None = None
+        self._final = returncode
+        self.killed = False
+        self.waited = False
+        self.pid = 424242  # a real Process carries one
+
+    async def wait(self) -> int:
+        self.waited = True
+        return await self._wait()
+
+    async def _wait(self) -> int:
+        # A real process whose output pipe fills while the caller blocks on
+        # wait() deadlocks. Draining stdout first is the safe ordering, so this
+        # fails loudly if the implementation ever awaits wait() before the pipe
+        # is empty.
+        assert self.stdout.exhausted, "wait() awaited before stdout was drained"
+        self.returncode = self._final
+        return self.returncode
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+
+class _Spawned:
+    """What the patched ``create_subprocess_exec`` was given, and handed back."""
+
+    def __init__(self) -> None:
+        self.kwargs: dict[str, object] = {}
+        self.proc: _FakeProc | None = None
+
+
+class TestPatchrightInstallStreaming:
+    """The install streams its output as it arrives rather than after it ends."""
+
+    def _patch_proc(
+        self, monkeypatch, chunks: list[bytes], returncode: int
+    ) -> "_Spawned":
+        """Patch the subprocess and record the exec kwargs and the fake process."""
+        spawned = _Spawned()
+
+        async def fake_exec(*_args: object, **kwargs: object) -> _FakeProc:
+            spawned.kwargs.update(kwargs)
+            spawned.proc = _FakeProc(chunks, returncode)
+            return spawned.proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        return spawned
+
+    async def test_the_callback_gets_every_line_in_order(self, monkeypatch):
+        from linkedin_mcp_server import bootstrap
+
+        spawned = self._patch_proc(
+            monkeypatch,
+            [b"Downloading 10%\n", b"\n", b"Downloading 100%\n"],
+            0,
+        )
+        seen: list[str] = []
+        await bootstrap._run_patchright_install("--no-shell", line_callback=seen.append)
+
+        # stderr folds into stdout so the two interleave in write order. The
+        # fake process's wait() also asserts the pipe was drained first, so a
+        # regression that awaited wait() before streaming would fail here.
+        assert spawned.kwargs["stderr"] is asyncio.subprocess.STDOUT
+        assert seen == ["Downloading 10%", "Downloading 100%"]  # blanks dropped
+
+    async def test_the_background_path_logs_every_line(self, monkeypatch, caplog):
+        """With no callback there is no bar, and the log is the only display."""
+        from linkedin_mcp_server import bootstrap
+
+        self._patch_proc(monkeypatch, [b"Downloading 100%\n"], 0)
+        with caplog.at_level(logging.DEBUG, logger="linkedin_mcp_server.bootstrap"):
+            await bootstrap._run_patchright_install("--no-shell")
+
+        assert any("Downloading 100%" in r.message for r in caplog.records)
+
+    async def test_the_cli_path_does_not_log_what_the_bar_shows(
+        self, monkeypatch, caplog
+    ):
+        """Otherwise every percentage is printed permanently above the bar."""
+        from linkedin_mcp_server import bootstrap
+
+        self._patch_proc(monkeypatch, [b"Downloading 100%\n"], 0)
+        with caplog.at_level(logging.DEBUG, logger="linkedin_mcp_server.bootstrap"):
+            await bootstrap._run_patchright_install(
+                "--no-shell", line_callback=lambda _l: None
+            )
+
+        assert not [r for r in caplog.records if "Downloading" in r.message]
+
+    async def test_lines_arrive_before_the_process_is_reaped(self, monkeypatch):
+        """Streaming, as opposed to replaying a drained buffer afterwards.
+
+        Draining everything and then replaying the callbacks passes an
+        assertion on the final list just as well, and restores the silence this
+        change removes. So the moment matters: each line must reach the
+        callback while the installer is still running.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        spawned = self._patch_proc(monkeypatch, [b"10%\n", b"20%\n"], 0)
+        waited_when_seen: list[bool] = []
+
+        def watch(_line: str) -> None:
+            proc = spawned.proc
+            assert proc is not None
+            waited_when_seen.append(proc.waited)
+
+        await bootstrap._run_patchright_install("--no-shell", line_callback=watch)
+
+        assert waited_when_seen == [False, False]
+
+    async def test_failure_message_is_built_from_streamed_lines(self, monkeypatch):
+        from linkedin_mcp_server import bootstrap
+        from linkedin_mcp_server.exceptions import BrowserSetupFailedError
+
+        self._patch_proc(monkeypatch, [b"resolving...\n", b"error: no network\n"], 1)
+
+        with pytest.raises(BrowserSetupFailedError, match="error: no network"):
+            await bootstrap._run_patchright_install("--no-shell")
+
+    async def test_failure_without_output_has_a_default_message(self, monkeypatch):
+        from linkedin_mcp_server import bootstrap
+        from linkedin_mcp_server.exceptions import BrowserSetupFailedError
+
+        self._patch_proc(monkeypatch, [], 1)
+
+        with pytest.raises(BrowserSetupFailedError, match="setup failed"):
+            await bootstrap._run_patchright_install("--no-shell")
+
+    async def test_a_line_past_the_reader_limit_still_arrives(self, monkeypatch):
+        """One line longer than asyncio's 64 KiB readline limit must not raise.
+
+        Patchright puts a whole non-200 response body into a single error line,
+        so a captive portal or a mirror answering with minified HTML produces
+        one. Reading through ``readline`` raises ValueError there, mid-download,
+        leaving the child running.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        long_line = "E" * 200_000
+        self._patch_proc(monkeypatch, [long_line.encode() + b"\n"], 0)
+        seen: list[str] = []
+
+        await bootstrap._run_patchright_install("--no-shell", line_callback=seen.append)
+
+        # Emitted in bounded pieces rather than buffered whole, and nothing of
+        # it is lost. Reading through readline would have raised instead.
+        assert "".join(seen) == long_line
+        assert max(len(piece) for piece in seen) <= bootstrap._MAX_LINE_CHARS
+
+    async def test_whitespace_at_a_forced_cut_survives(self, monkeypatch):
+        """A fragment boundary is not the end of a line, so it is not trimmed.
+
+        Trimming every fragment would eat a space the installer wrote, at
+        whatever offset the cap happens to fall on.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        cut = bootstrap._MAX_LINE_CHARS
+        payload = "A" * (cut - 1) + " " + "B" * bootstrap._MAX_LINE_CHARS
+        seen: list[str] = []
+
+        async def fake_exec(*_a: object, **_k: object):
+            return _FakeProc([payload.encode() + b"\n"], 0)
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        await bootstrap._run_patchright_install("--no-shell", line_callback=seen.append)
+
+        assert "".join(seen) == payload
+
+    async def test_output_that_never_ends_a_line_stays_bounded(self, monkeypatch):
+        """Output with no newline at all must not grow the buffer without limit."""
+        from linkedin_mcp_server import bootstrap
+
+        self._patch_proc(monkeypatch, [b"N" * 500_000], 0)
+        seen: list[str] = []
+
+        await bootstrap._run_patchright_install("--no-shell", line_callback=seen.append)
+
+        assert "".join(seen) == "N" * 500_000
+        assert max(len(piece) for piece in seen) <= bootstrap._MAX_LINE_CHARS
+
+    async def test_multibyte_split_across_reads_is_not_corrupted(self, monkeypatch):
+        """A UTF-8 character straddling two reads must survive decoding."""
+        from linkedin_mcp_server import bootstrap
+
+        encoded = "100% ■ fertig".encode()
+        self._patch_proc(monkeypatch, [encoded[:7], encoded[7:] + b"\n"], 0)
+        seen: list[str] = []
+
+        await bootstrap._run_patchright_install("--no-shell", line_callback=seen.append)
+
+        assert seen == ["100% ■ fertig"]
+
+    async def test_a_trailing_line_without_a_newline_arrives(self, monkeypatch):
+        from linkedin_mcp_server import bootstrap
+
+        self._patch_proc(monkeypatch, [b"no trailing newline"], 0)
+        seen: list[str] = []
+
+        await bootstrap._run_patchright_install("--no-shell", line_callback=seen.append)
+
+        assert seen == ["no trailing newline"]
+
+    async def test_mirror_credentials_are_not_logged(self, monkeypatch, caplog):
+        """Userinfo in a download URL reaches neither the terminal nor the log.
+
+        Userinfo and the query only. A credential an operator put in the *path*
+        still prints, on purpose and by a decision `_safe_to_print` records:
+        the path is also where the browser build is named, and blanking it
+        would take the diagnostic with it.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        url = "https://ci-bot:s3cr3t@mirror.example/chromium.zip"
+        self._patch_proc(monkeypatch, [f"Downloading from {url}\n".encode()], 0)
+        seen: list[str] = []
+
+        with caplog.at_level(logging.DEBUG, logger="linkedin_mcp_server.bootstrap"):
+            await bootstrap._run_patchright_install(
+                "--no-shell", line_callback=seen.append
+            )
+
+        everything = " ".join(seen) + " ".join(r.message for r in caplog.records)
+        assert "s3cr3t" not in everything
+        assert "ci-bot" not in everything
+        assert "mirror.example/chromium.zip" in everything
+
+    async def test_the_failure_message_is_bounded(self, monkeypatch):
+        """A pathological installer must not be quoted back in full."""
+        from linkedin_mcp_server import bootstrap
+        from linkedin_mcp_server.exceptions import BrowserSetupFailedError
+
+        chunk = b"".join(f"line {i}\n".encode() for i in range(5_000))
+        self._patch_proc(monkeypatch, [chunk], 1)
+
+        with pytest.raises(BrowserSetupFailedError) as excinfo:
+            await bootstrap._run_patchright_install("--no-shell")
+
+        reported = str(excinfo.value).splitlines()
+        assert len(reported) == bootstrap._MAX_RETAINED_LINES
+        # The tail is kept: that is the part that says why it failed.
+        assert reported[-1] == "line 4999"
+
+    async def test_a_few_huge_lines_are_bounded_by_characters(self, monkeypatch):
+        """The line count alone would allow 200 fragments of 60 KiB each.
+
+        That is 12 MiB in an exception message and in `last_error`, from one
+        response body. The character bound is what stops it, and a test built
+        from short lines never reaches it.
+        """
+        from linkedin_mcp_server import bootstrap
+        from linkedin_mcp_server.exceptions import BrowserSetupFailedError
+
+        big = b"".join((b"H" * 40_000) + b"\n" for _ in range(20))
+        self._patch_proc(monkeypatch, [big], 1)
+
+        with pytest.raises(BrowserSetupFailedError) as excinfo:
+            await bootstrap._run_patchright_install("--no-shell")
+
+        # The characters themselves are what `retained` counts; the newlines
+        # `join` puts between them are not, and there is one fewer of those
+        # than there are lines. Anything looser passes a regression that keeps
+        # twice the bound, which is what this test exists to catch.
+        assert len(str(excinfo.value)) <= (
+            bootstrap._MAX_RETAINED_CHARS + bootstrap._MAX_RETAINED_LINES
+        )
+
+    async def test_a_failing_callback_does_not_leave_the_installer_running(
+        self, monkeypatch
+    ):
+        """Any escape from the read loop must stop the child.
+
+        Reaches the Python wrapper. Node keeps running until this process
+        exits and its pipe closes, which is the bounded end of the trade
+        `_stop_installer` explains.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        spawned = self._patch_proc(monkeypatch, [b"downloading\n"], 0)
+
+        def explode(_line: str) -> None:
+            raise RuntimeError("consumer died")
+
+        with pytest.raises(RuntimeError, match="consumer died"):
+            await bootstrap._run_patchright_install("--no-shell", line_callback=explode)
+
+        assert spawned.proc is not None and spawned.proc.killed is True
+
+    async def test_cancellation_stops_the_installer(self, monkeypatch):
+        from linkedin_mcp_server import bootstrap
+
+        spawned = self._patch_proc(monkeypatch, [b"downloading\n"], 0)
+
+        def cancel(_line: str) -> None:
+            raise asyncio.CancelledError
+
+        with pytest.raises(asyncio.CancelledError):
+            await bootstrap._run_patchright_install("--no-shell", line_callback=cancel)
+
+        assert spawned.proc is not None and spawned.proc.killed is True
+
+
+class TestCredentialRedaction:
+    """Every userinfo shape a mirror URL can carry, not only user:password."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://ci-bot:s3cr3t@mirror.example/x.zip",
+            "https://s3cr3t@mirror.example/x.zip",
+            "https://s3cr3t:@mirror.example/x.zip",
+            "https://:s3cr3t@mirror.example/x.zip",
+            # A password may hold an "@". Stopping at the first one leaves the
+            # rest of it in the line.
+            "https://ci-bot:s3cr3t@x@mirror.example/x.zip",
+            # Node normalises backslashes before authenticating, so this is a
+            # working credential too.
+            "https:\\\\ci-bot:s3cr3t@mirror.example/x.zip",
+            # Not userinfo at all: patchright pastes its path onto whatever the
+            # download-host variable names.
+            "https://mirror.example/dl?token=s3cr3t&path=/builds/x.zip",
+            "https://mirror.example/dl?api_key=s3cr3t",
+            "https://mirror.example/dl?a=1&signature=s3cr3t&b=2",
+        ],
+    )
+    def test_the_secret_never_survives(self, url):
+        from linkedin_mcp_server.bootstrap import _safe_to_print
+
+        redacted = _safe_to_print(f"Downloading Chromium from {url}")
+        assert "s3cr3t" not in redacted
+        assert "mirror.example" in redacted
+
+    @pytest.mark.parametrize("straddle", [0, 1, 2, 3])
+    async def test_a_url_is_redacted_wherever_the_cut_falls(
+        self, monkeypatch, straddle
+    ):
+        """A credential must not escape by landing on a fragment boundary.
+
+        Redaction runs on the buffer, before it is cut, so a URL that has
+        arrived whole is replaced wherever the cut then falls. The offsets
+        sweep the boundaries a cut and a read can land on, and a version that
+        redacts the fragments instead leaks in at least one of them.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        secret = "https://ci-bot:s3cr3t@mirror.example/x.zip"
+        cap = bootstrap._MAX_LINE_CHARS
+        # Place the URL across each boundary a cut could land on.
+        offset = [cap, cap * 2, bootstrap._READ_CHUNK, bootstrap._READ_CHUNK * 3][
+            straddle
+        ] - len(secret) // 2
+        payload = "F" * offset + secret + "F" * bootstrap._MAX_LINE_CHARS
+        seen: list[str] = []
+
+        async def fake_exec(*_a: object, **_k: object):
+            return _FakeProc([payload.encode() + b"\n"], 0)
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        await bootstrap._run_patchright_install("--no-shell", line_callback=seen.append)
+
+        assert "s3cr3t" not in "".join(seen)
+
+
+class TestQuotedResponseBodiesAreDropped:
+    """The one part of this output a stranger writes is not printed at all.
+
+    Patchright's ``Download failed: server returned code N body '…'. URL: …``
+    quotes whatever a refusing mirror sent, verbatim and once per retry. That
+    body is where the escape sequences, the reflected credentials, the rich
+    markup and the 400-digit sizes all came from, so it is dropped between the
+    markers rather than defended against downstream.
+    """
+
+    #: Measured, not composed: one error block as patchright 1.61.2 wrote it to a
+    #: pipe when a mirror answered 403 with an HTML page. The body carries its
+    #: own newlines, which is why the drop has to hold across lines.
+    SAMPLE = (
+        "Error: Download failed: server returned code 403 body '<html>\n"
+        "<head>\x1b]0;PWNED\x07<title>denied</title></head>\n"
+        "<body>\x1b[2Jbad token: sup3rs3cr3tvalue\n"
+        "split: sup3r\x1b[31ms3cr3tvalue\n"
+        "|########| 999% of 12345678901234567890.5 MiB\n"
+        "</body>\n</html>\n"
+        "'. URL: http://user:sup3rs3cr3tvalue@mirror.example/?token=sup3rs3cr3tvalue"
+        "/builds/cft/149.0.7827.55/mac-arm64/chrome-headless-shell-mac-arm64.zip\n"
+        "    at IncomingMessage.handleError (/x/coreBundle.js:29308:23)\n"
+    )
+
+    async def _lines(self, monkeypatch, *chunks: bytes) -> list[str]:
+        from linkedin_mcp_server import bootstrap
+
+        seen: list[str] = []
+
+        async def fake_exec(*_a: object, **_k: object):
+            return _FakeProc(list(chunks), 0)
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        await bootstrap._run_patchright_install("--no-shell", line_callback=seen.append)
+        return seen
+
+    async def test_nothing_between_the_markers_is_printed(self, monkeypatch):
+        seen = await self._lines(monkeypatch, self.SAMPLE.encode())
+        printed = "\n".join(seen)
+
+        assert "<response body omitted>" in printed
+        assert "denied" not in printed
+        assert "999%" not in printed
+        assert "sup3rs3cr3tvalue" not in printed
+
+    async def test_what_patchright_wrote_itself_survives(self, monkeypatch):
+        """The diagnosis is the status code and the URL, and both are kept."""
+        seen = await self._lines(monkeypatch, self.SAMPLE.encode())
+        printed = "\n".join(seen)
+
+        assert "server returned code 403" in printed
+        # The mirror is named; its credential and its query are not, and the
+        # archive path sits behind the query in a host configured this way.
+        assert "URL: http://***@mirror.example/?***" in printed
+        assert "coreBundle.js:29308:23" in printed, "output resumes after the body"
+
+    async def test_one_body_does_not_swallow_the_next_download(self, monkeypatch):
+        """A failed attempt is followed by four more, and they must show."""
+        seen = await self._lines(
+            monkeypatch,
+            self.SAMPLE.encode(),
+            b"Downloading Chrome for Testing 149.0.7827.55 from https://cdn/x.zip\n",
+        )
+
+        assert any("Downloading Chrome for Testing" in line for line in seen)
+
+    async def test_a_body_that_never_closes_takes_the_rest_with_it(self, monkeypatch):
+        """A truncated response leaves the marker open, and open means dropped.
+
+        Losing the tail of a failed install's output is the cheaper mistake:
+        the alternative is guessing where a stranger's bytes stopped.
+        """
+        seen = await self._lines(
+            monkeypatch,
+            b"Error: Download failed: server returned code 500 body '<html>\n",
+            b"still the body\nand still\n",
+        )
+
+        assert seen == [
+            "Error: Download failed: server returned code 500 body "
+            "'<response body omitted>"
+        ]
+
+    async def test_a_body_quoting_the_opener_still_terminates(self, monkeypatch):
+        """The marker stays in what is kept, so a rescan must not find it again."""
+        seen = await self._lines(
+            monkeypatch,
+            b"Error: Download failed: server returned code 403 body "
+            b"'server returned code 403 body ''. URL: http://cdn/x.zip\n",
+        )
+
+        assert len(seen) == 1
+        assert seen[0].count("<response body omitted>") == 1
+
+    async def test_two_bodies_on_one_line_are_both_dropped(self, monkeypatch):
+        """Patchright writes one message per line, so this shape is the body's.
+
+        Only the closer whose URL ends the line is believed, which here is the
+        second one: the whole span from the first opener to it goes, and both
+        bodies with it. Dropping more than a body is the safe error to make;
+        the alternative is believing a marker a stranger wrote.
+        """
+        line = (
+            "A: server returned code 403 body 'first'. URL: http://a/x.zip "
+            "B: server returned code 404 body 'second'. URL: http://b/x.zip\n"
+        )
+        seen = await self._lines(monkeypatch, line.encode())
+
+        assert "first" not in seen[0] and "second" not in seen[0]
+        assert seen[0].count("<response body omitted>") == 1
+        assert seen[0].endswith("'. URL: http://b/x.zip")
+
+    async def test_a_body_cannot_close_itself_with_prose_behind_it(self, monkeypatch):
+        """The closer is anchored to the end of its line, so a forgery misses.
+
+        Measured against a refusing mirror: patchright's own closer starts a
+        line of its own and its URL runs to end of line. A body that writes the
+        marker mid-line is therefore still the body talking, and the drop stays
+        open rather than printing the rest of the page as if patchright had
+        written it.
+        """
+        stream = (
+            "Download failed: server returned code 403 body '<html>\n"
+            "'. URL: http://forged/x and then sup3rs3cr3tvalue\n"
+            "still inside the page\n"
+            "'. URL: http://real/x.zip\n"
+            "    at IncomingMessage.handleError (/x/coreBundle.js:1:1)\n"
+        )
+        seen = await self._lines(monkeypatch, stream.encode())
+        printed = "\n".join(seen)
+
+        assert "sup3rs3cr3tvalue" not in printed
+        assert "still inside the page" not in printed
+        assert "'. URL: http://real/x.zip" in printed
+        assert "coreBundle.js" in printed, "and patchright's own trace comes back"
+
+    async def test_a_body_line_ending_in_a_url_does_close_the_drop(self, monkeypatch):
+        """The limit the anchor leaves open, pinned so a change to it is visible.
+
+        The closer patchright writes is the marker, a URL, end of line, and
+        nothing at the source distinguishes that from a body line of the same
+        shape. So a page that ends a line with one closes the drop and the rest
+        of the page prints. Recorded rather than defended against: the
+        alternative is dropping the real closer too, which takes the URL, the
+        stack trace and every later retry with it.
+
+        What the drop is for does not rest on this. The rest of the page is
+        still stripped of terminal controls, still redacted, still capped, and
+        still rendered without markup, which is what the sibling tests hold.
+        """
+        stream = (
+            "Download failed: server returned code 403 body '<html>\n"
+            "'. URL: http://forged/x\n"
+            "reflected sup3rs3cr3tvalue\n"
+            "'. URL: http://real/x.zip\n"
+        )
+        seen = await self._lines(monkeypatch, stream.encode())
+        printed = "\n".join(seen)
+
+        assert "reflected sup3rs3cr3tvalue" in printed, (
+            "a body line of the closer's own shape ends the drop: known limit"
+        )
+        assert "\x1b" not in printed, "and the rest is still stripped"
+
+    @pytest.mark.parametrize("cuts", [1, 2])
+    async def test_a_closer_split_by_the_forced_cut_still_closes(
+        self, monkeypatch, cuts
+    ):
+        """A body over the line cap is cut wherever the cap falls.
+
+        Including inside ``'. URL: ``, which leaves half the marker on each
+        side of a fragment boundary. Without a carry across fragments the drop
+        would never see a whole marker again and would swallow the URL, the
+        stack trace and every later retry along with the page. Two cuts because
+        the elision carries in two places: where it opens, and on every
+        fragment it stays open across.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        cap = bootstrap._MAX_LINE_CHARS
+        opener = "Download failed: server returned code 403 body '"
+        closer = "'. URL: http://h/z.zip"
+        # Three characters of the marker land on the near side of the last cut.
+        body = "A" * (cuts * cap - 3 - len(opener))
+        stream = opener + body + closer + "\nback to normal\nDone\n"
+        seen = await self._lines(monkeypatch, stream.encode())
+        printed = "\n".join(seen)
+
+        assert "AAAA" not in printed, "the page itself is still dropped"
+        assert "back to normal" in printed
+        assert "Done" in printed
+
+    def test_the_markers_match_what_patchright_builds(self):
+        """Drawn from the installer's own source, not composed here.
+
+        A double written from memory tests this file against itself. So the
+        template comes out of the ``coreBundle.js`` that is actually installed
+        and the placeholders are filled in; if a release rewords the message,
+        the drop stops finding a body and this fails, rather than the body
+        appearing on someone's terminal.
+        """
+        import re
+
+        import patchright
+
+        from linkedin_mcp_server import bootstrap
+
+        # Searched rather than named: where patchright builds this moved
+        # between the versions this project accepts. `pyproject.toml` allows
+        # 1.55, which has it in `server/registry/oopDownloadBrowserMain.js`,
+        # and the locked 1.61 bundles it into `coreBundle.js`. Naming one file
+        # fails the suite of a contributor resolving the other, for a reason
+        # that has nothing to do with their change. The tree is 31 files.
+        lib = Path(patchright.__file__).parent / "driver" / "package" / "lib"
+        assert lib.is_dir(), f"the installed driver has no library at {lib}"
+        template = re.compile(r"`Download failed: server returned code [^`]*`")
+        found = None
+        for source in sorted(lib.rglob("*.js")):
+            found = template.search(source.read_text(errors="replace"))
+            if found is not None:
+                break
+        assert found is not None, "patchright no longer builds this message"
+
+        built = found.group(0)[1:-1]
+        for placeholder, value in (
+            (r"${response.statusCode}", "403"),
+            (r"${response2.statusCode}", "403"),
+            (r"${content}", "X"),
+            (r"${options.url}", "http://h/z"),
+        ):
+            built = built.replace(placeholder, value)
+        assert "${" not in built, f"unsubstituted placeholder in {built!r}"
+
+        opened = bootstrap._RESPONSE_BODY_OPENS.search(built)
+        assert opened is not None
+        assert built[opened.end() :].startswith("X")
+        assert built[opened.end() + 1 :].startswith(bootstrap._RESPONSE_BODY_CLOSES)
+        assert bootstrap._RESPONSE_BODY_CLOSED.search(built) is not None, (
+            "and the closer still runs to the end of its line"
+        )
+
+
+class TestTerminalControlsAreStripped:
+    """Installer output is data, and it reaches a terminal and a log."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "\x1b[2J",  # clear the screen
+            "\x1b]0;owned\x07",  # rename the window
+            "\x1b]52;c;cGF5bG9hZA==\x07",  # write the clipboard, where enabled
+            "before\x08\x08\x08after",  # backspace over what was printed
+            "\x9b2J",  # the same clear, in its eight-bit C1 form
+            "\x9d0;owned\x07",  # and the same window rename
+        ],
+    )
+    def test_a_response_body_cannot_drive_the_terminal(self, payload):
+        from linkedin_mcp_server.bootstrap import _safe_to_print
+
+        cleaned = _safe_to_print(f"Download failed: body '{payload}'")
+        assert "\x1b" not in cleaned
+        assert "\x08" not in cleaned
+        assert not any("\x80" <= c <= "\x9f" for c in cleaned), "C1 too"
+        assert "Download failed" in cleaned
+
+
+class TestControlsComeOutBeforeCredentials:
+    """Order matters: an escape sequence can hide a credential from a pattern.
+
+    Stripping after redacting would leave ``//us<ESC>[0mer:pw@host`` unmatched
+    and then hand the stripper the pieces to put back together.
+    """
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # A vertical tab and a form feed are whitespace to the pattern, so
+            # the userinfo stops being one until they are gone.
+            "from https://userbot:s3cr\x0b3tpw@mirror.example/x.zip",
+            "from https://userbot:s3cr\x0c3tpw@mirror.example/x.zip",
+            # And an OSC sequence can carry the other character the pattern
+            # refuses, which is the slash it opened on.
+            "from https://userbot:s3\x1b]0;/tmp/x\x07cr3tpw@mirror.example/x.zip",
+        ],
+    )
+    def test_a_credential_broken_up_by_controls_is_still_redacted(self, line):
+        from linkedin_mcp_server.bootstrap import _safe_to_print
+
+        cleaned = _safe_to_print(line)
+
+        assert "s3cr3tpw" not in cleaned
+        assert "mirror.example" in cleaned, "the mirror is the diagnosis"
+
+
+class TestPlainLinePrinting:
+    """The fallback used when no bar is drawn. It must never abort an install."""
+
+    def test_a_glyph_the_stream_cannot_encode_is_replaced(self, monkeypatch):
+        """Patchright draws its bar with U+25A0 and an ascii stream refuses it.
+
+        No ``capsys`` here, deliberately. It installs its own ``CaptureIO`` as
+        ``sys.stdout``, which is then what ``monkeypatch`` records as the value
+        to put back; ``capsys`` tears down first and closes that object, so the
+        undo reinstalls a *closed* stream and every later test in the process
+        prints into it. Under pytest's own capturing each test gets a fresh
+        ``sys.stdout`` and the wreckage is invisible, so this only surfaces
+        under ``-s``, which is how CI runs.
+        """
+        from linkedin_mcp_server.bootstrap import _print_whatever_the_stream_takes
+
+        class _Ascii(io.StringIO):
+            encoding = "ascii"
+
+            def write(self, s: str) -> int:
+                s.encode("ascii")  # raises exactly as a real ascii stream does
+                return super().write(s)
+
+        stream = _Ascii()
+        monkeypatch.setattr(sys, "stdout", stream)
+        _print_whatever_the_stream_takes("|■■■■   |  30% of 171.0 MiB")
+        assert "30% of 171.0 MiB" in stream.getvalue()
+
+    def test_each_line_is_flushed_as_it_is_written(self, monkeypatch):
+        """Progress that sits in a block buffer is not progress.
+
+        Redirected stdout is block-buffered, so without a flush per line the
+        download reports nothing until the buffer fills or the process ends,
+        which is the silence this change removes.
+        """
+        import builtins
+
+        from linkedin_mcp_server.bootstrap import _print_whatever_the_stream_takes
+
+        flushes: list[object] = []
+        monkeypatch.setattr(
+            builtins, "print", lambda *a, **k: flushes.append(k.get("flush"))
+        )
+        _print_whatever_the_stream_takes("|\u25a0\u25a0| 30% of 171.0 MiB")
+
+        assert flushes == [True]
+
+    def test_a_closed_stream_does_not_abort_the_install(self, monkeypatch):
+        """The replacement attempt can meet the same broken pipe as the first."""
+        from linkedin_mcp_server.bootstrap import _print_whatever_the_stream_takes
+
+        class _Broken(io.StringIO):
+            encoding = "ascii"
+
+            def write(self, s: str) -> int:
+                raise BrokenPipeError(32, "Broken pipe")
+
+        monkeypatch.setattr(sys, "stdout", _Broken())
+        _print_whatever_the_stream_takes("|■■■■   |  30%")  # must not raise
+
+    def test_a_stream_the_host_already_closed_does_not_abort_it_either(
+        self, monkeypatch
+    ):
+        """A closed ``TextIOBase`` answers ``ValueError``, not ``BrokenPipeError``.
+
+        Only a real pipe raises the latter. A host that closed the server's
+        stdout before starting it leaves the other one, and catching just the
+        pipe would turn a cosmetic write into a failed install.
+        """
+        from linkedin_mcp_server.bootstrap import _print_whatever_the_stream_takes
+
+        closed = io.StringIO()
+        closed.close()
+        monkeypatch.setattr(sys, "stdout", closed)
+        _print_whatever_the_stream_takes("|■■■■   |  30%")  # must not raise
+
+
+class TestRendererSurvivesOddOutput:
+    """The render callback runs inside patchright's retry loop; it must not raise."""
+
+    def _terminal(self, monkeypatch) -> list:
+        """Terminal branch, capturing both the output and the Progress built.
+
+        The Progress is captured by wrapping the class the module looked up,
+        so nothing in the production code exists only for this test.
+        """
+        import io as _io
+
+        from rich.progress import Progress
+
+        from linkedin_mcp_server import bootstrap
+
+        buffer = _io.StringIO()
+        built: list = [buffer]
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        quiet = bootstrap._ConsoleThatGoesQuiet
+        monkeypatch.setattr(
+            bootstrap,
+            "_ConsoleThatGoesQuiet",
+            lambda *a, **k: quiet(
+                file=buffer,
+                force_terminal=True,
+                width=100,
+                # Stated rather than inherited: a CI runner setting TERM=dumb
+                # would otherwise send these tests down the plain-line path and
+                # quietly stop exercising the bar at all.
+                _environ={"TERM": "xterm-256color"},
+                **k,
+            ),
+        )
+
+        def record(*args: Any, **kwargs: Any) -> Progress:
+            progress = Progress(*args, **kwargs)
+            built.append(progress)
+            return progress
+
+        monkeypatch.setattr(bootstrap, "Progress", record)
+        return built
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "error: access [/red] denied",  # rich markup in an error body
+            "|  10% of 171.0 MB",  # a unit the table does not know
+            "|  10% of . MiB",  # a number that will not parse
+            "|  10% of 171.0 EiB",  # a unit nobody has
+        ],
+    )
+    def test_it_prints_instead_of_raising(self, monkeypatch, line):
+        from linkedin_mcp_server import bootstrap
+
+        buffer = self._terminal(monkeypatch)[0]
+        with bootstrap._cli_progress() as report:
+            report(line)  # must not raise
+        assert buffer.getvalue().strip()
+
+    def test_markup_in_the_artifact_name_does_not_raise(self, monkeypatch):
+        """Measured against real patchright: a non-200 body whose text lands on
+        its own output line reaches the description, five times over. Without
+        escaping, the callback raises MarkupError and the retries are lost.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report("Downloading [/red] from https://example/x")
+            report("|  10% of 1.0 MiB")  # creating the task is what renders it
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "|  10% of " + "9" * 400 + ".0 MiB",  # OverflowError on conversion
+            "|  " + "1" * 5000 + "% of 171.0 MiB",  # past Python's digit limit
+        ],
+    )
+    def test_absurd_numbers_never_reach_a_conversion(self, monkeypatch, line):
+        """The digit counts in the pattern are the guard, so they are asserted.
+
+        Without them the conversions raise from inside the render callback,
+        which kills the installer and reports arithmetic in place of a
+        download failure.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        assert bootstrap._PATCHRIGHT_PERCENT.search(line) is None
+        self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report(line)
+
+    def test_a_retry_after_a_finished_bar_replaces_it_too(self, monkeypatch):
+        """Patchright reports 100% before it unpacks, and a corrupt archive
+        fails after that. It then retries the same artifact, up to five times.
+        Keeping the finished bar would leave four of them for one browser.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report("Downloading Chromium (v1) from https://a/b.zip")
+            report("| 100% of 171.0 MiB")
+            report("Downloading Chromium (v1) from https://mirror/b.zip")
+            report("|  10% of 171.0 MiB")
+            bars = list(built[1].tasks)
+            # Read inside: leaving drives whatever is still running to 100%,
+            # and these are live objects.
+            done = [t.finished for t in bars]
+
+        assert len(bars) == 1, "one artifact, one bar"
+        assert done == [False]
+
+    def test_a_silent_retry_reuses_its_bar(self, monkeypatch):
+        """A raised npm log level suppresses the retry announcement.
+
+        Patchright retries five times, so a renderer that starts a bar on every
+        backwards step leaves five of them for one download.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report("Downloading Chromium (v1) from https://a/b.zip")
+            report("|  40% of 171.0 MiB")
+            report("|   0% of 171.0 MiB")  # the retry, unannounced
+            report("|  10% of 171.0 MiB")
+            bars = list(built[1].tasks)
+
+        assert len(bars) == 1, "one artifact, one bar"
+        assert bars[0].description == "Chromium"
+
+    def test_a_silent_retry_after_a_full_bar_reuses_it(self, monkeypatch):
+        """Patchright reports 100% before it unpacks, and then retries.
+
+        A corrupt archive downloads to the end, fails to extract, and is
+        fetched again from the top: five times, with the announcements
+        suppressed. Read as five artifacts, the failure arrives under five
+        completed bars for one browser. The total is what tells a retry from
+        the next artifact, which is a different archive.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report("Downloading Chromium (v1) from https://a/b.zip")
+            report("| 100% of 171.0 MiB")
+            for _ in range(4):  # patchright allows five attempts in all
+                report("|   0% of 171.0 MiB")
+                report("| 100% of 171.0 MiB")
+            bars = list(built[1].tasks)
+
+        assert len(bars) == 1, "one archive, one bar"
+
+    def test_a_second_artifact_without_an_announcement_gets_its_own_bar(
+        self, monkeypatch
+    ):
+        """A raised npm log level suppresses the announcements and keeps the
+        percentages. Feeding ffmpeg's ten percent to the finished browser bar
+        leaves it finished at ten percent.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report("| 100% of 171.0 MiB")
+            report("|  10% of 1.6 MiB")
+            bars = list(built[1].tasks)
+            done = [t.finished for t in bars]
+
+        assert len(bars) == 2
+        assert done == [True, False]
+
+    def test_a_retry_replaces_its_unfinished_bar(self, monkeypatch):
+        """Patchright retries a failed download, announcing it the same way."""
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report("Downloading Chromium (v1) from https://a/b.zip")
+            report("|  40% of 171.0 MiB")
+            report("Downloading Chromium (v1) from https://mirror/b.zip")
+            report("|  10% of 171.0 MiB")
+            bars = len(built[1].tasks)
+        assert bars == 1, "the abandoned attempt should not keep spinning"
+
+    def test_a_finished_bar_stays_when_the_next_artifact_starts(self, monkeypatch):
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report("Downloading Chromium (v1) from https://a/b.zip")
+            report("| 100% of 171.0 MiB")
+            report("Downloading FFmpeg (v2) from https://a/c.zip")
+            report("|  10% of 1.6 MiB")
+            bars = len(built[1].tasks)
+        assert bars == 2, "the completed browser should stay on screen"
+
+
+class TestCliProgress:
+    """The terminal bar, and the plain lines everywhere else."""
+
+    def _terminal(self, monkeypatch) -> list:
+        """Make the CLI path believe it is on a terminal, and capture it.
+
+        Returns the buffer and the live ``Progress``. The bar refreshes on
+        rich's own schedule, so a test that wants to see an intermediate frame
+        has to ask for one; on the way out every bar is driven to completion.
+        """
+        from rich.progress import Progress
+
+        from linkedin_mcp_server import bootstrap
+
+        buffer = io.StringIO()
+        built: list = [buffer]
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        quiet = bootstrap._ConsoleThatGoesQuiet
+        monkeypatch.setattr(
+            bootstrap,
+            "_ConsoleThatGoesQuiet",
+            lambda *a, **k: quiet(file=buffer, force_terminal=True, width=100, **k),
+        )
+
+        def record(*args: Any, **kwargs: Any) -> Progress:
+            progress = Progress(*args, **kwargs)
+            built.append(progress)
+            return progress
+
+        monkeypatch.setattr(bootstrap, "Progress", record)
+        return built
+
+    def test_richs_own_console_exits_the_process_on_a_broken_pipe(self):
+        """The upstream behaviour this subclass exists to replace.
+
+        Measured rather than read, and in a subprocess because the default
+        implementation points the caller's ``sys.stdout`` at ``os.devnull``
+        before it raises. If a rich release stops exiting here, the subclass
+        stops being needed and this says so.
+        """
+        import subprocess
+
+        script = (
+            "import io, os, sys\n"
+            "from rich.console import Console\n"
+            "class Pipe(io.StringIO):\n"
+            "    def write(self, s):\n"
+            "        raise BrokenPipeError(32, 'Broken pipe')\n"
+            "try:\n"
+            "    Console(file=Pipe(), force_terminal=True).print('x')\n"
+            "except SystemExit:\n"
+            "    os._exit(7)\n"
+            "os._exit(0)\n"
+        )
+        run = subprocess.run([sys.executable, "-c", script], capture_output=True)
+
+        assert run.returncode == 7, "rich no longer exits; drop the subclass"
+
+    def test_a_broken_pipe_silences_the_bar_instead_of_killing_the_install(
+        self, monkeypatch
+    ):
+        """``--install-browser | head`` closes the pipe mid-download.
+
+        Which reaches rich whenever the bar is drawn at all, and
+        ``FORCE_COLOR=1`` arranges for that on a redirected stdout. Measured
+        before the subclass: exit code 1, empty stderr, the archive half
+        unpacked. Going quiet leaves the install running, which is the answer
+        the plain-line path already gives a stream that will not take a line.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        class _Pipe(io.StringIO):
+            def isatty(self) -> bool:
+                return True
+
+            def write(self, s: str) -> int:
+                raise BrokenPipeError(32, "Broken pipe")
+
+        pipe = _Pipe()
+        monkeypatch.setattr(sys, "stdout", pipe)
+        quiet = bootstrap._ConsoleThatGoesQuiet
+        consoles: list = []
+
+        def build(*a: Any, **k: Any):
+            console = quiet(file=pipe, force_terminal=True, width=100, **k)
+            consoles.append(console)
+            return console
+
+        monkeypatch.setattr(bootstrap, "_ConsoleThatGoesQuiet", build)
+
+        with bootstrap._cli_progress() as report:  # must not raise SystemExit
+            report("Downloading Chromium (v1) from https://a/b.zip")
+            report("|\u25a0\u25a0\u25a0| 40% of 171.0 MiB")
+
+        assert consoles and consoles[0].quiet, "and stops trying after the first"
+
+    def test_a_closed_stream_silences_the_bar_too(self, monkeypatch):
+        """A pipe is not the only way a terminal stops taking bytes.
+
+        rich catches ``BrokenPipeError`` and nothing else, so a stdout the host
+        has closed answers ``ValueError`` and an IDE terminal whose other end
+        detached answers ``OSError`` EIO, both straight out of the bar's own
+        refresh. From there it leaves the read loop and reports a failed
+        install for a browser already on disk.
+        """
+        from rich.console import Console
+
+        from linkedin_mcp_server import bootstrap
+
+        for error in (
+            ValueError("I/O operation on closed file"),
+            OSError(5, "Input/output error"),
+        ):
+
+            class _Gone(io.StringIO):
+                def isatty(self) -> bool:
+                    return True
+
+                def write(self, s: str) -> int:
+                    raise error
+
+                def flush(self) -> None:
+                    raise error
+
+            gone = _Gone()
+            with pytest.raises(type(error)):
+                Console(file=gone, force_terminal=True, width=80).print("contract")
+
+            console = bootstrap._ConsoleThatGoesQuiet(
+                file=gone, force_terminal=True, width=80
+            )
+            console.print("| 40% of 171.0 MiB")  # must not raise
+
+            assert console.quiet, f"and stops trying after {error!r}"
+
+    def test_a_failed_install_leaves_its_bar_where_it_died(self, monkeypatch):
+        """The completion on the way out is for a success, and only that.
+
+        Patchright can succeed in silence, so the bar is finished when the
+        caller leaves without raising. A caller that raises is a failed
+        install, and filling its bar to 100% would report the opposite.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with pytest.raises(RuntimeError):
+            with bootstrap._cli_progress() as report:
+                report("Downloading Chromium (v1) from https://a/b.zip")
+                report("|\u25a0\u25a0\u25a0| 40% of 171.0 MiB")
+                raise RuntimeError("the mirror refused")
+
+        assert not built[1].tasks[0].finished
+
+    def test_a_retried_download_reuses_its_bar(self, monkeypatch):
+        """Patchright restarts a failed download at zero, up to five times.
+
+        Adding a bar per attempt would leave four abandoned ones spinning at
+        the percentage where each died.
+        """
+        from rich.progress import Progress
+
+        from linkedin_mcp_server import bootstrap
+
+        self._terminal(monkeypatch)
+        created: list[str] = []
+        real_add = Progress.add_task
+
+        def counting(self, description: str, **kwargs):  # noqa: ANN003
+            created.append(description)
+            return real_add(self, description, **kwargs)
+
+        monkeypatch.setattr(Progress, "add_task", counting)
+
+        with bootstrap._cli_progress() as report:
+            report("Downloading Chrome for Testing 149.0.7827.55 from https://c/x")
+            report("|\u25a0\u25a0\u25a0| 40% of 171.0 MiB")
+            report("|\u25a0| 10% of 171.0 MiB")  # the retry, back at the start
+
+        # One bar for the whole thing: the placeholder the context opens with,
+        # renamed by the announcement and rewound by the retry.
+        assert len(created) == 1, created
+
+    def test_a_terminal_that_cannot_encode_the_spinner_gets_lines(self, monkeypatch):
+        """``PYTHONIOENCODING=ascii`` on a real terminal, which rich walks into.
+
+        Measured: rich downgrades the bar itself when the console encoding is
+        not utf, and does not downgrade the spinner, so the braille reaches
+        ``write`` and raises. Inside the live region that leaves the read loop,
+        kills the installer and reports an encoding error in place of a browser.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        class _AsciiTty(io.StringIO):
+            encoding = "ascii"
+
+            def isatty(self) -> bool:
+                return True
+
+            def write(self, s: str) -> int:
+                s.encode("ascii")  # exactly what a real ascii stream does
+                return super().write(s)
+
+        monkeypatch.setattr(sys, "stdout", _AsciiTty())
+
+        with bootstrap._cli_progress() as report:
+            assert report is bootstrap._print_whatever_the_stream_takes
+
+    def test_rich_draws_nothing_outside_the_glyphs_that_were_checked(self, monkeypatch):
+        """The encodability check is only as good as its list of glyphs.
+
+        Renders the shipped column set and looks for any non-ASCII character
+        that ``_BAR_GLYPHS`` does not name. A rich release that adds one to the
+        bar, the spinner or a column fails here rather than on the terminal of
+        whoever has an ascii stdout.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        buffer = self._terminal(monkeypatch)[0]
+
+        with bootstrap._cli_progress() as report:
+            report(
+                "Downloading Chrome for Testing 149.0.7827.55 "
+                "(playwright chromium v1228) from https://cdn.example/x.zip"
+            )
+            for percent in (0, 10, 40, 100):
+                report(f"|\u25a0\u25a0| {percent}% of 171.0 MiB")
+
+        drawn = {c for c in buffer.getvalue() if ord(c) > 127}
+        # The bar's three, which rich swaps for "-" and " " on an ascii
+        # console, plus whatever the spinner is drawing.
+        assert drawn <= set(bootstrap._BAR_GLYPHS + "\u2501\u2578\u257a"), drawn
+
+    def test_without_a_terminal_the_lines_are_printed(self, monkeypatch):
+        """Redirected output keeps the installer's own lines."""
+        from linkedin_mcp_server import bootstrap
+
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: False, raising=False)
+
+        with bootstrap._cli_progress() as report:
+            assert report is bootstrap._print_whatever_the_stream_takes
+
+    def test_a_terminal_gets_a_bar_carrying_the_artifact_name(self, monkeypatch):
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        buffer = built[0]
+
+        with bootstrap._cli_progress() as report:
+            report(
+                "Downloading Chrome for Testing 149.0.7827.55 "
+                "(playwright chromium v1228) from https://cdn.example/x.zip"
+            )
+            report("|■■■■     |  40% of 171.0 MiB")
+            # rich refreshes on its own schedule and leaving completes the bar,
+            # so the frame carrying 40% has to be asked for here.
+            built[1].refresh()
+            rendered = buffer.getvalue()
+
+        # The name without patchright's parenthetical, and the percentage it
+        # reported. The bar itself is rich's business, not this test's.
+        assert "Chrome for Testing 149.0.7827.55" in rendered
+        assert "(playwright" not in rendered
+        assert "40%" in rendered
+
+    def test_lines_that_are_not_progress_survive(self, monkeypatch):
+        """A format change must cost the bar, never the message."""
+        from linkedin_mcp_server import bootstrap
+
+        buffer = self._terminal(monkeypatch)[0]
+
+        with bootstrap._cli_progress() as report:
+            report("Host system is missing dependencies to run browsers.")
+
+        assert "missing dependencies" in buffer.getvalue()
+
+    def test_a_second_artifact_gets_its_own_bar(self, monkeypatch):
+        """ffmpeg follows the browser; it must not rewind the finished bar."""
+        from linkedin_mcp_server import bootstrap
+
+        buffer = self._terminal(monkeypatch)[0]
+
+        with bootstrap._cli_progress() as report:
+            report("Downloading Chrome for Testing 149.0 (x) from https://a/b.zip")
+            report("|■■■■■■■■■|  100% of 171.0 MiB")
+            report("Downloading FFmpeg (playwright ffmpeg v1011) from https://a/c.zip")
+            report("|■        |  10% of 1.6 MiB")
+
+        rendered = buffer.getvalue()
+        assert "Chrome for Testing 149.0" in rendered
+        assert "FFmpeg" in rendered
+
+
+class _StdoutThatClaimsATerminal(io.StringIO):
+    """The screen the bar is drawn on, as far as the moving rule can tell.
+
+    A plain ``StringIO`` would stand in for a terminal that answers False to
+    ``isatty``, which no terminal does, and the rule would then read the double
+    rather than the case.
+    """
+
+    def isatty(self) -> bool:
+        return True
+
+
+class _StreamThatClaimsATerminal(io.TextIOWrapper):
+    """A real descriptor behind an ``isatty`` that answers True.
+
+    A pty in every respect the destination rule can read, without needing one:
+    it can name where it writes *and* it claims a terminal, which is the pair
+    that separates a proven destination from a guessed one.
+    """
+
+    def __init__(self, file):
+        super().__init__(open(file.fileno(), "wb", closefd=False))
+
+    def isatty(self) -> bool:
+        return True
+
+
+class TestWhereAStreamWrites:
+    """Two streams share a destination, or they demonstrably do not."""
+
+    def test_one_known_device_and_one_unknown_is_not_a_match(self, tmp_path):
+        """A wrapper that hides its descriptor may be a second pane.
+
+        Guessing yes there moves a handler's records out of the destination
+        the operator chose. Guessing no draws one record through the bar. Only
+        the first is unrecoverable, so an unknown is never a match.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        class _TerminalWithoutADescriptor(io.StringIO):
+            def isatty(self) -> bool:
+                return True
+
+            def fileno(self) -> int:
+                raise io.UnsupportedOperation("no descriptor here")
+
+        # Both claim a terminal, so the guess would say yes; one of them can
+        # prove where it writes and the other cannot, which is the pty and the
+        # second pane. Only the pair that proves it counts as a match.
+        with (tmp_path / "out.log").open("w") as file:
+            known = _StreamThatClaimsATerminal(file)
+            assert known.isatty() and known.fileno() >= 0
+            assert not bootstrap._same_destination(known, _TerminalWithoutADescriptor())
+
+    def test_two_streams_that_cannot_name_a_device_still_use_the_terminal_guess(self):
+        """Both unknown is where the old answer is still the best one."""
+        from linkedin_mcp_server import bootstrap
+
+        assert bootstrap._same_destination(
+            _StdoutThatClaimsATerminal(), _StdoutThatClaimsATerminal()
+        )
+        assert not bootstrap._same_destination(io.StringIO(), io.StringIO())
+
+    def test_a_windows_pipe_reports_no_device_at_all(self, monkeypatch, tmp_path):
+        """``(0, 0)`` is Windows saying nothing, not a device two pipes share.
+
+        Measured in ``Python/fileutils.c``: ``_Py_fstat_noraise`` zeroes the
+        whole struct and then fills in ``st_mode`` alone for ``FILE_TYPE_PIPE``
+        and ``FILE_TYPE_CHAR``. Read as an identity, every pipe on Windows is
+        the same pipe, and a console and a pipe are the same destination: which
+        is exactly the pairing ``2>errors.log`` produces. Patched here because
+        the platform that answers this way cannot run the suite.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        zeroed = os.stat_result((0o010600, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+        monkeypatch.setattr(bootstrap.os, "fstat", lambda fd: zeroed)
+
+        with (tmp_path / "a").open("w") as one, (tmp_path / "b").open("w") as other:
+            assert bootstrap._device_of(one) is None
+            # Neither claims a terminal, so the fallback cannot rescue it
+            # either, which is the answer a pipe and a console need.
+            assert not bootstrap._same_destination(one, other)
+
+
+class TestLogHandlersDuringTheBar:
+    """Log records must not be drawn through the live region."""
+
+    def _terminal(self, monkeypatch, file: IO[str] | None = None) -> None:
+        from linkedin_mcp_server import bootstrap
+
+        drawn_on = _StdoutThatClaimsATerminal() if file is None else file
+        quiet = bootstrap._ConsoleThatGoesQuiet
+        monkeypatch.setattr(
+            bootstrap,
+            "_ConsoleThatGoesQuiet",
+            lambda *a, **k: quiet(
+                file=drawn_on,
+                force_terminal=True,
+                width=100,
+                _environ={"TERM": "xterm-256color"},
+                **k,
+            ),
+        )
+
+    def test_a_stream_handler_is_moved_and_restored(self, monkeypatch):
+        """rich swaps the streams; a handler built earlier holds the old one.
+
+        Measured in a pty: without this, a DEBUG record emitted while the bar
+        is up ends up on the same physical line as the bar.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        self._terminal(monkeypatch)
+
+        # A stream that claims to be a terminal, because only those collide
+        # with the bar and only those are moved. Under pytest the real stderr
+        # is captured and reports False, which is the behaviour the sibling
+        # test relies on.
+        class _TerminalStream(io.StringIO):
+            def isatty(self) -> bool:
+                return True
+
+        terminal_stderr = _TerminalStream()
+        monkeypatch.setattr(sys, "stderr", terminal_stderr)
+        handler = logging.StreamHandler()  # binds sys.stderr, as logging does
+        root = logging.getLogger()
+        root.addHandler(handler)
+        try:
+            bound = handler.stream
+            with bootstrap._cli_progress():
+                assert handler.stream is not bound, (
+                    "the handler must follow rich's redirection"
+                )
+            assert handler.stream is bound, "and be put back"
+        finally:
+            root.removeHandler(handler)
+
+    def test_a_redirected_stderr_keeps_its_destination(self, monkeypatch):
+        """Moving it would take records out of the file and onto the screen.
+
+        rich's stderr proxy writes through the progress console, which is on
+        stdout. A handler whose stderr is a file cannot collide with the bar,
+        so it has nothing to gain and a destination to lose.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        self._terminal(monkeypatch)
+        redirected = io.StringIO()  # isatty() is False, as a file's is
+        monkeypatch.setattr(sys, "stderr", redirected)
+        handler = logging.StreamHandler()
+        root = logging.getLogger()
+        root.addHandler(handler)
+        try:
+            with bootstrap._cli_progress():
+                assert handler.stream is redirected
+        finally:
+            root.removeHandler(handler)
+
+    def test_a_forced_terminal_moves_a_handler_that_shares_the_file(
+        self, monkeypatch, tmp_path
+    ):
+        """``FORCE_COLOR=1 ... >build.log 2>&1``: rich draws into the file.
+
+        ``Console.is_terminal`` returns True on ``FORCE_COLOR`` or
+        ``TTY_COMPATIBLE=1`` without consulting the stream, which is how a CI
+        runner keeps colour through a redirect. Both streams then answer False
+        to ``isatty`` while the bar is live, and measured against that: the
+        record was written into the middle of a rendered frame.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        log = tmp_path / "build.log"
+        with log.open("w") as out, log.open("a") as err:
+            self._terminal(monkeypatch, file=out)
+            assert not err.isatty(), "the case is a redirect, not a terminal"
+            monkeypatch.setattr(sys, "stderr", err)
+            handler = logging.StreamHandler()
+            root = logging.getLogger()
+            root.addHandler(handler)
+            try:
+                with bootstrap._cli_progress():
+                    assert handler.stream is not err, (
+                        "a handler on the file the bar is drawn into must follow it"
+                    )
+                assert handler.stream is err, "and be put back"
+            finally:
+                root.removeHandler(handler)
+
+    def test_a_forced_terminal_leaves_a_handler_on_another_file_alone(
+        self, monkeypatch, tmp_path
+    ):
+        """The other half of the same rule: ``FORCE_COLOR=1 ... 2>errors.log``.
+
+        Forcing a terminal must not start moving handlers that write somewhere
+        else. Both proxies write through the progress console, so this one's
+        records would leave the file the operator named.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        with (tmp_path / "build.log").open("w") as out:
+            with (tmp_path / "errors.log").open("w") as err:
+                self._terminal(monkeypatch, file=out)
+                monkeypatch.setattr(sys, "stderr", err)
+                handler = logging.StreamHandler()
+                root = logging.getLogger()
+                root.addHandler(handler)
+                try:
+                    with bootstrap._cli_progress():
+                        assert handler.stream is err, (
+                            "a separate file keeps its records"
+                        )
+                finally:
+                    root.removeHandler(handler)
+
+    def test_a_separate_stderr_is_left_unredirected(self, monkeypatch, tmp_path):
+        """rich redirects both streams by default, wherever they point.
+
+        ``Progress`` defaults to ``redirect_stderr=True`` and ``Live`` acts on
+        it whenever the console claims a terminal, so under ``2>errors.log`` a
+        direct ``sys.stderr.write`` would come out on the bar's screen and the
+        file the operator named would stay empty. Measured against rich 15.0.0.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        with (tmp_path / "build.log").open("w") as out:
+            with (tmp_path / "errors.log").open("w") as err:
+                self._terminal(monkeypatch, file=out)
+                monkeypatch.setattr(sys, "stderr", err)
+                with bootstrap._cli_progress():
+                    assert sys.stderr is err, (
+                        "a stderr going somewhere else keeps going there"
+                    )
+
+    def test_a_shared_stderr_is_still_redirected(self, monkeypatch, tmp_path):
+        """The other half: ``>build.log 2>&1`` must keep rich's redirection.
+
+        Turning it off wholesale would put every direct write back through the
+        rendered frame, which is what the redirection exists to prevent.
+        """
+        from rich.file_proxy import FileProxy
+
+        from linkedin_mcp_server import bootstrap
+
+        log = tmp_path / "build.log"
+        with log.open("w") as out, log.open("a") as err:
+            self._terminal(monkeypatch, file=out)
+            monkeypatch.setattr(sys, "stderr", err)
+            with bootstrap._cli_progress():
+                assert isinstance(sys.stderr, FileProxy), (
+                    "writes to the bar's own file must go above it"
+                )
+
+    def test_a_handler_reconfigured_during_the_download_keeps_its_new_stream(
+        self, monkeypatch
+    ):
+        """Restoring is putting back what was taken, not overwriting a choice.
+
+        A host that calls ``setStream`` while the bar is up has named a newer
+        destination, and the stream captured on the way in may have been closed
+        along with the configuration that held it.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        self._terminal(monkeypatch)
+
+        class _TerminalStream(io.StringIO):
+            def isatty(self) -> bool:
+                return True
+
+        monkeypatch.setattr(sys, "stderr", _TerminalStream())
+        handler = logging.StreamHandler()
+        root = logging.getLogger()
+        root.addHandler(handler)
+        chosen_later = io.StringIO()
+        try:
+            with bootstrap._cli_progress():
+                assert handler.stream is not sys.__stderr__
+                handler.setStream(chosen_later)
+            assert handler.stream is chosen_later, (
+                "the newer configuration outlives the bar"
+            )
+        finally:
+            root.removeHandler(handler)
+
+    def test_an_isatty_that_raises_falls_back_to_plain_lines(self, monkeypatch):
+        """A detached pty answers ``EIO`` rather than True or False.
+
+        rich guards that call for ``ValueError`` alone (measured in 15.0.0), so
+        an ``OSError`` comes back out of the console. Not knowing whether there
+        is a terminal is the plain-line case; raising would take the whole
+        browser install with it.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        class _DetachedTerminal(io.StringIO):
+            def isatty(self) -> bool:
+                raise OSError(5, "Input/output error")
+
+        quiet = bootstrap._ConsoleThatGoesQuiet
+        monkeypatch.setattr(
+            bootstrap,
+            "_ConsoleThatGoesQuiet",
+            lambda *a, **k: quiet(file=_DetachedTerminal(), _environ={}, **k),
+        )
+        with bootstrap._cli_progress() as report:
+            assert report is bootstrap._print_whatever_the_stream_takes
+
+    def test_a_handler_on_stdout_stays_when_the_bar_is_drawn_elsewhere(
+        self, monkeypatch, tmp_path
+    ):
+        """The rule is the destination, and it is asked of both streams.
+
+        rich redirects stdout unconditionally while the bar is up, so this one
+        is decided here and nowhere else: a handler writing where the bar is
+        not must keep its own file, whichever of the two streams it holds.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        with (tmp_path / "bar.log").open("w") as drawn_on:
+            with (tmp_path / "records.log").open("w") as elsewhere:
+                self._terminal(monkeypatch, file=drawn_on)
+                monkeypatch.setattr(sys, "stdout", elsewhere)
+                handler = logging.StreamHandler(elsewhere)
+                root = logging.getLogger()
+                root.addHandler(handler)
+                try:
+                    with bootstrap._cli_progress():
+                        assert handler.stream is elsewhere, (
+                            "records keep the file they were pointed at"
+                        )
+                finally:
+                    root.removeHandler(handler)
+
+    def test_a_file_handler_is_left_alone(self, monkeypatch, tmp_path):
+        """Only handlers on the real streams move; the trace file keeps its own."""
+        from linkedin_mcp_server import bootstrap
+
+        self._terminal(monkeypatch)
+        handler = logging.FileHandler(tmp_path / "server.log")
+        root = logging.getLogger()
+        root.addHandler(handler)
+        try:
+            with bootstrap._cli_progress():
+                assert handler.stream is not sys.stderr
+        finally:
+            root.removeHandler(handler)
+            handler.close()
+
+
+class TestProgressWithoutPercentages:
+    """A mirror can suppress patchright's progress entirely."""
+
+    def _terminal(self, monkeypatch, term: str = "xterm-256color") -> list:
+        import io as _io
+
+        from rich.progress import Progress
+
+        from linkedin_mcp_server import bootstrap
+
+        buffer = _io.StringIO()
+        built: list = [buffer]
+        quiet = bootstrap._ConsoleThatGoesQuiet
+        monkeypatch.setattr(
+            bootstrap,
+            "_ConsoleThatGoesQuiet",
+            lambda *a, **k: quiet(
+                file=buffer,
+                force_terminal=True,
+                width=100,
+                _environ={"TERM": term},
+                **k,
+            ),
+        )
+
+        def record(*args: Any, **kwargs: Any) -> Progress:
+            progress = Progress(*args, **kwargs)
+            built.append(progress)
+            return progress
+
+        monkeypatch.setattr(bootstrap, "Progress", record)
+        return built
+
+    def test_a_bar_exists_before_any_output_arrives(self, monkeypatch):
+        """Patchright has configurations where it says nothing at all.
+
+        `npm_config_loglevel=warn` suppresses its announcements, a chunked
+        response suppresses its percentages, and it waits on the registry lock
+        for up to ten minutes in silence. A bar created on the first
+        recognised line leaves every one of those blank.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with bootstrap._cli_progress():
+            bars = list(built[1].tasks)
+            pulsing = [t.total for t in bars]
+
+        assert len(bars) == 1
+        assert pulsing == [None], "an unknown size pulses"
+        assert bars[0].finished, "and does not pulse on past the install"
+
+    def test_the_first_announcement_names_the_waiting_bar(self, monkeypatch):
+        """Rather than leaving an unnamed one behind and starting a second."""
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report("Downloading Chromium (v1) from https://a/b.zip")
+            bars = list(built[1].tasks)
+
+        assert len(bars) == 1
+        assert bars[0].description == "Chromium"
+
+    def test_a_chunked_download_still_gets_a_bar(self, monkeypatch):
+        """`Transfer-Encoding: chunked` makes patchright report no percentage.
+
+        Its reporter is guarded by `if (!chunked && reportProgress)`, so a bar
+        created on the first percentage would never be created at all, and the
+        download would run behind exactly the silence #533 is about.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report("Downloading Chromium (v1) from https://mirror/b.zip")
+            bars = list(built[1].tasks)
+            assert len(bars) == 1, "the bar must exist before any percentage"
+            assert bars[0].total is None, "an unknown size pulses"
+            report("Chromium (v1) downloaded to /tmp/chromium-1228")
+            assert built[1].tasks[0].finished, "the archive is in place"
+
+    def test_a_percentage_fills_in_the_size_afterwards(self, monkeypatch):
+        from linkedin_mcp_server import bootstrap
+
+        built = self._terminal(monkeypatch)
+        with bootstrap._cli_progress() as report:
+            report("Downloading Chromium (v1) from https://a/b.zip")
+            report("|  40% of 171.0 MiB")
+            task = built[1].tasks[0]
+            assert task.total == int(171.0 * 1024**2)
+            assert task.completed == int(task.total * 0.4)
+
+    @pytest.mark.parametrize("term", ["dumb", "unknown"])
+    def test_a_dumb_terminal_gets_the_lines_instead(self, monkeypatch, term):
+        """rich refuses to draw live there, and does not fall back either.
+
+        `Live.refresh` renders through `elif not self._started`, which is once,
+        on the way out. Sending a dumb terminal down the bar would show nothing
+        for the whole download.
+        """
+        from linkedin_mcp_server import bootstrap
+
+        self._terminal(monkeypatch, term=term)
+        with bootstrap._cli_progress() as report:
+            assert report is bootstrap._print_whatever_the_stream_takes
+
+
+class TestInstallerLinesAgainstARealPipe:
+    """The reader, against a real ``StreamReader`` rather than the fake above.
+
+    ``_FakeStdout`` is a claim about asyncio: that ``read(n)`` returns at most
+    *n* bytes and b"" at EOF. These run the same scenarios through an actual
+    subprocess pipe, so the fake cannot quietly drift from what asyncio does and
+    take the tests that rely on it along.
+    """
+
+    async def _collect(self, script: str) -> list[str]:
+        from linkedin_mcp_server.bootstrap import _installer_lines
+
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            script,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        assert proc.stdout is not None
+        pieces = [line async for line in _installer_lines(proc.stdout)]
+        await proc.wait()
+        return pieces
+
+    async def test_a_line_past_the_readline_limit_survives(self):
+        """The shape that raises ValueError when read through readline."""
+        pieces = await self._collect(
+            "import sys; sys.stdout.write('x' * 200_000 + chr(10))"
+        )
+        assert "".join(pieces) == "x" * 200_000
+
+    async def test_output_without_any_newline_survives(self):
+        pieces = await self._collect("import sys; sys.stdout.write('z' * 200_000)")
+        assert "".join(pieces) == "z" * 200_000
+
+    async def test_multibyte_characters_survive_the_read_boundaries(self):
+        """40 000 three-byte characters cannot align with 64 KiB reads."""
+        pieces = await self._collect(
+            "import sys; sys.stdout.write('■' * 40_000 + chr(10))"
+        )
+        assert "".join(pieces) == "■" * 40_000
+
+    async def test_ordinary_lines_come_out_one_by_one(self):
+        pieces = await self._collect("import sys; sys.stdout.write('a\\nb\\n\\nc\\n')")
+        assert pieces == ["a", "b", "", "c"]
+
+    async def test_a_lines_own_leading_whitespace_survives(self):
+        """Only the end of a line is trimmed. Patchright indents its output."""
+        pieces = await self._collect("import sys; sys.stdout.write('   indented  \\n')")
+        assert pieces == ["   indented"]
+
+
+class TestInstallCallbackThreading:
+    """Only the CLI path prints; the background path stays silent."""
+
+    def _capture_install(self, monkeypatch) -> dict[str, object]:
+        from linkedin_mcp_server import bootstrap
+
+        seen: dict[str, object] = {}
+
+        async def fake_install(extra_arg: str, *, line_callback=None) -> None:
+            seen["extra_arg"] = extra_arg
+            seen["line_callback"] = line_callback
+
+        monkeypatch.setattr(bootstrap, "_run_patchright_install", fake_install)
+        return seen
+
+    async def test_background_setup_forwards_no_callback(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        from linkedin_mcp_server import bootstrap
+
+        _patch_targets_and_version(monkeypatch)
+        seen = self._capture_install(monkeypatch)
+
+        await bootstrap._run_browser_setup()
+
+        assert seen["line_callback"] is None
+
+    async def test_setup_forwards_an_explicit_callback(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        from linkedin_mcp_server import bootstrap
+
+        _patch_targets_and_version(monkeypatch)
+        seen = self._capture_install(monkeypatch)
+
+        def sink(line: str) -> None:
+            pass
+
+        await bootstrap._run_browser_setup(line_callback=sink)
+
+        assert seen["line_callback"] is sink
+
+    def test_cli_install_passes_a_flushing_print(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        from linkedin_mcp_server import bootstrap
+
+        _patch_targets_and_version(monkeypatch)
+        monkeypatch.setattr(bootstrap, "_uses_custom_chrome", lambda: False)
+        monkeypatch.setattr(bootstrap, "browser_ready", lambda: False)
+
+        captured: dict[str, object] = {}
+
+        async def fake_ensure(*, line_callback=None) -> None:
+            captured["line_callback"] = line_callback
+
+        monkeypatch.setattr(bootstrap, "_ensure_browser_installed", fake_ensure)
+
+        bootstrap.ensure_browser_installed()
+
+        # Flushing, because block buffering of a redirected stdout would hold
+        # every line until exit, and tolerant of a stream that cannot encode
+        # patchright's bar glyph.
+        assert captured["line_callback"] is bootstrap._print_whatever_the_stream_takes
+
+    async def test_setup_logs_the_download_duration(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        from linkedin_mcp_server import bootstrap
+
+        _patch_targets_and_version(monkeypatch)
+        self._capture_install(monkeypatch)
+
+        with caplog.at_level(logging.INFO, logger="linkedin_mcp_server.bootstrap"):
+            await bootstrap._run_browser_setup()
+
+        assert any(
+            "browser setup completed in" in record.message for record in caplog.records
+        )
+
+
 class TestEnsureBrowserInstalledSkipsCustomChrome:
     """A custom executable must not trigger a managed download.
 
@@ -1185,7 +3054,7 @@ class TestEnsureBrowserInstalledSkipsCustomChrome:
 
         called = {"value": 0}
 
-        async def fake_install(**kwargs: object) -> None:
+        async def fake_install(**_kwargs: object) -> None:
             called["value"] += 1
 
         monkeypatch.setattr(
@@ -1208,7 +3077,7 @@ class TestEnsureBrowserInstalledSkipsCustomChrome:
 
         called = {"value": 0}
 
-        async def fake_install(**kwargs: object) -> None:
+        async def fake_install(**_kwargs: object) -> None:
             called["value"] += 1
 
         monkeypatch.setattr(
@@ -1238,7 +3107,7 @@ class TestEnsureBrowserInstalled:
     def _stub(self, monkeypatch):
         calls = {"value": 0}
 
-        async def fake_install(**kwargs: object) -> None:
+        async def fake_install(**_kwargs: object) -> None:
             calls["value"] += 1
 
         monkeypatch.setattr(
@@ -1282,6 +3151,53 @@ class TestEnsureBrowserInstalled:
 
         assert calls["value"] == 1
 
+    def test_a_gone_stdout_does_not_take_a_successful_install_with_it(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """``--install-browser | head`` must not turn a success into a traceback.
+
+        The bar's own console goes quiet on a broken pipe, but the three lines
+        around it are printed directly, and an unguarded one raises straight
+        out of the installer: measured, a browser that installed cleanly
+        reported ``BrokenPipeError`` instead of "Browser installed."
+        """
+        _patch_targets_and_version(monkeypatch)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap.browser_ready", lambda: False
+        )
+        calls = self._stub(monkeypatch)
+        monkeypatch.setattr("sys.stdout", _StdoutThatIsGone())
+
+        ensure_browser_installed()
+
+        assert calls["value"] == 1
+
+    def test_a_gone_stdout_does_not_mask_why_the_install_failed(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """The failure line is on the same pipe, and it is printed first.
+
+        Raising from it would replace the error that says what went wrong with
+        one that says only that nobody was listening.
+        """
+        _patch_targets_and_version(monkeypatch)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap.browser_ready", lambda: False
+        )
+
+        from linkedin_mcp_server.exceptions import BrowserSetupFailedError
+
+        async def fake_install(**_kwargs: object) -> None:
+            raise BrowserSetupFailedError("the mirror refused")
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._ensure_browser_installed", fake_install
+        )
+        monkeypatch.setattr("sys.stdout", _StdoutThatIsGone())
+
+        with pytest.raises(BrowserSetupFailedError, match="the mirror refused"):
+            ensure_browser_installed()
+
 
 class TestLoginInstallBackstop:
     """The headed manual-login fallback installs full chromium before launching."""
@@ -1289,7 +3205,7 @@ class TestLoginInstallBackstop:
     def _stub(self, monkeypatch, *, custom_chrome: bool):
         order: list[str] = []
 
-        async def fake_full(**kwargs: object) -> None:
+        async def fake_full(**_kwargs: object) -> None:
             order.append("full")
 
         async def fake_login(_profile_dir, *, superseded_by=None) -> bool:

--- a/uv.lock
+++ b/uv.lock
@@ -1049,6 +1049,7 @@ dependencies = [
     { name = "packaging" },
     { name = "patchright" },
     { name = "python-dotenv" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -1071,6 +1072,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=26.2" },
     { name = "patchright", specifier = ">=1.55.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "rich", specifier = ">=15.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Instead of silently capturing subprocess output and discarding it, patchright install progress is now streamed line-by-line to logger.debug. This lets users see download progress (MB downloaded, percentage) when running with --log-level DEBUG.

CLI modes (--login, --status, --import-from-browser) additionally get live output via print() so the user is never left staring at a blank line.

The background task completion handler (_refresh_background_task_state) now logs the elapsed time, giving operators a clear signal that setup finished.

Fixes #533
