### PR TITLE
feat(search): paginate people results

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,3 +144,21 @@ This project favours **innerText extraction and URL navigation** over DOM select
 - **Lint/format:** `uv run ruff check . --fix && uv run ruff format .`
 - **Type check:** `uv run ty check`
 - **Tests:** `uv run pytest --cov`
+
+## Live People-Search Verification
+
+People-search pagination also has an opt-in live harness. It uses the production
+browser manager and extractor against an authenticated LinkedIn account while
+printing a JSON summary with only navigation and count metadata (never result
+names or text). Production failure diagnostics may still appear on stderr, so
+review terminal output before sharing it.
+
+```bash
+uv run -m linkedin_mcp_server --login
+uv run python scripts/verify_live_people_search.py "software engineer" --max-pages 2
+```
+
+The command fails unless page 2 was visited and extracted, page 2 contributed
+readable text and new person references, and the final person reference URLs
+were deduplicated. Keep it out of CI because it requires a contributor-owned
+LinkedIn session.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `search_companies` | Search for companies on LinkedIn by keywords | working |
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter | working |
 | `search_jobs` | Search for jobs with keywords and location filters | working |
-| `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | [#526](https://github.com/stickerdaniel/linkedin-mcp-server/issues/526) |
+| `search_people` | Search up to 10 pages of people by keywords, location, connection degree (1st/2nd/3rd), and current company | working |
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `close_session` | Close browser session and clean up resources | working |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -14,7 +14,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Company Search**: Search for companies by keyword
 - **Job Details**: Retrieve job posting information
 - **Job Search**: Search for jobs with keywords and location filters
-- **People Search**: Search for people by keywords and location
+- **People Search**: Search up to 10 pages of people by keywords, location, connection degree, and current company
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed
 - **Home Feed**: Get recent posts from the authenticated user's LinkedIn home feed

--- a/linkedin_mcp_server/live_verification.py
+++ b/linkedin_mcp_server/live_verification.py
@@ -1,0 +1,149 @@
+"""Opt-in verification helpers that exercise live LinkedIn behavior."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from patchright.async_api import Page
+
+from linkedin_mcp_server.drivers.browser import (
+    close_browser,
+    ensure_authenticated,
+    get_or_create_browser,
+    set_headless,
+)
+from linkedin_mcp_server.scraping.extractor import ExtractedSection, LinkedInExtractor
+
+_PEOPLE_SEARCH_PATH = "/search/results/people/"
+
+
+@dataclass
+class _PageEvidence:
+    text_characters: int
+    person_urls: set[str]
+
+
+class _EvidenceExtractor(LinkedInExtractor):
+    """Production extractor that records PII-free evidence for each page."""
+
+    def __init__(self, page: Page) -> None:
+        super().__init__(page)
+        self.page_evidence: dict[int, _PageEvidence] = {}
+
+    async def extract_page(
+        self,
+        url: str,
+        section_name: str,
+        max_scrolls: int | None = None,
+    ) -> ExtractedSection:
+        extracted = await super().extract_page(url, section_name, max_scrolls)
+        page_number = _page_number(url)
+        if page_number is not None:
+            self.page_evidence[page_number] = _PageEvidence(
+                text_characters=len(extracted.text),
+                person_urls={
+                    reference["url"]
+                    for reference in extracted.references
+                    if reference["kind"] == "person"
+                },
+            )
+        return extracted
+
+
+def _page_number(url: str) -> int | None:
+    parsed = urlparse(url)
+    if parsed.netloc != "www.linkedin.com" or parsed.path != _PEOPLE_SEARCH_PATH:
+        return None
+    raw_page = parse_qs(parsed.query).get("page", ["1"])[0]
+    try:
+        return int(raw_page)
+    except ValueError:
+        return None
+
+
+async def verify_live_people_search(
+    keywords: str,
+    *,
+    location: str | None,
+    max_pages: int,
+    headless: bool,
+) -> dict[str, Any]:
+    """Run production people search and return a PII-free JSON report."""
+    if not 2 <= max_pages <= 10:
+        raise ValueError("max_pages must be between 2 and 10 for live verification")
+
+    set_headless(headless)
+    visited_pages: list[int] = []
+
+    try:
+        await ensure_authenticated()
+        browser = await get_or_create_browser()
+        page = browser.page
+
+        def record_navigation(frame: Any) -> None:
+            if frame != page.main_frame:
+                return
+            page_number = _page_number(frame.url)
+            if page_number is not None and (
+                not visited_pages or visited_pages[-1] != page_number
+            ):
+                visited_pages.append(page_number)
+
+        page.on("framenavigated", record_navigation)
+        extractor = _EvidenceExtractor(page)
+        try:
+            result = await extractor.search_people(
+                keywords,
+                location=location,
+                max_pages=max_pages,
+            )
+        finally:
+            page.remove_listener("framenavigated", record_navigation)
+
+        section_text = result.get("sections", {}).get("search_results", "")
+        references = result.get("references", {}).get("search_results", [])
+        person_urls = [
+            reference["url"]
+            for reference in references
+            if reference.get("kind") == "person"
+        ]
+
+        if not section_text:
+            raise RuntimeError("Live search returned no search_results text")
+        if result.get("section_errors"):
+            raise RuntimeError("Live search returned search_results section errors")
+        if not person_urls:
+            raise RuntimeError("Live search returned no person references")
+        if 2 not in visited_pages:
+            raise RuntimeError(
+                "Live search did not navigate to page=2; use broader keywords"
+            )
+        page_one = extractor.page_evidence.get(1)
+        page_two = extractor.page_evidence.get(2)
+        if page_one is None or page_two is None:
+            raise RuntimeError("Live search did not extract both pages 1 and 2")
+        if not page_two.text_characters or not page_two.person_urls:
+            raise RuntimeError("Live search page 2 returned no usable people content")
+        new_page_two_people = page_two.person_urls - page_one.person_urls
+        if not new_page_two_people:
+            raise RuntimeError("Live search page 2 returned no new person references")
+        if len(person_urls) != len(set(person_urls)):
+            raise RuntimeError("Live search returned duplicate person URLs")
+
+        return {
+            "status": "passed",
+            "visited_pages": visited_pages,
+            "requested_max_pages": max_pages,
+            "page_result_characters": {
+                str(page_number): evidence.text_characters
+                for page_number, evidence in extractor.page_evidence.items()
+            },
+            "new_person_references_on_page_2": len(new_page_two_people),
+            "search_result_characters": len(section_text),
+            "unique_person_references": len(person_urls),
+            "has_section_errors": bool(result.get("section_errors")),
+        }
+    finally:
+        await close_browser()

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3245,8 +3245,9 @@ class LinkedInExtractor:
         location: str | None = None,
         network: list[str] | None = None,
         current_company: str | None = None,
+        max_pages: int = 1,
     ) -> dict[str, Any]:
-        """Search for people and extract the results page.
+        """Search for people and extract one or more results pages.
 
         Args:
             keywords: Free-text query ("software engineer", "recruiter at Google").
@@ -3262,6 +3263,7 @@ class LinkedInExtractor:
                 unfiltered result set. Look up a company's URN via
                 ``get_company_profile`` -- it is exposed under
                 ``references["about"]``.
+            max_pages: Maximum pages to load (1-10, default 1).
 
         Returns:
             {url, sections: {name: text}}
@@ -3290,25 +3292,49 @@ class LinkedInExtractor:
         if current_company:
             params += f"&currentCompany={_encode_list_facet([current_company])}"
 
-        url = f"https://www.linkedin.com/search/results/people/?{params}"
-        extracted = await self.extract_page(url, section_name="search_results")
-
-        sections: dict[str, str] = {}
-        references: dict[str, list[Reference]] = {}
+        base_url = f"https://www.linkedin.com/search/results/people/?{params}"
+        page_texts: list[str] = []
+        page_references: list[Reference] = []
+        seen_person_urls: set[str] = set()
         section_errors: dict[str, dict[str, Any]] = {}
-        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
-            sections["search_results"] = extracted.text
+
+        for page_num in range(1, max_pages + 1):
+            if page_num > 1:
+                await asyncio.sleep(_NAV_DELAY)
+
+            url = base_url if page_num == 1 else f"{base_url}&page={page_num}"
+            extracted = await self.extract_page(url, section_name="search_results")
+
+            if not extracted.text or extracted.text == _RATE_LIMITED_MSG:
+                if extracted.error:
+                    section_errors["search_results"] = extracted.error
+                break
+
+            page_texts.append(extracted.text)
             if extracted.references:
-                references["search_results"] = extracted.references
-        elif extracted.error:
-            section_errors["search_results"] = extracted.error
+                page_references.extend(extracted.references)
+
+            person_urls = {
+                reference["url"]
+                for reference in extracted.references
+                if reference["kind"] == "person"
+            }
+            new_person_urls = person_urls - seen_person_urls
+            if not new_person_urls:
+                logger.debug("No new people references on page %d, stopping", page_num)
+                break
+            seen_person_urls.update(new_person_urls)
 
         result: dict[str, Any] = {
-            "url": url,
-            "sections": sections,
+            "url": base_url,
+            "sections": {"search_results": "\n---\n".join(page_texts)}
+            if page_texts
+            else {},
         }
-        if references:
-            result["references"] = references
+        if page_references:
+            result["references"] = {
+                "search_results": dedupe_references(page_references)
+            }
         if section_errors:
             result["section_errors"] = section_errors
         return result

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -114,6 +114,7 @@ def register_person_tools(
         location: str | None = None,
         network: list[str] | None = None,
         current_company: str | None = None,
+        max_pages: Annotated[int, Field(ge=1, le=10)] = 1,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -134,6 +135,7 @@ def register_person_tools(
                 exposed under references["about"]. For company-wide employee
                 demographics (location/education/function breakdown) plus a
                 slug-based lookup, use get_company_employees instead.
+            max_pages: Maximum number of result pages to load (1-10, default 1).
 
         Returns:
             Dict with url, sections (name -> raw text), and optional references.
@@ -144,11 +146,12 @@ def register_person_tools(
                 ctx, tool_name="search_people"
             )
             logger.info(
-                "Searching people: keywords='%s', location='%s', network=%s, current_company='%s'",
+                "Searching people: keywords='%s', location='%s', network=%s, current_company='%s', max_pages=%d",
                 keywords,
                 location,
                 network,
                 current_company,
+                max_pages,
             )
 
             await ctx.report_progress(
@@ -161,6 +164,7 @@ def register_person_tools(
                     location,
                     network=network,
                     current_company=current_company,
+                    max_pages=max_pages,
                 )
             except FilterValidationError as e:
                 # Validation messages carry actionable detail; surface

--- a/manifest.json
+++ b/manifest.json
@@ -85,7 +85,7 @@
     },
     {
       "name": "search_people",
-      "description": "Search for people on LinkedIn by keywords, location, connection degree (1st/2nd/3rd), and current company"
+      "description": "Search up to 10 pages of people on LinkedIn by keywords, location, connection degree (1st/2nd/3rd), and current company"
     },
     {
       "name": "get_inbox",

--- a/scripts/verify_live_people_search.py
+++ b/scripts/verify_live_people_search.py
@@ -1,0 +1,71 @@
+"""Verify people-search pagination against live, authenticated LinkedIn.
+
+This is deliberately an opt-in development harness rather than a pytest test:
+it needs a contributor's real LinkedIn session and must never run in CI.
+
+Run after ``uv run -m linkedin_mcp_server --login``::
+
+    uv run python scripts/verify_live_people_search.py "software engineer"
+
+The JSON report contains only navigation/count metadata, never result text or
+names. Production failure diagnostics may still be emitted to stderr, so review
+terminal output before sharing it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+from linkedin_mcp_server.live_verification import verify_live_people_search
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify live LinkedIn people-search pagination"
+    )
+    parser.add_argument(
+        "keywords",
+        nargs="?",
+        default="software engineer",
+        help="Broad people-search keywords (default: software engineer)",
+    )
+    parser.add_argument("--location", help="Optional LinkedIn location filter")
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=2,
+        help="Pages to request, from 2 to 10 (default: 2)",
+    )
+    parser.add_argument(
+        "--headed",
+        action="store_true",
+        help="Show the browser while verification runs",
+    )
+    return parser.parse_args()
+
+
+async def _main() -> int:
+    args = _parse_args()
+    # The production config loader parses ``sys.argv`` lazily when browser
+    # startup begins. Keep harness-only arguments out of that second parser.
+    sys.argv = [sys.argv[0]]
+    try:
+        report = await verify_live_people_search(
+            args.keywords,
+            location=args.location,
+            max_pages=args.max_pages,
+            headless=not args.headed,
+        )
+    except Exception as exc:
+        print(f"Live people-search verification failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/test_people_search_pagination_dom.py
+++ b/tests/test_people_search_pagination_dom.py
@@ -1,0 +1,130 @@
+"""Real-browser coverage for people-search pagination.
+
+The browser route is fulfilled with deterministic LinkedIn-shaped HTML so the
+test exercises production navigation, innerText extraction, reference building,
+pagination, and early stopping without depending on a live account or locale.
+"""
+
+from urllib.parse import parse_qs, urlparse
+from unittest.mock import patch
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+
+pytestmark = pytest.mark.browser_dom
+
+
+def _search_page(page_number: int) -> str:
+    people = {
+        1: [
+            ("/in/jane-doe/", "Jane"),
+            ("/in/alex-smith/", "Alex Smith"),
+        ],
+        2: [
+            ("/in/jane-doe/", "Jane Doe"),
+            ("/in/robin-lee/", "Robin Lee"),
+        ],
+        # Repeating only known profiles represents LinkedIn's terminal page.
+        3: [
+            ("/in/jane-doe/", "Jane Doe"),
+            ("/in/robin-lee/", "Robin Lee"),
+        ],
+    }[page_number]
+    cards = "".join(
+        f'<article><a href="{url}">{name}</a><p>Software engineer</p></article>'
+        for url, name in people
+    )
+    return f"""
+        <!doctype html>
+        <html>
+          <head><title>People search page {page_number}</title></head>
+          <body>
+            <main>
+              <h1>Results page {page_number}</h1>
+              <p>People matching the requested role, location, and company filters.</p>
+              <p>This deterministic content is long enough to represent hydrated search results.</p>
+              {cards}
+            </main>
+          </body>
+        </html>
+    """
+
+
+@pytest.fixture
+async def routed_linkedin_page():
+    """Real Chromium page with deterministic LinkedIn search responses."""
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(headless=True)
+            page = await browser.new_page()
+        except Exception as exc:  # browser binary missing
+            pytest.skip(f"chromium unavailable: {exc}")
+
+        requested_pages: list[int] = []
+
+        async def fulfill_search(route) -> None:
+            query = parse_qs(urlparse(route.request.url).query)
+            page_number = int(query.get("page", ["1"])[0])
+            requested_pages.append(page_number)
+            await route.fulfill(
+                status=200,
+                content_type="text/html",
+                body=_search_page(page_number),
+            )
+
+        await page.route(
+            "https://www.linkedin.com/search/results/people/**", fulfill_search
+        )
+        try:
+            yield page, requested_pages
+        finally:
+            await browser.close()
+
+
+async def test_people_search_paginates_through_real_browser(routed_linkedin_page):
+    """Drive production extraction until a page has no new person URLs."""
+    page, requested_pages = routed_linkedin_page
+    extractor = LinkedInExtractor(page)
+
+    # Preserve real browser navigation and DOM work while removing only the
+    # production courtesy delay between deterministic test pages.
+    with patch("linkedin_mcp_server.scraping.extractor._NAV_DELAY", 0):
+        result = await extractor.search_people(
+            "software engineer",
+            location="New York",
+            max_pages=5,
+        )
+
+    assert requested_pages == [1, 2, 3]
+    assert result["url"] == (
+        "https://www.linkedin.com/search/results/people/"
+        "?keywords=software+engineer&location=New+York"
+    )
+    assert result["sections"]["search_results"].count("\n---\n") == 2
+    assert "Results page 1" in result["sections"]["search_results"]
+    assert "Results page 2" in result["sections"]["search_results"]
+    assert "Results page 3" in result["sections"]["search_results"]
+    assert result["references"] == {
+        "search_results": [
+            {
+                "kind": "person",
+                "url": "/in/jane-doe/",
+                "text": "Jane Doe",
+                "context": "search result",
+            },
+            {
+                "kind": "person",
+                "url": "/in/alex-smith/",
+                "text": "Alex Smith",
+                "context": "search result",
+            },
+            {
+                "kind": "person",
+                "url": "/in/robin-lee/",
+                "text": "Robin Lee",
+                "context": "search result",
+            },
+        ]
+    }

--- a/tests/test_people_search_pagination_dom.py
+++ b/tests/test_people_search_pagination_dom.py
@@ -6,12 +6,14 @@ pagination, and early stopping without depending on a live account or locale.
 """
 
 from urllib.parse import parse_qs, urlparse
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from patchright.async_api import async_playwright
 
 from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+from linkedin_mcp_server.live_verification import verify_live_people_search
 
 pytestmark = pytest.mark.browser_dom
 
@@ -128,3 +130,56 @@ async def test_people_search_paginates_through_real_browser(routed_linkedin_page
             },
         ]
     }
+
+
+async def test_live_harness_requires_usable_page_two_results(routed_linkedin_page):
+    """Exercise the opt-in live harness against deterministic browser pages."""
+    page, requested_pages = routed_linkedin_page
+
+    with (
+        patch(
+            "linkedin_mcp_server.live_verification.ensure_authenticated",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "linkedin_mcp_server.live_verification.get_or_create_browser",
+            new_callable=AsyncMock,
+            return_value=SimpleNamespace(page=page),
+        ),
+        patch(
+            "linkedin_mcp_server.live_verification.close_browser",
+            new_callable=AsyncMock,
+        ),
+        patch("linkedin_mcp_server.live_verification.set_headless"),
+        patch("linkedin_mcp_server.scraping.extractor._NAV_DELAY", 0),
+    ):
+        report = await verify_live_people_search(
+            "software engineer",
+            location="New York",
+            max_pages=2,
+            headless=True,
+        )
+
+        original_search_page = _search_page
+
+        def repeat_page_one_people(page_number: int) -> str:
+            return original_search_page(1 if page_number == 2 else page_number)
+
+        requested_pages.clear()
+        with (
+            patch(f"{__name__}._search_page", side_effect=repeat_page_one_people),
+            pytest.raises(RuntimeError, match="page 2 returned no new person"),
+        ):
+            await verify_live_people_search(
+                "software engineer",
+                location="New York",
+                max_pages=2,
+                headless=True,
+            )
+
+    assert requested_pages == [1, 2]
+    assert report["status"] == "passed"
+    assert report["visited_pages"] == [1, 2]
+    assert report["new_person_references_on_page_2"] == 1
+    assert report["unique_person_references"] == 3
+    assert report["page_result_characters"]["2"] > 0

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2621,6 +2621,110 @@ class TestSearchJobs:
         assert result["sections"] == {}
         assert "references" not in result
 
+    async def test_search_people_paginates_and_deduplicates_references(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        pages = iter(
+            [
+                extracted(
+                    "Page 1 text",
+                    [
+                        {"kind": "person", "url": "/in/jane/", "text": "Jane"},
+                        {"kind": "company", "url": "/company/acme/"},
+                    ],
+                ),
+                extracted(
+                    "Page 2 text",
+                    [
+                        {
+                            "kind": "person",
+                            "url": "/in/jane/",
+                            "text": "Jane Doe",
+                        },
+                        {"kind": "person", "url": "/in/john/", "text": "John"},
+                    ],
+                ),
+            ]
+        )
+        visited_urls: list[str] = []
+
+        async def mock_extract(url, *args, **kwargs):
+            visited_urls.append(url)
+            return next(pages)
+
+        with (
+            patch.object(extractor, "extract_page", side_effect=mock_extract),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep,
+        ):
+            result = await extractor.search_people("engineer", max_pages=2)
+
+        assert visited_urls == [
+            "https://www.linkedin.com/search/results/people/?keywords=engineer",
+            "https://www.linkedin.com/search/results/people/?keywords=engineer&page=2",
+        ]
+        assert result["sections"]["search_results"] == ("Page 1 text\n---\nPage 2 text")
+        assert result["references"] == {
+            "search_results": [
+                {"kind": "person", "url": "/in/jane/", "text": "Jane Doe"},
+                {"kind": "company", "url": "/company/acme/"},
+                {"kind": "person", "url": "/in/john/", "text": "John"},
+            ]
+        }
+        mock_sleep.assert_awaited_once()
+
+    async def test_search_people_stops_when_page_has_no_new_people(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        pages = iter(
+            [
+                extracted(
+                    "Page 1 text",
+                    [{"kind": "person", "url": "/in/jane/", "text": "Jane"}],
+                ),
+                extracted(
+                    "Page 2 text",
+                    [
+                        {
+                            "kind": "person",
+                            "url": "/in/jane/",
+                            "text": "Jane Doe",
+                        }
+                    ],
+                ),
+            ]
+        )
+
+        with (
+            patch.object(
+                extractor, "extract_page", new_callable=AsyncMock, side_effect=pages
+            ) as mock_extract,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_people("engineer", max_pages=10)
+
+        assert mock_extract.await_count == 2
+        assert result["sections"]["search_results"] == ("Page 1 text\n---\nPage 2 text")
+
+    async def test_search_people_stops_without_person_references(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted(
+                "No people",
+                [{"kind": "company", "url": "/company/acme/", "text": "Acme"}],
+            ),
+        ) as mock_extract:
+            result = await extractor.search_people("nobody", max_pages=10)
+
+        mock_extract.assert_awaited_once()
+        assert result["sections"] == {"search_results": "No people"}
+
     async def test_search_people_network_filter_first_degree(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         with patch.object(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -263,6 +263,7 @@ class TestPersonTool:
             "New York",
             network=None,
             current_company=None,
+            max_pages=1,
         )
 
     async def test_search_people_with_network_and_company_filters(self, mock_context):
@@ -289,6 +290,7 @@ class TestPersonTool:
             mock_context,
             network=["F"],
             current_company="1115",
+            max_pages=4,
             extractor=mock_extractor,
         )
         assert "search_results" in result["sections"]
@@ -297,7 +299,25 @@ class TestPersonTool:
             None,
             network=["F"],
             current_company="1115",
+            max_pages=4,
         )
+
+    @pytest.mark.parametrize("max_pages", [0, 11])
+    async def test_search_people_rejects_invalid_max_pages(
+        self, mock_context, max_pages
+    ):
+        from pydantic import ValidationError
+
+        from linkedin_mcp_server.tools.person import register_person_tools
+
+        mcp = FastMCP("test")
+        register_person_tools(mcp)
+
+        with pytest.raises(ValidationError, match="max_pages"):
+            await mcp.call_tool(
+                "search_people",
+                {"keywords": "engineer", "max_pages": max_pages},
+            )
 
     async def test_search_people_validation_error_surfaced_as_tool_error(
         self, mock_context


### PR DESCRIPTION
## Summary

- add an optional `max_pages` argument to `search_people`, validated from 1 to 10 and defaulting to 1
- navigate LinkedIn people-search pages with the 1-based `page` parameter, aggregate page text, and deduplicate references by URL
- stop pagination when a page produces no new person references, independent of locale-specific UI text
- add an opt-in authenticated live-search harness that verifies page 2 was visited and returned readable, genuinely new people results
- update README, Docker Hub documentation, manifest metadata, and contributor guidance
- cover tool validation, extractor behavior, the production browser/DOM path, and both pass/fail behavior of the live harness

## Why

People search previously returned only LinkedIn's first result page. Callers that need a broader shortlist can now opt into additional pages while existing calls retain their single-page behavior.

## Impact

`search_people` callers may request up to 10 pages in one tool call. Over-requesting is harmless because extraction stops once LinkedIn repeats known people or returns no person references.

## Testing

- `uv run pytest --cov -k "not test_get_runtime_id_marks_container"` — 805 passed, 7 skipped, 2 deselected; 75.52% coverage
- `uv run pytest tests/test_people_search_pagination_dom.py -vv` — 2 passed with real Patchright/Chromium browser automation
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `SKIP=end-of-file-fixer uv run pre-commit run --all-files` — remaining hooks passed; the skipped hook rewrites the Windows checkout representation of the `CLAUDE.md` symlink

The browser tests route deterministic LinkedIn-like HTML through Chromium. They verify that the live harness accepts a second page with new people and rejects a second page that merely repeats page 1.

The two deselected tests are existing Windows-only `session_state` container-detection failures and are unrelated to this change.

## Live verification

After authenticating a disposable/source profile with:

```console
uv run -m linkedin_mcp_server --login
```

run:

```console
uv run python scripts/verify_live_people_search.py "software engineer" --max-pages 2
```

The command fails unless the production browser visits page 2, extracts readable content and people there, observes at least one person not found on page 1, and returns deduplicated final references. Its JSON report contains counts and navigation metadata only; production diagnostics on stderr may still include extracted content.

An authenticated live LinkedIn run could not be completed on the authoring machine because no source session was available. The deterministic Chromium coverage above exercises the same production extractor and verification path without requiring credentials in CI.

## Synthetic prompt

> Add opt-in pagination to `search_people` with a validated `max_pages` argument (1–10, default 1), aggregate result text across LinkedIn's 1-based pages, deduplicate references by URL, stop when no new person references appear, add an authenticated live-search verification harness, and update unit tests, real-browser coverage, README, Docker docs, manifest metadata, and contributor guidance.

Generated with GPT-5 Codex.

Closes #526
