### PR TITLE
fix(http): reject cross-origin requests to the MCP endpoint

### DIFF
--- a/.github/workflows/check-attribution.yml
+++ b/.github/workflows/check-attribution.yml
@@ -1,8 +1,10 @@
 name: Check Attribution
 
 on:
+  # Every pull request, not only those targeting main: a stacked pull request
+  # is based on the branch below it, and a trailer that slips through there
+  # reaches main when the stack merges.
   pull_request:
-    branches: [main]
 
 # Coding agents sign their work either with a Co-Authored-By trailer or by
 # claiming the author/committer field. Squash-merging collects the trailers of

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ on:
     branches: [main]
   # Every pull request, not only those targeting main. A stacked pull request
   # is based on the branch below it, so filtering by base branch skipped CI
-  # entirely for the stacks this repository's workflow produces — the checks
-  # were not failing, they were absent.
+  # entirely for the stacks this repository's workflow produces.
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,11 @@ name: CI
 on:
   push:
     branches: [main]
+  # Every pull request, not only those targeting main. A stacked pull request
+  # is based on the branch below it, so filtering by base branch skipped CI
+  # entirely for the stacks this repository's workflow produces — the checks
+  # were not failing, they were absent.
   pull_request:
-    branches: [main]
 
 jobs:
   lint-and-check:

--- a/README.md
+++ b/README.md
@@ -347,6 +347,14 @@ docker run -it --rm \
 
 Runtime server logs are emitted by FastMCP/Uvicorn.
 
+The HTTP server answers requests addressed to `localhost` or to the address it
+is bound to, and refuses others with `421`. That is what stops a website you
+merely visit from pointing a domain at this server and using your LinkedIn
+session through your own browser. If you reach the server by a hostname
+instead — a machine name on your network, or through a reverse proxy — that
+request is refused, and the endpoint has no authentication, so put it behind
+something that does.
+
 **Test with mcp inspector:**
 
 1. Install and run mcp inspector ```bunx @modelcontextprotocol/inspector```

--- a/README.md
+++ b/README.md
@@ -350,10 +350,20 @@ Runtime server logs are emitted by FastMCP/Uvicorn.
 The HTTP server answers requests addressed to `localhost` or to the address it
 is bound to, and refuses others with `421`. That is what stops a website you
 merely visit from pointing a domain at this server and using your LinkedIn
-session through your own browser. If you reach the server by a hostname
-instead — a machine name on your network, or through a reverse proxy — that
-request is refused, and the endpoint has no authentication, so put it behind
-something that does.
+session through your own browser.
+
+Reaching the server by any other name is refused, including a machine name on
+your network and the public name in front of a reverse proxy. Either have the
+proxy rewrite the upstream `Host` to the backend address, or name the host you
+serve it under:
+
+```bash
+FASTMCP_HTTP_ALLOWED_HOSTS='["mcp.example"]'
+```
+
+That permits exactly that name and keeps refusing everything else. The endpoint
+still has no authentication, so anything reachable beyond your own machine
+belongs behind something that provides it.
 
 **Test with mcp inspector:**
 

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -19,6 +19,7 @@ from fastmcp import Context
 from linkedin_mcp_server.authentication import get_authentication_source
 from linkedin_mcp_server.common_utils import secure_mkdir, secure_write_text, utcnow_iso
 from linkedin_mcp_server.config import get_config
+from linkedin_mcp_server.config.schema import is_loopback_host
 from linkedin_mcp_server.drivers.browser import (
     close_browser,
     current_headless,
@@ -654,13 +655,9 @@ def _auto_import_allowed() -> bool:
     # request from a remote client. Gate on the BIND ADDRESS, not the transport
     # type: a streamable-http server on a loopback host is the documented local
     # dev / verify flow and IS a desktop case; only a non-loopback bind is the
-    # service case. This is an exact-match loopback allowlist that fails closed:
-    # any unrecognized host (0.0.0.0, ::, a LAN IP, an IPv4-mapped loopback)
-    # is treated as non-loopback and gated OFF.
-    if config.server.transport == "streamable-http" and config.server.host not in (
-        "127.0.0.1",
-        "::1",
-        "localhost",
+    # service case.
+    if config.server.transport == "streamable-http" and not is_loopback_host(
+        config.server.host
     ):
         return False
     return True

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -375,6 +375,15 @@ def main() -> None:
             if config.is_interactive and not config.server.transport_explicitly_set:
                 print("\n🚀 Server ready! Choose transport mode:")
                 transport = choose_transport_interactive()
+                # Record the answer rather than keeping it in a local. Two
+                # checks read the stored transport to decide how exposed this
+                # process is: the bind-address warning, and the gate that
+                # decides whether reading the local browser's LinkedIn cookie
+                # is safe. Leaving it at stdio told them a listening HTTP
+                # server was a private one. Re-validating applies the HTTP
+                # rules that were skipped when the value said stdio.
+                config.server.transport = transport
+                config.validate()
 
             # Create and run the MCP server
             mcp = create_mcp_server(tool_timeout=config.server.tool_timeout_seconds)
@@ -383,9 +392,9 @@ def main() -> None:
                 # Validate Host and Origin. Without this a website the user
                 # merely visits can point a hostname at this server's address
                 # and have the user's own browser drive tools with the
-                # logged-in LinkedIn session — the request comes from inside,
-                # so a firewall does not help. The MCP specification requires
-                # this for local HTTP servers, and it is off unless asked for.
+                # logged-in LinkedIn session. The request comes from inside, so
+                # a firewall does not help. The MCP specification requires this
+                # for local HTTP servers, and it is off unless asked for.
                 #
                 # Both checks are needed, and the Host one carries most of the
                 # weight. A rebinding attack sends its own domain as *both*
@@ -397,18 +406,18 @@ def main() -> None:
                 # True rather than "auto": "auto" only validates when the
                 # accepted connection landed on a loopback address, so a server
                 # bound to 0.0.0.0 and reached over its LAN address checked
-                # nothing at all — the exposed case, where it matters most.
-                # Measured before this: an attacker Host and Origin over the LAN
-                # address were served, while the same request to 127.0.0.1 was
-                # refused.
+                # nothing at all, which is the exposed case where it matters
+                # most. Measured before this: an attacker Host and Origin over
+                # the LAN address were served, while the same request to
+                # 127.0.0.1 was refused.
                 #
                 # Strict accepts localhost and the address the connection
                 # arrived on, which covers the documented flows. It does not
-                # accept a DNS name — a machine name, or a public name in front
-                # of a proxy — so those need the proxy to rewrite the upstream
-                # Host, or the name listed explicitly. The README says so next
-                # to the exposed-bind example, because a 421 nobody can explain
-                # is how a guard like this ends up switched off.
+                # accept a DNS name such as a machine name or a public name in
+                # front of a proxy, so those need the proxy to rewrite the
+                # upstream Host, or the name listed explicitly. The README says
+                # so next to the exposed-bind example, because a 421 nobody can
+                # explain is how a guard like this ends up switched off.
                 #
                 # Deliberately no host wildcard: it would accept any Host and
                 # reopen the same hole from the other side.

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -14,7 +14,6 @@ from linkedin_mcp_server.bootstrap import (
 from linkedin_mcp_server.core import AuthenticationError
 from linkedin_mcp_server.authentication import clear_auth_state
 from linkedin_mcp_server.config import get_config
-from linkedin_mcp_server.config.schema import is_loopback_host
 from linkedin_mcp_server.drivers.browser import (
     experimental_persist_derived_runtime,
     close_browser,
@@ -381,32 +380,31 @@ def main() -> None:
             mcp = create_mcp_server(tool_timeout=config.server.tool_timeout_seconds)
 
             if transport == "streamable-http":
-                # Reject cross-origin requests. Without this a website the user
-                # merely visits can reach a loopback server by DNS rebinding —
-                # the browser sends the request, so a firewall does not help —
-                # and drive tools with the logged-in LinkedIn session. The MCP
-                # specification requires validating Origin for exactly this
-                # reason, and the protection is off unless asked for.
+                # Validate Host and Origin. Without this a website the user
+                # merely visits can point a hostname at this server's address
+                # and have the user's own browser drive tools with the
+                # logged-in LinkedIn session — the request comes from inside,
+                # so a firewall does not help. The MCP specification requires
+                # this for local HTTP servers, and it is off unless asked for.
                 #
-                # Requests carrying no Origin at all stay allowed, which is
-                # every non-browser client.
+                # Both checks are needed, and the Host one carries most of the
+                # weight. A rebinding attack sends its own domain as *both*
+                # Host and Origin, so those agree and origin validation alone
+                # lets it through; what gives it away is that the Host is not a
+                # name this server answers to. Requests carrying no Origin at
+                # all stay allowed, which is every non-browser client.
+                #
+                # Deliberately no wildcard on an exposed bind: it would accept
+                # any Host and reopen exactly this hole. A client reaching a
+                # container under localhost is unaffected, since that is a name
+                # the guard already accepts; anything else needs the host named
+                # explicitly, which is a decision for whoever exposes it.
                 mcp.run(
                     transport=transport,
                     host=config.server.host,
                     port=config.server.port,
                     path=config.server.path,
                     host_origin_protection="auto",
-                    # A deliberately exposed bind is reached under a Host header
-                    # this server cannot predict — a LAN address, a hostname, a
-                    # reverse proxy's name — and the Host check would answer 421
-                    # to all of them. Origin validation is what stops rebinding;
-                    # the Host check only adds depth on a loopback bind, where
-                    # the accepted names are knowable. Wildcarding it off an
-                    # exposed bind keeps that server usable without weakening
-                    # the guard that matters.
-                    allowed_hosts=(
-                        None if is_loopback_host(config.server.host) else ["*"]
-                    ),
                 )
             else:
                 mcp.run(transport=transport)

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -400,9 +400,15 @@ def main() -> None:
                 # nothing at all — the exposed case, where it matters most.
                 # Measured before this: an attacker Host and Origin over the LAN
                 # address were served, while the same request to 127.0.0.1 was
-                # refused. Strict validates either way and accepts the address
-                # it is actually bound to, so a deliberately exposed server
-                # keeps working.
+                # refused.
+                #
+                # Strict accepts localhost and the address the connection
+                # arrived on, which covers the documented flows. It does not
+                # accept a DNS name — a machine name, or a public name in front
+                # of a proxy — so those need the proxy to rewrite the upstream
+                # Host, or the name listed explicitly. The README says so next
+                # to the exposed-bind example, because a 421 nobody can explain
+                # is how a guard like this ends up switched off.
                 #
                 # Deliberately no host wildcard: it would accept any Host and
                 # reopen the same hole from the other side.

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -380,11 +380,22 @@ def main() -> None:
             mcp = create_mcp_server(tool_timeout=config.server.tool_timeout_seconds)
 
             if transport == "streamable-http":
+                # Reject cross-origin requests. Without this a website the user
+                # merely visits can reach a loopback server by DNS rebinding —
+                # the browser sends the request, so a firewall does not help —
+                # and drive tools with the logged-in LinkedIn session. The MCP
+                # specification requires validating Origin for exactly this
+                # reason, and the protection is off unless asked for.
+                #
+                # "auto" allows the bound host and loopback origins, and keeps
+                # allowing requests that carry no Origin at all, which is every
+                # non-browser client.
                 mcp.run(
                     transport=transport,
                     host=config.server.host,
                     port=config.server.port,
                     path=config.server.path,
+                    host_origin_protection="auto",
                 )
             else:
                 mcp.run(transport=transport)

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -394,17 +394,24 @@ def main() -> None:
                 # name this server answers to. Requests carrying no Origin at
                 # all stay allowed, which is every non-browser client.
                 #
-                # Deliberately no wildcard on an exposed bind: it would accept
-                # any Host and reopen exactly this hole. A client reaching a
-                # container under localhost is unaffected, since that is a name
-                # the guard already accepts; anything else needs the host named
-                # explicitly, which is a decision for whoever exposes it.
+                # True rather than "auto": "auto" only validates when the
+                # accepted connection landed on a loopback address, so a server
+                # bound to 0.0.0.0 and reached over its LAN address checked
+                # nothing at all — the exposed case, where it matters most.
+                # Measured before this: an attacker Host and Origin over the LAN
+                # address were served, while the same request to 127.0.0.1 was
+                # refused. Strict validates either way and accepts the address
+                # it is actually bound to, so a deliberately exposed server
+                # keeps working.
+                #
+                # Deliberately no host wildcard: it would accept any Host and
+                # reopen the same hole from the other side.
                 mcp.run(
                     transport=transport,
                     host=config.server.host,
                     port=config.server.port,
                     path=config.server.path,
-                    host_origin_protection="auto",
+                    host_origin_protection=True,
                 )
             else:
                 mcp.run(transport=transport)

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -14,6 +14,7 @@ from linkedin_mcp_server.bootstrap import (
 from linkedin_mcp_server.core import AuthenticationError
 from linkedin_mcp_server.authentication import clear_auth_state
 from linkedin_mcp_server.config import get_config
+from linkedin_mcp_server.config.schema import is_loopback_host
 from linkedin_mcp_server.drivers.browser import (
     experimental_persist_derived_runtime,
     close_browser,
@@ -387,15 +388,25 @@ def main() -> None:
                 # specification requires validating Origin for exactly this
                 # reason, and the protection is off unless asked for.
                 #
-                # "auto" allows the bound host and loopback origins, and keeps
-                # allowing requests that carry no Origin at all, which is every
-                # non-browser client.
+                # Requests carrying no Origin at all stay allowed, which is
+                # every non-browser client.
                 mcp.run(
                     transport=transport,
                     host=config.server.host,
                     port=config.server.port,
                     path=config.server.path,
                     host_origin_protection="auto",
+                    # A deliberately exposed bind is reached under a Host header
+                    # this server cannot predict — a LAN address, a hostname, a
+                    # reverse proxy's name — and the Host check would answer 421
+                    # to all of them. Origin validation is what stops rebinding;
+                    # the Host check only adds depth on a loopback bind, where
+                    # the accepted names are knowable. Wildcarding it off an
+                    # exposed bind keeps that server usable without weakening
+                    # the guard that matters.
+                    allowed_hosts=(
+                        None if is_loopback_host(config.server.host) else ["*"]
+                    ),
                 )
             else:
                 mcp.run(transport=transport)

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -41,6 +41,18 @@ BROWSER_HANDOFF_MARGIN_SECONDS: float = 3.0
 DEFAULT_BROWSER_IDLE_TIMEOUT_SECONDS: float = 600.0
 
 
+# Hosts that only this machine can reach. An exact-match allowlist that fails
+# closed: anything unrecognised — 0.0.0.0, ::, a LAN address, an IPv4-mapped
+# loopback — counts as reachable from elsewhere. Erring towards "exposed" costs
+# a warning; erring the other way would hand a logged-in session to the network.
+LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def is_loopback_host(host: str) -> bool:
+    """Whether *host* is reachable only from this machine."""
+    return host in LOOPBACK_HOSTS
+
+
 class ConfigurationError(Exception):
     """Raised when configuration validation fails."""
 
@@ -240,12 +252,13 @@ class AppConfig:
             raise ConfigurationError("HTTP transport requires a valid host")
         if not self.server.port:
             raise ConfigurationError("HTTP transport requires a valid port")
-        if self.server.host in ("0.0.0.0", "::"):
+        if not is_loopback_host(self.server.host):
             logger.warning(
-                "HTTP transport is binding to %s which exposes the server to "
-                "all network interfaces. The MCP endpoint has no authentication "
-                "— anyone on your network can use your LinkedIn session. "
-                "Use 127.0.0.1 (default) unless you understand the risk.",
+                "HTTP transport is binding to %s, which is reachable from "
+                "outside this machine. The MCP endpoint has no authentication "
+                "— anyone who can reach that address can use your LinkedIn "
+                "session. Use 127.0.0.1 (default) unless you understand the "
+                "risk.",
                 self.server.host,
             )
 

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -50,11 +50,11 @@ LOOPBACK_HOSTNAMES: frozenset[str] = frozenset({"localhost"})
 def is_loopback_host(host: str) -> bool:
     """Whether *host* is reachable only from this machine.
 
-    Fails closed: anything this cannot positively identify as loopback — a
-    wildcard bind, a LAN address, a name that needs DNS to answer — counts as
-    reachable from elsewhere. Erring that way costs a warning and a skipped
-    cookie import; erring the other way would hand a logged-in session to the
-    network.
+    Fails closed: anything this cannot positively identify as loopback counts
+    as reachable from elsewhere, whether that is a wildcard bind, a LAN
+    address, or a name that needs DNS to answer. Erring that way costs a
+    warning and a skipped cookie import; erring the other way would hand a
+    logged-in session to the network.
 
     Address literals go through :mod:`ipaddress` rather than a spelling list,
     so the whole 127/8 range and IPv4-mapped forms are recognised for what they
@@ -280,8 +280,8 @@ class AppConfig:
         if not is_loopback_host(self.server.host):
             logger.warning(
                 "HTTP transport is binding to %s, which is reachable from "
-                "outside this machine. The MCP endpoint has no authentication "
-                "— anyone who can reach that address can use your LinkedIn "
+                "outside this machine. The MCP endpoint has no authentication, "
+                "so anyone who can reach that address can use your LinkedIn "
                 "session. Use 127.0.0.1 (default) unless you understand the "
                 "risk.",
                 self.server.host,

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -5,6 +5,7 @@ Defines the dataclass schemas that represent the application's configuration
 structure with type-safe configuration objects and default values.
 """
 
+import ipaddress
 import logging
 import math
 from dataclasses import dataclass, field
@@ -41,16 +42,40 @@ BROWSER_HANDOFF_MARGIN_SECONDS: float = 3.0
 DEFAULT_BROWSER_IDLE_TIMEOUT_SECONDS: float = 600.0
 
 
-# Hosts that only this machine can reach. An exact-match allowlist that fails
-# closed: anything unrecognised — 0.0.0.0, ::, a LAN address, an IPv4-mapped
-# loopback — counts as reachable from elsewhere. Erring towards "exposed" costs
-# a warning; erring the other way would hand a logged-in session to the network.
-LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
+# Names that resolve only on this machine. Compared case-insensitively and
+# without a trailing root dot, both of which are the same name to a resolver.
+LOOPBACK_HOSTNAMES: frozenset[str] = frozenset({"localhost"})
 
 
 def is_loopback_host(host: str) -> bool:
-    """Whether *host* is reachable only from this machine."""
-    return host in LOOPBACK_HOSTS
+    """Whether *host* is reachable only from this machine.
+
+    Fails closed: anything this cannot positively identify as loopback — a
+    wildcard bind, a LAN address, a name that needs DNS to answer — counts as
+    reachable from elsewhere. Erring that way costs a warning and a skipped
+    cookie import; erring the other way would hand a logged-in session to the
+    network.
+
+    Address literals go through :mod:`ipaddress` rather than a spelling list,
+    so the whole 127/8 range and IPv4-mapped forms are recognised for what they
+    are instead of being judged on how they were typed.
+    """
+    name = host.strip().rstrip(".").lower()
+    if not name:
+        return False
+    if name in LOOPBACK_HOSTNAMES:
+        return True
+
+    literal = name
+    if literal.startswith("[") and literal.endswith("]"):
+        literal = literal[1:-1]  # bracketed IPv6, as it appears in a URL
+    try:
+        address = ipaddress.ip_address(literal)
+    except ValueError:
+        # A name only DNS can resolve, and DNS can point anywhere.
+        return False
+    mapped = getattr(address, "ipv4_mapped", None)
+    return address.is_loopback or bool(mapped and mapped.is_loopback)
 
 
 class ConfigurationError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "cryptography>=48.0.1",
-    "fastmcp>=3.0.0",
+    "fastmcp>=3.4.4",
     "inquirer>=3.4.0",
     "packaging>=26.2",
     "patchright>=1.40.0",

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -2,6 +2,7 @@
 
 import importlib.metadata
 import json
+import logging
 from typing import Literal
 from unittest.mock import AsyncMock, MagicMock
 
@@ -82,6 +83,62 @@ def test_main_interactive_prompts_when_transport_not_explicit(
         path=config.server.path,
         host_origin_protection=True,
     )
+    assert config.server.transport == "streamable-http"
+
+
+def test_choosing_http_at_the_prompt_warns_about_an_exposed_bind(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Answering the prompt has to update the stored transport, not a local.
+
+    Several checks read it to decide how exposed this process is. Leaving it at
+    stdio told the bind-address warning there was no listener to warn about,
+    and told the cookie-import gate that a server listening on every interface
+    was a private one.
+    """
+    config = _make_config(
+        is_interactive=True, transport="stdio", transport_explicitly_set=False
+    )
+    config.server.host = "0.0.0.0"
+    _patch_main_dependencies(monkeypatch, config)
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.choose_transport_interactive",
+        lambda: "streamable-http",
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: MagicMock()
+    )
+
+    with caplog.at_level(logging.WARNING):
+        cli_main.main()
+
+    assert config.server.transport == "streamable-http"
+    assert "no authentication" in caplog.text
+
+
+def test_choosing_stdio_at_the_prompt_leaves_no_listener_recorded(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The host is meaningless without a listener, so it must not warn."""
+    config = _make_config(
+        is_interactive=True, transport="streamable-http", transport_explicitly_set=False
+    )
+    config.server.host = "0.0.0.0"
+    _patch_main_dependencies(monkeypatch, config)
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.choose_transport_interactive", lambda: "stdio"
+    )
+    mcp = MagicMock()
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
+    )
+
+    with caplog.at_level(logging.WARNING):
+        cli_main.main()
+
+    assert config.server.transport == "stdio"
+    assert "no authentication" not in caplog.text
+    mcp.run.assert_called_once_with(transport="stdio")
 
 
 def test_main_explicit_transport_skips_prompt(

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -81,7 +81,6 @@ def test_main_interactive_prompts_when_transport_not_explicit(
         port=config.server.port,
         path=config.server.path,
         host_origin_protection="auto",
-        allowed_hosts=None,
     )
 
 
@@ -134,20 +133,20 @@ def test_main_streamable_http_passes_host_port_path(
         port=8123,
         path="/custom-mcp",
         host_origin_protection="auto",
-        allowed_hosts=["*"],  # 0.0.0.0: see test_main_keeps_an_exposed_bind_reachable
     )
     captured = capsys.readouterr()
     assert captured.out == ""
 
 
-def test_main_streamable_http_always_rejects_foreign_origins(
+def test_main_streamable_http_enables_host_and_origin_validation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Origin validation is not optional and has no configuration switch.
+    """The guard is not optional and has no configuration switch.
 
-    Without it a site the user merely visits can reach this server by DNS
-    rebinding — the request comes from the user's own browser, so binding to
-    loopback does not help — and drive tools with the logged-in session.
+    Passing no ``allowed_hosts`` is the point rather than an omission: a
+    wildcard would accept an attacker's own domain as the Host and reopen the
+    hole this closes. See ``test_transport_security.py`` for what the resulting
+    server actually answers.
     """
     config = _make_config(
         is_interactive=False,
@@ -163,57 +162,7 @@ def test_main_streamable_http_always_rejects_foreign_origins(
     cli_main.main()
 
     assert mcp.run.call_args.kwargs["host_origin_protection"] == "auto"
-
-
-@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
-def test_main_checks_the_host_header_on_a_loopback_bind(
-    monkeypatch: pytest.MonkeyPatch, host: str
-) -> None:
-    """On loopback the acceptable Host values are knowable, so check them."""
-    config = _make_config(
-        is_interactive=False,
-        transport="streamable-http",
-        transport_explicitly_set=True,
-    )
-    config.server.host = host
-    _patch_main_dependencies(monkeypatch, config)
-    mcp = MagicMock()
-    monkeypatch.setattr(
-        "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
-    )
-
-    cli_main.main()
-
-    assert mcp.run.call_args.kwargs["allowed_hosts"] is None
-
-
-@pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.5", "::"])
-def test_main_keeps_an_exposed_bind_reachable(
-    monkeypatch: pytest.MonkeyPatch, host: str
-) -> None:
-    """A deliberately exposed server must still answer its own clients.
-
-    Those clients arrive under a Host this server cannot predict — a LAN
-    address, a hostname, a reverse proxy's name — and checking it would answer
-    421 to every one of them. Origin validation is what stops rebinding, and it
-    stays on regardless.
-    """
-    config = _make_config(
-        is_interactive=False,
-        transport="streamable-http",
-        transport_explicitly_set=True,
-    )
-    config.server.host = host
-    _patch_main_dependencies(monkeypatch, config)
-    mcp = MagicMock()
-    monkeypatch.setattr(
-        "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
-    )
-
-    cli_main.main()
-
-    assert mcp.run.call_args.kwargs["allowed_hosts"] == ["*"]
-    assert mcp.run.call_args.kwargs["host_origin_protection"] == "auto"
+    assert "allowed_hosts" not in mcp.run.call_args.kwargs
 
 
 def test_main_passes_configured_tool_timeout_to_factory(

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -80,7 +80,7 @@ def test_main_interactive_prompts_when_transport_not_explicit(
         host=config.server.host,
         port=config.server.port,
         path=config.server.path,
-        host_origin_protection="auto",
+        host_origin_protection=True,
     )
 
 
@@ -132,7 +132,7 @@ def test_main_streamable_http_passes_host_port_path(
         host="0.0.0.0",
         port=8123,
         path="/custom-mcp",
-        host_origin_protection="auto",
+        host_origin_protection=True,
     )
     captured = capsys.readouterr()
     assert captured.out == ""
@@ -143,10 +143,13 @@ def test_main_streamable_http_enables_host_and_origin_validation(
 ) -> None:
     """The guard is not optional and has no configuration switch.
 
-    Passing no ``allowed_hosts`` is the point rather than an omission: a
-    wildcard would accept an attacker's own domain as the Host and reopen the
-    hole this closes. See ``test_transport_security.py`` for what the resulting
-    server actually answers.
+    Two details here are load-bearing rather than incidental. ``True`` instead
+    of ``"auto"``: the latter validates only when the connection landed on a
+    loopback address, so an exposed server checked nothing over its own LAN
+    address. And no ``allowed_hosts``: a wildcard would accept an attacker's
+    domain as the Host and reopen the hole from the other side.
+
+    See ``test_transport_security.py`` for what the resulting server answers.
     """
     config = _make_config(
         is_interactive=False,
@@ -161,7 +164,7 @@ def test_main_streamable_http_enables_host_and_origin_validation(
 
     cli_main.main()
 
-    assert mcp.run.call_args.kwargs["host_origin_protection"] == "auto"
+    assert mcp.run.call_args.kwargs["host_origin_protection"] is True
     assert "allowed_hosts" not in mcp.run.call_args.kwargs
 
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -80,6 +80,7 @@ def test_main_interactive_prompts_when_transport_not_explicit(
         host=config.server.host,
         port=config.server.port,
         path=config.server.path,
+        host_origin_protection="auto",
     )
 
 
@@ -131,9 +132,35 @@ def test_main_streamable_http_passes_host_port_path(
         host="0.0.0.0",
         port=8123,
         path="/custom-mcp",
+        host_origin_protection="auto",
     )
     captured = capsys.readouterr()
     assert captured.out == ""
+
+
+def test_main_streamable_http_always_rejects_foreign_origins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Origin validation is not optional and has no configuration switch.
+
+    Without it a site the user merely visits can reach this server by DNS
+    rebinding — the request comes from the user's own browser, so binding to
+    loopback does not help — and drive tools with the logged-in session.
+    """
+    config = _make_config(
+        is_interactive=False,
+        transport="streamable-http",
+        transport_explicitly_set=True,
+    )
+    _patch_main_dependencies(monkeypatch, config)
+    mcp = MagicMock()
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
+    )
+
+    cli_main.main()
+
+    assert mcp.run.call_args.kwargs["host_origin_protection"] == "auto"
 
 
 def test_main_passes_configured_tool_timeout_to_factory(

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -81,6 +81,7 @@ def test_main_interactive_prompts_when_transport_not_explicit(
         port=config.server.port,
         path=config.server.path,
         host_origin_protection="auto",
+        allowed_hosts=None,
     )
 
 
@@ -133,6 +134,7 @@ def test_main_streamable_http_passes_host_port_path(
         port=8123,
         path="/custom-mcp",
         host_origin_protection="auto",
+        allowed_hosts=["*"],  # 0.0.0.0: see test_main_keeps_an_exposed_bind_reachable
     )
     captured = capsys.readouterr()
     assert captured.out == ""
@@ -160,6 +162,57 @@ def test_main_streamable_http_always_rejects_foreign_origins(
 
     cli_main.main()
 
+    assert mcp.run.call_args.kwargs["host_origin_protection"] == "auto"
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_main_checks_the_host_header_on_a_loopback_bind(
+    monkeypatch: pytest.MonkeyPatch, host: str
+) -> None:
+    """On loopback the acceptable Host values are knowable, so check them."""
+    config = _make_config(
+        is_interactive=False,
+        transport="streamable-http",
+        transport_explicitly_set=True,
+    )
+    config.server.host = host
+    _patch_main_dependencies(monkeypatch, config)
+    mcp = MagicMock()
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
+    )
+
+    cli_main.main()
+
+    assert mcp.run.call_args.kwargs["allowed_hosts"] is None
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.5", "::"])
+def test_main_keeps_an_exposed_bind_reachable(
+    monkeypatch: pytest.MonkeyPatch, host: str
+) -> None:
+    """A deliberately exposed server must still answer its own clients.
+
+    Those clients arrive under a Host this server cannot predict — a LAN
+    address, a hostname, a reverse proxy's name — and checking it would answer
+    421 to every one of them. Origin validation is what stops rebinding, and it
+    stays on regardless.
+    """
+    config = _make_config(
+        is_interactive=False,
+        transport="streamable-http",
+        transport_explicitly_set=True,
+    )
+    config.server.host = host
+    _patch_main_dependencies(monkeypatch, config)
+    mcp = MagicMock()
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
+    )
+
+    cli_main.main()
+
+    assert mcp.run.call_args.kwargs["allowed_hosts"] == ["*"]
     assert mcp.run.call_args.kwargs["host_origin_protection"] == "auto"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from linkedin_mcp_server.config.schema import (
@@ -6,6 +8,7 @@ from linkedin_mcp_server.config.schema import (
     ConfigurationError,
     MAX_LOGIN_INLINE_WAIT_SECONDS,
     ServerConfig,
+    is_loopback_host,
 )
 
 
@@ -81,6 +84,73 @@ class TestAppConfig:
         config.server.port = 99999
         with pytest.raises(ConfigurationError):
             config.validate()
+
+
+class TestExposedBindWarning:
+    """The endpoint has no authentication, so the bind address is the guard.
+
+    The warning used to fire only for a literal 0.0.0.0 or ::, which meant the
+    most likely way to expose a session by accident — naming a LAN address
+    outright — happened in silence.
+    """
+
+    @staticmethod
+    def _validate_with_host(host, caplog):
+        config = AppConfig()
+        config.server.transport = "streamable-http"
+        config.server.host = host
+        with caplog.at_level(
+            logging.WARNING, logger="linkedin_mcp_server.config.schema"
+        ):
+            config.validate()
+        return caplog.text
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])
+    def test_loopback_binds_are_silent(self, host, caplog):
+        assert self._validate_with_host(host, caplog) == ""
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "0.0.0.0",
+            "::",
+            "192.168.1.5",  # a LAN address warned about nothing before
+            "10.0.0.7",
+            "::ffff:127.0.0.1",  # IPv4-mapped loopback: not in the allowlist
+            "example.internal",
+        ],
+    )
+    def test_reachable_binds_warn(self, host, caplog):
+        text = self._validate_with_host(host, caplog)
+        assert host in text
+        assert "no authentication" in text
+
+    def test_stdio_never_warns_about_the_host(self, caplog):
+        """The host field is meaningless without an HTTP listener."""
+        config = AppConfig()
+        config.server.transport = "stdio"
+        config.server.host = "0.0.0.0"
+        with caplog.at_level(logging.WARNING):
+            config.validate()
+
+        assert "no authentication" not in caplog.text
+
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("127.0.0.1", True),
+            ("::1", True),
+            ("localhost", True),
+            ("0.0.0.0", False),
+            ("::", False),
+            ("192.168.1.5", False),
+            ("::ffff:127.0.0.1", False),
+            ("", False),
+        ],
+    )
+    def test_is_loopback_host_fails_closed(self, host, expected):
+        """Anything unrecognised counts as reachable, never the other way."""
+        assert is_loopback_host(host) is expected
 
 
 class TestConfigSingleton:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,8 +90,8 @@ class TestExposedBindWarning:
     """The endpoint has no authentication, so the bind address is the guard.
 
     The warning used to fire only for a literal 0.0.0.0 or ::, which meant the
-    most likely way to expose a session by accident — naming a LAN address
-    outright — happened in silence.
+    most likely way to expose a session by accident, naming a LAN address
+    outright, happened in silence.
     """
 
     @staticmethod

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,7 +116,6 @@ class TestExposedBindWarning:
             "::",
             "192.168.1.5",  # a LAN address warned about nothing before
             "10.0.0.7",
-            "::ffff:127.0.0.1",  # IPv4-mapped loopback: not in the allowlist
             "example.internal",
         ],
     )
@@ -138,18 +137,30 @@ class TestExposedBindWarning:
     @pytest.mark.parametrize(
         ("host", "expected"),
         [
+            # Reachable only from this machine, however it was spelled.
             ("127.0.0.1", True),
             ("::1", True),
             ("localhost", True),
+            ("LOCALHOST", True),  # case is not part of a hostname
+            ("  localhost  ", True),
+            ("localhost.", True),  # the root dot is the same name
+            ("127.0.0.2", True),  # the whole 127/8 range is loopback
+            ("127.255.255.254", True),
+            ("::ffff:127.0.0.1", True),  # IPv4-mapped loopback
+            ("[::1]", True),  # bracketed, as it appears in a URL
+            # Reachable from elsewhere, or not decidable without DNS.
             ("0.0.0.0", False),
             ("::", False),
             ("192.168.1.5", False),
-            ("::ffff:127.0.0.1", False),
+            ("10.0.0.7", False),
+            ("example.internal", False),
+            ("localhost.evil.example", False),  # a name DNS points anywhere
             ("", False),
+            ("   ", False),
         ],
     )
     def test_is_loopback_host_fails_closed(self, host, expected):
-        """Anything unrecognised counts as reachable, never the other way."""
+        """Anything not positively loopback counts as reachable."""
         assert is_loopback_host(host) is expected
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -145,7 +145,9 @@ class TestPersonTool:
 
     async def test_get_person_profile_rejects_invalid_max_scrolls(self, mock_context):
         """Verify max_scrolls=0 is rejected by Field(ge=1) validation."""
-        from pydantic import ValidationError
+        # FastMCP wraps the pydantic error raised by Field() constraints in
+        # its own ValidationError, which does not subclass pydantic's.
+        from fastmcp.exceptions import ValidationError
 
         from linkedin_mcp_server.tools.person import register_person_tools
 
@@ -1149,7 +1151,9 @@ class TestFeedTools:
 
     async def test_get_feed_rejects_zero_num_posts(self, mock_context):
         """Verify num_posts=0 is rejected by Field(ge=1) validation."""
-        from pydantic import ValidationError
+        # FastMCP wraps the pydantic error raised by Field() constraints in
+        # its own ValidationError, which does not subclass pydantic's.
+        from fastmcp.exceptions import ValidationError
 
         from linkedin_mcp_server.tools.feed import register_feed_tools
 
@@ -1161,7 +1165,9 @@ class TestFeedTools:
 
     async def test_get_feed_rejects_excessive_num_posts(self, mock_context):
         """Verify num_posts=51 is rejected by Field(le=50) validation."""
-        from pydantic import ValidationError
+        # FastMCP wraps the pydantic error raised by Field() constraints in
+        # its own ValidationError, which does not subclass pydantic's.
+        from fastmcp.exceptions import ValidationError
 
         from linkedin_mcp_server.tools.feed import register_feed_tools
 
@@ -1231,7 +1237,9 @@ class TestPostTools:
 
     async def test_search_posts_rejects_zero_max_pages(self, mock_context):
         """Verify max_pages=0 is rejected by Field(ge=1) validation."""
-        from pydantic import ValidationError
+        # FastMCP wraps the pydantic error raised by Field() constraints in
+        # its own ValidationError, which does not subclass pydantic's.
+        from fastmcp.exceptions import ValidationError
 
         from linkedin_mcp_server.tools.post import register_post_tools
 

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -174,15 +174,22 @@ class TestLegitimateClientsStillWork:
             "LOCALHOST:8000",  # case is not part of a hostname
         ],
     )
-    def test_loopback_hosts_are_served_on_a_local_server(
-        self, request: pytest.FixtureRequest, post, host: str
-    ) -> None:
-        """Including the documented Docker flow: the container binds 0.0.0.0
-        but publishes a port, so clients reach it at localhost and the
-        connection itself is local."""
-        if "exposed" in request.node.name:
-            pytest.skip("a localhost Host is genuinely foreign to a remote server")
+    def test_loopback_hosts_are_always_served(self, post, host: str) -> None:
+        """This is the documented Docker flow, and it needs both parameters.
+
+        A published container port is reached at ``localhost``, but inside the
+        container the connection lands on the container's own address — a
+        non-loopback scope. So the case that actually ships is a localhost Host
+        arriving on a non-loopback server, and only running this against both
+        scopes covers it.
+        """
         assert post({"Host": host}) == 200
+
+    def test_the_docker_flow_survives_a_matching_origin(self, post) -> None:
+        """A browser client at the published port sends an Origin too."""
+        assert (
+            post({"Host": "localhost:8000", "Origin": "http://localhost:8000"}) == 200
+        )
 
     def test_a_hostname_the_server_does_not_know_is_refused(self, post) -> None:
         """The documented cost of strict validation, recorded deliberately.

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -184,6 +184,18 @@ class TestLegitimateClientsStillWork:
             pytest.skip("a localhost Host is genuinely foreign to a remote server")
         assert post({"Host": host}) == 200
 
+    def test_a_hostname_the_server_does_not_know_is_refused(self, post) -> None:
+        """The documented cost of strict validation, recorded deliberately.
+
+        Reaching an exposed server by its machine name rather than its address
+        gets 421, because the guard trusts the address it is bound to and
+        nothing else. Every documented flow uses localhost or an address, so
+        this affects setups that are not described here — and it fails loudly
+        with a status that names the problem, rather than quietly working until
+        someone points a domain at the same address.
+        """
+        assert post({"Host": "my-laptop.local:8000"}) == 421
+
     def test_the_servers_own_address_is_served(self, post, base_url: str) -> None:
         """However the server is reached, its own address is a valid Host.
 

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -43,7 +43,7 @@ _ACCEPT = {
 _HOST_ORIGIN_PROTECTION = True
 
 # Every case runs against both, because the guard can behave differently
-# depending on which address the connection landed on — and it once did. The
+# depending on which address the connection landed on, and it once did. The
 # "auto" setting validated only a loopback connection, so a server bound to
 # 0.0.0.0 and reached over its LAN address checked nothing, which is precisely
 # the exposed case. A suite that only ever connected to 127.0.0.1 could not see
@@ -80,7 +80,7 @@ def post(base_url: str, monkeypatch: pytest.MonkeyPatch):
             path="/mcp", host_origin_protection=_HOST_ORIGIN_PROTECTION
         )
         # base_url sets the ASGI scope's server address, which is what decides
-        # whether the connection looks local — not the Host header.
+        # whether the connection looks local, not the Host header.
         # raise_server_exceptions=False so a rejection arrives as its status
         # rather than an exception, which is what a real client would see.
         with TestClient(
@@ -178,8 +178,8 @@ class TestLegitimateClientsStillWork:
         """This is the documented Docker flow, and it needs both parameters.
 
         A published container port is reached at ``localhost``, but inside the
-        container the connection lands on the container's own address — a
-        non-loopback scope. So the case that actually ships is a localhost Host
+        container the connection lands on the container's own address, which
+        is a non-loopback scope. So the case that ships is a localhost Host
         arriving on a non-loopback server, and only running this against both
         scopes covers it.
         """
@@ -197,8 +197,8 @@ class TestLegitimateClientsStillWork:
         Reaching an exposed server by its machine name rather than its address
         gets 421, because the guard trusts the address it is bound to and
         nothing else. Every documented flow uses localhost or an address, so
-        this affects setups that are not described here — and it fails loudly
-        with a status that names the problem, rather than quietly working until
+        this affects setups that are not described here, and it fails loudly
+        with a status that names the problem rather than quietly working until
         someone points a domain at the same address.
         """
         assert post({"Host": "my-laptop.local:8000"}) == 421

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -100,6 +100,43 @@ class TestDnsRebinding:
     def test_an_attacker_host_is_refused_even_without_an_origin(self, post) -> None:
         assert post({"Host": "attacker.example"}) == 421
 
+    @pytest.mark.parametrize(
+        ("label", "host"),
+        [
+            ("a subdomain of a trusted name", "localhost.attacker.example"),
+            ("a trusted name as a prefix", "127.0.0.1.attacker.example"),
+        ],
+    )
+    def test_a_host_that_merely_contains_a_trusted_name_is_refused(
+        self, post, label: str, host: str
+    ) -> None:
+        """The Host must be a trusted name, not merely contain one.
+
+        Both of these are domains an attacker can register and point anywhere,
+        and a substring check would wave them through.
+        """
+        assert post({"Host": host}) == 421
+
+    @pytest.mark.parametrize(
+        "spoof",
+        [{"X-Forwarded-Host": "127.0.0.1"}, {"Forwarded": "host=127.0.0.1"}],
+        ids=["x-forwarded-host", "forwarded"],
+    )
+    def test_a_forwarded_header_cannot_vouch_for_an_attacker_host(
+        self, post, spoof: dict[str, str]
+    ) -> None:
+        """Proxy headers are attacker-supplied here; only the real Host counts.
+
+        Nothing trustworthy sits in front of this server by default, so a guard
+        that believed these would accept any request that claimed to have come
+        through a proxy.
+        """
+        assert post({"Host": "attacker.example", **spoof}) == 421
+
+    def test_a_null_origin_is_refused(self, post) -> None:
+        """What a sandboxed iframe or a redirected form sends."""
+        assert post({"Origin": "null"}) == 403
+
 
 class TestLegitimateClientsStillWork:
     """A guard that breaks the documented flows would simply be turned off."""
@@ -108,7 +145,15 @@ class TestLegitimateClientsStillWork:
         """Every non-browser client: curl, the MCP inspector, an SDK."""
         assert post({}) == 200
 
-    @pytest.mark.parametrize("host", ["127.0.0.1:8000", "localhost:8000", "[::1]:8000"])
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1:8000",
+            "localhost:8000",
+            "[::1]:8000",  # IPv6 literal, bracketed as a URL carries it
+            "LOCALHOST:8000",  # case is not part of a hostname
+        ],
+    )
     def test_loopback_hosts_are_served(self, post, host: str) -> None:
         """Including the documented Docker flow, which publishes a port and is
         reached at localhost even though the container binds 0.0.0.0."""

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -40,11 +40,27 @@ _ACCEPT = {
 # What cli_main passes for a streamable-http server. Spelled out rather than
 # imported from it, so weakening the guard there has to be done here too and
 # cannot pass unnoticed.
-_HOST_ORIGIN_PROTECTION = "auto"
+_HOST_ORIGIN_PROTECTION = True
+
+# Every case runs against both, because the guard can behave differently
+# depending on which address the connection landed on — and it once did. The
+# "auto" setting validated only a loopback connection, so a server bound to
+# 0.0.0.0 and reached over its LAN address checked nothing, which is precisely
+# the exposed case. A suite that only ever connected to 127.0.0.1 could not see
+# that. 192.0.2.1 is the reserved documentation range, so it is never a real
+# host on the machine running these tests.
+_LOOPBACK_URL = "http://127.0.0.1:8000"
+_EXPOSED_URL = "http://192.0.2.1:8000"
+
+
+@pytest.fixture(params=[_LOOPBACK_URL, _EXPOSED_URL], ids=["loopback", "exposed"])
+def base_url(request: pytest.FixtureRequest) -> str:
+    """The address the server is reached at, loopback or not."""
+    return str(request.param)
 
 
 @pytest.fixture
-def post(monkeypatch: pytest.MonkeyPatch):
+def post(base_url: str, monkeypatch: pytest.MonkeyPatch):
     """POST an initialize request through the real app, returning the status."""
     # The lifespan starts browser setup and a handoff poller, neither of which
     # this file is about; stubbing them keeps the request path real while the
@@ -63,11 +79,15 @@ def post(monkeypatch: pytest.MonkeyPatch):
         app = create_mcp_server().http_app(
             path="/mcp", host_origin_protection=_HOST_ORIGIN_PROTECTION
         )
+        # base_url sets the ASGI scope's server address, which is what decides
+        # whether the connection looks local — not the Host header.
         # raise_server_exceptions=False so a rejection arrives as its status
         # rather than an exception, which is what a real client would see.
-        with TestClient(app, raise_server_exceptions=False) as client:
+        with TestClient(
+            app, base_url=base_url, raise_server_exceptions=False
+        ) as client:
             return client.post(
-                "http://127.0.0.1:8000/mcp",
+                f"{base_url}/mcp",
                 json=_INITIALIZE,
                 headers={**_ACCEPT, **headers},
             ).status_code
@@ -154,10 +174,23 @@ class TestLegitimateClientsStillWork:
             "LOCALHOST:8000",  # case is not part of a hostname
         ],
     )
-    def test_loopback_hosts_are_served(self, post, host: str) -> None:
-        """Including the documented Docker flow, which publishes a port and is
-        reached at localhost even though the container binds 0.0.0.0."""
+    def test_loopback_hosts_are_served_on_a_local_server(
+        self, request: pytest.FixtureRequest, post, host: str
+    ) -> None:
+        """Including the documented Docker flow: the container binds 0.0.0.0
+        but publishes a port, so clients reach it at localhost and the
+        connection itself is local."""
+        if "exposed" in request.node.name:
+            pytest.skip("a localhost Host is genuinely foreign to a remote server")
         assert post({"Host": host}) == 200
 
-    def test_a_loopback_origin_is_served(self, post) -> None:
-        assert post({"Origin": "http://localhost:8000"}) == 200
+    def test_the_servers_own_address_is_served(self, post, base_url: str) -> None:
+        """However the server is reached, its own address is a valid Host.
+
+        This is what keeps a deliberately exposed server usable: clients arrive
+        under the address it is bound to, and strict validation accepts it
+        without anything having to be configured.
+        """
+        host = base_url.removeprefix("http://")
+        assert post({"Host": host}) == 200
+        assert post({"Host": host, "Origin": base_url}) == 200

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -1,0 +1,118 @@
+"""What the HTTP transport actually answers, as opposed to how it is wired.
+
+These drive the real ASGI app rather than asserting on arguments passed to a
+mock. That distinction is the reason this file exists: an earlier version of the
+guard passed every wiring assertion while still serving a DNS-rebinding request,
+because the tests checked which keyword arguments were forwarded and never asked
+what the resulting server would reply.
+
+The attack: a site the user merely visits resolves its own domain to this
+server's address, so the user's own browser sends the request from inside the
+network. A firewall cannot see it, and neither can a bind address. What gives it
+away is the ``Host`` header, which carries the attacker's domain rather than a
+name this server answers to.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.testclient import TestClient
+
+from linkedin_mcp_server.server import create_mcp_server
+
+_INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "1.0"},
+    },
+}
+_ACCEPT = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+
+# What cli_main passes for a streamable-http server. Spelled out rather than
+# imported from it, so weakening the guard there has to be done here too and
+# cannot pass unnoticed.
+_HOST_ORIGIN_PROTECTION = "auto"
+
+
+@pytest.fixture
+def post(monkeypatch: pytest.MonkeyPatch):
+    """POST an initialize request through the real app, returning the status."""
+    # The lifespan starts browser setup and a handoff poller, neither of which
+    # this file is about; stubbing them keeps the request path real while the
+    # server startup stays offline.
+    import linkedin_mcp_server.server as server_module
+
+    monkeypatch.setattr(server_module, "initialize_bootstrap", MagicMock())
+    monkeypatch.setattr(server_module, "get_runtime_policy", MagicMock())
+    monkeypatch.setattr(
+        server_module, "start_background_browser_setup_if_needed", AsyncMock()
+    )
+    monkeypatch.setattr(server_module, "watch_for_handoff_requests", AsyncMock())
+    monkeypatch.setattr(server_module, "close_browser", AsyncMock())
+
+    def _post(headers: dict[str, str]) -> int:
+        app = create_mcp_server().http_app(
+            path="/mcp", host_origin_protection=_HOST_ORIGIN_PROTECTION
+        )
+        # raise_server_exceptions=False so a rejection arrives as its status
+        # rather than an exception, which is what a real client would see.
+        with TestClient(app, raise_server_exceptions=False) as client:
+            return client.post(
+                "http://127.0.0.1:8000/mcp",
+                json=_INITIALIZE,
+                headers={**_ACCEPT, **headers},
+            ).status_code
+
+    return _post
+
+
+class TestDnsRebinding:
+    def test_an_attacker_domain_is_refused(self, post) -> None:
+        """The real attack: Host and Origin both name the attacker's site.
+
+        They agree with each other, so origin validation alone has nothing to
+        object to. Only the Host check notices that this server was never known
+        by that name.
+        """
+        assert (
+            post(
+                {
+                    "Host": "attacker.example",
+                    "Origin": "http://attacker.example",
+                }
+            )
+            == 421
+        )
+
+    def test_a_cross_origin_request_is_refused(self, post) -> None:
+        """The simpler case, where the Origin does not match the Host."""
+        assert post({"Origin": "https://attacker.example"}) == 403
+
+    def test_an_attacker_host_is_refused_even_without_an_origin(self, post) -> None:
+        assert post({"Host": "attacker.example"}) == 421
+
+
+class TestLegitimateClientsStillWork:
+    """A guard that breaks the documented flows would simply be turned off."""
+
+    def test_a_client_without_an_origin_is_served(self, post) -> None:
+        """Every non-browser client: curl, the MCP inspector, an SDK."""
+        assert post({}) == 200
+
+    @pytest.mark.parametrize("host", ["127.0.0.1:8000", "localhost:8000", "[::1]:8000"])
+    def test_loopback_hosts_are_served(self, post, host: str) -> None:
+        """Including the documented Docker flow, which publishes a port and is
+        reached at localhost even though the container binds 0.0.0.0."""
+        assert post({"Host": host}) == 200
+
+    def test_a_loopback_origin_is_served(self, post) -> None:
+        assert post({"Origin": "http://localhost:8000"}) == 200

--- a/uv.lock
+++ b/uv.lock
@@ -565,19 +565,19 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.2"
+version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/f7/5188565d1b93ad611cbd80bf473e7ad669d1f3b689c4bedcd304e1ec3472/fastmcp-3.4.4.tar.gz", hash = "sha256:378202e26ec15b23819d9a1c0d1b0ebda096bc712720532010a0b82a45c2b1df", size = 28796458, upload-time = "2026-07-09T00:32:41.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/3cef84ba38a23dca1e1e776bfda8a35ab3c7a6c94a8ca81d0715de6dd3c5/fastmcp-3.4.4-py3-none-any.whl", hash = "sha256:f86f208713212260068cf55c32936839eee856fefc7808e18a032f31eb0f718e", size = 8019, upload-time = "2026-07-09T00:32:39.411Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.2"
+version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -587,9 +587,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/79/f35661c6a1d76dfbe17a079f912d96fffcfdd40fad5a9144bb9e7dfb1fdf/fastmcp_slim-3.4.4.tar.gz", hash = "sha256:dcaa3e0be2127d7eacdce592c2ef0039204923dc0ec396454615cb4a3275b078", size = 590203, upload-time = "2026-07-09T00:32:20.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
+    { url = "https://files.pythonhosted.org/packages/16/91/321e0b2e9ed70d0628b17ddaec76fc7b09f3e1d5d290f70bf101a2890142/fastmcp_slim-3.4.4-py3-none-any.whl", hash = "sha256:9d3a6327b9ee835188eb7323fc3b5d4cd061631b48da8ece56794bb538972505", size = 765158, upload-time = "2026-07-09T00:32:19.11Z" },
 ]
 
 [package.optional-dependencies]
@@ -1066,7 +1066,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "fastmcp", specifier = ">=3.4.4" },
     { name = "inquirer", specifier = ">=3.4.0" },
     { name = "packaging", specifier = ">=26.2" },
     { name = "patchright", specifier = ">=1.40.0" },


### PR DESCRIPTION
The `streamable-http` transport served requests from any origin. A website the user merely visits can resolve its own domain to this server's address, so the request arrives from the user's own browser, where a firewall cannot see it and neither can a bind address. It would have been answered with the logged-in LinkedIn session behind it. Measured against this server before the fix: `Origin: https://attacker.example` returned 200.

The cause is a default. FastMCP builds its session manager without transport security settings, and the SDK disables host and origin validation when none are supplied. Raising the FastMCP version alone changes nothing; the protection stays off until it is asked for.

Both halves of the guard matter, and the Host check carries most of the weight. A rebinding attack sends its own domain as *both* Host and Origin, so those agree and origin validation has nothing to object to. What gives the request away is that the Host names a server this one was never known by. Requests with no `Origin` at all stay served, which is every non-browser client.

Getting there took two corrections worth recording, because both passed the tests at the time. An earlier revision wildcarded the Host check off for exposed binds to keep them reachable, which accepted the attacker's Host and defeated the guard. The revision after that used FastMCP's `auto` policy, which only validates when the accepted connection landed on a loopback address, so a server bound to `0.0.0.0` and reached over its LAN address checked nothing at all. Every measurement that called itself an exposed bind had connected over `127.0.0.1`: the bind address was exposed, the connection was not. Strict validation applies either way.

Strict accepts localhost and the address a connection arrives on, which covers the documented flows including Docker, where a published port is reached at localhost. It does not accept a DNS name, so a machine name on the network or a public name in front of a reverse proxy is refused with 421. That is deliberate and now documented next to the exposed-bind example, along with the two ways out, rewriting the upstream Host or listing the name, because an unexplained refusal is how a guard like this ends up switched off.

Answering the interactive transport prompt used to leave the stored transport at `stdio` while an HTTP server ran. Both the bind warning and the gate that decides whether reading the local browser cookie is safe read that value, so a server listening on every interface looked private to them. The answer is now recorded and the configuration re-validated.

Only servers started with `--transport streamable-http` have a listener at all. The endpoint still has no authentication, so the bind address remains the boundary, and the warning about that fired only for a literal `0.0.0.0` or `::`, meaning a LAN address named outright warned about nothing. Loopback classification now resolves address literals through `ipaddress`, covering all of `127/8`, IPv4-mapped forms and case or trailing-dot spellings of `localhost`; names still fail closed, since DNS can point anywhere.

The wiring tests passed through both broken revisions, because they asserted on the keyword arguments handed to `mcp.run` and never asked what the server replies. `tests/test_transport_security.py` drives the real ASGI app instead, and runs every case against both a loopback and a non-loopback server address, which is the distinction the second bug hid behind. Reverting to `auto` fails nine of them, all on the exposed side.

Verified with 963 tests, plus end-to-end checks against real sockets reached over both loopback and a LAN address.

## Synthetic prompt

> The streamable-http MCP endpoint accepts requests from any origin, so a visited website can reach it by DNS rebinding and drive tools with the logged-in LinkedIn session. Enable host and origin validation on every connection, not just local ones, without breaking the documented Docker flow. Fix the exposed-bind warning so it covers every address reachable from outside the machine, and test it by asking a running server what it answers rather than by checking how it was configured.
