### PR TITLE
feat: add comment reading and analytics tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 
 | Tool | Description | Status |
 |------|-------------|--------|
-| `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
+| `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts, comments) | working |
 | `get_my_profile` | Get the authenticated user's own LinkedIn profile (same sections as get_person_profile) | working |
 | `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) [#432](https://github.com/stickerdaniel/linkedin-mcp-server/issues/432) [#454](https://github.com/stickerdaniel/linkedin-mcp-server/issues/454) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |
@@ -53,6 +53,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | working |
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
+| `get_post_comments` | Read a single post's permalink page including its comment thread (the comments and replies left on the post) | working |
 | `close_session` | Close browser session and clean up resources | working |
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `get_post_comments` | Read a single post's permalink page including its comment thread (the comments and replies left on the post) | working |
+| `get_my_analytics` | Get the authenticated user's own analytics dashboards with explicit section selection (content, audience, top_posts, profile_views, search_appearances) and optional time range (7d/28d/90d/365d) | working |
 | `close_session` | Close browser session and clean up resources | working |
 
 <br/>

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -20,6 +20,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Post Comments**: Read a single post with the comment thread others left on it
 - **Company Posts**: Get recent posts from a company's LinkedIn feed
 - **Home Feed**: Get recent posts from the authenticated user's LinkedIn home feed
+- **Analytics**: Read the authenticated user's own analytics dashboards (content performance, audience demographics, top posts, profile views, search appearances)
 - **Compact References**: Return typed per-section links alongside readable text without shipping full-page markdown
 
 ## Quick Start

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -16,6 +16,8 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Job Search**: Search for jobs with keywords and location filters
 - **People Search**: Search for people by keywords and location
 - **Person Posts**: Get recent activity/posts from a person's profile
+- **Person Comments**: Get the comments and replies a person wrote on other posts
+- **Post Comments**: Read a single post with the comment thread others left on it
 - **Company Posts**: Get recent posts from a company's LinkedIn feed
 - **Home Feed**: Get recent posts from the authenticated user's LinkedIn home feed
 - **Compact References**: Return typed per-section links alongside readable text without shipping full-page markdown

--- a/linkedin_mcp_server/scraping/__init__.py
+++ b/linkedin_mcp_server/scraping/__init__.py
@@ -2,16 +2,20 @@
 
 from .extractor import LinkedInExtractor
 from .fields import (
+    ANALYTICS_SECTIONS,
     COMPANY_SECTIONS,
     PERSON_SECTIONS,
+    parse_analytics_sections,
     parse_company_sections,
     parse_person_sections,
 )
 
 __all__ = [
+    "ANALYTICS_SECTIONS",
     "COMPANY_SECTIONS",
     "LinkedInExtractor",
     "PERSON_SECTIONS",
+    "parse_analytics_sections",
     "parse_company_sections",
     "parse_person_sections",
 ]

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -33,6 +33,7 @@ from linkedin_mcp_server.core.utils import (
 from linkedin_mcp_server.scraping.connection import ActionSignals
 from linkedin_mcp_server.scraping.link_metadata import (
     Reference,
+    _is_linkedin_host,
     build_references,
     dedupe_references,
 )
@@ -431,6 +432,60 @@ _POST_SLUG_URL_RE = re.compile(
 _FEED_DOCUMENT_URLS = {
     "https://www.linkedin.com/feed",
     "https://www.linkedin.com/feed/",
+}
+
+# Post permalink path shapes: /feed/update/<urn>/ (colons in the URN may be
+# percent-encoded in copied URLs) and /posts/<slug>. Matched against the URL
+# path only — query and fragment are stripped before navigation.
+_POST_PATH_RE = re.compile(
+    r"^/(?:feed/update/urn(?::|%3[Aa])li(?::|%3[Aa])(?:activity|ugcPost|share)"
+    r"(?::|%3[Aa])\d+|posts/[^/?#]+)/?$"
+)
+_POST_URN_RE = re.compile(r"^urn:li:(?:activity|ugcPost|share):\d+$")
+
+
+def normalize_post_url(post: str) -> str | None:
+    """Canonicalize a user-supplied post identifier to a permalink URL.
+
+    Accepts a bare activity/ugcPost/share URN, a relative permalink path
+    (``/feed/update/<urn>/`` or ``/posts/<slug>``), or a full http(s) URL on
+    a LinkedIn host with one of those paths. Returns None for anything else
+    so the tool layer can reject non-post targets before navigating.
+    """
+    value = post.strip()
+    if not value:
+        return None
+    if _POST_URN_RE.match(value):
+        return f"https://www.linkedin.com/feed/update/{value}/"
+    if value.startswith("/"):
+        path = value
+    else:
+        parsed = urlparse(value)
+        if parsed.scheme not in {"http", "https"}:
+            return None
+        if not _is_linkedin_host(parsed.netloc.lower()):
+            return None
+        path = parsed.path
+    if not _POST_PATH_RE.match(path):
+        return None
+    if not path.endswith("/"):
+        path += "/"
+    return f"https://www.linkedin.com{path}"
+
+
+# Comment pagination on a post permalink page is a plain <button> with no
+# structural signal — no href, no distinguishing ARIA attribute — so per the
+# Scraping Rules the visible label is matched via an explicit per-locale
+# table. BrowserManager forces the context locale to en-US (core/browser.py),
+# so the "en" entry is the operative one; a locale without an entry skips
+# pagination and returns only the initially rendered comments. The pattern
+# covers both thread-level pagination ("Load more comments") and collapsed
+# reply expansion ("See previous replies" / "Show more replies").
+_POST_MORE_COMMENTS_RE: dict[str, re.Pattern[str]] = {
+    "en": re.compile(
+        r"^(?:Load|Show|See)\s+(?:more|previous)\s+(?:comments|replies)\b",
+        re.IGNORECASE,
+    ),
 }
 
 
@@ -1350,6 +1405,166 @@ class LinkedInExtractor:
             text=cleaned,
             references=_build_feed_references(raw_result["references"], captured_urls),
         )
+
+    async def get_post_comments(
+        self,
+        url: str,
+        max_scrolls: int | None = None,
+    ) -> ExtractedSection:
+        """Scrape a single post permalink page including its comment thread.
+
+        ``url`` must already be canonicalized via ``normalize_post_url``.
+        Comments (and collapsed replies) are paginated up to *max_scrolls*
+        button clicks before extraction. Retries once after a backoff when
+        the page returns only LinkedIn chrome (soft rate limit), mirroring
+        ``extract_page``.
+        """
+        try:
+            result = await self._get_post_comments_once(url, max_scrolls)
+            if result.text != _RATE_LIMITED_MSG:
+                return result
+
+            logger.info("Retrying %s after %.0fs backoff", url, _RATE_LIMIT_RETRY_DELAY)
+            await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
+            return await self._get_post_comments_once(url, max_scrolls)
+
+        except LinkedInScraperException:
+            raise
+        except Exception as e:
+            logger.warning("Failed to extract post %s: %s", url, e)
+            return ExtractedSection(
+                text="",
+                references=[],
+                error=build_issue_diagnostics(
+                    e,
+                    context="get_post_comments",
+                    target_url=url,
+                ),
+            )
+
+    async def _get_post_comments_once(
+        self,
+        url: str,
+        max_scrolls: int | None = None,
+    ) -> ExtractedSection:
+        """Single attempt: navigate, expand the comment thread, extract."""
+        await self._navigate_to_page(url)
+        await detect_rate_limit(self._page)
+
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("No <main> element found on %s", url)
+
+        await handle_modal_close(self._page)
+        await self._wait_for_main_text(minimum_length=200, log_context="Post permalink")
+
+        # The comment block (composer + thread) hydrates well after the post
+        # body — extracting immediately captures only the reaction/comment
+        # counts. The composer is the structural, locale-independent signal
+        # that the block is attached: a contenteditable role="textbox" inside
+        # main, rendered on every post where commenting is enabled (attribute
+        # presence only, no label text). Timeout is tolerated — posts with
+        # comments disabled never render it.
+        try:
+            await self._page.wait_for_selector(
+                'main [role="textbox"][contenteditable="true"]',
+                timeout=7000,
+            )
+            # Give the first batch of comments a beat to attach below it.
+            await asyncio.sleep(1.0)
+        except PlaywrightTimeoutError:
+            logger.debug("Comment composer did not appear on %s", url)
+
+        max_rounds = max_scrolls if max_scrolls is not None else 5
+        await self._expand_post_comments(max_rounds)
+
+        # _extract_loaded_section re-runs the cheap rate-limit/modal checks,
+        # then handles scrolling, extraction, noise stripping, and reference
+        # building — identical to any other full-page section.
+        return await self._extract_loaded_section(url, "post", max_scrolls)
+
+    async def _main_text_length(self) -> int:
+        """Length of main's innerText — the comment-expansion progress signal."""
+        try:
+            length = await self._page.evaluate(
+                "() => document.querySelector('main')?.innerText.length || 0"
+            )
+            return int(length)
+        except Exception:
+            return 0
+
+    async def _click_more_comments_button(self, pattern: re.Pattern[str]) -> bool:
+        """Click a comment/reply pagination button when one is rendered.
+
+        Buttons are located by visible label through the per-locale
+        ``_POST_MORE_COMMENTS_RE`` table (see its docstring for why text
+        matching is unavoidable here). Returns True iff a click landed.
+        """
+        button = self._page.locator("main button").filter(has_text=pattern)
+        try:
+            if await button.count() == 0:
+                return False
+            target = button.first
+            if not await target.is_visible():
+                return False
+            await target.scroll_into_view_if_needed(timeout=2000)
+            await target.click(timeout=2000)
+            return True
+        except PlaywrightTimeoutError:
+            logger.debug("Comment pagination click timed out")
+            return False
+        except Exception as e:
+            logger.debug("Comment pagination click failed: %s", e)
+            return False
+
+    async def _expand_post_comments(self, max_rounds: int, locale: str = "en") -> None:
+        """Expand the comment thread on a post permalink page.
+
+        LinkedIn serves two pagination mechanisms depending on the
+        rendering: a "Load more comments" button (classic layout, matched
+        via the per-locale table) and lazy batches that attach when the
+        post's own scroll container scrolls (SDUI layout — window scrolling
+        is a no-op there, so mouse wheel is used, mirroring the feed;
+        verified live 2026-07-07). Each round clicks the button when
+        present, otherwise wheel-scrolls. Progress is measured by
+        main.innerText growth — locale-independent — and the loop stops
+        after two stale rounds or when the budget is spent.
+        """
+        pattern = _POST_MORE_COMMENTS_RE.get(locale)
+        stale = 0
+        last_length = -1
+
+        viewport = self._page.viewport_size or {"width": 1280, "height": 720}
+        try:
+            await self._page.mouse.move(viewport["width"] // 2, viewport["height"] // 2)
+        except Exception:
+            logger.debug("Mouse move over post failed", exc_info=True)
+            return
+
+        for i in range(max_rounds):
+            clicked = False
+            if pattern is not None:
+                clicked = await self._click_more_comments_button(pattern)
+            if not clicked:
+                try:
+                    await self._page.mouse.wheel(0, 2000)
+                except Exception:
+                    logger.debug("Wheel scroll over post failed", exc_info=True)
+                    break
+            await asyncio.sleep(1.0)
+
+            length = await self._main_text_length()
+            if length > last_length:
+                stale = 0
+                last_length = length
+            else:
+                stale += 1
+                if stale >= 2:
+                    logger.debug(
+                        "Comment thread stopped growing after %d rounds", i + 1
+                    )
+                    break
 
     async def extract_page(
         self,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -38,7 +38,12 @@ from linkedin_mcp_server.scraping.link_metadata import (
     dedupe_references,
 )
 
-from .fields import COMPANY_SECTIONS, PERSON_SECTIONS
+from .fields import (
+    ANALYTICS_SECTIONS,
+    ANALYTICS_TIME_RANGE_SECTIONS,
+    COMPANY_SECTIONS,
+    PERSON_SECTIONS,
+)
 
 if TYPE_CHECKING:
     from linkedin_mcp_server.callbacks import ProgressCallback
@@ -87,6 +92,19 @@ _JOB_TYPE_MAP = {
 }
 
 _WORK_TYPE_MAP = {"on_site": "1", "remote": "2", "hybrid": "3"}
+
+# Canonical values LinkedIn's analytics ?timeRange= param accepts (verified
+# live 2026-07-07), plus short aliases for tool ergonomics.
+_ANALYTICS_TIME_RANGE_MAP = {
+    "7d": "past_7_days",
+    "28d": "past_28_days",
+    "90d": "past_90_days",
+    "365d": "past_365_days",
+    "past_7_days": "past_7_days",
+    "past_28_days": "past_28_days",
+    "past_90_days": "past_90_days",
+    "past_365_days": "past_365_days",
+}
 
 _SORT_BY_MAP = {"date": "DD", "relevance": "R"}
 
@@ -1656,6 +1674,22 @@ class LinkedInExtractor:
             except PlaywrightTimeoutError:
                 logger.debug("Activity feed content did not appear on %s", url)
 
+        # Analytics dashboards render the page shell first and hydrate the
+        # stat cards afterwards; wait for enough text that the numbers are in.
+        is_analytics = "/analytics/" in url
+        if is_analytics:
+            try:
+                await self._page.wait_for_function(
+                    """() => {
+                        const main = document.querySelector('main');
+                        if (!main) return false;
+                        return main.innerText.length > 200;
+                    }""",
+                    timeout=10000,
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Analytics content did not appear on %s", url)
+
         # Search results pages load a placeholder first then fill in results
         # via JavaScript. Wait for actual content before extracting.
         is_search = "/search/results/" in url
@@ -1999,6 +2033,113 @@ class LinkedInExtractor:
             max_scrolls=max_scrolls,
             main_profile_already_loaded=True,
         )
+
+    async def get_my_analytics(
+        self,
+        requested: set[str],
+        time_range: str | None = None,
+        callbacks: ProgressCallback | None = None,
+        max_scrolls: int | None = None,
+    ) -> dict[str, Any]:
+        """Scrape the authenticated user's own analytics dashboards.
+
+        Navigates one page per requested ``ANALYTICS_SECTIONS`` entry
+        (content, audience, top_posts, profile_views, search_appearances).
+        ``time_range`` applies only to the sections in
+        ``ANALYTICS_TIME_RANGE_SECTIONS``; the other dashboards use
+        LinkedIn's fixed windows.
+
+        Returns:
+            {url, sections: {name: text}, references?, section_errors?}
+
+        Raises:
+            FilterValidationError: for an unrecognised ``time_range``.
+        """
+        normalized_range: str | None = None
+        if time_range is not None:
+            normalized_range = _ANALYTICS_TIME_RANGE_MAP.get(time_range.strip().lower())
+            if normalized_range is None:
+                raise FilterValidationError(
+                    f"Invalid time_range {time_range!r}. Valid values: "
+                    "7d, 28d, 90d, 365d (or past_7_days, past_28_days, "
+                    "past_90_days, past_365_days)."
+                )
+
+        base_url = "https://www.linkedin.com/analytics"
+        sections: dict[str, str] = {}
+        references: dict[str, list[Reference]] = {}
+        section_errors: dict[str, dict[str, Any]] = {}
+
+        requested_ordered = [
+            (name, suffix)
+            for name, suffix in ANALYTICS_SECTIONS.items()
+            if name in requested
+        ]
+        total = len(requested_ordered)
+
+        if callbacks:
+            await callbacks.on_start("analytics", base_url)
+
+        try:
+            for i, (section_name, suffix) in enumerate(requested_ordered):
+                if i > 0:
+                    await asyncio.sleep(_NAV_DELAY)
+
+                url = base_url + suffix
+                if (
+                    normalized_range is not None
+                    and section_name in ANALYTICS_TIME_RANGE_SECTIONS
+                ):
+                    url += f"?timeRange={normalized_range}"
+
+                try:
+                    extracted = await self.extract_page(
+                        url,
+                        section_name=section_name,
+                        max_scrolls=max_scrolls,
+                    )
+                    if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+                        sections[section_name] = extracted.text
+                        if extracted.references:
+                            references[section_name] = extracted.references
+                    elif extracted.error:
+                        section_errors[section_name] = extracted.error
+                except LinkedInScraperException:
+                    raise
+                except Exception as e:
+                    logger.warning(
+                        "Error scraping analytics section %s: %s", section_name, e
+                    )
+                    section_errors[section_name] = build_issue_diagnostics(
+                        e,
+                        context="get_my_analytics",
+                        target_url=url,
+                        section_name=section_name,
+                    )
+
+                if callbacks:
+                    percent = round((i + 1) / total * 95)
+                    await callbacks.on_progress(
+                        f"Scraped {section_name} ({i + 1}/{total})", percent
+                    )
+        except LinkedInScraperException as e:
+            if callbacks:
+                await callbacks.on_error(e)
+            raise
+
+        result: dict[str, Any] = {
+            "url": f"{base_url}/",
+            "sections": sections,
+        }
+        if references:
+            result["references"] = references
+        if section_errors:
+            result["section_errors"] = section_errors
+
+        if callbacks:
+            await callbacks.on_complete("analytics", result)
+
+        return result
 
     async def _read_action_signals(self, username: str) -> ActionSignals:
         """Read locale-independent structural signals for a profile's

--- a/linkedin_mcp_server/scraping/fields.py
+++ b/linkedin_mcp_server/scraping/fields.py
@@ -17,6 +17,7 @@ PERSON_SECTIONS: dict[str, tuple[str, bool]] = {
     "projects": ("/details/projects/", False),
     "contact_info": ("/overlay/contact-info/", True),
     "posts": ("/recent-activity/all/", False),
+    "comments": ("/recent-activity/comments/", False),
 }
 
 COMPANY_SECTIONS: dict[str, tuple[str, bool]] = {

--- a/linkedin_mcp_server/scraping/fields.py
+++ b/linkedin_mcp_server/scraping/fields.py
@@ -26,6 +26,22 @@ COMPANY_SECTIONS: dict[str, tuple[str, bool]] = {
     "jobs": ("/jobs/", False),
 }
 
+# Maps section name -> url_suffix under https://www.linkedin.com/analytics.
+# These are the authenticated user's own analytics dashboards ("Private to
+# you"); they have no per-username variant. /analytics/creator/ (overview)
+# is omitted because LinkedIn redirects it to the content page.
+ANALYTICS_SECTIONS: dict[str, str] = {
+    "content": "/creator/content/",
+    "audience": "/creator/audience/",
+    "top_posts": "/creator/top-posts/",
+    "profile_views": "/profile-views/",
+    "search_appearances": "/search-appearances/",
+}
+
+# Sections whose page honours the ?timeRange= query param (verified live
+# 2026-07-07 on content and audience; the other pages use fixed windows).
+ANALYTICS_TIME_RANGE_SECTIONS: frozenset[str] = frozenset({"content", "audience"})
+
 
 def parse_person_sections(
     sections: str | None,
@@ -55,6 +71,40 @@ def parse_person_sections(
                 name,
                 ", ".join(sorted(PERSON_SECTIONS)),
             )
+    return requested, unknown
+
+
+def parse_analytics_sections(
+    sections: str | None,
+) -> tuple[set[str], list[str]]:
+    """Parse comma-separated section names into a set of requested sections.
+
+    Unlike the profile parsers there is no always-included baseline: the
+    tool exists to pull the analytics dashboards, so empty/None selects ALL
+    sections. Unknown section names are logged as warnings and returned.
+
+    Returns:
+        Tuple of (requested_sections, unknown_section_names).
+    """
+    if not sections:
+        return set(ANALYTICS_SECTIONS), []
+    requested: set[str] = set()
+    unknown: list[str] = []
+    for name in sections.split(","):
+        name = name.strip().lower()
+        if not name:
+            continue
+        if name in ANALYTICS_SECTIONS:
+            requested.add(name)
+        else:
+            unknown.append(name)
+            logger.warning(
+                "Unknown analytics section %r ignored. Valid: %s",
+                name,
+                ", ".join(sorted(ANALYTICS_SECTIONS)),
+            )
+    if not requested:
+        requested = set(ANALYTICS_SECTIONS)
     return requested, unknown
 
 

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -95,6 +95,11 @@ _REFERENCE_CAPS = {
     "honors": 12,
     "languages": 12,
     "posts": 12,
+    "comments": 12,
+    # A post permalink page carries one anchor per commenter plus the post
+    # author and attachments; headroom above the default keeps long comment
+    # threads' participants addressable.
+    "post": 30,
     "jobs": 8,
     "search_results": 15,
     "job_posting": 8,
@@ -383,6 +388,26 @@ def derive_context(
             return "post author"
         if kind == "feed_post":
             return "company post"
+        return "post attachment"
+
+    if section_name == "comments":
+        # Comments activity page: feed_post anchors are the posts the person
+        # commented on; person anchors are the authors of those posts (and
+        # the commenter themselves).
+        if kind == "feed_post":
+            return "commented post"
+        if kind == "person":
+            return "post author"
+        return "post attachment"
+
+    if section_name == "post":
+        # Post permalink page: person anchors mix the post author and
+        # commenters; the surrounding innerText carries the roles, so no
+        # context guess is made for them.
+        if kind == "person":
+            return None
+        if kind == "feed_post":
+            return "post"
         return "post attachment"
 
     if section_name in {"main_profile", "about"}:

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -24,6 +24,7 @@ from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
 from linkedin_mcp_server.update_check import UpdateNoticeMiddleware
+from linkedin_mcp_server.tools.analytics import register_analytics_tools
 from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.feed import register_feed_tools
 from linkedin_mcp_server.tools.job import register_job_tools
@@ -66,6 +67,7 @@ def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> 
     register_job_tools(mcp, tool_timeout=tool_timeout)
     register_messaging_tools(mcp, tool_timeout=tool_timeout)
     register_feed_tools(mcp, tool_timeout=tool_timeout)
+    register_analytics_tools(mcp, tool_timeout=tool_timeout)
 
     # Register session management tool
     @mcp.tool(

--- a/linkedin_mcp_server/tools/analytics.py
+++ b/linkedin_mcp_server/tools/analytics.py
@@ -1,0 +1,121 @@
+"""
+LinkedIn analytics scraping tool.
+
+Reads the authenticated user's own analytics dashboards ("Private to you"
+pages under /analytics/) using innerText extraction: content performance,
+audience/follower demographics, top posts, profile views, and search
+appearances.
+"""
+
+import logging
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+from pydantic import Field
+
+from linkedin_mcp_server.callbacks import MCPContextProgressCallback
+from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.core.exceptions import AuthenticationError
+from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
+from linkedin_mcp_server.error_handler import raise_tool_error
+from linkedin_mcp_server.scraping import parse_analytics_sections
+from linkedin_mcp_server.scraping.extractor import FilterValidationError
+
+logger = logging.getLogger(__name__)
+
+
+def register_analytics_tools(
+    mcp: FastMCP, *, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS
+) -> None:
+    """Register analytics-related tools with the MCP server."""
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Get My Analytics",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"analytics", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_my_analytics(
+        ctx: Context,
+        sections: str | None = None,
+        time_range: str | None = None,
+        max_scrolls: Annotated[int, Field(ge=1, le=50)] | None = None,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get the authenticated user's own LinkedIn analytics dashboards.
+
+        These are the "Private to you" analytics pages, so they only exist
+        for the logged-in account — there is no per-username variant.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+            sections: Comma-separated list of sections to scrape.
+                Available sections:
+                - content: impressions, members reached, engagement breakdown
+                  (reactions/comments/reposts/saves/sends), top performing posts
+                - audience: total followers, follower growth, top demographics
+                  (job title, location, seniority, company, industry)
+                - top_posts: recent posts ranked by impressions, with per-post
+                  impression/engagement counts
+                - profile_views: profile viewers over the past 90 days and
+                  viewer highlights
+                - search_appearances: profile/search appearance counts and
+                  where the profile appeared
+                Default (None) scrapes ALL sections (~5 page navigations).
+            time_range: Optional reporting window for the content and audience
+                sections: "7d", "28d", "90d", or "365d" (past_7_days-style
+                values also accepted). Other sections use LinkedIn's fixed
+                windows (top_posts: 14 days, profile_views: 90 days).
+                Default (None) uses LinkedIn's default of 7 days.
+            max_scrolls: Maximum scroll-to-bottom iterations per section
+                (default 5). Rarely needed; the dashboards are short pages.
+
+        Returns:
+            Dict with url, sections (name -> raw text), and optional
+            references / section_errors / unknown_sections keys. The LLM
+            should parse the raw text in each section; chart data appears as
+            axis-description text with min/max values.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_my_analytics"
+            )
+            requested, unknown = parse_analytics_sections(sections)
+
+            logger.info(
+                "Scraping own analytics (sections=%s, time_range=%s)",
+                sections,
+                time_range,
+            )
+
+            cb = MCPContextProgressCallback(ctx)
+            try:
+                result = await extractor.get_my_analytics(
+                    requested,
+                    time_range=time_range,
+                    callbacks=cb,
+                    max_scrolls=max_scrolls,
+                )
+            except FilterValidationError as e:
+                # Validation messages carry actionable detail; surface them
+                # as ToolError so mask_error_details doesn't reduce them to
+                # "Error calling tool 'get_my_analytics'".
+                raise ToolError(str(e)) from e
+
+            if unknown:
+                result["unknown_sections"] = unknown
+
+            return result
+
+        except ToolError:
+            raise
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_my_analytics")
+        except Exception as e:
+            raise_tool_error(e, "get_my_analytics")  # NoReturn

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -1,24 +1,28 @@
 """
-LinkedIn feed scraping tool.
+LinkedIn feed and post scraping tools.
 
 Fetches posts from the authenticated user's LinkedIn home feed using
 innerText extraction. Scrolls until the requested number of post
 permalinks have been observed in SDUI pagination responses — a
 locale-independent progress signal, since the feed DOM exposes no
 stable per-post container selector.
+
+Also reads a single post's permalink page (get_post_comments), paginating
+its comment thread so replies on the post are captured.
 """
 
 import logging
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
 from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
-from linkedin_mcp_server.scraping.extractor import _RATE_LIMITED_MSG
+from linkedin_mcp_server.scraping.extractor import _RATE_LIMITED_MSG, normalize_post_url
 from linkedin_mcp_server.scraping.link_metadata import Reference
 
 logger = logging.getLogger(__name__)
@@ -108,3 +112,94 @@ def register_feed_tools(
                 raise_tool_error(relogin_exc, "get_feed")
         except Exception as e:
             raise_tool_error(e, "get_feed")
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Get Post Comments",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"feed", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_post_comments(
+        post_url: str,
+        ctx: Context,
+        max_scrolls: Annotated[int, Field(ge=1, le=50)] | None = None,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get a single LinkedIn post with its full comment thread.
+
+        Use this to read the comments (and nested replies) other people
+        left on a post — e.g. on the authenticated user's own posts. Obtain
+        post URLs from references["feed"] (get_feed), the posts/comments
+        sections of get_person_profile / get_my_profile, or get_company_posts.
+
+        Args:
+            post_url: Post permalink. Accepts a full or relative URL in
+                either ``/feed/update/<urn>/`` or ``/posts/<slug>`` form, or
+                a bare URN like ``urn:li:activity:7203847...``.
+            ctx: FastMCP context for progress reporting
+            max_scrolls: Maximum "load more comments" / "see previous
+                replies" pagination clicks (default 5). Increase for posts
+                with long comment threads.
+
+        Returns:
+            Dict with url and sections["post"] containing the post body and
+            comment thread as raw text. references["post"] lists commenter
+            profiles and linked posts. section_errors is present when the
+            page is rate-limited or extraction fails. The LLM should parse
+            the raw text; the comment thread follows the post body.
+        """
+        try:
+            url = normalize_post_url(post_url)
+            if url is None:
+                raise ToolError(
+                    "post_url must be a LinkedIn post permalink "
+                    "(/feed/update/<urn>/ or /posts/<slug>, full or relative "
+                    "URL) or a bare urn:li:activity:<id>."
+                )
+
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_post_comments"
+            )
+            logger.info("Scraping post comments: %s", url)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Loading post and comments"
+            )
+
+            extracted = await extractor.get_post_comments(url, max_scrolls=max_scrolls)
+
+            sections: dict[str, str] = {}
+            references: dict[str, list[Reference]] = {}
+            section_errors: dict[str, dict[str, Any]] = {}
+            if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+                sections["post"] = extracted.text
+                if extracted.references:
+                    references["post"] = extracted.references
+            elif extracted.text == _RATE_LIMITED_MSG:
+                section_errors["post"] = {
+                    "error_type": "rate_limit",
+                    "error_message": extracted.text,
+                }
+            elif extracted.error:
+                section_errors["post"] = extracted.error
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            result: dict[str, Any] = {"url": url, "sections": sections}
+            if references:
+                result["references"] = references
+            if section_errors:
+                result["section_errors"] = section_errors
+            return result
+
+        except ToolError:
+            raise
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_post_comments")
+        except Exception as e:
+            raise_tool_error(e, "get_post_comments")

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -50,9 +50,13 @@ def register_person_tools(
             ctx: FastMCP context for progress reporting
             sections: Comma-separated list of extra sections to scrape.
                 The main profile page is always included.
-                Available sections: experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts
-                Examples: "experience,education", "contact_info", "skills,projects", "honors,languages", "posts"
+                Available sections: experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts, comments
+                Examples: "experience,education", "contact_info", "skills,projects", "honors,languages", "posts", "comments"
                 Default (None) scrapes only the main profile page.
+                The "comments" section is the person's comment activity —
+                comments and replies they wrote on other posts. To read the
+                comments other people left on a specific post, pass a post
+                URL from the "posts" section's references to get_post_comments.
             max_scrolls: Maximum pagination attempts per section to load more content.
                 On detail sections (experience, certifications, skills, etc.) this
                 is the max number of "Show more" button clicks. On activity/posts
@@ -330,9 +334,13 @@ def register_person_tools(
             ctx: FastMCP context for progress reporting
             sections: Comma-separated list of extra sections to scrape.
                 The main profile page is always included.
-                Available sections: experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts
-                Examples: "experience,education", "contact_info", "skills,projects"
+                Available sections: experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts, comments
+                Examples: "experience,education", "contact_info", "posts,comments"
                 Default (None) scrapes only the main profile page.
+                "posts" lists the user's own posts; "comments" lists the
+                comments and replies the user wrote on other posts. To read
+                the comments others left on one of the user's posts, pass a
+                post URL from the "posts" references to get_post_comments.
             max_scrolls: Maximum pagination attempts per section (same as get_person_profile).
 
         Returns:

--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,7 @@
   "tools": [
     {
       "name": "get_person_profile",
-      "description": "Get detailed information from a LinkedIn profile including work history, education, certifications, skills, projects, connections, and recent posts"
+      "description": "Get detailed information from a LinkedIn profile including work history, education, certifications, skills, projects, connections, recent posts, and comment activity"
     },
     {
       "name": "get_my_profile",
@@ -106,6 +106,10 @@
     {
       "name": "get_feed",
       "description": "Get recent posts from the authenticated user's LinkedIn home feed"
+    },
+    {
+      "name": "get_post_comments",
+      "description": "Read a single LinkedIn post's permalink page including the comments and replies left on it"
     },
     {
       "name": "close_session",

--- a/manifest.json
+++ b/manifest.json
@@ -112,6 +112,10 @@
       "description": "Read a single LinkedIn post's permalink page including the comments and replies left on it"
     },
     {
+      "name": "get_my_analytics",
+      "description": "Get the authenticated user's own LinkedIn analytics dashboards: content performance, audience demographics, top posts, profile views, and search appearances"
+    },
+    {
       "name": "close_session",
       "description": "Properly close browser session and clean up resources"
     }

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,8 +1,11 @@
 """Tests for scraping section config dicts and section parsers."""
 
 from linkedin_mcp_server.scraping.fields import (
+    ANALYTICS_SECTIONS,
+    ANALYTICS_TIME_RANGE_SECTIONS,
     COMPANY_SECTIONS,
     PERSON_SECTIONS,
+    parse_analytics_sections,
     parse_company_sections,
     parse_person_sections,
 )
@@ -47,6 +50,61 @@ class TestCompanySections:
     def test_no_overlays(self):
         for name, (_suffix, is_overlay) in COMPANY_SECTIONS.items():
             assert is_overlay is False, f"{name} should not be an overlay"
+
+
+class TestAnalyticsSections:
+    def test_expected_keys(self):
+        assert set(ANALYTICS_SECTIONS) == {
+            "content",
+            "audience",
+            "top_posts",
+            "profile_views",
+            "search_appearances",
+        }
+
+    def test_all_suffixes_start_with_slash(self):
+        for name, suffix in ANALYTICS_SECTIONS.items():
+            assert suffix.startswith("/"), f"{name} suffix should start with /"
+
+    def test_time_range_sections_are_known(self):
+        assert ANALYTICS_TIME_RANGE_SECTIONS <= set(ANALYTICS_SECTIONS)
+
+
+class TestParseAnalyticsSections:
+    def test_none_returns_all_sections(self):
+        requested, unknown = parse_analytics_sections(None)
+        assert requested == set(ANALYTICS_SECTIONS)
+        assert unknown == []
+
+    def test_empty_string_returns_all_sections(self):
+        requested, unknown = parse_analytics_sections("")
+        assert requested == set(ANALYTICS_SECTIONS)
+        assert unknown == []
+
+    def test_single_section(self):
+        requested, unknown = parse_analytics_sections("content")
+        assert requested == {"content"}
+        assert unknown == []
+
+    def test_multiple_sections(self):
+        requested, unknown = parse_analytics_sections("content,audience")
+        assert requested == {"content", "audience"}
+        assert unknown == []
+
+    def test_invalid_names_returned(self):
+        requested, unknown = parse_analytics_sections("content,bogus")
+        assert requested == {"content"}
+        assert unknown == ["bogus"]
+
+    def test_only_invalid_names_falls_back_to_all(self):
+        requested, unknown = parse_analytics_sections("bogus")
+        assert requested == set(ANALYTICS_SECTIONS)
+        assert unknown == ["bogus"]
+
+    def test_whitespace_and_case_handling(self):
+        requested, unknown = parse_analytics_sections(" Content , AUDIENCE ")
+        assert requested == {"content", "audience"}
+        assert unknown == []
 
 
 class TestParsePersonSections:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -22,6 +22,7 @@ class TestPersonSections:
             "projects",
             "contact_info",
             "posts",
+            "comments",
         }
         assert set(PERSON_SECTIONS) == expected
 
@@ -91,7 +92,7 @@ class TestParsePersonSections:
 
     def test_all_sections(self):
         requested, unknown = parse_person_sections(
-            "experience,education,interests,honors,languages,certifications,skills,projects,contact_info,posts"
+            "experience,education,interests,honors,languages,certifications,skills,projects,contact_info,posts,comments"
         )
         assert requested == set(PERSON_SECTIONS)
         assert unknown == []

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -19,6 +19,7 @@ from linkedin_mcp_server.scraping.extractor import (
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
+    normalize_post_url,
     strip_conversation_chrome,
     strip_linkedin_noise,
 )
@@ -119,6 +120,79 @@ class TestBuildJobSearchUrl:
         assert "f_WT=2" in url
         assert "f_EA=true" in url
         assert "sortBy=DD" in url
+
+
+class TestNormalizePostUrl:
+    """Tests for normalize_post_url canonicalization and rejection."""
+
+    def test_bare_activity_urn(self):
+        assert (
+            normalize_post_url("urn:li:activity:7203847000000000000")
+            == "https://www.linkedin.com/feed/update/urn:li:activity:7203847000000000000/"
+        )
+
+    def test_bare_ugcpost_urn(self):
+        assert (
+            normalize_post_url("urn:li:ugcPost:12345")
+            == "https://www.linkedin.com/feed/update/urn:li:ugcPost:12345/"
+        )
+
+    def test_relative_feed_update_path(self):
+        assert (
+            normalize_post_url("/feed/update/urn:li:activity:123/")
+            == "https://www.linkedin.com/feed/update/urn:li:activity:123/"
+        )
+
+    def test_relative_posts_slug_path(self):
+        assert (
+            normalize_post_url("/posts/johndoe_topic-activity-123-Ab_c")
+            == "https://www.linkedin.com/posts/johndoe_topic-activity-123-Ab_c/"
+        )
+
+    def test_full_url_with_query_stripped(self):
+        assert (
+            normalize_post_url(
+                "https://www.linkedin.com/feed/update/urn:li:activity:123/?utm_source=share"
+            )
+            == "https://www.linkedin.com/feed/update/urn:li:activity:123/"
+        )
+
+    def test_percent_encoded_urn(self):
+        assert (
+            normalize_post_url(
+                "https://www.linkedin.com/feed/update/urn%3Ali%3Aactivity%3A123"
+            )
+            == "https://www.linkedin.com/feed/update/urn%3Ali%3Aactivity%3A123/"
+        )
+
+    def test_missing_trailing_slash_added(self):
+        assert (
+            normalize_post_url("/feed/update/urn:li:activity:123")
+            == "https://www.linkedin.com/feed/update/urn:li:activity:123/"
+        )
+
+    def test_rejects_non_linkedin_host(self):
+        assert (
+            normalize_post_url(
+                "https://evil.example.com/feed/update/urn:li:activity:1/"
+            )
+            is None
+        )
+
+    def test_rejects_profile_path(self):
+        assert normalize_post_url("/in/johndoe/") is None
+
+    def test_rejects_arbitrary_linkedin_path(self):
+        assert normalize_post_url("https://www.linkedin.com/jobs/view/123/") is None
+
+    def test_rejects_non_numeric_urn(self):
+        assert normalize_post_url("urn:li:activity:abc") is None
+
+    def test_rejects_empty(self):
+        assert normalize_post_url("  ") is None
+
+    def test_rejects_plain_text(self):
+        assert normalize_post_url("check out my post") is None
 
 
 @pytest.fixture
@@ -669,6 +743,7 @@ class TestScrapePersonUrls:
             "projects",
             "contact_info",
             "posts",
+            "comments",
         }
         with (
             patch.object(
@@ -693,8 +768,8 @@ class TestScrapePersonUrls:
         page_urls = [call.args[0] for call in mock_extract.call_args_list]
         overlay_urls = [call.args[0] for call in mock_overlay.call_args_list]
         all_urls = page_urls + overlay_urls
-        # 10 full-page sections + 1 overlay (contact_info)
-        assert len(page_urls) == 10
+        # 11 full-page sections + 1 overlay (contact_info)
+        assert len(page_urls) == 11
         assert len(overlay_urls) == 1
         # Verify each expected suffix was navigated
         assert any(u.endswith("/in/testuser/") for u in all_urls)
@@ -708,6 +783,7 @@ class TestScrapePersonUrls:
         assert any("/details/projects/" in u for u in all_urls)
         assert any("/overlay/contact-info/" in u for u in overlay_urls)
         assert any("/recent-activity/all/" in u for u in all_urls)
+        assert any("/recent-activity/comments/" in u for u in all_urls)
         assert set(result["sections"]) == all_sections
 
     async def test_posts_visits_recent_activity(self, mock_page):
@@ -735,6 +811,32 @@ class TestScrapePersonUrls:
         urls = [call.args[0] for call in mock_extract.call_args_list]
         assert any("/recent-activity/all/" in url for url in urls)
         assert "posts" in result["sections"]
+
+    async def test_comments_visits_recent_activity_comments(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Commented on a post\nGreat insight!"),
+            ) as mock_extract,
+            patch.object(
+                extractor,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_person("test-user", {"comments"})
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert any("/recent-activity/comments/" in url for url in urls)
+        assert "comments" in result["sections"]
 
     async def test_certifications_visits_details_page(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
@@ -5214,3 +5316,126 @@ class TestBuildFeedReferences:
             "/posts/alice_x-ugcPost-1-xx",
         ]
         assert kinds == {"feed_post"}
+
+
+class TestGetPostComments:
+    """Tests for the get_post_comments extractor method."""
+
+    async def test_navigates_expands_and_extracts(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        url = "https://www.linkedin.com/feed/update/urn:li:activity:123/"
+        with (
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as mock_nav,
+            patch.object(
+                extractor, "_expand_post_comments", new_callable=AsyncMock
+            ) as mock_expand,
+            patch.object(
+                extractor,
+                "_extract_loaded_section",
+                new_callable=AsyncMock,
+                return_value=extracted("Post body\nGreat point!\nThanks!"),
+            ) as mock_section,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_post_comments(url)
+
+        mock_nav.assert_awaited_once_with(url)
+        mock_expand.assert_awaited_once_with(5)
+        assert mock_section.call_args.args[1] == "post"
+        assert result.text == "Post body\nGreat point!\nThanks!"
+
+    async def test_max_scrolls_bounds_pagination_clicks(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        url = "https://www.linkedin.com/posts/alice_x-activity-1-yy/"
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_expand_post_comments", new_callable=AsyncMock
+            ) as mock_expand,
+            patch.object(
+                extractor,
+                "_extract_loaded_section",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_section,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await extractor.get_post_comments(url, max_scrolls=12)
+
+        mock_expand.assert_awaited_once_with(12)
+        assert mock_section.call_args.args[2] == 12
+
+    async def test_returns_error_diagnostics_on_failure(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "_navigate_to_page",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            result = await extractor.get_post_comments(
+                "https://www.linkedin.com/feed/update/urn:li:activity:1/"
+            )
+        assert result.text == ""
+        assert result.error is not None
+
+    @staticmethod
+    def _wire_scrollable_page(mock_page, text_lengths):
+        """Equip the mock page with mouse/viewport and innerText growth."""
+        mock_page.viewport_size = {"width": 1280, "height": 720}
+        mock_page.mouse = MagicMock()
+        mock_page.mouse.move = AsyncMock()
+        mock_page.mouse.wheel = AsyncMock()
+        mock_page.evaluate = AsyncMock(side_effect=text_lengths)
+
+    async def test_expand_unknown_locale_still_wheel_scrolls(self, mock_page):
+        # Scroll-based pagination is locale-independent; only the button
+        # fallback needs the per-locale table.
+        self._wire_scrollable_page(mock_page, [100, 100, 100])
+        extractor = LinkedInExtractor(mock_page)
+        with patch(
+            "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await extractor._expand_post_comments(5, locale="xx")
+        mock_page.locator.assert_not_called()
+        assert mock_page.mouse.wheel.await_count >= 1
+
+    async def test_expand_stops_after_two_stale_rounds(self, mock_page):
+        # innerText length never grows past the first measurement -> the
+        # loop exits after two stale rounds instead of burning the budget.
+        self._wire_scrollable_page(mock_page, [100, 100, 100, 100, 100])
+        extractor = LinkedInExtractor(mock_page)
+        with patch(
+            "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await extractor._expand_post_comments(10)
+        # round 1: 100 > -1 (progress); rounds 2-3: stale -> stop
+        assert mock_page.mouse.wheel.await_count == 3
+
+    async def test_expand_keeps_scrolling_while_growing(self, mock_page):
+        self._wire_scrollable_page(mock_page, [100, 200, 300, 400])
+        extractor = LinkedInExtractor(mock_page)
+        with patch(
+            "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await extractor._expand_post_comments(4)
+        assert mock_page.mouse.wheel.await_count == 4

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5439,3 +5439,122 @@ class TestGetPostComments:
         ):
             await extractor._expand_post_comments(4)
         assert mock_page.mouse.wheel.await_count == 4
+
+
+class TestGetMyAnalytics:
+    """Tests for the get_my_analytics extractor method."""
+
+    async def test_all_sections_visit_analytics_urls(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("21,182\nImpressions"),
+            ) as mock_extract,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_my_analytics(
+                {
+                    "content",
+                    "audience",
+                    "top_posts",
+                    "profile_views",
+                    "search_appearances",
+                }
+            )
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert len(urls) == 5
+        assert any(u.endswith("/analytics/creator/content/") for u in urls)
+        assert any(u.endswith("/analytics/creator/audience/") for u in urls)
+        assert any(u.endswith("/analytics/creator/top-posts/") for u in urls)
+        assert any(u.endswith("/analytics/profile-views/") for u in urls)
+        assert any(u.endswith("/analytics/search-appearances/") for u in urls)
+        assert result["url"] == "https://www.linkedin.com/analytics/"
+        assert set(result["sections"]) == {
+            "content",
+            "audience",
+            "top_posts",
+            "profile_views",
+            "search_appearances",
+        }
+
+    async def test_time_range_applied_only_to_range_sections(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_extract,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await extractor.get_my_analytics(
+                {"content", "audience", "profile_views"}, time_range="28d"
+            )
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        with_range = [u for u in urls if "timeRange=past_28_days" in u]
+        assert len(with_range) == 2
+        assert all(
+            "/creator/content/" in u or "/creator/audience/" in u for u in with_range
+        )
+        profile_views_url = next(u for u in urls if "/profile-views/" in u)
+        assert "timeRange" not in profile_views_url
+
+    async def test_time_range_accepts_canonical_form(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_extract,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await extractor.get_my_analytics({"content"}, time_range="past_90_days")
+
+        url = mock_extract.call_args.args[0]
+        assert "timeRange=past_90_days" in url
+
+    async def test_invalid_time_range_raises(self, mock_page):
+        from linkedin_mcp_server.scraping.extractor import FilterValidationError
+
+        extractor = LinkedInExtractor(mock_page)
+        with pytest.raises(FilterValidationError, match="time_range"):
+            await extractor.get_my_analytics({"content"}, time_range="14d")
+
+    async def test_section_error_isolated(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                side_effect=[
+                    extracted("stats"),
+                    RuntimeError("boom"),
+                ],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_my_analytics({"content", "audience"})
+
+        assert len(result["sections"]) == 1
+        assert len(result["section_errors"]) == 1

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1265,6 +1265,95 @@ class TestGetPostCommentsTool:
         assert "post" in result["section_errors"]
 
 
+class TestGetMyAnalyticsTool:
+    async def test_get_my_analytics_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/analytics/",
+            "sections": {"content": "21,182\nImpressions"},
+        }
+        mock_extractor = MagicMock()
+        mock_extractor.get_my_analytics = AsyncMock(return_value=expected)
+
+        from linkedin_mcp_server.tools.analytics import register_analytics_tools
+
+        mcp = FastMCP("test")
+        register_analytics_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_my_analytics")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert result["url"] == "https://www.linkedin.com/analytics/"
+        assert "content" in result["sections"]
+        # Default (None) requests all sections
+        call_args = mock_extractor.get_my_analytics.call_args
+        assert call_args.args[0] == {
+            "content",
+            "audience",
+            "top_posts",
+            "profile_views",
+            "search_appearances",
+        }
+
+    async def test_get_my_analytics_passes_sections_and_time_range(self, mock_context):
+        expected = {"url": "https://www.linkedin.com/analytics/", "sections": {}}
+        mock_extractor = MagicMock()
+        mock_extractor.get_my_analytics = AsyncMock(return_value=expected)
+
+        from linkedin_mcp_server.tools.analytics import register_analytics_tools
+
+        mcp = FastMCP("test")
+        register_analytics_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_my_analytics")
+        await tool_fn(
+            mock_context,
+            sections="content,audience",
+            time_range="28d",
+            extractor=mock_extractor,
+        )
+        call_args = mock_extractor.get_my_analytics.call_args
+        assert call_args.args[0] == {"content", "audience"}
+        assert call_args.kwargs["time_range"] == "28d"
+
+    async def test_get_my_analytics_unknown_section(self, mock_context):
+        expected = {"url": "https://www.linkedin.com/analytics/", "sections": {}}
+        mock_extractor = MagicMock()
+        mock_extractor.get_my_analytics = AsyncMock(return_value=expected)
+
+        from linkedin_mcp_server.tools.analytics import register_analytics_tools
+
+        mcp = FastMCP("test")
+        register_analytics_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_my_analytics")
+        result = await tool_fn(
+            mock_context, sections="content,bogus", extractor=mock_extractor
+        )
+        assert result["unknown_sections"] == ["bogus"]
+
+    async def test_get_my_analytics_invalid_time_range_surfaces_tool_error(
+        self, mock_context
+    ):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.scraping.extractor import FilterValidationError
+
+        mock_extractor = MagicMock()
+        mock_extractor.get_my_analytics = AsyncMock(
+            side_effect=FilterValidationError(
+                "Invalid time_range '14d'. Valid values: 7d, 28d, 90d, 365d."
+            )
+        )
+
+        from linkedin_mcp_server.tools.analytics import register_analytics_tools
+
+        mcp = FastMCP("test")
+        register_analytics_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_my_analytics")
+        with pytest.raises(ToolError, match="time_range"):
+            await tool_fn(mock_context, time_range="14d", extractor=mock_extractor)
+
+
 class TestToolTimeouts:
     async def test_all_tools_have_global_timeout(self):
         from linkedin_mcp_server.server import create_mcp_server
@@ -1286,6 +1375,8 @@ class TestToolTimeouts:
             "search_conversations",
             "send_message",
             "get_feed",
+            "get_post_comments",
+            "get_my_analytics",
             "close_session",
         )
 
@@ -1317,6 +1408,8 @@ class TestToolTimeouts:
             "search_conversations",
             "send_message",
             "get_feed",
+            "get_post_comments",
+            "get_my_analytics",
             "close_session",
         )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1151,6 +1151,120 @@ class TestFeedTools:
             await mcp.call_tool("get_feed", {"num_posts": 51})
 
 
+class TestGetPostCommentsTool:
+    async def test_get_post_comments_success(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.get_post_comments = AsyncMock(
+            return_value=ExtractedSection(
+                text="Post body\nAlice: Great post!\nBob: Agreed",
+                references=[{"kind": "person", "url": "/in/alice/", "text": "Alice"}],
+            )
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_post_comments")
+        result = await tool_fn(
+            "urn:li:activity:123", mock_context, extractor=mock_extractor
+        )
+        assert (
+            result["url"] == "https://www.linkedin.com/feed/update/urn:li:activity:123/"
+        )
+        assert (
+            result["sections"]["post"] == "Post body\nAlice: Great post!\nBob: Agreed"
+        )
+        assert result["references"]["post"][0]["url"] == "/in/alice/"
+        mock_extractor.get_post_comments.assert_awaited_once_with(
+            "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+            max_scrolls=None,
+        )
+
+    async def test_get_post_comments_accepts_full_permalink(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.get_post_comments = AsyncMock(
+            return_value=ExtractedSection(text="Post body", references=[])
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_post_comments")
+        result = await tool_fn(
+            "https://www.linkedin.com/posts/alice_x-activity-1-yy?utm_source=share",
+            mock_context,
+            max_scrolls=10,
+            extractor=mock_extractor,
+        )
+        assert result["url"] == "https://www.linkedin.com/posts/alice_x-activity-1-yy/"
+        mock_extractor.get_post_comments.assert_awaited_once_with(
+            "https://www.linkedin.com/posts/alice_x-activity-1-yy/",
+            max_scrolls=10,
+        )
+
+    async def test_get_post_comments_rejects_invalid_url(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_post_comments")
+        with pytest.raises(ToolError, match="post_url"):
+            await tool_fn(
+                "https://www.linkedin.com/in/alice/",
+                mock_context,
+                extractor=MagicMock(),
+            )
+
+    async def test_get_post_comments_rate_limited_surfaces_section_error(
+        self, mock_context
+    ):
+        mock_extractor = MagicMock()
+        mock_extractor.get_post_comments = AsyncMock(
+            return_value=ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_post_comments")
+        result = await tool_fn(
+            "urn:li:activity:123", mock_context, extractor=mock_extractor
+        )
+        assert result["sections"] == {}
+        assert result["section_errors"]["post"]["error_type"] == "rate_limit"
+
+    async def test_get_post_comments_returns_section_errors(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.get_post_comments = AsyncMock(
+            return_value=ExtractedSection(
+                text="",
+                references=[],
+                error={"issue_template_path": "/tmp/post-issue.md"},
+            )
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_post_comments")
+        result = await tool_fn(
+            "urn:li:activity:123", mock_context, extractor=mock_extractor
+        )
+        assert result["sections"] == {}
+        assert "post" in result["section_errors"]
+
+
 class TestToolTimeouts:
     async def test_all_tools_have_global_timeout(self):
         from linkedin_mcp_server.server import create_mcp_server


### PR DESCRIPTION
## Summary

Adds comment reading and own-account analytics:

- **`comments` person section** on `get_person_profile` / `get_my_profile` — scrapes `/in/<user>/recent-activity/comments/` (the comments and replies the person wrote on other posts). One section = one navigation, following the existing `posts` section pattern.
- **`get_post_comments` tool** — opens a single post permalink and returns the post body plus its full comment thread under `sections["post"]`, with commenter profiles in `references["post"]`. Accepts `/feed/update/<urn>/` or `/posts/<slug>` URLs (full or relative) or a bare `urn:li:activity:<id>`; input is validated before navigation.
- **`get_my_analytics` tool** — scrapes the authenticated user's "Private to you" analytics dashboards, one navigation per section: `content` (impressions, members reached, engagement breakdown, top performing posts), `audience` (followers + demographics), `top_posts` (14-day ranking with per-post counts), `profile_views` (90-day viewers), `search_appearances`. Defaults to all five; optional `time_range` (`7d`/`28d`/`90d`/`365d`) re-windows the content and audience pages via LinkedIn's `?timeRange=` param.

## Implementation notes

- The comment block on a permalink page hydrates well after the post body. The extractor waits for the comment composer — `main [role="textbox"][contenteditable="true"]`, attribute presence only, locale-independent — before expanding the thread.
- LinkedIn serves two comment-pagination mechanisms: the SDUI layout attaches comment batches when the post's own scroll container scrolls (window scrolling is a no-op, so mouse wheel is used, mirroring `get_feed`), and the classic layout renders a "Load more comments" button. Expansion wheel-scrolls with growth-based stale detection (locale-independent) and clicks the button when present, guarded behind an explicit per-locale table per the Scraping Rules.
- Analytics pages render the shell first and hydrate stat cards afterwards; `_extract_loaded_section` gains an `is_analytics` wait. `timeRange` values are normalized through an explicit map and rejected with an actionable `ToolError` otherwise. Chart data survives as accessible-text descriptions (axis ranges/min/max), which is enough for an LLM to read the trend.
- Reference metadata: `post` section capped at 30 (one anchor per commenter), context hints for `comments`/`post` sections.

## Verification

Verified live end-to-end via streamable-http per CLAUDE.md:

- `get_my_profile(sections="posts,comments")` returned 40 comment-activity entries (~36k chars) with the commented posts and comment bodies.
- `get_post_comments` on a 10-comment post returned all comments with authors, timestamps, and bodies, plus 14 references including commenter profiles.
- `get_my_analytics()` (all five sections) returned impressions/engagement breakdowns, follower demographics, a 26-entry top-posts ranking, 90-day profile viewers, and appearance counts; `timeRange=past_28_days`/`past_365_days` verified to change the reporting window on the content and audience pages.
- Known limitation (LinkedIn platform behavior, confirmed by DOM probing): posts from ~2015 and earlier render no comment thread at all on their permalink page — `get_post_comments` returns the post body and social counts only. Premium-gated analytics values (viewer identities, click counts) come through as LinkedIn renders them.

`ruff check`, `ruff format`, `ty check`, and `pytest` (839 passed) are green.

## Synthetic prompt

> Add comment reading and own-account analytics: a `comments` section for `get_person_profile`/`get_my_profile` scraping `/recent-activity/comments/`; a `get_post_comments` tool that opens a post permalink (URL or bare URN), waits for the comment thread to hydrate, paginates it locale-independently, and returns it as `sections["post"]` with commenter references; and a `get_my_analytics` tool covering the /analytics/ dashboards (content, audience, top_posts, profile_views, search_appearances) with an optional 7d/28d/90d/365d time range. Update fields, extractor, link metadata, tools, server registration, tests, README, docker-hub docs, and manifest.

Generated with Claude Fable 5 (claude-fable-5)
