### PR TITLE
test(lease): run the profile lease on every platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,30 @@ jobs:
         run: uv run pytest --cov --cov-report=term-missing -n auto -v -s
 
       - run: uv cache prune --ci
+
+  # The lease coordinates server processes through kernel file locks, and the
+  # Windows backend is a different implementation from the POSIX one
+  # (LockFileEx rather than flock). The Ubuntu job above never executes it, so
+  # these two files run on every platform we ship on. Serial by choice: the
+  # tests spawn their own competing processes, and xdist would only add
+  # scheduling noise on top of that.
+  profile-lease-platforms:
+    name: Profile lease (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+
+      - run: uv sync --group dev
+
+      - name: Run profile lease tests
+        run: uv run pytest tests/test_profile_lease.py tests/test_profile_lease_integration.py
+
+      - run: uv cache prune --ci

--- a/linkedin_mcp_server/profile_lease.py
+++ b/linkedin_mcp_server/profile_lease.py
@@ -54,6 +54,19 @@ class ProfileLeaseUnavailableError(RuntimeError):
     """Raised when the profile lease could not be acquired in time."""
 
 
+# The single Windows error meaning "someone else holds it". Anything else,
+# whether a bad handle, access denied or an invalid parameter, is a real
+# failure, and reporting it as contention would leave the lease permanently
+# and silently busy. Defined outside the Windows-only block so the classification can be
+# tested on any platform; the branch itself only ever runs on Windows.
+_ERROR_LOCK_VIOLATION = 33
+
+
+def _windows_failure_is_contention(error_code: int) -> bool:
+    """Whether a failed ``LockFileEx`` call means the lock is simply held."""
+    return error_code == _ERROR_LOCK_VIOLATION
+
+
 # --------------------------------------------------------------------------- #
 # Platform backends
 # --------------------------------------------------------------------------- #
@@ -131,11 +144,6 @@ def _unlock(fd: int) -> None:
 if not _HAS_FCNTL and _HAS_WINDOWS_LOCKS:  # pragma: no cover - Windows
     _LOCKFILE_EXCLUSIVE_LOCK = 0x00000002
     _LOCKFILE_FAIL_IMMEDIATELY = 0x00000001
-    # The one failure that means "someone else holds it" rather than "the call
-    # was wrong". Anything else is a real error and must not be mistaken for
-    # contention, or the lease would report a permanently busy profile and the
-    # handoff probe would close a working browser for no reason.
-    _ERROR_LOCK_VIOLATION = 33
     _LOCK_BYTES = 1
 
     class _Overlapped(ctypes.Structure):
@@ -162,7 +170,7 @@ if not _HAS_FCNTL and _HAS_WINDOWS_LOCKS:  # pragma: no cover - Windows
 
     # ``ctypes`` raises AttributeError for a symbol the DLL does not export, and
     # this runs at import time. Both have existed since Windows XP, so a failure
-    # here means something is badly wrong — but it must surface as our own
+    # here means something is badly wrong, but it must surface as our own
     # refusal rather than as an unexplained import error on server startup.
     if not hasattr(_kernel32, "LockFileEx") or not hasattr(_kernel32, "UnlockFileEx"):
         raise ProfileLeaseUnavailableError(
@@ -174,7 +182,7 @@ if not _HAS_FCNTL and _HAS_WINDOWS_LOCKS:  # pragma: no cover - Windows
 
     # Without explicit argtypes ctypes passes Python ints as C int, truncating
     # a pointer-sized HANDLE on 64-bit. Windows guarantees handle values fit in
-    # 32 bits, so this happens to survive — but the prototype is still wrong,
+    # 32 bits, so this happens to survive, but the prototype is still wrong,
     # and nothing about that guarantee covers the OVERLAPPED pointer.
     _lock_file_ex = _kernel32.LockFileEx
     _lock_file_ex.argtypes = [
@@ -216,7 +224,7 @@ if not _HAS_FCNTL and _HAS_WINDOWS_LOCKS:  # pragma: no cover - Windows
         ):
             return True
         error = _get_last_error()
-        if error == _ERROR_LOCK_VIOLATION:
+        if _windows_failure_is_contention(error):
             return False
         cause = _win_error(error)
         raise ProfileLeaseUnavailableError(
@@ -257,15 +265,29 @@ def _acquire_locked_fd(path: Path, *, exclusive: bool) -> int | None:
     """
     for _ in range(3):
         fd = _open_lock_file(path)
-        if not _try_lock(fd, exclusive=exclusive):
-            os.close(fd)
-            return None
-        if os.fstat(fd).st_nlink > 0:
-            return fd
-        # The path was unlinked while we locked it: our inode is orphaned and
-        # protects nothing. Drop it and retry against the live path.
-        _unlock(fd)
-        os.close(fd)
+        locked = False
+        try:
+            if not _try_lock(fd, exclusive=exclusive):
+                return None
+            locked = True
+            if os.fstat(fd).st_nlink > 0:
+                keep = fd
+                fd = -1  # handed to the caller; not ours to close below
+                return keep
+        finally:
+            # The lock backend raises for a genuine failure, such as a bad
+            # handle or a platform with no locking, and the handoff probe
+            # swallows that so a broken signal cannot make an owner give up its
+            # browser. Without this the descriptor would escape on every poll.
+            if fd != -1:
+                if locked:
+                    _unlock(fd)
+                try:
+                    os.close(fd)
+                except OSError:
+                    logger.debug("Closing lock descriptor failed", exc_info=True)
+        # The path was unlinked while we held the lock: our inode is orphaned
+        # and protects nothing. Retry against the live path.
     raise ProfileLeaseUnavailableError(
         f"The lock file {path} keeps being replaced; refusing to continue."
     )
@@ -378,8 +400,8 @@ class ProfileLease:
                 # Close it, do not merely forget it. fork duplicates the
                 # descriptor, and the kernel lock lives as long as *any* copy is
                 # open. A child that only cleared its bookkeeping would keep the
-                # parent's lease alive after the parent died — leaving every
-                # other process locked out until the child happened to exit.
+                # parent's lease alive after the parent died, locking every
+                # other process out until the child happened to exit.
                 # Never unlock first: that would drop the lock the parent still
                 # believes it holds, both descriptions being the same one.
                 try:
@@ -549,6 +571,26 @@ class _Announcement:
 # --------------------------------------------------------------------------- #
 
 _leases: dict[Path, ProfileLease] = {}
+
+
+def _discard_inherited_leases() -> None:
+    """Drop every lease the child inherited, immediately after a fork.
+
+    Waiting for the child to touch a lease is not enough, and no amount of
+    checking inside individual methods would be: a child that never mentions
+    the lease still inherited the descriptor, and the kernel lock lives as long
+    as any copy of it is open. Such a child silently holds its parent's lease,
+    locking every other process out until it happens to exit, with nothing in
+    its own state to explain why.
+
+    Registered rather than polled, so it also covers a child that forks again.
+    """
+    for lease in _leases.values():
+        lease._reset_if_forked()
+
+
+if hasattr(os, "register_at_fork"):  # pragma: no branch - POSIX
+    os.register_at_fork(after_in_child=_discard_inherited_leases)
 
 
 def get_profile_lease(source_profile_dir: Path | None = None) -> ProfileLease:

--- a/linkedin_mcp_server/profile_lease.py
+++ b/linkedin_mcp_server/profile_lease.py
@@ -70,7 +70,11 @@ if not _HAS_FCNTL:  # pragma: no cover - Windows
         import ctypes
         from ctypes import wintypes
 
-        _HAS_WINDOWS_LOCKS = True
+        # Probed here rather than assumed: the block below binds kernel32 at
+        # import time, and an ImportError or a missing symbol there would take
+        # the whole server down with an obscure message instead of the explicit
+        # "no usable file locking" refusal that _try_lock raises.
+        _HAS_WINDOWS_LOCKS = hasattr(ctypes, "WinDLL")
     except ImportError:
         _HAS_WINDOWS_LOCKS = False
 else:  # pragma: no cover - POSIX
@@ -99,8 +103,9 @@ def _try_lock(fd: int, *, exclusive: bool) -> bool:
 
     raise ProfileLeaseUnavailableError(
         "This platform provides no usable file locking, so concurrent server "
-        "processes cannot be prevented from corrupting the LinkedIn profile. "
-        "Run only one server process against this profile directory."
+        "processes cannot be prevented from corrupting the shared Chromium "
+        "profile directory that holds your logged-in session. Run only one "
+        "server process against this profile directory."
     )
 
 
@@ -114,22 +119,83 @@ def _unlock(fd: int) -> None:
         return
 
     if _HAS_WINDOWS_LOCKS:  # pragma: no cover - Windows
-        _windows_unlock(fd)
+        try:
+            _windows_unlock(fd)
+        except OSError:
+            # Same tolerance as the POSIX branch above. Release runs from
+            # teardown paths where the descriptor may already be closed, and
+            # ``msvcrt.get_osfhandle`` raises OSError for a closed one.
+            logger.debug("Unlock failed (ignored)", exc_info=True)
 
 
 if not _HAS_FCNTL and _HAS_WINDOWS_LOCKS:  # pragma: no cover - Windows
     _LOCKFILE_EXCLUSIVE_LOCK = 0x00000002
     _LOCKFILE_FAIL_IMMEDIATELY = 0x00000001
+    # The one failure that means "someone else holds it" rather than "the call
+    # was wrong". Anything else is a real error and must not be mistaken for
+    # contention, or the lease would report a permanently busy profile and the
+    # handoff probe would close a working browser for no reason.
+    _ERROR_LOCK_VIOLATION = 33
     _LOCK_BYTES = 1
 
     class _Overlapped(ctypes.Structure):
+        # Internal/InternalHigh are ULONG_PTR, so pointer-sized on both 32- and
+        # 64-bit. c_size_t matches; a plain c_ulong would not.
         _fields_ = [
-            ("Internal", wintypes.LPVOID),
-            ("InternalHigh", wintypes.LPVOID),
+            ("Internal", ctypes.c_size_t),
+            ("InternalHigh", ctypes.c_size_t),
             ("Offset", wintypes.DWORD),
             ("OffsetHigh", wintypes.DWORD),
             ("hEvent", wintypes.HANDLE),
         ]
+
+    # ``WinDLL``, ``get_last_error`` and ``WinError`` exist only on Windows, so
+    # they are resolved dynamically: a type checker running on another platform
+    # cannot see them and would report the module as having no such member.
+    _win_dll = getattr(ctypes, "WinDLL")
+    _get_last_error = getattr(ctypes, "get_last_error")
+    _win_error = getattr(ctypes, "WinError")
+
+    # use_last_error keeps GetLastError from being clobbered between the call
+    # and our read of it.
+    _kernel32 = _win_dll("kernel32", use_last_error=True)
+
+    # ``ctypes`` raises AttributeError for a symbol the DLL does not export, and
+    # this runs at import time. Both have existed since Windows XP, so a failure
+    # here means something is badly wrong — but it must surface as our own
+    # refusal rather than as an unexplained import error on server startup.
+    if not hasattr(_kernel32, "LockFileEx") or not hasattr(_kernel32, "UnlockFileEx"):
+        raise ProfileLeaseUnavailableError(
+            "kernel32 does not export LockFileEx/UnlockFileEx, so concurrent "
+            "server processes cannot be prevented from corrupting the shared "
+            "Chromium profile directory that holds your logged-in session. Run "
+            "only one server process against this profile directory."
+        )
+
+    # Without explicit argtypes ctypes passes Python ints as C int, truncating
+    # a pointer-sized HANDLE on 64-bit. Windows guarantees handle values fit in
+    # 32 bits, so this happens to survive — but the prototype is still wrong,
+    # and nothing about that guarantee covers the OVERLAPPED pointer.
+    _lock_file_ex = _kernel32.LockFileEx
+    _lock_file_ex.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_Overlapped),
+    ]
+    _lock_file_ex.restype = wintypes.BOOL
+
+    _unlock_file_ex = _kernel32.UnlockFileEx
+    _unlock_file_ex.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_Overlapped),
+    ]
+    _unlock_file_ex.restype = wintypes.BOOL
 
     def _handle(fd: int) -> int:
         import msvcrt
@@ -138,25 +204,31 @@ if not _HAS_FCNTL and _HAS_WINDOWS_LOCKS:  # pragma: no cover - Windows
         # checker running on another platform cannot see it.
         return getattr(msvcrt, "get_osfhandle")(fd)
 
-    def _kernel32():  # type: ignore[no-untyped-def]
-        return getattr(ctypes, "windll").kernel32
-
     def _windows_try_lock(fd: int, *, exclusive: bool) -> bool:
         flags = _LOCKFILE_FAIL_IMMEDIATELY
         if exclusive:
             flags |= _LOCKFILE_EXCLUSIVE_LOCK
+        # Zero-initialised by ctypes, so the lock starts at offset 0 and hEvent
+        # is NULL, which LockFileEx accepts for a synchronous call.
         overlapped = _Overlapped()
-        return bool(
-            _kernel32().LockFileEx(
-                _handle(fd), flags, 0, _LOCK_BYTES, 0, ctypes.byref(overlapped)
-            )
-        )
+        if _lock_file_ex(
+            _handle(fd), flags, 0, _LOCK_BYTES, 0, ctypes.byref(overlapped)
+        ):
+            return True
+        error = _get_last_error()
+        if error == _ERROR_LOCK_VIOLATION:
+            return False
+        cause = _win_error(error)
+        raise ProfileLeaseUnavailableError(
+            f"LockFileEx failed for descriptor {fd}: {cause}"
+        ) from cause
 
     def _windows_unlock(fd: int) -> None:
         overlapped = _Overlapped()
-        _kernel32().UnlockFileEx(
+        if not _unlock_file_ex(
             _handle(fd), 0, _LOCK_BYTES, 0, ctypes.byref(overlapped)
-        )
+        ):
+            raise _win_error(_get_last_error())
 
 
 # --------------------------------------------------------------------------- #
@@ -200,11 +272,16 @@ def _acquire_locked_fd(path: Path, *, exclusive: bool) -> int | None:
 
 
 def _release_locked_fd(fd: int) -> None:
-    _unlock(fd)
+    # The close is in a finally so an unexpected unlock failure cannot leak the
+    # descriptor. Closing it releases the lock regardless, which is the outcome
+    # that matters; leaking it would hold the profile until the process exits.
     try:
-        os.close(fd)
-    except OSError:
-        logger.debug("Closing lock descriptor failed (ignored)", exc_info=True)
+        _unlock(fd)
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            logger.debug("Closing lock descriptor failed (ignored)", exc_info=True)
 
 
 # --------------------------------------------------------------------------- #
@@ -246,12 +323,24 @@ class ProfileLease:
 
     @property
     def held(self) -> bool:
-        """Whether this process currently holds the lease."""
+        """Whether this process currently holds the lease.
+
+        Runs the fork reset rather than merely reporting ``False`` for a foreign
+        owner: a child that only *asked* whether it held the lease would keep the
+        inherited descriptor open, and with it the parent's kernel lock.
+        """
+        self._reset_if_forked()
         return self._fd is not None and self._owner_pid == os.getpid()
 
     @property
     def held_seconds(self) -> float:
-        """How long the lease has been held, or 0.0 when it is not."""
+        """How long the lease has been held, or 0.0 when it is not.
+
+        Also resets after a fork; without it a child would report the parent's
+        hold time, and the min-hold window would decide against a duration this
+        process never spent holding anything.
+        """
+        self._reset_if_forked()
         if self._acquired_at is None:
             return 0.0
         return time.monotonic() - self._acquired_at
@@ -279,11 +368,27 @@ class ProfileLease:
         """Drop inherited state after a fork: the child does not own the lock."""
         if self._owner_pid is not None and self._owner_pid != os.getpid():
             logger.debug("Discarding profile lease state inherited across fork")
+            inherited_fd = self._fd
             self._fd = None
             self._refs = 0
             self._owner_pid = None
             self._acquired_at = None
             self._browser_open = False
+            if inherited_fd is not None:
+                # Close it, do not merely forget it. fork duplicates the
+                # descriptor, and the kernel lock lives as long as *any* copy is
+                # open. A child that only cleared its bookkeeping would keep the
+                # parent's lease alive after the parent died — leaving every
+                # other process locked out until the child happened to exit.
+                # Never unlock first: that would drop the lock the parent still
+                # believes it holds, both descriptions being the same one.
+                try:
+                    os.close(inherited_fd)
+                except OSError:
+                    logger.debug(
+                        "Closing the inherited lock descriptor failed (ignored)",
+                        exc_info=True,
+                    )
 
     # -- acquisition ------------------------------------------------------- #
 
@@ -408,6 +513,15 @@ class _Announcement:
     def __init__(self, path: Path) -> None:
         self._path = path
         self._fd: int | None = None
+
+    @property
+    def holds_lock(self) -> bool:
+        """Whether the shared lock was actually taken.
+
+        Announcing degrades to a no-op rather than failing a tool call, so this
+        distinguishes "waiting, and the owner can see it" from "waiting quietly".
+        """
+        return self._fd is not None
 
     def __enter__(self) -> _Announcement:
         try:

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -64,7 +64,15 @@ async def browser_lifespan(app: FastMCP) -> AsyncIterator[dict[str, Any]]:
             try:
                 await handoff_watch
             except asyncio.CancelledError:
-                pass
+                # Only the cancellation we just asked for is ours to absorb.
+                # While the watcher winds down, one aimed at this task arrives
+                # as the same exception, and a bare pass would swallow it,
+                # leaving whoever asked us to stop with a teardown that
+                # reported success. cancelling() counts the requests made
+                # against *this* task, which is what tells the two apart.
+                task = asyncio.current_task()
+                if task is not None and task.cancelling():
+                    raise
             except Exception:
                 # A poller that already died re-raises here. Swallowing it keeps
                 # shutdown on course; leaving Chromium running on the shared

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -7,7 +7,6 @@ person profiles, company data, job information, and session management capabilit
 
 import asyncio
 import logging
-from contextlib import suppress
 from typing import Any, AsyncIterator
 
 from fastmcp import FastMCP
@@ -61,9 +60,22 @@ async def browser_lifespan(app: FastMCP) -> AsyncIterator[dict[str, Any]]:
     finally:
         logger.info("LinkedIn MCP Server shutting down...")
         handoff_watch.cancel()
-        with suppress(asyncio.CancelledError):
-            await handoff_watch
-        await close_browser()
+        try:
+            try:
+                await handoff_watch
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                # A poller that already died re-raises here. Swallowing it keeps
+                # shutdown on course; leaving Chromium running on the shared
+                # profile is the corruption this whole mechanism exists to
+                # prevent, and it matters more than the reason the poll failed.
+                logger.warning("Profile handoff watcher failed", exc_info=True)
+        finally:
+            # In a finally, not after the except, so a BaseException the poller
+            # raised still closes the browser on its way out. Those are not ours
+            # to swallow, but they are also no reason to abandon the profile.
+            await close_browser()
 
 
 def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> FastMCP:

--- a/tests/helpers/profile_lease_worker.py
+++ b/tests/helpers/profile_lease_worker.py
@@ -70,10 +70,35 @@ def _critical(auth_root: str, log_path: str, rounds: int) -> int:
 
 
 def _announce(auth_root: str, seconds: float) -> int:
+    """Hold a shared lock on the handoff file, reporting whether it was taken.
+
+    Retries briefly first. An owner probing the same file exclusively holds it
+    for a few microseconds at a time, and losing that race is transient and
+    expected — unlike a platform whose shared locks do not coexist at all, which
+    is the failure this reports.
+    """
     lease = _lease(auth_root)
-    with lease.announce():
+    deadline = time.monotonic() + 5
+    while True:
+        announcement = lease.announce()
+        announcement.__enter__()
+        # Reported rather than assumed: announcing degrades to a silent no-op
+        # when the lock cannot be had, so a caller waiting only for "ANNOUNCED"
+        # would be satisfied by a backend whose shared locks are really
+        # exclusive, and every handoff test would pass proving nothing.
+        if announcement.holds_lock:
+            break
+        announcement.__exit__(None, None, None)
+        if time.monotonic() >= deadline:
+            print("ANNOUNCE_FAILED", flush=True)
+            return 1
+        time.sleep(0.01)
+
+    try:
         print("ANNOUNCED", flush=True)
         time.sleep(seconds)
+    finally:
+        announcement.__exit__(None, None, None)
     print("WITHDRAWN", flush=True)
     return 0
 

--- a/tests/helpers/profile_lease_worker.py
+++ b/tests/helpers/profile_lease_worker.py
@@ -74,7 +74,7 @@ def _announce(auth_root: str, seconds: float) -> int:
 
     Retries briefly first. An owner probing the same file exclusively holds it
     for a few microseconds at a time, and losing that race is transient and
-    expected — unlike a platform whose shared locks do not coexist at all, which
+    expected, unlike a platform whose shared locks do not coexist at all, which
     is the failure this reports.
     """
     lease = _lease(auth_root)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,13 @@ import pytest
 
 from linkedin_mcp_server.config.schema import (
     AppConfig,
+    BROWSER_HANDOFF_MARGIN_SECONDS,
     BrowserConfig,
     ConfigurationError,
+    DEFAULT_BROWSER_IDLE_TIMEOUT_SECONDS,
+    DEFAULT_BROWSER_MIN_HOLD_SECONDS,
+    DEFAULT_BROWSER_WAIT_SECONDS,
+    MAX_BROWSER_WAIT_SECONDS,
     MAX_LOGIN_INLINE_WAIT_SECONDS,
     ServerConfig,
     is_loopback_host,
@@ -58,6 +63,127 @@ class TestBrowserConfig:
         config = BrowserConfig(login_inline_wait_seconds=120)
         config.validate()  # Clamps, does not raise
         assert config.login_inline_wait_seconds == MAX_LOGIN_INLINE_WAIT_SECONDS
+
+
+class TestProfileSharingConfig:
+    """The wait/hold/idle values that govern cross-process browser handoff.
+
+    The clamping here is not cosmetic. A hold window that outlasts the waiter's
+    budget produces spurious busy errors, and a wait budget above the ceiling
+    eats into the client's own request timeout.
+    """
+
+    def test_defaults(self):
+        config = BrowserConfig()
+        assert config.browser_wait_seconds == DEFAULT_BROWSER_WAIT_SECONDS
+        assert config.browser_min_hold_seconds == DEFAULT_BROWSER_MIN_HOLD_SECONDS
+        assert (
+            config.browser_idle_timeout_seconds == DEFAULT_BROWSER_IDLE_TIMEOUT_SECONDS
+        )
+
+    def test_defaults_leave_room_for_a_handover(self):
+        """The shipped defaults must satisfy their own clamp, unchanged."""
+        config = BrowserConfig()
+        config.validate()
+
+        assert config.browser_wait_seconds == DEFAULT_BROWSER_WAIT_SECONDS
+        assert config.browser_min_hold_seconds == DEFAULT_BROWSER_MIN_HOLD_SECONDS
+        assert (
+            config.browser_min_hold_seconds
+            <= config.browser_wait_seconds - BROWSER_HANDOFF_MARGIN_SECONDS
+        )
+
+    def test_zero_is_allowed(self):
+        """0 is a meaningful sentinel for all three, not a missing value.
+
+        Wait 0 reports busy at once, hold 0 hands over after every call, idle 0
+        keeps the browser until the process exits.
+        """
+        BrowserConfig(
+            browser_wait_seconds=0,
+            browser_min_hold_seconds=0,
+            browser_idle_timeout_seconds=0,
+        ).validate()  # No error
+
+    @pytest.mark.parametrize(
+        "bad_value", [-1.0, float("nan"), float("inf"), float("-inf")]
+    )
+    def test_rejects_a_negative_or_non_finite_wait(self, bad_value):
+        with pytest.raises(ConfigurationError, match="browser_wait_seconds"):
+            BrowserConfig(browser_wait_seconds=bad_value).validate()
+
+    @pytest.mark.parametrize(
+        "bad_value", [-1.0, float("nan"), float("inf"), float("-inf")]
+    )
+    def test_rejects_a_negative_or_non_finite_hold(self, bad_value):
+        with pytest.raises(ConfigurationError, match="browser_min_hold_seconds"):
+            BrowserConfig(browser_min_hold_seconds=bad_value).validate()
+
+    @pytest.mark.parametrize(
+        "bad_value", [-1.0, float("nan"), float("inf"), float("-inf")]
+    )
+    def test_rejects_a_negative_or_non_finite_idle_timeout(self, bad_value):
+        with pytest.raises(ConfigurationError, match="browser_idle_timeout_seconds"):
+            BrowserConfig(browser_idle_timeout_seconds=bad_value).validate()
+
+    def test_clamps_wait_to_the_ceiling(self):
+        config = BrowserConfig(browser_wait_seconds=120, browser_min_hold_seconds=0)
+        config.validate()  # Clamps, does not raise
+        assert config.browser_wait_seconds == MAX_BROWSER_WAIT_SECONDS
+
+    def test_clamps_hold_below_the_wait_budget(self):
+        """A hold window as long as the wait budget would time every waiter out.
+
+        The owner notices on a one-second poll and then has to tear Chromium
+        down, so the window has to end a margin *before* the waiter's deadline,
+        not at it.
+        """
+        config = BrowserConfig(browser_wait_seconds=10, browser_min_hold_seconds=10)
+        config.validate()
+
+        assert config.browser_min_hold_seconds == 10 - BROWSER_HANDOFF_MARGIN_SECONDS
+
+    def test_clamping_the_wait_also_reins_in_the_hold(self):
+        """The hold clamp reads the wait *after* it was itself clamped.
+
+        Ordering matters: against the raw 600s the hold would look fine, and a
+        180s hold would survive a 45s budget.
+        """
+        config = BrowserConfig(browser_wait_seconds=600, browser_min_hold_seconds=180)
+        config.validate()
+
+        assert config.browser_wait_seconds == MAX_BROWSER_WAIT_SECONDS
+        assert (
+            config.browser_min_hold_seconds
+            == MAX_BROWSER_WAIT_SECONDS - BROWSER_HANDOFF_MARGIN_SECONDS
+        )
+
+    def test_hold_never_clamps_below_zero(self):
+        """A wait budget under the margin must not produce a negative window."""
+        config = BrowserConfig(browser_wait_seconds=1, browser_min_hold_seconds=30)
+        config.validate()
+
+        assert config.browser_min_hold_seconds == 0.0
+
+    def test_zero_wait_disables_the_hold_window(self):
+        """Reporting busy immediately leaves nothing for a hold window to buy."""
+        config = BrowserConfig(browser_wait_seconds=0, browser_min_hold_seconds=25)
+        config.validate()
+
+        assert config.browser_min_hold_seconds == 0.0
+
+    def test_hold_inside_the_budget_is_left_alone(self):
+        config = BrowserConfig(browser_wait_seconds=45, browser_min_hold_seconds=5)
+        config.validate()
+
+        assert config.browser_min_hold_seconds == 5
+
+    def test_a_long_idle_timeout_is_not_clamped(self):
+        """The idle timer is a backstop, not part of the request path."""
+        config = BrowserConfig(browser_idle_timeout_seconds=86_400)
+        config.validate()
+
+        assert config.browser_idle_timeout_seconds == 86_400
 
 
 class TestServerConfig:
@@ -430,6 +556,82 @@ class TestLoaders:
         # validate() clamps in one place for both env and CLI paths.
         config.validate()
         assert config.browser.login_inline_wait_seconds == MAX_LOGIN_INLINE_WAIT_SECONDS
+
+    @pytest.mark.parametrize(
+        ("env_key", "attribute"),
+        [
+            ("BROWSER_WAIT", "browser_wait_seconds"),
+            ("BROWSER_MIN_HOLD", "browser_min_hold_seconds"),
+            ("BROWSER_IDLE_TIMEOUT", "browser_idle_timeout_seconds"),
+        ],
+    )
+    def test_load_from_env_profile_sharing(self, monkeypatch, env_key, attribute):
+        monkeypatch.setenv(env_key, "12.5")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert getattr(config.browser, attribute) == 12.5
+
+    @pytest.mark.parametrize(
+        ("env_key", "attribute"),
+        [
+            ("BROWSER_WAIT", "browser_wait_seconds"),
+            ("BROWSER_MIN_HOLD", "browser_min_hold_seconds"),
+            ("BROWSER_IDLE_TIMEOUT", "browser_idle_timeout_seconds"),
+        ],
+    )
+    def test_load_from_env_profile_sharing_zero(self, monkeypatch, env_key, attribute):
+        """0 has to survive the loader: it is a sentinel, not an empty value."""
+        monkeypatch.setenv(env_key, "0")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert getattr(config.browser, attribute) == 0.0
+
+    @pytest.mark.parametrize(
+        "env_key", ["BROWSER_WAIT", "BROWSER_MIN_HOLD", "BROWSER_IDLE_TIMEOUT"]
+    )
+    @pytest.mark.parametrize("bad_value", ["abc", "-5", "nan", "inf", "-inf"])
+    def test_load_from_env_invalid_profile_sharing(
+        self, monkeypatch, env_key, bad_value
+    ):
+        monkeypatch.setenv(env_key, bad_value)
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        with pytest.raises(ConfigurationError, match=f"Invalid {env_key}"):
+            load_from_env(AppConfig())
+
+    @pytest.mark.parametrize(
+        ("flag", "attribute"),
+        [
+            ("--browser-wait", "browser_wait_seconds"),
+            ("--browser-min-hold", "browser_min_hold_seconds"),
+            ("--browser-idle-timeout", "browser_idle_timeout_seconds"),
+        ],
+    )
+    def test_load_from_args_profile_sharing(self, monkeypatch, flag, attribute):
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", flag, "8"])
+        from linkedin_mcp_server.config.loaders import load_from_args
+
+        config = load_from_args(AppConfig())
+        assert getattr(config.browser, attribute) == 8.0
+
+    def test_profile_sharing_clamped_at_validate_not_in_the_loader(self, monkeypatch):
+        """One clamp, applied after both loaders, so CLI and env agree."""
+        monkeypatch.setenv("BROWSER_WAIT", "99")
+        monkeypatch.setenv("BROWSER_MIN_HOLD", "99")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.browser_wait_seconds == 99.0
+        assert config.browser.browser_min_hold_seconds == 99.0
+
+        config.validate()
+        assert config.browser.browser_wait_seconds == MAX_BROWSER_WAIT_SECONDS
+        assert (
+            config.browser.browser_min_hold_seconds
+            == MAX_BROWSER_WAIT_SECONDS - BROWSER_HANDOFF_MARGIN_SECONDS
+        )
 
     @pytest.mark.parametrize(
         ("value", "expected"),

--- a/tests/test_profile_lease.py
+++ b/tests/test_profile_lease.py
@@ -276,7 +276,7 @@ class TestAsyncAcquire:
         afterwards would pass either way. What actually matters is that the
         handoff file is never touched, because announcing and withdrawing around
         every acquisition is what an owner's own next probe would misread as a
-        waiter — and hand the browser straight back to nobody.
+        waiter, and hand the browser straight back to nobody.
         """
         lease = ProfileLease(tmp_path)
         announcements = 0
@@ -501,8 +501,22 @@ class TestRegistry:
             "lease.held",
             "lease.held_seconds",
             "lease.browser_open",
+            # Public methods that have no reason to check for a fork, and the
+            # case that decides the design: a child touching the lease at all is
+            # a coincidence, not something to rely on.
+            "lease.handoff_requested()",
+            "lease.mark_browser_closed()",
+            "pass  # touches nothing",
         ],
-        ids=["explicit", "held", "held_seconds", "browser_open"],
+        ids=[
+            "explicit",
+            "held",
+            "held_seconds",
+            "browser_open",
+            "handoff_requested",
+            "mark_browser_closed",
+            "no_touch",
+        ],
     )
     def test_a_forked_child_does_not_keep_the_lease_alive(
         self, tmp_path: Path, trigger: str
@@ -512,8 +526,13 @@ class TestRegistry:
         ``fork`` duplicates the descriptor, and the kernel lock survives as long
         as *any* copy is open. A child that only forgot it had inherited one
         would keep the parent's lease held after the parent died, locking every
-        other process out until the child happened to exit — with nothing in the
-        child's own state to explain why.
+        other process out until the child happened to exit, with nothing in
+        the child's own state to explain why.
+
+        The ``no_touch`` case is why this is handled at ``fork`` time rather
+        than inside the accessors: a child that never mentions the lease has
+        still inherited it, so no amount of checking on entry could ever cover
+        every path.
 
         Every accessor a child could plausibly touch first is covered, not just
         the private reset: reading ``held`` and getting an honest ``False`` is
@@ -522,13 +541,15 @@ class TestRegistry:
         The child outlives the parent here, which is the shape of a server that
         spawns a helper and then exits.
         """
+        # Through the registry, which is how every caller in the server obtains
+        # a lease and the only place that can know what a fork must discard.
         script = textwrap.dedent(f"""
             import os, sys, time
             sys.path.insert(0, {str(Path(__file__).resolve().parents[1])!r})
             from pathlib import Path
-            from linkedin_mcp_server.profile_lease import ProfileLease
+            from linkedin_mcp_server.profile_lease import get_profile_lease
 
-            lease = ProfileLease(Path({str(tmp_path)!r}))
+            lease = get_profile_lease(Path({str(tmp_path)!r}) / "profile")
             assert lease.try_acquire()
             lease.mark_browser_open()
             if os.fork() == 0:
@@ -704,6 +725,82 @@ class TestDegradedSignals:
         monkeypatch.setattr(module, "_open_lock_file", always_unlink)
         with pytest.raises(ProfileLeaseUnavailableError, match="keeps being"):
             ProfileLease(tmp_path).try_acquire()
+
+    @pytest.mark.parametrize(
+        ("error_code", "is_contention"),
+        [
+            (33, True),  # ERROR_LOCK_VIOLATION: someone else holds it
+            (6, False),  # ERROR_INVALID_HANDLE
+            (5, False),  # ERROR_ACCESS_DENIED
+            (87, False),  # ERROR_INVALID_PARAMETER
+            (997, False),  # ERROR_IO_PENDING: async only, not our call
+            (0, False),
+        ],
+    )
+    def test_only_a_lock_violation_counts_as_contention(
+        self, error_code: int, is_contention: bool
+    ) -> None:
+        """Windows reports "held" and "the call was wrong" the same way.
+
+        Treating every failure as contention would make the lease report a
+        permanently busy profile no client could ever use, and would make the
+        handoff probe close a working browser on the strength of an error. The
+        matrix job cannot catch a regression here, because a healthy run never
+        produces anything but 33, so the classification is pinned directly.
+        """
+        from linkedin_mcp_server.profile_lease import _windows_failure_is_contention
+
+        assert _windows_failure_is_contention(error_code) is is_contention
+
+    def test_a_failing_backend_does_not_leak_descriptors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A lock backend that raises must not leave the file open.
+
+        The handoff probe swallows that failure so a broken signal cannot make
+        an owner give up a working browser, and the poller runs every second,
+        so a descriptor escaping here accumulates one per poll for the life of
+        the process.
+        """
+        from linkedin_mcp_server import profile_lease as module
+
+        opened: list[int] = []
+        real_open = module._open_lock_file
+
+        def spy(path: Path) -> int:
+            fd = real_open(path)
+            opened.append(fd)
+            return fd
+
+        def refuse(fd: int, *, exclusive: bool) -> bool:
+            raise ProfileLeaseUnavailableError("backend unavailable")
+
+        monkeypatch.setattr(module, "_open_lock_file", spy)
+        monkeypatch.setattr(module, "_try_lock", refuse)
+
+        for _ in range(3):
+            with pytest.raises(ProfileLeaseUnavailableError):
+                module._acquire_locked_fd(tmp_path / "probe.lock", exclusive=True)
+
+        assert opened, "the spy never ran, so this proves nothing"
+        for fd in set(opened):
+            with pytest.raises(OSError):
+                os.fstat(fd)  # a live descriptor would not raise
+
+    def test_cleanup_tolerates_an_already_closed_descriptor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cleanup must not raise on top of the failure that triggered it."""
+        from linkedin_mcp_server import profile_lease as module
+
+        def close_then_refuse(fd: int, *, exclusive: bool) -> bool:
+            os.close(fd)  # as if something else had already reclaimed it
+            raise ProfileLeaseUnavailableError("backend unavailable")
+
+        monkeypatch.setattr(module, "_try_lock", close_then_refuse)
+
+        with pytest.raises(ProfileLeaseUnavailableError, match="backend unavailable"):
+            module._acquire_locked_fd(tmp_path / "probe.lock", exclusive=True)
 
     def test_an_inconclusive_probe_does_not_hand_the_profile_over(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_profile_lease.py
+++ b/tests/test_profile_lease.py
@@ -9,9 +9,12 @@ spawn ``tests/helpers/profile_lease_worker.py`` with ``subprocess``.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
+import signal
 import subprocess
 import sys
+import textwrap
 import time
 from pathlib import Path
 
@@ -25,6 +28,20 @@ from linkedin_mcp_server.profile_lease import (
 
 _WORKER = Path(__file__).parent / "helpers" / "profile_lease_worker.py"
 
+# Windows opens files without FILE_SHARE_DELETE, so a path cannot be unlinked
+# while a descriptor on it is open. The inode race these tests provoke is
+# therefore unreachable there, and the guard against it is POSIX-only.
+_posix_unlink_race = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows refuses to unlink a file that is still open",
+)
+
+# The forked child inherits the parent's descriptor, which has no Windows
+# equivalent: CreateProcess starts from nothing.
+_posix_fork = pytest.mark.skipif(
+    not hasattr(os, "fork"), reason="fork is unavailable on this platform"
+)
+
 
 def _spawn(*args: str) -> subprocess.Popen[str]:
     return subprocess.Popen(
@@ -36,16 +53,24 @@ def _spawn(*args: str) -> subprocess.Popen[str]:
 
 
 def _await_line(process: subprocess.Popen[str], expected: str) -> None:
+    """Block until *process* prints a line containing *expected*.
+
+    Fails rather than hangs when the worker dies early: ``readline`` returns
+    ``""`` forever at EOF, so a loop that only checked its content would spin
+    until the CI job's own timeout with no explanation.
+    """
     assert process.stdout is not None
-    deadline = time.monotonic() + 20
-    while time.monotonic() < deadline:
+    while True:
         line = process.stdout.readline()
         if expected in line:
             return
-        if line == "" and process.poll() is not None:
+        if line == "":  # EOF: the worker will never say anything more
             break
     stderr = process.stderr.read() if process.stderr else ""
-    raise AssertionError(f"worker never reported {expected!r}: {stderr}")
+    raise AssertionError(
+        f"worker exited (status {process.poll()}) without reporting "
+        f"{expected!r}: {stderr}"
+    )
 
 
 class TestSingleProcess:
@@ -79,6 +104,28 @@ class TestSingleProcess:
         lease = ProfileLease(tmp_path)
         with lease.hold():
             assert lease.held
+        assert not lease.held
+
+    def test_a_hold_released_twice_drops_only_one_reference(
+        self, tmp_path: Path
+    ) -> None:
+        """Explicit release plus context-manager exit must not double-count.
+
+        Otherwise a handle released early would take a *second* caller's
+        reference with it on the way out, freeing the profile while that caller
+        still has a browser open on it.
+        """
+        lease = ProfileLease(tmp_path)
+        outer = lease.hold()  # someone else's reference
+        handle = lease.hold()
+
+        handle.release()
+        handle.release()  # idempotent, not a second decrement
+        with handle:
+            pass
+
+        assert lease.held, "an extra release dropped another caller's reference"
+        outer.release()
         assert not lease.held
 
     def test_hold_raises_when_another_process_owns_it(self, tmp_path: Path) -> None:
@@ -152,6 +199,14 @@ class TestHandoff:
             lease.release()
 
     def test_several_waiters_can_announce_at_once(self, tmp_path: Path) -> None:
+        """Shared locks must genuinely coexist, not merely appear to.
+
+        The worker reports ANNOUNCE_FAILED rather than ANNOUNCED when it could
+        not take the shared lock, because announcing degrades to a silent no-op
+        by design. Without that distinction a platform whose "shared" locks are
+        really exclusive would pass this test with only the first waiter holding
+        anything, and the whole handoff protocol would rest on nothing.
+        """
         lease = ProfileLease(tmp_path)
         lease.try_acquire()
         waiters = [_spawn("announce", str(tmp_path), "10") for _ in range(3)]
@@ -159,11 +214,25 @@ class TestHandoff:
             for waiter in waiters:
                 _await_line(waiter, "ANNOUNCED")
             assert lease.handoff_requested()
+            # Still running means still holding: a worker that failed to
+            # announce exits immediately with status 1.
+            for waiter in waiters:
+                assert waiter.poll() is None, "a waiter dropped its announcement"
         finally:
             for waiter in waiters:
                 waiter.kill()
                 waiter.wait(timeout=10)
             lease.release()
+
+    def test_an_announcement_reports_whether_it_took_the_lock(
+        self, tmp_path: Path
+    ) -> None:
+        """The signal the worker relies on, pinned in-process too."""
+        lease = ProfileLease(tmp_path)
+        with lease.announce() as announcement:
+            assert announcement.holds_lock is True
+        with lease.announce() as second:
+            assert second.holds_lock is True, "shared locks must coexist serially"
 
     async def test_new_owner_does_not_hand_over_to_itself(self, tmp_path: Path) -> None:
         """A waiter must drop its announcement before it becomes the owner.
@@ -195,6 +264,36 @@ class TestAsyncAcquire:
         finally:
             holder.wait(timeout=10)
             lease.release()
+
+    async def test_a_free_lease_is_taken_without_announcing(
+        self, tmp_path: Path
+    ) -> None:
+        """The uncontended path must not touch the handoff file at all.
+
+        Asserted by counting calls, not by inspecting the aftermath: an
+        implementation that announced and then withdrew cleanly would leave
+        exactly the same observable state, so checking ``handoff_requested()``
+        afterwards would pass either way. What actually matters is that the
+        handoff file is never touched, because announcing and withdrawing around
+        every acquisition is what an owner's own next probe would misread as a
+        waiter — and hand the browser straight back to nobody.
+        """
+        lease = ProfileLease(tmp_path)
+        announcements = 0
+        real_announce = lease.announce
+
+        def counting_announce() -> object:
+            nonlocal announcements
+            announcements += 1
+            return real_announce()
+
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(lease, "announce", counting_announce)
+            assert await lease.acquire(timeout=0)
+
+        assert announcements == 0, "the uncontended path announced"
+        assert lease.held
+        lease.release()
 
     async def test_times_out_while_the_owner_keeps_it(self, tmp_path: Path) -> None:
         lease = ProfileLease(tmp_path)
@@ -267,6 +366,23 @@ class TestCrossProcess:
         assert current is None
         assert len(tokens) == 200
 
+    @staticmethod
+    def _assert_freed_within(tmp_path: Path, message: str, seconds: float = 10) -> None:
+        """Poll until the lease is free, rather than probing once.
+
+        POSIX frees a ``flock`` synchronously with the dying process, but
+        Windows documents lock release at process exit as depending on
+        available resources, so a single immediate probe would flake there.
+        """
+        lease = ProfileLease(tmp_path)
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            if lease.try_acquire():
+                lease.release()
+                return
+            time.sleep(0.05)
+        raise AssertionError(message)
+
     def test_kernel_releases_the_lease_when_the_holder_dies(
         self, tmp_path: Path
     ) -> None:
@@ -275,24 +391,20 @@ class TestCrossProcess:
         _await_line(victim, "HELD")
         victim.wait(timeout=10)
 
-        lease = ProfileLease(tmp_path)
-        assert lease.try_acquire(), "a dead holder still blocks the lease"
-        lease.release()
+        self._assert_freed_within(tmp_path, "a dead holder still blocks the lease")
 
-    def test_kill_nine_releases_the_lease(self, tmp_path: Path) -> None:
+    def test_forced_termination_releases_the_lease(self, tmp_path: Path) -> None:
+        """``Popen.kill`` is SIGKILL on POSIX and TerminateProcess on Windows.
+
+        Neither gives the holder a chance to clean up, which is the point: the
+        operating system has to free the lock on its own.
+        """
         holder = _spawn("hold", str(tmp_path), "30")
         _await_line(holder, "HELD")
         holder.kill()
         holder.wait(timeout=10)
 
-        lease = ProfileLease(tmp_path)
-        deadline = time.monotonic() + 10
-        while time.monotonic() < deadline:
-            if lease.try_acquire():
-                lease.release()
-                return
-            time.sleep(0.05)
-        raise AssertionError("SIGKILL did not free the lease")
+        self._assert_freed_within(tmp_path, "forced termination did not free the lease")
 
     def test_a_late_waiter_is_not_starved(self, tmp_path: Path) -> None:
         log = tmp_path / "starve.log"
@@ -320,12 +432,10 @@ class TestRegistry:
         second = get_profile_lease(tmp_path / "profile")
         assert first is second
 
+    @_posix_fork
     @pytest.mark.filterwarnings("ignore:This process .* is multi-threaded")
     def test_fork_does_not_inherit_ownership(self, tmp_path: Path) -> None:
         """A forked child must not believe it owns the parent's lease."""
-        if not hasattr(os, "fork"):  # pragma: no cover - Windows
-            pytest.skip("fork is unavailable on this platform")
-
         lease = ProfileLease(tmp_path)
         assert lease.try_acquire()
         read_fd, write_fd = os.pipe()
@@ -343,3 +453,329 @@ class TestRegistry:
         lease.release()
 
         assert child_says_held == b"0", "child inherited ownership state"
+
+    @_posix_fork
+    @pytest.mark.filterwarnings("ignore:This process .* is multi-threaded")
+    def test_the_reset_does_not_drop_the_living_parents_lock(
+        self, tmp_path: Path
+    ) -> None:
+        """A child clearing its inherited state must not unlock for the parent.
+
+        Both descriptions refer to the same open file, so unlocking in the child
+        would release the lock the parent still believes it holds. Closing is
+        safe; unlocking is not.
+        """
+        lease = ProfileLease(tmp_path)
+        assert lease.try_acquire()
+        lease.mark_browser_open()
+
+        read_fd, write_fd = os.pipe()
+        pid = os.fork()
+        if pid == 0:  # pragma: no cover - child
+            os.close(read_fd)
+            # browser_open must reset too: the browser belongs to the parent.
+            inherited_browser = lease.browser_open
+            lease.release()  # a no-op; there is nothing of ours to release
+            os.write(write_fd, b"1" if inherited_browser else b"0")
+            os.close(write_fd)
+            os._exit(0)
+
+        os.close(write_fd)
+        child_says_browser_open = os.read(read_fd, 1)
+        os.close(read_fd)
+        os.waitpid(pid, 0)
+
+        assert child_says_browser_open == b"0"
+        assert lease.held
+        assert lease.browser_open is True
+        # An outside process must still be locked out: the child's cleanup must
+        # not have handed our profile away.
+        assert not ProfileLease(tmp_path).try_acquire()
+        lease.release()
+
+    @_posix_fork
+    @pytest.mark.parametrize(
+        "trigger",
+        [
+            "lease._reset_if_forked()",
+            "lease.held",
+            "lease.held_seconds",
+            "lease.browser_open",
+        ],
+        ids=["explicit", "held", "held_seconds", "browser_open"],
+    )
+    def test_a_forked_child_does_not_keep_the_lease_alive(
+        self, tmp_path: Path, trigger: str
+    ) -> None:
+        """Clearing the bookkeeping is not enough; the descriptor must be closed.
+
+        ``fork`` duplicates the descriptor, and the kernel lock survives as long
+        as *any* copy is open. A child that only forgot it had inherited one
+        would keep the parent's lease held after the parent died, locking every
+        other process out until the child happened to exit — with nothing in the
+        child's own state to explain why.
+
+        Every accessor a child could plausibly touch first is covered, not just
+        the private reset: reading ``held`` and getting an honest ``False`` is
+        exactly the case where nothing would otherwise prompt the cleanup.
+
+        The child outlives the parent here, which is the shape of a server that
+        spawns a helper and then exits.
+        """
+        script = textwrap.dedent(f"""
+            import os, sys, time
+            sys.path.insert(0, {str(Path(__file__).resolve().parents[1])!r})
+            from pathlib import Path
+            from linkedin_mcp_server.profile_lease import ProfileLease
+
+            lease = ProfileLease(Path({str(tmp_path)!r}))
+            assert lease.try_acquire()
+            lease.mark_browser_open()
+            if os.fork() == 0:
+                {trigger}
+                print("CHILD_READY:%d" % os.getpid(), flush=True)
+                time.sleep(30)
+                os._exit(0)
+            os._exit(0)  # parent dies still believing it holds the lease
+        """)
+        holder = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        child_pid: int | None = None
+        try:
+            assert holder.stdout is not None
+            while True:
+                line = holder.stdout.readline()
+                if line.startswith("CHILD_READY:"):
+                    child_pid = int(line.split(":", 1)[1])
+                    break
+                if line == "":
+                    stderr = holder.stderr.read() if holder.stderr else ""
+                    raise AssertionError(f"helper never forked a child: {stderr}")
+            holder.wait(timeout=10)  # the parent exits; the child lives on
+
+            lease = ProfileLease(tmp_path)
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if lease.try_acquire():
+                    lease.release()
+                    return
+                time.sleep(0.05)
+            raise AssertionError("the forked child leaked its parent's kernel lock")
+        finally:
+            holder.kill()
+            # The grandchild is not ours to wait on, but leaving it asleep for
+            # 30s would hold the lock through the rest of the run on failure.
+            if child_pid is not None:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.kill(child_pid, signal.SIGKILL)
+
+    def test_stale_ownership_from_another_pid_is_discarded(
+        self, tmp_path: Path
+    ) -> None:
+        """The fork reset, observable without forking.
+
+        The child of a fork exercises this, but its coverage is invisible and
+        its assertions have to travel back through a pipe. Driving it directly
+        pins the behaviour: state recorded under a foreign pid is not ours.
+        """
+        lease = ProfileLease(tmp_path)
+        assert lease.try_acquire()
+        lease.mark_browser_open()
+
+        lease._owner_pid = os.getpid() + 1_000_000  # as if inherited
+
+        assert lease.browser_open is False  # the property runs the reset
+        assert lease.held is False
+        assert lease.held_seconds == 0.0
+        assert lease._fd is None
+        assert lease._refs == 0
+
+    def test_an_already_closed_inherited_descriptor_is_tolerated(
+        self, tmp_path: Path
+    ) -> None:
+        """The reset runs on paths where the descriptor may already be gone.
+
+        Raising here would surface as a failure in whatever ordinary call
+        happened to trigger the reset, long after the fork that caused it.
+        """
+        lease = ProfileLease(tmp_path)
+        assert lease.try_acquire()
+        assert lease._fd is not None
+        os.close(lease._fd)
+        lease._owner_pid = os.getpid() + 1_000_000  # as if inherited
+
+        lease._reset_if_forked()  # must not raise
+
+        assert lease._fd is None
+        assert not lease.held
+
+    def test_marking_the_browser_closed_clears_the_flag(self, tmp_path: Path) -> None:
+        """Only ever called on a *confirmed* close; a timed-out one keeps it."""
+        lease = ProfileLease(tmp_path)
+        lease.mark_browser_open()
+        assert lease.browser_open is True
+
+        lease.mark_browser_closed()
+
+        assert lease.browser_open is False
+
+    def test_leases_are_reset_between_tests(self, tmp_path: Path) -> None:
+        """``reset_leases_for_testing`` must free even a multiply-held lease.
+
+        The autouse fixture calls it after every test. If it dropped only one
+        reference, a leaked lease would silently wedge every later test that
+        touches the same auth root.
+        """
+        from linkedin_mcp_server.profile_lease import reset_leases_for_testing
+
+        lease = get_profile_lease(tmp_path / "profile")
+        assert lease.try_acquire()
+        assert lease.try_acquire()  # a second reference, as middleware + browser
+        assert lease.held
+
+        reset_leases_for_testing()
+
+        assert not lease.held
+        probe = ProfileLease(lease.auth_root)
+        assert probe.try_acquire(), "reset left the kernel lock held"
+        probe.release()
+
+
+class TestDegradedSignals:
+    """Behaviour when the lock files themselves misbehave.
+
+    These paths cannot be reached by ordinary use, only by another process
+    replacing or removing the files. They still have to fail in a defined
+    direction: never silently, and never towards handing the profile away.
+    """
+
+    @_posix_unlink_race
+    def test_an_unlinked_lock_file_is_reacquired(self, tmp_path: Path) -> None:
+        """An orphaned inode protects nothing, so acquisition must retry.
+
+        Without the ``st_nlink`` check two processes end up holding locks on
+        different inodes for the same path and both believe they are the owner.
+        """
+        from linkedin_mcp_server import profile_lease as module
+
+        lease = ProfileLease(tmp_path)
+        lock_path = tmp_path / "profile.lock"
+        real_open = module._open_lock_file
+        attempts: list[int] = []
+
+        def unlink_once(path: Path) -> int:
+            fd = real_open(path)
+            attempts.append(fd)
+            if len(attempts) == 1:
+                path.unlink()  # orphan the inode we just opened
+            return fd
+
+        # A private context rather than the shared fixture: undoing that one
+        # would also revert the autouse profile-directory patches in conftest,
+        # silently unpinning this test from its tmp_path for the rest of the run.
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(module, "_open_lock_file", unlink_once)
+            assert lease.try_acquire()
+
+        assert len(attempts) == 2, "the orphaned inode was accepted"
+        assert lease._fd is not None
+        assert os.fstat(lease._fd).st_nlink > 0
+        assert lock_path.exists()
+        lease.release()
+
+    @_posix_unlink_race
+    def test_a_path_that_keeps_being_replaced_gives_up(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retrying forever would hang a tool call; refuse instead."""
+        from linkedin_mcp_server import profile_lease as module
+
+        real_open = module._open_lock_file
+
+        def always_unlink(path: Path) -> int:
+            fd = real_open(path)
+            path.unlink()
+            return fd
+
+        monkeypatch.setattr(module, "_open_lock_file", always_unlink)
+        with pytest.raises(ProfileLeaseUnavailableError, match="keeps being"):
+            ProfileLease(tmp_path).try_acquire()
+
+    def test_an_inconclusive_probe_does_not_hand_the_profile_over(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fail closed: a broken signal is not evidence that anyone is waiting.
+
+        Reporting a waiter here would make the owner close a working browser on
+        the strength of a signal it could not actually read.
+        """
+        from linkedin_mcp_server import profile_lease as module
+
+        lease = ProfileLease(tmp_path)
+
+        def refuse(path: Path, *, exclusive: bool) -> int | None:
+            raise ProfileLeaseUnavailableError("signal unreadable")
+
+        monkeypatch.setattr(module, "_acquire_locked_fd", refuse)
+        assert lease.handoff_requested() is False
+
+    def test_a_failed_announcement_degrades_to_waiting_quietly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Not being able to announce costs a prompt handoff, not the call."""
+        from linkedin_mcp_server import profile_lease as module
+
+        lease = ProfileLease(tmp_path)
+
+        def refuse(path: Path, *, exclusive: bool) -> int | None:
+            raise ProfileLeaseUnavailableError("signal unreadable")
+
+        monkeypatch.setattr(module, "_acquire_locked_fd", refuse)
+        with lease.announce() as announcement:
+            assert announcement.holds_lock is False
+
+    def test_no_locking_backend_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Running unprotected is the one outcome that must never happen.
+
+        Silently continuing would put us back where we started: two processes on
+        one profile, one silently losing its cookie.
+        """
+        from linkedin_mcp_server import profile_lease as module
+
+        fd = os.open(tmp_path / "probe", os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            monkeypatch.setattr(module, "_HAS_FCNTL", False)
+            monkeypatch.setattr(module, "_HAS_WINDOWS_LOCKS", False)
+            with pytest.raises(
+                ProfileLeaseUnavailableError, match="no usable file locking"
+            ):
+                module._try_lock(fd, exclusive=True)
+            # Unlocking has nothing to undo and must stay silent, or a cleanup
+            # path would raise on top of the original failure.
+            module._unlock(fd)
+        finally:
+            os.close(fd)
+
+    def test_releasing_an_unheld_lease_is_a_no_op(self, tmp_path: Path) -> None:
+        """Release is called from ``finally`` blocks that may not have acquired."""
+        lease = ProfileLease(tmp_path)
+        lease.release()  # must not raise
+        assert not lease.held
+        assert lease.held_seconds == 0.0
+
+    def test_a_closed_descriptor_does_not_break_release(self, tmp_path: Path) -> None:
+        """Release runs during teardown, where descriptors may already be gone."""
+        lease = ProfileLease(tmp_path)
+        assert lease.try_acquire()
+        assert lease._fd is not None
+        os.close(lease._fd)
+
+        lease.release()  # must not raise
+
+        assert not lease.held

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -26,6 +26,27 @@ from linkedin_mcp_server.session_state import clear_auth_state, rotate_source_pr
 _WORKER = Path(__file__).parent / "helpers" / "profile_lease_worker.py"
 
 
+def _await_line(process: subprocess.Popen[str], expected: str) -> None:
+    """Block until *process* prints a line containing *expected*.
+
+    Fails rather than hangs when the worker dies early: ``readline`` returns
+    ``""`` forever at EOF, so a loop that only checked its content would spin
+    until the CI job's own timeout with no explanation.
+    """
+    assert process.stdout is not None
+    while True:
+        line = process.stdout.readline()
+        if expected in line:
+            return
+        if line == "":  # EOF: the worker will never say anything more
+            break
+    stderr = process.stderr.read() if process.stderr else ""
+    raise AssertionError(
+        f"worker exited (status {process.poll()}) without reporting "
+        f"{expected!r}: {stderr}"
+    )
+
+
 def _hold_profile(auth_root: Path, seconds: float) -> subprocess.Popen[str]:
     """Spawn a process that owns *auth_root*'s lease, and wait until it does."""
     process = subprocess.Popen(
@@ -34,13 +55,12 @@ def _hold_profile(auth_root: Path, seconds: float) -> subprocess.Popen[str]:
         stderr=subprocess.PIPE,
         text=True,
     )
-    assert process.stdout is not None
-    deadline = time.monotonic() + 20
-    while time.monotonic() < deadline:
-        if "HELD" in process.stdout.readline():
-            return process
-    process.kill()
-    raise AssertionError("helper never acquired the lease")
+    try:
+        _await_line(process, "HELD")
+    except AssertionError:
+        process.kill()
+        raise
+    return process
 
 
 def _call_context(tool_name: str = "get_person_profile") -> MagicMock:
@@ -290,16 +310,18 @@ class TestIdleOwnerHandsOver:
                     sys.executable,
                     str(_WORKER),
                     "announce",
-                    str(tmp_path / "profile").rsplit("/profile", 1)[0],
+                    # The auth root is the profile's *parent*, which is tmp_path
+                    # itself. Deriving it by trimming the "/profile" suffix off
+                    # the string worked only on POSIX separators.
+                    str(tmp_path),
                     "5",
                 ],
                 stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
             )
             try:
-                assert waiter.stdout is not None
-                while "ANNOUNCED" not in waiter.stdout.readline():
-                    pass
+                _await_line(waiter, "ANNOUNCED")
 
                 # No tool call happens here: only the poller can notice.
                 deadline = time.monotonic() + 5
@@ -338,12 +360,11 @@ class TestPollerDoesNotInterruptWork:
         waiter = subprocess.Popen(
             [sys.executable, str(_WORKER), "announce", str(tmp_path), "5"],
             stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
         )
         try:
-            assert waiter.stdout is not None
-            while "ANNOUNCED" not in waiter.stdout.readline():
-                pass
+            _await_line(waiter, "ANNOUNCED")
 
             with (
                 patch.multiple(
@@ -401,12 +422,11 @@ class TestMinimumHoldWindow:
         waiter = subprocess.Popen(
             [sys.executable, str(_WORKER), "announce", str(tmp_path), "5"],
             stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
         )
         try:
-            assert waiter.stdout is not None
-            while "ANNOUNCED" not in waiter.stdout.readline():
-                pass
+            _await_line(waiter, "ANNOUNCED")
 
             with (
                 patch.multiple(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -143,7 +143,7 @@ class TestBrowserLifespan:
 
         Awaiting a task that already failed re-raises its exception. If that
         propagated out of the teardown, ``close_browser`` would be skipped and
-        Chromium would stay on the shared profile past shutdown — exactly the
+        Chromium would stay on the shared profile past shutdown, which is the
         corruption the lease exists to prevent.
         """
         from linkedin_mcp_server.server import browser_lifespan

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -184,6 +184,55 @@ class TestBrowserLifespan:
 
         close_browser.assert_awaited_once()
 
+    async def test_cancelling_the_lifespan_itself_is_not_swallowed(self, monkeypatch):
+        """Shutdown must not report success after being told to stop.
+
+        Cancelling the watcher and being cancelled ourselves surface as the
+        same exception in the same handler, because a watcher takes a moment to
+        wind down and a cancellation aimed at the teardown lands during exactly
+        that window. Absorbing it would leave whoever asked us to stop waiting
+        on a teardown that claimed to have finished normally.
+        """
+        from linkedin_mcp_server.server import browser_lifespan
+
+        async def watcher():
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                # Stands in for a poller mid-probe: cancellation is requested,
+                # but the task does not finish until it has unwound.
+                await asyncio.sleep(0.5)
+                raise
+
+        close_browser = self._patched(monkeypatch, watcher)
+
+        async def run_server() -> None:
+            # Entered and exited by hand so the cancellation lands *during*
+            # teardown. Cancelling an `async with` body is a different path: it
+            # interrupts the yield and never reaches this handler.
+            lifespan = browser_lifespan(MagicMock())
+            await lifespan.__aenter__()
+            await asyncio.sleep(0.05)  # let the watcher reach its sleep
+
+            task = asyncio.current_task()
+            assert task is not None
+
+            async def cancel_during_teardown() -> None:
+                await asyncio.sleep(0.1)
+                task.cancel()
+
+            asyncio.create_task(cancel_during_teardown())
+            await lifespan.__aexit__(None, None, None)
+
+        server = asyncio.create_task(run_server())
+
+        with pytest.raises(asyncio.CancelledError):
+            await server
+
+        # Still closed: a cancelled shutdown is no reason to leave a browser
+        # running on the shared profile.
+        close_browser.assert_awaited_once()
+
     async def test_teardown_closes_the_browser_when_the_body_raises(self, monkeypatch):
         from linkedin_mcp_server.server import browser_lifespan
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, call
 
 import mcp.types as mt
+import pytest
 from fastmcp import FastMCP
 from fastmcp.server.middleware import MiddlewareContext
 
@@ -88,6 +89,114 @@ class TestSequentialToolExecutionMiddleware:
                 ),
             ]
         )
+
+
+class TestBrowserLifespan:
+    """The lifespan owns the background handoff poller.
+
+    Nothing else starts it, and nothing else stops it. Without the poller an
+    owner that goes idle never notices a waiting process; without the cancel a
+    stdio server would not exit.
+    """
+
+    @staticmethod
+    def _patched(monkeypatch, watcher):
+        """Replace the lifespan's collaborators, returning the close spy."""
+        import linkedin_mcp_server.server as server_module
+
+        monkeypatch.setattr(server_module, "initialize_bootstrap", MagicMock())
+        monkeypatch.setattr(server_module, "get_runtime_policy", MagicMock())
+        monkeypatch.setattr(
+            server_module, "start_background_browser_setup_if_needed", AsyncMock()
+        )
+        monkeypatch.setattr(server_module, "watch_for_handoff_requests", watcher)
+        close_browser = AsyncMock()
+        monkeypatch.setattr(server_module, "close_browser", close_browser)
+        return close_browser
+
+    async def test_poller_runs_for_the_life_of_the_server(self, monkeypatch):
+        from linkedin_mcp_server.server import browser_lifespan
+
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def watcher():
+            started.set()
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        close_browser = self._patched(monkeypatch, watcher)
+
+        async with browser_lifespan(MagicMock()):
+            await asyncio.wait_for(started.wait(), timeout=1)
+            assert not cancelled.is_set()
+            close_browser.assert_not_awaited()
+
+        assert cancelled.is_set()
+        close_browser.assert_awaited_once()
+
+    async def test_a_dead_poller_still_lets_the_browser_close(self, monkeypatch):
+        """A poller that raised must not take the browser down with it.
+
+        Awaiting a task that already failed re-raises its exception. If that
+        propagated out of the teardown, ``close_browser`` would be skipped and
+        Chromium would stay on the shared profile past shutdown — exactly the
+        corruption the lease exists to prevent.
+        """
+        from linkedin_mcp_server.server import browser_lifespan
+
+        async def watcher():
+            raise RuntimeError("poller crashed")
+
+        close_browser = self._patched(monkeypatch, watcher)
+
+        async with browser_lifespan(MagicMock()):
+            # Let the doomed task reach its exception before teardown.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        close_browser.assert_awaited_once()
+
+    async def test_a_fatal_poller_error_still_closes_but_propagates(self, monkeypatch):
+        """A BaseException is not ours to swallow, but the browser still closes.
+
+        ``Exception`` is caught deliberately; ``KeyboardInterrupt`` and friends
+        must keep travelling. What must not happen is that they take the profile
+        with them by skipping the close.
+        """
+        from linkedin_mcp_server.server import browser_lifespan
+
+        class Fatal(BaseException):
+            """Stands in for KeyboardInterrupt, which would abort the run."""
+
+        async def watcher():
+            raise Fatal("fatal")
+
+        close_browser = self._patched(monkeypatch, watcher)
+
+        with pytest.raises(Fatal):
+            async with browser_lifespan(MagicMock()):
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+
+        close_browser.assert_awaited_once()
+
+    async def test_teardown_closes_the_browser_when_the_body_raises(self, monkeypatch):
+        from linkedin_mcp_server.server import browser_lifespan
+
+        async def watcher():
+            await asyncio.sleep(3600)
+
+        close_browser = self._patched(monkeypatch, watcher)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async with browser_lifespan(MagicMock()):
+                raise RuntimeError("boom")
+
+        close_browser.assert_awaited_once()
 
 
 class TestServerVersion:


### PR DESCRIPTION
The profile lease coordinates server processes through kernel file locks, and its Windows backend is a separate implementation built on `LockFileEx` rather than `flock`. CI runs on Ubuntu only, so that code had never executed anywhere. This adds a small matrix job running the two lease test files on macOS and Windows, which is the first time the Windows path runs at all. Writing tests to make that job meaningful surfaced defects in the backend and in the lease itself.

A forked child kept its parent's lease alive. `fork` duplicates the descriptor and the kernel lock survives as long as any copy is open, so a child that outlived its parent held the profile with nothing in its own state to explain why, and a third process stayed locked out until the child happened to exit. Resetting inside the accessors was not enough: a child calling only `handoff_requested()` still leaked, and so did one that touched the lease at all, which no amount of checking on entry could have caught. The reset now runs from a `fork` handler, so an inherited lease is discarded the moment the child exists, including after a nested fork. Closing is safe there but unlocking would not be, since both descriptions refer to the same open file and would release a lock the living parent still believes it holds.

On the Windows side, every `LockFileEx` failure was treated as contention, so a bad handle would have reported a permanently busy profile; only `ERROR_LOCK_VIOLATION` means that. That decision now has a name and is pinned on every platform, because a healthy run only ever produces error 33 and the matrix job would stay green if it regressed. Unlock had none of the `OSError` tolerance the POSIX path has, kernel32 was bound without prototypes, and binding it at import time could have taken the server down with an obscure error instead of the explicit refusal the lease already raises. A backend that raises also leaked the descriptor, which matters because the handoff probe swallows that error by design and the poller runs every second.

The lifespan skipped closing the browser when the handoff poller had died, leaving Chromium on the shared profile past shutdown, which is the corruption the lease exists to prevent reached through its own teardown.

One finding is about the tests rather than the code. The announce worker printed success even when the shared lock was never taken, because announcing degrades to a silent no-op by design. A platform whose shared locks are really exclusive would have passed every handoff test with only the first waiter holding anything, so the new matrix job would have gone green proving nothing. The worker now distinguishes the two cases and retries the genuinely transient race against the owner's probe, and the harness fails on worker EOF rather than spinning until the CI job's own timeout.

Config clamping and the poller's lifespan wiring had no tests at all; both are covered now.

Verified with 1044 tests and no skips, `profile_lease.py` at full line coverage, and mutation tests confirming each fix fails loudly when reverted. The Windows behaviour itself can only be proven by the new CI job, which passes.

## Synthetic prompt

> The profile lease's Windows LockFileEx backend has never run in CI, and config clamping plus the lifespan poller wiring have no tests. Add a platform matrix job running the lease tests on macOS and Windows, write the missing tests, and fix whatever the exercise turns up, verifying each fix with a mutation test.

