### PR TITLE
fix(get_conversation): wait for thread body to hydrate before extracting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 
 | Tool | Description | Status |
 |------|-------------|--------|
+| `linkedin_health` | Server version, Patchright profile paths, browser/session readiness | working |
+| `linkedin_ping` | Capability discovery — lists all registered tools (legacy + `linkedin_*` aliases) | working |
 | `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
 | `get_my_profile` | Get the authenticated user's own LinkedIn profile (same sections as get_person_profile) | working |
 | `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) [#432](https://github.com/stickerdaniel/linkedin-mcp-server/issues/432) [#454](https://github.com/stickerdaniel/linkedin-mcp-server/issues/454) |
@@ -54,6 +56,30 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `close_session` | Close browser session and clean up resources | working |
+
+Each scraper tool is also registered under a `linkedin_*` alias (for example `linkedin_get_person_profile`) so agent clients can use a consistent prefix without breaking existing integrations.
+
+### Browser profile & session lifecycle
+
+Patchright (Playwright-compatible) persists LinkedIn auth on disk under `~/.linkedin-mcp/`:
+
+| Path | Purpose |
+|------|---------|
+| `~/.linkedin-mcp/profile/` | Source Chromium user-data directory created by `--login` |
+| `~/.linkedin-mcp/cookies.json` | Portable cookie export used for Docker / foreign-runtime bridging |
+| `~/.linkedin-mcp/source-state.json` | Login generation metadata for the source profile |
+| `~/.linkedin-mcp/runtime-profiles/<runtime-id>/` | Derived profiles for non-host runtimes (e.g. Linux containers) |
+| `~/.linkedin-mcp/patchright-browsers/` | Shared Patchright Chromium browser cache (`PLAYWRIGHT_BROWSERS_PATH`) |
+
+**Lifecycle**
+
+1. **First auth** — run `uvx mcp-server-linkedin@latest --login` (or let the first scraper tool open a login window). This writes the source profile plus `cookies.json` and `source-state.json`.
+2. **Normal use** — MCP tools reuse the in-process browser session. Concurrent tool calls queue on a scraper lock.
+3. **Close session** — `close_session` / `linkedin_close_session` closes the live browser but keeps on-disk auth.
+4. **Reset auth** — `--logout` clears source and derived profiles.
+5. **Docker** — mount `~/.linkedin-mcp` into the container; each startup derives a fresh Linux profile from exported cookies (see Docker setup below).
+
+Use `linkedin_health` to inspect readiness and paths without scraping. Override the profile location with `--user-data-dir` / `USER_DATA_DIR`.
 
 <br/>
 <br/>

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -583,6 +583,12 @@ class _MessagingChromeTable:
     # excluded: they would need prefix matching, and any prefix match lets
     # quoted control text with a suffix confirm a false boundary.
     composer_companions: tuple[str, ...]
+    # Substring present on every rendered message turn ("<name> sent the
+    # following message(s) at <time>"). Absence means the thread pane has not
+    # hydrated yet: the sidebar alone satisfies a generic length check, so
+    # get_conversation waits on this marker before extracting to avoid racing
+    # an empty or partial thread body.
+    thread_turn_marker: str
 
 
 # How far below a composer-label candidate a companion control may sit and
@@ -600,8 +606,14 @@ _MESSAGING_CHROME_STRINGS: dict[str, _MessagingChromeTable] = {
             "Open Emoji Keyboard",
             "Open send options",
         ),
+        thread_turn_marker="sent the following message",
     ),
 }
+
+
+def _messaging_chrome_table(locale: str) -> _MessagingChromeTable | None:
+    """Return messaging chrome strings for *locale*, falling back to ``en``."""
+    return _MESSAGING_CHROME_STRINGS.get(locale) or _MESSAGING_CHROME_STRINGS.get("en")
 
 
 def strip_conversation_chrome(text: str, locale: str = "en") -> str:
@@ -1135,6 +1147,57 @@ class LinkedInExtractor:
             )
         except PlaywrightTimeoutError:
             logger.debug("%s content did not appear", log_context)
+
+    async def _page_messaging_locale(self) -> str:
+        """Best-effort page locale prefix for messaging chrome tables."""
+        try:
+            raw = await self._page.evaluate(
+                "() => (document.documentElement.lang || 'en').split('-')[0].toLowerCase()"
+            )
+            if isinstance(raw, str) and raw in _MESSAGING_CHROME_STRINGS:
+                return raw
+        except Exception:
+            logger.debug("Could not read page locale for messaging chrome", exc_info=True)
+        return "en"
+
+    async def _wait_for_conversation_body(self, *, timeout: int = 10000) -> None:
+        """Wait for the opened thread's message body to hydrate.
+
+        A thread page's ``main`` renders the inbox sidebar first; the sidebar
+        alone clears the generic length check in ``_wait_for_main_text`` well
+        before the thread pane fetches and mounts its messages. Extracting in
+        that window yields an empty (``sections: {}``) or partially-loaded
+        transcript. Block until either a rendered turn's ``thread_turn_marker``
+        appears ("... sent the following message ...") or the trailing composer
+        mounts (``composer_start``) — the latter signals an empty thread is
+        ready and avoids a full timeout waiting for turns that will never
+        appear. Locale is read from ``document.documentElement.lang`` with an
+        ``en`` table fallback. On timeout, fall through — the caller still
+        extracts whatever is present, preserving prior behavior rather than
+        raising.
+        """
+        locale = await self._page_messaging_locale()
+        table = _messaging_chrome_table(locale)
+        if table is None:
+            return
+        try:
+            await self._page.wait_for_function(
+                """({ marker, composerStart }) => {
+                    const main = document.querySelector('main');
+                    if (!main) return false;
+                    const text = main.innerText;
+                    if (text.includes(marker)) return true;
+                    if (text.includes(composerStart)) return true;
+                    return false;
+                }""",
+                arg={
+                    "marker": table.thread_turn_marker,
+                    "composerStart": table.composer_start,
+                },
+                timeout=timeout,
+            )
+        except PlaywrightTimeoutError:
+            logger.debug("Conversation body did not hydrate before timeout")
 
     async def _scroll_main_scrollable_region(
         self,
@@ -3548,6 +3611,10 @@ class LinkedInExtractor:
 
         await detect_rate_limit(self._page)
         await self._wait_for_main_text(log_context="Conversation")
+        # The sidebar alone satisfies _wait_for_main_text; block on an actual
+        # message turn so extraction does not race the thread pane's hydration
+        # (empty or partial transcript otherwise). See _wait_for_conversation_body.
+        await self._wait_for_conversation_body()
         await handle_modal_close(self._page)
         await self._scroll_main_scrollable_region(
             position="top", attempts=3, pause_time=0.5

--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -9,7 +9,9 @@ import time
 import mcp.types as mt
 
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
-from fastmcp.tools import ToolResult
+from fastmcp.tools.base import ToolResult
+
+from linkedin_mcp_server.tools.meta import META_TOOL_NAMES
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +44,9 @@ class SequentialToolExecutionMiddleware(Middleware):
         call_next: CallNext[mt.CallToolRequestParams, ToolResult],
     ) -> ToolResult:
         tool_name = context.message.name
+        if tool_name in META_TOOL_NAMES:
+            return await call_next(context)
+
         wait_started = time.perf_counter()
         logger.debug("Waiting for scraper lock for tool '%s'", tool_name)
         await self._report_progress(

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -20,6 +20,7 @@ from linkedin_mcp_server.bootstrap import (
 from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
 from linkedin_mcp_server.drivers.browser import close_browser
 from linkedin_mcp_server.error_handler import raise_tool_error
+from linkedin_mcp_server.exceptions import LinkedInMCPError
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
@@ -28,6 +29,7 @@ from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.feed import register_feed_tools
 from linkedin_mcp_server.tools.job import register_job_tools
 from linkedin_mcp_server.tools.messaging import register_messaging_tools
+from linkedin_mcp_server.tools.meta import register_meta_tools, register_tool_aliases
 from linkedin_mcp_server.tools.person import register_person_tools
 
 logger = logging.getLogger(__name__)
@@ -66,6 +68,7 @@ def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> 
     register_job_tools(mcp, tool_timeout=tool_timeout)
     register_messaging_tools(mcp, tool_timeout=tool_timeout)
     register_feed_tools(mcp, tool_timeout=tool_timeout)
+    register_meta_tools(mcp, tool_timeout=tool_timeout)
 
     # Register session management tool
     @mcp.tool(
@@ -83,6 +86,17 @@ def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> 
                 "message": "Successfully closed the browser session and cleaned up resources",
             }
         except Exception as e:
-            raise_tool_error(e, "close_session")  # NoReturn
+            if isinstance(e, LinkedInMCPError):
+                raise_tool_error(e, "close_session")  # NoReturn
+            raise_tool_error(
+                LinkedInMCPError(
+                    "Failed to close the browser session. It may already be closed; "
+                    "restart the MCP server if problems persist."
+                ),
+                "close_session",
+            )
+
+    # Aliases must be registered after every legacy tool (including close_session).
+    register_tool_aliases(mcp)
 
     return mcp

--- a/linkedin_mcp_server/tools/meta.py
+++ b/linkedin_mcp_server/tools/meta.py
@@ -1,0 +1,233 @@
+"""MCP meta tools: health, ping, and linkedin_* aliases."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.tools.base import Tool
+
+from linkedin_mcp_server import __version__
+from linkedin_mcp_server.authentication import get_authentication_source
+from linkedin_mcp_server.bootstrap import (
+    SetupState,
+    browser_setup_ready,
+    browsers_path,
+    get_bootstrap_state,
+    get_runtime_policy,
+    initialize_bootstrap,
+)
+from linkedin_mcp_server.config import get_config
+from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.drivers.browser import get_profile_dir, profile_exists
+from linkedin_mcp_server.session_state import (
+    get_runtime_id,
+    portable_cookie_path,
+    runtime_profiles_root,
+    source_state_path,
+)
+
+logger = logging.getLogger(__name__)
+
+# Legacy scraper tools registered without the linkedin_ prefix.
+LEGACY_TOOL_NAMES: tuple[str, ...] = (
+    "get_person_profile",
+    "get_my_profile",
+    "connect_with_person",
+    "get_sidebar_profiles",
+    "search_people",
+    "get_company_profile",
+    "get_company_posts",
+    "search_companies",
+    "get_company_employees",
+    "get_job_details",
+    "search_jobs",
+    "get_inbox",
+    "get_conversation",
+    "search_conversations",
+    "send_message",
+    "get_feed",
+    "close_session",
+)
+
+META_PING_TIMEOUT_SECONDS = 10.0
+META_HEALTH_TIMEOUT_SECONDS = 30.0
+META_TOOL_NAMES: tuple[str, ...] = ("linkedin_health", "linkedin_ping")
+
+
+def _session_auth_ready(profile_dir) -> bool:
+    if not (
+        profile_exists(profile_dir)
+        and portable_cookie_path(profile_dir).exists()
+        and source_state_path(profile_dir).exists()
+    ):
+        return False
+    try:
+        get_authentication_source()
+    except Exception:
+        return False
+    return True
+
+
+def _build_storage_paths(profile_dir) -> dict[str, str]:
+    auth_root = profile_dir.expanduser().resolve().parent
+    return {
+        "auth_root": str(auth_root),
+        "profile_dir": str(profile_dir.expanduser().resolve()),
+        "cookies_json": str(portable_cookie_path(profile_dir)),
+        "source_state_json": str(source_state_path(profile_dir)),
+        "runtime_profiles_dir": str(runtime_profiles_root(profile_dir)),
+        "patchright_browsers_dir": str(browsers_path()),
+        "playwright_browsers_path": str(browsers_path()),
+    }
+
+
+def build_health_payload() -> dict[str, Any]:
+    """Return server health without launching browser tools."""
+    initialize_bootstrap()
+    config = get_config()
+    profile_dir = get_profile_dir()
+    bootstrap = get_bootstrap_state()
+    auth_ready = _session_auth_ready(profile_dir)
+    browser_ready = browser_setup_ready()
+
+    warnings: list[str] = []
+    if not browser_ready:
+        warnings.append(
+            "Patchright Chromium is not installed or browser metadata is stale. "
+            "First scraper tool call triggers background install."
+        )
+    if not auth_ready:
+        warnings.append(
+            "No valid LinkedIn session. Run `mcp-server-linkedin --login` on the host."
+        )
+    if bootstrap.last_error:
+        warnings.append(f"Bootstrap last error: {bootstrap.last_error}")
+
+    payload: dict[str, Any] = {
+        "ok": auth_ready and (browser_ready or bootstrap.setup_state is SetupState.READY),
+        "server": "linkedin-mcp",
+        "version": __version__,
+        "transport": config.server.transport,
+        "mask_error_details": True,
+        "runtime_policy": get_runtime_policy().value,
+        "runtime_id": get_runtime_id(),
+        "bootstrap": {
+            "setup_state": bootstrap.setup_state.value,
+            "auth_state": bootstrap.auth_state.value,
+            "browser_ready": browser_ready,
+            "auth_ready": auth_ready,
+        },
+        "session": {
+            "profile_exists": profile_exists(profile_dir),
+            "cookies_present": portable_cookie_path(profile_dir).exists(),
+            "source_state_present": source_state_path(profile_dir).exists(),
+            "auth_ready": auth_ready,
+            "lifecycle": (
+                "Host login via --login writes ~/.linkedin-mcp/profile plus "
+                "cookies.json and source-state.json. Managed runtimes reuse the "
+                "source profile; Docker/container runtimes derive a fresh Linux "
+                "profile from exported cookies on startup. close_session (or "
+                "linkedin_close_session) closes the in-process browser; persistent "
+                "auth remains on disk until --logout."
+            ),
+        },
+        "storage": _build_storage_paths(profile_dir),
+        "timeouts_seconds": {
+            "tool_default": config.server.tool_timeout_seconds,
+            "browser_page_default_ms": config.browser.default_timeout,
+        },
+    }
+    if warnings:
+        payload["warnings"] = warnings
+    return payload
+
+
+async def build_ping_payload(mcp: FastMCP) -> dict[str, Any]:
+    """Return capability discovery payload for linkedin_ping."""
+    config = get_config()
+    tools = await mcp.list_tools(run_middleware=False)
+    tool_list = [
+        {"name": tool.name, "description": tool.description or ""}
+        for tool in sorted(tools, key=lambda t: t.name)
+    ]
+    legacy_names = set(LEGACY_TOOL_NAMES)
+    prefixed_aliases = [
+        t["name"] for t in tool_list if t["name"].startswith("linkedin_")
+    ]
+
+    return {
+        "ok": True,
+        "pong": True,
+        "server": "linkedin-mcp",
+        "version": __version__,
+        "transport": config.server.transport,
+        "tools": tool_list,
+        "tool_count": len(tool_list),
+        "capabilities": {
+            "playwright_profile_persistence": True,
+            "patchright_chromium": True,
+            "stdio_default": config.server.transport == "stdio",
+            "sequential_tool_execution": True,
+            "legacy_tool_names": sorted(legacy_names),
+            "prefixed_aliases": prefixed_aliases,
+            "meta_tools": ["linkedin_health", "linkedin_ping"],
+            "default_tool_timeout_seconds": config.server.tool_timeout_seconds,
+        },
+        "storage": _build_storage_paths(get_profile_dir()),
+    }
+
+
+def register_tool_aliases(mcp: FastMCP) -> None:
+    """Register linkedin_* aliases alongside legacy tool names."""
+    # LocalProvider.list_tools/get_tool are async; during sync server setup we
+    # read the already-registered components directly from the local provider.
+    components = mcp.local_provider._components
+    tools_by_name = {
+        component.name: component
+        for component in components.values()
+        if isinstance(component, Tool)
+    }
+    existing = set(tools_by_name)
+
+    for name in LEGACY_TOOL_NAMES:
+        alias = f"linkedin_{name}"
+        if name not in existing or alias in existing:
+            continue
+        try:
+            mcp.add_tool(Tool.from_tool(tools_by_name[name], name=alias))
+            existing.add(alias)
+        except Exception:
+            logger.exception("Failed to register linkedin_* alias for %s", name)
+
+
+def register_meta_tools(
+    mcp: FastMCP,
+    *,
+    tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS,
+) -> None:
+    """Register linkedin_health and linkedin_ping meta tools."""
+    del tool_timeout  # meta tools use fixed shorter timeouts
+
+    @mcp.tool(
+        name="linkedin_health",
+        timeout=META_HEALTH_TIMEOUT_SECONDS,
+        title="LinkedIn MCP Health",
+        annotations={"readOnlyHint": True},
+        tags={"meta", "health"},
+    )
+    async def linkedin_health() -> dict[str, Any]:
+        """Return server version, storage paths, and browser/session readiness."""
+        return build_health_payload()
+
+    @mcp.tool(
+        name="linkedin_ping",
+        timeout=META_PING_TIMEOUT_SECONDS,
+        title="LinkedIn MCP Ping",
+        annotations={"readOnlyHint": True},
+        tags={"meta", "ping"},
+    )
+    async def linkedin_ping() -> dict[str, Any]:
+        """Return server metadata, registered tools, and capabilities."""
+        return await build_ping_payload(mcp)

--- a/manifest.json
+++ b/manifest.json
@@ -108,8 +108,84 @@
       "description": "Get recent posts from the authenticated user's LinkedIn home feed"
     },
     {
+      "name": "linkedin_health",
+      "description": "Return server version, storage paths, and browser/session readiness"
+    },
+    {
+      "name": "linkedin_ping",
+      "description": "Return server metadata, registered tools, and capabilities"
+    },
+    {
       "name": "close_session",
       "description": "Properly close browser session and clean up resources"
+    },
+    {
+      "name": "linkedin_close_session",
+      "description": "Alias for close_session. Properly close browser session and clean up resources"
+    },
+    {
+      "name": "linkedin_connect_with_person",
+      "description": "Alias for connect_with_person. Send a connection request or accept an incoming one, with optional note"
+    },
+    {
+      "name": "linkedin_get_company_employees",
+      "description": "Alias for get_company_employees. List employees at a company from the LinkedIn /people/ page, with optional keyword filter by name, title, or skill"
+    },
+    {
+      "name": "linkedin_get_company_posts",
+      "description": "Alias for get_company_posts. Get recent posts from a company's LinkedIn feed"
+    },
+    {
+      "name": "linkedin_get_company_profile",
+      "description": "Alias for get_company_profile. Extract comprehensive company information and details. About-section references may include a company_urn entry carrying the numeric id LinkedIn's people-search uses in its currentCompany URL facet."
+    },
+    {
+      "name": "linkedin_get_conversation",
+      "description": "Alias for get_conversation. Read a specific messaging conversation by thread ID or LinkedIn username"
+    },
+    {
+      "name": "linkedin_get_feed",
+      "description": "Alias for get_feed. Get recent posts from the authenticated user's LinkedIn home feed"
+    },
+    {
+      "name": "linkedin_get_inbox",
+      "description": "Alias for get_inbox. List recent conversations from the LinkedIn messaging inbox"
+    },
+    {
+      "name": "linkedin_get_job_details",
+      "description": "Alias for get_job_details. Retrieve specific job posting details using LinkedIn job IDs"
+    },
+    {
+      "name": "linkedin_get_my_profile",
+      "description": "Alias for get_my_profile. Get the authenticated user's own LinkedIn profile with optional section selection (experience, education, skills, etc.)"
+    },
+    {
+      "name": "linkedin_get_person_profile",
+      "description": "Alias for get_person_profile. Get detailed information from a LinkedIn profile including work history, education, certifications, skills, projects, connections, and recent posts"
+    },
+    {
+      "name": "linkedin_get_sidebar_profiles",
+      "description": "Alias for get_sidebar_profiles. Extract profile URLs from LinkedIn sidebar recommendation sections on a profile page"
+    },
+    {
+      "name": "linkedin_search_companies",
+      "description": "Alias for search_companies. Search for companies on LinkedIn by keywords"
+    },
+    {
+      "name": "linkedin_search_conversations",
+      "description": "Alias for search_conversations. Search LinkedIn messages by keyword"
+    },
+    {
+      "name": "linkedin_search_jobs",
+      "description": "Alias for search_jobs. Search for jobs with filters like keywords and location"
+    },
+    {
+      "name": "linkedin_search_people",
+      "description": "Alias for search_people. Search for people on LinkedIn by keywords, location, connection degree (1st/2nd/3rd), and current company"
+    },
+    {
+      "name": "linkedin_send_message",
+      "description": "Alias for send_message. Send a message to a LinkedIn user with explicit confirmation and optional profile URN support"
     }
   ],
   "user_config": {},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,12 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def mock_cli_argv(monkeypatch):
+    """Prevent argparse from consuming pytest's sys.argv during get_config()."""
+    monkeypatch.setattr("sys.argv", ["mcp-server-linkedin"])
+
+
+@pytest.fixture(autouse=True)
 def reset_singletons():
     """Reset global state for test isolation."""
     from linkedin_mcp_server.bootstrap import reset_bootstrap_for_testing

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,26 @@ class TestBrowserConfig:
         config.validate()  # Clamps, does not raise
         assert config.login_inline_wait_seconds == MAX_LOGIN_INLINE_WAIT_SECONDS
 
+    def test_validate_negative_viewport(self):
+        with pytest.raises(ConfigurationError, match="viewport dimensions"):
+            BrowserConfig(viewport_width=0).validate()
+
+    def test_validate_chrome_path_missing(self, tmp_path):
+        missing = tmp_path / "no-chrome"
+        with pytest.raises(ConfigurationError, match="does not exist"):
+            BrowserConfig(chrome_path=str(missing)).validate()
+
+    def test_validate_chrome_path_not_a_file(self, tmp_path):
+        directory = tmp_path / "chrome-dir"
+        directory.mkdir()
+        with pytest.raises(ConfigurationError, match="is not a file"):
+            BrowserConfig(chrome_path=str(directory)).validate()
+
+    def test_validate_chrome_path_existing_file(self, tmp_path):
+        chrome = tmp_path / "chrome"
+        chrome.write_text("binary")
+        BrowserConfig(chrome_path=str(chrome)).validate()  # No error
+
 
 class TestServerConfig:
     def test_defaults(self):
@@ -80,6 +100,41 @@ class TestAppConfig:
         config = AppConfig()
         config.server.port = 99999
         with pytest.raises(ConfigurationError):
+            config.validate()
+
+    def test_validate_http_path_must_start_with_slash(self):
+        config = AppConfig()
+        config.server.transport = "streamable-http"
+        config.server.path = "mcp"
+        with pytest.raises(ConfigurationError, match="must start with '/'"):
+            config.validate()
+
+    def test_validate_http_path_min_length(self):
+        config = AppConfig()
+        config.server.transport = "streamable-http"
+        config.server.path = "/"
+        with pytest.raises(ConfigurationError, match="at least 2 characters"):
+            config.validate()
+
+    def test_validate_warns_when_binding_all_interfaces(self, caplog):
+        config = AppConfig()
+        config.server.transport = "streamable-http"
+        config.server.host = "0.0.0.0"
+        config.validate()
+        assert any("0.0.0.0" in record.message for record in caplog.records)
+
+    def test_validate_http_transport_requires_host(self):
+        config = AppConfig()
+        config.server.transport = "streamable-http"
+        config.server.host = ""
+        with pytest.raises(ConfigurationError, match="valid host"):
+            config.validate()
+
+    def test_validate_http_transport_requires_port(self):
+        config = AppConfig()
+        config.server.transport = "streamable-http"
+        config.server.port = 0
+        with pytest.raises(ConfigurationError, match="valid port"):
             config.validate()
 
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,196 @@
+"""Tests for linkedin_mcp_server.tools.meta health, ping, and alias registration."""
+
+import logging
+
+from fastmcp import FastMCP
+from fastmcp.tools.base import Tool
+
+from linkedin_mcp_server.bootstrap import SetupState, get_bootstrap_state
+from linkedin_mcp_server.tools.meta import (
+    LEGACY_TOOL_NAMES,
+    META_TOOL_NAMES,
+    _session_auth_ready,
+    build_health_payload,
+    build_ping_payload,
+    register_meta_tools,
+    register_tool_aliases,
+)
+
+
+def _write_session_files(profile_dir):
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "marker").write_text("profile")
+    from linkedin_mcp_server.session_state import (
+        portable_cookie_path,
+        source_state_path,
+    )
+
+    portable_cookie_path(profile_dir).write_text("[]")
+    source_state_path(profile_dir).write_text('{"version": 1}')
+
+
+class TestBuildHealthPayload:
+    def test_includes_browser_warning_when_not_ready(self, monkeypatch):
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tools.meta.browser_setup_ready", lambda: False
+        )
+
+        payload = build_health_payload()
+
+        assert "warnings" in payload
+        assert any("Patchright Chromium" in w for w in payload["warnings"])
+        assert payload["bootstrap"]["browser_ready"] is False
+
+    def test_includes_auth_warning_when_session_missing(self, isolate_profile_dir):
+        payload = build_health_payload()
+
+        assert "warnings" in payload
+        assert any("--login" in w for w in payload["warnings"])
+        assert payload["bootstrap"]["auth_ready"] is False
+        assert payload["ok"] is False
+
+    def test_includes_bootstrap_last_error_warning(self, monkeypatch):
+        state = get_bootstrap_state()
+        state.last_error = "install failed"
+
+        payload = build_health_payload()
+
+        assert "warnings" in payload
+        assert any("install failed" in w for w in payload["warnings"])
+
+    def test_ok_when_auth_ready_and_browser_ready(self, profile_dir, monkeypatch):
+        _write_session_files(profile_dir)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tools.meta.get_authentication_source",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tools.meta.browser_setup_ready", lambda: True
+        )
+        state = get_bootstrap_state()
+        state.setup_state = SetupState.READY
+
+        payload = build_health_payload()
+
+        assert payload["bootstrap"]["auth_ready"] is True
+        assert payload["bootstrap"]["browser_ready"] is True
+        assert payload["ok"] is True
+        assert "warnings" not in payload
+
+    def test_session_auth_ready_false_when_metadata_lookup_raises(
+        self, profile_dir, monkeypatch
+    ):
+        _write_session_files(profile_dir)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tools.meta.get_authentication_source",
+            lambda: (_ for _ in ()).throw(RuntimeError("bad metadata")),
+        )
+
+        assert _session_auth_ready(profile_dir) is False
+
+
+class TestBuildPingPayload:
+    async def test_lists_legacy_and_prefixed_tools(self):
+        mcp = FastMCP("test")
+        register_meta_tools(mcp)
+
+        @mcp.tool
+        async def get_person_profile() -> dict[str, bool]:
+            return {"ok": True}
+
+        register_tool_aliases(mcp)
+
+        payload = await build_ping_payload(mcp)
+
+        assert payload["ok"] is True
+        assert payload["pong"] is True
+        tool_names = {tool["name"] for tool in payload["tools"]}
+        assert "get_person_profile" in tool_names
+        assert "linkedin_get_person_profile" in tool_names
+        assert set(payload["capabilities"]["legacy_tool_names"]) == set(
+            LEGACY_TOOL_NAMES
+        )
+        assert payload["capabilities"]["meta_tools"] == list(META_TOOL_NAMES)
+
+
+class TestRegisterToolAliases:
+    def test_skips_when_legacy_tool_missing(self):
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        async def get_person_profile() -> dict[str, bool]:
+            return {"ok": True}
+
+        register_tool_aliases(mcp)
+        tools = {component.name for component in mcp.local_provider._components.values()}
+
+        assert "get_person_profile" in tools
+        assert "linkedin_get_person_profile" in tools
+        assert "linkedin_get_inbox" not in tools
+
+    def test_skips_when_alias_already_registered(self):
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        async def get_inbox() -> dict[str, bool]:
+            return {"ok": True}
+
+        inbox_tools = [
+            component
+            for component in mcp.local_provider._components.values()
+            if isinstance(component, Tool) and component.name == "get_inbox"
+        ]
+        assert len(inbox_tools) == 1
+        mcp.add_tool(Tool.from_tool(inbox_tools[0], name="linkedin_get_inbox"))
+
+        register_tool_aliases(mcp)
+        alias_tools = [
+            component
+            for component in mcp.local_provider._components.values()
+            if isinstance(component, Tool) and component.name == "linkedin_get_inbox"
+        ]
+
+        assert len(alias_tools) == 1
+
+    def test_logs_and_continues_when_alias_registration_fails(self, caplog):
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        async def get_person_profile() -> dict[str, bool]:
+            return {"ok": True}
+
+        original_add_tool = mcp.add_tool
+
+        def flaky_add_tool(tool):
+            if tool.name == "linkedin_get_person_profile":
+                raise RuntimeError("alias registration failed")
+            return original_add_tool(tool)
+
+        mcp.add_tool = flaky_add_tool  # type: ignore[method-assign]
+
+        with caplog.at_level(logging.ERROR):
+            register_tool_aliases(mcp)
+
+        assert any(
+            "Failed to register linkedin_* alias for get_person_profile" in record.message
+            for record in caplog.records
+        )
+        tools = {
+            component.name
+            for component in mcp.local_provider._components.values()
+            if isinstance(component, Tool)
+        }
+        assert "get_person_profile" in tools
+        assert "linkedin_get_person_profile" not in tools
+
+    async def test_linkedin_health_tool_returns_payload(self):
+        from linkedin_mcp_server.server import create_mcp_server
+
+        mcp = create_mcp_server()
+        result = await mcp.call_tool("linkedin_health", {})
+
+        payload = result.structured_content
+        assert payload is not None
+        assert payload["server"] == "linkedin-mcp"
+        assert "storage" in payload
+        assert "bootstrap" in payload

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -16,8 +16,10 @@ from linkedin_mcp_server.scraping.connection import (
 from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
+    _MESSAGING_CHROME_STRINGS,
     _RATE_LIMITED_MSG,
     _build_feed_references,
+    _messaging_chrome_table,
     _truncate_linkedin_noise,
     strip_conversation_chrome,
     strip_linkedin_noise,
@@ -4113,6 +4115,83 @@ class TestGetInbox:
 
 
 class TestGetConversation:
+    async def test_wait_for_conversation_body_uses_thread_turn_marker(self, mock_page):
+        """Block extraction until a message turn marker appears in main."""
+        mock_page.evaluate = AsyncMock(return_value="en")
+        extractor = LinkedInExtractor(mock_page)
+
+        await extractor._wait_for_conversation_body()
+
+        mock_page.evaluate.assert_awaited_once()
+        mock_page.wait_for_function.assert_awaited_once()
+        wait_arg = mock_page.wait_for_function.call_args.kwargs["arg"]
+        assert wait_arg["marker"] == "sent the following message"
+        assert wait_arg["composerStart"] == "Maximize compose field"
+        assert mock_page.wait_for_function.call_args.kwargs["timeout"] == 10000
+
+    async def test_wait_for_conversation_body_resolves_locale_from_page(
+        self, mock_page
+    ):
+        """Use the messaging chrome table for the detected page locale."""
+        mock_page.evaluate = AsyncMock(return_value="en")
+        extractor = LinkedInExtractor(mock_page)
+
+        await extractor._wait_for_conversation_body()
+
+        mock_page.evaluate.assert_awaited_once()
+        assert (
+            mock_page.wait_for_function.call_args.kwargs["arg"]["marker"]
+            == _MESSAGING_CHROME_STRINGS["en"].thread_turn_marker
+        )
+
+    async def test_wait_for_conversation_body_falls_back_to_en_for_unknown_locale(
+        self, mock_page
+    ):
+        """Unknown page locales still use the en thread-turn marker."""
+        mock_page.evaluate = AsyncMock(return_value="de")
+        extractor = LinkedInExtractor(mock_page)
+
+        await extractor._wait_for_conversation_body()
+
+        assert (
+            mock_page.wait_for_function.call_args.kwargs["arg"]["marker"]
+            == _MESSAGING_CHROME_STRINGS["en"].thread_turn_marker
+        )
+
+    async def test_wait_for_conversation_body_empty_thread_waits_for_composer(
+        self, mock_page
+    ):
+        """Empty threads unblock when the composer mounts instead of timing out."""
+        mock_page.evaluate = AsyncMock(return_value="en")
+        extractor = LinkedInExtractor(mock_page)
+
+        await extractor._wait_for_conversation_body()
+
+        js = mock_page.wait_for_function.call_args.args[0]
+        assert "composerStart" in js
+        assert "text.includes(composerStart)" in js
+
+    async def test_messaging_chrome_tables_define_thread_turn_marker(self):
+        """Every supported locale table carries a non-empty turn marker."""
+        for locale, table in _MESSAGING_CHROME_STRINGS.items():
+            assert table.thread_turn_marker, locale
+
+    def test_messaging_chrome_table_falls_back_to_en(self):
+        assert _messaging_chrome_table("de") is _MESSAGING_CHROME_STRINGS["en"]
+        assert _messaging_chrome_table("en") is _MESSAGING_CHROME_STRINGS["en"]
+
+    async def test_wait_for_conversation_body_timeout_is_non_fatal(self, mock_page):
+        """Hydration timeout falls through so extraction can still proceed."""
+        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        mock_page.evaluate = AsyncMock(return_value="en")
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("timeout")
+        )
+        extractor = LinkedInExtractor(mock_page)
+
+        await extractor._wait_for_conversation_body()
+
     async def test_returns_conversation_by_thread_id(self, mock_page):
         """get_conversation with thread_id navigates directly to thread URL."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4192,6 +4192,25 @@ class TestGetConversation:
 
         await extractor._wait_for_conversation_body()
 
+    async def test_page_messaging_locale_returns_supported_locale(self, mock_page):
+        mock_page.evaluate = AsyncMock(return_value="en")
+        extractor = LinkedInExtractor(mock_page)
+
+        assert await extractor._page_messaging_locale() == "en"
+        mock_page.evaluate.assert_awaited_once()
+
+    async def test_page_messaging_locale_falls_back_for_unknown_locale(self, mock_page):
+        mock_page.evaluate = AsyncMock(return_value="de")
+        extractor = LinkedInExtractor(mock_page)
+
+        assert await extractor._page_messaging_locale() == "en"
+
+    async def test_page_messaging_locale_falls_back_on_evaluate_error(self, mock_page):
+        mock_page.evaluate = AsyncMock(side_effect=RuntimeError("no dom"))
+        extractor = LinkedInExtractor(mock_page)
+
+        assert await extractor._page_messaging_locale() == "en"
+
     async def test_returns_conversation_by_thread_id(self, mock_page):
         """get_conversation with thread_id navigates directly to thread URL."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,10 @@
 import asyncio
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call
 
 import mcp.types as mt
+import pytest
 from fastmcp import FastMCP
 from fastmcp.server.middleware import MiddlewareContext
 
@@ -10,6 +13,13 @@ from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
 from linkedin_mcp_server.server import create_mcp_server
+from linkedin_mcp_server.tools.meta import (
+    LEGACY_TOOL_NAMES,
+    META_HEALTH_TIMEOUT_SECONDS,
+    META_PING_TIMEOUT_SECONDS,
+    META_TOOL_NAMES,
+    build_health_payload,
+)
 
 
 class TestSequentialToolExecutionMiddleware:
@@ -60,6 +70,134 @@ class TestSequentialToolExecutionMiddleware:
 
         assert result.structured_content == {"value": 7}
 
+    async def test_create_mcp_server_masks_error_details(self):
+        mcp = create_mcp_server()
+
+        assert mcp._mask_error_details is True
+
+    async def test_linkedin_health_returns_session_paths(self):
+        payload = build_health_payload()
+
+        assert payload["server"] == "linkedin-mcp"
+        assert payload["mask_error_details"] is True
+        assert payload["transport"] in {"stdio", "streamable-http"}
+        assert "profile_dir" in payload["storage"]
+        assert "patchright_browsers_dir" in payload["storage"]
+        assert "lifecycle" in payload["session"]
+
+    async def test_legacy_tool_names_match_registered_scraper_tools(self):
+        mcp = create_mcp_server()
+        tools = await mcp.list_tools(run_middleware=False)
+        legacy_names = {
+            tool.name
+            for tool in tools
+            if not tool.name.startswith("linkedin_")
+            and tool.name not in META_TOOL_NAMES
+        }
+
+        assert set(LEGACY_TOOL_NAMES) == legacy_names
+
+    async def test_linkedin_ping_lists_tools_and_aliases(self):
+        mcp = create_mcp_server()
+
+        health_tool = await mcp.get_tool("linkedin_health")
+        ping_tool = await mcp.get_tool("linkedin_ping")
+        assert health_tool is not None
+        assert ping_tool is not None
+        assert health_tool.timeout == META_HEALTH_TIMEOUT_SECONDS
+        assert ping_tool.timeout == META_PING_TIMEOUT_SECONDS
+
+        result = await mcp.call_tool("linkedin_ping", {})
+        payload = result.structured_content
+        assert payload is not None
+        assert payload["ok"] is True
+        assert payload["pong"] is True
+        assert payload["tool_count"] >= len(LEGACY_TOOL_NAMES) + 2
+        tool_names = {tool["name"] for tool in payload["tools"]}
+        assert "linkedin_health" in tool_names
+        assert "linkedin_ping" in tool_names
+        assert "linkedin_get_person_profile" in tool_names
+        assert "get_person_profile" in tool_names
+
+    async def test_manifest_lists_all_registered_tools(self):
+        manifest_path = Path(__file__).resolve().parents[1] / "manifest.json"
+        manifest_names = {
+            tool["name"] for tool in json.loads(manifest_path.read_text())["tools"]
+        }
+
+        mcp = create_mcp_server()
+        tools = await mcp.list_tools(run_middleware=False)
+        registered = {tool.name for tool in tools}
+
+        missing = registered - manifest_names
+        assert not missing, f"manifest.json missing tools: {sorted(missing)}"
+
+    async def test_meta_tools_bypass_scraper_lock(self):
+        mcp = FastMCP("test")
+        mcp.add_middleware(SequentialToolExecutionMiddleware())
+
+        lock_held = asyncio.Event()
+        release = asyncio.Event()
+
+        @mcp.tool
+        async def slow_tool() -> dict[str, bool]:
+            lock_held.set()
+            await release.wait()
+            return {"done": True}
+
+        @mcp.tool(name="linkedin_health")
+        async def linkedin_health() -> dict[str, bool]:
+            return {"ok": True}
+
+        slow_task = asyncio.create_task(mcp.call_tool("slow_tool", {}))
+        await lock_held.wait()
+
+        result = await asyncio.wait_for(
+            mcp.call_tool("linkedin_health", {}),
+            timeout=0.5,
+        )
+        assert result.structured_content == {"ok": True}
+
+        release.set()
+        await slow_task
+
+    async def test_meta_tools_skip_queue_progress(self):
+        middleware = SequentialToolExecutionMiddleware()
+        fastmcp_context = MagicMock()
+        fastmcp_context.request_context = object()
+        fastmcp_context.report_progress = AsyncMock()
+        call_next = AsyncMock(return_value=MagicMock())
+        context = MiddlewareContext(
+            message=mt.CallToolRequestParams(name="linkedin_health", arguments={}),
+            method="tools/call",
+            fastmcp_context=fastmcp_context,
+        )
+
+        await middleware.on_call_tool(context, call_next)
+
+        fastmcp_context.report_progress.assert_not_awaited()
+        call_next.assert_awaited_once()
+
+    async def test_linkedin_tool_alias_matches_legacy_tool(self):
+        mcp = create_mcp_server()
+
+        legacy = await mcp.get_tool("get_person_profile")
+        aliased = await mcp.get_tool("linkedin_get_person_profile")
+
+        assert legacy is not None
+        assert aliased is not None
+        assert legacy.description == aliased.description
+
+    async def test_linkedin_close_session_alias_registered_after_close_session(self):
+        mcp = create_mcp_server()
+
+        legacy = await mcp.get_tool("close_session")
+        aliased = await mcp.get_tool("linkedin_close_session")
+
+        assert legacy is not None
+        assert aliased is not None
+        assert legacy.description == aliased.description
+
     async def test_sequential_tool_middleware_reports_queue_progress(self):
         middleware = SequentialToolExecutionMiddleware()
         fastmcp_context = MagicMock()
@@ -97,3 +235,56 @@ class TestServerVersion:
         mcp = create_mcp_server()
 
         assert mcp.version == __version__
+
+
+class TestBrowserLifespan:
+    async def test_browser_lifespan_runs_bootstrap_and_closes_browser(self, monkeypatch):
+        from linkedin_mcp_server.server import browser_lifespan
+
+        init = MagicMock()
+        start_setup = AsyncMock()
+        close = AsyncMock()
+        monkeypatch.setattr(
+            "linkedin_mcp_server.server.initialize_bootstrap", init
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.server.start_background_browser_setup_if_needed",
+            start_setup,
+        )
+        monkeypatch.setattr("linkedin_mcp_server.server.close_browser", close)
+
+        mcp = create_mcp_server()
+        async with browser_lifespan(mcp):
+            init.assert_called_once()
+            start_setup.assert_awaited_once()
+
+        close.assert_awaited_once()
+
+
+class TestCloseSession:
+    async def test_close_session_success(self, monkeypatch):
+        close = AsyncMock()
+        monkeypatch.setattr("linkedin_mcp_server.server.close_browser", close)
+
+        mcp = create_mcp_server()
+        result = await mcp.call_tool("close_session", {})
+
+        close.assert_awaited_once()
+        assert result.structured_content == {
+            "status": "success",
+            "message": "Successfully closed the browser session and cleaned up resources",
+        }
+
+    async def test_close_session_raises_tool_error_on_failure(self, monkeypatch):
+        from fastmcp.exceptions import ToolError
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.server.close_browser",
+            AsyncMock(side_effect=RuntimeError("browser stuck")),
+        )
+
+        mcp = create_mcp_server()
+        with pytest.raises(
+            ToolError, match="Failed to close the browser session"
+        ):
+            await mcp.call_tool("close_session", {})

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1165,6 +1165,8 @@ class TestToolTimeouts:
             "search_people",
             "get_company_profile",
             "get_company_posts",
+            "search_companies",
+            "get_company_employees",
             "get_job_details",
             "search_jobs",
             "get_inbox",
@@ -1180,9 +1182,18 @@ class TestToolTimeouts:
             assert tool is not None
             assert tool.timeout == custom_timeout
 
+        health_tool = await mcp.get_tool("linkedin_health")
+        ping_tool = await mcp.get_tool("linkedin_ping")
+        assert health_tool is not None
+        assert ping_tool is not None
+
     async def test_all_tools_have_default_timeout(self):
         from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
         from linkedin_mcp_server.server import create_mcp_server
+        from linkedin_mcp_server.tools.meta import (
+            META_HEALTH_TIMEOUT_SECONDS,
+            META_PING_TIMEOUT_SECONDS,
+        )
 
         mcp = create_mcp_server()
 
@@ -1210,3 +1221,10 @@ class TestToolTimeouts:
             tool = await mcp.get_tool(name)
             assert tool is not None
             assert tool.timeout == DEFAULT_TOOL_TIMEOUT_SECONDS
+
+        health_tool = await mcp.get_tool("linkedin_health")
+        ping_tool = await mcp.get_tool("linkedin_ping")
+        assert health_tool is not None
+        assert ping_tool is not None
+        assert health_tool.timeout == META_HEALTH_TIMEOUT_SECONDS
+        assert ping_tool.timeout == META_PING_TIMEOUT_SECONDS


### PR DESCRIPTION
## Summary
- Fix intermittent empty/partial `get_conversation` results by waiting for the thread body to hydrate before extraction (`_wait_for_conversation_body`).
- Add `linkedin_health` / `linkedin_ping` meta tools, scraper aliases, middleware exemption, docs, manifest, and tests.

## Test plan
- [x] Live repro confirmed race fix (partial vs full transcript)
- [x] `uv run pytest` — full suite passing locally