### PR TITLE
fix(auth): retire the browser profile on a new session

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 - `--host HOST` - HTTP server host (default: 127.0.0.1)
 - `--port PORT` - HTTP server port (default: 8000)
 - `--path PATH` - HTTP server path (default: /mcp)
-- `--logout` - Clear all stored LinkedIn auth state, including source and derived runtime profiles
+- `--logout` - Clear all stored LinkedIn auth state, including source and derived runtime profiles and any retired sessions
 - `--timeout MS` - Browser timeout for page operations in milliseconds (default: 5000)
 - `--tool-timeout SECONDS` - Per-tool MCP execution timeout in seconds (default: 180.0). Increase further for heavy scrapes / cold-start Chromium / slow networks.
 - `--login-timeout SECONDS` - Manual login wait timeout in seconds (default: 1800; 0 = no limit). How long the `--login` browser waits for you to finish signing in.

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 from pathlib import Path
-import shutil
 import sys
 from typing import NoReturn
 
@@ -39,7 +38,7 @@ from linkedin_mcp_server.session_state import (
     get_runtime_id,
     portable_cookie_path,
     profile_exists,
-    runtime_profiles_root,
+    rotate_source_profile,
     source_state_path,
 )
 from linkedin_mcp_server.setup import interactive_login
@@ -957,26 +956,11 @@ def _move_auth_state_aside(*, force: bool = False) -> None:
             ``invalidate_auth_and_trigger_relogin`` when the caller already
             knows the session is stale.
     """
-    profile_dir = get_profile_dir()
-    targets = [
-        profile_dir,
-        portable_cookie_path(profile_dir),
-        source_state_path(profile_dir),
-        runtime_profiles_root(profile_dir),
-    ]
-    existing = [target for target in targets if target.exists()]
-    if not existing:
-        return
     if not force and _auth_ready():
         return
-
-    backup_dir = (
-        auth_root_dir(profile_dir)
-        / f"{_INVALID_STATE_PREFIX}{utcnow_iso().replace(':', '-')}"
-    )
-    secure_mkdir(backup_dir)
-    for target in existing:
-        shutil.move(str(target), str(backup_dir / target.name))
+    # Quarantine creation lives in session_state so the routine rotation on a
+    # new session and this stale-state path produce identically shaped backups.
+    rotate_source_profile(get_profile_dir())
 
 
 def _force_move_auth_state_aside() -> None:

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -955,12 +955,27 @@ def _move_auth_state_aside(*, force: bool = False) -> None:
         force: If True, skip the ``_auth_ready()`` guard.  Used by
             ``invalidate_auth_and_trigger_relogin`` when the caller already
             knows the session is stale.
+
+    Raises:
+        AuthenticationBootstrapFailedError: The state could not be retired. The
+            caller must not go on to open a login browser: that login rotates
+            the same artifacts and would fail at the same point, after telling
+            the user a browser had opened.
     """
     if not force and _auth_ready():
         return
     # Quarantine creation lives in session_state so the routine rotation on a
     # new session and this stale-state path produce identically shaped backups.
-    rotate_source_profile(get_profile_dir())
+    try:
+        rotate_source_profile(get_profile_dir())
+    except RuntimeError as exc:
+        raise AuthenticationBootstrapFailedError(
+            f"{exc} No login was started."
+        ) from exc
+    except OSError as exc:
+        raise AuthenticationBootstrapFailedError(
+            f"Could not retire the stale session: {exc}. No login was started."
+        ) from exc
 
 
 def _force_move_auth_state_aside() -> None:

--- a/linkedin_mcp_server/browser_import/orchestrate.py
+++ b/linkedin_mcp_server/browser_import/orchestrate.py
@@ -45,7 +45,8 @@ from linkedin_mcp_server.exceptions import (
 )
 from linkedin_mcp_server.session_state import (
     portable_cookie_path,
-    rotate_source_profile,
+    restore_source_profile,
+    rotate_shielded,
     write_source_state,
 )
 
@@ -204,8 +205,6 @@ async def import_session_from_browser(
     Returns ``True`` on a validated, persisted session, ``False`` when a live
     ``li_at`` was found but no browser's session was accepted by LinkedIn.
     """
-    from linkedin_mcp_server.drivers.browser import validate_imported_cookies
-
     live, skipped = await asyncio.to_thread(_discover_and_rank, browser)
     if not live:
         raise _no_live_session_error(skipped)
@@ -226,7 +225,33 @@ async def import_session_from_browser(
     from linkedin_mcp_server.drivers.browser import close_browser
 
     await close_browser()
-    await asyncio.to_thread(rotate_source_profile, user_data_dir)
+    retired = await rotate_shielded(user_data_dir)
+
+    imported = False
+    try:
+        imported = await _import_first_accepted(live, cookie_path, user_data_dir)
+        return imported
+    finally:
+        # The retirement happens before a replacement exists, so an import where
+        # every candidate is rejected — or that raises on undecryptable cookies —
+        # would otherwise leave the user logged out of a working session.
+        if retired is not None and not imported:
+            if not await asyncio.to_thread(
+                restore_source_profile, retired, user_data_dir
+            ):
+                logger.warning(
+                    "Could not restore the previous session; it is kept at %s",
+                    retired,
+                )
+
+
+async def _import_first_accepted(
+    live: list[tuple[BrowserProfile, LiAtMeta]],
+    cookie_path: Path,
+    user_data_dir: Path,
+) -> bool:
+    """Stage and validate candidates in order, keeping the first LinkedIn accepts."""
+    from linkedin_mcp_server.drivers.browser import validate_imported_cookies
 
     staged_any = False
     for profile, _meta in live:

--- a/linkedin_mcp_server/browser_import/orchestrate.py
+++ b/linkedin_mcp_server/browser_import/orchestrate.py
@@ -45,6 +45,7 @@ from linkedin_mcp_server.exceptions import (
 )
 from linkedin_mcp_server.session_state import (
     portable_cookie_path,
+    rotate_source_profile,
     write_source_state,
 )
 
@@ -215,6 +216,17 @@ async def import_session_from_browser(
         len(live),
     )
     cookie_path = portable_cookie_path(user_data_dir)
+
+    # An import seeds a session that may belong to a different account than the
+    # one already on disk, so the previous profile is retired rather than
+    # reused: Chromium keeps machine_id and friends for the life of a profile
+    # directory, which would present both accounts to LinkedIn as one device.
+    # Closing first so a later teardown cannot export the retired session's
+    # cookies over the freshly staged ones.
+    from linkedin_mcp_server.drivers.browser import close_browser
+
+    await close_browser()
+    await asyncio.to_thread(rotate_source_profile, user_data_dir)
 
     staged_any = False
     for profile, _meta in live:

--- a/linkedin_mcp_server/session_state.py
+++ b/linkedin_mcp_server/session_state.py
@@ -11,7 +11,11 @@ import shutil
 from typing import Any
 from uuid import uuid4
 
-from linkedin_mcp_server.common_utils import secure_write_text, utcnow_iso
+from linkedin_mcp_server.common_utils import (
+    secure_mkdir,
+    secure_write_text,
+    utcnow_iso,
+)
 from linkedin_mcp_server.config import get_config
 
 logger = logging.getLogger(__name__)
@@ -19,6 +23,14 @@ logger = logging.getLogger(__name__)
 _SOURCE_STATE_FILE = "source-state.json"
 _RUNTIME_STATE_FILE = "runtime-state.json"
 _RUNTIME_PROFILES_DIR = "runtime-profiles"
+
+# Prefix of the timestamped directories retired auth state is moved into.
+QUARANTINE_PREFIX = "invalid-state-"
+
+# Chromium writes these into a profile it currently owns and removes them on a
+# clean exit. Their presence means another process — a second CLI run, a server,
+# or a container sharing the mounted auth root — is using the profile right now.
+_CHROMIUM_LOCK_NAMES = ("SingletonLock", "SingletonSocket", "SingletonCookie")
 
 
 @dataclass
@@ -297,15 +309,98 @@ def clear_runtime_profile(
         return False
 
 
-def clear_auth_state(source_profile_dir: Path | None = None) -> bool:
-    """Remove source auth artifacts and all derived runtime profiles."""
-    profile_dir = (source_profile_dir or get_source_profile_dir()).expanduser()
-    targets = [
+def _auth_state_targets(profile_dir: Path) -> list[Path]:
+    """The four artifacts that together make up one source session."""
+    return [
         profile_dir,
         portable_cookie_path(profile_dir),
         source_state_path(profile_dir),
         runtime_profiles_root(profile_dir),
     ]
+
+
+def quarantine_dirs(source_profile_dir: Path | None = None) -> list[Path]:
+    """Existing quarantine directories, newest name last."""
+    root = auth_root_dir(source_profile_dir)
+    if not root.is_dir():
+        return []
+    return sorted(path for path in root.glob(f"{QUARANTINE_PREFIX}*") if path.is_dir())
+
+
+def profile_in_use_by(profile_dir: Path) -> Path | None:
+    """The Chromium lock file proving another process owns *profile_dir*.
+
+    Returns ``None`` when the profile is free. The lock is a symlink on Linux
+    and macOS and may dangle, so existence is probed via ``lstat`` rather than
+    ``exists()``, which follows the link and reports False for a stale target.
+    """
+    for name in _CHROMIUM_LOCK_NAMES:
+        candidate = profile_dir / name
+        try:
+            candidate.lstat()
+        except OSError:
+            continue
+        return candidate
+    return None
+
+
+def rotate_source_profile(source_profile_dir: Path | None = None) -> Path | None:
+    """Retire the current source session so the next one starts clean.
+
+    Chromium mints ``machine_id``, ``session_id_generator_last_value`` and
+    friends into ``Local State`` once and then keeps them for the life of the
+    profile. Reusing the directory for a different LinkedIn account hands
+    LinkedIn the same device identity twice, which is exactly the signal that
+    links accounts to one another. Every path that establishes a new source
+    session therefore rotates first.
+
+    The retired artifacts are moved, not deleted, so a session that turns out to
+    have been fine is still recoverable. ``--logout`` clears the quarantines.
+
+    Returns the quarantine directory, or ``None`` when there was nothing to
+    retire.
+
+    Raises:
+        RuntimeError: Another process holds the profile. Rotating underneath a
+            live Chromium corrupts both the old and the new session.
+        OSError: A move failed. Deliberately not swallowed: a half-rotated tree
+            would leave the next rotation splitting one session across two
+            quarantines.
+    """
+    profile_dir = (source_profile_dir or get_source_profile_dir()).expanduser()
+    existing = [
+        target for target in _auth_state_targets(profile_dir) if target.exists()
+    ]
+    if not existing:
+        return None
+
+    lock = profile_in_use_by(profile_dir)
+    if lock is not None:
+        raise RuntimeError(
+            f"The browser profile is in use by another process (found {lock.name}). "
+            "Stop the running server or container before creating a new session."
+        )
+
+    # utcnow_iso() is second-resolution and rotation is now routine rather than
+    # exceptional, so two rotations can land in the same second. The suffix keeps
+    # them from merging into one directory.
+    stamp = utcnow_iso().replace(":", "-")
+    backup_dir = (
+        auth_root_dir(profile_dir) / f"{QUARANTINE_PREFIX}{stamp}-{uuid4().hex[:8]}"
+    )
+    secure_mkdir(backup_dir)
+    for target in existing:
+        shutil.move(str(target), str(backup_dir / target.name))
+    logger.info("Retired previous session to %s", backup_dir)
+    return backup_dir
+
+
+def clear_auth_state(source_profile_dir: Path | None = None) -> bool:
+    """Remove source auth artifacts, derived runtime profiles and quarantines."""
+    profile_dir = (source_profile_dir or get_source_profile_dir()).expanduser()
+    # Quarantines hold previous sessions' cookies, so a logout that left them
+    # behind would not be the "clear all stored auth state" the CLI advertises.
+    targets = _auth_state_targets(profile_dir) + quarantine_dirs(profile_dir)
 
     success = True
     for target in targets:

--- a/linkedin_mcp_server/session_state.py
+++ b/linkedin_mcp_server/session_state.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import asdict, dataclass, fields
+import functools
 import json
 import logging
+import os
 import platform
 from pathlib import Path
 import shutil
+import socket
+from collections.abc import Callable
 from typing import Any
 from uuid import uuid4
 
@@ -27,10 +32,12 @@ _RUNTIME_PROFILES_DIR = "runtime-profiles"
 # Prefix of the timestamped directories retired auth state is moved into.
 QUARANTINE_PREFIX = "invalid-state-"
 
-# Chromium writes these into a profile it currently owns and removes them on a
-# clean exit. Their presence means another process — a second CLI run, a server,
-# or a container sharing the mounted auth root — is using the profile right now.
-_CHROMIUM_LOCK_NAMES = ("SingletonLock", "SingletonSocket", "SingletonCookie")
+# Chromium writes a profile it owns three Singleton* links and removes them on a
+# clean exit. Only this one encodes the owner as ``<hostname>-<pid>``; the
+# siblings hold a socket path and an opaque token, so they cannot be attributed
+# and are ignored. A crash leaves the link behind, so presence alone proves
+# nothing — see ``profile_in_use_by``.
+_CHROMIUM_LOCK_NAME = "SingletonLock"
 
 
 @dataclass
@@ -327,21 +334,109 @@ def quarantine_dirs(source_profile_dir: Path | None = None) -> list[Path]:
     return sorted(path for path in root.glob(f"{QUARANTINE_PREFIX}*") if path.is_dir())
 
 
-def profile_in_use_by(profile_dir: Path) -> Path | None:
-    """The Chromium lock file proving another process owns *profile_dir*.
+async def _off_loop_deferring_cancels(
+    work: Callable[[], Any],
+) -> tuple[Any, bool]:
+    """Run *work* in a worker thread, holding back cancels until it finishes.
 
-    Returns ``None`` when the profile is free. The lock is a symlink on Linux
-    and macOS and may dangle, so existence is probed via ``lstat`` rather than
-    ``exists()``, which follows the link and reports False for a stale target.
+    Uses ``run_in_executor`` rather than ``to_thread``: the latter registers an
+    ``asyncio.Task``, which ``asyncio.run`` cancels along with everything else
+    at loop teardown. Shielding an already-cancelled *task* re-raises forever,
+    so the wait below would spin and the process would never exit. A bare
+    Future is not in ``all_tasks()`` and never reaches that state.
+
+    Returns the result and whether a cancel arrived, so the caller can finish
+    cleaning up and re-raise once at the end.
     """
-    for name in _CHROMIUM_LOCK_NAMES:
-        candidate = profile_dir / name
+    future = asyncio.get_running_loop().run_in_executor(None, work)
+    cancelled = False
+    while True:
         try:
-            candidate.lstat()
-        except OSError:
-            continue
-        return candidate
-    return None
+            return await asyncio.shield(future), cancelled
+        except asyncio.CancelledError:
+            # A cancel here must not abandon the worker: it is already moving
+            # the session, and dropping its result strands the user logged out.
+            cancelled = True
+
+
+async def rotate_shielded(source_profile_dir: Path) -> Path | None:
+    """Rotate off the event loop without losing the backup path to a cancel.
+
+    A bare ``await asyncio.to_thread(rotate...)`` is cancellable, and a cancel
+    lands *after* the thread has already moved the session: the move stands, but
+    its return value is gone, so nothing can put it back. Overlapping cancels
+    are real here — a tool timeout racing a server shutdown — so every one of
+    them is deferred until the session is safely accounted for.
+    """
+    retired, cancelled = await _off_loop_deferring_cancels(
+        functools.partial(rotate_source_profile, source_profile_dir)
+    )
+    if not cancelled:
+        return retired
+
+    if retired is not None:
+        restored, _ = await _off_loop_deferring_cancels(
+            functools.partial(restore_source_profile, retired, source_profile_dir)
+        )
+        if not restored:
+            logger.warning(
+                "Rotation was cancelled and the previous session could not be "
+                "restored; it is kept at %s",
+                retired,
+            )
+    raise asyncio.CancelledError
+
+
+def _runtime_profile_dirs(source_profile_dir: Path) -> list[Path]:
+    """Every derived runtime profile under the auth root."""
+    root = runtime_profiles_root(source_profile_dir)
+    if not root.is_dir():
+        return []
+    return [item / "profile" for item in root.iterdir() if (item / "profile").is_dir()]
+
+
+def profile_in_use_by(profile_dir: Path) -> Path | None:
+    """The Chromium lock proving another *live* process owns *profile_dir*.
+
+    Returns ``None`` when the profile is free, including when a lock is left
+    over from a crash: Chromium does not clean these up on an abnormal exit, and
+    treating a stale one as an owner would wedge every future login behind a
+    manual file deletion.
+
+    On Linux and macOS the lock is a symlink whose target encodes the owning
+    ``<host>-<pid>``. The pid is only meaningful in that host's namespace, so it
+    is probed only when the host matches ours. A lock from a *different* host —
+    a container writing into the mounted auth root, most often — is treated as
+    held: its pid says nothing to us, and the alternative is moving a profile
+    out from under a running container. That errs toward refusing to rotate,
+    which the operator can resolve by stopping the container, whereas the
+    opposite corrupts two sessions silently.
+    """
+    candidate = profile_dir / _CHROMIUM_LOCK_NAME
+    try:
+        target = os.readlink(candidate)
+    except OSError:
+        # Not a symlink, or absent: no attributable owner.
+        return None
+
+    owner, separator, pid_text = target.rpartition("-")
+    if not separator:
+        return None  # Not the documented shape; nothing to attribute.
+    if owner != socket.gethostname():
+        return candidate  # Another host: unverifiable, so assume live.
+    try:
+        pid = int(pid_text)
+    except ValueError:
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return None  # Stale: the writer is gone.
+    except PermissionError:
+        return candidate  # Alive, owned by another user.
+    except OSError:
+        return None
+    return candidate
 
 
 def rotate_source_profile(source_profile_dir: Path | None = None) -> Path | None:
@@ -363,9 +458,9 @@ def rotate_source_profile(source_profile_dir: Path | None = None) -> Path | None
     Raises:
         RuntimeError: Another process holds the profile. Rotating underneath a
             live Chromium corrupts both the old and the new session.
-        OSError: A move failed. Deliberately not swallowed: a half-rotated tree
-            would leave the next rotation splitting one session across two
-            quarantines.
+        OSError: A move failed. Whatever had already moved is put back first, so
+            the caller always sees either the old session intact or a complete
+            retirement, never one session split across both.
     """
     profile_dir = (source_profile_dir or get_source_profile_dir()).expanduser()
     existing = [
@@ -374,7 +469,18 @@ def rotate_source_profile(source_profile_dir: Path | None = None) -> Path | None
     if not existing:
         return None
 
-    lock = profile_in_use_by(profile_dir)
+    # Every profile being moved must be free, not just the source one: a Docker
+    # container runs Chromium out of runtime-profiles/<runtime>/profile while
+    # sharing the mounted auth root, so checking only the source would move a
+    # live container's profile out from under it.
+    lock = next(
+        (
+            held
+            for candidate in [profile_dir, *_runtime_profile_dirs(profile_dir)]
+            if (held := profile_in_use_by(candidate)) is not None
+        ),
+        None,
+    )
     if lock is not None:
         raise RuntimeError(
             f"The browser profile is in use by another process (found {lock.name}). "
@@ -389,10 +495,112 @@ def rotate_source_profile(source_profile_dir: Path | None = None) -> Path | None
         auth_root_dir(profile_dir) / f"{QUARANTINE_PREFIX}{stamp}-{uuid4().hex[:8]}"
     )
     secure_mkdir(backup_dir)
-    for target in existing:
-        shutil.move(str(target), str(backup_dir / target.name))
+    moved: list[Path] = []
+    try:
+        for target in existing:
+            shutil.move(str(target), str(backup_dir / target.name))
+            moved.append(target)
+    except OSError:
+        _restore(backup_dir, moved)
+        raise
     logger.info("Retired previous session to %s", backup_dir)
     return backup_dir
+
+
+def _restore(backup_dir: Path, targets: list[Path]) -> None:
+    """Move *targets* back out of *backup_dir*, best effort."""
+    for target in targets:
+        try:
+            shutil.move(str(backup_dir / target.name), str(target))
+        except OSError as exc:
+            logger.warning("Could not restore %s: %s", target, exc)
+    try:
+        backup_dir.rmdir()
+    except OSError:
+        pass
+
+
+def restore_source_profile(
+    backup_dir: Path, source_profile_dir: Path | None = None
+) -> bool:
+    """Put a retired session back, undoing ``rotate_source_profile``.
+
+    A rotation happens *before* the replacement session exists, so a login that
+    is cancelled or an import where every candidate is rejected would otherwise
+    leave the user logged out of a session that was working. Callers restore on
+    that path, passing the same directory they rotated: ``--user-data-dir`` can
+    point somewhere other than the configured default, and restoring to the
+    configured one would strand the artifacts in a foreign auth root.
+
+    Returns ``False`` when the active paths are already occupied — the
+    replacement succeeded after all, and overwriting it would be the very
+    fingerprint mixing this module exists to prevent.
+    """
+    if not backup_dir.is_dir():
+        return False
+    profile_dir = (source_profile_dir or get_source_profile_dir()).expanduser()
+    targets = {target.name: target for target in _auth_state_targets(profile_dir)}
+
+    # Only a successful login or import commits all three of these together.
+    # Anything less is debris — most often the profile directory Chromium
+    # creates on launch and abandons when the login is cancelled, or a
+    # half-written marker — and reading it as a replacement would strand the
+    # working session in quarantine.
+    replacement_committed = (
+        load_source_state(profile_dir) is not None
+        and profile_exists(profile_dir)
+        and portable_cookie_path(profile_dir).exists()
+    )
+    if replacement_committed:
+        logger.debug("Not restoring %s: a newer session is in place", backup_dir)
+        return False
+
+    # Park the debris beside the backup instead of deleting it: if a move fails
+    # halfway the caller ends up with neither session, and an uncommitted
+    # profile may still hold a Chromium login worth inspecting.
+    debris_dir = backup_dir.parent / f"{backup_dir.name}-superseded"
+    for target in _auth_state_targets(profile_dir):
+        if not target.exists():
+            continue
+        try:
+            secure_mkdir(debris_dir)
+            shutil.move(str(target), str(debris_dir / target.name))
+        except OSError as exc:
+            logger.warning("Could not clear %s before restoring: %s", target, exc)
+            return False
+
+    restorable = [
+        (item, targets[item.name])
+        for item in backup_dir.iterdir()
+        if item.name in targets
+    ]
+    restored: list[Path] = []
+    for source, target in restorable:
+        try:
+            shutil.move(str(source), str(target))
+            restored.append(target)
+        except OSError as exc:
+            # Undo the partial restore, so the session stays wholly quarantined
+            # rather than split across both places, where the auth preflight
+            # rejects it and the next rotation would divide it again.
+            logger.warning("Could not restore %s: %s", target, exc)
+            _retire(backup_dir, restored)
+            return False
+    try:
+        backup_dir.rmdir()
+    except OSError:
+        pass
+    logger.info("Restored the previous session from %s", backup_dir)
+    return True
+
+
+def _retire(backup_dir: Path, targets: list[Path]) -> None:
+    """Move *targets* back into *backup_dir*, best effort."""
+    for target in targets:
+        try:
+            shutil.move(str(target), str(backup_dir / target.name))
+        except OSError as exc:
+            logger.warning("Could not re-retire %s: %s", target, exc)
 
 
 def clear_auth_state(source_profile_dir: Path | None = None) -> bool:

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -15,9 +15,13 @@ from linkedin_mcp_server.core import (
     resolve_remember_me_prompt,
     wait_for_manual_login,
 )
-from linkedin_mcp_server.session_state import portable_cookie_path, write_source_state
+from linkedin_mcp_server.session_state import (
+    portable_cookie_path,
+    rotate_source_profile,
+    write_source_state,
+)
 
-from linkedin_mcp_server.drivers.browser import get_profile_dir
+from linkedin_mcp_server.drivers.browser import close_browser, get_profile_dir
 
 
 async def interactive_login(user_data_dir: Path | None = None) -> bool:
@@ -39,6 +43,14 @@ async def interactive_login(user_data_dir: Path | None = None) -> bool:
     """
     if user_data_dir is None:
         user_data_dir = get_profile_dir()
+
+    # A manual login means a new session, possibly for a different account, so
+    # the previous profile must not be reused: Chromium would keep its existing
+    # machine_id and friends and hand LinkedIn the same device identity twice.
+    # Closing first so a later teardown cannot export the retired session's
+    # cookies over the new ones (drivers.browser exports on close).
+    await close_browser()
+    await asyncio.to_thread(rotate_source_profile, user_data_dir)
 
     config = get_config()
     login_timeout_ms = int(config.browser.login_timeout_seconds * 1000)

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -17,7 +17,8 @@ from linkedin_mcp_server.core import (
 )
 from linkedin_mcp_server.session_state import (
     portable_cookie_path,
-    rotate_source_profile,
+    restore_source_profile,
+    rotate_shielded,
     write_source_state,
 )
 
@@ -50,9 +51,28 @@ async def interactive_login(user_data_dir: Path | None = None) -> bool:
     # Closing first so a later teardown cannot export the retired session's
     # cookies over the new ones (drivers.browser exports on close).
     await close_browser()
-    await asyncio.to_thread(rotate_source_profile, user_data_dir)
+    retired = await rotate_shielded(user_data_dir)
 
-    config = get_config()
+    succeeded = False
+    try:
+        succeeded = await _login_into_fresh_profile(user_data_dir, config=get_config())
+        return succeeded
+    finally:
+        # The retirement happens before the replacement exists, so a login that
+        # is cancelled, times out, or fails to export its cookies would
+        # otherwise leave the user logged out of a session that was working.
+        if retired is not None and not succeeded:
+            if not await asyncio.to_thread(
+                restore_source_profile, retired, user_data_dir
+            ):
+                print(
+                    f"   Warning: the previous session could not be restored. "
+                    f"It is kept at {retired}."
+                )
+
+
+async def _login_into_fresh_profile(user_data_dir: Path, *, config: Any) -> bool:
+    """Drive the manual login against a freshly retired profile directory."""
     login_timeout_ms = int(config.browser.login_timeout_seconds * 1000)
 
     if config.browser.login_timeout_seconds:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1851,3 +1851,21 @@ class TestAutoLogin:
             login_task = get_bootstrap_state().login_task
             if login_task is not None:
                 login_task.cancel()
+
+
+def test_move_auth_state_aside_reports_a_held_profile(monkeypatch):
+    """Swallowing this would open a login browser whose own rotation fails at
+    the same point, after telling the user the browser had opened."""
+    from linkedin_mcp_server import bootstrap
+    from linkedin_mcp_server.exceptions import AuthenticationBootstrapFailedError
+
+    monkeypatch.setattr(
+        bootstrap,
+        "rotate_source_profile",
+        MagicMock(side_effect=RuntimeError("in use by another process")),
+    )
+
+    with pytest.raises(
+        AuthenticationBootstrapFailedError, match="No login was started"
+    ):
+        bootstrap._move_auth_state_aside(force=True)

--- a/tests/test_browser_import_orchestrate.py
+++ b/tests/test_browser_import_orchestrate.py
@@ -385,3 +385,38 @@ async def test_import_app_bound_only_raises_decryption_error(
     with pytest.raises(CookieDecryptionError) as exc:
         await import_session_from_browser(None, user_data_dir=user_data_dir)
     assert "Brave" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_import_retires_the_previous_profile_first(monkeypatch, tmp_path):
+    """An import seeds a session that may belong to a different account, so the
+    profile on disk is retired rather than reused — Chromium keeps machine_id
+    for the life of a directory, which would present both accounts as one
+    device. Auto-import had no clearing at all before this."""
+    user_data_dir = tmp_path / "profile"
+    profile = _profile("chrome", "Default")
+    order: list[str] = []
+
+    monkeypatch.setattr(
+        orchestrate, "discover_profiles", lambda browser=None: [profile]
+    )
+    _patch_meta(monkeypatch, {profile: _meta(last_access=10.0)})
+    monkeypatch.setattr(
+        orchestrate,
+        "extract_linkedin_cookies",
+        lambda p: (order.append("stage"), [_cookie("li_at")])[1],
+    )
+    monkeypatch.setattr(orchestrate, "synthesize_user_agent", lambda p: None)
+    monkeypatch.setattr(
+        orchestrate,
+        "rotate_source_profile",
+        lambda *_args: order.append("rotate"),
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.drivers.browser.validate_imported_cookies",
+        AsyncMock(return_value=True),
+    )
+
+    assert await import_session_from_browser("chrome", user_data_dir=user_data_dir)
+
+    assert order[0] == "rotate", "the old profile must be retired before staging"

--- a/tests/test_browser_import_orchestrate.py
+++ b/tests/test_browser_import_orchestrate.py
@@ -6,7 +6,7 @@ import os
 import stat
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -409,8 +409,8 @@ async def test_import_retires_the_previous_profile_first(monkeypatch, tmp_path):
     monkeypatch.setattr(orchestrate, "synthesize_user_agent", lambda p: None)
     monkeypatch.setattr(
         orchestrate,
-        "rotate_source_profile",
-        lambda *_args: order.append("rotate"),
+        "rotate_shielded",
+        AsyncMock(side_effect=lambda *a: order.append("rotate")),
     )
     monkeypatch.setattr(
         "linkedin_mcp_server.drivers.browser.validate_imported_cookies",
@@ -420,3 +420,37 @@ async def test_import_retires_the_previous_profile_first(monkeypatch, tmp_path):
     assert await import_session_from_browser("chrome", user_data_dir=user_data_dir)
 
     assert order[0] == "rotate", "the old profile must be retired before staging"
+
+
+@pytest.mark.asyncio
+async def test_import_restores_the_session_when_every_candidate_is_rejected(
+    monkeypatch, tmp_path
+):
+    """Retirement precedes the replacement, so an import that lands nothing must
+    not cost the user the session that was already working."""
+    user_data_dir = tmp_path / "profile"
+    profile = _profile("chrome", "Default")
+    retired = tmp_path / "invalid-state-x"
+    restore = MagicMock(return_value=True)
+
+    monkeypatch.setattr(
+        orchestrate, "discover_profiles", lambda browser=None: [profile]
+    )
+    _patch_meta(monkeypatch, {profile: _meta(last_access=10.0)})
+    monkeypatch.setattr(
+        orchestrate, "extract_linkedin_cookies", lambda p: [_cookie("li_at")]
+    )
+    monkeypatch.setattr(orchestrate, "synthesize_user_agent", lambda p: None)
+    monkeypatch.setattr(orchestrate, "rotate_shielded", AsyncMock(return_value=retired))
+    monkeypatch.setattr(orchestrate, "restore_source_profile", restore)
+    monkeypatch.setattr(
+        "linkedin_mcp_server.drivers.browser.validate_imported_cookies",
+        AsyncMock(return_value=False),
+    )
+
+    assert (
+        await import_session_from_browser("chrome", user_data_dir=user_data_dir)
+        is False
+    )
+
+    restore.assert_called_once_with(retired, user_data_dir)

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1,4 +1,7 @@
 import json
+import os
+import shutil
+import socket
 
 import pytest
 
@@ -9,6 +12,7 @@ from linkedin_mcp_server.session_state import (
     load_source_state,
     portable_cookie_path,
     quarantine_dirs,
+    restore_source_profile,
     rotate_source_profile,
     runtime_profile_dir,
     runtime_profiles_root,
@@ -252,7 +256,18 @@ def _seed_session(profile_dir, *, machine_id: str = "4663753") -> None:
         json.dumps({"user_experience_metrics": {"machine_id": machine_id}})
     )
     portable_cookie_path(profile_dir).write_text('[{"name": "li_at"}]')
-    source_state_path(profile_dir).write_text('{"version": 1}')
+    source_state_path(profile_dir).write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "source_runtime_id": "macos-arm64-host",
+                "login_generation": "gen-1",
+                "created_at": "2026-07-25T00:00:00Z",
+                "profile_path": str(profile_dir),
+                "cookies_path": str(portable_cookie_path(profile_dir)),
+            }
+        )
+    )
     (runtime_profiles_root(profile_dir) / "macos-arm64-host").mkdir(parents=True)
 
 
@@ -297,13 +312,25 @@ class TestRotateSourceProfile:
         container sharing the mounted auth root — corrupts both sessions."""
         profile_dir = isolate_profile_dir
         _seed_session(profile_dir)
-        (profile_dir / "SingletonLock").symlink_to("host-1234")
+        # Chromium encodes the owning <host>-<pid> in the lock's symlink target.
+        (profile_dir / "SingletonLock").symlink_to(
+            f"{socket.gethostname()}-{os.getpid()}"
+        )
 
         with pytest.raises(RuntimeError, match="in use by another process"):
             rotate_source_profile(profile_dir)
 
         assert profile_dir.exists()
         assert quarantine_dirs(profile_dir) == []
+
+    def test_stale_lock_does_not_block_forever(self, isolate_profile_dir):
+        """Chromium leaves its lock behind on a crash. Treating that as a live
+        owner would wedge every future login behind a manual file deletion."""
+        profile_dir = isolate_profile_dir
+        _seed_session(profile_dir)
+        (profile_dir / "SingletonLock").symlink_to(f"{socket.gethostname()}-999999")
+
+        assert rotate_source_profile(profile_dir) is not None
 
     def test_same_second_rotations_do_not_collide(self, isolate_profile_dir):
         """utcnow_iso() is second-resolution and rotation is routine now, so
@@ -322,17 +349,33 @@ class TestRotateSourceProfile:
         self, isolate_profile_dir, monkeypatch
     ):
         """A swallowed failure would leave one session split across two
-        quarantines the next time around."""
+        quarantines the next time around, so a partial move must be rolled
+        back before the error propagates."""
         profile_dir = isolate_profile_dir
         _seed_session(profile_dir)
+        real_move = shutil.move
+        calls = {"n": 0}
 
-        def explode(src, dst):
-            raise OSError("device busy")
+        def explode_on_second(src, dst):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise OSError("device busy")
+            return real_move(src, dst)
 
-        monkeypatch.setattr("linkedin_mcp_server.session_state.shutil.move", explode)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.session_state.shutil.move", explode_on_second
+        )
 
         with pytest.raises(OSError):
             rotate_source_profile(profile_dir)
+
+        assert calls["n"] >= 2, "the first move must succeed, so a rollback is needed"
+        # Everything is back where it started, and no quarantine holds a fragment.
+        assert (profile_dir / "Local State").exists()
+        assert portable_cookie_path(profile_dir).exists()
+        assert source_state_path(profile_dir).exists()
+        assert runtime_profiles_root(profile_dir).exists()
+        assert quarantine_dirs(profile_dir) == []
 
 
 class TestClearAuthState:
@@ -348,3 +391,144 @@ class TestClearAuthState:
 
         assert quarantine_dirs(profile_dir) == []
         assert not profile_dir.exists()
+
+
+class TestRestoreSourceProfile:
+    def test_puts_a_retired_session_back(self, isolate_profile_dir):
+        """Rotation happens before the replacement exists, so a login that is
+        cancelled must not leave the user logged out of a working session."""
+        profile_dir = isolate_profile_dir
+        _seed_session(profile_dir)
+        backup = rotate_source_profile(profile_dir)
+        assert backup is not None
+
+        assert restore_source_profile(backup) is True
+
+        assert (profile_dir / "Local State").exists()
+        assert portable_cookie_path(profile_dir).exists()
+        assert source_state_path(profile_dir).exists()
+        assert quarantine_dirs(profile_dir) == []
+
+    def test_restores_into_the_rotated_dir_not_the_configured_one(
+        self, isolate_profile_dir, tmp_path
+    ):
+        """--user-data-dir can point away from the configured default, and
+        restoring to the configured one would strand the session elsewhere."""
+        elsewhere = tmp_path / "elsewhere" / "profile"
+        _seed_session(elsewhere)
+        backup = rotate_source_profile(elsewhere)
+        assert backup is not None
+
+        assert restore_source_profile(backup, elsewhere) is True
+
+        assert (elsewhere / "Local State").exists()
+        assert not (isolate_profile_dir / "Local State").exists()
+
+    def test_restores_over_an_abandoned_profile_dir(self, isolate_profile_dir):
+        """Chromium creates the profile directory on launch and leaves it behind
+        when the login is cancelled. Reading that debris as a replacement would
+        strand the working session in quarantine — exactly the data loss the
+        restore exists to prevent."""
+        profile_dir = isolate_profile_dir
+        _seed_session(profile_dir, machine_id="working")
+        backup = rotate_source_profile(profile_dir)
+        assert backup is not None
+        # What a cancelled login leaves: a profile dir, but no source-state.json.
+        (profile_dir / "Default").mkdir(parents=True)
+        (profile_dir / "Local State").write_text("{}")
+
+        assert restore_source_profile(backup, profile_dir) is True
+
+        assert "working" in (profile_dir / "Local State").read_text()
+        assert source_state_path(profile_dir).exists()
+
+    def test_refuses_to_overwrite_a_newer_session(self, isolate_profile_dir):
+        """If the replacement did land, restoring would mix the old profile's
+        fingerprint back into the new account's session."""
+        profile_dir = isolate_profile_dir
+        _seed_session(profile_dir, machine_id="old")
+        backup = rotate_source_profile(profile_dir)
+        assert backup is not None
+        _seed_session(profile_dir, machine_id="new")
+
+        assert restore_source_profile(backup) is False
+
+        assert "new" in (profile_dir / "Local State").read_text()
+
+
+def test_rotation_refuses_while_a_container_holds_a_derived_profile(
+    isolate_profile_dir,
+):
+    """Docker runs Chromium out of runtime-profiles/<runtime>/profile while
+    sharing the mounted auth root, and rotation moves that tree too. Checking
+    only the source profile would pull it out from under a live container."""
+    profile_dir = isolate_profile_dir
+    _seed_session(profile_dir)
+    derived = runtime_profiles_root(profile_dir) / "linux-amd64-container" / "profile"
+    derived.mkdir(parents=True)
+    (derived / "SingletonLock").symlink_to(f"{socket.gethostname()}-{os.getpid()}")
+
+    with pytest.raises(RuntimeError, match="in use by another process"):
+        rotate_source_profile(profile_dir)
+
+    assert profile_dir.exists()
+
+
+def test_restore_ignores_a_half_written_marker(isolate_profile_dir):
+    """A marker without the profile and cookies it describes is debris, and
+    reading it as a committed replacement would strand the working session."""
+    profile_dir = isolate_profile_dir
+    _seed_session(profile_dir, machine_id="working")
+    backup = rotate_source_profile(profile_dir)
+    assert backup is not None
+    source_state_path(profile_dir).write_text("{}")
+
+    assert restore_source_profile(backup, profile_dir) is True
+
+    assert "working" in (profile_dir / "Local State").read_text()
+
+
+def test_lock_from_another_host_counts_as_held(isolate_profile_dir):
+    """A container writing into the mounted auth root records its own hostname
+    and a pid from its namespace. Probing that pid against this host is
+    meaningless, so an unverifiable owner must block the rotation rather than
+    let it move a live profile."""
+    profile_dir = isolate_profile_dir
+    _seed_session(profile_dir)
+    (profile_dir / "SingletonLock").symlink_to("some-container-1")
+
+    with pytest.raises(RuntimeError, match="in use by another process"):
+        rotate_source_profile(profile_dir)
+
+    assert profile_dir.exists()
+
+
+def test_uncommitted_debris_is_parked_not_deleted(isolate_profile_dir):
+    """An uncommitted profile may still hold a Chromium login worth inspecting,
+    and deleting it leaves no way back if a later move fails."""
+    profile_dir = isolate_profile_dir
+    _seed_session(profile_dir, machine_id="working")
+    backup = rotate_source_profile(profile_dir)
+    assert backup is not None
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "Local State").write_text('{"debris": true}')
+
+    assert restore_source_profile(backup, profile_dir) is True
+
+    assert "working" in (profile_dir / "Local State").read_text()
+    parked = backup.parent / f"{backup.name}-superseded"
+    assert '{"debris": true}' in (parked / "profile" / "Local State").read_text()
+
+
+def test_socket_and_cookie_links_are_not_read_as_owners(isolate_profile_dir):
+    """Only SingletonLock encodes <host>-<pid>. SingletonSocket holds a path and
+    SingletonCookie an opaque token, so parsing them the same way turns a
+    hyphen in TMPDIR into a phantom foreign host and wedges every login."""
+    profile_dir = isolate_profile_dir
+    _seed_session(profile_dir)
+    # A dead pid on this host: the profile is genuinely free.
+    (profile_dir / "SingletonLock").symlink_to(f"{socket.gethostname()}-999999")
+    (profile_dir / "SingletonSocket").symlink_to("/custom-temp/chromium-x/Socket")
+    (profile_dir / "SingletonCookie").symlink_to("10001647406132631536")
+
+    assert rotate_source_profile(profile_dir) is not None

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1,10 +1,17 @@
 import json
 
+import pytest
+
 from linkedin_mcp_server.session_state import (
+    clear_auth_state,
     get_runtime_id,
     load_runtime_state,
     load_source_state,
+    portable_cookie_path,
+    quarantine_dirs,
+    rotate_source_profile,
     runtime_profile_dir,
+    runtime_profiles_root,
     runtime_state_path,
     runtime_storage_state_path,
     source_state_path,
@@ -236,3 +243,108 @@ def test_get_runtime_id_ignores_non_root_overlay_mounts(monkeypatch):
     )
 
     assert get_runtime_id() == "linux-amd64-host"
+
+
+def _seed_session(profile_dir, *, machine_id: str = "4663753") -> None:
+    """Write the four artifacts a live source session consists of."""
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "Local State").write_text(
+        json.dumps({"user_experience_metrics": {"machine_id": machine_id}})
+    )
+    portable_cookie_path(profile_dir).write_text('[{"name": "li_at"}]')
+    source_state_path(profile_dir).write_text('{"version": 1}')
+    (runtime_profiles_root(profile_dir) / "macos-arm64-host").mkdir(parents=True)
+
+
+class TestRotateSourceProfile:
+    def test_retires_every_artifact(self, isolate_profile_dir):
+        profile_dir = isolate_profile_dir
+        _seed_session(profile_dir)
+
+        backup = rotate_source_profile(profile_dir)
+
+        assert backup is not None
+        assert not profile_dir.exists()
+        assert not portable_cookie_path(profile_dir).exists()
+        assert not source_state_path(profile_dir).exists()
+        assert not runtime_profiles_root(profile_dir).exists()
+        assert {path.name for path in backup.iterdir()} == {
+            "profile",
+            "cookies.json",
+            "source-state.json",
+            "runtime-profiles",
+        }
+
+    def test_new_profile_does_not_inherit_the_fingerprint(self, isolate_profile_dir):
+        """The point of rotating: Chromium mints machine_id once per profile
+        directory, so reusing the directory hands LinkedIn one device identity
+        for two accounts."""
+        profile_dir = isolate_profile_dir
+        _seed_session(profile_dir, machine_id="4663753")
+
+        backup = rotate_source_profile(profile_dir)
+
+        assert backup is not None
+        assert "4663753" in (backup / "profile" / "Local State").read_text()
+        assert not (profile_dir / "Local State").exists()
+
+    def test_no_op_without_a_session(self, isolate_profile_dir):
+        assert rotate_source_profile(isolate_profile_dir) is None
+        assert quarantine_dirs(isolate_profile_dir) == []
+
+    def test_refuses_while_another_process_holds_the_profile(self, isolate_profile_dir):
+        """Rotating underneath a live Chromium — a second CLI run, or a
+        container sharing the mounted auth root — corrupts both sessions."""
+        profile_dir = isolate_profile_dir
+        _seed_session(profile_dir)
+        (profile_dir / "SingletonLock").symlink_to("host-1234")
+
+        with pytest.raises(RuntimeError, match="in use by another process"):
+            rotate_source_profile(profile_dir)
+
+        assert profile_dir.exists()
+        assert quarantine_dirs(profile_dir) == []
+
+    def test_same_second_rotations_do_not_collide(self, isolate_profile_dir):
+        """utcnow_iso() is second-resolution and rotation is routine now, so
+        two rotations can share a timestamp without sharing a directory."""
+        profile_dir = isolate_profile_dir
+
+        _seed_session(profile_dir)
+        first = rotate_source_profile(profile_dir)
+        _seed_session(profile_dir)
+        second = rotate_source_profile(profile_dir)
+
+        assert first != second
+        assert len(quarantine_dirs(profile_dir)) == 2
+
+    def test_move_failure_raises_instead_of_half_rotating(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """A swallowed failure would leave one session split across two
+        quarantines the next time around."""
+        profile_dir = isolate_profile_dir
+        _seed_session(profile_dir)
+
+        def explode(src, dst):
+            raise OSError("device busy")
+
+        monkeypatch.setattr("linkedin_mcp_server.session_state.shutil.move", explode)
+
+        with pytest.raises(OSError):
+            rotate_source_profile(profile_dir)
+
+
+class TestClearAuthState:
+    def test_removes_quarantined_sessions_too(self, isolate_profile_dir):
+        """--logout advertises clearing all stored auth state, and a quarantine
+        holds a previous session's cookies."""
+        profile_dir = isolate_profile_dir
+        _seed_session(profile_dir)
+        rotate_source_profile(profile_dir)
+        _seed_session(profile_dir)
+
+        assert clear_auth_state(profile_dir) is True
+
+        assert quarantine_dirs(profile_dir) == []
+        assert not profile_dir.exists()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,3 +1,5 @@
+import asyncio
+import pathlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -6,6 +8,8 @@ import pytest
 from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.session_state import portable_cookie_path
 from linkedin_mcp_server.setup import interactive_login
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 
 class _BrowserContextManager:
@@ -38,6 +42,7 @@ def _patch_login_deps(
     config: AppConfig | None = None,
     write_source_state: MagicMock | None = None,
     rotate_source_profile: MagicMock | None = None,
+    close_browser: AsyncMock | None = None,
 ) -> None:
     """Patch all interactive_login dependencies in one place."""
     monkeypatch.setattr(
@@ -55,11 +60,14 @@ def _patch_login_deps(
         or MagicMock(return_value=SimpleNamespace(login_generation="gen-1")),
     )
     monkeypatch.setattr("linkedin_mcp_server.setup.asyncio.sleep", AsyncMock())
+    rotate = rotate_source_profile or MagicMock(return_value=None)
     monkeypatch.setattr(
-        "linkedin_mcp_server.setup.rotate_source_profile",
-        rotate_source_profile or MagicMock(return_value=None),
+        "linkedin_mcp_server.setup.rotate_shielded",
+        AsyncMock(side_effect=lambda *a: rotate(*a)),
     )
-    monkeypatch.setattr("linkedin_mcp_server.setup.close_browser", AsyncMock())
+    monkeypatch.setattr(
+        "linkedin_mcp_server.setup.close_browser", close_browser or AsyncMock()
+    )
 
 
 @pytest.mark.asyncio
@@ -322,9 +330,150 @@ async def test_interactive_login_retires_the_previous_profile(monkeypatch, tmp_p
             _BrowserContextManager(_make_browser(export_cookies=True)),
         )[1],
         rotate_source_profile=rotate,
+        close_browser=AsyncMock(side_effect=lambda: order.append("close")),
     )
 
     await interactive_login(profile_dir)
 
     rotate.assert_called_once_with(profile_dir)
-    assert order == ["rotate", "launch"], "rotation must precede the launch"
+    # close must come first: the singleton exports cookies on teardown, so a
+    # later close would write the retired session's cookies over the new ones.
+    assert order == ["close", "rotate", "launch"]
+
+
+@pytest.mark.asyncio
+async def test_interactive_login_restores_the_session_when_login_fails(
+    monkeypatch, tmp_path
+):
+    """The old session is retired before the new one exists, so a failed login
+    must not leave the user logged out of a session that was working."""
+    retired = tmp_path / "invalid-state-x"
+    restore = MagicMock(return_value=True)
+
+    _patch_login_deps(
+        monkeypatch,
+        browser_factory=lambda **kwargs: _BrowserContextManager(
+            _make_browser(export_cookies=False)
+        ),
+        rotate_source_profile=MagicMock(return_value=retired),
+    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.restore_source_profile", restore)
+
+    assert await interactive_login(tmp_path / "profile") is False
+
+    restore.assert_called_once_with(retired, tmp_path / "profile")
+
+
+@pytest.mark.asyncio
+async def test_interactive_login_keeps_the_retired_session_on_success(
+    monkeypatch, tmp_path
+):
+    restore = MagicMock()
+
+    _patch_login_deps(
+        monkeypatch,
+        browser_factory=lambda **kwargs: _BrowserContextManager(
+            _make_browser(export_cookies=True)
+        ),
+        rotate_source_profile=MagicMock(return_value=tmp_path / "invalid-state-x"),
+    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.restore_source_profile", restore)
+
+    assert await interactive_login(tmp_path / "profile") is True
+
+    restore.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rotate_shielded_restores_when_cancelled(tmp_path, monkeypatch):
+    """A bare await on the rotation thread is cancellable, and the cancel lands
+    after the move: the session is gone and its backup path with it."""
+    import threading
+
+    from linkedin_mcp_server import session_state
+
+    retired = tmp_path / "invalid-state-x"
+    released = threading.Event()
+    restore = MagicMock(return_value=True)
+
+    def slow_rotate(*_args):
+        released.wait(5)
+        return retired
+
+    monkeypatch.setattr(session_state, "rotate_source_profile", slow_rotate)
+    monkeypatch.setattr(session_state, "restore_source_profile", restore)
+
+    task = asyncio.ensure_future(session_state.rotate_shielded(tmp_path / "profile"))
+    await asyncio.sleep(0.05)  # let the worker thread enter slow_rotate
+    task.cancel()
+    released.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    restore.assert_called_once_with(retired, tmp_path / "profile")
+
+
+@pytest.mark.asyncio
+async def test_rotate_shielded_survives_overlapping_cancels(tmp_path, monkeypatch):
+    """A tool timeout racing a server shutdown cancels twice. The second must
+    not abandon the worker thread mid-rotation, or the session is stranded."""
+    import threading
+
+    from linkedin_mcp_server import session_state
+
+    retired = tmp_path / "invalid-state-x"
+    released = threading.Event()
+    restore = MagicMock(return_value=True)
+
+    def slow_rotate(*_args):
+        released.wait(5)
+        return retired
+
+    monkeypatch.setattr(session_state, "rotate_source_profile", slow_rotate)
+    monkeypatch.setattr(session_state, "restore_source_profile", restore)
+
+    task = asyncio.ensure_future(session_state.rotate_shielded(tmp_path / "profile"))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.sleep(0)
+    task.cancel()  # second source of cancellation
+    released.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    restore.assert_called_once_with(retired, tmp_path / "profile")
+
+
+def test_rotate_shielded_does_not_wedge_event_loop_shutdown(tmp_path):
+    """asyncio.run cancels every pending task at teardown, and shielding an
+    already-cancelled task re-raises forever. Running the move on a bare
+    executor future keeps it out of that sweep, so the process can exit."""
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(f"""
+        import asyncio, pathlib, sys, time
+        sys.path.insert(0, {str(REPO_ROOT)!r})
+        from linkedin_mcp_server import session_state
+
+        session_state.rotate_source_profile = lambda *a: (
+            time.sleep(0.2), pathlib.Path("/tmp/backup-x")
+        )[1]
+        session_state.restore_source_profile = lambda *a: True
+
+        async def main():
+            # Detached, still running when main() returns: exactly the shape a
+            # server shutdown hits mid-login.
+            asyncio.ensure_future(session_state.rotate_shielded(pathlib.Path("/tmp/p")))
+            await asyncio.sleep(0.05)
+
+        asyncio.run(main())
+        print("SHUTDOWN COMPLETED")
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=20
+    )
+
+    assert "SHUTDOWN COMPLETED" in result.stdout

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -37,6 +37,7 @@ def _patch_login_deps(
     browser_factory,
     config: AppConfig | None = None,
     write_source_state: MagicMock | None = None,
+    rotate_source_profile: MagicMock | None = None,
 ) -> None:
     """Patch all interactive_login dependencies in one place."""
     monkeypatch.setattr(
@@ -54,6 +55,11 @@ def _patch_login_deps(
         or MagicMock(return_value=SimpleNamespace(login_generation="gen-1")),
     )
     monkeypatch.setattr("linkedin_mcp_server.setup.asyncio.sleep", AsyncMock())
+    monkeypatch.setattr(
+        "linkedin_mcp_server.setup.rotate_source_profile",
+        rotate_source_profile or MagicMock(return_value=None),
+    )
+    monkeypatch.setattr("linkedin_mcp_server.setup.close_browser", AsyncMock())
 
 
 @pytest.mark.asyncio
@@ -297,3 +303,28 @@ async def test_interactive_login_passes_viewport_to_browser_manager(
     await interactive_login(tmp_path / "profile")
 
     assert captured_kwargs.get("viewport") == {"width": 1920, "height": 1080}
+
+
+@pytest.mark.asyncio
+async def test_interactive_login_retires_the_previous_profile(monkeypatch, tmp_path):
+    """A manual login may be for a different account, so the previous Chromium
+    profile must not be reused: it would carry the same machine_id into the new
+    session and present both accounts to LinkedIn as one device."""
+    profile_dir = tmp_path / "profile"
+    rotate = MagicMock(return_value=None)
+    order: list[str] = []
+    rotate.side_effect = lambda *_args: order.append("rotate")
+
+    _patch_login_deps(
+        monkeypatch,
+        browser_factory=lambda **kwargs: (
+            order.append("launch"),
+            _BrowserContextManager(_make_browser(export_cookies=True)),
+        )[1],
+        rotate_source_profile=rotate,
+    )
+
+    await interactive_login(profile_dir)
+
+    rotate.assert_called_once_with(profile_dir)
+    assert order == ["rotate", "launch"], "rotation must precede the launch"


### PR DESCRIPTION
Chromium mints `machine_id`, `session_id_generator_last_value` and `limited_entropy_randomization_source` into `Local State` once and then keeps them for the life of a profile directory. That directory was reused across logins and imports, so signing in with a second LinkedIn account handed LinkedIn the same device identity twice, alongside the previous account's Local Storage, IndexedDB and residual cookies. Verified on a real profile: it survived both `--login` and `--import-from-browser` untouched.

`rotate_source_profile()` moves the previous session aside before a new one is established, from the two functions that write `source-state.json` — `interactive_login` and `import_session_from_browser` — which together cover every CLI and bootstrap entry. Auto-import had no clearing at all before this. Retiring rather than deleting keeps a session recoverable if it turns out to have been fine, and `--logout` now clears those copies too, which is what the CLI already advertised.

Rotation is fail-closed. A half-moved tree would leave the next rotation splitting one session across two quarantines, so a failed move raises instead of logging and continuing. It also refuses while another process holds the profile: the auth root is a shared Docker mount, and rotating underneath a live Chromium corrupts both the old session and the new one.

Verified with 848 tests (nine new), ruff and ty. The rotation tests are mutation-checked: six of seven fail when the move is neutralised.