### PR TITLE
refactor(server): Attach middleware by what a process does

### DIFF
--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -6,6 +6,7 @@ person profiles, company data, job information, and session management capabilit
 """
 
 import asyncio
+import enum
 import logging
 from typing import Any, AsyncIterator
 
@@ -36,6 +37,38 @@ from linkedin_mcp_server.tools.person import register_person_tools
 from linkedin_mcp_server.tools.post import register_post_tools
 
 logger = logging.getLogger(__name__)
+
+
+class ServerRole(enum.Enum):
+    """Which job a server process does for the shared LinkedIn profile.
+
+    One process per MCP client is the transport's doing, not a choice: a stdio
+    server is spawned per client instance. That makes "who drives Chromium" a
+    property of the process rather than of the code, and every difference below
+    follows from it.
+    """
+
+    #: Drives its own browser and talks to its own client. The historical
+    #: behaviour, and still what an explicit HTTP bind or an embedder gets.
+    DIRECT = "direct"
+
+    #: Drives the browser on behalf of other processes over loopback HTTP.
+    #: Never speaks to an end client, so nothing user-facing belongs here.
+    OWNER = "owner"
+
+    #: Speaks to an end client and forwards to an owner. Never touches
+    #: Chromium, so it must not participate in profile ownership at all.
+    PROXY = "proxy"
+
+    @property
+    def drives_browser(self) -> bool:
+        """Whether this role launches Chromium against the shared profile."""
+        return self in (ServerRole.DIRECT, ServerRole.OWNER)
+
+    @property
+    def faces_a_client(self) -> bool:
+        """Whether an end user reads this server's tool results."""
+        return self in (ServerRole.DIRECT, ServerRole.PROXY)
 
 
 @lifespan
@@ -86,16 +119,35 @@ async def browser_lifespan(app: FastMCP) -> AsyncIterator[dict[str, Any]]:
             await close_browser()
 
 
-def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> FastMCP:
-    """Create and configure the MCP server with all LinkedIn tools."""
+def create_mcp_server(
+    *,
+    tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS,
+    role: ServerRole = ServerRole.DIRECT,
+) -> FastMCP:
+    """Create and configure the MCP server with all LinkedIn tools.
+
+    *role* selects which parts belong to this process. It defaults to
+    :attr:`ServerRole.DIRECT`, which is exactly the historical server, so every
+    existing caller keeps what it had.
+    """
     mcp = FastMCP(
         "mcp-server-linkedin",
         version=__version__,
         lifespan=browser_lifespan,
         mask_error_details=True,
     )
-    mcp.add_middleware(SequentialToolExecutionMiddleware())
-    mcp.add_middleware(UpdateNoticeMiddleware())
+    # Profile ownership belongs to whoever launches Chromium. A process that
+    # only forwards calls must not take the lease: it would either block itself
+    # until its own timeout, or take the lease and leave the process that
+    # actually needs it waiting for one held by a caller that never uses it.
+    if role.drives_browser:
+        mcp.add_middleware(SequentialToolExecutionMiddleware())
+    # The notice is appended to one tool result per process, so it belongs
+    # wherever a user reads results. On a shared owner it would reach whichever
+    # client happened to call first and nobody after that, however many clients
+    # attach over the owner's life.
+    if role.faces_a_client:
+        mcp.add_middleware(UpdateNoticeMiddleware())
 
     # Register all tools
     register_person_tools(mcp, tool_timeout=tool_timeout)

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -56,9 +56,10 @@ class ServerRole(enum.Enum):
     #: Never speaks to an end client, so nothing user-facing belongs here.
     OWNER = "owner"
 
-    #: Speaks to an end client and forwards to an owner. Never touches
-    #: Chromium, so it must not participate in profile ownership at all.
-    PROXY = "proxy"
+    # A forwarding role belongs here too, but only once something actually
+    # forwards. Adding it now would mean a server that registers the local
+    # browser-backed tools and then declines to serialize them, which is a
+    # worse starting point than not having the role at all.
 
     @property
     def drives_browser(self) -> bool:
@@ -68,7 +69,7 @@ class ServerRole(enum.Enum):
     @property
     def faces_a_client(self) -> bool:
         """Whether an end user reads this server's tool results."""
-        return self in (ServerRole.DIRECT, ServerRole.PROXY)
+        return self is ServerRole.DIRECT
 
 
 @lifespan

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,71 @@ from linkedin_mcp_server import __version__
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
-from linkedin_mcp_server.server import create_mcp_server
+from linkedin_mcp_server.server import ServerRole, create_mcp_server
+from linkedin_mcp_server.update_check import UpdateNoticeMiddleware
+
+
+def _has_middleware(mcp: FastMCP, kind: type) -> bool:
+    return any(isinstance(middleware, kind) for middleware in mcp.middleware)
+
+
+class TestServerRoles:
+    """Which middleware each role gets, and why the split has to exist.
+
+    These are not restatements of the implementation: each one pins a failure
+    that is invisible in a single-process test run and only shows up once two
+    processes share a profile.
+    """
+
+    def test_the_default_role_is_the_historical_server(self):
+        # Every existing caller passes only tool_timeout, so the default has to
+        # keep giving them exactly what they had before the split.
+        default = create_mcp_server()
+        direct = create_mcp_server(role=ServerRole.DIRECT)
+
+        for mcp in (default, direct):
+            assert _has_middleware(mcp, SequentialToolExecutionMiddleware)
+            assert _has_middleware(mcp, UpdateNoticeMiddleware)
+
+    def test_a_proxy_never_competes_for_the_profile(self):
+        # A proxy forwards to whoever owns the browser. Taking the profile
+        # lease here would make it wait for a lease it will never use, and the
+        # owner it forwards to would then wait for the lease the proxy holds.
+        mcp = create_mcp_server(role=ServerRole.PROXY)
+
+        assert not _has_middleware(mcp, SequentialToolExecutionMiddleware)
+
+    def test_an_owner_still_serializes_calls(self):
+        # The owner is the process that actually drives Chromium, so it keeps
+        # the serialization the shared profile depends on.
+        mcp = create_mcp_server(role=ServerRole.OWNER)
+
+        assert _has_middleware(mcp, SequentialToolExecutionMiddleware)
+
+    def test_the_update_notice_follows_the_client_not_the_browser(self):
+        # The notice is appended once per process. On a shared owner that means
+        # one client sees it and every later one never does, however long the
+        # owner lives, so it belongs on the processes clients talk to.
+        owner = create_mcp_server(role=ServerRole.OWNER)
+        proxy = create_mcp_server(role=ServerRole.PROXY)
+
+        assert not _has_middleware(owner, UpdateNoticeMiddleware)
+        assert _has_middleware(proxy, UpdateNoticeMiddleware)
+
+    def test_every_role_serves_the_same_tools(self):
+        # The proxy advertises what it forwards, so a tool missing from one
+        # role would silently disappear from a client's list.
+        async def tool_names(role: ServerRole) -> set[str]:
+            tools = await create_mcp_server(role=role).list_tools()
+            return {tool.name for tool in tools}
+
+        direct, owner, proxy = (
+            asyncio.run(tool_names(role))
+            for role in (ServerRole.DIRECT, ServerRole.OWNER, ServerRole.PROXY)
+        )
+
+        assert direct == owner == proxy
+        assert "get_person_profile" in direct
 
 
 class TestSequentialToolExecutionMiddleware:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,45 +36,35 @@ class TestServerRoles:
             assert _has_middleware(mcp, SequentialToolExecutionMiddleware)
             assert _has_middleware(mcp, UpdateNoticeMiddleware)
 
-    def test_a_proxy_never_competes_for_the_profile(self):
-        # A proxy forwards to whoever owns the browser. Taking the profile
-        # lease here would make it wait for a lease it will never use, and the
-        # owner it forwards to would then wait for the lease the proxy holds.
-        mcp = create_mcp_server(role=ServerRole.PROXY)
+    def test_every_role_that_drives_a_browser_serializes_its_calls(self):
+        # The invariant the shared profile depends on: any server that can
+        # reach Chromium takes the lease first. A role added later that skips
+        # this would corrupt the session rather than merely run slowly.
+        for role in ServerRole:
+            mcp = create_mcp_server(role=role)
 
-        assert not _has_middleware(mcp, SequentialToolExecutionMiddleware)
+            assert role.drives_browser
+            assert _has_middleware(mcp, SequentialToolExecutionMiddleware), role
 
-    def test_an_owner_still_serializes_calls(self):
-        # The owner is the process that actually drives Chromium, so it keeps
-        # the serialization the shared profile depends on.
-        mcp = create_mcp_server(role=ServerRole.OWNER)
-
-        assert _has_middleware(mcp, SequentialToolExecutionMiddleware)
-
-    def test_the_update_notice_follows_the_client_not_the_browser(self):
-        # The notice is appended once per process. On a shared owner that means
-        # one client sees it and every later one never does, however long the
-        # owner lives, so it belongs on the processes clients talk to.
+    def test_the_update_notice_goes_only_where_a_user_reads_it(self):
+        # Appended to one tool result per process. On a server shared by many
+        # clients that means the first caller sees it and nobody afterwards
+        # does, however long that server lives.
         owner = create_mcp_server(role=ServerRole.OWNER)
-        proxy = create_mcp_server(role=ServerRole.PROXY)
 
         assert not _has_middleware(owner, UpdateNoticeMiddleware)
-        assert _has_middleware(proxy, UpdateNoticeMiddleware)
 
     def test_every_role_serves_the_same_tools(self):
-        # The proxy advertises what it forwards, so a tool missing from one
-        # role would silently disappear from a client's list.
+        # A tool present in one role and missing from another would disappear
+        # from a client's list depending on how its server happened to start.
         async def tool_names(role: ServerRole) -> set[str]:
             tools = await create_mcp_server(role=role).list_tools()
             return {tool.name for tool in tools}
 
-        direct, owner, proxy = (
-            asyncio.run(tool_names(role))
-            for role in (ServerRole.DIRECT, ServerRole.OWNER, ServerRole.PROXY)
-        )
+        served = {role: asyncio.run(tool_names(role)) for role in ServerRole}
 
-        assert direct == owner == proxy
-        assert "get_person_profile" in direct
+        assert len(set(map(frozenset, served.values()))) == 1
+        assert "get_person_profile" in served[ServerRole.DIRECT]
 
 
 class TestSequentialToolExecutionMiddleware:


### PR DESCRIPTION
Closes #607

`create_mcp_server()` attached `SequentialToolExecutionMiddleware` and `UpdateNoticeMiddleware` to every server, but each answers a different question about the process it runs in. Serialization protects the shared Chromium profile, so it belongs to a process that launches a browser. The update notice is appended once per process, so it belongs to a process an end user reads results from.

This adds a role to `create_mcp_server()` and attaches each middleware where it makes sense. The default is the historical server, so every existing caller is unchanged.

The failure this prevents is not hypothetical. Serialization on a process that does not drive a browser would take the profile lease it never uses and then either wait out its own `browser_wait_seconds` or hold the lease while the process that actually needs it times out. The update notice on a server shared by many clients would reach whichever called first and nobody after that, however long that server lives.

There are two roles rather than three. A forwarding role was written and then removed: nothing forwards yet, so it would have registered the local browser-backed tools and declined to serialize them, which is a worse starting point than not having the role. It returns with the code that gives it something to forward to.

Groundwork for #606; useful on its own for making an implicit assumption explicit and testable.

Verified with 1137 tests, four of them new, covering each role's middleware and that both serve the same tools. The middleware assertion iterates the roles rather than naming them, so one added later cannot quietly skip it.

## Synthetic prompt

> `create_mcp_server()` attaches the sequential-execution and update-notice middleware unconditionally, but one protects the shared browser profile and the other is user-facing. Add a role parameter so each is attached only where it belongs, keeping the current behaviour as the default, and test what breaks if either is attached in the wrong place.