### PR TITLE
fix(browser): serialize concurrent browser singleton creation

### DIFF
--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -6,6 +6,7 @@ context. Implements a singleton pattern for browser reuse across tool calls with
 automatic profile persistence.
 """
 
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -48,6 +49,11 @@ DEFAULT_PROFILE_DIR = Path.home() / ".linkedin-mcp" / "profile"
 _browser: BrowserManager | None = None
 _browser_cookie_export_path: Path | None = None
 _headless: bool = True
+# Serializes singleton creation: tool calls are serialized by the tool-call
+# middleware, but the background login flow started at startup can resume into
+# this path and race the first tool call, and an unguarded check-then-create
+# would launch two browsers against the same profile.
+_browser_create_lock = asyncio.Lock()
 
 
 def _debug_skip_checkpoint_restart() -> bool:
@@ -415,13 +421,24 @@ async def get_or_create_browser(
     Raises:
         AuthenticationError: If no valid authentication found
     """
-    global _browser, _browser_cookie_export_path, _headless
+    global _headless
 
     if headless is not None:
         _headless = headless
 
     if _browser is not None:
         return _browser
+
+    # Double-checked: only one concurrent caller may create the singleton.
+    async with _browser_create_lock:
+        if _browser is not None:
+            return _browser
+        return await _create_browser()
+
+
+async def _create_browser() -> BrowserManager:
+    """Create and initialize the singleton (caller holds _browser_create_lock)."""
+    global _browser, _browser_cookie_export_path
 
     launch_options, viewport = _launch_options()
     source_profile_dir = get_profile_dir()

--- a/tests/test_browser_driver.py
+++ b/tests/test_browser_driver.py
@@ -867,3 +867,32 @@ async def test_validate_uses_local_manager_not_singleton(tmp_path):
     # The singleton globals must remain untouched by the import validator.
     assert browser_module._browser is None
     assert browser_module._browser_cookie_export_path is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_get_or_create_creates_single_browser(monkeypatch):
+    """Two concurrent callers (a tool call and a background caller resuming at
+    startup) must not both launch a browser against the same profile."""
+    import asyncio
+    from typing import Any, cast
+
+    from linkedin_mcp_server.drivers import browser as browser_module
+
+    # Clean starting state regardless of test order; auto-restored at teardown.
+    monkeypatch.setattr(browser_module, "_browser", None)
+
+    calls = {"n": 0}
+    sentinel = cast(Any, object())
+
+    async def fake_create():
+        calls["n"] += 1
+        await asyncio.sleep(0.02)  # hold the lock so the second caller waits
+        browser_module._browser = sentinel
+        return sentinel
+
+    monkeypatch.setattr(browser_module, "_create_browser", fake_create)
+    first, second = await asyncio.gather(
+        get_or_create_browser(), get_or_create_browser()
+    )
+    assert first is sentinel and second is sentinel
+    assert calls["n"] == 1


### PR DESCRIPTION
get_or_create_browser() reuses a single module-level BrowserManager across calls, but it decided whether to create that singleton with an unguarded check-then-create. The tool-call middleware already serializes tool invocations, so overlapping tool calls were safe, but the background login flow that starts at startup resumes into this same path and can reach it at the same moment as the first tool call. Both callers then observe the singleton as None and each launch a browser against the same persistent profile directory, which corrupts the profile lock.

This wraps singleton creation in an asyncio.Lock and re-checks the singleton once the lock is held, so the first caller through creates the browser and every other caller reuses it. The creation body moves into a small _create_browser() helper that runs under the lock, leaving get_or_create_browser() as the fast lock-free path when the singleton already exists.

uv run pytest passes (796 passed, 11 skipped), including a new concurrent get_or_create test that asserts two overlapping callers create only one browser.