### PR TITLE
fix(skills): return full list + structured parse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ All scraping tools return: `{url, sections: {name: raw_text}}`.
 Optional additional keys:
 
 - `references: {section_name: [{kind, url, text?, context?, value?}]}` — LinkedIn URLs are relative paths; `value` carries non-URL identifiers (e.g. company URN id for `kind: "company_urn"`)
+- `structured: {section_name: [...]}` — parsed records for sections that support it. Currently only `skills`: `[{name, endorsements (int), endorsements_display (str, e.g. "99+"), endorsers (list[str])}]`, in page order. The raw `sections["skills"]` text is still returned alongside.
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs only)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 
 | Tool | Description | Status |
 |------|-------------|--------|
-| `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts) | working |
+| `get_person_profile` | Get profile info with explicit section selection (experience, education, interests, honors, languages, certifications, skills, projects, contact_info, posts). The `skills` section returns the **full** list (not just the top ~10) and adds `structured.skills` with parsed `{name, endorsements, endorsements_display, endorsers}` records | working |
 | `get_my_profile` | Get the authenticated user's own LinkedIn profile (same sections as get_person_profile) | working |
 | `connect_with_person` | Send a connection request or accept an incoming one, with optional note | [#407](https://github.com/stickerdaniel/linkedin-mcp-server/issues/407) [#432](https://github.com/stickerdaniel/linkedin-mcp-server/issues/432) [#454](https://github.com/stickerdaniel/linkedin-mcp-server/issues/454) |
 | `get_sidebar_profiles` | Extract profile URLs from sidebar recommendation sections ("More profiles for you", "Explore premium profiles", "People you may know") on a profile page | working |

--- a/linkedin_mcp_server/scraping/__init__.py
+++ b/linkedin_mcp_server/scraping/__init__.py
@@ -7,6 +7,7 @@ from .fields import (
     parse_company_sections,
     parse_person_sections,
 )
+from .skills_parser import parse_skills, skill_names_from_aria_labels
 
 __all__ = [
     "COMPANY_SECTIONS",
@@ -14,4 +15,6 @@ __all__ = [
     "PERSON_SECTIONS",
     "parse_company_sections",
     "parse_person_sections",
+    "parse_skills",
+    "skill_names_from_aria_labels",
 ]

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -38,6 +38,7 @@ from linkedin_mcp_server.scraping.link_metadata import (
 )
 
 from .fields import COMPANY_SECTIONS, PERSON_SECTIONS
+from .skills_parser import parse_skills, skill_names_from_aria_labels
 
 if TYPE_CHECKING:
     from linkedin_mcp_server.callbacks import ProgressCallback
@@ -417,6 +418,9 @@ class ExtractedSection:
     text: str
     references: list[Reference]
     error: dict[str, Any] | None = None
+    # Structured records for sections that support it (currently only skills).
+    # None means "not applicable to this section"; [] means "parsed, none found".
+    structured: list[dict[str, Any]] | None = None
 
 
 _FEED_RSC_MARKER = "sduiid=com.linkedin.sdui.pagers.feed.mainFeed"
@@ -1483,6 +1487,14 @@ class LinkedInExtractor:
         # panel loads asynchronously. Wait until the panel replaces the sidebar.
         # The sidebar placeholder starts with "Load more" or "More profiles for you".
         is_details = "/details/" in url
+        # The skills detail page is a special case: it has NO list-level "Show
+        # more" pager and does not paginate on window scroll. Instead it is an
+        # SDUI list that appends more skills only when the viewport-centre mouse
+        # wheel fires (like the home feed). It also renders a per-skill "Show all
+        # N details" button that matches the generic Show-more regex — clicking
+        # it would navigate away — so skills must bypass the Show-more loop and
+        # use the dedicated wheel-scroll path below.
+        is_skills = url.rstrip("/").endswith("/details/skills")
         if is_details:
             try:
                 await self._page.wait_for_function(
@@ -1501,7 +1513,7 @@ class LinkedInExtractor:
 
         # Detail pages paginate with a "Show more" button inside <main>, not scroll.
         # Click it until it disappears or the budget runs out.
-        if is_details:
+        if is_details and not is_skills:
             max_clicks = max_scrolls if max_scrolls is not None else 5
             for i in range(max_clicks):
                 button = self._page.locator("main button").filter(
@@ -1525,12 +1537,23 @@ class LinkedInExtractor:
                     break
 
         # Scroll to trigger lazy loading
-        if is_activity:
+        if is_skills:
+            # LinkedIn caps the initial skills render at ~10; the rest append via
+            # SDUI pagination that only fires on a viewport-centre wheel scroll.
+            scrolls = max_scrolls if max_scrolls is not None else 25
+            await self._wheel_scroll_until_stable(max_scrolls=scrolls)
+        elif is_activity:
             scrolls = max_scrolls if max_scrolls is not None else 10
             await scroll_to_bottom(self._page, pause_time=1.0, max_scrolls=scrolls)
         else:
             scrolls = max_scrolls if max_scrolls is not None else 5
             await scroll_to_bottom(self._page, pause_time=0.5, max_scrolls=scrolls)
+
+        # Authoritative skill names come from per-skill aria-labels; read them
+        # before extraction so the structured parser can key on them.
+        skill_names: list[str] = []
+        if is_skills:
+            skill_names = await self._collect_skill_names()
 
         # Extract text from main content area
         raw_result = await self._extract_root_content(["main"])
@@ -1545,10 +1568,76 @@ class LinkedInExtractor:
             )
             return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
         cleaned = _filter_linkedin_noise_lines(truncated)
+        structured = parse_skills(cleaned, skill_names) if is_skills else None
         return ExtractedSection(
             text=cleaned,
             references=build_references(raw_result["references"], section_name),
+            structured=structured,
         )
+
+    async def _wheel_scroll_until_stable(
+        self,
+        max_scrolls: int,
+        *,
+        stale_limit: int = 3,
+        pause_time: float = 1.3,
+    ) -> None:
+        """Wheel-scroll the viewport centre until <main> innerText stops growing.
+
+        LinkedIn's SDUI lists (skills, and the feed) ignore ``window.scrollTo``;
+        only a mouse wheel over the viewport centre triggers the pagination that
+        appends more items. innerText length is a locale-independent progress
+        signal — when it stays flat for ``stale_limit`` consecutive checks the
+        list is fully loaded.
+        """
+        viewport = self._page.viewport_size or {"width": 1280, "height": 720}
+        cx, cy = viewport["width"] // 2, viewport["height"] // 2
+        await self._page.mouse.move(cx, cy)
+
+        async def _length() -> int:
+            try:
+                return await self._page.evaluate(
+                    "() => { const m = document.querySelector('main');"
+                    " return m ? m.innerText.length : 0; }"
+                )
+            except Exception:
+                return 0
+
+        prev = -1
+        stale = 0
+        for _ in range(max_scrolls):
+            current = await _length()
+            if current == prev:
+                stale += 1
+                if stale >= stale_limit:
+                    break
+            else:
+                stale = 0
+            prev = current
+            await self._page.mouse.wheel(0, 2500)
+            await asyncio.sleep(pause_time)
+
+    async def _collect_skill_names(self) -> list[str]:
+        """Read authoritative skill names from per-skill aria-labels in <main>.
+
+        Own profile exposes ``Edit <name> skill``; other profiles expose
+        ``Endorse <name>`` / ``Endorsed <name>``. Returns [] when neither is
+        present (the parser then falls back to heuristic segmentation).
+        """
+        try:
+            labels = await self._page.evaluate(
+                """() => {
+                    const main = document.querySelector('main');
+                    if (!main) return [];
+                    return [...main.querySelectorAll('[aria-label]')]
+                        .map(e => e.getAttribute('aria-label'))
+                        .filter(Boolean);
+                }"""
+            )
+        except Exception:
+            logger.debug("Failed to read skill aria-labels", exc_info=True)
+            return []
+        return skill_names_from_aria_labels(labels)
 
     async def _extract_overlay(
         self,
@@ -1655,6 +1744,7 @@ class LinkedInExtractor:
         base_url = f"https://www.linkedin.com/in/{username}"
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
+        structured: dict[str, list[dict[str, Any]]] = {}
         section_errors: dict[str, dict[str, Any]] = {}
         profile_urn: str | None = None
 
@@ -1712,6 +1802,8 @@ class LinkedInExtractor:
                         sections[section_name] = extracted.text
                         if extracted.references:
                             references[section_name] = extracted.references
+                        if extracted.structured is not None:
+                            structured[section_name] = extracted.structured
                     elif extracted.error:
                         section_errors[section_name] = extracted.error
 
@@ -1748,6 +1840,8 @@ class LinkedInExtractor:
             result["profile_urn"] = profile_urn
         if references:
             result["references"] = references
+        if structured:
+            result["structured"] = structured
         if section_errors:
             result["section_errors"] = section_errors
 

--- a/linkedin_mcp_server/scraping/skills_parser.py
+++ b/linkedin_mcp_server/scraping/skills_parser.py
@@ -1,0 +1,183 @@
+"""Parse the fully-scrolled LinkedIn skills section into structured records.
+
+The skills detail page (``/details/skills/``) renders each skill as a block::
+
+    <Skill Name>
+    [<N> experiences at <company> ...]      (optional)
+    [Endorsed by <...>]                     (zero or more lines)
+    [Passed LinkedIn Skill Assessment]      (optional)
+    [<N> endorsements | 99+ endorsements]   (optional)
+
+Some skills additionally render an inline "associated experience" preview (a job
+title such as "Director, Solutions Architecture at Acme") plus a "Show all N
+details" expander. Those lines are structurally indistinguishable from a skill
+name in plain text, so pure segmentation mis-reads them as skills.
+
+To avoid that, the parser is *keyed* on an authoritative list of skill names
+supplied by the caller. The extractor reads those names from the per-skill
+aria-labels — ``Edit <name> skill`` on the owner's own profile, or
+``Endorse <name>`` / ``Endorsed <name>`` on other people's profiles. Only a line
+that exactly matches a known name starts a new record; every following line up to
+the next known name is that skill's metadata. This makes the associated-experience
+and expander lines fall through harmlessly (they are not in the name set).
+
+When no authoritative names are available (rare — e.g. a profile that exposes
+neither edit nor endorse affordances) the parser falls back to a heuristic
+segmentation that treats any non-metadata line as a skill name.
+
+LOCALE NOTE: the metadata keywords and aria verbs handled here are English-only.
+Per this repo's locale-independence rule that is a documented limitation; extend
+the token tables below to support other UI languages.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# --- Locale-dependent tokens (English UI). Documented limitation; see module doc. ---
+
+# Filter tabs at the top of the skills panel, plus category headers.
+_TAB_HEADERS: frozenset[str] = frozenset(
+    {
+        "Skills",
+        "All",
+        "Industry Knowledge",
+        "Tools & Technologies",
+        "Interpersonal Skills",
+        "Other Skills",
+        "Languages",
+    }
+)
+
+# aria-label verb prefixes that carry an authoritative skill name.
+# "Edit <name> skill" (own profile), "Endorse/Endorsed <name>" (others).
+_ARIA_EDIT_RE = re.compile(r"^Edit (?P<name>.+) skill$")
+_ARIA_ENDORSE_RE = re.compile(r"^Endorsed? (?P<name>.+)$")
+
+# Metadata line patterns (used by the heuristic fallback and count extraction).
+_RE_ENDORSEMENT_COUNT = re.compile(r"^(?P<n>\d+\+?) endorsements?$", re.IGNORECASE)
+_RE_EXPERIENCES = re.compile(r"^\d+ experiences? at ", re.IGNORECASE)
+_RE_SHOW_ALL_DETAILS = re.compile(r"^Show all \d+ details?$", re.IGNORECASE)
+_META_EXACT: frozenset[str] = frozenset({"Passed LinkedIn Skill Assessment"})
+_META_PREFIXES: tuple[str, ...] = ("Endorsed by ",)
+
+
+def skill_names_from_aria_labels(aria_labels: list[str]) -> list[str]:
+    """Extract authoritative, de-duplicated skill names from per-skill aria-labels.
+
+    Order is preserved (LinkedIn renders skills most-endorsed / pinned first).
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    for label in aria_labels:
+        label = (label or "").strip()
+        m = _ARIA_EDIT_RE.match(label) or _ARIA_ENDORSE_RE.match(label)
+        if not m:
+            continue
+        name = m.group("name").strip()
+        if name and name not in seen:
+            seen.add(name)
+            names.append(name)
+    return names
+
+
+def _parse_count(line: str) -> tuple[int, str] | None:
+    """Return (numeric_count, display) for an 'N endorsements' line, else None.
+
+    '99+ endorsements' -> (99, '99+'); '32 endorsements' -> (32, '32').
+    """
+    m = _RE_ENDORSEMENT_COUNT.match(line)
+    if not m:
+        return None
+    raw = m.group("n")
+    numeric = int(raw.rstrip("+"))
+    return numeric, raw
+
+
+def _new_record(name: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "endorsements": 0,
+        "endorsements_display": "0",
+        "endorsers": [],
+    }
+
+
+def _apply_meta(record: dict[str, Any], line: str) -> None:
+    """Attach a single metadata line to the current skill record."""
+    count = _parse_count(line)
+    if count is not None:
+        record["endorsements"], record["endorsements_display"] = count
+    elif line.startswith(_META_PREFIXES):
+        record["endorsers"].append(line)
+
+
+def _is_metadata(line: str) -> bool:
+    """Heuristic: does this line look like skill metadata rather than a name?"""
+    if line in _META_EXACT:
+        return True
+    if line.startswith(_META_PREFIXES):
+        return True
+    if _RE_ENDORSEMENT_COUNT.match(line):
+        return True
+    if _RE_EXPERIENCES.match(line):
+        return True
+    if _RE_SHOW_ALL_DETAILS.match(line):
+        return True
+    return False
+
+
+def parse_skills(text: str, names: list[str] | None = None) -> list[dict[str, Any]]:
+    """Parse the skills section innerText into ``[{name, endorsements, ...}]``.
+
+    Args:
+        text: The noise-truncated innerText of the fully-scrolled skills panel.
+        names: Authoritative skill names (from aria-labels). When provided, the
+            parser keys on them for robust segmentation. When ``None``/empty it
+            falls back to heuristic segmentation.
+
+    Returns:
+        One record per skill: ``{name, endorsements (int), endorsements_display
+        (str, e.g. "99+"), endorsers (list[str])}``, in page order.
+    """
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    if names:
+        return _parse_keyed(lines, names)
+    return _parse_heuristic(lines)
+
+
+def _parse_keyed(lines: list[str], names: list[str]) -> list[dict[str, Any]]:
+    nameset = set(names)
+    records: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line in nameset and line not in records:
+            record = _new_record(line)
+            records[line] = record
+            order.append(line)
+            j = i + 1
+            while j < len(lines) and lines[j] not in nameset:
+                _apply_meta(record, lines[j])
+                j += 1
+            i = j
+        else:
+            i += 1
+    return [records[n] for n in order]
+
+
+def _parse_heuristic(lines: list[str]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    for line in lines:
+        if line in _TAB_HEADERS or _RE_SHOW_ALL_DETAILS.match(line):
+            continue
+        if _is_metadata(line):
+            if current is not None:
+                _apply_meta(current, line)
+            continue
+        current = _new_record(line)
+        records.append(current)
+    return records

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -54,16 +54,21 @@ def register_person_tools(
                 Examples: "experience,education", "contact_info", "skills,projects", "honors,languages", "posts"
                 Default (None) scrapes only the main profile page.
             max_scrolls: Maximum pagination attempts per section to load more content.
-                On detail sections (experience, certifications, skills, etc.) this
-                is the max number of "Show more" button clicks. On activity/posts
-                it is the max scroll-to-bottom iterations. Applies to all sections
-                in this call. Default (None) uses 5 for detail sections and 10 for
-                posts. Increase when a profile has many items in a section
-                (e.g., 30+ certifications, max_scrolls=20). To avoid slowing down
-                other sections, request heavy sections in a separate call.
+                On most detail sections (experience, certifications, etc.) this is
+                the max number of "Show more" button clicks. The skills section
+                instead wheel-scrolls to load its full list (default budget 25);
+                activity/posts scroll to the bottom. Applies to all sections in
+                this call. Default (None) uses 5 for detail sections, 25 for
+                skills, and 10 for posts. Increase when a profile has many items
+                in a section (e.g., 30+ certifications, max_scrolls=20). To avoid
+                slowing down other sections, request heavy sections separately.
 
         Returns:
             Dict with url, sections (name -> raw text), and optional references.
+            When "skills" is requested the full list is returned (not just the
+            top ~10 LinkedIn shows by default), and result["structured"]["skills"]
+            carries parsed records: {name, endorsements (int), endorsements_display
+            (str, e.g. "99+"), endorsers (list[str])}, in page order.
             Sections may be absent if extraction yielded no content for that page.
             Includes unknown_sections list when unrecognised names are passed.
             The LLM should parse the raw text in each section.
@@ -337,6 +342,9 @@ def register_person_tools(
 
         Returns:
             Dict with url, sections (name -> raw text), and optional references.
+            When "skills" is requested the full list is returned (not just the
+            top ~10), plus result["structured"]["skills"] with parsed records
+            {name, endorsements, endorsements_display, endorsers}.
             The url field reflects the resolved profile URL, revealing the real username.
         """
         try:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3238,6 +3238,81 @@ class TestActivityFeedExtraction:
 
         show_more.click.assert_not_awaited()
 
+    async def test_skills_page_bypasses_show_more_and_wheel_scrolls(self, mock_page):
+        """Skills page skips the Show-more loop and wheel-scrolls to load the list."""
+        skills_text = (
+            "Skills\nAll\n\nIPTV\n99+ endorsements\n\nDVB\n8 endorsements\n\nDRM"
+        )
+        aria = ["Edit IPTV skill", "Edit DVB skill", "Edit DRM skill", "Dismiss"]
+
+        def evaluate_side_effect(js, *args, **kwargs):
+            if "innerText.length" in js:
+                return 500  # constant -> wheel loop goes stale and stops
+            if "querySelectorAll('[aria-label]')" in js:
+                return aria
+            return {"source": "root", "text": skills_text, "references": []}
+
+        mock_page.evaluate = AsyncMock(side_effect=evaluate_side_effect)
+        mock_page.wait_for_function = AsyncMock()
+        mock_page.viewport_size = {"width": 1280, "height": 720}
+        mock_page.mouse = MagicMock()
+        mock_page.mouse.move = AsyncMock()
+        mock_page.mouse.wheel = AsyncMock()
+
+        show_more = MagicMock()
+        show_more.count = AsyncMock(return_value=1)
+        show_more.is_visible = AsyncMock(return_value=True)
+        show_more.click = AsyncMock()
+        show_more.first = show_more
+        show_more.filter = MagicMock(return_value=show_more)
+
+        def locator_side_effect(selector):
+            if selector == "main button":
+                return show_more
+            return MagicMock(count=AsyncMock(return_value=0))
+
+        mock_page.locator = MagicMock(side_effect=locator_side_effect)
+        extractor = LinkedInExtractor(mock_page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_window_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/in/billgates/details/skills/",
+                section_name="skills",
+            )
+
+        # never clicks the (per-skill "Show all N details") button, never uses
+        # the window-scroll helper, and does wheel-scroll instead
+        show_more.click.assert_not_awaited()
+        mock_window_scroll.assert_not_awaited()
+        assert mock_page.mouse.wheel.await_count > 0
+
+        # structured skills parsed and keyed on aria names
+        assert result.structured is not None
+        by_name = {s["name"]: s for s in result.structured}
+        assert set(by_name) == {"IPTV", "DVB", "DRM"}
+        assert by_name["IPTV"]["endorsements"] == 99
+        assert by_name["IPTV"]["endorsements_display"] == "99+"
+        assert by_name["DVB"]["endorsements"] == 8
+        assert by_name["DRM"]["endorsements"] == 0
+
     async def test_activity_page_timeout_proceeds_gracefully(self, mock_page):
         """When activity feed content never loads, extraction proceeds with available text."""
         from patchright.async_api import TimeoutError as PlaywrightTimeoutError

--- a/tests/test_skills_parser.py
+++ b/tests/test_skills_parser.py
@@ -1,0 +1,107 @@
+"""Tests for the skills text -> structured parser (scraping/skills_parser.py)."""
+
+from linkedin_mcp_server.scraping.skills_parser import (
+    parse_skills,
+    skill_names_from_aria_labels,
+)
+
+# A realistic skills panel innerText (post noise-truncation), modelled on live
+# data: a 99+ skill, a skill with an inline associated-experience preview + a
+# "Show all N details" expander (both must NOT become skills), an assessment-only
+# skill, and a bare skill with no metadata.
+SKILLS_TEXT = """Skills
+All
+Industry Knowledge
+Tools & Technologies
+Interpersonal Skills
+
+Set Top Box
+6 experiences at Acme and 3 other companies
+Endorsed by Muhammad Khan and 13 others who are highly skilled at this
+Endorsed by 29 mutual connections
+99+ endorsements
+
+Software Architecture
+Director, Solutions Architecture at Acme
+Show all 4 details
+Endorsed by 2 colleagues at Acme
+32 endorsements
+
+IPTV
+Passed LinkedIn Skill Assessment
+
+Conditional Access"""
+
+NAMES = ["Set Top Box", "Software Architecture", "IPTV", "Conditional Access"]
+
+
+class TestSkillNamesFromAriaLabels:
+    def test_extracts_edit_and_endorse_variants_in_order(self):
+        labels = [
+            "Navigate back to profile main screen",
+            "Edit Set Top Box skill",
+            "Endorse Software Architecture",
+            "Endorsed IPTV",
+            "Dismiss",
+            "Report this ad",
+        ]
+        assert skill_names_from_aria_labels(labels) == [
+            "Set Top Box",
+            "Software Architecture",
+            "IPTV",
+        ]
+
+    def test_dedupes_preserving_first_order(self):
+        labels = ["Edit DASH skill", "Endorse DASH", "Edit VOD skill"]
+        assert skill_names_from_aria_labels(labels) == ["DASH", "VOD"]
+
+    def test_ignores_non_skill_labels(self):
+        assert skill_names_from_aria_labels(["Dismiss", "Submit", ""]) == []
+
+
+class TestParseSkillsKeyed:
+    def test_returns_one_record_per_authoritative_name(self):
+        skills = parse_skills(SKILLS_TEXT, NAMES)
+        assert [s["name"] for s in skills] == NAMES
+
+    def test_parses_capped_endorsement_count(self):
+        stb = parse_skills(SKILLS_TEXT, NAMES)[0]
+        assert stb["endorsements"] == 99
+        assert stb["endorsements_display"] == "99+"
+        assert len(stb["endorsers"]) == 2
+
+    def test_parses_numeric_endorsement_count(self):
+        sa = parse_skills(SKILLS_TEXT, NAMES)[1]
+        assert sa["endorsements"] == 32
+        assert sa["endorsements_display"] == "32"
+        assert sa["endorsers"] == ["Endorsed by 2 colleagues at Acme"]
+
+    def test_excludes_associated_experience_and_show_all_details(self):
+        # "Director, ... at Acme" and "Show all 4 details" must not appear as skills
+        names = [s["name"] for s in parse_skills(SKILLS_TEXT, NAMES)]
+        assert "Director, Solutions Architecture at Acme" not in names
+        assert not any(n.startswith("Show all") for n in names)
+
+    def test_skill_without_metadata_has_zero_endorsements(self):
+        by_name = {s["name"]: s for s in parse_skills(SKILLS_TEXT, NAMES)}
+        assert by_name["Conditional Access"]["endorsements"] == 0
+        assert by_name["Conditional Access"]["endorsers"] == []
+        assert by_name["IPTV"]["endorsements"] == 0
+
+
+class TestParseSkillsHeuristicFallback:
+    def test_finds_real_skills_without_names(self):
+        skills = parse_skills(SKILLS_TEXT, None)
+        names = [s["name"] for s in skills]
+        for expected in ["Set Top Box", "Software Architecture", "IPTV", "Conditional Access"]:
+            assert expected in names
+
+    def test_fallback_filters_tab_headers_and_show_all(self):
+        names = [s["name"] for s in parse_skills(SKILLS_TEXT, None)]
+        assert "All" not in names
+        assert "Industry Knowledge" not in names
+        assert not any(n.startswith("Show all") for n in names)
+
+    def test_empty_text_returns_empty(self):
+        assert parse_skills("", NAMES) == []
+        assert parse_skills("", None) == []


### PR DESCRIPTION
Closes #590.

## Summary

The `skills` section returned only the top ~10 skills LinkedIn renders initially. This PR makes it return the **full** list and adds structured skill records.

## Root cause

The `/details/skills/` page has **no list-level "Show more" pager** and does **not** paginate on `window.scrollTo` (what `scroll_to_bottom` uses). It is an SDUI list that appends more skills only when a viewport-centre **mouse wheel** fires — the same mechanism the home-feed scraper already relies on. The generic detail "Show more" loop also matched per-skill **"Show all N details"** buttons, which navigate away rather than paginate.

## What changed

- **`scraping/extractor.py`**
  - Skills bypass the "Show more" loop and use a new `_wheel_scroll_until_stable` (wheel at viewport centre; stops when `<main>` innerText length is stable for N checks — a locale-independent progress signal, mirroring the feed scroll).
  - Authoritative skill names read from per-skill aria-labels via `_collect_skill_names` (`Edit <name> skill` on own profile, `Endorse`/`Endorsed <name>` on others).
  - New optional `ExtractedSection.structured`; surfaced as `result["structured"]["skills"]`.
- **`scraping/skills_parser.py`** (new) — pure, text-based parser producing `{name, endorsements (int), endorsements_display (str, e.g. "99+"), endorsers (list[str])}`. Keyed on the authoritative names so associated-experience previews and "Show all N details" expanders don't leak; heuristic segmentation fallback when no aria names are present. Locale-dependent tokens are documented per the repo's locale rule.
- Docstrings (`tools/person.py`), `README.md`, `AGENTS.md` return-format section updated.

## Testing

- New `tests/test_skills_parser.py` (11 tests): aria-name extraction, name-keyed parse, 99+/numeric counts, leak exclusion, heuristic fallback.
- New extraction-path test in `tests/test_scraping.py`: skills bypasses Show-more, wheel-scrolls (not `scroll_to_bottom`), and returns structured records.
- Full suite: **819 passed**; `ruff check`, `ruff format --check`, `ty check` clean.
- Live (own + other profiles): a profile went from 10 → 53 skills (IPTV, DVB, Conditional Access, DRM now present); another 10 → 42 with "Set Top Box" at 99+ endorsements.

## Synthetic prompt

> The `skills` section of `get_person_profile`/`get_my_profile` only returns ~10 skills. Investigate against live LinkedIn, fix it so the full list is returned, and additionally return structured `{name, endorsement count, endorsers}` records. Follow the repo's contribution workflow (issue, tests, docs, draft PR).

Generated with Claude Opus 4.8 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)