### PR TITLE
feat(messaging): message invitation senders

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_conversation` | Read a specific messaging conversation by username or thread ID | working |
 | `search_conversations` | Search messages by keyword | working |
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) [#483](https://github.com/stickerdaniel/linkedin-mcp-server/issues/483) [#560](https://github.com/stickerdaniel/linkedin-mcp-server/issues/560) [#573](https://github.com/stickerdaniel/linkedin-mcp-server/issues/573) |
+| `message_invitation_sender` | Message a received connection-invitation sender using its invitation compose URL (requires confirmation) | [#613](https://github.com/stickerdaniel/linkedin-mcp-server/issues/613) |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
 | `search_companies` | Search for companies on LinkedIn by keywords | working |
@@ -56,6 +57,10 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `search_posts` | Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter (past-24h/past-week/past-month) | working |
 | `close_session` | Close browser session and clean up resources | working |
+
+`message_invitation_sender` accepts the relative `/messaging/compose/` URL
+exposed by a received invitation plus the sender's `linkedin_username`; set
+`confirm_send=true` to send.
 
 <br/>
 <br/>

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -9,6 +9,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Profile Access**: Get detailed LinkedIn profile information including experience, education, skills, projects, certifications, and more
 - **Own Profile**: Fetch the authenticated user's own profile to give agents self-context
 - **Profile Connections**: Send connection requests or accept incoming ones, with optional notes
+- **Invitation Messaging**: Message received connection-invitation senders through their invitation compose URL with explicit confirmation
 - **Company Profiles**: Extract comprehensive company data, including the LinkedIn company URN id (used by LinkedIn's people-search `currentCompany` URL facet)
 - **Company Employees**: List employees at a company with optional keyword filtering
 - **Company Search**: Search for companies by keyword

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2591,6 +2591,20 @@ class LinkedInExtractor:
         """Wait for the usable LinkedIn message composer to appear."""
         return await self._resolve_message_compose_box() is not None
 
+    async def _resolve_recipient_message_compose_box(
+        self, *candidates: str
+    ) -> Any | None:
+        """Wait for the newest compose box to identify the intended recipient."""
+        for _ in range(20):
+            compose_box = await self._resolve_message_compose_box()
+            if compose_box is not None and await self._compose_page_matches_recipient(
+                compose_box,
+                *candidates,
+            ):
+                return compose_box
+            await asyncio.sleep(0.25)
+        return None
+
     async def _resolve_message_compose_box(self) -> Any | None:
         """Resolve the visible compose box used for writing a LinkedIn message.
 
@@ -4228,11 +4242,11 @@ class LinkedInExtractor:
             linkedin_username,
         )
 
-        if not await self._compose_page_matches_recipient(
-            compose_box,
+        recipient_compose_box = await self._resolve_recipient_message_compose_box(
             display_name or "",
             linkedin_username,
-        ):
+        )
+        if recipient_compose_box is None:
             logger.debug(
                 "Recipient match still failed for %s after compose hydration",
                 linkedin_username,
@@ -4244,6 +4258,7 @@ class LinkedInExtractor:
                 "LinkedIn opened a compose page, but the visible recipient did not match the requested profile.",
                 recipient_selected=recipient_selected,
             )
+        compose_box = recipient_compose_box
         recipient_selected = True
 
         if not confirm_send:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4007,6 +4007,74 @@ class LinkedInExtractor:
             references=references,
         )
 
+    async def _open_invitation_message_compose(
+        self,
+        linkedin_username: str,
+        message_url: str,
+    ) -> bool:
+        """Open an invitation's message modal from the received-invitations page."""
+        username = _normalize_invitation_username(linkedin_username)
+        await self._navigate_to_page(_invitation_manager_url("received"))
+        await detect_rate_limit(self._page)
+        await self._wait_for_main_text(log_context="Invitations (received)")
+        await handle_modal_close(self._page)
+        # Invitation links render before LinkedIn attaches their SPA modal handlers.
+        await self._page.wait_for_timeout(2000)
+
+        for attempt in range(20):
+            invitations = await self._extract_invitation_cards(
+                kind="received",
+                limit=100,
+            )
+            matching_invitation = next(
+                (
+                    invitation
+                    for invitation in invitations
+                    if invitation.get("type") == "connection_request"
+                    and invitation.get("message_url") == message_url
+                    and _normalize_invitation_username(
+                        ((invitation.get("sender") or {}).get("url") or "")
+                    )
+                    == username
+                ),
+                None,
+            )
+            if matching_invitation is not None:
+                # DOM access is required to trigger LinkedIn's modal; direct URL
+                # navigation renders an empty compose shell.
+                link_index = await self._page.evaluate(
+                    """({ expected }) => Array.from(
+                        document.querySelectorAll('a[href*="/messaging/compose/"]')
+                    ).findIndex(anchor => {
+                        const url = new URL(
+                            anchor.getAttribute('href'),
+                            location.origin
+                        );
+                        return url.pathname + url.search === expected;
+                    })""",
+                    {"expected": message_url},
+                )
+                if not isinstance(link_index, int) or link_index < 0:
+                    return False
+                try:
+                    await (
+                        self._page.locator('a[href*="/messaging/compose/"]')
+                        .nth(link_index)
+                        .click()
+                    )
+                except Exception:
+                    logger.debug(
+                        "Could not click invitation message link",
+                        exc_info=True,
+                    )
+                    return False
+                return True
+
+            if attempt >= 19 or not await self._scroll_invitation_manager_down():
+                break
+
+        return False
+
     async def send_message(
         self,
         linkedin_username: str,
@@ -4014,6 +4082,7 @@ class LinkedInExtractor:
         *,
         confirm_send: bool,
         profile_urn: str | None = None,
+        compose_url: str | None = None,
     ) -> dict[str, Any]:
         """Send a message to a LinkedIn user with explicit confirmation gating.
 
@@ -4023,8 +4092,26 @@ class LinkedInExtractor:
             confirm_send: Must be True to actually send (False does a dry run).
             profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
                 compose URL directly, bypassing the Message-button lookup.
+            compose_url: Optional relative invitation compose URL returned by
+                ``get_pending_invitations``.
         """
         profile_url = f"https://www.linkedin.com/in/{linkedin_username}/"
+        if compose_url is not None:
+            parsed_compose_url = urlparse(compose_url)
+            if (
+                parsed_compose_url.scheme
+                or parsed_compose_url.netloc
+                or parsed_compose_url.path != "/messaging/compose/"
+                or not parsed_compose_url.query
+                or parsed_compose_url.fragment
+            ):
+                return self._message_action_result(
+                    profile_url,
+                    "message_unavailable",
+                    "Invitation message URL must be a relative "
+                    "/messaging/compose/ path with a query string.",
+                )
+
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
 
@@ -4035,38 +4122,51 @@ class LinkedInExtractor:
 
         await handle_modal_close(self._page)
         display_name = await self._read_profile_display_name()
-        if profile_urn:
-            # Build the full compose URL that LinkedIn's own Message button
-            # generates. The minimal ?recipient=<URN> form works for established
-            # connections but shows a "Say hello" widget (no compose box) for new
-            # connections. Adding profileUrn + screenContext + interop=msgOverlay
-            # consistently opens the real composer regardless of connection age.
-            _encoded = quote_plus(f"urn:li:fsd_profile:{profile_urn}")
-            compose_url: str | None = (
-                f"https://www.linkedin.com/messaging/compose/"
-                f"?profileUrn={_encoded}"
-                f"&recipient={profile_urn}"
-                f"&screenContext=NON_SELF_PROFILE_VIEW"
-                f"&interop=msgOverlay"
-            )
+        if compose_url is not None:
+            if not await self._open_invitation_message_compose(
+                linkedin_username,
+                compose_url,
+            ):
+                return self._message_action_result(
+                    profile_url,
+                    "message_unavailable",
+                    "LinkedIn did not expose the requested invitation message action.",
+                )
         else:
-            compose_url = await self._resolve_message_compose_href()
-        if not compose_url:
-            return self._message_action_result(
-                profile_url,
-                "message_unavailable",
-                "LinkedIn did not expose a usable Message action for this profile.",
-            )
+            if profile_urn:
+                # Build the full compose URL that LinkedIn's own Message button
+                # generates. The minimal ?recipient=<URN> form works for established
+                # connections but shows a "Say hello" widget (no compose box) for new
+                # connections. Adding profileUrn + screenContext + interop=msgOverlay
+                # consistently opens the real composer regardless of connection age.
+                _encoded = quote_plus(f"urn:li:fsd_profile:{profile_urn}")
+                compose_url = (
+                    f"https://www.linkedin.com/messaging/compose/"
+                    f"?profileUrn={_encoded}"
+                    f"&recipient={profile_urn}"
+                    f"&screenContext=NON_SELF_PROFILE_VIEW"
+                    f"&interop=msgOverlay"
+                )
+            else:
+                compose_url = await self._resolve_message_compose_href()
+            if not compose_url:
+                return self._message_action_result(
+                    profile_url,
+                    "message_unavailable",
+                    "LinkedIn did not expose a usable Message action for this profile.",
+                )
 
-        await self._navigate_to_page(compose_url)
-        await detect_rate_limit(self._page)
+            await self._navigate_to_page(compose_url)
+            await detect_rate_limit(self._page)
 
-        try:
-            await self._page.wait_for_selector("main")
-        except PlaywrightTimeoutError:
-            logger.debug("Compose page did not fully load for %s", linkedin_username)
+            try:
+                await self._page.wait_for_selector("main")
+            except PlaywrightTimeoutError:
+                logger.debug(
+                    "Compose page did not fully load for %s", linkedin_username
+                )
 
-        await handle_modal_close(self._page)
+            await handle_modal_close(self._page)
         message_surface = await self._wait_for_message_surface()
         logger.debug(
             "Message surface for %s before hydration was %s",

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2707,7 +2707,8 @@ class LinkedInExtractor:
                     return True
             except Exception:
                 logger.debug("Could not verify sent message", exc_info=True)
-                return False
+                # LinkedIn can replace the composer node while rendering the
+                # sent bubble; retry until the verification deadline.
             await asyncio.sleep(0.25)
         return False
 
@@ -4022,8 +4023,10 @@ class LinkedInExtractor:
         message_url: str,
     ) -> bool:
         """Open an invitation's message modal from the received-invitations page."""
-        username = _normalize_invitation_username(linkedin_username)
-        await self._navigate_to_page(_invitation_manager_url("received"))
+        username = linkedin_username.strip().lower()
+        await self._navigate_to_page(
+            "https://www.linkedin.com/mynetwork/invitation-manager/received/"
+        )
         await detect_rate_limit(self._page)
         await self._wait_for_main_text(log_context="Invitations (received)")
         await handle_modal_close(self._page)
@@ -4031,43 +4034,57 @@ class LinkedInExtractor:
         await self._page.wait_for_timeout(2000)
 
         for attempt in range(20):
-            invitations = await self._extract_invitation_cards(
-                kind="received",
-                limit=100,
-            )
-            matching_invitation = next(
-                (
-                    invitation
-                    for invitation in invitations
-                    if invitation.get("type") == "connection_request"
-                    and invitation.get("message_url") == message_url
-                    and _normalize_invitation_username(
-                        ((invitation.get("sender") or {}).get("url") or "")
-                    )
-                    == username
-                ),
-                None,
-            )
-            if matching_invitation is not None:
-                # DOM access is required to trigger LinkedIn's modal; direct URL
-                # navigation renders an empty compose shell.
-                link_index = await self._page.evaluate(
-                    """({ expected }) => Array.from(
-                        document.querySelectorAll('a[href*="/messaging/compose/"]')
+            link_index = await self._page.evaluate(
+                """({ expected, username }) => {
+                    const main = document.querySelector('main');
+                    if (!main) return -1;
+                    const profileUsername = href => {
+                        try {
+                            const match = new URL(href, location.origin)
+                                .pathname.match(/^\\/in\\/([^/]+)/);
+                            return decodeURIComponent(match?.[1] || '').toLowerCase();
+                        } catch {
+                            return '';
+                        }
+                    };
+                    return Array.from(
+                        main.querySelectorAll('a[href*="/messaging/compose/"]')
                     ).findIndex(anchor => {
                         const url = new URL(
                             anchor.getAttribute('href'),
                             location.origin
                         );
-                        return url.pathname + url.search === expected;
-                    })""",
-                    {"expected": message_url},
-                )
-                if not isinstance(link_index, int) or link_index < 0:
-                    return False
+                        if (url.pathname + url.search !== expected) return false;
+                        for (
+                            let root = anchor.parentElement;
+                            root && root !== main;
+                            root = root.parentElement
+                        ) {
+                            if (
+                                root.querySelectorAll(
+                                    'a[href*="/messaging/compose/"]'
+                                ).length > 1
+                            ) return false;
+                            if (
+                                Array.from(
+                                    root.querySelectorAll('a[href*="/in/"]')
+                                ).some(profile =>
+                                    profileUsername(profile.getAttribute('href'))
+                                        === username
+                                )
+                            ) return true;
+                        }
+                        return false;
+                    });
+                }""",
+                {"expected": message_url, "username": username},
+            )
+            if isinstance(link_index, int) and link_index >= 0:
+                # DOM access is required to trigger LinkedIn's modal; direct URL
+                # navigation renders an empty compose shell.
                 try:
                     await (
-                        self._page.locator('a[href*="/messaging/compose/"]')
+                        self._page.locator('main a[href*="/messaging/compose/"]')
                         .nth(link_index)
                         .click()
                     )
@@ -4079,8 +4096,11 @@ class LinkedInExtractor:
                     return False
                 return True
 
-            if attempt >= 19 or not await self._scroll_invitation_manager_down():
-                break
+            if attempt < 19:
+                await self._scroll_main_scrollable_region(
+                    position="bottom",
+                    attempts=1,
+                )
 
         return False
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2683,24 +2683,33 @@ class LinkedInExtractor:
         )
         return bool(matched)
 
-    async def _message_text_visible(self, message: str) -> bool:
-        """Wait until the compose page visibly contains the just-sent message text.
-
-        Uses the page-level default timeout (``BrowserConfig.default_timeout``).
-        """
-        try:
-            await self._page.wait_for_function(
-                """({ expected }) => {
-                    const normalize = value =>
-                        (value || '').replace(/\\s+/g, ' ').trim();
-                    const bodyText = normalize(document.body?.innerText || '');
-                    return bodyText.includes(normalize(expected));
-                }""",
-                arg={"expected": message},
-            )
-            return True
-        except PlaywrightTimeoutError:
-            return False
+    async def _message_text_visible(self, message: str, compose_box: Any) -> bool:
+        """Confirm the editor cleared and a sent bubble contains ``message``."""
+        for _ in range(20):
+            try:
+                visible = await compose_box.evaluate(
+                    """(editor, expected) => {
+                        const normalize = value =>
+                            (value || '').replace(/\\s+/g, ' ').trim();
+                        const root = editor.getRootNode();
+                        const messageVisible = Array.from(
+                            root.querySelectorAll('p, div, span')
+                        ).some(element =>
+                            !element.closest('[contenteditable="true"]')
+                            && normalize(element.innerText || element.textContent)
+                                === normalize(expected)
+                        );
+                        return !normalize(editor.innerText) && messageVisible;
+                    }""",
+                    message,
+                )
+                if visible:
+                    return True
+            except Exception:
+                logger.debug("Could not verify sent message", exc_info=True)
+                return False
+            await asyncio.sleep(0.25)
+        return False
 
     async def _dismiss_message_ui(self) -> None:
         """Best-effort dismissal for the profile messaging UI."""
@@ -4242,25 +4251,30 @@ class LinkedInExtractor:
 
         # patchright quirk: compose_box.click() and press_sequentially() use
         # actionability checks internally and hit the same wait_for timeout.
-        # Instead: focus via page.evaluate() (no actionability check) and type
-        # via page.keyboard.type() which operates on the active element directly
-        # and fires the real keydown/input/keyup events React needs to enable Send.
+        # Instead: focus the resolved element via evaluate() (no actionability
+        # check) and type via page.keyboard, which fires the real events React
+        # needs to enable Send.
         #
-        # DOM dependency: innerText extraction is not applicable here — we need
-        # to call .focus() on the element reference, which requires querySelector.
-        # Selectors use only role + contenteditable + aria-label (ARIA attributes,
-        # not layout class names) so they are stable across LinkedIn UI changes.
-        focused = await self._page.evaluate(
-            """() => {
-                const el = document.querySelector(
-                    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
-                    + 'div[role="textbox"][contenteditable="true"]'
-                );
-                if (!el) return false;
-                el.focus();
-                return true;
-            }"""
-        )
+        # Newlines are emitted as Shift+Enter (see _type_message_with_newlines):
+        # plain Enter submits LinkedIn's composer, so a literal "\n" inside
+        # keyboard.type() would split a multi-paragraph message into one send
+        # per line. See issue #441.
+        #
+        # DOM dependency: innerText cannot focus an element. The resolved
+        # locator uses role + contenteditable + aria-label, not layout classes.
+        try:
+            focused = await compose_box.evaluate(
+                """el => {
+                    el.focus();
+                    return (
+                        document.activeElement === el
+                        || el.getRootNode().activeElement === el
+                    );
+                }"""
+            )
+        except Exception:
+            logger.debug("Could not focus resolved compose box", exc_info=True)
+            focused = False
         if not focused:
             await self._dismiss_message_ui()
             return self._message_action_result(
@@ -4274,16 +4288,18 @@ class LinkedInExtractor:
         await asyncio.sleep(0.3)
 
         # patchright actionability also blocks send_button.click(). Use JS click
-        # on any visible, enabled send button; fall back to Enter key which
-        # LinkedIn's composer also accepts for submission.
+        # on a visible, enabled send button in this editor's form; fall back to
+        # Enter, which LinkedIn's composer also accepts for submission.
         #
         # DOM dependency: we need btn.click() on the element reference — not
         # achievable via innerText or URL navigation. Selectors use only type,
         # aria-label, and data attributes (no layout class names).
         await asyncio.sleep(1.0)  # allow React to process keyboard input
-        sent_via_js = await self._page.evaluate(
-            """() => {
-                const btn = Array.from(document.querySelectorAll(
+        sent_via_js = await compose_box.evaluate(
+            """editor => {
+                const form = editor.closest('form');
+                if (!form) return false;
+                const btn = Array.from(form.querySelectorAll(
                     'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
                     + 'button[data-control-name="send"]'
                 )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
@@ -4295,7 +4311,7 @@ class LinkedInExtractor:
         if not sent_via_js:
             await self._page.keyboard.press("Enter")
 
-        if not await self._message_text_visible(message):
+        if not await self._message_text_visible(message, compose_box):
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2665,34 +2665,15 @@ class LinkedInExtractor:
             """(editor, { candidates }) => {
                 const normalize = value =>
                     (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth ||
-                            element.offsetHeight ||
-                            element.getClientRects().length)
-                    );
-
-                const targetValues = candidates.map(normalize).filter(Boolean);
                 const root =
                     editor.closest('[role="dialog"]') || editor.closest('form');
                 if (!root) return false;
-
-                const entries = Array.from(
-                    root.querySelectorAll(
-                        'button, [role="button"], a, span, div, li, p, h1, h2, h3'
-                    )
-                )
-                    .filter(isVisible)
-                    .map(element =>
-                        [
-                            normalize(element.innerText || element.textContent || ''),
-                            normalize(element.getAttribute('aria-label') || ''),
-                        ].filter(Boolean)
-                    )
-                    .flat();
-
-                return targetValues.some(candidate =>
+                const entries = [
+                    normalize(root.innerText),
+                    ...Array.from(root.querySelectorAll('[aria-label]'))
+                        .map(element => normalize(element.getAttribute('aria-label'))),
+                ].filter(Boolean);
+                return candidates.map(normalize).filter(Boolean).some(candidate =>
                     entries.some(entry => entry === candidate || entry.includes(candidate))
                 );
             }""",
@@ -4227,8 +4208,7 @@ class LinkedInExtractor:
                 message_surface,
             )
 
-        compose_box = await self._resolve_message_compose_box()
-        if compose_box is None:
+        if message_surface is None:
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
@@ -4237,16 +4217,11 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
 
-        logger.debug(
-            "Message compose box resolved for %s after hydration",
-            linkedin_username,
-        )
-
-        recipient_compose_box = await self._resolve_recipient_message_compose_box(
+        compose_box = await self._resolve_recipient_message_compose_box(
             display_name or "",
             linkedin_username,
         )
-        if recipient_compose_box is None:
+        if compose_box is None:
             logger.debug(
                 "Recipient match still failed for %s after compose hydration",
                 linkedin_username,
@@ -4258,7 +4233,6 @@ class LinkedInExtractor:
                 "LinkedIn opened a compose page, but the visible recipient did not match the requested profile.",
                 recipient_selected=recipient_selected,
             )
-        compose_box = recipient_compose_box
         recipient_selected = True
 
         if not confirm_send:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2639,14 +2639,16 @@ class LinkedInExtractor:
 
         return None
 
-    async def _compose_page_matches_recipient(self, *candidates: str) -> bool:
-        """Verify the compose page visibly identifies the intended recipient."""
+    async def _compose_page_matches_recipient(
+        self, compose_box: Any, *candidates: str
+    ) -> bool:
+        """Verify the resolved compose dialog identifies the intended recipient."""
         normalized_candidates = [value.strip() for value in candidates if value.strip()]
         if not normalized_candidates:
             return False
 
-        matched = await self._page.evaluate(
-            """({ candidates }) => {
+        matched = await compose_box.evaluate(
+            """(editor, { candidates }) => {
                 const normalize = value =>
                     (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
                 const isVisible = element =>
@@ -2658,7 +2660,8 @@ class LinkedInExtractor:
                     );
 
                 const targetValues = candidates.map(normalize).filter(Boolean);
-                const root = document.querySelector('main') || document.body;
+                const root =
+                    editor.closest('[role="dialog"]') || editor.closest('form');
                 if (!root) return false;
 
                 const entries = Array.from(
@@ -2691,7 +2694,9 @@ class LinkedInExtractor:
                     """(editor, expected) => {
                         const normalize = value =>
                             (value || '').replace(/\\s+/g, ' ').trim();
-                        const root = editor.getRootNode();
+                        const root =
+                            editor.closest('[role="dialog"]') || editor.closest('form');
+                        if (!root) return false;
                         const messageVisible = Array.from(
                             root.querySelectorAll('p, div, span')
                         ).some(element =>
@@ -4224,6 +4229,7 @@ class LinkedInExtractor:
         )
 
         if not await self._compose_page_matches_recipient(
+            compose_box,
             display_name or "",
             linkedin_username,
         ):

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -269,3 +269,47 @@ def register_messaging_tools(
                 raise_tool_error(relogin_exc, "send_message")
         except Exception as e:
             raise_tool_error(e, "send_message")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Message Invitation Sender",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"messaging", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def message_invitation_sender(
+        linkedin_username: str,
+        message_url: str,
+        message: str,
+        confirm_send: bool,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """Message the sender of a received connection invitation.
+
+        ``message_url`` must be the relative compose URL returned by
+        ``get_pending_invitations`` for the sender. Set ``confirm_send`` to
+        ``True`` to send; ``False`` performs a recipient-verified dry run.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="message_invitation_sender"
+            )
+            logger.info(
+                "Messaging invitation sender %s (confirm_send=%s)",
+                linkedin_username,
+                confirm_send,
+            )
+            return await extractor.send_message(
+                linkedin_username,
+                message,
+                confirm_send=confirm_send,
+                compose_url=message_url,
+            )
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "message_invitation_sender")
+        except Exception as e:
+            raise_tool_error(e, "message_invitation_sender")  # NoReturn

--- a/manifest.json
+++ b/manifest.json
@@ -112,6 +112,10 @@
       "description": "Send a message to a LinkedIn user with explicit confirmation and optional profile URN support"
     },
     {
+      "name": "message_invitation_sender",
+      "description": "Message a received connection-invitation sender through its invitation compose URL with explicit confirmation"
+    },
+    {
       "name": "get_feed",
       "description": "Get recent posts from the authenticated user's LinkedIn home feed"
     },

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5865,6 +5865,35 @@ class TestSendMessageComposerInteraction:
         assert "editor.closest('[role=\"dialog\"]')" in verification_script
         assert "document.querySelector('main')" not in verification_script
 
+    async def test_waits_for_recipient_composer_to_hydrate(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        wrong_compose_box = MagicMock()
+        recipient_compose_box = MagicMock()
+
+        with (
+            patch.object(
+                extractor,
+                "_resolve_message_compose_box",
+                new_callable=AsyncMock,
+                side_effect=[wrong_compose_box, recipient_compose_box],
+            ),
+            patch.object(
+                extractor,
+                "_compose_page_matches_recipient",
+                new_callable=AsyncMock,
+                side_effect=[False, True],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            resolved = await extractor._resolve_recipient_message_compose_box(
+                "Test User"
+            )
+
+        assert resolved is recipient_compose_box
+
 
 class TestBuildFeedReferences:
     """Tests for _build_feed_references SDUI-capture / DOM-anchor merging."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5416,6 +5416,204 @@ class TestSendMessage:
         assert "screenContext=NON_SELF_PROFILE_VIEW" in compose_url
         assert "interop=msgOverlay" in compose_url
 
+    async def test_uses_invitation_compose_url_when_provided(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        invitation_url = (
+            "/messaging/compose/?recipient=ACoAAB"
+            "&invitation=urn%3Ali%3Afsd_invitation%3A123"
+        )
+
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_read_profile_display_name",
+                new_callable=AsyncMock,
+                return_value="Test User",
+            ),
+            patch.object(
+                extractor,
+                "_open_invitation_message_compose",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_open_invitation_compose,
+            patch.object(
+                extractor,
+                "_resolve_message_compose_href",
+                new_callable=AsyncMock,
+            ) as mock_resolve_href,
+            patch.object(
+                extractor,
+                "_wait_for_message_surface",
+                new_callable=AsyncMock,
+                return_value="composer",
+            ),
+            patch.object(
+                extractor,
+                "_resolve_message_compose_box",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                extractor,
+                "_compose_page_matches_recipient",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                extractor,
+                "_dismiss_message_ui",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser",
+                "Hello!",
+                confirm_send=False,
+                profile_urn="ignored",
+                compose_url=invitation_url,
+            )
+
+        assert result["status"] == "confirmation_required"
+        mock_open_invitation_compose.assert_awaited_once_with(
+            "testuser",
+            invitation_url,
+        )
+        mock_resolve_href.assert_not_awaited()
+
+    async def test_opens_matching_invitation_message_modal(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        invitation_url = (
+            "/messaging/compose/?recipient=ACoAAB"
+            "&invitation=urn%3Ali%3Afsd_invitation%3A123"
+        )
+        message_link = MagicMock()
+        message_link.click = AsyncMock()
+        message_links = MagicMock()
+        message_links.nth.return_value = message_link
+        mock_page.locator = MagicMock(return_value=message_links)
+        mock_page.evaluate = AsyncMock(return_value=0)
+        mock_page.wait_for_timeout = AsyncMock()
+
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_wait_for_main_text",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_extract_invitation_cards",
+                new_callable=AsyncMock,
+                return_value=[
+                    {
+                        "type": "connection_request",
+                        "sender": {"url": "/in/testuser/"},
+                        "message_url": invitation_url,
+                    }
+                ],
+            ),
+        ):
+            opened = await extractor._open_invitation_message_compose(
+                "testuser",
+                invitation_url,
+            )
+
+        assert opened is True
+        message_links.nth.assert_called_once_with(0)
+        message_link.click.assert_awaited_once()
+
+    async def test_rejects_invitation_url_for_different_sender(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        invitation_url = "/messaging/compose/?recipient=ACoAAB&invitation=urn"
+        mock_page.evaluate = AsyncMock()
+        mock_page.wait_for_timeout = AsyncMock()
+
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_wait_for_main_text",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_extract_invitation_cards",
+                new_callable=AsyncMock,
+                return_value=[
+                    {
+                        "type": "connection_request",
+                        "sender": {"url": "/in/someone-else/"},
+                        "message_url": invitation_url,
+                    }
+                ],
+            ),
+            patch.object(
+                extractor,
+                "_scroll_invitation_manager_down",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            opened = await extractor._open_invitation_message_compose(
+                "testuser",
+                invitation_url,
+            )
+
+        assert opened is False
+        mock_page.evaluate.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "compose_url",
+        [
+            "https://example.com/messaging/compose/?recipient=ACoAAB",
+            "/in/testuser/",
+            "/messaging/compose/",
+        ],
+    )
+    async def test_rejects_invalid_invitation_compose_url(self, mock_page, compose_url):
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "_navigate_to_page",
+            new_callable=AsyncMock,
+        ) as mock_navigate:
+            result = await extractor.send_message(
+                "testuser",
+                "Hello!",
+                confirm_send=True,
+                compose_url=compose_url,
+            )
+
+        assert result["status"] == "message_unavailable"
+        assert result["sent"] is False
+        mock_navigate.assert_not_awaited()
+
 
 class TestResolveMessageComposeBox:
     async def test_returns_locator_when_count_positive(self, mock_page):

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5846,6 +5846,24 @@ class TestSendMessageComposerInteraction:
 
         assert visible is True
         assert compose_box.evaluate.await_count == 2
+        verification_script = compose_box.evaluate.await_args_list[0].args[0]
+        assert "editor.closest('[role=\"dialog\"]')" in verification_script
+        assert "editor.getRootNode()" not in verification_script
+
+    async def test_recipient_verification_uses_resolved_composer(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        compose_box = MagicMock()
+        compose_box.evaluate = AsyncMock(return_value=True)
+
+        matched = await extractor._compose_page_matches_recipient(
+            compose_box,
+            "Test User",
+        )
+
+        assert matched is True
+        verification_script = compose_box.evaluate.await_args_list[0].args[0]
+        assert "editor.closest('[role=\"dialog\"]')" in verification_script
+        assert "document.querySelector('main')" not in verification_script
 
 
 class TestBuildFeedReferences:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5518,18 +5518,6 @@ class TestSendMessage:
                 "linkedin_mcp_server.scraping.extractor.handle_modal_close",
                 new_callable=AsyncMock,
             ),
-            patch.object(
-                extractor,
-                "_extract_invitation_cards",
-                new_callable=AsyncMock,
-                return_value=[
-                    {
-                        "type": "connection_request",
-                        "sender": {"url": "/in/testuser/"},
-                        "message_url": invitation_url,
-                    }
-                ],
-            ),
         ):
             opened = await extractor._open_invitation_message_compose(
                 "testuser",
@@ -5543,7 +5531,7 @@ class TestSendMessage:
     async def test_rejects_invitation_url_for_different_sender(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         invitation_url = "/messaging/compose/?recipient=ACoAAB&invitation=urn"
-        mock_page.evaluate = AsyncMock()
+        mock_page.evaluate = AsyncMock(return_value=-1)
         mock_page.wait_for_timeout = AsyncMock()
 
         with (
@@ -5563,21 +5551,8 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_extract_invitation_cards",
+                "_scroll_main_scrollable_region",
                 new_callable=AsyncMock,
-                return_value=[
-                    {
-                        "type": "connection_request",
-                        "sender": {"url": "/in/someone-else/"},
-                        "message_url": invitation_url,
-                    }
-                ],
-            ),
-            patch.object(
-                extractor,
-                "_scroll_invitation_manager_down",
-                new_callable=AsyncMock,
-                return_value=False,
             ),
         ):
             opened = await extractor._open_invitation_message_compose(
@@ -5586,7 +5561,7 @@ class TestSendMessage:
             )
 
         assert opened is False
-        mock_page.evaluate.assert_not_awaited()
+        assert mock_page.evaluate.await_count == 20
 
     @pytest.mark.parametrize(
         "compose_url",
@@ -5833,7 +5808,7 @@ class TestSendMessageComposerInteraction:
     async def test_sent_message_verification_uses_resolved_composer(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         compose_box = MagicMock()
-        compose_box.evaluate = AsyncMock(side_effect=[False, True])
+        compose_box.evaluate = AsyncMock(side_effect=[RuntimeError, True])
 
         with patch(
             "linkedin_mcp_server.scraping.extractor.asyncio.sleep",

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5674,6 +5674,8 @@ class TestSendMessageComposerInteraction:
 
     def _patch_send_message_to_compose(self, extractor, mock_page):
         """Return a context manager that patches send_message up to the compose step."""
+        self.compose_box = MagicMock()
+        self.compose_box.evaluate = AsyncMock(side_effect=[True, True])
         return (
             patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
             patch(
@@ -5706,7 +5708,7 @@ class TestSendMessageComposerInteraction:
                 extractor,
                 "_resolve_message_compose_box",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                return_value=self.compose_box,
             ),
             patch.object(
                 extractor,
@@ -5732,8 +5734,7 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), True (send button click)
-        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        mock_page.evaluate = AsyncMock(return_value=True)
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -5760,6 +5761,7 @@ class TestSendMessageComposerInteraction:
 
         assert result["status"] == "sent"
         assert result["sent"] is True
+        assert self.compose_box.evaluate.await_count == 2
         # Verify keyboard.type was used (not press_sequentially)
         mock_keyboard.type.assert_awaited_once_with("Hello!", delay=15)
 
@@ -5769,9 +5771,9 @@ class TestSendMessageComposerInteraction:
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns False (focus failed)
-        mock_page.evaluate = AsyncMock(return_value=False)
         patches = self._patch_send_message_to_compose(extractor, mock_page)
+        self.compose_box.evaluate.side_effect = None
+        self.compose_box.evaluate.return_value = False
 
         with (
             patches[0],
@@ -5799,9 +5801,8 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), False (no send button found)
-        mock_page.evaluate = AsyncMock(side_effect=[True, False])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
+        self.compose_box.evaluate.side_effect = [True, False]
 
         with (
             patches[0],
@@ -5828,6 +5829,23 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "sent"
         # Enter was pressed as fallback
         mock_keyboard.press.assert_awaited_once_with("Enter")
+
+    async def test_sent_message_verification_uses_resolved_composer(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        compose_box = MagicMock()
+        compose_box.evaluate = AsyncMock(side_effect=[False, True])
+
+        with patch(
+            "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            visible = await extractor._message_text_visible(
+                "Hello!",
+                compose_box,
+            )
+
+        assert visible is True
+        assert compose_box.evaluate.await_count == 2
 
 
 class TestBuildFeedReferences:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -843,6 +843,40 @@ class TestMessagingTools:
             "testuser", "Hello!", confirm_send=True, profile_urn="ACoAAB1IelEB"
         )
 
+    async def test_message_invitation_sender_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/abc123/",
+            "status": "confirmation_required",
+            "message": "Set confirm_send=true to send the message.",
+            "recipient_selected": True,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "message_invitation_sender")
+        result = await tool_fn(
+            "testuser",
+            "/messaging/compose/?recipient=ACoAAB&invitation=urn",
+            "Hello!",
+            False,
+            mock_context,
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "confirmation_required"
+        assert result["sent"] is False
+        mock_extractor.send_message.assert_awaited_once_with(
+            "testuser",
+            "Hello!",
+            confirm_send=False,
+            compose_url="/messaging/compose/?recipient=ACoAAB&invitation=urn",
+        )
+
     async def test_send_message_error(self, mock_context):
         from fastmcp.exceptions import ToolError
 
@@ -1271,6 +1305,7 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "message_invitation_sender",
             "get_feed",
             "search_posts",
             "close_session",
@@ -1304,6 +1339,7 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "message_invitation_sender",
             "get_feed",
             "search_posts",
             "close_session",


### PR DESCRIPTION
## Summary

- add `message_invitation_sender` with explicit confirmation
- accept only a relative LinkedIn `/messaging/compose/` invitation URL
- find the exact URL and sender in the received-invitations manager, then open LinkedIn's modal
- reuse the existing recipient, composer, newline, send, and verification flow
- keep the invitation lookup self-contained so the change does not import the pending-invitations scraper from #447

## Validation

- `uv run pytest`: 1,132 passed, 11 skipped
- targeted invitation and verification tests: 5 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pre-commit run --all-files`
- `git diff --check upstream/main`
- live Bastien dry run: `confirmation_required`, `recipient_selected: true`, `sent: false`

Closes #613

## Synthetic prompt

> Add a `message_invitation_sender` MCP tool that takes a received invitation sender's username and relative compose URL, opens the invitation modal from the received-invitations manager, reuses the existing send confirmation and recipient checks, validates URL and sender matching, and updates tests, documentation, and manifest.

Generated with OpenAI Codex (GPT-5)
