### PR TITLE
fix(auth): validate portable cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ while a container is running.
 
 - LinkedIn may require a login confirmation in the LinkedIn mobile app for `--login`
 - LinkedIn may show a captcha challenge during login. Run `uvx mcp-server-linkedin@latest --login` which opens a browser where you can solve it manually.
+- If Google rejects the managed browser as insecure, use direct LinkedIn email/password login in that browser and let `--login` exit cleanly, then run `--status` and follow any bridge/runtime guidance it reports.
+- If `--status` explicitly reports a valid session but MCP tools still return `Transport closed`, restart the MCP client session; the client transport may be stale even though LinkedIn authentication is valid.
 
 **Timeout issues:**
 

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -538,9 +538,55 @@ class BrowserManager:
         domain, but Chromium's internal store uses ``.linkedin.com``.
         """
         domain = cookie.get("domain", "")
-        if domain in (".www.linkedin.com", "www.linkedin.com"):
+        if isinstance(domain, str) and domain.lstrip(".").lower() == "www.linkedin.com":
             cookie = {**cookie, "domain": ".linkedin.com"}
         return cookie
+
+    @staticmethod
+    def _is_linkedin_cookie(cookie: Any) -> bool:
+        if not isinstance(cookie, dict):
+            return False
+        domain = cookie.get("domain")
+        if not isinstance(domain, str):
+            return False
+        domain = domain.lstrip(".").lower()
+        return domain == "linkedin.com" or domain.endswith(".linkedin.com")
+
+    @classmethod
+    def _portable_linkedin_cookies(
+        cls,
+        all_cookies: list[Any],
+        allowed_names: frozenset[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Normalize and deduplicate cookies safe for portable persistence."""
+        cookies_by_identity: dict[tuple[Any, Any, Any, Any], dict[str, Any]] = {}
+        for raw_cookie in all_cookies:
+            if not cls._is_linkedin_cookie(raw_cookie):
+                continue
+            cookie = cls._normalize_cookie_domain(raw_cookie)
+            name = cookie.get("name")
+            if allowed_names is not None and name not in allowed_names:
+                continue
+            value = cookie.get("value")
+            if name == "li_at" and (not isinstance(value, str) or not value.strip()):
+                continue
+            identity = (
+                name,
+                cookie.get("domain"),
+                cookie.get("path", "/"),
+                cookie.get("partitionKey"),
+            )
+            cookies_by_identity[identity] = cookie
+        return list(cookies_by_identity.values())
+
+    @staticmethod
+    def _has_usable_li_at(cookies: list[dict[str, Any]]) -> bool:
+        return any(
+            cookie.get("name") == "li_at"
+            and isinstance(cookie.get("value"), str)
+            and bool(cookie["value"].strip())
+            for cookie in cookies
+        )
 
     async def export_cookies(self, cookie_path: str | Path | None = None) -> bool:
         """Export LinkedIn cookies to a portable JSON file."""
@@ -561,11 +607,13 @@ class BrowserManager:
             all_cookies = await asyncio.wait_for(
                 self._context.cookies(), timeout=_CLEANUP_TIMEOUT_SECONDS
             )
-            cookies = [
-                self._normalize_cookie_domain(c)
-                for c in all_cookies
-                if "linkedin.com" in c.get("domain", "")
-            ]
+            cookies = self._portable_linkedin_cookies(all_cookies)
+            if not self._has_usable_li_at(cookies):
+                logger.warning(
+                    "Cannot export cookies: LinkedIn session cookie li_at is missing "
+                    "or empty"
+                )
+                return False
             secure_mkdir(path.parent)
             harden_linkedin_tree(path.parent)
             secure_write_text(
@@ -686,16 +734,13 @@ class BrowserManager:
                 preset_name
             )
 
-            cookies = [
-                self._normalize_cookie_domain(c)
-                for c in all_cookies
-                if "linkedin.com" in c.get("domain", "")
-                and c.get("name") in bridge_cookie_names
-            ]
-
-            has_li_at = any(c.get("name") == "li_at" for c in cookies)
+            cookies = self._portable_linkedin_cookies(
+                all_cookies,
+                allowed_names=bridge_cookie_names,
+            )
+            has_li_at = self._has_usable_li_at(cookies)
             if not has_li_at:
-                logger.warning("No li_at cookie found in %s", path)
+                logger.warning("No non-empty li_at cookie found in %s", path)
                 return False
 
             await self._context.add_cookies(

--- a/tests/test_core_browser.py
+++ b/tests/test_core_browser.py
@@ -503,6 +503,7 @@ def _make_cookie(
 def _make_browser_manager(tmp_path) -> tuple[BrowserManager, MagicMock]:
     browser = BrowserManager(user_data_dir=tmp_path / "profile")
     context = MagicMock()
+    context.cookies = AsyncMock()
     context.clear_cookies = AsyncMock()
     context.add_cookies = AsyncMock()
     context.storage_state = AsyncMock()
@@ -595,6 +596,120 @@ async def test_import_cookies_preserves_existing_cookies(tmp_path):
     assert imported is True
     context.clear_cookies.assert_not_awaited()
     context.add_cookies.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cookies",
+    [
+        [_make_cookie("JSESSIONID")],
+        [_make_cookie("li_at", ""), _make_cookie("JSESSIONID")],
+        [_make_cookie("li_at", "   "), _make_cookie("JSESSIONID")],
+        [_make_cookie("li_at", "wrong-domain", domain=".notlinkedin.com")],
+    ],
+    ids=["missing-li-at", "empty-li-at", "blank-li-at", "wrong-domain-li-at"],
+)
+async def test_export_cookies_rejects_unusable_session(
+    tmp_path, cookies: list[dict[str, str]], caplog
+):
+    browser, context = _make_browser_manager(tmp_path)
+    context.cookies.return_value = cookies
+    cookie_path = tmp_path / "cookies.json"
+    cookie_path.write_text("last-known-good")
+
+    exported = await browser.export_cookies(cookie_path)
+
+    assert exported is False
+    assert cookie_path.read_text() == "last-known-good"
+    assert "li_at is missing or empty" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_export_cookies_writes_usable_linkedin_session(tmp_path):
+    browser, context = _make_browser_manager(tmp_path)
+    context.cookies.return_value = [
+        _make_cookie("li_at", "session-token", domain=".www.linkedin.com"),
+        _make_cookie("JSESSIONID"),
+        _make_cookie("unrelated", domain=".example.com"),
+    ]
+    cookie_path = tmp_path / "cookies.json"
+
+    exported = await browser.export_cookies(cookie_path)
+
+    assert exported is True
+    assert json.loads(cookie_path.read_text()) == [
+        _make_cookie("li_at", "session-token"),
+        _make_cookie("JSESSIONID"),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("valid_first", [True, False])
+async def test_export_cookies_drops_empty_duplicate_li_at(tmp_path, valid_first):
+    browser, context = _make_browser_manager(tmp_path)
+    valid = _make_cookie("li_at", "session-token")
+    empty = _make_cookie("li_at", "", domain=".www.linkedin.com")
+    context.cookies.return_value = [valid, empty] if valid_first else [empty, valid]
+    cookie_path = tmp_path / "cookies.json"
+
+    exported = await browser.export_cookies(cookie_path)
+
+    assert exported is True
+    assert json.loads(cookie_path.read_text()) == [valid]
+
+
+@pytest.mark.asyncio
+async def test_export_cookies_preserves_partitioned_cookie_identity(tmp_path):
+    browser, context = _make_browser_manager(tmp_path)
+    partitioned = {
+        **_make_cookie("bcookie", "partitioned"),
+        "partitionKey": "https://example.com",
+    }
+    context.cookies.return_value = [
+        _make_cookie("li_at", "session-token"),
+        _make_cookie("bcookie", "unpartitioned"),
+        partitioned,
+    ]
+    cookie_path = tmp_path / "cookies.json"
+
+    exported = await browser.export_cookies(cookie_path)
+
+    assert exported is True
+    assert json.loads(cookie_path.read_text()) == [
+        _make_cookie("li_at", "session-token"),
+        _make_cookie("bcookie", "unpartitioned"),
+        partitioned,
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "blank"])
+async def test_import_cookies_rejects_empty_li_at(tmp_path, value, caplog):
+    browser, context = _make_browser_manager(tmp_path)
+    cookie_path = tmp_path / "cookies.json"
+    cookie_path.write_text(
+        json.dumps([_make_cookie("li_at", value), _make_cookie("JSESSIONID")])
+    )
+
+    imported = await browser.import_cookies(cookie_path)
+
+    assert imported is False
+    context.add_cookies.assert_not_awaited()
+    assert "No non-empty li_at cookie found" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_import_cookies_ignores_non_linkedin_li_at(tmp_path):
+    browser, context = _make_browser_manager(tmp_path)
+    cookie_path = tmp_path / "cookies.json"
+    cookie_path.write_text(
+        json.dumps([_make_cookie("li_at", "wrong", domain=".notlinkedin.com")])
+    )
+
+    imported = await browser.import_cookies(cookie_path)
+
+    assert imported is False
+    context.add_cookies.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- reject portable cookie exports and imports unless they contain a non-empty LinkedIn `li_at` cookie
- preserve the last-known-good snapshot, enforce LinkedIn domain boundaries, and deduplicate normalized identities without merging partitioned cookies
- document the direct-login fallback and stale MCP client recovery path

## Testing

- `uv run pytest tests/test_core_browser.py tests/test_browser_security.py tests/test_core_auth.py -q`
- `uv run pytest -q -k 'not live_macos_keychain_throwaway_item'`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv build`

Closes https://github.com/stickerdaniel/linkedin-mcp-server/issues/558

## Synthetic prompt

> Make portable LinkedIn cookie import and export fail closed when `li_at` is missing or empty, preserve last-known-good snapshots, normalize and deduplicate cookie identities safely including partitioned cookies, add regression tests, and document the direct-login and stale-client recovery paths from issue #558.

Generated with OpenAI GPT-5.6