### PR TITLE
feat(search): add geoUrn facet and coerce stringified list filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `search_companies` | Search for companies on LinkedIn by keywords | working |
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter | working |
 | `search_jobs` | Search for jobs with keywords and location filters | working |
-| `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | working |
+| `search_people` | Search for people by keywords, location (free text or reliable geo URN facet), connection degree (1st/2nd/3rd), and current company | working |
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `close_session` | Close browser session and clean up resources | working |

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3244,6 +3244,7 @@ class LinkedInExtractor:
         keywords: str,
         location: str | None = None,
         network: list[str] | None = None,
+        geo_urn: list[str] | None = None,
         current_company: str | None = None,
     ) -> dict[str, Any]:
         """Search for people and extract the results page.
@@ -3255,6 +3256,11 @@ class LinkedInExtractor:
                 ``"F"`` (1st-degree), ``"S"`` (2nd-degree), ``"O"`` (3rd-degree
                 and beyond). Example: ``["F"]`` to only return 1st-degree
                 connections. Invalid tokens raise ``ValueError``.
+            geo_urn: Optional location facet filter — numeric LinkedIn geo
+                URN ids (e.g. ``["101728296"]`` for Russia). This is the
+                facet LinkedIn's own UI uses and it filters reliably, unlike
+                the free-text ``location`` parameter. Non-numeric values
+                raise ``FilterValidationError``.
             current_company: Optional current-employer filter. LinkedIn's
                 ``currentCompany`` facet only filters on the numeric company
                 URN id (e.g. ``"1115"`` for SAP); plain company names are
@@ -3282,11 +3288,23 @@ class LinkedInExtractor:
                 f'URN via get_company_profile -> references["about"].'
             )
 
+        if geo_urn:
+            invalid = [g for g in geo_urn if not re.fullmatch(r"[0-9]+", g)]
+            if invalid:
+                raise FilterValidationError(
+                    f"geo_urn values must be numeric LinkedIn geo URN ids "
+                    f"(e.g. '101728296'); got {invalid!r}. Find the id by "
+                    f"applying the Locations filter in a linkedin.com people "
+                    f"search and copying geoUrn from the result URL."
+                )
+
         params = f"keywords={quote_plus(keywords)}"
         if location:
             params += f"&location={quote_plus(location)}"
         if network:
             params += f"&network={_encode_list_facet(network)}"
+        if geo_urn:
+            params += f"&geoUrn={_encode_list_facet(geo_urn)}"
         if current_company:
             params += f"&currentCompany={_encode_list_facet([current_company])}"
 

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -5,6 +5,7 @@ Uses innerText extraction for resilient profile data capture
 with configurable section selection.
 """
 
+import json
 import logging
 from typing import Annotated, Any
 
@@ -21,6 +22,28 @@ from linkedin_mcp_server.scraping import parse_person_sections
 from linkedin_mcp_server.scraping.extractor import FilterValidationError
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_str_list(value: list[str] | str | None) -> list[str] | None:
+    """Coerce a list-valued tool argument that a client sent as a string.
+
+    Some MCP clients flatten ``list[str] | None`` parameters to plain
+    strings (e.g. '["F"]' or "F" or "F,S"). Accept JSON-array strings,
+    comma-separated strings, and bare tokens; pass lists through unchanged.
+    """
+    if value is None or isinstance(value, list):
+        return value
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if stripped.startswith("["):
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed]
+    return [token.strip() for token in stripped.split(",") if token.strip()]
 
 
 def register_person_tools(
@@ -112,7 +135,8 @@ def register_person_tools(
         keywords: str,
         ctx: Context,
         location: str | None = None,
-        network: list[str] | None = None,
+        network: list[str] | str | None = None,
+        geo_urn: list[str] | str | None = None,
         current_company: str | None = None,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
@@ -122,10 +146,24 @@ def register_person_tools(
         Args:
             keywords: Search keywords (e.g., "software engineer", "recruiter at Google")
             ctx: FastMCP context for progress reporting
-            location: Optional location filter (e.g., "New York", "Remote")
+            location: Optional free-text location filter. WARNING: LinkedIn
+                frequently ignores this plain URL parameter and returns
+                unfiltered results. For reliable location filtering use
+                geo_urn instead.
             network: Optional connection-degree filter. Each element is one of
                 "F" (1st-degree), "S" (2nd-degree), "O" (3rd-degree and beyond).
                 Example: ["F"] to only return 1st-degree connections.
+                Also accepts a JSON-array string ('["F"]') or comma-separated
+                string ("F,S") for clients that flatten list parameters.
+            geo_urn: Optional location facet filter — a list of numeric
+                LinkedIn geo URN ids (e.g. ["101728296"] for Russia,
+                ["101705918"] for Belarus). This is the facet LinkedIn's own
+                UI uses and it filters reliably, unlike the location text
+                parameter. To find an id: run a people search on
+                linkedin.com, apply the Locations filter in the UI, and copy
+                the geoUrn value from the result URL. Also accepts a
+                JSON-array or comma-separated string. Verify the first page
+                of results looks right before acting on them.
             current_company: Optional current-employer filter. LinkedIn's
                 currentCompany facet only filters on the numeric company URN id
                 (e.g. "1115" for SAP); plain company names are accepted by the
@@ -143,11 +181,15 @@ def register_person_tools(
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="search_people"
             )
+            network = _coerce_str_list(network)
+            geo_urn = _coerce_str_list(geo_urn)
             logger.info(
-                "Searching people: keywords='%s', location='%s', network=%s, current_company='%s'",
+                "Searching people: keywords='%s', location='%s', network=%s, "
+                "geo_urn=%s, current_company='%s'",
                 keywords,
                 location,
                 network,
+                geo_urn,
                 current_company,
             )
 
@@ -160,6 +202,7 @@ def register_person_tools(
                     keywords,
                     location,
                     network=network,
+                    geo_urn=geo_urn,
                     current_company=current_company,
                 )
             except FilterValidationError as e:

--- a/manifest.json
+++ b/manifest.json
@@ -85,7 +85,7 @@
     },
     {
       "name": "search_people",
-      "description": "Search for people on LinkedIn by keywords, location, connection degree (1st/2nd/3rd), and current company"
+      "description": "Search for people on LinkedIn by keywords, location (free text or reliable geo URN facet), connection degree (1st/2nd/3rd), and current company"
     },
     {
       "name": "get_inbox",

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2706,6 +2706,44 @@ class TestSearchJobs:
         assert "network=%5B%22F%22%5D" in result["url"]
         assert "currentCompany=%5B%221115%22%5D" in result["url"]
 
+    async def test_search_people_geo_urn_filter(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("Jane Doe"),
+        ):
+            result = await extractor.search_people("engineer", geo_urn=["101728296"])
+
+        assert "geoUrn=%5B%22101728296%22%5D" in result["url"]
+
+    async def test_search_people_geo_urn_multi(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("Jane Doe"),
+        ):
+            result = await extractor.search_people(
+                "engineer", geo_urn=["101728296", "102257491"]
+            )
+
+        assert "geoUrn=%5B%22101728296%22%2C%22102257491%22%5D" in result["url"]
+
+    async def test_search_people_rejects_non_numeric_geo_urn(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with pytest.raises(ValueError, match="numeric LinkedIn geo URN"):
+            await extractor.search_people("engineer", geo_urn=["abc"])
+
+    async def test_search_people_rejects_unicode_digit_geo_urn(self, mock_page):
+        """geoUrn ids are ASCII decimal; reject Unicode digits that
+        ``str.isdigit()`` would otherwise accept."""
+        extractor = LinkedInExtractor(mock_page)
+        with pytest.raises(ValueError, match="numeric LinkedIn geo URN"):
+            await extractor.search_people("engineer", geo_urn=["١٠١"])
+
 
 class TestStripLinkedInNoise:
     def test_strips_footer(self):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -43,6 +43,35 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     return mock
 
 
+class TestCoerceStrList:
+    """Unit coverage for every branch of ``tools.person._coerce_str_list``."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (None, None),
+            (["F", "S"], ["F", "S"]),
+            ("", None),
+            ("   ", None),
+            ('["F"]', ["F"]),
+            ('["F", "S"]', ["F", "S"]),
+            ("[101728296]", ["101728296"]),
+            ("F,S", ["F", "S"]),
+            ("F, S", ["F", "S"]),
+            ("101728296", ["101728296"]),
+            ("[not json", ["[not json"]),
+        ],
+    )
+    def test_coerces_all_input_shapes(
+        self,
+        value: list[str] | str | None,
+        expected: list[str] | None,
+    ):
+        from linkedin_mcp_server.tools.person import _coerce_str_list
+
+        assert _coerce_str_list(value) == expected
+
+
 class TestPersonTool:
     async def test_get_person_profile_success(self, mock_context):
         expected = {
@@ -262,6 +291,7 @@ class TestPersonTool:
             "AI engineer",
             "New York",
             network=None,
+            geo_urn=None,
             current_company=None,
         )
 
@@ -296,7 +326,41 @@ class TestPersonTool:
             "engineer",
             None,
             network=["F"],
+            geo_urn=None,
             current_company="1115",
+        )
+
+    async def test_search_people_coerces_stringified_list_filters(self, mock_context):
+        """MCP clients that flatten list params send network / geo_urn as
+        strings; the tool must coerce them before calling the extractor."""
+        expected = {
+            "url": (
+                "https://www.linkedin.com/search/results/people/"
+                "?keywords=&network=%5B%22F%22%5D&geoUrn=%5B%22101728296%22%5D"
+            ),
+            "sections": {"search_results": "Someone\n1st"},
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.person import register_person_tools
+
+        mcp = FastMCP("test")
+        register_person_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "search_people")
+        await tool_fn(
+            "",
+            mock_context,
+            network='["F"]',
+            geo_urn="101728296",
+            extractor=mock_extractor,
+        )
+        mock_extractor.search_people.assert_awaited_once_with(
+            "",
+            None,
+            network=["F"],
+            geo_urn=["101728296"],
+            current_company=None,
         )
 
     async def test_search_people_validation_error_surfaced_as_tool_error(


### PR DESCRIPTION
## What

Add a `geo_urn` facet filter to `search_people`: a list of numeric LinkedIn
geo URN ids (e.g. `["101728296"]` for Russia). This is the facet LinkedIn's
own UI uses and it filters reliably, unlike the free-text `location`
parameter, which LinkedIn frequently ignores.

Also coerce list-valued tool arguments that some MCP clients flatten to
strings: `network` and `geo_urn` now accept JSON-array strings (`'["F"]'`),
comma-separated strings (`"F,S"`), and bare tokens, in addition to real lists.

## Tests

geoUrn URL construction / validation and the string-coercion cases in
`test_scraping.py` and `test_tools.py`.

## Synthetic prompt

> Add a `geo_urn` list facet to `search_people` (numeric LinkedIn geo URN ids)
> that maps to LinkedIn's geoUrn facet for reliable location filtering, and
> coerce `network`/`geo_urn` arguments that clients send as JSON-array or
> comma-separated strings into lists. Add tests.
