### PR TITLE
docs: link send_message status issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | working |
 | `search_conversations` | Search messages by keyword | working |
-| `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) [#483](https://github.com/stickerdaniel/linkedin-mcp-server/issues/483) |
+| `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) [#483](https://github.com/stickerdaniel/linkedin-mcp-server/issues/483) [#560](https://github.com/stickerdaniel/linkedin-mcp-server/issues/560) |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_companies` | Search for companies on LinkedIn by keywords | working |


### PR DESCRIPTION
## Summary

- Add the open `send_message` contract/status issue #560 to the README Features & Tool Status table.

Closes #569.

## Tests

- Pre-commit hooks run by `git commit`.
- Not run: full test suite; README-only documentation table change.

## Synthetic prompt

> Keep the README Features & Tool Status table in sync with open tool-specific issues by adding the missing `send_message` issue #560 link, and create a documentation tracking issue for the mismatch.

Generated with GPT-5 Codex
