### PR TITLE
fix(references): keep non-Latin reference labels

### DIFF
--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -322,7 +322,13 @@ def choose_reference_text(
 
 
 def clean_label(value: str, kind: ReferenceKind) -> str | None:
-    """Normalize and compact a candidate label."""
+    """Normalize and compact a candidate label.
+
+    A label must contain at least one letter or digit in any script —
+    ``[^\\W_]`` matches a Unicode word character that is not an
+    underscore, so Cyrillic (and other non-Latin) profile names survive
+    while punctuation-only strings are rejected.
+    """
     value = _WHITESPACE_RE.sub(" ", value).strip()
     if not value:
         return None
@@ -358,7 +364,7 @@ def clean_label(value: str, kind: ReferenceKind) -> str | None:
         return None
     if len(value) > 80:
         return None
-    if not re.search(r"[A-Za-z0-9]", value):
+    if not re.search(r"[^\W_]", value):
         return None
 
     return value

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -107,6 +107,15 @@ _REFERENCE_CAPS = {
     "feed": 50,
 }
 
+# A label must carry at least one letter or digit in any script, so the class is
+# Unicode-aware rather than ``[A-Za-z0-9]`` — otherwise every reference on a
+# Cyrillic, CJK or Arabic-script profile is dropped. The four Hangul fillers are
+# excluded because they carry the word property while rendering as nothing: a
+# label made only of them would pass as valid and yield an invisible reference
+# text, shadowing the aria-label fallback. They are the only invisible code
+# points in ``[^\W_]`` (verified by scanning the full Unicode range).
+_LABEL_CONTENT_RE = re.compile("[^\\W_\u115f\u1160\u3164\uffa0]")
+
 _URL_LIKE_RE = re.compile(r"^(?:https?://|/)\S+$", re.IGNORECASE)
 _DUPLICATE_HALVES_RE = re.compile(r"^(?P<value>.+?)\s+(?P=value)$")
 _WHITESPACE_RE = re.compile(r"\s+")
@@ -324,10 +333,9 @@ def choose_reference_text(
 def clean_label(value: str, kind: ReferenceKind) -> str | None:
     """Normalize and compact a candidate label.
 
-    A label must contain at least one letter or digit in any script —
-    ``[^\\W_]`` matches a Unicode word character that is not an
-    underscore, so Cyrillic (and other non-Latin) profile names survive
-    while punctuation-only strings are rejected.
+    Rejects the label when nothing visible survives normalization, so
+    non-Latin names are kept while punctuation-only strings are dropped.
+    See ``_LABEL_CONTENT_RE``.
     """
     value = _WHITESPACE_RE.sub(" ", value).strip()
     if not value:
@@ -364,7 +372,7 @@ def clean_label(value: str, kind: ReferenceKind) -> str | None:
         return None
     if len(value) > 80:
         return None
-    if not re.search(r"[^\W_]", value):
+    if not _LABEL_CONTENT_RE.search(value):
         return None
 
     return value

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -257,6 +257,53 @@ class TestBuildReferences:
             }
         ]
 
+    def test_keeps_cyrillic_only_names(self):
+        """Regression: a non-Latin (Cyrillic) name must survive label
+        cleaning — the alphanumeric guard uses a Unicode word check, not
+        [A-Za-z0-9], so search results from RU/BY/other locales keep
+        their person references instead of being dropped."""
+        references = build_references(
+            [
+                {
+                    "href": "https://www.linkedin.com/in/margo-yunanova/",
+                    "text": "Маргарита Юнанова",
+                }
+            ],
+            "search_results",
+        )
+
+        assert references == [
+            {
+                "kind": "person",
+                "url": "/in/margo-yunanova/",
+                "text": "Маргарита Юнанова",
+                "context": "search result",
+            }
+        ]
+
+    def test_rejects_punctuation_only_labels_across_scripts(self):
+        """The Unicode word guard must still reject pure punctuation and
+        symbols (no letter or digit in any script)."""
+        references = build_references(
+            [
+                {
+                    "href": "https://www.linkedin.com/in/williamhgates/",
+                    "text": "—·—",
+                    "aria_label": "Bill Gates",
+                }
+            ],
+            "main_profile",
+        )
+
+        assert references == [
+            {
+                "kind": "person",
+                "url": "/in/williamhgates/",
+                "text": "Bill Gates",
+                "context": "top card",
+            }
+        ]
+
     def test_preserves_words_starting_with_view(self):
         references = build_references(
             [

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -304,6 +304,30 @@ class TestBuildReferences:
             }
         ]
 
+    def test_rejects_invisible_hangul_filler_labels(self):
+        """Hangul fillers carry the Unicode word property but render as
+        nothing, so a label made only of them must not shadow the
+        aria-label fallback with invisible text."""
+        references = build_references(
+            [
+                {
+                    "href": "https://www.linkedin.com/in/williamhgates/",
+                    "text": "\u115f\u1160\u3164\uffa0",
+                    "aria_label": "Bill Gates",
+                }
+            ],
+            "main_profile",
+        )
+
+        assert references == [
+            {
+                "kind": "person",
+                "url": "/in/williamhgates/",
+                "text": "Bill Gates",
+                "context": "top card",
+            }
+        ]
+
     def test_preserves_words_starting_with_view(self):
         references = build_references(
             [


### PR DESCRIPTION
## What

`clean_label` rejected any reference label without an ASCII alphanumeric
character (`[A-Za-z0-9]`), so Cyrillic and other non-Latin profile names —
common in RU/BY and other locales' people-search results — were silently
dropped. Relax the guard to the Unicode word-character check `[^\W_]`: a label
is kept when it has at least one letter or digit in any script, while pure
punctuation/symbol labels are still rejected.

## Tests

- `test_keeps_cyrillic_only_names` — a Cyrillic-only name survives cleaning.
- `test_rejects_punctuation_only_labels_across_scripts` — punctuation-only
  labels are still dropped.

## Synthetic prompt

> In `link_metadata.clean_label`, the `[A-Za-z0-9]` guard drops valid non-Latin
> (e.g. Cyrillic) profile names. Relax it to a Unicode word-character check so
> any-script letters/digits pass while punctuation-only labels stay rejected.
> Add regression tests.
