### PR TITLE
fix(messaging): harden send_message confirmation and share-info prompt

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2620,23 +2620,180 @@ class LinkedInExtractor:
         )
         return bool(matched)
 
-    async def _message_text_visible(self, message: str) -> bool:
-        """Wait until the compose page visibly contains the just-sent message text.
-
-        Uses the page-level default timeout (``BrowserConfig.default_timeout``).
-        """
-        try:
-            await self._page.wait_for_function(
+    async def _message_text_occurrences_outside_composer(self, message: str) -> int:
+        """Count visible message text occurrences outside editable compose boxes."""
+        return int(
+            await self._page.evaluate(
                 """({ expected }) => {
                     const normalize = value =>
                         (value || '').replace(/\\s+/g, ' ').trim();
-                    const bodyText = normalize(document.body?.innerText || '');
-                    return bodyText.includes(normalize(expected));
+                    const target = normalize(expected);
+                    if (!target) return 0;
+                    const root = document.querySelector('main') || document.body;
+                    if (!root) return 0;
+                    const walker = document.createTreeWalker(
+                        root,
+                        NodeFilter.SHOW_TEXT,
+                        {
+                            acceptNode: node => {
+                                const parent = node.parentElement;
+                                if (!parent) return NodeFilter.FILTER_REJECT;
+                                if (parent.closest('[contenteditable="true"], [role="textbox"]')) {
+                                    return NodeFilter.FILTER_REJECT;
+                                }
+                                if (!(parent.offsetWidth || parent.offsetHeight || parent.getClientRects().length)) {
+                                    return NodeFilter.FILTER_REJECT;
+                                }
+                                return NodeFilter.FILTER_ACCEPT;
+                            },
+                        }
+                    );
+                    let count = 0;
+                    let node;
+                    while ((node = walker.nextNode())) {
+                        if (normalize(node.nodeValue || '').includes(target)) {
+                            count++;
+                        }
+                    }
+                    return count;
                 }""",
-                arg={"expected": message},
+                {"expected": message},
+            )
+        )
+
+    async def _message_text_visible_outside_composer(
+        self,
+        message: str,
+        *,
+        after_count: int = 0,
+    ) -> bool:
+        """Wait until message text gains a non-composer occurrence."""
+        try:
+            await self._page.wait_for_function(
+                """({ expected, afterCount }) => {
+                    const normalize = value =>
+                        (value || '').replace(/\\s+/g, ' ').trim();
+                    const target = normalize(expected);
+                    if (!target) return false;
+                    const root = document.querySelector('main') || document.body;
+                    if (!root) return false;
+                    const walker = document.createTreeWalker(
+                        root,
+                        NodeFilter.SHOW_TEXT,
+                        {
+                            acceptNode: node => {
+                                const parent = node.parentElement;
+                                if (!parent) return NodeFilter.FILTER_REJECT;
+                                if (parent.closest('[contenteditable="true"], [role="textbox"]')) {
+                                    return NodeFilter.FILTER_REJECT;
+                                }
+                                if (!(parent.offsetWidth || parent.offsetHeight || parent.getClientRects().length)) {
+                                    return NodeFilter.FILTER_REJECT;
+                                }
+                                return NodeFilter.FILTER_ACCEPT;
+                            },
+                        }
+                    );
+                    let count = 0;
+                    let node;
+                    while ((node = walker.nextNode())) {
+                        if (normalize(node.nodeValue || '').includes(target)) {
+                            count++;
+                        }
+                    }
+                    return count > afterCount;
+                }""",
+                arg={"expected": message, "afterCount": after_count},
             )
             return True
         except PlaywrightTimeoutError:
+            return False
+
+    async def _handle_profile_info_share_prompt(self) -> bool:
+        """Dismiss LinkedIn's optional profile-info sharing prompt after Send.
+
+        Some InMail/message sends show a post-click dialog asking whether to
+        share profile/contact information with the recipient. If the operator
+        has already approved the exact message text, the safe/default action is
+        to send the message without sharing extra profile information.
+
+        DOM dependency: LinkedIn exposes this as a transient modal without a
+        stable URL or data attribute, so text matching is the only practical
+        signal. Keep the phrase tables explicit and limited to observed PL/EN
+        prompt/action copy.
+        """
+        try:
+            handled = await self._page.evaluate(
+                r"""() => {
+                    const visible = el => !!(
+                        el &&
+                        (el.offsetWidth || el.offsetHeight || el.getClientRects().length)
+                    );
+                    const norm = value => (value || '')
+                        .replace(/\s+/g, ' ')
+                        .trim()
+                        .toLowerCase();
+
+                    const dialogSelectors = [
+                        'dialog[open]',
+                        '[role="dialog"]',
+                        '[aria-modal="true"]',
+                    ];
+                    const dialogs = [...new Set(
+                        dialogSelectors.flatMap(sel => [...document.querySelectorAll(sel)])
+                    )].filter(visible);
+
+                    const promptNeedles = [
+                        'udostępn',
+                        'informacje profil',
+                        'profile information',
+                        'share profile',
+                        'share your profile',
+                        'share your contact',
+                    ];
+                    const negativeButtonNeedles = [
+                        'nie udostępniaj',
+                        'nie teraz',
+                        'pomiń',
+                        'odrzuć',
+                        "don't share",
+                        'do not share',
+                        'not now',
+                        'skip',
+                    ];
+
+                    for (const dialog of dialogs) {
+                        const dialogText = norm(dialog.innerText || dialog.textContent || '');
+                        if (!promptNeedles.some(needle => dialogText.includes(needle))) {
+                            continue;
+                        }
+                        const buttons = [...dialog.querySelectorAll('button, [role="button"]')]
+                            .filter(visible);
+                        const negative = buttons.find(button => {
+                            const text = norm(
+                                (button.innerText || button.textContent || '') + ' ' +
+                                (button.getAttribute('aria-label') || '')
+                            );
+                            return negativeButtonNeedles.some(needle => text.includes(needle));
+                        });
+                        if (!negative) {
+                            return false;
+                        }
+                        negative.click();
+                        return true;
+                    }
+                    return false;
+                }"""
+            )
+            if handled:
+                await asyncio.sleep(1.0)
+                logger.debug("Dismissed LinkedIn profile-info sharing prompt")
+            return bool(handled)
+        except Exception:
+            logger.debug(
+                "Could not handle LinkedIn profile-info sharing prompt",
+                exc_info=True,
+            )
             return False
 
     async def _dismiss_message_ui(self) -> None:
@@ -3621,6 +3778,130 @@ class LinkedInExtractor:
             references=references,
         )
 
+    async def _send_current_message_surface(
+        self,
+        message: str,
+        *,
+        confirm_send: bool,
+        recipient_selected: bool = True,
+    ) -> dict[str, Any]:
+        """Type and send a message on the currently-open LinkedIn composer."""
+        compose_box = await self._resolve_message_compose_box()
+        if compose_box is None:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "composer_unavailable",
+                "LinkedIn did not expose a usable message composer.",
+                recipient_selected=recipient_selected,
+            )
+
+        if not confirm_send:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "confirmation_required",
+                "Set confirm_send=true to send the message.",
+                recipient_selected=recipient_selected,
+            )
+
+        pre_send_count = await self._message_text_occurrences_outside_composer(message)
+
+        # patchright actionability can block normal locator.click()/type flows on
+        # LinkedIn's composer. Evaluating on the resolved locator scopes the
+        # focus step to the composer selected above without relying on global
+        # document order.
+        focused = await compose_box.evaluate(
+            """el => {
+                el.focus();
+                return document.activeElement === el || el.contains(document.activeElement);
+            }"""
+        )
+        if not focused:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "compose_interact_failed",
+                "Could not focus compose box via JavaScript.",
+                recipient_selected=recipient_selected,
+            )
+        await asyncio.sleep(0.1)
+        await self._page.keyboard.type(message, delay=15)
+        await asyncio.sleep(0.3)
+
+        await asyncio.sleep(1.0)
+        sent_via_js = await self._page.evaluate(
+            """() => {
+                const visible = el => !!(
+                    el && (el.offsetWidth || el.offsetHeight || el.getClientRects().length)
+                );
+                const textbox = document.activeElement?.closest(
+                    '[contenteditable="true"], [role="textbox"]'
+                );
+                if (!textbox) return false;
+                const sendSelector = [
+                    'button[type="submit"]',
+                    'button[aria-label*="Send"]',
+                    'button[aria-label*="send"]',
+                    'button[aria-label*="Wyślij"]',
+                    'button[aria-label*="wyślij"]',
+                    'button[data-control-name="send"]',
+                ].join(',');
+                let scope = textbox;
+                while (scope && scope !== document.body) {
+                    const btn = Array.from(scope.querySelectorAll(sendSelector))
+                        .find(b => !b.disabled && visible(b));
+                    if (btn) {
+                        btn.click();
+                        return true;
+                    }
+                    scope = scope.parentElement;
+                }
+                return false;
+            }"""
+        )
+        if not sent_via_js:
+            await self._page.keyboard.press("Enter")
+
+        # Give LinkedIn time to either clear the composer, mount its optional
+        # profile-info sharing prompt, or render the outbound message. Without
+        # this pause a generic body-text check can see the still-typed composer
+        # text and falsely report sent=true before the click is processed.
+        await asyncio.sleep(1.5)
+        await self._handle_profile_info_share_prompt()
+
+        if not await self._message_text_visible_outside_composer(
+            message,
+            after_count=pre_send_count,
+        ):
+            if await self._handle_profile_info_share_prompt():
+                if await self._message_text_visible_outside_composer(
+                    message,
+                    after_count=pre_send_count,
+                ):
+                    return self._message_action_result(
+                        self._page.url,
+                        "sent",
+                        "Message sent.",
+                        recipient_selected=recipient_selected,
+                        sent=True,
+                    )
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "send_unavailable",
+                "LinkedIn did not confirm that the message was sent.",
+                recipient_selected=recipient_selected,
+            )
+
+        return self._message_action_result(
+            self._page.url,
+            "sent",
+            "Message sent.",
+            recipient_selected=recipient_selected,
+            sent=True,
+        )
+
     async def send_message(
         self,
         linkedin_username: str,
@@ -3745,85 +4026,10 @@ class LinkedInExtractor:
             )
         recipient_selected = True
 
-        if not confirm_send:
-            await self._dismiss_message_ui()
-            return self._message_action_result(
-                self._page.url,
-                "confirmation_required",
-                "Set confirm_send=true to send the message.",
-                recipient_selected=recipient_selected,
-            )
-
-        # patchright quirk: compose_box.click() and press_sequentially() use
-        # actionability checks internally and hit the same wait_for timeout.
-        # Instead: focus via page.evaluate() (no actionability check) and type
-        # via page.keyboard.type() which operates on the active element directly
-        # and fires the real keydown/input/keyup events React needs to enable Send.
-        #
-        # DOM dependency: innerText extraction is not applicable here — we need
-        # to call .focus() on the element reference, which requires querySelector.
-        # Selectors use only role + contenteditable + aria-label (ARIA attributes,
-        # not layout class names) so they are stable across LinkedIn UI changes.
-        focused = await self._page.evaluate(
-            """() => {
-                const el = document.querySelector(
-                    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
-                    + 'div[role="textbox"][contenteditable="true"]'
-                );
-                if (!el) return false;
-                el.focus();
-                return true;
-            }"""
-        )
-        if not focused:
-            await self._dismiss_message_ui()
-            return self._message_action_result(
-                self._page.url,
-                "compose_interact_failed",
-                "Could not focus compose box via JavaScript.",
-                recipient_selected=recipient_selected,
-            )
-        await asyncio.sleep(0.1)
-        await self._page.keyboard.type(message, delay=15)
-        await asyncio.sleep(0.3)
-
-        # patchright actionability also blocks send_button.click(). Use JS click
-        # on any visible, enabled send button; fall back to Enter key which
-        # LinkedIn's composer also accepts for submission.
-        #
-        # DOM dependency: we need btn.click() on the element reference — not
-        # achievable via innerText or URL navigation. Selectors use only type,
-        # aria-label, and data attributes (no layout class names).
-        await asyncio.sleep(1.0)  # allow React to process keyboard input
-        sent_via_js = await self._page.evaluate(
-            """() => {
-                const btn = Array.from(document.querySelectorAll(
-                    'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
-                    + 'button[data-control-name="send"]'
-                )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
-                if (!btn) return false;
-                btn.click();
-                return true;
-            }"""
-        )
-        if not sent_via_js:
-            await self._page.keyboard.press("Enter")
-
-        if not await self._message_text_visible(message):
-            await self._dismiss_message_ui()
-            return self._message_action_result(
-                self._page.url,
-                "send_unavailable",
-                "LinkedIn did not confirm that the message was sent.",
-                recipient_selected=recipient_selected,
-            )
-
-        return self._message_action_result(
-            self._page.url,
-            "sent",
-            "Message sent.",
+        return await self._send_current_message_surface(
+            message,
+            confirm_send=confirm_send,
             recipient_selected=recipient_selected,
-            sent=True,
         )
 
     async def _extract_root_content(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -125,6 +125,125 @@ _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Close"]'
 )
 
+# Shared by baseline counting and post-send polling so both paths always use
+# identical visibility and editable-ancestor rules.
+_MESSAGE_CONFIRMATION_RETRY_TIMEOUT_MS = 5_000
+_PROFILE_INFO_SHARE_PROMPT_LOCALES = {
+    "de": {
+        "prompts": (
+            "profilinformationen teilen",
+            "profil teilen",
+            "kontaktdaten teilen",
+        ),
+        "negative_actions": (
+            "nicht teilen",
+            "jetzt nicht",
+            "überspringen",
+            "nein, danke",
+        ),
+    },
+    "en": {
+        "prompts": (
+            "profile information",
+            "share profile",
+            "share your profile",
+            "share your contact",
+        ),
+        "negative_actions": (
+            "don't share",
+            "do not share",
+            "not now",
+            "skip",
+            "no, thanks",
+        ),
+    },
+    "es": {
+        "prompts": (
+            "compartir la información del perfil",
+            "compartir tu perfil",
+            "compartir tus datos de contacto",
+        ),
+        "negative_actions": (
+            "no compartir",
+            "ahora no",
+            "omitir",
+            "no, gracias",
+        ),
+    },
+    "fr": {
+        "prompts": (
+            "partager les informations du profil",
+            "partager votre profil",
+            "partager vos coordonnées",
+        ),
+        "negative_actions": (
+            "ne pas partager",
+            "pas maintenant",
+            "ignorer",
+            "non merci",
+        ),
+    },
+    "pl": {
+        "prompts": (
+            "udostępn",
+            "informacje profil",
+        ),
+        "negative_actions": (
+            "nie udostępniaj",
+            "nie teraz",
+            "pomiń",
+            "odrzuć",
+        ),
+    },
+    "pt": {
+        "prompts": (
+            "compartilhar informações do perfil",
+            "compartilhar seu perfil",
+            "compartilhar suas informações de contato",
+        ),
+        "negative_actions": (
+            "não compartilhar",
+            "agora não",
+            "pular",
+            "não, obrigado",
+            "não, obrigada",
+        ),
+    },
+}
+_MESSAGE_TEXT_OCCURRENCES_OUTSIDE_COMPOSER_JS = r"""({ expected, afterCount }) => {
+    const normalize = value =>
+        (value || '').replace(/\s+/g, ' ').trim();
+    const target = normalize(expected);
+    if (!target) return afterCount === null ? 0 : false;
+    const root = document.querySelector('main') || document.body;
+    if (!root) return afterCount === null ? 0 : false;
+    const walker = document.createTreeWalker(
+        root,
+        NodeFilter.SHOW_TEXT,
+        {
+            acceptNode: node => {
+                const parent = node.parentElement;
+                if (!parent) return NodeFilter.FILTER_REJECT;
+                if (parent.closest('[contenteditable="true"], [role="textbox"]')) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+                if (!(parent.offsetWidth || parent.offsetHeight || parent.getClientRects().length)) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+                return NodeFilter.FILTER_ACCEPT;
+            },
+        }
+    );
+    let count = 0;
+    let node;
+    while ((node = walker.nextNode())) {
+        if (normalize(node.nodeValue || '').includes(target)) {
+            count++;
+        }
+    }
+    return afterCount === null ? count : count > afterCount;
+}"""
+
 # Shared JS function that walks up from any /messaging/compose/ anchor
 # inside <main> to find the smallest ancestor that satisfies the
 # action-root predicate (>=2 interactive children, >=1 button). This is
@@ -2624,40 +2743,8 @@ class LinkedInExtractor:
         """Count visible message text occurrences outside editable compose boxes."""
         return int(
             await self._page.evaluate(
-                """({ expected }) => {
-                    const normalize = value =>
-                        (value || '').replace(/\\s+/g, ' ').trim();
-                    const target = normalize(expected);
-                    if (!target) return 0;
-                    const root = document.querySelector('main') || document.body;
-                    if (!root) return 0;
-                    const walker = document.createTreeWalker(
-                        root,
-                        NodeFilter.SHOW_TEXT,
-                        {
-                            acceptNode: node => {
-                                const parent = node.parentElement;
-                                if (!parent) return NodeFilter.FILTER_REJECT;
-                                if (parent.closest('[contenteditable="true"], [role="textbox"]')) {
-                                    return NodeFilter.FILTER_REJECT;
-                                }
-                                if (!(parent.offsetWidth || parent.offsetHeight || parent.getClientRects().length)) {
-                                    return NodeFilter.FILTER_REJECT;
-                                }
-                                return NodeFilter.FILTER_ACCEPT;
-                            },
-                        }
-                    );
-                    let count = 0;
-                    let node;
-                    while ((node = walker.nextNode())) {
-                        if (normalize(node.nodeValue || '').includes(target)) {
-                            count++;
-                        }
-                    }
-                    return count;
-                }""",
-                {"expected": message},
+                _MESSAGE_TEXT_OCCURRENCES_OUTSIDE_COMPOSER_JS,
+                {"expected": message, "afterCount": None},
             )
         )
 
@@ -2666,44 +2753,18 @@ class LinkedInExtractor:
         message: str,
         *,
         after_count: int = 0,
+        timeout_ms: float | None = None,
     ) -> bool:
         """Wait until message text gains a non-composer occurrence."""
+        wait_options: dict[str, Any] = {
+            "arg": {"expected": message, "afterCount": after_count}
+        }
+        if timeout_ms is not None:
+            wait_options["timeout"] = timeout_ms
         try:
             await self._page.wait_for_function(
-                """({ expected, afterCount }) => {
-                    const normalize = value =>
-                        (value || '').replace(/\\s+/g, ' ').trim();
-                    const target = normalize(expected);
-                    if (!target) return false;
-                    const root = document.querySelector('main') || document.body;
-                    if (!root) return false;
-                    const walker = document.createTreeWalker(
-                        root,
-                        NodeFilter.SHOW_TEXT,
-                        {
-                            acceptNode: node => {
-                                const parent = node.parentElement;
-                                if (!parent) return NodeFilter.FILTER_REJECT;
-                                if (parent.closest('[contenteditable="true"], [role="textbox"]')) {
-                                    return NodeFilter.FILTER_REJECT;
-                                }
-                                if (!(parent.offsetWidth || parent.offsetHeight || parent.getClientRects().length)) {
-                                    return NodeFilter.FILTER_REJECT;
-                                }
-                                return NodeFilter.FILTER_ACCEPT;
-                            },
-                        }
-                    );
-                    let count = 0;
-                    let node;
-                    while ((node = walker.nextNode())) {
-                        if (normalize(node.nodeValue || '').includes(target)) {
-                            count++;
-                        }
-                    }
-                    return count > afterCount;
-                }""",
-                arg={"expected": message, "afterCount": after_count},
+                _MESSAGE_TEXT_OCCURRENCES_OUTSIDE_COMPOSER_JS,
+                **wait_options,
             )
             return True
         except PlaywrightTimeoutError:
@@ -2719,12 +2780,12 @@ class LinkedInExtractor:
 
         DOM dependency: LinkedIn exposes this as a transient modal without a
         stable URL or data attribute, so text matching is the only practical
-        signal. Keep the phrase tables explicit and limited to observed PL/EN
-        prompt/action copy.
+        signal. Matching is selected from an explicit per-locale table using
+        the document language; unsupported locales are left untouched.
         """
         try:
             handled = await self._page.evaluate(
-                r"""() => {
+                r"""({ localeTable }) => {
                     const visible = el => !!(
                         el &&
                         (el.offsetWidth || el.offsetHeight || el.getClientRects().length)
@@ -2734,6 +2795,13 @@ class LinkedInExtractor:
                         .trim()
                         .toLowerCase();
 
+                    const language = norm(document.documentElement.lang || 'en')
+                        .split('-')[0];
+                    const locale = localeTable[language];
+                    if (!locale) return false;
+                    const promptNeedles = locale.prompts.map(norm);
+                    const negativeButtonNeedles = locale.negative_actions.map(norm);
+
                     const dialogSelectors = [
                         'dialog[open]',
                         '[role="dialog"]',
@@ -2742,25 +2810,6 @@ class LinkedInExtractor:
                     const dialogs = [...new Set(
                         dialogSelectors.flatMap(sel => [...document.querySelectorAll(sel)])
                     )].filter(visible);
-
-                    const promptNeedles = [
-                        'udostępn',
-                        'informacje profil',
-                        'profile information',
-                        'share profile',
-                        'share your profile',
-                        'share your contact',
-                    ];
-                    const negativeButtonNeedles = [
-                        'nie udostępniaj',
-                        'nie teraz',
-                        'pomiń',
-                        'odrzuć',
-                        "don't share",
-                        'do not share',
-                        'not now',
-                        'skip',
-                    ];
 
                     for (const dialog of dialogs) {
                         const dialogText = norm(dialog.innerText || dialog.textContent || '');
@@ -2783,7 +2832,8 @@ class LinkedInExtractor:
                         return true;
                     }
                     return false;
-                }"""
+                }""",
+                {"localeTable": _PROFILE_INFO_SHARE_PROMPT_LOCALES},
             )
             if handled:
                 await asyncio.sleep(1.0)
@@ -3841,10 +3891,6 @@ class LinkedInExtractor:
                 if (!textbox) return false;
                 const sendSelector = [
                     'button[type="submit"]',
-                    'button[aria-label*="Send"]',
-                    'button[aria-label*="send"]',
-                    'button[aria-label*="Wyślij"]',
-                    'button[aria-label*="wyślij"]',
                     'button[data-control-name="send"]',
                 ].join(',');
                 let scope = textbox;
@@ -3878,6 +3924,7 @@ class LinkedInExtractor:
                 if await self._message_text_visible_outside_composer(
                     message,
                     after_count=pre_send_count,
+                    timeout_ms=_MESSAGE_CONFIRMATION_RETRY_TIMEOUT_MS,
                 ):
                     return self._message_action_result(
                         self._page.url,

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4954,8 +4954,12 @@ class TestResolveMessageComposeBox:
 class TestSendMessageComposerInteraction:
     """Tests for the page.evaluate + keyboard.type send path (patchright workaround)."""
 
-    def _patch_send_message_to_compose(self, extractor, mock_page):
+    def _patch_send_message_to_compose(
+        self, extractor, mock_page, *, focus_result=True, pre_send_count=0
+    ):
         """Return a context manager that patches send_message up to the compose step."""
+        compose_box = MagicMock()
+        compose_box.evaluate = AsyncMock(return_value=focus_result)
         return (
             patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
             patch(
@@ -4988,7 +4992,7 @@ class TestSendMessageComposerInteraction:
                 extractor,
                 "_resolve_message_compose_box",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                return_value=compose_box,
             ),
             patch.object(
                 extractor,
@@ -5005,6 +5009,12 @@ class TestSendMessageComposerInteraction:
                 "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
+            patch.object(
+                extractor,
+                "_message_text_occurrences_outside_composer",
+                new_callable=AsyncMock,
+                return_value=pre_send_count,
+            ),
         )
 
     async def test_focus_and_type_via_evaluate_and_keyboard(self, mock_page):
@@ -5014,8 +5024,8 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), True (send button click)
-        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        # evaluate returns: True (send button click), False (no share prompt)
+        mock_page.evaluate = AsyncMock(side_effect=[True, False])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -5029,9 +5039,10 @@ class TestSendMessageComposerInteraction:
             patches[7],
             patches[8],
             patches[9],
+            patches[10],
             patch.object(
                 extractor,
-                "_message_text_visible",
+                "_message_text_visible_outside_composer",
                 new_callable=AsyncMock,
                 return_value=True,
             ),
@@ -5051,9 +5062,10 @@ class TestSendMessageComposerInteraction:
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns False (focus failed)
         mock_page.evaluate = AsyncMock(return_value=False)
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
+        patches = self._patch_send_message_to_compose(
+            extractor, mock_page, focus_result=False
+        )
 
         with (
             patches[0],
@@ -5066,6 +5078,7 @@ class TestSendMessageComposerInteraction:
             patches[7],
             patches[8],
             patches[9],
+            patches[10],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
@@ -5081,8 +5094,8 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), False (no send button found)
-        mock_page.evaluate = AsyncMock(side_effect=[True, False])
+        # evaluate returns: False (no send button found), False (no share prompt)
+        mock_page.evaluate = AsyncMock(side_effect=[False, False])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -5096,9 +5109,10 @@ class TestSendMessageComposerInteraction:
             patches[7],
             patches[8],
             patches[9],
+            patches[10],
             patch.object(
                 extractor,
-                "_message_text_visible",
+                "_message_text_visible_outside_composer",
                 new_callable=AsyncMock,
                 return_value=True,
             ),
@@ -5110,6 +5124,171 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "sent"
         # Enter was pressed as fallback
         mock_keyboard.press.assert_awaited_once_with("Enter")
+
+    async def test_does_not_confirm_sent_when_text_only_in_composer(self, mock_page):
+        """A sent result requires the message outside the editable composer."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(return_value=True)
+        patches = self._patch_send_message_to_compose(
+            extractor, mock_page, pre_send_count=2
+        )
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patch.object(
+                extractor,
+                "_handle_profile_info_share_prompt",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible_outside_composer",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as visible_check,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert result["sent"] is False
+        visible_check.assert_awaited_with("Hello!", after_count=2)
+
+    async def test_existing_text_plus_new_occurrence_confirms_sent(self, mock_page):
+        """Existing matching thread text is OK only when a new occurrence appears."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(return_value=True)
+        patches = self._patch_send_message_to_compose(
+            extractor, mock_page, pre_send_count=2
+        )
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patch.object(
+                extractor,
+                "_message_text_visible_outside_composer",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as visible_check,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "sent"
+        assert result["sent"] is True
+        visible_check.assert_awaited_with("Hello!", after_count=2)
+
+    async def test_profile_info_share_prompt_can_be_dismissed_before_confirmation(
+        self, mock_page
+    ):
+        """The send path dismisses LinkedIn's optional share-info prompt."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(return_value=True)
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patch.object(
+                extractor,
+                "_handle_profile_info_share_prompt",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as prompt_handler,
+            patch.object(
+                extractor,
+                "_message_text_visible_outside_composer",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "sent"
+        prompt_handler.assert_awaited_once()
+
+    async def test_profile_info_share_prompt_handler_clicks_negative_option(
+        self, mock_page
+    ):
+        """The prompt handler only looks for negative share-info actions."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=True)
+
+        with patch(
+            "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep_mock:
+            handled = await extractor._handle_profile_info_share_prompt()
+
+        assert handled is True
+        sleep_mock.assert_awaited_once_with(1.0)
+        evaluate_call = mock_page.evaluate.await_args
+        assert evaluate_call is not None
+        js = evaluate_call.args[0]
+        assert "share profile" in js
+        assert "don't share" in js
+        assert "not now" in js
+        assert ".artdeco-modal" not in js
+
+    async def test_message_visible_outside_composer_excludes_editable_text(
+        self, mock_page
+    ):
+        """Confirmation ignores text that is still inside the composer."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock()
+
+        assert await extractor._message_text_visible_outside_composer("Hello!") is True
+
+        wait_call = mock_page.wait_for_function.await_args
+        assert wait_call is not None
+        js = wait_call.args[0]
+        assert '[contenteditable="true"], [role="textbox"]' in js
 
 
 class TestBuildFeedReferences:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5055,6 +5055,10 @@ class TestSendMessageComposerInteraction:
         assert result["sent"] is True
         # Verify keyboard.type was used (not press_sequentially)
         mock_keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        send_js = mock_page.evaluate.await_args_list[0].args[0]
+        assert 'button[type="submit"]' in send_js
+        assert 'button[data-control-name="send"]' in send_js
+        assert "aria-label" not in send_js
 
     async def test_compose_interact_failed_when_focus_fails(self, mock_page):
         """send_message returns compose_interact_failed when JS focus fails."""
@@ -5253,6 +5257,53 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "sent"
         prompt_handler.assert_awaited_once()
 
+    async def test_late_share_prompt_uses_short_confirmation_retry(self, mock_page):
+        """A late prompt must not trigger a second full confirmation timeout."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(return_value=True)
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patch.object(
+                extractor,
+                "_handle_profile_info_share_prompt",
+                new_callable=AsyncMock,
+                side_effect=[False, True],
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible_outside_composer",
+                new_callable=AsyncMock,
+                side_effect=[False, False],
+            ) as visible_check,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert visible_check.await_count == 2
+        assert visible_check.await_args_list[0].kwargs == {"after_count": 0}
+        assert visible_check.await_args_list[1].kwargs == {
+            "after_count": 0,
+            "timeout_ms": 5_000,
+        }
+
     async def test_profile_info_share_prompt_handler_clicks_negative_option(
         self, mock_page
     ):
@@ -5270,11 +5321,30 @@ class TestSendMessageComposerInteraction:
         sleep_mock.assert_awaited_once_with(1.0)
         evaluate_call = mock_page.evaluate.await_args
         assert evaluate_call is not None
-        js = evaluate_call.args[0]
-        assert "share profile" in js
-        assert "don't share" in js
-        assert "not now" in js
+        js, args = evaluate_call.args
+        assert "locale.prompts" in js
+        assert "locale.negative_actions" in js
+        assert "don't share" in args["localeTable"]["en"]["negative_actions"]
+        assert "not now" in args["localeTable"]["en"]["negative_actions"]
         assert ".artdeco-modal" not in js
+
+    async def test_profile_info_share_prompt_uses_explicit_common_locale_table(
+        self, mock_page
+    ):
+        """Prompt matching stays conservative while covering common locales."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=False)
+
+        await extractor._handle_profile_info_share_prompt()
+
+        evaluate_call = mock_page.evaluate.await_args
+        assert evaluate_call is not None
+        js, args = evaluate_call.args
+        assert "document.documentElement.lang" in js
+        locale_table = args["localeTable"]
+        assert set(locale_table) == {"de", "en", "es", "fr", "pl", "pt"}
+        assert all(config["prompts"] for config in locale_table.values())
+        assert all(config["negative_actions"] for config in locale_table.values())
 
     async def test_message_visible_outside_composer_excludes_editable_text(
         self, mock_page
@@ -5289,6 +5359,23 @@ class TestSendMessageComposerInteraction:
         assert wait_call is not None
         js = wait_call.args[0]
         assert '[contenteditable="true"], [role="textbox"]' in js
+
+    async def test_message_occurrence_helpers_share_one_browser_predicate(
+        self, mock_page
+    ):
+        """Baseline counting and confirmation must use identical DOM rules."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=0)
+        mock_page.wait_for_function = AsyncMock()
+
+        await extractor._message_text_occurrences_outside_composer("Hello!")
+        await extractor._message_text_visible_outside_composer("Hello!")
+
+        evaluate_call = mock_page.evaluate.await_args
+        wait_call = mock_page.wait_for_function.await_args
+        assert evaluate_call is not None
+        assert wait_call is not None
+        assert evaluate_call.args[0] == wait_call.args[0]
 
 
 class TestBuildFeedReferences:


### PR DESCRIPTION
## Summary

Hardens the existing `send_message` flow in two ways, without adding or changing any public tool surface:

1. Sent confirmation now requires a new visible occurrence of the message text outside the editable composer, compared against a pre-send baseline count. Previously any body-text match (including text still in the composer or already present in the visible conversation) could report `sent: true`.
2. Adds handling for LinkedIn's optional post-send prompt asking whether to share profile/contact information with the recipient. When present, the flow selects the no-share action, so an operator who approved only the message body does not implicitly share extra profile/contact info.

The confirmation search and occurrence count are scoped to `main` and skip editable/`textbox` ancestors, so composer text and hidden nodes do not count as delivery.

Closes #573

## Scope notes

- No new MCP tool is introduced. `send_message` keeps the same arguments and return shape.
- No docs/manifest tool-table changes are needed for this scope.
- Detection follows the repo scraping rules: send-button selection uses only structural selectors scoped to the active composer, while the transient profile/contact-info prompt uses an explicit per-document-language table for DE/EN/ES/FR/PL/PT because LinkedIn exposes no stable URL or data attribute.
- Baseline counting and confirmation share one JS predicate, and a late-modal retry is capped at 5 seconds rather than starting a second full timeout.

## Tests

- `tests/test_scraping.py` covers composer-only false positives, pre-existing text plus a new occurrence, negative share-prompt dismissal, explicit locale-table selection, structural send-button selectors, editable/textbox exclusion, one shared browser predicate, and the bounded late-prompt retry.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest` (full suite green; one unrelated skip is macOS-keychain only)
- `uv run pre-commit run --all-files`

## Synthetic prompt

> Harden `send_message` without changing its public API: confirm success only when a shared DOM predicate sees a new visible message-text occurrence outside editable composers; select Send through structural selectors scoped to the active composer; dismiss the optional profile/contact-info prompt through explicit DE/EN/ES/FR/PL/PT negative-action tables; cap a late-prompt confirmation retry at 5 seconds. Add regression tests for false positives, existing matching text, prompt handling, locale selection, selector safety, shared predicate reuse, and bounded retry latency.

Generated with GPT-5.5 (review) and Claude Opus 4.8 (implementation)

