### PR TITLE
fix(navigation): auto-recover from LinkedIn cookie redirect loops

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -786,8 +786,22 @@ class LinkedInExtractor:
         *,
         wait_until: WaitUntil = "domcontentloaded",
         allow_remember_me: bool = True,
+        allow_redirect_loop_recovery: bool = True,
     ) -> None:
-        """Navigate to a LinkedIn page and fail fast on auth barriers."""
+        """Navigate to a LinkedIn page and fail fast on auth barriers.
+
+        A ``net::ERR_TOO_MANY_REDIRECTS`` navigation failure is treated as a
+        stale/corrupt LinkedIn cookie state (login <-> checkpoint loop): the
+        live context's cookies and the persisted auth artifacts are cleared
+        automatically — so a server restart does not re-seed the broken
+        state — and the navigation is retried once. The retry then lands on
+        a logged-out page, the auth-barrier check raises
+        AuthenticationError, and the interactive re-login flow takes over —
+        no manual profile cleanup needed. Artifact cleanup is best-effort
+        per target: even if the live profile directory cannot be fully
+        removed (locked files on Windows), dropping ``source-state.json``
+        alone forces the interactive re-login on the next start.
+        """
         hops: list[str] = []
         listener_registered = False
 
@@ -822,6 +836,58 @@ class LinkedInExtractor:
                     extra={"target_url": url, "wait_until": wait_until},
                 )
             except Exception as exc:
+                if allow_redirect_loop_recovery and "ERR_TOO_MANY_REDIRECTS" in str(
+                    exc
+                ):
+                    logger.warning(
+                        "Redirect loop navigating to %s — clearing browser "
+                        "cookies and persisted auth state, then retrying once "
+                        "(stale/corrupt LinkedIn session state).",
+                        url,
+                    )
+                    try:
+                        await record_page_trace(
+                            self._page,
+                            "extractor-redirect-loop-recovery",
+                            extra={"target_url": url, "hops": hops},
+                        )
+                    except Exception:
+                        logger.debug(
+                            "record_page_trace during redirect-loop recovery failed",
+                            exc_info=True,
+                        )
+                    try:
+                        await self._page.context.clear_cookies()
+                    except Exception:
+                        logger.debug(
+                            "clear_cookies during redirect-loop recovery failed",
+                            exc_info=True,
+                        )
+                    try:
+                        from linkedin_mcp_server.session_state import (
+                            clear_auth_state,
+                        )
+
+                        if not clear_auth_state():
+                            logger.warning(
+                                "Some persisted auth artifacts could not be "
+                                "removed during redirect-loop recovery; if the "
+                                "loop returns after a restart, delete "
+                                "~/.linkedin-mcp/profile manually."
+                            )
+                    except Exception:
+                        logger.debug(
+                            "clear_auth_state during redirect-loop recovery failed",
+                            exc_info=True,
+                        )
+                    unregister_navigation_listener()
+                    await self._goto_with_auth_checks(
+                        url,
+                        wait_until=wait_until,
+                        allow_remember_me=allow_remember_me,
+                        allow_redirect_loop_recovery=False,
+                    )
+                    return
                 if allow_remember_me and await resolve_remember_me_prompt(self._page):
                     await stabilize_navigation(
                         f"remember-me resolution for {url}", logger
@@ -849,6 +915,7 @@ class LinkedInExtractor:
                         url,
                         wait_until=wait_until,
                         allow_remember_me=False,
+                        allow_redirect_loop_recovery=allow_redirect_loop_recovery,
                     )
                     return
                 await record_page_trace(
@@ -881,6 +948,7 @@ class LinkedInExtractor:
                     url,
                     wait_until=wait_until,
                     allow_remember_me=False,
+                    allow_redirect_loop_recovery=allow_redirect_loop_recovery,
                 )
                 return
 

--- a/tests/test_redirect_loop_recovery.py
+++ b/tests/test_redirect_loop_recovery.py
@@ -1,0 +1,226 @@
+"""Redirect-loop recovery in extractor navigation.
+
+A ``net::ERR_TOO_MANY_REDIRECTS`` failure means LinkedIn is bouncing the
+session between login/checkpoint — a stale or corrupt cookie state. The
+extractor must recover autonomously: clear the live context's cookies,
+drop persisted auth artifacts, and retry the navigation once so the
+existing auth-barrier flow can raise AuthenticationError and hand off to
+the interactive re-login. Without this, users had to quit the client and
+delete ~/.linkedin-mcp/profile manually.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+
+
+class _FakeFrame:
+    url = "https://www.linkedin.com/"
+
+
+class _FakePage:
+    """Page whose goto redirect-loops once, then succeeds."""
+
+    def __init__(self, failures: int = 1) -> None:
+        self._failures = failures
+        self.goto_calls: list[str] = []
+        self.main_frame = _FakeFrame()
+        self.context = SimpleNamespace(clear_cookies=AsyncMock())
+
+    def on(self, *_args) -> None:
+        """Accept framenavigated listener registration."""
+
+    def remove_listener(self, *_args) -> None:
+        pass
+
+    async def goto(self, url: str, **_kwargs) -> None:
+        self.goto_calls.append(url)
+        if self._failures > 0:
+            self._failures -= 1
+            raise RuntimeError("Page.goto: net::ERR_TOO_MANY_REDIRECTS at " + url)
+
+
+class _ScriptedPage(_FakePage):
+    """Page whose goto follows a scripted list of outcomes."""
+
+    def __init__(self, outcomes: list[str]) -> None:
+        super().__init__(failures=0)
+        self._outcomes = outcomes
+
+    async def goto(self, url: str, **_kwargs) -> None:
+        self.goto_calls.append(url)
+        outcome = self._outcomes.pop(0) if self._outcomes else "ok"
+        if outcome == "loop":
+            raise RuntimeError("Page.goto: net::ERR_TOO_MANY_REDIRECTS at " + url)
+
+
+def _make_extractor(page: _FakePage) -> LinkedInExtractor:
+    extractor = LinkedInExtractor.__new__(LinkedInExtractor)
+    extractor._page = page
+    return extractor
+
+
+@pytest.fixture()
+def nav_env():
+    """Neutralize tracing/stabilization and observe auth-state clearing."""
+    with (
+        patch(
+            "linkedin_mcp_server.scraping.extractor.record_page_trace",
+            new=AsyncMock(),
+        ),
+        patch(
+            "linkedin_mcp_server.scraping.extractor.stabilize_navigation",
+            new=AsyncMock(),
+        ),
+        patch(
+            "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "linkedin_mcp_server.session_state.clear_auth_state",
+            return_value=True,
+        ) as clear_auth,
+    ):
+        yield clear_auth
+
+
+class TestRedirectLoopRecovery:
+    async def test_clears_state_and_retries_once(self, nav_env):
+        """One redirect loop clears auth state and retries exactly once:
+        two goto calls — the original attempt plus one retry."""
+        page = _FakePage(failures=1)
+        extractor = _make_extractor(page)
+
+        await extractor._goto_with_auth_checks("https://www.linkedin.com/feed/")
+
+        assert len(page.goto_calls) == 2
+        page.context.clear_cookies.assert_awaited_once()
+        nav_env.assert_called_once()
+
+    async def test_persistent_loop_propagates_after_single_recovery(self, nav_env):
+        """Recovery must not retry endlessly: a second consecutive loop is
+        a real failure (e.g. LinkedIn soft-flag) and propagates to the
+        caller."""
+        page = _FakePage(failures=2)
+        extractor = _make_extractor(page)
+
+        with (
+            patch.object(
+                LinkedInExtractor,
+                "_log_navigation_failure",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                LinkedInExtractor,
+                "_raise_if_auth_barrier",
+                new=AsyncMock(),
+            ),
+            pytest.raises(RuntimeError, match="ERR_TOO_MANY_REDIRECTS"),
+        ):
+            await extractor._goto_with_auth_checks("https://www.linkedin.com/feed/")
+
+        assert len(page.goto_calls) == 2
+        page.context.clear_cookies.assert_awaited_once()
+        nav_env.assert_called_once()
+
+    async def test_remember_me_retry_does_not_rearm_recovery(self, nav_env):
+        """A remember-me retry on the error path must not re-arm redirect
+        loop recovery: with the prompt still resolvable from the stale DOM,
+        two consecutive loops clear auth state exactly once and the third
+        goto failure propagates instead of triggering a second cleanup."""
+        page = _FakePage(failures=3)
+        extractor = _make_extractor(page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(
+                LinkedInExtractor,
+                "_log_navigation_failure",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                LinkedInExtractor,
+                "_raise_if_auth_barrier",
+                new=AsyncMock(),
+            ),
+            pytest.raises(RuntimeError, match="ERR_TOO_MANY_REDIRECTS"),
+        ):
+            await extractor._goto_with_auth_checks("https://www.linkedin.com/feed/")
+
+        assert len(page.goto_calls) == 3
+        page.context.clear_cookies.assert_awaited_once()
+        nav_env.assert_called_once()
+
+    async def test_barrier_retry_after_recovery_does_not_rearm_recovery(self, nav_env):
+        """When the recovery retry lands on an auth barrier and remember-me
+        resolves it, the follow-up navigation must not re-arm recovery: a
+        redirect loop there propagates instead of wiping the freshly
+        selected session with a second cleanup."""
+        page = _ScriptedPage(["loop", "ok", "loop"])
+        extractor = _make_extractor(page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick",
+                new=AsyncMock(return_value="login page"),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(
+                LinkedInExtractor,
+                "_log_navigation_failure",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                LinkedInExtractor,
+                "_raise_if_auth_barrier",
+                new=AsyncMock(),
+            ),
+            pytest.raises(RuntimeError, match="ERR_TOO_MANY_REDIRECTS"),
+        ):
+            await extractor._goto_with_auth_checks("https://www.linkedin.com/feed/")
+
+        assert len(page.goto_calls) == 3
+        page.context.clear_cookies.assert_awaited_once()
+        nav_env.assert_called_once()
+
+    async def test_other_navigation_errors_do_not_touch_auth_state(self, nav_env):
+        page = _FakePage(failures=1)
+
+        async def goto(url, **_kwargs):
+            page.goto_calls.append(url)
+            raise RuntimeError("Page.goto: net::ERR_NAME_NOT_RESOLVED")
+
+        page.goto = goto  # ty: ignore[invalid-assignment]
+        extractor = _make_extractor(page)
+
+        with (
+            patch.object(
+                LinkedInExtractor,
+                "_log_navigation_failure",
+                new=AsyncMock(),
+            ),
+            patch.object(
+                LinkedInExtractor,
+                "_raise_if_auth_barrier",
+                new=AsyncMock(),
+            ),
+            pytest.raises(RuntimeError, match="ERR_NAME_NOT_RESOLVED"),
+        ):
+            await extractor._goto_with_auth_checks("https://www.linkedin.com/feed/")
+
+        assert len(page.goto_calls) == 1
+        page.context.clear_cookies.assert_not_awaited()
+        nav_env.assert_not_called()

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -224,7 +224,7 @@ class TestExtractPage:
         assert result.error == {"issue_template_path": "/tmp/issue.md"}
 
     async def test_extract_page_raises_auth_error_for_account_picker(self, mock_page):
-        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_TOO_MANY_REDIRECTS"))
+        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_NAME_NOT_RESOLVED"))
         extractor = LinkedInExtractor(mock_page)
 
         with (
@@ -404,7 +404,7 @@ class TestNavigationDiagnostics:
 
         async def goto_side_effect(*args, **kwargs):
             if mock_page.goto.await_count == 1:
-                raise Exception("net::ERR_TOO_MANY_REDIRECTS")
+                raise Exception("net::ERR_NAME_NOT_RESOLVED")
             return None
 
         mock_page.goto = AsyncMock(side_effect=goto_side_effect)
@@ -472,7 +472,7 @@ class TestNavigationDiagnostics:
         extractor = LinkedInExtractor(mock_page)
         mock_page.goto = AsyncMock(
             side_effect=[
-                Exception("net::ERR_TOO_MANY_REDIRECTS"),
+                Exception("net::ERR_NAME_NOT_RESOLVED"),
                 Exception("retry failed"),
             ]
         )
@@ -508,12 +508,12 @@ class TestNavigationDiagnostics:
         )
         assert (
             trace_call.kwargs["extra"]["error"]
-            == "Exception: net::ERR_TOO_MANY_REDIRECTS"
+            == "Exception: net::ERR_NAME_NOT_RESOLVED"
         )
 
     async def test_goto_with_auth_checks_logs_failure_context(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_TOO_MANY_REDIRECTS"))
+        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_NAME_NOT_RESOLVED"))
 
         with (
             patch(
@@ -531,7 +531,7 @@ class TestNavigationDiagnostics:
                 "_log_navigation_failure",
                 new_callable=AsyncMock,
             ) as mock_log_failure,
-            pytest.raises(Exception, match="ERR_TOO_MANY_REDIRECTS"),
+            pytest.raises(Exception, match="ERR_NAME_NOT_RESOLVED"),
         ):
             await extractor._goto_with_auth_checks(
                 "https://www.linkedin.com/in/testuser/"


### PR DESCRIPTION
## What

When LinkedIn falls into a login <-> checkpoint redirect loop from a
stale/corrupt cookie state, navigation fails with
`net::ERR_TOO_MANY_REDIRECTS` and every tool call errors until the profile is
manually wiped. This adds one-shot automatic recovery to
`_goto_with_auth_checks`: on `ERR_TOO_MANY_REDIRECTS` it clears the live
context cookies and the persisted auth artifacts (`clear_auth_state`), then
retries the navigation once. The retry lands logged-out, the auth-barrier
check raises `AuthenticationError`, and the normal interactive re-login flow
takes over — no manual cleanup.

Recovery is guarded by `allow_redirect_loop_recovery` (set False on the retry
and propagated through the remember-me retry on the error path) so it can
never loop itself and cannot be re-armed mid-recovery. A page trace is
recorded before recovery for diagnostics; a trace failure cannot abort the
recovery itself.

## Scope

Only extractor navigation is covered. The startup warmup path
(`_feed_auth_succeeds` in `drivers/browser.py`) still surfaces a redirect
loop as `AuthenticationError` without auto-clearing state — extending
recovery there is deliberately left out of this PR to keep the change
contained to `_goto_with_auth_checks`.

## Tests

`tests/test_redirect_loop_recovery.py` covers: recovery clears cookies + auth
state and retries once; the retry does not recurse; a remember-me retry on
the error path does not re-arm recovery (state is cleared exactly once across
consecutive loops); non-redirect errors are unaffected.

## Synthetic prompt

> Make `_goto_with_auth_checks` auto-recover from LinkedIn
> `net::ERR_TOO_MANY_REDIRECTS` login/checkpoint loops: on that error clear the
> browser context cookies and persisted auth state, then retry the navigation
> exactly once (guarded so it can't recurse or be re-armed via the remember-me
> retry path) so the interactive re-login flow can take over. Add tests.
