### PR TITLE
docs: Link send_message status issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox | working |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | working |
 | `search_conversations` | Search messages by keyword | working |
-| `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) [#483](https://github.com/stickerdaniel/linkedin-mcp-server/issues/483) [#560](https://github.com/stickerdaniel/linkedin-mcp-server/issues/560) |
+| `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) [#483](https://github.com/stickerdaniel/linkedin-mcp-server/issues/483) [#560](https://github.com/stickerdaniel/linkedin-mcp-server/issues/560) [#573](https://github.com/stickerdaniel/linkedin-mcp-server/issues/573) |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_companies` | Search for companies on LinkedIn by keywords | working |


### PR DESCRIPTION
## Summary

- Link open `send_message` bug #573 in the README Features & Tool Status table
- Keep the status table aligned with the open tool-specific limitation list

Closes #576

## Synthetic prompt

> Update the README Features & Tool Status table so the `send_message` row links open tool-specific issue #573 alongside the existing linked send_message issues. Create a docs issue for the mismatch and make the PR close it.

Generated with GPT-5 Codex