### PR TITLE
feat(security): Store local secrets owner-only on every platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,15 @@ jobs:
 
       - run: uv cache prune --ci
 
-  # The lease coordinates server processes through kernel file locks, and the
-  # Windows backend is a different implementation from the POSIX one
-  # (LockFileEx rather than flock). The Ubuntu job above never executes it, so
-  # these two files run on every platform we ship on. Serial by choice: the
+  # Everything here coordinates or protects state through the operating system
+  # rather than through Python, so each platform runs a different
+  # implementation: the lease locks with flock or with LockFileEx, and
+  # owner-only storage is a permission bit or an access control list. The
+  # Ubuntu job above executes neither Windows path. Serial by choice: the lease
   # tests spawn their own competing processes, and xdist would only add
   # scheduling noise on top of that.
-  profile-lease-platforms:
-    name: Profile lease (${{ matrix.os }})
+  platform-behaviour:
+    name: Platform behaviour (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -70,7 +71,7 @@ jobs:
 
       - run: uv sync --group dev
 
-      - name: Run profile lease tests
-        run: uv run pytest tests/test_profile_lease.py tests/test_profile_lease_integration.py
+      - name: Run platform behaviour tests
+        run: uv run pytest tests/test_profile_lease.py tests/test_profile_lease_integration.py tests/test_private_state.py
 
       - run: uv cache prune --ci

--- a/linkedin_mcp_server/common_utils.py
+++ b/linkedin_mcp_server/common_utils.py
@@ -60,6 +60,25 @@ def harden_linkedin_tree(path: Path) -> None:
             return
 
 
+def is_still_at(fd: int, path: Path) -> bool:
+    """Whether *fd* is still the file that *path* names.
+
+    Compared by device and inode rather than by counting links. A count catches
+    an unlink and misses a rename: the inode keeps its one link while the name
+    comes to mean a different file, so the count still reads as one. A path that
+    has since vanished counts as changed.
+
+    Only meaningful once whatever the caller wanted to establish is in hand.
+    Asked earlier, the answer can stop being true immediately afterwards.
+    """
+    held = os.fstat(fd)
+    try:
+        current = path.stat()
+    except OSError:
+        return False
+    return (held.st_dev, held.st_ino) == (current.st_dev, current.st_ino)
+
+
 def secure_write_text(path: Path, content: str, mode: int = 0o600) -> None:
     """Atomically write *content* to *path* with owner-only permissions.
 

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -22,10 +22,11 @@ keeps out root or an administrator, and no file permission ever has.
 
 from __future__ import annotations
 
+import ctypes
+import ctypes.util
 import logging
 import os
 import stat
-import subprocess
 from pathlib import Path
 
 from linkedin_mcp_server.common_utils import secure_mkdir
@@ -96,6 +97,64 @@ def _harden_posix(path: Path, mode: int) -> None:
     _verify_no_extended_acl(path)
 
 
+#: macOS ``acl_get_file``/``acl_set_file`` selector for the list that sits
+#: alongside the mode bits.
+_ACL_TYPE_EXTENDED = 0x00000100
+
+#: Resolved once, on first use. Two variables rather than a sentinel value, so
+#: "not looked up yet" and "looked up and unavailable" stay distinguishable
+#: without a type the caller has to narrow.
+_libc_resolved = False
+_libc_cache: ctypes.CDLL | None = None
+
+
+def _libc() -> ctypes.CDLL | None:
+    """Return libc with the ACL calls bound, or None where they do not exist.
+
+    Through libc rather than by running ``chmod`` and reading ``ls``. Shelling
+    out made this fail open: measured with no usable ``PATH``, hardening
+    reported success while the token stayed readable by ``everyone``, because
+    neither the clearing nor the check could run and both treated that as
+    nothing to report. A missing library is a fact this can establish; a
+    missing executable was not.
+    """
+    global _libc_cache, _libc_resolved
+    if _libc_resolved:
+        return _libc_cache
+
+    _libc_resolved = True
+    name = ctypes.util.find_library("c")
+    if name is not None:
+        library = ctypes.CDLL(name, use_errno=True)
+        if hasattr(library, "acl_get_file") and hasattr(library, "acl_set_file"):
+            library.acl_get_file.argtypes = [ctypes.c_char_p, ctypes.c_uint]
+            library.acl_get_file.restype = ctypes.c_void_p
+            library.acl_set_file.argtypes = [
+                ctypes.c_char_p,
+                ctypes.c_uint,
+                ctypes.c_void_p,
+            ]
+            library.acl_set_file.restype = ctypes.c_int
+            library.acl_init.argtypes = [ctypes.c_int]
+            library.acl_init.restype = ctypes.c_void_p
+            library.acl_free.argtypes = [ctypes.c_void_p]
+            library.acl_free.restype = ctypes.c_int
+            _libc_cache = library
+    return _libc_cache
+
+
+def _has_extended_acl(path: Path) -> bool:
+    """Whether *path* carries an access list beyond its permission bits."""
+    library = _libc()
+    if library is None:  # pragma: no cover - no ACL support to report on
+        return False
+    handle = library.acl_get_file(str(path).encode(), _ACL_TYPE_EXTENDED)
+    if not handle:
+        return False
+    library.acl_free(handle)
+    return True
+
+
 def _drop_extended_acl(path: Path) -> None:
     """Remove an extended ACL, which the mode bits do not describe.
 
@@ -108,47 +167,34 @@ def _drop_extended_acl(path: Path) -> None:
     Linux ACLs behave the same way in principle, but ``chmod`` there already
     clamps the mask so the extra entries grant nothing.
     """
-    if not hasattr(os, "O_NOFOLLOW"):  # pragma: no cover - POSIX only
+    library = _libc()
+    if library is None:  # pragma: no cover - nothing to clear
         return
-    try:
-        subprocess.run(
-            ["chmod", "-N", str(path)],
-            check=False,
-            capture_output=True,
-            timeout=10,
+
+    empty = library.acl_init(0)
+    if not empty:
+        raise PrivateStateError(
+            f"Could not build an empty access list to apply to {path}"
         )
-    except (OSError, subprocess.SubprocessError):
-        # Absence of the tool is not a failure by itself: the verification
-        # below decides, and it fails closed if an ACL is still there.
-        logger.debug("Could not clear an extended ACL on %s", path, exc_info=True)
+    try:
+        if library.acl_set_file(str(path).encode(), _ACL_TYPE_EXTENDED, empty) != 0:
+            # Not swallowed. The verification below would catch a list that is
+            # still there, but a failure here is worth reporting on its own
+            # terms rather than as a mysterious refusal one step later.
+            raise PrivateStateError(
+                f"Could not clear the access list on {path}: "
+                f"{os.strerror(ctypes.get_errno())}"
+            )
+    finally:
+        library.acl_free(empty)
 
 
 def _verify_no_extended_acl(path: Path) -> None:
     """Refuse when an extended ACL still grants access the mode does not show."""
-    try:
-        listing = subprocess.run(
-            ["ls", "-lde", str(path)],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.SubprocessError):  # pragma: no cover - no ls
-        return
-
-    # An ACL entry is printed as a numbered line under the mode. The mode line
-    # itself also ends in "@" or "+" when one is present, but reading the
-    # entries is the part that cannot be misread.
-    entries = [
-        line
-        for line in listing.stdout.splitlines()[1:]
-        if line.strip() and line.strip()[0].isdigit()
-    ]
-    if entries:
+    if _has_extended_acl(path):
         raise PrivateStateError(
             f"{path} carries an access control list that the permission bits "
-            f"do not describe, so it may still be readable by other accounts:\n"
-            f"{chr(10).join(entries)}\n"
+            f"do not describe, so it may still be readable by other accounts. "
             f"Clear it with: chmod -N {path}"
         )
 

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -30,7 +30,8 @@ import os
 import stat
 import sys
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from linkedin_mcp_server.common_utils import is_still_at, secure_mkdir
@@ -45,11 +46,32 @@ _MACOS = sys.platform == "darwin"
 
 
 class PrivateStateError(RuntimeError):
-    """Owner-only storage could not be established, so nothing was written.
+    """Owner-only storage could not be established.
 
     Always fatal to the operation that asked for it. A caller that catches this
-    and continues has written a secret somewhere it did not verify.
+    and carries on is working with a path whose permissions were never
+    established, and its next step is usually to write a secret there.
     """
+
+
+@contextmanager
+def _as_private_state_error(path: Path, action: str) -> Iterator[None]:
+    """Turn a filesystem failure into this module's own error.
+
+    Every entry point here promises to raise :class:`PrivateStateError` when it
+    cannot establish owner-only storage. The operating system does not know
+    that, so a file where a directory belongs, an unreadable parent, or a path
+    that vanishes mid-flight arrives as NotADirectoryError, PermissionError or
+    FileNotFoundError and crosses the boundary as itself. Measured: a file at
+    the state root surfaced as NotADirectoryError from inside a lock
+    acquisition, several layers from anything that could explain it.
+    """
+    try:
+        yield
+    except PrivateStateError:
+        raise
+    except OSError as exc:
+        raise PrivateStateError(f"Could not {action} {path}: {exc}") from exc
 
 
 def harden_directory(path: Path) -> None:
@@ -68,42 +90,46 @@ def harden_directory(path: Path) -> None:
     ordinary arrangement. A file name, by contrast, is built from an identifier
     and lands in a directory this hardens first.
     """
-    if path.exists() and not path.is_dir():
-        raise PrivateStateError(f"Not a directory: {path}")
+    with _as_private_state_error(path, "prepare the private directory"):
+        if path.exists() and not path.is_dir():
+            raise PrivateStateError(f"Not a directory: {path}")
 
-    secure_mkdir(path, mode=_PRIVATE_DIR_MODE)
+        secure_mkdir(path, mode=_PRIVATE_DIR_MODE)
 
-    if _WINDOWS:
-        from linkedin_mcp_server.windows_acl import restrict_to_current_user
+        if _WINDOWS:
+            from linkedin_mcp_server.windows_acl import restrict_to_current_user
 
-        restrict_to_current_user(path, directory=True)
-        return
+            restrict_to_current_user(path, directory=True)
+            return
 
-    _harden_posix(path, _PRIVATE_DIR_MODE)
+        _harden_posix(path, _PRIVATE_DIR_MODE)
 
 
 def harden_file(path: Path) -> None:
     """Leave the existing file *path* readable only by this account.
 
-    Harden the file before writing the secret into it, not after: the window in
-    between is a window in which the secret is on disk under whatever
-    permissions it was created with.
+    The file has to exist already, so a caller writing a secret creates it with
+    owner-only permissions itself and calls this to *establish* that rather
+    than assume it: the mode, the owner and the access list are read back, and
+    on Windows the access list is replaced outright. A refusal therefore means
+    the permissions could not be confirmed, not that the file is exposed.
     """
-    if not path.exists():
-        raise PrivateStateError(f"Cannot harden a file that does not exist: {path}")
+    with _as_private_state_error(path, "inspect"):
+        if not path.exists():
+            raise PrivateStateError(f"Cannot harden a file that does not exist: {path}")
 
-    # Before the platform split, because both halves get it wrong in their own
-    # way. POSIX opens a directory with O_RDONLY quite happily and would take it
-    # from 0700 to 0600, which stops it being searchable; Windows would give it
-    # a file's non-inheritable access list, so files created inside afterwards
-    # no longer inherit the owner-only entry that is the point of hardening the
-    # directory. Neither is something a caller should discover later.
-    #
-    # lstat, so a link is judged as itself rather than as its target. POSIX
-    # refuses one again at open time through O_NOFOLLOW; Windows has no
-    # equivalent, so this is where both learn about it, and a link is worth its
-    # own message because it is the case a caller is most likely to hit.
-    entry = path.lstat()
+        # Before the platform split, because both halves get it wrong in their own
+        # way. POSIX opens a directory with O_RDONLY quite happily and would take it
+        # from 0700 to 0600, which stops it being searchable; Windows would give it
+        # a file's non-inheritable access list, so files created inside afterwards
+        # no longer inherit the owner-only entry that is the point of hardening the
+        # directory. Neither is something a caller should discover later.
+        #
+        # lstat, so a link is judged as itself rather than as its target. POSIX
+        # refuses one again at open time through O_NOFOLLOW; Windows has no
+        # equivalent, so this is where both learn about it, and a link is worth its
+        # own message because it is the case a caller is most likely to hit.
+        entry = path.lstat()
     if stat.S_ISLNK(entry.st_mode):
         raise PrivateStateError(
             f"{path} is a symbolic link rather than a file. Hardening it would "

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -71,7 +71,10 @@ def _as_private_state_error(path: Path, action: str) -> Iterator[None]:
         yield
     except PrivateStateError:
         raise
-    except OSError as exc:
+    except (OSError, RuntimeError, ValueError) as exc:
+        # RuntimeError and ValueError alongside OSError: a home directory that
+        # cannot be determined raises the first, an embedded NUL the second,
+        # and both arrive from a path a caller was entitled to hand over.
         raise PrivateStateError(f"Could not {action} {path}: {exc}") from exc
 
 
@@ -92,6 +95,18 @@ def harden_directory(path: Path) -> None:
     and lands in a directory this hardens first.
     """
     with _as_private_state_error(path, "prepare the private directory"):
+        # An unexpanded tilde means expanduser could not resolve it, which
+        # happens for a user this system does not know. Left alone it becomes a
+        # directory literally named "~something" wherever the process happens
+        # to be running: measured, one appeared in the working directory. A
+        # path that was meant to be somewhere else is not somewhere to keep a
+        # secret.
+        if str(path).startswith("~"):
+            raise PrivateStateError(
+                f"{path} still begins with a tilde, so the home directory it "
+                f"names could not be resolved"
+            )
+
         if path.exists() and not path.is_dir():
             raise PrivateStateError(f"Not a directory: {path}")
 

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -34,6 +34,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from linkedin_mcp_server.common_utils import secure_mkdir
+from linkedin_mcp_server.profile_lease import is_still_at
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +120,26 @@ def harden_file(path: Path) -> None:
         raise PrivateStateError(f"{path} could not be opened to harden: {exc}") from exc
 
     try:
+        # O_RDONLY opens a directory quite happily on POSIX, and hardening one
+        # as if it were a file takes 0700 down to 0600, which removes the bit
+        # that makes it searchable. A caller that passes the wrong path should
+        # be told so rather than have its state directory quietly broken.
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise PrivateStateError(f"{path} is not a regular file")
+
         _harden_posix_fd(fd, path, _PRIVATE_FILE_MODE)
+
+        # The descriptor is now provably private, but the promise is about the
+        # path: the caller's next step is to write a secret to it by name. If
+        # the name has come to mean something else in the meantime, hardening
+        # the old inode says nothing about where that write will land.
+        # Measured: this returned success while the path was already 0644
+        # again.
+        if not is_still_at(fd, path):
+            raise PrivateStateError(
+                f"{path} was replaced while it was being hardened, so it no "
+                f"longer refers to the file this made private."
+            )
     finally:
         os.close(fd)
 

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -166,10 +166,12 @@ def harden_file(path: Path) -> None:
         raise PrivateStateError(f"{path} could not be opened to harden: {exc}") from exc
 
     try:
-        # The whole descriptor half is inside the translation, not just the
-        # path work before it: fchmod, fstat, the access list calls and the
-        # close can each fail with an OSError of their own. Measured with
-        # fchmod made to answer EIO: it crossed the boundary as itself.
+        # The work is inside the translation, not just the path checks before
+        # it: fstat, fchmod and the access list calls each fail with an OSError
+        # of their own. Measured with fchmod made to answer EIO: it crossed the
+        # boundary as itself. The close below is the exception, and
+        # deliberately: it runs in a finally, where raising would replace
+        # whatever sent us there with a less useful error.
         with _as_private_state_error(path, "make private"):
             # Asked again of the descriptor, not the name. The check above was
             # made before the open, so it says what the path was then; this

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -30,6 +30,7 @@ import os
 import stat
 import sys
 import threading
+from collections.abc import Callable
 from pathlib import Path
 
 from linkedin_mcp_server.common_utils import secure_mkdir
@@ -91,26 +92,36 @@ def harden_file(path: Path) -> None:
     if not path.exists():
         raise PrivateStateError(f"Cannot harden a file that does not exist: {path}")
 
-    # A link here would send the whole operation somewhere else: chmod follows
-    # it, so hardening would set 0600 on whatever it points at and report that
-    # the secret's own file is private. Measured: an unrelated 0644 file was
-    # changed to 0600 while the caller was told its token was protected. The
-    # only caller writes into a directory hardened to 0700 first, so nothing
-    # else can plant the link there, but this promise should not depend on
-    # where it happens to be called from.
-    if path.is_symlink():
-        raise PrivateStateError(
-            f"{path} is a symbolic link rather than a file. Hardening it would "
-            f"change permissions somewhere else and say nothing about this path."
-        )
-
     if _WINDOWS:
         from linkedin_mcp_server.windows_acl import restrict_to_current_user
 
         restrict_to_current_user(path, directory=False)
         return
 
-    _harden_posix(path, _PRIVATE_FILE_MODE)
+    # Opened once, then hardened through the descriptor. Checking the path for
+    # a link and then calling chmod on that same path resolves it twice, and
+    # anything that swaps the file in between is followed by the second
+    # resolution: measured, an unrelated file became 0600 while this reported
+    # the token as private. O_NOFOLLOW refuses the link at open time, and every
+    # step afterwards names the descriptor, so there is no second lookup to
+    # race. The only caller writes into a directory hardened to 0700 first, so
+    # nothing else can plant the link there, but a promise this specific should
+    # not rest on where it happens to be called from.
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0))
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.EMLINK):
+            raise PrivateStateError(
+                f"{path} is a symbolic link rather than a file. Hardening it "
+                f"would change permissions somewhere else and say nothing "
+                f"about this path."
+            ) from exc
+        raise PrivateStateError(f"{path} could not be opened to harden: {exc}") from exc
+
+    try:
+        _harden_posix_fd(fd, path, _PRIVATE_FILE_MODE)
+    finally:
+        os.close(fd)
 
 
 def _require_acl_support(path: Path) -> None:
@@ -134,16 +145,38 @@ def _require_acl_support(path: Path) -> None:
 
 
 def _harden_posix(path: Path, mode: int) -> None:
-    """Apply *mode*, drop any extended ACL, and check the result."""
+    """Apply *mode*, drop any extended ACL, and check the result.
+
+    By path, which is right for a directory: the caller passes one that has
+    already been resolved, and a directory reached through a link is an ordinary
+    layout. A file goes through :func:`_harden_posix_fd` instead, because its
+    name is built rather than resolved and a second lookup could be aimed
+    elsewhere in between.
+    """
     _require_acl_support(path)
     path.chmod(mode)
     _drop_extended_acl(path)
-    _verify_posix_owner(path)
-    _verify_posix_mode(path, mode)
+    _verify_posix_owner(path.stat(), path)
+    _verify_posix_mode(path.stat(), mode, path)
     _verify_no_extended_acl(path)
 
 
-def _verify_posix_owner(path: Path) -> None:
+def _harden_posix_fd(fd: int, path: Path, mode: int) -> None:
+    """The same, applied and verified through an open descriptor.
+
+    Every step names *fd* rather than the path, so nothing between them can be
+    redirected by swapping what the name refers to. *path* is carried only to
+    say where a failure happened.
+    """
+    _require_acl_support(path)
+    os.fchmod(fd, mode)
+    _drop_extended_acl_fd(fd, path)
+    _verify_posix_owner(os.fstat(fd), path)
+    _verify_posix_mode(os.fstat(fd), mode, path)
+    _verify_no_extended_acl_fd(fd, path)
+
+
+def _verify_posix_owner(info: os.stat_result, path: Path) -> None:
     """Refuse a path owned by another account.
 
     ``0600`` says "only the owner", which is worth nothing when the owner is
@@ -156,10 +189,9 @@ def _verify_posix_owner(path: Path) -> None:
     pre-existing state tree is exactly that. The Windows side already reads its
     owner back for the same reason; this is the POSIX half of that promise.
     """
-    owner = path.stat().st_uid
-    if owner != os.geteuid():
+    if info.st_uid != os.geteuid():
         raise PrivateStateError(
-            f"{path} is owned by uid {owner}, not by this account (uid "
+            f"{path} is owned by uid {info.st_uid}, not by this account (uid "
             f"{os.geteuid()}), so its permission bits grant that account rather "
             f"than this one and it can widen them again at any time"
         )
@@ -233,6 +265,12 @@ def _libc() -> ctypes.CDLL | None:
                     candidate.acl_init.restype = ctypes.c_void_p
                     candidate.acl_free.argtypes = [ctypes.c_void_p]
                     candidate.acl_free.restype = ctypes.c_int
+                    # The descriptor forms, used where a second lookup of the
+                    # name would be a second chance to redirect it.
+                    candidate.acl_get_fd.argtypes = [ctypes.c_int]
+                    candidate.acl_get_fd.restype = ctypes.c_void_p
+                    candidate.acl_set_fd.argtypes = [ctypes.c_int, ctypes.c_void_p]
+                    candidate.acl_set_fd.restype = ctypes.c_int
                     library = candidate
         except OSError:
             # A failure to load is not an answer about the platform, so it is
@@ -256,13 +294,27 @@ def _has_extended_acl(path: Path) -> bool:
     reading that as "no list" would report a path as owner-only precisely when
     its permissions could not be established.
     """
+    return _has_extended_acl_via(
+        lambda library: library.acl_get_file(str(path).encode(), _ACL_TYPE_EXTENDED),
+        path,
+    )
+
+
+def _has_extended_acl_fd(fd: int, path: Path) -> bool:
+    """The same question, asked of an open descriptor."""
+    return _has_extended_acl_via(lambda library: library.acl_get_fd(fd), path)
+
+
+def _has_extended_acl_via(
+    read: Callable[[ctypes.CDLL], int | None], path: Path
+) -> bool:
     library = _libc()
     if library is None:  # pragma: no cover - no ACL support to report on
         return False
     # Cleared first: errno keeps whatever an earlier call left there, so a
     # stale value would be read as this call's outcome.
     ctypes.set_errno(0)
-    handle = library.acl_get_file(str(path).encode(), _ACL_TYPE_EXTENDED)
+    handle = read(library)
     if not handle:
         code = ctypes.get_errno()
         if code in _NO_EXTENDED_ACL_ERRNOS:
@@ -287,6 +339,25 @@ def _drop_extended_acl(path: Path) -> None:
     Linux ACLs behave the same way in principle, but ``chmod`` there already
     clamps the mask so the extra entries grant nothing.
     """
+    _drop_extended_acl_via(
+        lambda library, empty: library.acl_set_file(
+            str(path).encode(), _ACL_TYPE_EXTENDED, empty
+        ),
+        path,
+    )
+
+
+def _drop_extended_acl_fd(fd: int, path: Path) -> None:
+    """The same, applied to an open descriptor."""
+    _drop_extended_acl_via(
+        lambda library, empty: library.acl_set_fd(fd, empty),
+        path,
+    )
+
+
+def _drop_extended_acl_via(
+    apply_empty: Callable[[ctypes.CDLL, int], int], path: Path
+) -> None:
     library = _libc()
     if library is None:  # pragma: no cover - nothing to clear
         return
@@ -297,7 +368,7 @@ def _drop_extended_acl(path: Path) -> None:
             f"Could not build an empty access list to apply to {path}"
         )
     try:
-        if library.acl_set_file(str(path).encode(), _ACL_TYPE_EXTENDED, empty) != 0:
+        if apply_empty(library, empty) != 0:
             # Not swallowed. The verification below would catch a list that is
             # still there, but a failure here is worth reporting on its own
             # terms rather than as a mysterious refusal one step later.
@@ -312,21 +383,30 @@ def _drop_extended_acl(path: Path) -> None:
 def _verify_no_extended_acl(path: Path) -> None:
     """Refuse when an extended ACL still grants access the mode does not show."""
     if _has_extended_acl(path):
-        raise PrivateStateError(
-            f"{path} carries an access control list that the permission bits "
-            f"do not describe, so it may still be readable by other accounts. "
-            f"Clear it with: chmod -N {path}"
-        )
+        raise PrivateStateError(_EXTENDED_ACL_REMAINS.format(path=path))
 
 
-def _verify_posix_mode(path: Path, expected: int) -> None:
+def _verify_no_extended_acl_fd(fd: int, path: Path) -> None:
+    """The same check, made through the descriptor that was hardened."""
+    if _has_extended_acl_fd(fd, path):
+        raise PrivateStateError(_EXTENDED_ACL_REMAINS.format(path=path))
+
+
+_EXTENDED_ACL_REMAINS = (
+    "{path} carries an access control list that the permission bits do not "
+    "describe, so it may still be readable by other accounts. Clear it with: "
+    "chmod -N {path}"
+)
+
+
+def _verify_posix_mode(info: os.stat_result, expected: int, path: Path) -> None:
     """Read the mode back, because chmod can silently do nothing.
 
     A filesystem that does not carry POSIX permission bits, such as a mounted
     share or a FAT volume, accepts the call and keeps the old mode. Trusting the
     call to have worked is exactly how a secret ends up world-readable.
     """
-    actual = stat.S_IMODE(path.stat().st_mode)
+    actual = stat.S_IMODE(info.st_mode)
     if actual != expected:
         raise PrivateStateError(
             f"{path} could not be made owner-only: asked for {expected:04o}, "

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -27,6 +27,7 @@ import ctypes.util
 import logging
 import os
 import stat
+import threading
 from pathlib import Path
 
 from linkedin_mcp_server.common_utils import secure_mkdir
@@ -106,6 +107,7 @@ _ACL_TYPE_EXTENDED = 0x00000100
 #: without a type the caller has to narrow.
 _libc_resolved = False
 _libc_cache: ctypes.CDLL | None = None
+_libc_lock = threading.Lock()
 
 
 def _libc() -> ctypes.CDLL | None:
@@ -119,28 +121,47 @@ def _libc() -> ctypes.CDLL | None:
     missing executable was not.
     """
     global _libc_cache, _libc_resolved
-    if _libc_resolved:
-        return _libc_cache
+    # Under the lock for the whole resolution, and the flag is set last.
+    # Published early, the flag would tell a concurrent caller the lookup was
+    # finished while the cache was still empty, and an empty cache reads as
+    # "this platform has no access lists" everywhere below. Measured: a second
+    # thread entering that window hardened a directory that kept an inherited
+    # everyone entry, and the call reported success.
+    with _libc_lock:
+        if _libc_resolved:
+            return _libc_cache
 
-    _libc_resolved = True
-    name = ctypes.util.find_library("c")
-    if name is not None:
-        library = ctypes.CDLL(name, use_errno=True)
-        if hasattr(library, "acl_get_file") and hasattr(library, "acl_set_file"):
-            library.acl_get_file.argtypes = [ctypes.c_char_p, ctypes.c_uint]
-            library.acl_get_file.restype = ctypes.c_void_p
-            library.acl_set_file.argtypes = [
-                ctypes.c_char_p,
-                ctypes.c_uint,
-                ctypes.c_void_p,
-            ]
-            library.acl_set_file.restype = ctypes.c_int
-            library.acl_init.argtypes = [ctypes.c_int]
-            library.acl_init.restype = ctypes.c_void_p
-            library.acl_free.argtypes = [ctypes.c_void_p]
-            library.acl_free.restype = ctypes.c_int
-            _libc_cache = library
-    return _libc_cache
+        library: ctypes.CDLL | None = None
+        try:
+            name = ctypes.util.find_library("c")
+            if name is not None:
+                candidate = ctypes.CDLL(name, use_errno=True)
+                if hasattr(candidate, "acl_get_file") and hasattr(
+                    candidate, "acl_set_file"
+                ):
+                    candidate.acl_get_file.argtypes = [ctypes.c_char_p, ctypes.c_uint]
+                    candidate.acl_get_file.restype = ctypes.c_void_p
+                    candidate.acl_set_file.argtypes = [
+                        ctypes.c_char_p,
+                        ctypes.c_uint,
+                        ctypes.c_void_p,
+                    ]
+                    candidate.acl_set_file.restype = ctypes.c_int
+                    candidate.acl_init.argtypes = [ctypes.c_int]
+                    candidate.acl_init.restype = ctypes.c_void_p
+                    candidate.acl_free.argtypes = [ctypes.c_void_p]
+                    candidate.acl_free.restype = ctypes.c_int
+                    library = candidate
+        except OSError:
+            # A failure to load is not an answer about the platform, so it is
+            # not cached as one: the next caller looks again rather than living
+            # with a verdict reached while something was momentarily wrong.
+            logger.debug("Could not load the access list functions", exc_info=True)
+            raise
+
+        _libc_cache = library
+        _libc_resolved = True
+        return _libc_cache
 
 
 def _has_extended_acl(path: Path) -> bool:

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -22,11 +22,15 @@ keeps out root or an administrator, and no file permission ever has.
 
 from __future__ import annotations
 
+import logging
 import os
 import stat
+import subprocess
 from pathlib import Path
 
 from linkedin_mcp_server.common_utils import secure_mkdir
+
+logger = logging.getLogger(__name__)
 
 _PRIVATE_DIR_MODE = 0o700
 _PRIVATE_FILE_MODE = 0o600
@@ -62,8 +66,7 @@ def harden_directory(path: Path) -> None:
         restrict_to_current_user(path, directory=True)
         return
 
-    path.chmod(_PRIVATE_DIR_MODE)
-    _verify_posix_mode(path, _PRIVATE_DIR_MODE)
+    _harden_posix(path, _PRIVATE_DIR_MODE)
 
 
 def harden_file(path: Path) -> None:
@@ -82,8 +85,72 @@ def harden_file(path: Path) -> None:
         restrict_to_current_user(path, directory=False)
         return
 
-    path.chmod(_PRIVATE_FILE_MODE)
-    _verify_posix_mode(path, _PRIVATE_FILE_MODE)
+    _harden_posix(path, _PRIVATE_FILE_MODE)
+
+
+def _harden_posix(path: Path, mode: int) -> None:
+    """Apply *mode*, drop any extended ACL, and check the result."""
+    path.chmod(mode)
+    _drop_extended_acl(path)
+    _verify_posix_mode(path, mode)
+    _verify_no_extended_acl(path)
+
+
+def _drop_extended_acl(path: Path) -> None:
+    """Remove an extended ACL, which the mode bits do not describe.
+
+    On macOS an ACL sits alongside the mode rather than inside it, and
+    ``chmod`` leaves it untouched. Measured: an auth root carrying an
+    inheritable ``everyone`` entry produced a token file reporting exactly
+    ``0600`` while ``everyone`` could still read it. Verifying only the mode
+    is therefore not verifying anything about who has access.
+
+    Linux ACLs behave the same way in principle, but ``chmod`` there already
+    clamps the mask so the extra entries grant nothing.
+    """
+    if not hasattr(os, "O_NOFOLLOW"):  # pragma: no cover - POSIX only
+        return
+    try:
+        subprocess.run(
+            ["chmod", "-N", str(path)],
+            check=False,
+            capture_output=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # Absence of the tool is not a failure by itself: the verification
+        # below decides, and it fails closed if an ACL is still there.
+        logger.debug("Could not clear an extended ACL on %s", path, exc_info=True)
+
+
+def _verify_no_extended_acl(path: Path) -> None:
+    """Refuse when an extended ACL still grants access the mode does not show."""
+    try:
+        listing = subprocess.run(
+            ["ls", "-lde", str(path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):  # pragma: no cover - no ls
+        return
+
+    # An ACL entry is printed as a numbered line under the mode. The mode line
+    # itself also ends in "@" or "+" when one is present, but reading the
+    # entries is the part that cannot be misread.
+    entries = [
+        line
+        for line in listing.stdout.splitlines()[1:]
+        if line.strip() and line.strip()[0].isdigit()
+    ]
+    if entries:
+        raise PrivateStateError(
+            f"{path} carries an access control list that the permission bits "
+            f"do not describe, so it may still be readable by other accounts:\n"
+            f"{chr(10).join(entries)}\n"
+            f"Clear it with: chmod -N {path}"
+        )
 
 
 def _verify_posix_mode(path: Path, expected: int) -> None:

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -33,8 +33,7 @@ import threading
 from collections.abc import Callable
 from pathlib import Path
 
-from linkedin_mcp_server.common_utils import secure_mkdir
-from linkedin_mcp_server.profile_lease import is_still_at
+from linkedin_mcp_server.common_utils import is_still_at, secure_mkdir
 
 logger = logging.getLogger(__name__)
 

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -30,6 +30,7 @@ import os
 import stat
 import sys
 import threading
+import contextlib
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -165,27 +166,34 @@ def harden_file(path: Path) -> None:
         raise PrivateStateError(f"{path} could not be opened to harden: {exc}") from exc
 
     try:
-        # Asked again of the descriptor, not the name. The check above was made
-        # before the open, so it says what the path was then; this says what
-        # was actually opened, which is what the next few calls will change.
-        if not stat.S_ISREG(os.fstat(fd).st_mode):
-            raise PrivateStateError(f"{path} is not a regular file")
+        # The whole descriptor half is inside the translation, not just the
+        # path work before it: fchmod, fstat, the access list calls and the
+        # close can each fail with an OSError of their own. Measured with
+        # fchmod made to answer EIO: it crossed the boundary as itself.
+        with _as_private_state_error(path, "make private"):
+            # Asked again of the descriptor, not the name. The check above was
+            # made before the open, so it says what the path was then; this
+            # says what was actually opened, which is what the next few calls
+            # will change.
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise PrivateStateError(f"{path} is not a regular file")
 
-        _harden_posix_fd(fd, path, _PRIVATE_FILE_MODE)
+            _harden_posix_fd(fd, path, _PRIVATE_FILE_MODE)
 
-        # The descriptor is now provably private, but the promise is about the
-        # path: the caller's next step is to write a secret to it by name. If
-        # the name has come to mean something else in the meantime, hardening
-        # the old inode says nothing about where that write will land.
-        # Measured: this returned success while the path was already 0644
-        # again.
-        if not is_still_at(fd, path):
-            raise PrivateStateError(
-                f"{path} was replaced while it was being hardened, so it no "
-                f"longer refers to the file this made private."
-            )
+            # The descriptor is provably private now, but the promise is about
+            # the path, and the caller reaches this file by name. If the name
+            # has come to mean something else in the meantime, hardening the
+            # old inode says nothing about the file that answers to it.
+            # Measured: this returned success while the path was already 0644
+            # again.
+            if not is_still_at(fd, path):
+                raise PrivateStateError(
+                    f"{path} was replaced while it was being hardened, so it "
+                    f"no longer refers to the file this made private."
+                )
     finally:
-        os.close(fd)
+        with contextlib.suppress(OSError):
+            os.close(fd)
 
 
 def _require_acl_support(path: Path) -> None:

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -92,6 +92,26 @@ def harden_file(path: Path) -> None:
     if not path.exists():
         raise PrivateStateError(f"Cannot harden a file that does not exist: {path}")
 
+    # Before the platform split, because both halves get it wrong in their own
+    # way. POSIX opens a directory with O_RDONLY quite happily and would take it
+    # from 0700 to 0600, which stops it being searchable; Windows would give it
+    # a file's non-inheritable access list, so files created inside afterwards
+    # no longer inherit the owner-only entry that is the point of hardening the
+    # directory. Neither is something a caller should discover later.
+    #
+    # lstat, so a link is judged as itself rather than as its target. POSIX
+    # refuses one again at open time through O_NOFOLLOW; Windows has no
+    # equivalent, so this is where both learn about it, and a link is worth its
+    # own message because it is the case a caller is most likely to hit.
+    entry = path.lstat()
+    if stat.S_ISLNK(entry.st_mode):
+        raise PrivateStateError(
+            f"{path} is a symbolic link rather than a file. Hardening it would "
+            f"change permissions somewhere else and say nothing about this path."
+        )
+    if not stat.S_ISREG(entry.st_mode):
+        raise PrivateStateError(f"{path} is not a regular file")
+
     if _WINDOWS:
         from linkedin_mcp_server.windows_acl import restrict_to_current_user
 
@@ -119,10 +139,9 @@ def harden_file(path: Path) -> None:
         raise PrivateStateError(f"{path} could not be opened to harden: {exc}") from exc
 
     try:
-        # O_RDONLY opens a directory quite happily on POSIX, and hardening one
-        # as if it were a file takes 0700 down to 0600, which removes the bit
-        # that makes it searchable. A caller that passes the wrong path should
-        # be told so rather than have its state directory quietly broken.
+        # Asked again of the descriptor, not the name. The check above was made
+        # before the open, so it says what the path was then; this says what
+        # was actually opened, which is what the next few calls will change.
         if not stat.S_ISREG(os.fstat(fd).st_mode):
             raise PrivateStateError(f"{path} is not a regular file")
 

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -107,7 +107,13 @@ _ACL_TYPE_EXTENDED = 0x00000100
 #: without a type the caller has to narrow.
 _libc_resolved = False
 _libc_cache: ctypes.CDLL | None = None
-_libc_lock = threading.Lock()
+# Reentrant, because loading a library raises a ctypes.dlopen audit event and
+# a hook on it runs synchronously, inside this lock. A hook that reached back
+# into hardening would deadlock the resolving thread against itself on a plain
+# lock. Measured: one that re-entered left the thread waiting indefinitely.
+# Nothing in this project installs such a hook, but an embedding process or a
+# security monitor can, and the cost of allowing for it is one word.
+_libc_lock = threading.RLock()
 
 
 def _libc() -> ctypes.CDLL | None:

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -24,9 +24,11 @@ from __future__ import annotations
 
 import ctypes
 import ctypes.util
+import errno
 import logging
 import os
 import stat
+import sys
 import threading
 from pathlib import Path
 
@@ -38,6 +40,7 @@ _PRIVATE_DIR_MODE = 0o700
 _PRIVATE_FILE_MODE = 0o600
 
 _WINDOWS = os.name == "nt"
+_MACOS = sys.platform == "darwin"
 
 
 class PrivateStateError(RuntimeError):
@@ -90,17 +93,70 @@ def harden_file(path: Path) -> None:
     _harden_posix(path, _PRIVATE_FILE_MODE)
 
 
+def _require_acl_support(path: Path) -> None:
+    """Refuse to promise owner-only where access lists cannot be read at all.
+
+    macOS puts an access list alongside the mode on every filesystem this runs
+    on, and the functions that reach it are part of its libc. Not finding them
+    there means something is wrong with the interpreter or the library, not that
+    the platform has no access lists, and treating it as the latter is what made
+    this fail open. Measured with the bindings absent: a directory carrying an
+    inherited ``everyone`` entry came back from hardening unchanged, and the
+    call reported success. Elsewhere a missing binding genuinely does mean there
+    is no list to clear.
+    """
+    if _MACOS and _libc() is None:
+        raise PrivateStateError(
+            f"The access list functions are missing from this system's C "
+            f"library, so it cannot be established that only this account can "
+            f"read {path}. Refusing to treat it as private."
+        )
+
+
 def _harden_posix(path: Path, mode: int) -> None:
     """Apply *mode*, drop any extended ACL, and check the result."""
+    _require_acl_support(path)
     path.chmod(mode)
     _drop_extended_acl(path)
+    _verify_posix_owner(path)
     _verify_posix_mode(path, mode)
     _verify_no_extended_acl(path)
+
+
+def _verify_posix_owner(path: Path) -> None:
+    """Refuse a path owned by another account.
+
+    ``0600`` says "only the owner", which is worth nothing when the owner is
+    somebody else: those bits are then granting *them* the access, and an owner
+    can chmod their own path back open whenever they like. The mode alone
+    cannot distinguish the two cases.
+
+    It takes a privileged process to get here, since chmod on another account's
+    path fails otherwise, and a container or service started against a
+    pre-existing state tree is exactly that. The Windows side already reads its
+    owner back for the same reason; this is the POSIX half of that promise.
+    """
+    owner = path.stat().st_uid
+    if owner != os.geteuid():
+        raise PrivateStateError(
+            f"{path} is owned by uid {owner}, not by this account (uid "
+            f"{os.geteuid()}), so its permission bits grant that account rather "
+            f"than this one and it can widen them again at any time"
+        )
 
 
 #: macOS ``acl_get_file``/``acl_set_file`` selector for the list that sits
 #: alongside the mode bits.
 _ACL_TYPE_EXTENDED = 0x00000100
+
+#: The errno values that mean "this path carries no extended access list"
+#: rather than "the question could not be answered". ENOENT is what macOS
+#: returns for a perfectly ordinary directory without one, measured. The other
+#: two are how a filesystem says it does not implement access lists at all,
+#: which is equally an answer: there is no list to worry about.
+_NO_EXTENDED_ACL_ERRNOS = frozenset(
+    {errno.ENOENT, errno.ENOTSUP, getattr(errno, "EOPNOTSUPP", errno.ENOTSUP)}
+)
 
 #: Resolved once, on first use. Two variables rather than a sentinel value, so
 #: "not looked up yet" and "looked up and unavailable" stay distinguishable
@@ -171,13 +227,30 @@ def _libc() -> ctypes.CDLL | None:
 
 
 def _has_extended_acl(path: Path) -> bool:
-    """Whether *path* carries an access list beyond its permission bits."""
+    """Whether *path* carries an access list beyond its permission bits.
+
+    ``acl_get_file`` returns NULL for *any* failure and sets errno to say
+    which, so NULL alone does not mean the path carries no list. Measured on
+    macOS: a directory with no extended ACL returns NULL with ENOENT, which is
+    the answer this wants. Anything else is the call failing to answer, and
+    reading that as "no list" would report a path as owner-only precisely when
+    its permissions could not be established.
+    """
     library = _libc()
     if library is None:  # pragma: no cover - no ACL support to report on
         return False
+    # Cleared first: errno keeps whatever an earlier call left there, so a
+    # stale value would be read as this call's outcome.
+    ctypes.set_errno(0)
     handle = library.acl_get_file(str(path).encode(), _ACL_TYPE_EXTENDED)
     if not handle:
-        return False
+        code = ctypes.get_errno()
+        if code in _NO_EXTENDED_ACL_ERRNOS:
+            return False
+        raise PrivateStateError(
+            f"Could not read the access list on {path}: {os.strerror(code)}. "
+            f"Refusing to report it as owner-only without having checked."
+        )
     library.acl_free(handle)
     return True
 

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -59,6 +59,13 @@ def harden_directory(path: Path) -> None:
     daemon directory inside an auth root that some earlier version or the user
     created with a default umask would otherwise keep those wider permissions
     while the token inside it looked safe.
+
+    A link is followed rather than refused, unlike :func:`harden_file`. The
+    difference is where the two get their paths. Every caller here passes one
+    that ``daemon_state_root`` or ``daemon_dir`` already resolved, so a link is
+    part of the layout the user chose, and a home reached through one is an
+    ordinary arrangement. A file name, by contrast, is built from an identifier
+    and lands in a directory this hardens first.
     """
     if path.exists() and not path.is_dir():
         raise PrivateStateError(f"Not a directory: {path}")
@@ -83,6 +90,19 @@ def harden_file(path: Path) -> None:
     """
     if not path.exists():
         raise PrivateStateError(f"Cannot harden a file that does not exist: {path}")
+
+    # A link here would send the whole operation somewhere else: chmod follows
+    # it, so hardening would set 0600 on whatever it points at and report that
+    # the secret's own file is private. Measured: an unrelated 0644 file was
+    # changed to 0600 while the caller was told its token was protected. The
+    # only caller writes into a directory hardened to 0700 first, so nothing
+    # else can plant the link there, but this promise should not depend on
+    # where it happens to be called from.
+    if path.is_symlink():
+        raise PrivateStateError(
+            f"{path} is a symbolic link rather than a file. Hardening it would "
+            f"change permissions somewhere else and say nothing about this path."
+        )
 
     if _WINDOWS:
         from linkedin_mcp_server.windows_acl import restrict_to_current_user

--- a/linkedin_mcp_server/private_state.py
+++ b/linkedin_mcp_server/private_state.py
@@ -1,0 +1,103 @@
+"""Storage that only this user account can read.
+
+The daemon work needs somewhere to keep a bearer token, and a token file that
+any local account can read is the same as no token at all. POSIX already has an
+answer in ``common_utils``: ``0700`` on the directory, ``0600`` on the file.
+Windows does not, because ``os.chmod`` there only toggles the read-only
+attribute and leaves the ACL, which is what actually decides access, untouched.
+
+So this module owns one promise, made the same way on both platforms and
+checked rather than assumed: after :func:`harden_directory` or
+:func:`harden_file` returns, no other account can read the path. If that cannot
+be arranged, it raises. Nothing here degrades to a warning, because the caller's
+next step is to write a secret.
+
+On Windows a normal user profile is already closed to other non-administrator
+accounts, so the ACL work below is defence in depth rather than the only thing
+standing in the way. It earns its place when the profile has been redirected,
+when a parent directory was created with wider permissions, or when the auth
+root lives somewhere outside the profile entirely. Neither platform's mechanism
+keeps out root or an administrator, and no file permission ever has.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from linkedin_mcp_server.common_utils import secure_mkdir
+
+_PRIVATE_DIR_MODE = 0o700
+_PRIVATE_FILE_MODE = 0o600
+
+_WINDOWS = os.name == "nt"
+
+
+class PrivateStateError(RuntimeError):
+    """Owner-only storage could not be established, so nothing was written.
+
+    Always fatal to the operation that asked for it. A caller that catches this
+    and continues has written a secret somewhere it did not verify.
+    """
+
+
+def harden_directory(path: Path) -> None:
+    """Create *path* if needed and leave it readable only by this account.
+
+    Existing directories are hardened too, which is the case that matters:
+    ``secure_mkdir`` applies its mode only to directories it creates, so a
+    daemon directory inside an auth root that some earlier version or the user
+    created with a default umask would otherwise keep those wider permissions
+    while the token inside it looked safe.
+    """
+    if path.exists() and not path.is_dir():
+        raise PrivateStateError(f"Not a directory: {path}")
+
+    secure_mkdir(path, mode=_PRIVATE_DIR_MODE)
+
+    if _WINDOWS:
+        from linkedin_mcp_server.windows_acl import restrict_to_current_user
+
+        restrict_to_current_user(path, directory=True)
+        return
+
+    path.chmod(_PRIVATE_DIR_MODE)
+    _verify_posix_mode(path, _PRIVATE_DIR_MODE)
+
+
+def harden_file(path: Path) -> None:
+    """Leave the existing file *path* readable only by this account.
+
+    Harden the file before writing the secret into it, not after: the window in
+    between is a window in which the secret is on disk under whatever
+    permissions it was created with.
+    """
+    if not path.exists():
+        raise PrivateStateError(f"Cannot harden a file that does not exist: {path}")
+
+    if _WINDOWS:
+        from linkedin_mcp_server.windows_acl import restrict_to_current_user
+
+        restrict_to_current_user(path, directory=False)
+        return
+
+    path.chmod(_PRIVATE_FILE_MODE)
+    _verify_posix_mode(path, _PRIVATE_FILE_MODE)
+
+
+def _verify_posix_mode(path: Path, expected: int) -> None:
+    """Read the mode back, because chmod can silently do nothing.
+
+    A filesystem that does not carry POSIX permission bits, such as a mounted
+    share or a FAT volume, accepts the call and keeps the old mode. Trusting the
+    call to have worked is exactly how a secret ends up world-readable.
+    """
+    actual = stat.S_IMODE(path.stat().st_mode)
+    if actual != expected:
+        raise PrivateStateError(
+            f"{path} could not be made owner-only: asked for {expected:04o}, "
+            f"the filesystem reports {actual:04o}. It may not support Unix "
+            f"permissions. Move the LinkedIn MCP data directory to a local "
+            f"disk."
+        )

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -6,6 +6,7 @@ person profiles, company data, job information, and session management capabilit
 """
 
 import asyncio
+import enum
 import logging
 from typing import Any, AsyncIterator
 
@@ -36,6 +37,38 @@ from linkedin_mcp_server.tools.person import register_person_tools
 from linkedin_mcp_server.tools.post import register_post_tools
 
 logger = logging.getLogger(__name__)
+
+
+class ServerRole(enum.Enum):
+    """Which job a server process does for the shared LinkedIn profile.
+
+    One process per MCP client is the transport's doing, not a choice: a stdio
+    server is spawned per client instance. That makes "who drives Chromium" a
+    property of the process rather than of the code, and every difference below
+    follows from it.
+    """
+
+    #: Drives its own browser and talks to its own client. The historical
+    #: behaviour, and still what an explicit HTTP bind or an embedder gets.
+    DIRECT = "direct"
+
+    #: Drives the browser on behalf of other processes over loopback HTTP.
+    #: Never speaks to an end client, so nothing user-facing belongs here.
+    OWNER = "owner"
+
+    #: Speaks to an end client and forwards to an owner. Never touches
+    #: Chromium, so it must not participate in profile ownership at all.
+    PROXY = "proxy"
+
+    @property
+    def drives_browser(self) -> bool:
+        """Whether this role launches Chromium against the shared profile."""
+        return self in (ServerRole.DIRECT, ServerRole.OWNER)
+
+    @property
+    def faces_a_client(self) -> bool:
+        """Whether an end user reads this server's tool results."""
+        return self in (ServerRole.DIRECT, ServerRole.PROXY)
 
 
 @lifespan
@@ -86,16 +119,35 @@ async def browser_lifespan(app: FastMCP) -> AsyncIterator[dict[str, Any]]:
             await close_browser()
 
 
-def create_mcp_server(*, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> FastMCP:
-    """Create and configure the MCP server with all LinkedIn tools."""
+def create_mcp_server(
+    *,
+    tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS,
+    role: ServerRole = ServerRole.DIRECT,
+) -> FastMCP:
+    """Create and configure the MCP server with all LinkedIn tools.
+
+    *role* selects which parts belong to this process. It defaults to
+    :attr:`ServerRole.DIRECT`, which is exactly the historical server, so every
+    existing caller keeps what it had.
+    """
     mcp = FastMCP(
         "mcp-server-linkedin",
         version=__version__,
         lifespan=browser_lifespan,
         mask_error_details=True,
     )
-    mcp.add_middleware(SequentialToolExecutionMiddleware())
-    mcp.add_middleware(UpdateNoticeMiddleware())
+    # Profile ownership belongs to whoever launches Chromium. A process that
+    # only forwards calls must not take the lease: it would either block itself
+    # until its own timeout, or take the lease and leave the process that
+    # actually needs it waiting for one held by a caller that never uses it.
+    if role.drives_browser:
+        mcp.add_middleware(SequentialToolExecutionMiddleware())
+    # The notice is appended to one tool result per process, so it belongs
+    # wherever a user reads results. On a shared owner it would reach whichever
+    # client happened to call first and nobody after that, however many clients
+    # attach over the owner's life.
+    if role.faces_a_client:
+        mcp.add_middleware(UpdateNoticeMiddleware())
 
     # Register all tools
     register_person_tools(mcp, tool_timeout=tool_timeout)

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -56,9 +56,10 @@ class ServerRole(enum.Enum):
     #: Never speaks to an end client, so nothing user-facing belongs here.
     OWNER = "owner"
 
-    #: Speaks to an end client and forwards to an owner. Never touches
-    #: Chromium, so it must not participate in profile ownership at all.
-    PROXY = "proxy"
+    # A forwarding role belongs here too, but only once something actually
+    # forwards. Adding it now would mean a server that registers the local
+    # browser-backed tools and then declines to serialize them, which is a
+    # worse starting point than not having the role at all.
 
     @property
     def drives_browser(self) -> bool:
@@ -68,7 +69,7 @@ class ServerRole(enum.Enum):
     @property
     def faces_a_client(self) -> bool:
         """Whether an end user reads this server's tool results."""
-        return self in (ServerRole.DIRECT, ServerRole.PROXY)
+        return self is ServerRole.DIRECT
 
 
 @lifespan

--- a/linkedin_mcp_server/windows_acl.py
+++ b/linkedin_mcp_server/windows_acl.py
@@ -64,11 +64,23 @@ CONTAINER_INHERITANCE = OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE
 ACCESS_ALLOWED_ACE_TYPE = 0x00
 SE_FILE_OBJECT = 1
 
+OWNER_SECURITY_INFORMATION = 0x00000001
 DACL_SECURITY_INFORMATION = 0x00000004
 PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
 # Replace the DACL *and* stop the parent's entries being inherited back in.
 # Without the second flag the first one is close to cosmetic.
-REPLACE_PROTECTED_DACL = DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION
+#
+# The owner goes with them, because a DACL is only as good as who may rewrite
+# it. Windows grants an object's owner READ_CONTROL and WRITE_DAC implicitly,
+# with no ACE saying so, so a directory this account merely had permission to
+# modify would keep its previous owner and that owner could widen the DACL
+# straight back. Taking ownership is what makes the entry we just wrote the
+# last word.
+REPLACE_PROTECTED_DACL = (
+    OWNER_SECURITY_INFORMATION
+    | DACL_SECURITY_INFORMATION
+    | PROTECTED_DACL_SECURITY_INFORMATION
+)
 
 SE_DACL_PROTECTED = 0x1000
 FILE_ALL_ACCESS = 0x001F01FF
@@ -378,7 +390,7 @@ def restrict_to_current_user(path: Path, *, directory: bool) -> None:
     acl = _build_owner_only_acl(sid, directory=directory)
     try:
         code = _advapi32.SetNamedSecurityInfoW(
-            str(path), SE_FILE_OBJECT, REPLACE_PROTECTED_DACL, None, None, acl, None
+            str(path), SE_FILE_OBJECT, REPLACE_PROTECTED_DACL, sid, None, acl, None
         )
         # This one returns the error code rather than setting the thread's last
         # error, so checking GetLastError here would read a stale value from
@@ -498,6 +510,33 @@ def _sid_to_string(sid: _PSID) -> str:
         _kernel32.LocalFree(ctypes.cast(text, _HLOCAL))
 
 
+def read_owner(path: Path) -> str:
+    """Return the SID string of *path*'s owner."""
+    _advapi32, _kernel32 = _load()
+
+    owner = _PSID()
+    descriptor = _PSECURITY_DESCRIPTOR()
+    code = _advapi32.GetNamedSecurityInfoW(
+        str(path),
+        SE_FILE_OBJECT,
+        OWNER_SECURITY_INFORMATION,
+        ctypes.byref(owner),
+        None,
+        None,
+        None,
+        ctypes.byref(descriptor),
+    )
+    if code != ERROR_SUCCESS:
+        _fail("GetNamedSecurityInfoW", code)
+    try:
+        if not owner:
+            raise PrivateStateError(f"{path} has no owner")
+        return _sid_to_string(owner)
+    finally:
+        if descriptor:
+            _kernel32.LocalFree(descriptor)
+
+
 def verify_owner_only(path: Path, *, directory: bool) -> None:
     """Raise unless *path*'s DACL grants this account and nothing else."""
     sid, sid_buffer = current_user_sid()
@@ -505,6 +544,17 @@ def verify_owner_only(path: Path, *, directory: bool) -> None:
         expected_sid = _sid_to_string(sid)
     finally:
         del sid_buffer
+
+    # Checked first, because it decides what the rest is worth. Windows grants
+    # an owner READ_CONTROL and WRITE_DAC with no ACE saying so, so a DACL that
+    # names only this account still means nothing while someone else owns the
+    # path and can rewrite it at will.
+    actual_owner = read_owner(path)
+    if actual_owner != expected_sid:
+        raise PrivateStateError(
+            f"{path} is owned by {actual_owner}, not by this account, so that "
+            f"owner can widen its permissions again at any time"
+        )
 
     described = describe_dacl(path)
     if not described.protected:

--- a/linkedin_mcp_server/windows_acl.py
+++ b/linkedin_mcp_server/windows_acl.py
@@ -583,3 +583,15 @@ def verify_owner_only(path: Path, *, directory: bool) -> None:
             f"{path} has inheritance flags {entry.flags:#04x}, expected "
             f"{expected_flags:#04x}"
         )
+    # The entry names the right account and nobody else, which is half the
+    # question; the other half is what it actually grants. A backend that
+    # accepts the call and stores a reduced mask would leave this account
+    # unable to read its own token, or unable to create files in its own state
+    # directory, while everything above still looked correct. Measured with a
+    # read-back of zero: verification passed.
+    if entry.mask != FILE_ALL_ACCESS:
+        raise PrivateStateError(
+            f"{path} grants this account {entry.mask:#010x} rather than the "
+            f"{FILE_ALL_ACCESS:#010x} that was asked for, so the filesystem "
+            f"stored something other than what was requested"
+        )

--- a/linkedin_mcp_server/windows_acl.py
+++ b/linkedin_mcp_server/windows_acl.py
@@ -1,0 +1,535 @@
+"""Owner-only file permissions on Windows, via the Win32 security APIs.
+
+``os.chmod`` on Windows sets the read-only attribute and nothing else, so the
+``0600`` that protects a secret on POSIX protects nothing here. Access is
+decided by the DACL instead, and setting one means calling Win32 directly.
+
+Two details do the real work. The DACL is replaced rather than merged, so
+whatever the parent granted does not survive; and it is marked *protected*, so
+the parent's inheritable entries are not reapplied afterwards. A directory's
+single entry is marked inheritable, which means files created inside it are
+already owner-only at the moment they exist rather than from whenever something
+gets around to hardening them.
+
+Everything is read back and checked before returning. A caller only gets a
+quiet return when the descriptor on disk actually says what it should.
+
+``ctypes`` rather than ``pywin32``: this is the only place in the project that
+needs Win32, and a dependency that installs on one platform to serve one module
+is a poor trade. Deliberately no fallback path. If any of this fails, the
+caller must not write the secret.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from ctypes import wintypes
+from dataclasses import dataclass
+from pathlib import Path
+
+from linkedin_mcp_server.private_state import PrivateStateError
+
+# Importable anywhere so tests can reach the helpers; every entry point refuses
+# to run off Windows rather than failing obscurely inside a missing DLL.
+_IS_WINDOWS = os.name == "nt"
+
+# Loaded on first use rather than at import, so this module can be imported and
+# type-checked on any platform while the libraries themselves only ever exist on
+# Windows. Cached: binding the signatures is not free, and every call needs them.
+_libraries: tuple[ctypes.CDLL, ctypes.CDLL] | None = None
+
+_PSID = ctypes.c_void_p
+_PACL = ctypes.c_void_p
+_PSECURITY_DESCRIPTOR = ctypes.c_void_p
+_HLOCAL = ctypes.c_void_p
+
+ERROR_SUCCESS = 0
+ERROR_INSUFFICIENT_BUFFER = 122
+
+TOKEN_QUERY = 0x0008
+TOKEN_USER_CLASS = 1  # TOKEN_INFORMATION_CLASS.TokenUser
+
+NO_MULTIPLE_TRUSTEE = 0
+TRUSTEE_IS_SID = 0
+TRUSTEE_IS_USER = 1
+SET_ACCESS = 2
+
+NO_INHERITANCE = 0x00
+OBJECT_INHERIT_ACE = 0x01
+CONTAINER_INHERIT_ACE = 0x02
+INHERITED_ACE = 0x10
+CONTAINER_INHERITANCE = OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE
+
+ACCESS_ALLOWED_ACE_TYPE = 0x00
+SE_FILE_OBJECT = 1
+
+DACL_SECURITY_INFORMATION = 0x00000004
+PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+# Replace the DACL *and* stop the parent's entries being inherited back in.
+# Without the second flag the first one is close to cosmetic.
+REPLACE_PROTECTED_DACL = DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION
+
+SE_DACL_PROTECTED = 0x1000
+FILE_ALL_ACCESS = 0x001F01FF
+
+FILE_PERSISTENT_ACLS = 0x00000008
+
+
+class _SID_AND_ATTRIBUTES(ctypes.Structure):
+    _fields_ = [("Sid", _PSID), ("Attributes", wintypes.DWORD)]
+
+
+class _TOKEN_USER(ctypes.Structure):
+    _fields_ = [("User", _SID_AND_ATTRIBUTES)]
+
+
+class _ACL(ctypes.Structure):
+    _fields_ = [
+        ("AclRevision", wintypes.BYTE),
+        ("Sbz1", wintypes.BYTE),
+        ("AclSize", wintypes.WORD),
+        ("AceCount", wintypes.WORD),
+        ("Sbz2", wintypes.WORD),
+    ]
+
+
+class _ACE_HEADER(ctypes.Structure):
+    _fields_ = [
+        ("AceType", wintypes.BYTE),
+        ("AceFlags", wintypes.BYTE),
+        ("AceSize", wintypes.WORD),
+    ]
+
+
+class _ACCESS_ALLOWED_ACE(ctypes.Structure):
+    # SidStart is the first word of a variable-length SID that continues past
+    # the end of this struct, so the SID is read from its offset rather than
+    # from the field.
+    _fields_ = [
+        ("Header", _ACE_HEADER),
+        ("Mask", wintypes.DWORD),
+        ("SidStart", wintypes.DWORD),
+    ]
+
+
+class _TRUSTEE_W(ctypes.Structure):
+    pass
+
+
+_TRUSTEE_W._fields_ = [
+    ("pMultipleTrustee", ctypes.POINTER(_TRUSTEE_W)),
+    ("MultipleTrusteeOperation", ctypes.c_int),
+    ("TrusteeForm", ctypes.c_int),
+    ("TrusteeType", ctypes.c_int),
+    # Typed as a string in the SDK, but for TRUSTEE_IS_SID it carries a SID.
+    ("ptstrName", ctypes.c_void_p),
+]
+
+
+@dataclass(frozen=True)
+class AccessEntry:
+    """One permission entry, as Windows reports it."""
+
+    sid: str
+    type: int
+    flags: int
+    mask: int
+
+    @property
+    def inherited(self) -> bool:
+        return bool(self.flags & INHERITED_ACE)
+
+
+@dataclass(frozen=True)
+class Dacl:
+    """What a path's permissions currently say."""
+
+    #: Whether the parent's inheritable entries are kept out. Without this the
+    #: entries below are only what is there until the next inheritance pass.
+    protected: bool
+    entries: tuple[AccessEntry, ...]
+
+
+class _EXPLICIT_ACCESS_W(ctypes.Structure):
+    _fields_ = [
+        ("grfAccessPermissions", wintypes.DWORD),
+        ("grfAccessMode", ctypes.c_int),
+        ("grfInheritance", wintypes.DWORD),
+        ("Trustee", _TRUSTEE_W),
+    ]
+
+
+def _load() -> tuple[ctypes.CDLL, ctypes.CDLL]:
+    """Return the two security libraries, binding their signatures once.
+
+    Declaring the signatures is not optional bookkeeping: ctypes otherwise
+    assumes every argument is int-sized, which silently truncates pointers in a
+    64-bit process. What that produces is not a crash but an unrelated error
+    code from a function that never received the arguments meant for it.
+    """
+    global _libraries
+    if _libraries is not None:
+        return _libraries
+    if not _IS_WINDOWS:
+        raise PrivateStateError("Windows ACL support was called off Windows")
+
+    # Resolved through getattr for the same reason profile_lease does it:
+    # WinDLL exists only on Windows, and a type checker running elsewhere
+    # reports the module as having no such member.
+    _win_dll = getattr(ctypes, "WinDLL")
+    # use_last_error keeps GetLastError from being clobbered between a call and
+    # our read of it.
+    _advapi32 = _win_dll("advapi32", use_last_error=True)
+    _kernel32 = _win_dll("kernel32", use_last_error=True)
+
+    _advapi32.OpenProcessToken.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.HANDLE),
+    ]
+    _advapi32.OpenProcessToken.restype = wintypes.BOOL
+
+    _advapi32.GetTokenInformation.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    _advapi32.GetTokenInformation.restype = wintypes.BOOL
+
+    _advapi32.SetEntriesInAclW.argtypes = [
+        wintypes.ULONG,
+        ctypes.POINTER(_EXPLICIT_ACCESS_W),
+        _PACL,
+        ctypes.POINTER(_PACL),
+    ]
+    _advapi32.SetEntriesInAclW.restype = wintypes.DWORD
+
+    _advapi32.SetNamedSecurityInfoW.argtypes = [
+        wintypes.LPWSTR,
+        ctypes.c_int,
+        wintypes.DWORD,
+        _PSID,
+        _PSID,
+        _PACL,
+        _PACL,
+    ]
+    _advapi32.SetNamedSecurityInfoW.restype = wintypes.DWORD
+
+    _advapi32.GetNamedSecurityInfoW.argtypes = [
+        wintypes.LPCWSTR,
+        ctypes.c_int,
+        wintypes.DWORD,
+        ctypes.POINTER(_PSID),
+        ctypes.POINTER(_PSID),
+        ctypes.POINTER(_PACL),
+        ctypes.POINTER(_PACL),
+        ctypes.POINTER(_PSECURITY_DESCRIPTOR),
+    ]
+    _advapi32.GetNamedSecurityInfoW.restype = wintypes.DWORD
+
+    _advapi32.GetSecurityDescriptorControl.argtypes = [
+        _PSECURITY_DESCRIPTOR,
+        ctypes.POINTER(wintypes.WORD),
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    _advapi32.GetSecurityDescriptorControl.restype = wintypes.BOOL
+
+    _advapi32.GetAce.argtypes = [
+        _PACL,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.LPVOID),
+    ]
+    _advapi32.GetAce.restype = wintypes.BOOL
+
+    _advapi32.EqualSid.argtypes = [_PSID, _PSID]
+    _advapi32.EqualSid.restype = wintypes.BOOL
+
+    _advapi32.ConvertSidToStringSidW.argtypes = [
+        _PSID,
+        ctypes.POINTER(wintypes.LPWSTR),
+    ]
+    _advapi32.ConvertSidToStringSidW.restype = wintypes.BOOL
+
+    _kernel32.GetCurrentProcess.argtypes = []
+    _kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+
+    _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+
+    _kernel32.LocalFree.argtypes = [_HLOCAL]
+    _kernel32.LocalFree.restype = _HLOCAL
+
+    _kernel32.GetVolumeInformationW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+    ]
+    _kernel32.GetVolumeInformationW.restype = wintypes.BOOL
+
+    _libraries = (_advapi32, _kernel32)
+    return _libraries
+
+
+def _last_error() -> int:
+    """This thread's last Win32 error code."""
+    return getattr(ctypes, "get_last_error")()
+
+
+def _clear_last_error() -> None:
+    """Reset the error code, so a stale one cannot be read as a fresh result."""
+    getattr(ctypes, "set_last_error")(0)
+
+
+def _fail(api: str, code: int | None = None) -> None:
+    """Raise for a failed Win32 call, naming the call that failed."""
+    if code is None:
+        code = _last_error() or 1
+    raise PrivateStateError(f"{api} failed: {getattr(ctypes, 'WinError')(code)}")
+
+
+def current_user_sid() -> tuple[_PSID, ctypes.Array]:
+    """Return this process's account SID and the buffer that backs it.
+
+    The buffer must outlive the pointer, hence returning both: the SID lives
+    inside that allocation, and letting it be collected leaves a pointer into
+    freed memory.
+
+    Read from the process token rather than looked up by name, which is what
+    makes it right for a service account or SYSTEM as well as a normal login,
+    and avoids a name lookup that can reach for a domain controller.
+    """
+    _advapi32, _kernel32 = _load()
+
+    token = wintypes.HANDLE()
+    if not _advapi32.OpenProcessToken(
+        _kernel32.GetCurrentProcess(), TOKEN_QUERY, ctypes.byref(token)
+    ):
+        _fail("OpenProcessToken")
+
+    try:
+        needed = wintypes.DWORD(0)
+        _clear_last_error()
+        # Expected to fail: this asks how large the buffer has to be.
+        if _advapi32.GetTokenInformation(
+            token, TOKEN_USER_CLASS, None, 0, ctypes.byref(needed)
+        ):
+            raise PrivateStateError("GetTokenInformation sizing call succeeded")
+        code = _last_error()
+        if code != ERROR_INSUFFICIENT_BUFFER:
+            _fail("GetTokenInformation", code)
+
+        buffer = ctypes.create_string_buffer(needed.value)
+        if not _advapi32.GetTokenInformation(
+            token, TOKEN_USER_CLASS, buffer, needed.value, ctypes.byref(needed)
+        ):
+            _fail("GetTokenInformation")
+
+        token_user = ctypes.cast(buffer, ctypes.POINTER(_TOKEN_USER)).contents
+        if not token_user.User.Sid:
+            raise PrivateStateError("The process token carries no user SID")
+        return _PSID(token_user.User.Sid), buffer
+    finally:
+        _kernel32.CloseHandle(token)
+
+
+def _build_owner_only_acl(sid: _PSID, *, directory: bool) -> _PACL:
+    """Build a one-entry ACL granting full access to *sid* and nobody else."""
+    _advapi32, _ = _load()
+
+    entry = _EXPLICIT_ACCESS_W()
+    entry.grfAccessPermissions = FILE_ALL_ACCESS
+    entry.grfAccessMode = SET_ACCESS
+    # An inheritable entry on the directory is what makes a file created inside
+    # it owner-only from the instant it exists, rather than from whenever it is
+    # hardened afterwards.
+    entry.grfInheritance = CONTAINER_INHERITANCE if directory else NO_INHERITANCE
+    entry.Trustee.pMultipleTrustee = None
+    entry.Trustee.MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE
+    entry.Trustee.TrusteeForm = TRUSTEE_IS_SID
+    entry.Trustee.TrusteeType = TRUSTEE_IS_USER
+    entry.Trustee.ptstrName = sid.value
+
+    acl = _PACL()
+    # A null "old ACL" builds a fresh one instead of merging into what is
+    # already there, which is the whole point: merging would keep entries this
+    # is meant to remove.
+    code = _advapi32.SetEntriesInAclW(1, ctypes.byref(entry), None, ctypes.byref(acl))
+    if code != ERROR_SUCCESS:
+        _fail("SetEntriesInAclW", code)
+    if not acl:
+        raise PrivateStateError("SetEntriesInAclW returned no ACL")
+    return acl
+
+
+def restrict_to_current_user(path: Path, *, directory: bool) -> None:
+    """Give only this account access to *path*, and verify it afterwards."""
+    _advapi32, _kernel32 = _load()
+    _require_acl_capable_volume(path)
+
+    sid, sid_buffer = current_user_sid()
+    acl = _build_owner_only_acl(sid, directory=directory)
+    try:
+        code = _advapi32.SetNamedSecurityInfoW(
+            str(path), SE_FILE_OBJECT, REPLACE_PROTECTED_DACL, None, None, acl, None
+        )
+        # This one returns the error code rather than setting the thread's last
+        # error, so checking GetLastError here would read a stale value from
+        # some earlier call and report success for a failure.
+        if code != ERROR_SUCCESS:
+            _fail("SetNamedSecurityInfoW", code)
+    finally:
+        _kernel32.LocalFree(acl)
+        del sid_buffer
+
+    verify_owner_only(path, directory=directory)
+
+
+def _require_acl_capable_volume(path: Path) -> None:
+    """Refuse a volume that cannot keep permissions at all.
+
+    FAT and exFAT accept the call and store nothing. Checking the volume first
+    turns that into a clear refusal before the secret is written, rather than a
+    file that looks protected and is not.
+    """
+    _, _kernel32 = _load()
+
+    drive = os.path.splitdrive(os.path.abspath(str(path)))[0]
+    if not drive:
+        # A UNC path has no drive letter. The volume query does not answer for
+        # remote storage, so the read-back verification below is what has to
+        # carry it.
+        return
+    flags = wintypes.DWORD(0)
+    if not _kernel32.GetVolumeInformationW(
+        f"{drive}\\", None, 0, None, None, ctypes.byref(flags), None, 0
+    ):
+        _fail("GetVolumeInformationW")
+    if not flags.value & FILE_PERSISTENT_ACLS:
+        raise PrivateStateError(
+            f"The volume holding {path} does not keep file permissions, so a "
+            f"secret stored there would be readable by any local account. Move "
+            f"the LinkedIn MCP data directory to an NTFS volume."
+        )
+
+
+def describe_dacl(path: Path) -> Dacl:
+    """Read back what the DACL actually says. Used by hardening and by tests."""
+    _advapi32, _kernel32 = _load()
+
+    dacl = _PACL()
+    descriptor = _PSECURITY_DESCRIPTOR()
+    code = _advapi32.GetNamedSecurityInfoW(
+        str(path),
+        SE_FILE_OBJECT,
+        DACL_SECURITY_INFORMATION,
+        None,
+        None,
+        ctypes.byref(dacl),
+        None,
+        ctypes.byref(descriptor),
+    )
+    if code != ERROR_SUCCESS:
+        _fail("GetNamedSecurityInfoW", code)
+
+    try:
+        if not descriptor:
+            raise PrivateStateError(f"{path} has no security descriptor")
+        # A null DACL is not an empty one: it grants everyone full access.
+        if not dacl:
+            raise PrivateStateError(f"{path} has a null DACL, which grants everyone")
+
+        control = wintypes.WORD()
+        revision = wintypes.DWORD()
+        if not _advapi32.GetSecurityDescriptorControl(
+            descriptor, ctypes.byref(control), ctypes.byref(revision)
+        ):
+            _fail("GetSecurityDescriptorControl")
+
+        header = ctypes.cast(dacl, ctypes.POINTER(_ACL)).contents
+        entries: list[AccessEntry] = []
+        for index in range(header.AceCount):
+            ace = wintypes.LPVOID()
+            if not _advapi32.GetAce(dacl, index, ctypes.byref(ace)):
+                _fail("GetAce")
+            if not ace.value:
+                # GetAce reported success without filling in the entry. Nothing
+                # can be said about who has access, so say nothing rather than
+                # returning a list that looks complete.
+                raise PrivateStateError(f"{path} returned an empty permission entry")
+            ace_header = ctypes.cast(ace, ctypes.POINTER(_ACE_HEADER)).contents
+            # The SID runs past the end of the struct, so it is read from the
+            # offset of its first word rather than from the field itself.
+            ace_sid = _PSID(ace.value + _ACCESS_ALLOWED_ACE.SidStart.offset)
+            allowed = ctypes.cast(ace, ctypes.POINTER(_ACCESS_ALLOWED_ACE)).contents
+            entries.append(
+                AccessEntry(
+                    sid=_sid_to_string(ace_sid),
+                    type=ace_header.AceType,
+                    flags=ace_header.AceFlags,
+                    mask=allowed.Mask,
+                )
+            )
+
+        return Dacl(
+            protected=bool(control.value & SE_DACL_PROTECTED),
+            entries=tuple(entries),
+        )
+    finally:
+        _kernel32.LocalFree(descriptor)
+
+
+def _sid_to_string(sid: _PSID) -> str:
+    _advapi32, _kernel32 = _load()
+
+    text = wintypes.LPWSTR()
+    if not _advapi32.ConvertSidToStringSidW(sid, ctypes.byref(text)):
+        _fail("ConvertSidToStringSidW")
+    try:
+        return text.value or ""
+    finally:
+        _kernel32.LocalFree(ctypes.cast(text, _HLOCAL))
+
+
+def verify_owner_only(path: Path, *, directory: bool) -> None:
+    """Raise unless *path*'s DACL grants this account and nothing else."""
+    sid, sid_buffer = current_user_sid()
+    try:
+        expected_sid = _sid_to_string(sid)
+    finally:
+        del sid_buffer
+
+    described = describe_dacl(path)
+    if not described.protected:
+        raise PrivateStateError(
+            f"{path} still inherits permissions from its parent directory"
+        )
+
+    if len(described.entries) != 1:
+        granted = ", ".join(entry.sid for entry in described.entries) or "nobody"
+        raise PrivateStateError(
+            f"{path} grants access to more than this account ({granted})"
+        )
+
+    entry = described.entries[0]
+    if entry.sid != expected_sid:
+        raise PrivateStateError(
+            f"{path} grants access to {entry.sid}, not to this account"
+        )
+    if entry.type != ACCESS_ALLOWED_ACE_TYPE:
+        raise PrivateStateError(f"{path} carries an unexpected permission entry")
+    if entry.inherited:
+        raise PrivateStateError(f"{path} still carries an inherited permission entry")
+    expected_flags = CONTAINER_INHERITANCE if directory else 0
+    if entry.flags != expected_flags:
+        raise PrivateStateError(
+            f"{path} has inheritance flags {entry.flags:#04x}, expected "
+            f"{expected_flags:#04x}"
+        )

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -351,6 +351,25 @@ class TestRefusals:
 
         assert stat.S_IMODE(victim.stat().st_mode) == 0o644
 
+    @posix_only
+    def test_a_failure_while_hardening_is_this_module_s_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The descriptor half can fail too: fchmod, fstat, the access list
+        # calls and the close each have their own OSError. Measured with fchmod
+        # answering EIO before the translation covered them: it crossed the
+        # boundary as itself.
+        target = tmp_path / "token"
+        target.touch()
+
+        def failing(fd: int, mode: int) -> None:
+            raise OSError(errno.EIO, "I/O error")
+
+        monkeypatch.setattr(os, "fchmod", failing)
+
+        with pytest.raises(PrivateStateError, match="make private"):
+            harden_file(target)
+
     def test_a_file_where_a_directory_belongs_refuses(self, tmp_path: Path):
         occupied = tmp_path / "daemon"
         occupied.write_text("not a directory")

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -1,0 +1,214 @@
+"""Storage that only the current account can read.
+
+The Windows tests here run only on Windows and are the reason the CI matrix
+covers it: the ACL path cannot be exercised anywhere else, and mocking it would
+only assert that the mock was called.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from linkedin_mcp_server.private_state import (
+    PrivateStateError,
+    harden_directory,
+    harden_file,
+)
+
+posix_only = pytest.mark.skipif(
+    os.name == "nt", reason="POSIX permission bits do not exist on Windows"
+)
+windows_only = pytest.mark.skipif(
+    os.name != "nt", reason="Windows ACLs cannot be set or read on POSIX"
+)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+class TestHardeningOnPosix:
+    @posix_only
+    def test_a_new_directory_is_owner_only(self, tmp_path: Path):
+        target = tmp_path / "auth-root" / "daemon"
+
+        harden_directory(target)
+
+        assert _mode(target) == 0o700
+
+    @posix_only
+    def test_an_existing_wide_directory_is_narrowed(self, tmp_path: Path):
+        # The case that actually happens: the auth root predates this code, or
+        # the user made it, and it carries whatever the umask gave it. Creating
+        # the token inside it with 0600 would look right while the directory
+        # let anyone list and open it.
+        target = tmp_path / "daemon"
+        target.mkdir(mode=0o755)
+
+        harden_directory(target)
+
+        assert _mode(target) == 0o700
+
+    @posix_only
+    def test_hardening_works_outside_a_linkedin_mcp_tree(self, tmp_path: Path):
+        # USER_DATA_DIR can point anywhere, and the older tree-hardening helper
+        # deliberately does nothing outside a .linkedin-mcp directory. A token
+        # stored under a custom root has to be protected just the same.
+        target = tmp_path / "somewhere-else" / "daemon"
+        target.parent.mkdir(mode=0o755)
+        target.mkdir(mode=0o755)
+
+        harden_directory(target)
+
+        assert _mode(target) == 0o700
+
+    @posix_only
+    def test_a_file_is_owner_only(self, tmp_path: Path):
+        target = tmp_path / "token"
+        target.touch(mode=0o644)
+
+        harden_file(target)
+
+        assert _mode(target) == 0o600
+
+    @posix_only
+    def test_repeated_hardening_is_stable(self, tmp_path: Path):
+        # Called on every daemon start, so it has to be safe to repeat.
+        target = tmp_path / "daemon"
+
+        harden_directory(target)
+        harden_directory(target)
+
+        assert _mode(target) == 0o700
+
+
+class TestRefusals:
+    def test_hardening_a_missing_file_refuses(self, tmp_path: Path):
+        # Hardening has to happen before the secret is written. Being asked to
+        # harden something that does not exist means the caller has the order
+        # wrong, and staying quiet would hide it until the file was readable.
+        with pytest.raises(PrivateStateError, match="does not exist"):
+            harden_file(tmp_path / "absent")
+
+    def test_a_file_where_a_directory_belongs_refuses(self, tmp_path: Path):
+        occupied = tmp_path / "daemon"
+        occupied.write_text("not a directory")
+
+        with pytest.raises(PrivateStateError, match="Not a directory"):
+            harden_directory(occupied)
+
+    @posix_only
+    def test_a_filesystem_that_ignores_chmod_refuses(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A share or a FAT volume accepts chmod and keeps the old mode. Without
+        # reading the mode back, the secret lands on disk readable and nothing
+        # says so. Simulated, since neither can be mounted in a test run.
+        target = tmp_path / "token"
+        target.touch(mode=0o644)
+        monkeypatch.setattr(Path, "chmod", lambda self, mode: None)
+
+        with pytest.raises(PrivateStateError, match="owner-only"):
+            harden_file(target)
+
+
+class TestWindowsAcl:
+    """Only meaningful on Windows, where a DACL rather than a mode decides."""
+
+    @windows_only
+    def test_a_directory_grants_only_this_account(self, tmp_path: Path):
+        from linkedin_mcp_server.windows_acl import (
+            CONTAINER_INHERITANCE,
+            current_user_sid,
+            describe_dacl,
+            _sid_to_string,
+        )
+
+        target = tmp_path / "daemon"
+        harden_directory(target)
+
+        sid, buffer = current_user_sid()
+        try:
+            expected = _sid_to_string(sid)
+        finally:
+            del buffer
+
+        described = describe_dacl(target)
+        assert described.protected is True
+        assert len(described.entries) == 1
+        assert described.entries[0].sid == expected
+        # Inheritable, so a file created inside is owner-only from the start
+        # rather than from whenever it gets hardened.
+        assert described.entries[0].flags == CONTAINER_INHERITANCE
+
+    @windows_only
+    def test_a_file_grants_only_this_account_and_inherits_nothing(self, tmp_path: Path):
+        from linkedin_mcp_server.windows_acl import describe_dacl
+
+        target = tmp_path / "token"
+        target.touch()
+        harden_file(target)
+
+        described = describe_dacl(target)
+        assert described.protected is True
+        assert len(described.entries) == 1
+        assert described.entries[0].flags == 0
+
+    @windows_only
+    def test_a_permissive_parent_does_not_leak_in(self, tmp_path: Path):
+        # The reason the DACL is replaced and marked protected rather than
+        # merged: a parent granting Everyone would otherwise pass that straight
+        # down to the token file.
+        from linkedin_mcp_server.windows_acl import describe_dacl
+
+        parent = tmp_path / "wide"
+        parent.mkdir()
+        # Argument list rather than a shell string: the path comes from a
+        # fixture and could carry spaces or shell metacharacters.
+        subprocess.run(
+            ["icacls", str(parent), "/grant", "*S-1-1-0:(OI)(CI)F"],
+            check=True,
+            capture_output=True,
+        )
+
+        target = parent / "daemon"
+        harden_directory(target)
+
+        described = describe_dacl(target)
+        granted = {entry.sid for entry in described.entries}
+        assert "S-1-1-0" not in granted  # Everyone
+        assert "S-1-5-32-545" not in granted  # BUILTIN\Users
+        assert "S-1-5-11" not in granted  # Authenticated Users
+
+    @windows_only
+    def test_the_struct_layouts_match_the_windows_headers(self):
+        # ctypes sizes a struct from its declared fields, so a wrong field type
+        # produces a struct Windows reads at the wrong offsets and reports as
+        # an unrelated error. These are the documented sizes on 64-bit.
+        import ctypes
+
+        from linkedin_mcp_server import windows_acl as acl
+
+        assert ctypes.sizeof(acl._ACL) == 8
+        assert ctypes.sizeof(acl._ACE_HEADER) == 4
+        assert ctypes.sizeof(acl._ACCESS_ALLOWED_ACE) == 12
+        assert ctypes.sizeof(acl._SID_AND_ATTRIBUTES) == 16
+        assert ctypes.sizeof(acl._TRUSTEE_W) == 32
+        assert ctypes.sizeof(acl._EXPLICIT_ACCESS_W) == 48
+
+
+class TestWindowsAclOffWindows:
+    @posix_only
+    def test_the_windows_helpers_refuse_rather_than_pretend(self, tmp_path: Path):
+        # Importable everywhere so the module can be reasoned about and typed on
+        # any platform, but every entry point refuses off Windows rather than
+        # failing somewhere inside a DLL that is not there.
+        from linkedin_mcp_server.windows_acl import current_user_sid
+
+        with pytest.raises(PrivateStateError, match="off Windows"):
+            current_user_sid()

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -320,6 +320,34 @@ class TestRefusals:
 
         assert stat.S_IMODE(elsewhere.stat().st_mode) == 0o644
 
+    @posix_only
+    def test_a_file_swapped_for_a_link_mid_hardening_is_not_followed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Checking the path and then chmodding it resolves the name twice, so a
+        # swap in between is followed by the second resolution. Measured with a
+        # path-based implementation: an unrelated file became 0600 while this
+        # reported the token as private.
+        token = tmp_path / "token"
+        token.touch()
+        token.chmod(0o644)
+        victim = tmp_path / "victim"
+        victim.write_text("not ours")
+        victim.chmod(0o644)
+        real = os.fchmod
+
+        def swap_then_chmod(fd: int, mode: int) -> None:
+            if token.exists() and not token.is_symlink():
+                token.unlink()
+                token.symlink_to(victim)
+            real(fd, mode)
+
+        monkeypatch.setattr(os, "fchmod", swap_then_chmod)
+
+        harden_file(token)
+
+        assert stat.S_IMODE(victim.stat().st_mode) == 0o644
+
     def test_a_file_where_a_directory_belongs_refuses(self, tmp_path: Path):
         occupied = tmp_path / "daemon"
         occupied.write_text("not a directory")
@@ -390,7 +418,10 @@ class TestRefusals:
         # says so. Simulated, since neither can be mounted in a test run.
         target = tmp_path / "token"
         target.touch(mode=0o644)
-        monkeypatch.setattr(Path, "chmod", lambda self, mode: None)
+        # fchmod rather than Path.chmod: a file is hardened through the
+        # descriptor it was opened on, so that is the call such a filesystem
+        # would accept and ignore.
+        monkeypatch.setattr(os, "fchmod", lambda fd, mode: None)
 
         with pytest.raises(PrivateStateError, match="owner-only"):
             harden_file(target)

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -153,6 +153,45 @@ class TestExtendedAcls:
         with pytest.raises(PrivateStateError, match="access control list"):
             harden_directory(target)
 
+    @pytest.mark.skipif(
+        sys.platform != "darwin", reason="extended ACLs are a macOS mechanism here"
+    )
+    def test_hardening_does_not_depend_on_an_executable_being_findable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # This ran chmod and read ls once, and that failed open: measured with
+        # no usable PATH, hardening reported success while everyone could still
+        # read the token, because neither step could run and both treated that
+        # as nothing to report. Going through libc removes the dependency
+        # rather than adding a check for it.
+        subprocess.run(
+            [
+                "chmod",
+                "+a",
+                "everyone allow read,list,search,file_inherit,directory_inherit",
+                str(tmp_path),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        monkeypatch.setenv("PATH", "")
+
+        target = tmp_path / "daemon"
+        harden_directory(target)
+        token = target / "token"
+        token.touch()
+        harden_file(token)
+
+        listing = subprocess.run(
+            ["/bin/ls", "-lde", str(token)], capture_output=True, text=True, check=True
+        ).stdout
+        entries = [
+            line
+            for line in listing.splitlines()[1:]
+            if line.strip() and line.strip()[0].isdigit()
+        ]
+        assert entries == [], "the token is still readable outside this account"
+
 
 class TestRefusals:
     def test_hardening_a_missing_file_refuses(self, tmp_path: Path):

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -370,6 +370,21 @@ class TestRefusals:
         with pytest.raises(PrivateStateError, match="make private"):
             harden_file(target)
 
+    @pytest.mark.parametrize(
+        "path",
+        [Path("~definitely-no-such-user-xyz/state"), Path("/tmp/state\x00x")],
+    )
+    def test_a_path_that_cannot_be_resolved_is_refused(self, path: Path):
+        # Both arrive from configuration a caller was entitled to supply, and
+        # both used to leave this module as somebody else's exception: an
+        # embedded NUL as ValueError, and an unknown user as a directory
+        # literally named "~something" created wherever the process was
+        # running. Measured: one appeared in the working directory.
+        with pytest.raises(PrivateStateError):
+            harden_directory(path)
+
+        assert not path.exists()
+
     def test_a_file_where_a_directory_belongs_refuses(self, tmp_path: Path):
         occupied = tmp_path / "daemon"
         occupied.write_text("not a directory")

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -391,6 +391,47 @@ class TestWindowsAcl:
         assert "S-1-5-11" not in granted  # Authenticated Users
 
     @windows_only
+    def test_hardening_takes_ownership(self, tmp_path: Path):
+        # Windows grants an owner READ_CONTROL and WRITE_DAC implicitly, with
+        # no ACE saying so. A DACL naming only this account is therefore worth
+        # nothing while someone else owns the path: that owner can widen it
+        # again between hardening the directory and writing the token into it.
+        from linkedin_mcp_server.windows_acl import (
+            current_user_sid,
+            read_owner,
+            _sid_to_string,
+        )
+
+        target = tmp_path / "daemon"
+        harden_directory(target)
+
+        sid, buffer = current_user_sid()
+        try:
+            expected = _sid_to_string(sid)
+        finally:
+            del buffer
+
+        assert read_owner(target) == expected
+
+    @windows_only
+    def test_a_foreign_owner_is_refused(self, tmp_path: Path):
+        # The verification has to fail rather than report success, since the
+        # DACL alone looks correct in exactly this case.
+        from unittest.mock import patch
+
+        from linkedin_mcp_server.windows_acl import verify_owner_only
+
+        target = tmp_path / "daemon"
+        harden_directory(target)
+
+        with patch(
+            "linkedin_mcp_server.windows_acl.read_owner",
+            return_value="S-1-5-21-0-0-0-1234",
+        ):
+            with pytest.raises(PrivateStateError, match="owned by"):
+                verify_owner_only(target, directory=True)
+
+    @windows_only
     def test_the_struct_layouts_match_the_windows_headers(self):
         # ctypes sizes a struct from its declared fields, so a wrong field type
         # produces a struct Windows reads at the wrong offsets and reports as

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -7,6 +7,8 @@ only assert that the mock was called.
 
 from __future__ import annotations
 
+import ctypes
+import errno
 import os
 import stat
 import subprocess
@@ -15,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+from linkedin_mcp_server import private_state
 from linkedin_mcp_server.private_state import (
     PrivateStateError,
     harden_directory,
@@ -306,6 +309,60 @@ class TestRefusals:
 
         with pytest.raises(PrivateStateError, match="Not a directory"):
             harden_directory(occupied)
+
+    @pytest.mark.skipif(
+        sys.platform != "darwin", reason="macOS is where an access list needs libc"
+    )
+    def test_missing_access_list_functions_refuse(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Measured before the check: with the bindings absent, a directory
+        # carrying an inherited everyone entry came back from hardening
+        # unchanged while the call reported success. On macOS these functions
+        # are part of libc, so their absence is a broken system rather than a
+        # platform without access lists.
+        monkeypatch.setattr(private_state, "_libc", lambda: None)
+
+        with pytest.raises(PrivateStateError, match="access list functions"):
+            harden_directory(tmp_path / "daemon")
+
+    @posix_only
+    def test_an_unreadable_access_list_refuses(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # acl_get_file returns NULL for any failure and sets errno to say which.
+        # Only the errnos meaning "there is no list" are an answer; reading
+        # EACCES as one would report a path as private without having checked.
+        target = tmp_path / "daemon"
+        target.mkdir()
+
+        class _Failing:
+            def __call__(self, *args: object) -> None:
+                ctypes.set_errno(errno.EACCES)
+                return None
+
+        library = private_state._libc()
+        if library is None:
+            pytest.skip("this platform has no access list functions to fail")
+        monkeypatch.setattr(library, "acl_get_file", _Failing())
+
+        with pytest.raises(PrivateStateError, match="Could not read the access list"):
+            private_state._has_extended_acl(target)
+
+    @posix_only
+    def test_a_path_owned_by_another_account_refuses(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # 0600 says "only the owner", which is worth nothing when the owner is
+        # somebody else: the bits grant them, and they can widen them again. It
+        # takes a privileged process to reach this, which is exactly what a
+        # container started against a pre-existing state tree is.
+        target = tmp_path / "token"
+        target.touch()
+        monkeypatch.setattr(os, "geteuid", lambda: os.stat(target).st_uid + 1)
+
+        with pytest.raises(PrivateStateError, match="is owned by uid"):
+            harden_file(target)
 
     @posix_only
     def test_a_filesystem_that_ignores_chmod_refuses(

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -85,6 +86,72 @@ class TestHardeningOnPosix:
         harden_directory(target)
 
         assert _mode(target) == 0o700
+
+
+class TestExtendedAcls:
+    """Access the permission bits do not describe.
+
+    On macOS an ACL sits alongside the mode rather than inside it, so a file
+    can report 0600 while another account still reads it. Checking only the
+    mode is not checking who has access.
+    """
+
+    @pytest.mark.skipif(
+        sys.platform != "darwin", reason="extended ACLs are a macOS mechanism here"
+    )
+    def test_an_inherited_acl_does_not_survive_hardening(self, tmp_path: Path):
+        # Measured before the fix: an auth root carrying an inheritable
+        # everyone entry produced a token reporting exactly 0600 that everyone
+        # could still read, and hardening returned without complaint.
+        subprocess.run(
+            [
+                "chmod",
+                "+a",
+                "everyone allow read,list,search,file_inherit,directory_inherit",
+                str(tmp_path),
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        target = tmp_path / "daemon"
+        harden_directory(target)
+        token = target / "token"
+        token.touch()
+        harden_file(token)
+
+        for path in (target, token):
+            listing = subprocess.run(
+                ["ls", "-lde", str(path)], capture_output=True, text=True, check=True
+            ).stdout
+            entries = [
+                line
+                for line in listing.splitlines()[1:]
+                if line.strip() and line.strip()[0].isdigit()
+            ]
+            assert entries == [], f"{path} still grants access outside its mode"
+
+    @pytest.mark.skipif(
+        sys.platform != "darwin", reason="extended ACLs are a macOS mechanism here"
+    )
+    def test_an_acl_that_cannot_be_cleared_refuses(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Fails closed. If the entries cannot be removed, the caller must not
+        # go on to write a secret into a file other accounts can read.
+        target = tmp_path / "daemon"
+        target.mkdir()
+        subprocess.run(
+            ["chmod", "+a", "everyone allow read", str(target)],
+            check=True,
+            capture_output=True,
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.private_state._drop_extended_acl", lambda path: None
+        )
+
+        with pytest.raises(PrivateStateError, match="access control list"):
+            harden_directory(target)
 
 
 class TestRefusals:

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -355,10 +355,10 @@ class TestRefusals:
     def test_a_failure_while_hardening_is_this_module_s_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        # The descriptor half can fail too: fchmod, fstat, the access list
-        # calls and the close each have their own OSError. Measured with fchmod
-        # answering EIO before the translation covered them: it crossed the
-        # boundary as itself.
+        # The descriptor half can fail too: fstat, fchmod and the access list
+        # calls each have their own OSError. Measured with fchmod answering EIO
+        # before the translation covered them: it crossed the boundary as
+        # itself.
         target = tmp_path / "token"
         target.touch()
 

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -257,6 +257,40 @@ class TestExtendedAcls:
             ]
             assert entries == [], f"{target} kept an inherited access list"
 
+    def test_resolution_survives_an_audit_hook_reaching_back_in(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Loading a library raises a ctypes.dlopen audit event, and a hook on
+        # it runs synchronously inside the resolution lock. Measured with a
+        # plain lock: a hook that called back in left the resolving thread
+        # waiting on itself and it never finished.
+        import sys
+        import threading
+
+        from linkedin_mcp_server import private_state
+
+        monkeypatch.setattr(private_state, "_libc_resolved", False)
+        monkeypatch.setattr(private_state, "_libc_cache", None)
+
+        reentered: list[str] = []
+
+        def hook(event: str, args: object) -> None:
+            if event == "ctypes.dlopen" and not reentered:
+                reentered.append(event)
+                private_state._libc()
+
+        sys.addaudithook(hook)  # cannot be removed, hence the one-shot guard
+
+        finished = threading.Event()
+
+        def resolve() -> None:
+            private_state._libc()
+            finished.set()
+
+        threading.Thread(target=resolve, daemon=True).start()
+
+        assert finished.wait(5), "resolution deadlocked against its own lock"
+
 
 class TestRefusals:
     def test_hardening_a_missing_file_refuses(self, tmp_path: Path):

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -192,6 +192,71 @@ class TestExtendedAcls:
         ]
         assert entries == [], "the token is still readable outside this account"
 
+    @pytest.mark.skipif(
+        sys.platform != "darwin", reason="extended ACLs are a macOS mechanism here"
+    )
+    def test_concurrent_first_use_does_not_skip_the_access_list(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The library is resolved once and cached. Publishing "resolved" before
+        # the cache was filled let a second thread read an empty cache, which
+        # reads as "this platform has no access lists" everywhere below.
+        # Measured: that thread hardened a directory which kept an inherited
+        # everyone entry, and the call reported success.
+        import threading
+        import time
+
+        from linkedin_mcp_server import private_state
+
+        monkeypatch.setattr(private_state, "_libc_resolved", False)
+        monkeypatch.setattr(private_state, "_libc_cache", None)
+        real_find = private_state.ctypes.util.find_library
+        monkeypatch.setattr(
+            private_state.ctypes.util,
+            "find_library",
+            lambda name: (time.sleep(0.2), real_find(name))[1],
+        )
+
+        hardened: list[Path] = []
+
+        def harden(index: int) -> None:
+            root = tmp_path / f"root{index}"
+            root.mkdir()
+            subprocess.run(
+                [
+                    "chmod",
+                    "+a",
+                    "everyone allow list,file_inherit,directory_inherit",
+                    str(root),
+                ],
+                check=True,
+                capture_output=True,
+            )
+            target = root / "daemon"
+            harden_directory(target)
+            hardened.append(target)
+
+        threads = [threading.Thread(target=harden, args=(i,)) for i in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(hardened) == 4
+        for target in hardened:
+            listing = subprocess.run(
+                ["/bin/ls", "-lde", str(target)],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+            entries = [
+                line
+                for line in listing.splitlines()[1:]
+                if line.strip() and line.strip()[0].isdigit()
+            ]
+            assert entries == [], f"{target} kept an inherited access list"
+
 
 class TestRefusals:
     def test_hardening_a_missing_file_refuses(self, tmp_path: Path):

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -303,6 +303,23 @@ class TestRefusals:
         with pytest.raises(PrivateStateError, match="does not exist"):
             harden_file(tmp_path / "absent")
 
+    @posix_only
+    def test_hardening_a_linked_file_refuses(self, tmp_path: Path):
+        # chmod follows a link, so hardening one would set 0600 on whatever it
+        # points at and report the secret's own file as private. Measured: an
+        # unrelated 0644 file became 0600 while the caller was told its token
+        # was protected.
+        elsewhere = tmp_path / "someone-elses"
+        elsewhere.write_text("not ours")
+        elsewhere.chmod(0o644)
+        link = tmp_path / "token"
+        link.symlink_to(elsewhere)
+
+        with pytest.raises(PrivateStateError, match="symbolic link"):
+            harden_file(link)
+
+        assert stat.S_IMODE(elsewhere.stat().st_mode) == 0o644
+
     def test_a_file_where_a_directory_belongs_refuses(self, tmp_path: Path):
         occupied = tmp_path / "daemon"
         occupied.write_text("not a directory")

--- a/tests/test_private_state.py
+++ b/tests/test_private_state.py
@@ -327,7 +327,9 @@ class TestRefusals:
         # Checking the path and then chmodding it resolves the name twice, so a
         # swap in between is followed by the second resolution. Measured with a
         # path-based implementation: an unrelated file became 0600 while this
-        # reported the token as private.
+        # reported the token as private. Hardening through the descriptor keeps
+        # the other file untouched, and the swap is then reported rather than
+        # passed off as success.
         token = tmp_path / "token"
         token.touch()
         token.chmod(0o644)
@@ -344,7 +346,8 @@ class TestRefusals:
 
         monkeypatch.setattr(os, "fchmod", swap_then_chmod)
 
-        harden_file(token)
+        with pytest.raises(PrivateStateError, match="was replaced"):
+            harden_file(token)
 
         assert stat.S_IMODE(victim.stat().st_mode) == 0o644
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,71 @@ from linkedin_mcp_server import __version__
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
-from linkedin_mcp_server.server import create_mcp_server
+from linkedin_mcp_server.server import ServerRole, create_mcp_server
+from linkedin_mcp_server.update_check import UpdateNoticeMiddleware
+
+
+def _has_middleware(mcp: FastMCP, kind: type) -> bool:
+    return any(isinstance(middleware, kind) for middleware in mcp.middleware)
+
+
+class TestServerRoles:
+    """Which middleware each role gets, and why the split has to exist.
+
+    These are not restatements of the implementation: each one pins a failure
+    that is invisible in a single-process test run and only shows up once two
+    processes share a profile.
+    """
+
+    def test_the_default_role_is_the_historical_server(self):
+        # Every existing caller passes only tool_timeout, so the default has to
+        # keep giving them exactly what they had before the split.
+        default = create_mcp_server()
+        direct = create_mcp_server(role=ServerRole.DIRECT)
+
+        for mcp in (default, direct):
+            assert _has_middleware(mcp, SequentialToolExecutionMiddleware)
+            assert _has_middleware(mcp, UpdateNoticeMiddleware)
+
+    def test_a_proxy_never_competes_for_the_profile(self):
+        # A proxy forwards to whoever owns the browser. Taking the profile
+        # lease here would make it wait for a lease it will never use, and the
+        # owner it forwards to would then wait for the lease the proxy holds.
+        mcp = create_mcp_server(role=ServerRole.PROXY)
+
+        assert not _has_middleware(mcp, SequentialToolExecutionMiddleware)
+
+    def test_an_owner_still_serializes_calls(self):
+        # The owner is the process that actually drives Chromium, so it keeps
+        # the serialization the shared profile depends on.
+        mcp = create_mcp_server(role=ServerRole.OWNER)
+
+        assert _has_middleware(mcp, SequentialToolExecutionMiddleware)
+
+    def test_the_update_notice_follows_the_client_not_the_browser(self):
+        # The notice is appended once per process. On a shared owner that means
+        # one client sees it and every later one never does, however long the
+        # owner lives, so it belongs on the processes clients talk to.
+        owner = create_mcp_server(role=ServerRole.OWNER)
+        proxy = create_mcp_server(role=ServerRole.PROXY)
+
+        assert not _has_middleware(owner, UpdateNoticeMiddleware)
+        assert _has_middleware(proxy, UpdateNoticeMiddleware)
+
+    def test_every_role_serves_the_same_tools(self):
+        # The proxy advertises what it forwards, so a tool missing from one
+        # role would silently disappear from a client's list.
+        async def tool_names(role: ServerRole) -> set[str]:
+            tools = await create_mcp_server(role=role).list_tools()
+            return {tool.name for tool in tools}
+
+        direct, owner, proxy = (
+            asyncio.run(tool_names(role))
+            for role in (ServerRole.DIRECT, ServerRole.OWNER, ServerRole.PROXY)
+        )
+
+        assert direct == owner == proxy
+        assert "get_person_profile" in direct
 
 
 class TestSequentialToolExecutionMiddleware:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,45 +36,35 @@ class TestServerRoles:
             assert _has_middleware(mcp, SequentialToolExecutionMiddleware)
             assert _has_middleware(mcp, UpdateNoticeMiddleware)
 
-    def test_a_proxy_never_competes_for_the_profile(self):
-        # A proxy forwards to whoever owns the browser. Taking the profile
-        # lease here would make it wait for a lease it will never use, and the
-        # owner it forwards to would then wait for the lease the proxy holds.
-        mcp = create_mcp_server(role=ServerRole.PROXY)
+    def test_every_role_that_drives_a_browser_serializes_its_calls(self):
+        # The invariant the shared profile depends on: any server that can
+        # reach Chromium takes the lease first. A role added later that skips
+        # this would corrupt the session rather than merely run slowly.
+        for role in ServerRole:
+            mcp = create_mcp_server(role=role)
 
-        assert not _has_middleware(mcp, SequentialToolExecutionMiddleware)
+            assert role.drives_browser
+            assert _has_middleware(mcp, SequentialToolExecutionMiddleware), role
 
-    def test_an_owner_still_serializes_calls(self):
-        # The owner is the process that actually drives Chromium, so it keeps
-        # the serialization the shared profile depends on.
-        mcp = create_mcp_server(role=ServerRole.OWNER)
-
-        assert _has_middleware(mcp, SequentialToolExecutionMiddleware)
-
-    def test_the_update_notice_follows_the_client_not_the_browser(self):
-        # The notice is appended once per process. On a shared owner that means
-        # one client sees it and every later one never does, however long the
-        # owner lives, so it belongs on the processes clients talk to.
+    def test_the_update_notice_goes_only_where_a_user_reads_it(self):
+        # Appended to one tool result per process. On a server shared by many
+        # clients that means the first caller sees it and nobody afterwards
+        # does, however long that server lives.
         owner = create_mcp_server(role=ServerRole.OWNER)
-        proxy = create_mcp_server(role=ServerRole.PROXY)
 
         assert not _has_middleware(owner, UpdateNoticeMiddleware)
-        assert _has_middleware(proxy, UpdateNoticeMiddleware)
 
     def test_every_role_serves_the_same_tools(self):
-        # The proxy advertises what it forwards, so a tool missing from one
-        # role would silently disappear from a client's list.
+        # A tool present in one role and missing from another would disappear
+        # from a client's list depending on how its server happened to start.
         async def tool_names(role: ServerRole) -> set[str]:
             tools = await create_mcp_server(role=role).list_tools()
             return {tool.name for tool in tools}
 
-        direct, owner, proxy = (
-            asyncio.run(tool_names(role))
-            for role in (ServerRole.DIRECT, ServerRole.OWNER, ServerRole.PROXY)
-        )
+        served = {role: asyncio.run(tool_names(role)) for role in ServerRole}
 
-        assert direct == owner == proxy
-        assert "get_person_profile" in direct
+        assert len(set(map(frozenset, served.values()))) == 1
+        assert "get_person_profile" in served[ServerRole.DIRECT]
 
 
 class TestSequentialToolExecutionMiddleware:


### PR DESCRIPTION
Closes #608

The server is about to keep a bearer token on disk (#606), and a token any local account can read is the same as no token.

On POSIX the existing helpers answer this. On Windows they do not: `os.chmod` there only toggles the read-only attribute, access is decided by the file's access control list, and `harden_linkedin_tree` is an explicit no-op (`common_utils.py:43-51`).

Two gaps existed on POSIX too, both measured. `secure_mkdir` applies its mode only to directories it creates, so a `0600` token could sit inside a pre-existing `0755` directory and look protected. And `harden_linkedin_tree` deliberately stops outside a `.linkedin-mcp` directory, so a custom `USER_DATA_DIR` was never covered.

A third turned up during review and is the reason this is not just a Windows change: on macOS an access list sits alongside the mode rather than inside it, and `chmod` leaves it untouched. An auth root carrying an inheritable `everyone` entry produced a token file reporting exactly `0600` that everyone could still read, while hardening returned without complaint. Checking the mode was not checking access.

So this adds one helper that makes the same promise on both platforms and verifies it rather than assuming it. On Windows the access list is replaced rather than merged, so a permissive parent does not pass its grants down, and marked protected so they are not inherited back. A directory's entry is inheritable, which means a file created inside is owner-only from the instant it exists rather than from whenever something hardens it. On macOS the list is cleared through libc and read back; going through `chmod` and `ls` failed open when neither could be found on `PATH`.

Every path fails closed. A filesystem that accepts the call and stores nothing, which is what a share or a FAT volume does, is caught by reading the result back.

Worth being plain about the value: a normal Windows profile is already closed to other non-administrator accounts, so that half is defence in depth. It earns its place when the profile has been redirected, when a parent was created with wider permissions, or when the data directory sits outside the profile. Neither platform's mechanism keeps out an administrator or root.

The Win32 calls follow Microsoft's documentation, including that `SetNamedSecurityInfoW` returns its error code directly rather than setting the thread's last error, so checking `GetLastError` there would read a stale value and report a failure as success.

Verified with 1156 tests, 25 of them new. The four Windows tests cannot run on Linux or macOS, so the cross-platform CI job now covers them; they assert the resulting access list rather than mocking the calls.

## Synthetic prompt

> The daemon work needs a bearer token on disk. `os.chmod` does not protect a file on Windows, macOS access lists survive it, and the existing helpers do not harden a directory that already exists or one outside a `.linkedin-mcp` tree. Add a helper that makes a path readable only by the current account on both platforms, using the Win32 security APIs through ctypes on Windows and libc on macOS, verifying the result rather than trusting the call, and failing closed with no dependency on an external tool being findable. Extend the cross-platform CI job to run the Windows tests.






