### PR TITLE
feat(tools): add get_saved_posts for /my-items/saved-posts/

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | [#526](https://github.com/stickerdaniel/linkedin-mcp-server/issues/526) |
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
+| `get_saved_posts` | List posts saved (bookmarked) by the authenticated user | working |
 | `search_posts` | Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter (past-24h/past-week/past-month) | working |
 | `close_session` | Close browser session and clean up resources | working |
 

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -19,6 +19,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed
 - **Home Feed**: Get recent posts from the authenticated user's LinkedIn home feed
+- **Saved Posts**: List posts saved (bookmarked) by the authenticated user
 - **Post Search**: Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter
 - **Compact References**: Return typed per-section links alongside readable text without shipping full-page markdown
 

--- a/linkedin_mcp_server/core/utils.py
+++ b/linkedin_mcp_server/core/utils.py
@@ -66,7 +66,10 @@ async def detect_rate_limit(page: Page) -> None:
 
 
 async def scroll_to_bottom(
-    page: Page, pause_time: float = 1.0, max_scrolls: int = 10
+    page: Page,
+    pause_time: float = 1.0,
+    max_scrolls: int = 10,
+    stop_fingerprints: list[str] | None = None,
 ) -> None:
     """Scroll to the bottom of the page to trigger lazy loading.
 
@@ -74,8 +77,22 @@ async def scroll_to_bottom(
         page: Patchright page object
         pause_time: Time to pause between scrolls (seconds)
         max_scrolls: Maximum number of scroll attempts
+        stop_fingerprints: Stop as soon as any of these strings appears in the
+            page text. Lets a caller that already processed part of a feed
+            avoid lazy-loading content it would discard anyway. Empty strings
+            are dropped: they match every page and would stop the first scroll.
     """
+    fingerprints = [fp for fp in stop_fingerprints or [] if fp]
+
     for i in range(max_scrolls):
+        if fingerprints:
+            current_text: str = await page.evaluate(
+                "() => (document.querySelector('main') || document.body).innerText"
+            )
+            if any(fp in current_text for fp in fingerprints):
+                logger.debug("Stop fingerprint found after %d scrolls, halting", i)
+                return
+
         previous_height = await page.evaluate("document.body.scrollHeight")
         await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
         await asyncio.sleep(pause_time)

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -60,6 +60,8 @@ _PAGE_SIZE = 25
 
 _SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
 
+_SAVED_POSTS_URL = "https://www.linkedin.com/my-items/saved-posts/"
+
 # The my-items lists page in 10s, unlike job search. Verified live: ?start=10
 # returns the 11th saved job, while ?start=25 lands past the end of a two-page
 # list and yields nothing.
@@ -1218,6 +1220,32 @@ class LinkedInExtractor:
                 error=build_issue_diagnostics(e, context="extract_feed"),
             )
 
+    async def extract_saved_posts(
+        self,
+        num_posts: int = 10,
+        stop_fingerprints: list[str] | None = None,
+    ) -> ExtractedSection:
+        """Scrape the saved posts page (``/my-items/saved-posts/``).
+
+        Unlike ``/my-items/saved-jobs/``, this list lazy-loads on scroll rather
+        than paginating with ``?start=``, so it runs through the standard page
+        pipeline with a scroll budget derived from *num_posts* (~5 posts load
+        per scroll).
+
+        Args:
+            num_posts: Rough number of posts wanted; sizes the scroll budget.
+            stop_fingerprints: Scrolling stops as soon as any of these strings
+                appears in the page, so a caller resuming an earlier run does
+                not lazy-load posts it already processed.
+        """
+        max_scrolls = min(max(1, (num_posts + 4) // 5), 20)
+        return await self.extract_page(
+            _SAVED_POSTS_URL,
+            section_name="saved_posts",
+            max_scrolls=max_scrolls,
+            stop_fingerprints=stop_fingerprints,
+        )
+
     async def _extract_feed_once(
         self,
         num_posts: int,
@@ -1388,6 +1416,7 @@ class LinkedInExtractor:
         url: str,
         section_name: str,
         max_scrolls: int | None = None,
+        stop_fingerprints: list[str] | None = None,
     ) -> ExtractedSection:
         """Navigate to a URL, scroll to load lazy content, and extract innerText.
 
@@ -1400,14 +1429,18 @@ class LinkedInExtractor:
         Returns empty string for unexpected non-domain failures (error isolation).
         """
         try:
-            result = await self._extract_page_once(url, section_name, max_scrolls)
+            result = await self._extract_page_once(
+                url, section_name, max_scrolls, stop_fingerprints
+            )
             if result.text != _RATE_LIMITED_MSG:
                 return result
 
             # Retry once after backoff
             logger.info("Retrying %s after %.0fs backoff", url, _RATE_LIMIT_RETRY_DELAY)
             await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
-            return await self._extract_page_once(url, section_name, max_scrolls)
+            return await self._extract_page_once(
+                url, section_name, max_scrolls, stop_fingerprints
+            )
 
         except LinkedInScraperException:
             raise
@@ -1429,16 +1462,20 @@ class LinkedInExtractor:
         url: str,
         section_name: str,
         max_scrolls: int | None = None,
+        stop_fingerprints: list[str] | None = None,
     ) -> ExtractedSection:
         """Single attempt to navigate, scroll, and extract innerText."""
         await self._navigate_to_page(url)
-        return await self._extract_loaded_section(url, section_name, max_scrolls)
+        return await self._extract_loaded_section(
+            url, section_name, max_scrolls, stop_fingerprints
+        )
 
     async def _extract_loaded_section(
         self,
         url: str,
         section_name: str,
         max_scrolls: int | None = None,
+        stop_fingerprints: list[str] | None = None,
     ) -> ExtractedSection:
         """Run the post-navigation extraction pipeline on the current page.
 
@@ -1459,13 +1496,16 @@ class LinkedInExtractor:
         await handle_modal_close(self._page)
 
         # Activity feed pages lazy-load post content after the tab header.
-        # Company posts pages (/company/<slug>/posts/) lazy-load the same way
-        # but don't carry a /recent-activity/ path, so match them too. Matched
-        # on the parsed path, since the url can carry a query string
-        # (?viewAsMember=true) that a raw suffix check would miss.
+        # Company posts pages (/company/<slug>/posts/) and the saved posts list
+        # (/my-items/saved-posts/) lazy-load the same way but don't carry a
+        # /recent-activity/ path, so match them too. Matched on the parsed
+        # path, since the url can carry a query string (?viewAsMember=true)
+        # that a raw suffix check would miss.
         path = urlparse(url).path
-        is_activity = "/recent-activity/" in path or (
-            "/company/" in path and path.rstrip("/").endswith("/posts")
+        is_activity = (
+            "/recent-activity/" in path
+            or ("/company/" in path and path.rstrip("/").endswith("/posts"))
+            or "/my-items/saved-posts" in path
         )
         if is_activity:
             try:
@@ -1566,10 +1606,20 @@ class LinkedInExtractor:
         # Scroll to trigger lazy loading
         if is_activity:
             scrolls = max_scrolls if max_scrolls is not None else 10
-            await scroll_to_bottom(self._page, pause_time=1.0, max_scrolls=scrolls)
+            await scroll_to_bottom(
+                self._page,
+                pause_time=1.0,
+                max_scrolls=scrolls,
+                stop_fingerprints=stop_fingerprints,
+            )
         else:
             scrolls = max_scrolls if max_scrolls is not None else 5
-            await scroll_to_bottom(self._page, pause_time=0.5, max_scrolls=scrolls)
+            await scroll_to_bottom(
+                self._page,
+                pause_time=0.5,
+                max_scrolls=scrolls,
+                stop_fingerprints=stop_fingerprints,
+            )
 
         # Extract text from main content area
         raw_result = await self._extract_root_content(["main"])

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -105,6 +105,9 @@ _REFERENCE_CAPS = {
     # Kept in sync with the literal cap=50 in extractor._build_feed_references
     # where SDUI-derived /posts/<slug> permalinks are appended.
     "feed": 50,
+    # Same headroom for get_saved_posts' num_posts ceiling (Field(ge=1, le=50)),
+    # otherwise the text carries posts absent from the reference list.
+    "saved_posts": 50,
 }
 
 # A label must carry at least one letter or digit in any script, so the class is

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -108,3 +108,92 @@ def register_feed_tools(
                 raise_tool_error(relogin_exc, "get_feed")
         except Exception as e:
             raise_tool_error(e, "get_feed")
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Get Saved Posts",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"feed", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_saved_posts(
+        ctx: Context,
+        num_posts: Annotated[int, Field(ge=1, le=50)] = 10,
+        stop_fingerprints: Annotated[
+            list[str] | None,
+            Field(
+                default=None,
+                description=(
+                    "Stop scrolling as soon as any of these strings appears in the "
+                    "page text. Pass the first ~80 chars of already-processed posts "
+                    "to avoid loading content that was already handled."
+                ),
+            ),
+        ] = None,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get posts saved (bookmarked) by the authenticated user.
+
+        Navigates to linkedin.com/my-items/saved-posts/ and scrolls to load
+        the requested number of posts. Stops early when a known post is detected.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+            num_posts: Number of saved posts to fetch (1-50, default 10).
+            stop_fingerprints: Substrings of already-processed posts. Scroll
+                stops as soon as any appears in the page, minimising network
+                and compute cost.
+
+        Returns:
+            Dict with url, sections (name -> raw text), and optional keys:
+            - references["saved_posts"]: list of post reference objects.
+            - section_errors: present when rate-limited or extraction fails.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_saved_posts"
+            )
+            logger.info("Scraping saved posts (num_posts=%d)", num_posts)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Starting saved posts scrape"
+            )
+
+            extracted = await extractor.extract_saved_posts(
+                num_posts=num_posts,
+                stop_fingerprints=stop_fingerprints,
+            )
+
+            url = "https://www.linkedin.com/my-items/saved-posts/"
+            sections: dict[str, str] = {}
+            references: dict[str, list[Reference]] = {}
+            section_errors: dict[str, dict[str, Any]] = {}
+            if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+                sections["saved_posts"] = extracted.text
+                if extracted.references:
+                    references["saved_posts"] = extracted.references
+            elif extracted.text == _RATE_LIMITED_MSG:
+                section_errors["saved_posts"] = {
+                    "error_type": "rate_limit",
+                    "error_message": extracted.text,
+                }
+            elif extracted.error:
+                section_errors["saved_posts"] = extracted.error
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            result: dict[str, Any] = {"url": url, "sections": sections}
+            if references:
+                result["references"] = references
+            if section_errors:
+                result["section_errors"] = section_errors
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_saved_posts")
+        except Exception as e:
+            raise_tool_error(e, "get_saved_posts")

--- a/manifest.json
+++ b/manifest.json
@@ -112,6 +112,10 @@
       "description": "Get recent posts from the authenticated user's LinkedIn home feed"
     },
     {
+      "name": "get_saved_posts",
+      "description": "List posts saved (bookmarked) by the authenticated LinkedIn user"
+    },
+    {
       "name": "search_posts",
       "description": "Search LinkedIn posts/content globally by keyword (the 'Posts' tab) with an optional recency filter (past-24h/past-week/past-month)"
     },

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from linkedin_mcp_server.core.exceptions import RateLimitError
-from linkedin_mcp_server.core.utils import detect_rate_limit
+from linkedin_mcp_server.core.utils import detect_rate_limit, scroll_to_bottom
 
 
 @pytest.fixture
@@ -109,3 +109,43 @@ class TestDetectRateLimit:
 
         mock_page.locator = MagicMock(side_effect=locator_side_effect)
         await detect_rate_limit(mock_page)
+
+
+class TestScrollToBottom:
+    async def test_stop_fingerprint_halts_before_scrolling(self):
+        page = MagicMock()
+        page.evaluate = AsyncMock(return_value="A post already processed")
+
+        await scroll_to_bottom(
+            page, pause_time=0, stop_fingerprints=["already processed"]
+        )
+
+        # Only the fingerprint probe ran — nothing was scrolled
+        page.evaluate.assert_awaited_once()
+        await_args = page.evaluate.await_args
+        assert await_args is not None
+        assert "innerText" in await_args.args[0]
+
+    async def test_without_fingerprints_scrolls_until_height_stable(self):
+        page = MagicMock()
+        page.evaluate = AsyncMock(return_value=1000)  # height never grows
+
+        await scroll_to_bottom(page, pause_time=0, max_scrolls=5)
+
+        scripts = [call.args[0] for call in page.evaluate.await_args_list]
+        assert "window.scrollTo(0, document.body.scrollHeight)" in scripts
+        assert not any("innerText" in s for s in scripts)
+        assert len(scripts) == 3  # prev height, scroll, new height -> stop
+
+    async def test_empty_fingerprint_is_dropped(self):
+        """An empty string matches every page — it must not stop the scroll."""
+        page = MagicMock()
+        page.evaluate = AsyncMock(return_value=1000)
+
+        await scroll_to_bottom(
+            page, pause_time=0, max_scrolls=5, stop_fingerprints=[""]
+        )
+
+        scripts = [call.args[0] for call in page.evaluate.await_args_list]
+        assert "window.scrollTo(0, document.body.scrollHeight)" in scripts
+        assert not any("innerText" in s for s in scripts)

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -442,6 +442,19 @@ class TestBuildReferences:
         assert references[0]["url"] == "/jobs/view/0/"
         assert references[-1]["url"] == "/jobs/view/7/"
 
+    def test_caps_saved_posts_at_num_posts_ceiling(self):
+        raw: list[RawReference] = [
+            {
+                "href": f"https://www.linkedin.com/feed/update/urn:li:activity:{idx}/",
+                "text": f"Post {idx}",
+            }
+            for idx in range(60)
+        ]
+
+        references = build_references(raw, "saved_posts")
+
+        assert len(references) == 50
+
     def test_uses_default_cap_for_unknown_section(self):
         raw: list[RawReference] = [
             {

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2897,6 +2897,68 @@ class TestGetSavedJobs:
         assert result["sections"]["saved_jobs"] == "Login page content"
 
 
+class TestExtractSavedPosts:
+    """Tests for extract_saved_posts (scroll-loaded, unlike saved jobs)."""
+
+    async def test_navigates_saved_posts_url_with_activity_scrolling(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor.extract_saved_posts(
+                num_posts=10, stop_fingerprints=["already processed"]
+            )
+
+        assert mock_page.goto.await_args.args[0] == (
+            "https://www.linkedin.com/my-items/saved-posts/"
+        )
+        assert result.text == "Sample page text"
+        # /my-items/saved-posts is treated as an activity feed: 1.0s pause,
+        # scroll budget from num_posts, fingerprints forwarded for early stop.
+        mock_scroll.assert_awaited_once_with(
+            mock_page,
+            pause_time=1.0,
+            max_scrolls=2,
+            stop_fingerprints=["already processed"],
+        )
+        # Lazy-loaded content wait ran (is_activity branch)
+        mock_page.wait_for_function.assert_awaited()
+
+    @pytest.mark.parametrize(
+        "num_posts,expected_scrolls", [(1, 1), (10, 2), (50, 10), (200, 20)]
+    )
+    async def test_scroll_budget_scales_with_num_posts(
+        self, mock_page, num_posts, expected_scrolls
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("posts"),
+        ) as mock_extract:
+            await extractor.extract_saved_posts(num_posts=num_posts)
+
+        mock_extract.assert_awaited_once_with(
+            "https://www.linkedin.com/my-items/saved-posts/",
+            section_name="saved_posts",
+            max_scrolls=expected_scrolls,
+            stop_fingerprints=None,
+        )
+
+
 class TestSearchPeople:
     async def test_search_people_omits_orphaned_references(self, mock_page):
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -42,6 +42,9 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
         return_value=ExtractedSection(text="some text", references=[])
     )
     mock.extract_feed = AsyncMock(return_value=ExtractedSection(text="", references=[]))
+    mock.extract_saved_posts = AsyncMock(
+        return_value=ExtractedSection(text="", references=[])
+    )
     return mock
 
 
@@ -1171,6 +1174,71 @@ class TestFeedTools:
         with pytest.raises(ValidationError, match="num_posts"):
             await mcp.call_tool("get_feed", {"num_posts": 51})
 
+    async def test_get_saved_posts_success(self, mock_context):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_saved_posts = AsyncMock(
+            return_value=ExtractedSection(
+                text="Saved post 1\nSaved post 2",
+                references=[
+                    {
+                        "kind": "feed_post",
+                        "url": "/feed/update/urn:li:activity:1234567890/",
+                    }
+                ],
+            )
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_saved_posts")
+        result = await tool_fn(
+            mock_context,
+            num_posts=5,
+            stop_fingerprints=["already seen"],
+            extractor=mock_extractor,
+        )
+        assert result["url"] == "https://www.linkedin.com/my-items/saved-posts/"
+        assert result["sections"]["saved_posts"] == "Saved post 1\nSaved post 2"
+        assert result["references"]["saved_posts"][0]["url"] == (
+            "/feed/update/urn:li:activity:1234567890/"
+        )
+        mock_extractor.extract_saved_posts.assert_awaited_once_with(
+            num_posts=5, stop_fingerprints=["already seen"]
+        )
+
+    async def test_get_saved_posts_rate_limited_surfaces_section_error(
+        self, mock_context
+    ):
+        mock_extractor = MagicMock()
+        mock_extractor.extract_saved_posts = AsyncMock(
+            return_value=ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+        )
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_saved_posts")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert "saved_posts" not in result["sections"]
+        assert result["section_errors"]["saved_posts"]["error_type"] == "rate_limit"
+
+    async def test_get_saved_posts_rejects_excessive_num_posts(self, mock_context):
+        """Verify num_posts=51 is rejected by Field(le=50) validation."""
+        from pydantic import ValidationError
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        with pytest.raises(ValidationError, match="num_posts"):
+            await mcp.call_tool("get_saved_posts", {"num_posts": 51})
+
 
 class TestPostTools:
     async def test_search_posts_success(self, mock_context):
@@ -1264,6 +1332,7 @@ class TestToolTimeouts:
             "search_conversations",
             "send_message",
             "get_feed",
+            "get_saved_posts",
             "search_posts",
             "close_session",
         )
@@ -1297,6 +1366,7 @@ class TestToolTimeouts:
             "search_conversations",
             "send_message",
             "get_feed",
+            "get_saved_posts",
             "search_posts",
             "close_session",
         )


### PR DESCRIPTION
Closes #600

Adds `get_saved_posts`, the counterpart of `get_saved_jobs` for `/my-items/saved-posts/`.

### Why it is not a copy of get_saved_jobs

Saved jobs paginate with `?start=`; the saved posts list lazy-loads on scroll. So instead of a second pagination loop, this goes through `extract_page` unchanged and only sizes the scroll budget from `num_posts` (~5 posts load per scroll):

```python
async def extract_saved_posts(self, num_posts=10, stop_fingerprints=None):
    max_scrolls = min(max(1, (num_posts + 4) // 5), 20)
    return await self.extract_page(
        _SAVED_POSTS_URL,
        section_name="saved_posts",
        max_scrolls=max_scrolls,
        stop_fingerprints=stop_fingerprints,
    )
```

`/my-items/saved-posts` joins `/recent-activity/` and `/company/<slug>/posts` in the `is_activity` predicate, so it gets the same lazy-content wait and 1.0s scroll pause. Matching is done on the parsed path, consistent with the existing branch.

### stop_fingerprints

`scroll_to_bottom` takes an optional `stop_fingerprints: list[str]`. Scrolling stops as soon as one of those strings appears in the page text. The saved posts list is typically consumed incrementally: passing the first ~80 chars of the last posts already processed avoids lazy-loading a page of content the caller will discard. Default is `None`, so every existing call site behaves exactly as before.

### Notes

- Follows the scraping philosophy: no new DOM selector, `innerText` only, `main` as the   broadest scope, URL navigation rather than clicks.
- Verified against live LinkedIn (the tool has been in daily use on a fork).
- Tests: extractor-level (URL, scroll budget, activity routing, fingerprint forwarding),   `scroll_to_bottom` early stop, tool-level (success, references, rate limit,   `num_posts` validation, timeout registry).
- Docs: `README.md` tool table, `docs/docker-hub.md` feature list, `manifest.json`.