### PR TITLE
feat(daemon): Decide which process owns the browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,6 @@ jobs:
       - run: uv sync --group dev
 
       - name: Run platform behaviour tests
-        run: uv run pytest tests/test_profile_lease.py tests/test_profile_lease_integration.py tests/test_private_state.py
+        run: uv run pytest tests/test_profile_lease.py tests/test_profile_lease_integration.py tests/test_private_state.py tests/test_daemon_lock.py
 
       - run: uv cache prune --ci

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -209,31 +209,36 @@ def daemon_state_root() -> Path:
     return (_account_home() / _APPLICATION_STATE_DIR / _DAEMON_DIR).resolve()
 
 
-def _directory_identity(path: Path, *, label: str) -> tuple[int, int]:
-    """Return the stable filesystem identity of a directory, creating it once.
+def _auth_root_identity(auth_root: Path) -> bytes:
+    """Return the stable filesystem identity of *auth_root*, creating it once.
 
-    For the process that is establishing state. The first daemon on a fresh
-    install must not key a missing path and then switch to an inode after
-    creating it, which would leave its own lock at an address nothing else
-    computes. ``secure_mkdir`` creates only what is missing and deliberately
-    leaves permissions on existing parents alone.
+    Created rather than merely inspected, because this runs in the process that
+    is establishing state: the first daemon on a fresh install must not key a
+    missing path and then switch to an inode after creating it, which would
+    leave its own lock at an address nothing else computes. ``secure_mkdir``
+    creates only what is missing and deliberately leaves permissions on
+    existing parents alone.
+
+    Device plus inode identifies the physical directory rather than one
+    spelling of it, which keeps case and Unicode aliases together on an
+    insensitive volume without conflating distinct directories on a sensitive
+    one. The auth root can be keyed this way because nothing rotates it; the
+    profile inside it cannot, and :func:`profile_identity` says why.
     """
-    canonical = path.expanduser().resolve()
+    canonical = auth_root.expanduser().resolve()
     secure_mkdir(canonical, mode=0o700)
     info = canonical.stat()
 
     if not stat.S_ISDIR(info.st_mode):
-        raise DescriptorError(f"The {label} is not a directory: {canonical}")
-
-    # Device plus inode identifies the physical directory, not one spelling of
-    # it. That keeps case and Unicode aliases together on insensitive volumes
-    # without conflating distinct directories on a case-sensitive volume.
+        raise DescriptorError(
+            f"The authentication root is not a directory: {canonical}"
+        )
     if not info.st_ino:
         raise DescriptorError(
             f"The filesystem does not provide a stable identity for {canonical}, "
             "so browser ownership cannot be coordinated safely"
         )
-    return info.st_dev, info.st_ino
+    return f"inode\0{info.st_dev}\0{info.st_ino}".encode("ascii")
 
 
 def profile_identity(profile: Path) -> str:
@@ -278,11 +283,6 @@ def profile_identity(profile: Path) -> str:
     except OSError:
         return spelled
     return f"under\0{info.st_dev}\0{info.st_ino}\0{name}"
-
-
-def _auth_root_identity(auth_root: Path) -> bytes:
-    device, inode = _directory_identity(auth_root, label="authentication root")
-    return f"inode\0{device}\0{inode}".encode("ascii")
 
 
 def daemon_dir(auth_root: Path) -> Path:

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -1,0 +1,416 @@
+"""What a running daemon publishes about itself, and what a client checks.
+
+A client that finds a descriptor is about to send a bearer token to whatever
+address it names and then drive a logged-in LinkedIn session through it. So
+nothing here is taken on trust: the endpoint is checked to be loopback before
+the token goes anywhere, the profile path is compared exactly, and the
+configuration is compared through a fingerprint.
+
+Two fields exist because of measurements rather than tidiness:
+
+``profile_path``
+    ``auth_root_dir`` returns the profile's *parent*, so ``.../profile`` and
+    ``.../profile2`` share one auth root and therefore one lock. Without an
+    exact comparison here, a client configured for the second would attach to
+    the first one's browser and never notice.
+
+``config_fingerprint``
+    Two clients that disagree about ``headless``, the user agent or the proxy
+    are not interchangeable, because the owner's browser can only be one of
+    them. The fingerprint is keyed rather than a plain digest: ``proxy_password``
+    is part of what must match, and a plain hash over otherwise-guessable
+    configuration would be an offline check for password guesses.
+
+The token itself is deliberately *not* here. It lives beside the descriptor in
+its own file, named after the instance, and the descriptor carries only its
+digest. Fixed names would let a client pair one generation's descriptor with the
+next generation's token and read that mismatch as corruption rather than as the
+restart it is.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import secrets
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from linkedin_mcp_server.common_utils import secure_write_text, utcnow_iso
+from linkedin_mcp_server.config.schema import AppConfig, is_loopback_host
+from linkedin_mcp_server.private_state import harden_directory, harden_file
+
+#: Bumped when the shape below changes incompatibly. A client that does not
+#: recognise the value refuses rather than guessing at fields it cannot read.
+SCHEMA_VERSION = 1
+
+#: Bumped when the daemon's own protocol changes: the control routes, the call
+#: metadata, or the ping contract. Compatibility keys on this rather than on the
+#: package version, because the documented install is ``@latest`` and this
+#: project releases often. Matching exact versions would mean a manual shutdown
+#: after almost every release, which is precisely the friction the daemon exists
+#: to remove.
+PROTOCOL_VERSION = 1
+
+_DESCRIPTOR_FILE = "daemon.json"
+_DAEMON_DIR = "daemon"
+
+# Enough that guessing is not a strategy. Read straight from the OS source.
+_TOKEN_BYTES = 32
+
+#: Configuration a client must share with the owner to be served by it. Each of
+#: these either changes what the browser *is* (its fingerprint, its exit
+#: address, where its profile lives) or how long the owner keeps it. Anything
+#: not listed here may differ freely between clients.
+SHARED_CONFIG_FIELDS = (
+    "user_data_dir",
+    "headless",
+    "slow_mo",
+    "user_agent",
+    "viewport_width",
+    "viewport_height",
+    "default_timeout",
+    "chrome_path",
+    "proxy_server",
+    "proxy_username",
+    "proxy_password",
+    "proxy_bypass",
+    "login_timeout_seconds",
+    "login_inline_wait_seconds",
+    "auto_import_from_browser",
+    "eager_full_chromium",
+    "browser_idle_timeout_seconds",
+)
+
+
+class DescriptorError(RuntimeError):
+    """A descriptor could not be trusted, so nothing was sent to it."""
+
+
+def _text(raw: Mapping[Any, Any], name: str) -> str:
+    value = raw.get(name)
+    if not isinstance(value, str):
+        raise DescriptorError(
+            f"The daemon descriptor field {name} is missing or not text"
+        )
+    return value
+
+
+def _number(raw: Mapping[Any, Any], name: str, *, default: int | None = None) -> int:
+    value = raw.get(name, default)
+    # bool is an int as far as isinstance is concerned, and a port of True is
+    # not a port.
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise DescriptorError(
+            f"The daemon descriptor field {name} is missing or not a number"
+        )
+    return value
+
+
+def daemon_dir(auth_root: Path) -> Path:
+    """Where a daemon's descriptor and token live for *auth_root*."""
+    return auth_root.expanduser().resolve() / _DAEMON_DIR
+
+
+def descriptor_path(auth_root: Path) -> Path:
+    return daemon_dir(auth_root) / _DESCRIPTOR_FILE
+
+
+def token_path(auth_root: Path, instance_id: str) -> Path:
+    """Where the bearer token lives, named for the instance that owns it.
+
+    Named rather than fixed so a descriptor and a token can never belong to
+    different generations. With one shared name, a client that read the old
+    descriptor and then the new token would find a digest that does not match
+    and, following the discovery rules, call it corruption instead of a restart.
+    """
+    return daemon_dir(auth_root) / f"token-{instance_id}"
+
+
+def new_token() -> str:
+    """A fresh bearer token. One per daemon start, never reused."""
+    return secrets.token_urlsafe(_TOKEN_BYTES)
+
+
+def _digest(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _canonical(value: object) -> str:
+    """Render *value* so that equal configuration always hashes equally."""
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _normalize(name: str, value: Any) -> Any:
+    """Reduce a field to the form two processes should agree on.
+
+    Only differences that would actually make the owner's browser wrong for a
+    client should count. Two spellings of the same path are the same profile,
+    and an unset optional string is the same as an empty one.
+    """
+    if value is None:
+        return None
+    if name in ("user_data_dir", "chrome_path"):
+        path = Path(str(value)).expanduser().resolve()
+        # Windows paths differ only in case, so comparing them literally would
+        # split one owner into several.
+        return os.path.normcase(str(path))
+    if name == "proxy_bypass":
+        # An ordered, comma-separated list where neither the order nor the
+        # spacing changes which hosts bypass the proxy.
+        hosts = sorted({host.strip().lower() for host in str(value).split(",")} - {""})
+        return ",".join(hosts)
+    if isinstance(value, str) and not value:
+        return None
+    return value
+
+
+def config_fingerprint(config: AppConfig, *, key: str) -> str:
+    """Digest the configuration an owner and its clients must agree on.
+
+    Keyed with the daemon's own token. That is not belt and braces: the shared
+    fields include ``proxy_password``, and the remaining fields are mostly
+    guessable, so an unkeyed digest sitting in a world-readable descriptor would
+    let anyone test password guesses offline. The key never leaves the token
+    file, so only a process already entitled to talk to the daemon can compute
+    or compare it.
+    """
+    material = {
+        name: _normalize(name, getattr(config.browser, name, None))
+        for name in SHARED_CONFIG_FIELDS
+    }
+    material["tool_timeout_seconds"] = config.server.tool_timeout_seconds
+    return hmac.new(
+        key.encode("utf-8"), _canonical(material).encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def mismatched_fields(config: AppConfig, other: AppConfig) -> tuple[str, ...]:
+    """Which shared fields differ, for an explanation that names no values.
+
+    A mismatch message has to say enough to act on and nothing more: the values
+    include a proxy password and the path to someone's browser profile.
+    """
+    differing = [
+        name
+        for name in SHARED_CONFIG_FIELDS
+        if _normalize(name, getattr(config.browser, name, None))
+        != _normalize(name, getattr(other.browser, name, None))
+    ]
+    if config.server.tool_timeout_seconds != other.server.tool_timeout_seconds:
+        differing.append("tool_timeout_seconds")
+    return tuple(differing)
+
+
+@dataclass(frozen=True)
+class DaemonDescriptor:
+    """Everything a client needs to decide whether to attach, and where."""
+
+    instance_id: str
+    schema_version: int
+    protocol_version: int
+    package_version: str
+    runtime_id: str
+    profile_path: str
+    host: str
+    port: int
+    path: str
+    token_sha256: str
+    config_fingerprint: str
+    started_at: str
+    log_path: str
+    #: Diagnostics only. Never used to decide whether the daemon is alive: a
+    #: recycled process id reads as alive forever, which is how a comparable
+    #: server wedged itself permanently.
+    pid: int = field(default=0)
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}{self.path}"
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__, indent=2, sort_keys=True) + "\n"
+
+    @classmethod
+    def from_mapping(cls, raw: object) -> DaemonDescriptor:
+        """Build one from parsed JSON, refusing anything unusable.
+
+        Field by field rather than by unpacking the mapping, because this is
+        reading a file that another process wrote and that anything with write
+        access could have edited. Unpacking would accept a port that is a string
+        and fail much later, somewhere that cannot explain why.
+        """
+        if not isinstance(raw, Mapping):
+            raise DescriptorError("The daemon descriptor is not an object")
+
+        descriptor = cls(
+            instance_id=_text(raw, "instance_id"),
+            schema_version=_number(raw, "schema_version"),
+            protocol_version=_number(raw, "protocol_version"),
+            package_version=_text(raw, "package_version"),
+            runtime_id=_text(raw, "runtime_id"),
+            profile_path=_text(raw, "profile_path"),
+            host=_text(raw, "host"),
+            port=_number(raw, "port"),
+            path=_text(raw, "path"),
+            token_sha256=_text(raw, "token_sha256"),
+            config_fingerprint=_text(raw, "config_fingerprint"),
+            started_at=_text(raw, "started_at"),
+            log_path=_text(raw, "log_path"),
+            pid=_number(raw, "pid", default=0),
+        )
+        descriptor.check_endpoint_is_local()
+        return descriptor
+
+    def check_endpoint_is_local(self) -> None:
+        """Refuse an endpoint that is not this machine, before sending a token.
+
+        The descriptor is a file on disk, so it can be edited. Reading a host
+        from it and posting a bearer token there without checking would turn any
+        write access to the auth root into a way to collect the token and,
+        through it, the LinkedIn session behind it.
+        """
+        if not is_loopback_host(self.host):
+            raise DescriptorError(
+                f"The daemon descriptor points at {self.host}, which is not "
+                f"this machine. Refusing to send credentials there."
+            )
+        if not 1 <= self.port <= 65535:
+            raise DescriptorError(
+                f"The daemon descriptor names port {self.port}, which is not a "
+                f"usable port number"
+            )
+        if not self.path.startswith("/"):
+            raise DescriptorError("The daemon descriptor has no usable path")
+
+    def matches_token(self, token: str) -> bool:
+        """Whether *token* is the one this descriptor was published with."""
+        return hmac.compare_digest(self.token_sha256, _digest(token))
+
+    def serves(self, profile: Path) -> bool:
+        """Whether this daemon owns exactly *profile*.
+
+        Exact, because the lock is shared by every profile under one auth root.
+        Two directories side by side elect one owner between them, and a client
+        that only checked the auth root would be served the wrong browser.
+        """
+        wanted = os.path.normcase(str(profile.expanduser().resolve()))
+        return wanted == os.path.normcase(self.profile_path)
+
+
+def publish(
+    auth_root: Path, descriptor: DaemonDescriptor, token: str
+) -> tuple[Path, Path]:
+    """Write the token and then the descriptor, in that order.
+
+    Order matters. The descriptor is what makes a daemon discoverable, so it is
+    written last: a client that finds one can rely on the token beside it
+    already existing. Written the other way round, discovery would race the
+    token into existence.
+    """
+    directory = daemon_dir(auth_root)
+    harden_directory(directory)
+
+    token_file = token_path(auth_root, descriptor.instance_id)
+    secure_write_text(token_file, token)
+    harden_file(token_file)
+
+    descriptor_file = descriptor_path(auth_root)
+    secure_write_text(descriptor_file, descriptor.to_json())
+    return descriptor_file, token_file
+
+
+def read(auth_root: Path) -> DaemonDescriptor | None:
+    """Return the published descriptor, or None when there is none.
+
+    Raises :class:`DescriptorError` for one that exists but cannot be trusted,
+    which the caller must distinguish from absence: a corrupt descriptor beside
+    a *held* lock means a live daemon this client cannot talk to, and deleting
+    it would strand every other client attached to that daemon.
+    """
+    path = descriptor_path(auth_root)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise DescriptorError(
+            f"The daemon descriptor could not be read: {exc}"
+        ) from exc
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise DescriptorError(
+            f"The daemon descriptor is not valid JSON: {exc}"
+        ) from exc
+
+    descriptor = DaemonDescriptor.from_mapping(parsed)
+    if descriptor.schema_version != SCHEMA_VERSION:
+        raise DescriptorError(
+            f"The daemon descriptor is version {descriptor.schema_version}, and "
+            f"this client understands version {SCHEMA_VERSION}"
+        )
+    return descriptor
+
+
+def read_token(auth_root: Path, descriptor: DaemonDescriptor) -> str:
+    """Read the token belonging to *descriptor*, checking it is the right one."""
+    path = token_path(auth_root, descriptor.instance_id)
+    try:
+        token = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise DescriptorError(
+            "The daemon is publishing a descriptor with no token beside it"
+        ) from exc
+    except OSError as exc:
+        raise DescriptorError(f"The daemon token could not be read: {exc}") from exc
+
+    if not descriptor.matches_token(token):
+        raise DescriptorError(
+            "The daemon token does not match its descriptor, so they belong to "
+            "different daemon generations"
+        )
+    return token
+
+
+def build(
+    *,
+    instance_id: str,
+    package_version: str,
+    runtime_id: str,
+    profile: Path,
+    host: str,
+    port: int,
+    path: str,
+    token: str,
+    config: AppConfig,
+    log_path: Path,
+) -> DaemonDescriptor:
+    """Assemble a descriptor for a daemon that is already listening."""
+    return DaemonDescriptor(
+        instance_id=instance_id,
+        schema_version=SCHEMA_VERSION,
+        protocol_version=PROTOCOL_VERSION,
+        package_version=package_version,
+        runtime_id=runtime_id,
+        profile_path=str(profile.expanduser().resolve()),
+        host=host,
+        port=port,
+        path=path,
+        token_sha256=_digest(token),
+        config_fingerprint=config_fingerprint(config, key=token),
+        started_at=utcnow_iso(),
+        log_path=str(log_path),
+        pid=os.getpid(),
+    )

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -46,11 +46,13 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import ipaddress
 import json
 import os
 import secrets
 import socket
 import stat
+import unicodedata
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -263,13 +265,18 @@ def _auth_root_identity(auth_root: Path) -> bytes:
             f"The authentication root is not a directory: {canonical}"
         )
 
+    # Creating and then reading it back are one operation as far as a caller is
+    # concerned, and both can fail in ways the operating system describes in its
+    # own vocabulary. Measured: an auth root that vanished between the two
+    # surfaced as FileNotFoundError, several layers from anything that could
+    # explain it as a descriptor problem.
     try:
         secure_mkdir(canonical, mode=0o700)
+        info = canonical.stat()
     except OSError as exc:
         raise DescriptorError(
-            f"The authentication root {canonical} could not be created: {exc}"
+            f"The authentication root {canonical} could not be prepared: {exc}"
         ) from exc
-    info = canonical.stat()
 
     if not stat.S_ISDIR(info.st_mode):
         raise DescriptorError(
@@ -334,8 +341,12 @@ def profile_identity(profile: Path) -> str:
     # volume, once with both present and once with only the sibling: two
     # distinct profiles shared an identity, which would have served a client
     # the other one's logged-in session.
+    # Folded and normalised. casefold settles case; NFC settles composition,
+    # which is a separate axis macOS also collapses: an accented name written
+    # decomposed and composed is one directory there, and comparing the two
+    # spellings without normalising gave them different identities.
     wanted = canonical.name
-    folded = wanted.casefold()
+    folded = unicodedata.normalize("NFC", wanted).casefold()
     try:
         entries = [entry.name for entry in os.scandir(canonical.parent)]
     except OSError:
@@ -344,7 +355,7 @@ def profile_identity(profile: Path) -> str:
         entries = []
     if wanted not in entries:
         for name in entries:
-            if name.casefold() != folded:
+            if unicodedata.normalize("NFC", name).casefold() != folded:
                 continue
             # samefile answers what folding only guesses at, and it is safe to
             # ask here: the candidate exists by definition, and the profile
@@ -658,10 +669,22 @@ class DaemonDescriptor:
         # passed as loopback while getaddrinfo refused them outright; and it
         # accepts "localhost" by name, which says nothing about where the
         # resolver on this machine actually sends it.
+        hostname = parsed.hostname or ""
         try:
-            resolved = socket.getaddrinfo(
-                parsed.hostname, self.port, type=socket.SOCK_STREAM
-            )
+            # An address literal is its own answer, and asking the resolver
+            # about one would be a needless trip through a component that can
+            # hang: getaddrinfo takes no deadline, so a wedged NSS or mDNS
+            # responder blocks for as long as it likes. Measured with a stalled
+            # resolver: two seconds for a two second stall, and unbounded in
+            # principle. This is what a daemon publishes for itself, so the
+            # common path never reaches the call below.
+            ipaddress.ip_address(hostname)
+            return
+        except ValueError:
+            pass
+
+        try:
+            resolved = socket.getaddrinfo(hostname, self.port, type=socket.SOCK_STREAM)
         except (OSError, UnicodeError) as exc:
             raise DescriptorError(
                 f"The daemon descriptor names host {self.host!r}, which does "
@@ -714,9 +737,19 @@ def publish(
     harden_directory(daemon_state_root())
     harden_directory(directory)
 
+    # secure_write_text already creates the file 0600, inside a directory this
+    # just made 0700, so the token is never on disk under wider permissions.
+    # harden_file is what establishes that rather than assuming it: it reads
+    # the mode, the owner and the access list back, and on Windows replaces the
+    # access list outright. If it refuses, the token it refused to vouch for
+    # goes away again rather than staying behind as state nothing verified.
     token_file = token_path(auth_root, descriptor.instance_id)
     secure_write_text(token_file, token)
-    harden_file(token_file)
+    try:
+        harden_file(token_file)
+    except BaseException:
+        token_file.unlink(missing_ok=True)
+        raise
 
     descriptor_file = descriptor_path(auth_root)
     secure_write_text(descriptor_file, descriptor.to_json())

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -267,22 +267,38 @@ def profile_identity(profile: Path) -> str:
     discover afterwards.
     """
     canonical = profile.expanduser().resolve()
-    spelled = f"path\0{os.path.normcase(str(canonical))}"
     try:
         info = canonical.parent.stat()
-        if not stat.S_ISDIR(info.st_mode) or not info.st_ino:
-            return spelled
-        # The name as the filesystem holds it. scandir is one syscall over a
-        # directory this already resolved, and it is the only way to learn which
-        # spelling is the real one where several address one entry.
-        name = os.path.normcase(canonical.name)
+    except OSError:
+        # No parent to key on. Two clients naming the same absent directory
+        # still agree with each other, which is all this can offer.
+        return f"path\0{os.path.normcase(str(canonical))}"
+
+    if not stat.S_ISDIR(info.st_mode) or not info.st_ino:
+        return f"path\0{os.path.normcase(str(canonical))}"
+
+    # The name as the filesystem holds it, where it holds one. Only the parent
+    # is consulted, never the profile itself, because the profile legitimately
+    # does not exist yet before the first login: an identity that changed when
+    # it appeared would leave a descriptor published beforehand no longer
+    # matching its own profile. Measured, with the auth root non-empty so the
+    # scan had something to walk: serves() went from True to False across the
+    # login that created the directory.
+    # casefold rather than normcase: normcase is a no-op on POSIX, while macOS
+    # is case-insensitive regardless, so Profile and profile name one directory
+    # there and the listing holds only one of the two spellings.
+    wanted = canonical.name
+    folded = wanted.casefold()
+    try:
         for entry in os.scandir(canonical.parent):
-            if os.path.normcase(entry.name) == name or canonical.samefile(entry.path):
-                name = entry.name
+            if entry.name == wanted or entry.name.casefold() == folded:
+                wanted = entry.name
                 break
     except OSError:
-        return spelled
-    return f"under\0{info.st_dev}\0{info.st_ino}\0{name}"
+        # The parent stopped being readable between the two calls. The spelling
+        # the caller gave still identifies it well enough to compare.
+        pass
+    return f"under\0{info.st_dev}\0{info.st_ino}\0{wanted}"
 
 
 def daemon_dir(auth_root: Path) -> Path:
@@ -515,6 +531,17 @@ class DaemonDescriptor:
         write access to the auth root into a way to collect the token and,
         through it, the LinkedIn session behind it.
         """
+        # Compared against the host as written, because that is the string the
+        # URL is built from. is_loopback_host trims before classifying, so a
+        # host with whitespace around it passes as loopback and then produces a
+        # URL no client can parse: measured, "[::1] " was accepted here and
+        # failed later with "Invalid port: ' :49152'", outside anything that
+        # could explain it as a bad descriptor.
+        if self.host != self.host.strip():
+            raise DescriptorError(
+                f"The daemon descriptor names host {self.host!r}, which carries "
+                f"whitespace and cannot be used to reach anything"
+            )
         if not is_loopback_host(self.host):
             raise DescriptorError(
                 f"The daemon descriptor points at {self.host}, which is not "

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -193,6 +193,10 @@ def _normalize(name: str, value: Any) -> Any:
     names the field. Erring the other way hands a client a browser configured
     differently from what it asked for.
     """
+    if name == "auto_import_from_browser":
+        # Auto-import is enabled by default. None and True therefore ask for the
+        # same browser behaviour; only an explicit False disables it.
+        return value is not False
     if value is None:
         return None
     if name in ("user_data_dir", "chrome_path"):

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -55,6 +55,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from linkedin_mcp_server.common_utils import secure_mkdir, secure_write_text, utcnow_iso
 from linkedin_mcp_server.config.schema import AppConfig, is_loopback_host
@@ -531,17 +532,6 @@ class DaemonDescriptor:
         write access to the auth root into a way to collect the token and,
         through it, the LinkedIn session behind it.
         """
-        # Compared against the host as written, because that is the string the
-        # URL is built from. is_loopback_host trims before classifying, so a
-        # host with whitespace around it passes as loopback and then produces a
-        # URL no client can parse: measured, "[::1] " was accepted here and
-        # failed later with "Invalid port: ' :49152'", outside anything that
-        # could explain it as a bad descriptor.
-        if self.host != self.host.strip():
-            raise DescriptorError(
-                f"The daemon descriptor names host {self.host!r}, which carries "
-                f"whitespace and cannot be used to reach anything"
-            )
         if not is_loopback_host(self.host):
             raise DescriptorError(
                 f"The daemon descriptor points at {self.host}, which is not "
@@ -554,6 +544,43 @@ class DaemonDescriptor:
             )
         if not self.path.startswith("/"):
             raise DescriptorError("The daemon descriptor has no usable path")
+
+        # A request line is one line. A control character in any of these ends
+        # up in the URL and, in the wrong place, would let a descriptor written
+        # by something else decide where one header stops and the next begins.
+        # urlsplit is happy to carry them, so they are refused here.
+        for name, value in (("host", self.host), ("path", self.path)):
+            if any(character in value for character in "\r\n\t\x00"):
+                raise DescriptorError(
+                    f"The daemon descriptor's {name} contains a control "
+                    f"character, so it cannot name an endpoint"
+                )
+
+        # The fields are individually plausible; whether they compose into
+        # something a client can use is a separate question, and the only one
+        # that finally matters. is_loopback_host trims before classifying, for
+        # instance, so a host with whitespace around it is loopback by that
+        # measure and produces a URL that parses as a bad port. Measured
+        # accepting three such descriptors: "[::1] ", a bracketed IPv4, and a
+        # path with a newline, each failing later in the client rather than
+        # here where it could be explained as a descriptor this did not write.
+        #
+        # urlsplit rather than an HTTP client's parser: this has no business
+        # depending on which client the caller happens to use, and reading the
+        # port back is what catches a host that ran into it.
+        try:
+            parsed = urlsplit(self.url)
+            reachable = parsed.port == self.port and parsed.scheme == "http"
+        except ValueError as exc:
+            raise DescriptorError(
+                f"The daemon descriptor describes an endpoint that cannot be "
+                f"used to reach anything: {exc}"
+            ) from exc
+        if not reachable:
+            raise DescriptorError(
+                f"The daemon descriptor's host, port and path do not compose "
+                f"into a usable address: {self.url!r}"
+            )
 
     def matches_token(self, token: str) -> bool:
         """Whether *token* is the one this descriptor was published with."""

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -375,6 +375,62 @@ def publish(
     return descriptor_file, token_file
 
 
+#: A descriptor is a few hundred bytes of JSON. Bounded for the same reason the
+#: token read is: whatever sits at the path may not be what this wrote.
+_MAX_DESCRIPTOR_BYTES = 64 * 1024
+
+
+def _read_own_file(path: Path, limit: int, *, missing_is_none: bool) -> str | None:
+    """Read a file this daemon wrote, refusing anything that is not one.
+
+    Both files under the daemon directory go through here, because both are
+    read by a client that is about to act on them and neither is safe to open
+    by path alone. Three things are established before a byte is used:
+
+    * it is not a symbolic link, so the path cannot aim the read elsewhere;
+    * it is a regular file, so a named pipe cannot stand in for one;
+    * the open does not block, so such a pipe cannot hang the client inside
+      ``open`` before either check has run.
+
+    *missing_is_none* separates the two callers. Absence of a descriptor is the
+    ordinary first-start case; absence of a token beside a published descriptor
+    is not.
+    """
+    # O_NOFOLLOW fails on a symlink rather than resolving it, so the check and
+    # the read cannot disagree about which file they mean. O_NONBLOCK has no
+    # effect on the regular file this expects.
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        fd = os.open(path, flags)
+        try:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise DescriptorError(
+                    f"{path} is not a regular file, so it is not something this "
+                    f"daemon wrote"
+                )
+            raw = os.read(fd, limit)
+        finally:
+            os.close(fd)
+    except FileNotFoundError:
+        if missing_is_none:
+            return None
+        raise DescriptorError(
+            "The daemon is publishing a descriptor with no token beside it"
+        ) from None
+    except OSError as exc:
+        # ELOOP arrives here when the path is a symlink, which is never
+        # something this wrote and never something to follow.
+        raise DescriptorError(f"{path} could not be read: {exc}") from exc
+
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        # Wrapped, because a caller distinguishing absence from untrusted state
+        # through DescriptorError would otherwise meet an unrelated exception
+        # for what is simply a file this did not write.
+        raise DescriptorError(f"{path} is not text this daemon wrote") from exc
+
+
 def read(auth_root: Path) -> DaemonDescriptor | None:
     """Return the published descriptor, or None when there is none.
 
@@ -384,30 +440,9 @@ def read(auth_root: Path) -> DaemonDescriptor | None:
     it would strand every other client attached to that daemon.
     """
     path = descriptor_path(auth_root)
-    # Checked without following, before anything is read. A symlink here is
-    # never something this wrote, and the two ways of getting it wrong both
-    # matter: a dangling one reads as absence, so a client elects a second owner
-    # while the first is still running, and a live one aims the read somewhere
-    # this never published.
-    try:
-        if path.is_symlink():
-            raise DescriptorError(
-                f"{path} is a symbolic link rather than a descriptor this "
-                f"daemon wrote. Remove it and start the server again."
-            )
-    except OSError as exc:
-        raise DescriptorError(
-            f"The daemon descriptor could not be read: {exc}"
-        ) from exc
-
-    try:
-        raw = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
+    raw = _read_own_file(path, _MAX_DESCRIPTOR_BYTES, missing_is_none=True)
+    if raw is None:
         return None
-    except OSError as exc:
-        raise DescriptorError(
-            f"The daemon descriptor could not be read: {exc}"
-        ) from exc
 
     try:
         parsed = json.loads(raw)
@@ -451,34 +486,9 @@ def read_token(auth_root: Path, descriptor: DaemonDescriptor) -> str:
     client before any of the checks ran.
     """
     path = token_path(auth_root, descriptor.instance_id)
-    try:
-        # O_NOFOLLOW fails on a symlink rather than resolving it, so the check
-        # and the read cannot disagree about which file they mean. O_NONBLOCK
-        # is what stops a named pipe planted at this path from hanging the
-        # client inside open(), before any check has had a chance to run; it
-        # has no effect on the regular file this expects.
-        flags = (
-            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
-        )
-        fd = os.open(path, flags)
-        try:
-            info = os.fstat(fd)
-            if not stat.S_ISREG(info.st_mode):
-                raise DescriptorError(
-                    f"{path} is not a regular file, so it is not a token this "
-                    f"daemon wrote"
-                )
-            token = os.read(fd, _MAX_TOKEN_BYTES).decode("utf-8").strip()
-        finally:
-            os.close(fd)
-    except FileNotFoundError as exc:
-        raise DescriptorError(
-            "The daemon is publishing a descriptor with no token beside it"
-        ) from exc
-    except OSError as exc:
-        # ELOOP lands here when the path is a symlink, which is never something
-        # this wrote and never something to follow.
-        raise DescriptorError(f"The daemon token could not be read: {exc}") from exc
+    text = _read_own_file(path, _MAX_TOKEN_BYTES, missing_is_none=False)
+    assert text is not None  # missing_is_none=False raises rather than returning
+    token = text.strip()
 
     if not descriptor.matches_token(token):
         raise DescriptorError(

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -239,6 +239,26 @@ def daemon_state_root() -> Path:
     return (_account_home() / _APPLICATION_STATE_DIR / _DAEMON_DIR).resolve()
 
 
+def _canonical_path(path: Path, label: str) -> Path:
+    """Resolve *path*, in this module's vocabulary rather than the runtime's.
+
+    expanduser and resolve are the first thing every caller reaches, and they
+    have failure modes of their own: a home directory that cannot be
+    determined raises RuntimeError, an embedded NUL raises ValueError, and an
+    unreadable parent raises PermissionError. All three arrive from
+    type-correct configuration, so they are refusals rather than defects, and
+    they belong in the error every caller of this module is written to expect.
+    """
+    try:
+        return path.expanduser().resolve()
+    except DescriptorError:
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise DescriptorError(
+            f"The {label} {path!r} is not a usable path: {exc}"
+        ) from exc
+
+
 def _auth_root_identity(auth_root: Path) -> bytes:
     """Return the stable filesystem identity of *auth_root*, creating it once.
 
@@ -255,7 +275,7 @@ def _auth_root_identity(auth_root: Path) -> bytes:
     one. The auth root can be keyed this way because nothing rotates it; the
     profile inside it cannot, and :func:`profile_identity` says why.
     """
-    canonical = auth_root.expanduser().resolve()
+    canonical = _canonical_path(auth_root, "authentication root")
     # Checked before creating, not after. secure_mkdir refuses an existing
     # non-directory itself, with a NotADirectoryError that reaches the caller
     # instead of the DescriptorError this module is read through, and the check
@@ -316,7 +336,7 @@ def profile_identity(profile: Path) -> str:
     profile behind to explain one would be a strange thing for a client to
     discover afterwards.
     """
-    canonical = profile.expanduser().resolve()
+    canonical = _canonical_path(profile, "browser profile")
     try:
         info = canonical.parent.stat()
     except OSError:

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -380,7 +380,13 @@ def publish(
 _MAX_DESCRIPTOR_BYTES = 64 * 1024
 
 
-def _read_own_file(path: Path, limit: int, *, missing_is_none: bool) -> str | None:
+def _read_own_file(
+    path: Path,
+    limit: int,
+    *,
+    missing_is_none: bool,
+    missing_message: str | None = None,
+) -> str | None:
     """Read a file this daemon wrote, refusing anything that is not one.
 
     Both files under the daemon directory go through here, because both are
@@ -394,7 +400,7 @@ def _read_own_file(path: Path, limit: int, *, missing_is_none: bool) -> str | No
 
     *missing_is_none* separates the two callers. Absence of a descriptor is the
     ordinary first-start case; absence of a token beside a published descriptor
-    is not.
+    is not, and *missing_message* is how that caller says why.
     """
     # O_NOFOLLOW fails on a symlink rather than resolving it, so the check and
     # the read cannot disagree about which file they mean. O_NONBLOCK has no
@@ -403,10 +409,20 @@ def _read_own_file(path: Path, limit: int, *, missing_is_none: bool) -> str | No
     try:
         fd = os.open(path, flags)
         try:
-            if not stat.S_ISREG(os.fstat(fd).st_mode):
+            info = os.fstat(fd)
+            if not stat.S_ISREG(info.st_mode):
                 raise DescriptorError(
                     f"{path} is not a regular file, so it is not something this "
                     f"daemon wrote"
+                )
+            # Size checked before reading rather than by noticing a full
+            # buffer afterwards. Truncating instead would hand the caller a
+            # fragment, and a fragment of JSON is reported as malformed, which
+            # sends whoever reads that message looking for the wrong problem.
+            if info.st_size > limit:
+                raise DescriptorError(
+                    f"{path} is {info.st_size} bytes, far larger than anything "
+                    f"this daemon writes, so it is not one of its files"
                 )
             raw = os.read(fd, limit)
         finally:
@@ -414,9 +430,10 @@ def _read_own_file(path: Path, limit: int, *, missing_is_none: bool) -> str | No
     except FileNotFoundError:
         if missing_is_none:
             return None
-        raise DescriptorError(
-            "The daemon is publishing a descriptor with no token beside it"
-        ) from None
+        # Worded by the caller. Naming the token here would be right only for
+        # as long as it stays the only caller that asks absence to raise, and
+        # wrong without anything failing if that changes.
+        raise DescriptorError(missing_message or f"{path} is missing") from None
     except OSError as exc:
         # ELOOP arrives here when the path is a symlink, which is never
         # something this wrote and never something to follow.
@@ -486,8 +503,21 @@ def read_token(auth_root: Path, descriptor: DaemonDescriptor) -> str:
     client before any of the checks ran.
     """
     path = token_path(auth_root, descriptor.instance_id)
-    text = _read_own_file(path, _MAX_TOKEN_BYTES, missing_is_none=False)
-    assert text is not None  # missing_is_none=False raises rather than returning
+    # None only comes back for a missing file, and this caller asked for that
+    # to raise instead: a token missing beside a published descriptor is a
+    # daemon in a state it should not be in, not an ordinary absence. Checked
+    # rather than asserted, since assertions are removed under -O and this one
+    # guards what gets used as a credential.
+    text = _read_own_file(
+        path,
+        _MAX_TOKEN_BYTES,
+        missing_is_none=False,
+        missing_message=(
+            "The daemon is publishing a descriptor with no token beside it"
+        ),
+    )
+    if text is None:  # pragma: no cover - unreachable while the flag is False
+        raise DescriptorError(f"{path} could not be read")
     token = text.strip()
 
     if not descriptor.matches_token(token):

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -44,6 +44,7 @@ directory of their own.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import hmac
 import ipaddress
@@ -361,12 +362,19 @@ def profile_identity(profile: Path) -> str:
             # ask here: the candidate exists by definition, and the profile
             # need not, which is the case that made an earlier version of this
             # fall back to a path and change its answer at the first login.
+            #
+            # Keep looking when it says no. Several entries can fold alike on a
+            # volume that distinguishes them, so stopping at the first
+            # candidate would settle on a directory the filesystem had just
+            # denied was the same one: measured with É and é present and é
+            # asked for, the scan met É first, was told they differ, and gave
+            # up before reaching the entry that did match.
             try:
                 if canonical.parent.joinpath(name).samefile(canonical):
                     wanted = name
+                    break
             except OSError:
-                pass
-            break
+                continue
     return f"under\0{info.st_dev}\0{info.st_ino}\0{wanted}"
 
 
@@ -748,7 +756,13 @@ def publish(
     try:
         harden_file(token_file)
     except BaseException:
-        token_file.unlink(missing_ok=True)
+        # Best effort, and quiet about its own failure: this runs while another
+        # error is on its way out, and replacing that one with a complaint
+        # about the tidying would hide what actually went wrong. Measured with
+        # the unlink refused: the caller saw PermissionError instead of the
+        # verification failure that caused it.
+        with contextlib.suppress(OSError):
+            token_file.unlink(missing_ok=True)
         raise
 
     descriptor_file = descriptor_path(auth_root)

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -650,23 +650,41 @@ class DaemonDescriptor:
                 f"into a usable address: {self.url!r}"
             )
 
-        # And finally: can this name be turned into an address at all. Spelling
-        # rules keep answering slightly the wrong question, because a host can
-        # be well formed and still resolve to nothing. is_loopback_host strips
-        # trailing dots before deciding whether it is looking at a literal or a
-        # name, so "127.0.0.1." and "localhost.." were both accepted as
-        # loopback while getaddrinfo refused them outright. Asking the resolver
-        # settles it without this having to know which spellings it likes.
-        #
-        # Local by definition, so no name lookup leaves the machine: anything
-        # that resolved to something not loopback was already refused above.
+        # And finally: what does this name actually resolve to. Spelling rules
+        # keep answering slightly the wrong question, because a host can be
+        # well formed and still resolve to nothing, or to somewhere else.
+        # is_loopback_host strips trailing dots before deciding whether it is
+        # looking at a literal or a name, so "127.0.0.1." and "localhost.."
+        # passed as loopback while getaddrinfo refused them outright; and it
+        # accepts "localhost" by name, which says nothing about where the
+        # resolver on this machine actually sends it.
         try:
-            socket.getaddrinfo(parsed.hostname, self.port, type=socket.SOCK_STREAM)
+            resolved = socket.getaddrinfo(
+                parsed.hostname, self.port, type=socket.SOCK_STREAM
+            )
         except (OSError, UnicodeError) as exc:
             raise DescriptorError(
                 f"The daemon descriptor names host {self.host!r}, which does "
                 f"not resolve to an address on this machine: {exc}"
             ) from exc
+
+        # Every answer, not merely the first: a name can carry several, and one
+        # of them being loopback says nothing about the one a client picks.
+        # Measured with the resolver made to answer 203.0.113.9 for localhost:
+        # the descriptor was accepted, and the token would have been posted off
+        # this machine.
+        #
+        # This does not close the gap entirely, because the client resolves the
+        # name again when it connects and can get a different answer. What it
+        # does is stop a descriptor naming a host that resolves elsewhere right
+        # now, which is the difference between a check and a decoration.
+        for *_, address in resolved:
+            if not is_loopback_host(str(address[0])):
+                raise DescriptorError(
+                    f"The daemon descriptor names host {self.host!r}, which "
+                    f"resolves to {address[0]}, somewhere other than this "
+                    f"machine. Refusing to send credentials there."
+                )
 
     def matches_token(self, token: str) -> bool:
         """Whether *token* is the one this descriptor was published with."""

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -35,6 +35,7 @@ import hmac
 import json
 import os
 import secrets
+import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -127,8 +128,31 @@ def token_path(auth_root: Path, instance_id: str) -> Path:
     different generations. With one shared name, a client that read the old
     descriptor and then the new token would find a digest that does not match
     and, following the discovery rules, call it corruption instead of a restart.
+
+    The identifier is checked to be a UUID before it becomes part of a path.
+    It arrives from a file anything with write access to the auth root can
+    edit, and building a filename from it unchecked would let ``..`` walk out
+    of the daemon directory and turn any readable file into what this client
+    sends to the endpoint as its bearer token.
     """
-    return daemon_dir(auth_root) / f"token-{instance_id}"
+    return daemon_dir(auth_root) / f"token-{_checked_instance_id(instance_id)}"
+
+
+def _checked_instance_id(instance_id: str) -> str:
+    """Return *instance_id* if it is a UUID, and refuse otherwise."""
+    try:
+        # str() of the parsed value, not the input: it rejects the separators
+        # and casing that would otherwise give one instance several filenames.
+        return str(uuid.UUID(instance_id))
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise DescriptorError(
+            "The daemon descriptor carries an instance id that is not a UUID"
+        ) from exc
+
+
+def new_instance_id() -> str:
+    """A fresh identity for one daemon run."""
+    return str(uuid.uuid4())
 
 
 def new_token() -> str:
@@ -254,7 +278,10 @@ class DaemonDescriptor:
             raise DescriptorError("The daemon descriptor is not an object")
 
         descriptor = cls(
-            instance_id=_text(raw, "instance_id"),
+            # Checked here as well as where it becomes a path, so a descriptor
+            # is rejected on the way in rather than at whichever call site
+            # happens to touch the identifier first.
+            instance_id=_checked_instance_id(_text(raw, "instance_id")),
             schema_version=_number(raw, "schema_version"),
             protocol_version=_number(raw, "protocol_version"),
             package_version=_text(raw, "package_version"),

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -8,11 +8,11 @@ configuration is compared through a fingerprint.
 
 Two fields exist because of measurements rather than tidiness:
 
-``profile_path``
+``profile_path`` and its filesystem identity
     ``auth_root_dir`` returns the profile's *parent*, so ``.../profile`` and
-    ``.../profile2`` share one auth root and therefore one lock. Without an
-    exact comparison here, a client configured for the second would attach to
-    the first one's browser and never notice.
+    ``.../profile2`` share one auth root and therefore one lock. The path is
+    retained for diagnostics, while device and inode decide identity so case or
+    Unicode aliases of one profile match without conflating sibling profiles.
 
 ``config_fingerprint``
     Two clients that disagree about ``headless``, the user agent or the proxy
@@ -26,6 +26,15 @@ its own file, named after the instance, and the descriptor carries only its
 digest. Fixed names would let a client pair one generation's descriptor with the
 next generation's token and read that mismatch as corruption rather than as the
 restart it is.
+
+State lives under the account's own directory rather than under the auth root,
+which is configurable and may be a directory this application does not own. One
+consequence is worth stating before anything is wired to it: two containers
+sharing a bind-mounted auth root do *not* share this state, because each has its
+own home. Measured with two containers on one mounted profile: both saw the same
+auth root identity and both took the lock. Whatever adopts this has to either
+keep containers on the existing per-operation lease or give them a shared state
+directory of their own.
 """
 
 from __future__ import annotations
@@ -42,13 +51,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from linkedin_mcp_server.common_utils import secure_write_text, utcnow_iso
+from linkedin_mcp_server.common_utils import secure_mkdir, secure_write_text, utcnow_iso
 from linkedin_mcp_server.config.schema import AppConfig, is_loopback_host
 from linkedin_mcp_server.private_state import harden_directory, harden_file
 
 #: Bumped when the shape below changes incompatibly. A client that does not
 #: recognise the value refuses rather than guessing at fields it cannot read.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 #: Bumped when the daemon's own protocol changes: the control routes, the call
 #: metadata, or the ping contract. Compatibility keys on this rather than on the
@@ -60,6 +69,7 @@ PROTOCOL_VERSION = 1
 
 _DESCRIPTOR_FILE = "daemon.json"
 _DAEMON_DIR = "daemon"
+_APPLICATION_STATE_DIR = ".mcp-server-linkedin"
 
 # Enough that guessing is not a strategy. Read straight from the OS source.
 _TOKEN_BYTES = 32
@@ -113,9 +123,148 @@ def _number(raw: Mapping[Any, Any], name: str, *, default: int | None = None) ->
     return value
 
 
+def _account_home() -> Path:
+    """Return the operating system account's home, ignoring process overrides."""
+    if os.name == "nt":  # pragma: no cover - exercised on the Windows CI runner
+        import ctypes
+        from ctypes import wintypes
+
+        # CSIDL_PROFILE asks Windows for the current account's profile directory.
+        # Unlike Path.home(), this does not change when a launcher overrides
+        # HOME or USERPROFILE for one process and would otherwise split one
+        # account's daemon election into several roots.
+        shell32 = getattr(ctypes, "WinDLL")("shell32", use_last_error=True)
+        get_folder = shell32.SHGetFolderPathW
+        get_folder.argtypes = [
+            wintypes.HWND,
+            ctypes.c_int,
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.LPWSTR,
+        ]
+        get_folder.restype = ctypes.c_long
+        buffer = ctypes.create_unicode_buffer(32768)
+        result = get_folder(None, 0x0028, None, 0, buffer)
+        if result != 0 or not buffer.value:
+            raise DescriptorError(
+                "Windows could not identify the current account's profile directory"
+            )
+        return Path(buffer.value)
+
+    import pwd
+
+    try:
+        entry = pwd.getpwuid(os.getuid()).pw_dir
+    except KeyError as exc:
+        raise DescriptorError(
+            "The operating system could not identify the current account's home directory"
+        ) from exc
+
+    # An empty or relative entry is not an answer. Path("") is ".", so two
+    # processes of one account started from different working directories would
+    # key their state under different roots and each elect its own owner.
+    home = Path(entry)
+    if not entry or not home.is_absolute():
+        raise DescriptorError(
+            "The current account has no absolute home directory, so daemon state "
+            "has nowhere stable to live"
+        )
+    return home
+
+
+def daemon_state_root() -> Path:
+    """Return the private application root shared by every local daemon.
+
+    Refuses a symbolic link on the way, because the lock is taken by path: with
+    a link here, retargeting it between two acquisitions puts two owners on two
+    inodes while both believe they hold the one lock. Measured before the check.
+
+    This is a consistency guard, not a security boundary. Only the account that
+    owns this directory can plant or retarget the link, and that same account
+    could equally rename the real directory or delete the lock file. What it
+    buys is that an unusual layout fails loudly instead of quietly electing a
+    second browser owner.
+    """
+    root = _account_home() / _APPLICATION_STATE_DIR / _DAEMON_DIR
+    for part in (root.parent, root):
+        if part.is_symlink():
+            raise DescriptorError(
+                f"{part} is a symbolic link. Daemon state has to sit at a real "
+                f"path, because a link that is retargeted between two starts "
+                f"would let two processes each own the browser. Replace it with "
+                f"a directory."
+            )
+    return root
+
+
+def _directory_identity(path: Path, *, label: str) -> tuple[int, int]:
+    """Return the stable filesystem identity of a directory, creating it once.
+
+    For the process that is establishing state. The first daemon on a fresh
+    install must not key a missing path and then switch to an inode after
+    creating it, which would leave its own lock at an address nothing else
+    computes. ``secure_mkdir`` creates only what is missing and deliberately
+    leaves permissions on existing parents alone.
+    """
+    canonical = path.expanduser().resolve()
+    secure_mkdir(canonical, mode=0o700)
+    info = canonical.stat()
+
+    if not stat.S_ISDIR(info.st_mode):
+        raise DescriptorError(f"The {label} is not a directory: {canonical}")
+
+    # Device plus inode identifies the physical directory, not one spelling of
+    # it. That keeps case and Unicode aliases together on insensitive volumes
+    # without conflating distinct directories on a case-sensitive volume.
+    if not info.st_ino:
+        raise DescriptorError(
+            f"The filesystem does not provide a stable identity for {canonical}, "
+            "so browser ownership cannot be coordinated safely"
+        )
+    return info.st_dev, info.st_ino
+
+
+def _comparable_identity(path: Path) -> tuple[int, int] | str:
+    """Return an identity for *path* without creating or touching anything.
+
+    Comparison must not have side effects. ``serves`` and ``mismatched_fields``
+    answer questions, and one of them runs while assembling a refusal message:
+    creating a browser profile directory in order to explain why a client was
+    turned away would be an odd thing for a client to discover afterwards.
+
+    A path that does not exist yet falls back to its spelling, which can never
+    equal a real device and inode pair. Two clients naming the same missing
+    directory still agree; a missing one and a real one do not. That errs
+    towards a refusal, which this module prefers over serving a client a browser
+    that is not the one it asked for.
+    """
+    canonical = path.expanduser().resolve()
+    try:
+        info = canonical.stat()
+    except OSError:
+        return f"path\0{os.path.normcase(str(canonical))}"
+    if not stat.S_ISDIR(info.st_mode) or not info.st_ino:
+        return f"path\0{os.path.normcase(str(canonical))}"
+    return info.st_dev, info.st_ino
+
+
+def _auth_root_identity(auth_root: Path) -> bytes:
+    device, inode = _directory_identity(auth_root, label="authentication root")
+    return f"inode\0{device}\0{inode}".encode("ascii")
+
+
 def daemon_dir(auth_root: Path) -> Path:
-    """Where a daemon's descriptor and token live for *auth_root*."""
-    return auth_root.expanduser().resolve() / _DAEMON_DIR
+    """Where daemon state for *auth_root* lives.
+
+    The auth root is user-configurable and may be a shared directory such as
+    ``/tmp`` or a home directory. Storing state below it would either change
+    permissions on a directory this application does not own or trust a
+    replaceable directory link for the ownership lock. Keep state under the
+    operating system account's private application directory instead, keyed by
+    the physical auth root so sibling profiles still share exactly one election.
+    """
+    key = hashlib.sha256(_auth_root_identity(auth_root)).hexdigest()
+    return daemon_state_root() / key
 
 
 def descriptor_path(auth_root: Path) -> Path:
@@ -199,10 +348,13 @@ def _normalize(name: str, value: Any) -> Any:
         return value is not False
     if value is None:
         return None
-    if name in ("user_data_dir", "chrome_path"):
+    if name == "user_data_dir":
+        # The profile is shared state, so compare the physical directory rather
+        # than one spelling. macOS can preserve case and Unicode aliases in a
+        # resolved path even when both names address the same directory.
+        return _comparable_identity(Path(str(value)))
+    if name == "chrome_path":
         path = Path(str(value)).expanduser().resolve()
-        # Windows paths differ only in case, so comparing them literally would
-        # split one owner into several.
         return os.path.normcase(str(path))
     if name == "proxy_bypass":
         # An ordered, comma-separated list where neither the order nor the
@@ -261,6 +413,8 @@ class DaemonDescriptor:
     package_version: str
     runtime_id: str
     profile_path: str
+    profile_device: int
+    profile_inode: int
     host: str
     port: int
     path: str
@@ -309,6 +463,8 @@ class DaemonDescriptor:
             package_version=_text(raw, "package_version"),
             runtime_id=_text(raw, "runtime_id"),
             profile_path=_text(raw, "profile_path"),
+            profile_device=_number(raw, "profile_device"),
+            profile_inode=_number(raw, "profile_inode"),
             host=_text(raw, "host"),
             port=_number(raw, "port"),
             path=_text(raw, "path"),
@@ -353,8 +509,10 @@ class DaemonDescriptor:
         Two directories side by side elect one owner between them, and a client
         that only checked the auth root would be served the wrong browser.
         """
-        wanted = os.path.normcase(str(profile.expanduser().resolve()))
-        return wanted == os.path.normcase(self.profile_path)
+        return _comparable_identity(profile) == (
+            self.profile_device,
+            self.profile_inode,
+        )
 
 
 def publish(
@@ -368,6 +526,7 @@ def publish(
     token into existence.
     """
     directory = daemon_dir(auth_root)
+    harden_directory(daemon_state_root())
     harden_directory(directory)
 
     token_file = token_path(auth_root, descriptor.instance_id)
@@ -562,6 +721,9 @@ def build(
     log_path: Path,
 ) -> DaemonDescriptor:
     """Assemble a descriptor for a daemon that is already listening."""
+    profile_device, profile_inode = _directory_identity(
+        profile, label="browser profile"
+    )
     return DaemonDescriptor(
         instance_id=instance_id,
         schema_version=SCHEMA_VERSION,
@@ -569,6 +731,8 @@ def build(
         package_version=package_version,
         runtime_id=runtime_id,
         profile_path=str(profile.expanduser().resolve()),
+        profile_device=profile_device,
+        profile_inode=profile_inode,
         host=host,
         port=port,
         path=path,

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -270,7 +270,14 @@ class DaemonDescriptor:
 
     @property
     def url(self) -> str:
-        return f"http://{self.host}:{self.port}{self.path}"
+        # An IPv6 literal has to be bracketed, or the colons in the address run
+        # into the one before the port and the whole thing parses as a bad
+        # port. Measured: a valid ::1 endpoint produced a URL no client could
+        # use. Bracketed already, or a name, it is left alone.
+        host = self.host
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        return f"http://{host}:{self.port}{self.path}"
 
     def to_json(self) -> str:
         return json.dumps(self.__dict__, indent=2, sort_keys=True) + "\n"
@@ -376,6 +383,22 @@ def read(auth_root: Path) -> DaemonDescriptor | None:
     it would strand every other client attached to that daemon.
     """
     path = descriptor_path(auth_root)
+    # Checked without following, before anything is read. A symlink here is
+    # never something this wrote, and the two ways of getting it wrong both
+    # matter: a dangling one reads as absence, so a client elects a second owner
+    # while the first is still running, and a live one aims the read somewhere
+    # this never published.
+    try:
+        if path.is_symlink():
+            raise DescriptorError(
+                f"{path} is a symbolic link rather than a descriptor this "
+                f"daemon wrote. Remove it and start the server again."
+            )
+    except OSError as exc:
+        raise DescriptorError(
+            f"The daemon descriptor could not be read: {exc}"
+        ) from exc
+
     try:
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -49,6 +49,7 @@ import hmac
 import json
 import os
 import secrets
+import socket
 import stat
 import uuid
 from collections.abc import Mapping
@@ -124,13 +125,16 @@ def _text(raw: Mapping[Any, Any], name: str) -> str:
 def _digest_text(raw: Mapping[Any, Any], name: str) -> str:
     """Read a field that must be a SHA-256 digest, and check that it is one.
 
-    Both digests are compared with ``hmac.compare_digest``, which refuses a
+    ``token_sha256`` is compared with ``hmac.compare_digest``, which refuses a
     string carrying anything outside ASCII and raises TypeError doing so.
     Measured with an accented character: the descriptor was accepted here and
     the comparison failed later with a TypeError, outside the DescriptorError
-    every caller of this module is written to expect. A digest has one shape,
-    so checking it costs nothing and keeps the failure where it can be
-    explained.
+    every caller of this module is written to expect.
+
+    ``config_fingerprint`` is only produced and parsed so far, and is checked
+    the same way because it is the same kind of value and will be compared the
+    same way once there is something to compare it against. A digest has one
+    shape, so establishing it costs nothing.
     """
     value = _text(raw, name)
     if len(value) != 64 or any(character not in _HEX_DIGITS for character in value):
@@ -645,6 +649,24 @@ class DaemonDescriptor:
                 f"The daemon descriptor's host, port and path do not compose "
                 f"into a usable address: {self.url!r}"
             )
+
+        # And finally: can this name be turned into an address at all. Spelling
+        # rules keep answering slightly the wrong question, because a host can
+        # be well formed and still resolve to nothing. is_loopback_host strips
+        # trailing dots before deciding whether it is looking at a literal or a
+        # name, so "127.0.0.1." and "localhost.." were both accepted as
+        # loopback while getaddrinfo refused them outright. Asking the resolver
+        # settles it without this having to know which spellings it likes.
+        #
+        # Local by definition, so no name lookup leaves the machine: anything
+        # that resolved to something not loopback was already refused above.
+        try:
+            socket.getaddrinfo(parsed.hostname, self.port, type=socket.SOCK_STREAM)
+        except (OSError, UnicodeError) as exc:
+            raise DescriptorError(
+                f"The daemon descriptor names host {self.host!r}, which does "
+                f"not resolve to an address on this machine: {exc}"
+            ) from exc
 
     def matches_token(self, token: str) -> bool:
         """Whether *token* is the one this descriptor was published with."""

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -169,32 +169,39 @@ def _account_home() -> Path:
             "The current account has no absolute home directory, so daemon state "
             "has nowhere stable to live"
         )
-    return home
+
+    # The home has to be there already. Creating it would be wrong twice: a home
+    # that is merely not mounted yet would be shadowed by an empty directory,
+    # and the daemon that did so would key its state under that directory while
+    # every process started after the mount keys it under the real one.
+    if not home.is_dir():
+        raise DescriptorError(
+            f"The current account's home directory {home} does not exist. Daemon "
+            f"state has nowhere to live until it does."
+        )
+
+    # Resolved, not merely checked for links. A home reached through a symlink
+    # is an ordinary layout on POSIX, and refusing it would refuse a working
+    # machine. What matters is that every process agrees, which resolving gives
+    # and an is_symlink() refusal does not.
+    return home.resolve()
 
 
 def daemon_state_root() -> Path:
     """Return the private application root shared by every local daemon.
 
-    Refuses a symbolic link on the way, because the lock is taken by path: with
-    a link here, retargeting it between two acquisitions puts two owners on two
-    inodes while both believe they hold the one lock. Measured before the check.
+    Fully resolved, so that processes reaching this directory by different
+    routes still agree on one lock. Symbolic links along the way are followed
+    rather than refused: they are a normal way to lay out a home directory.
 
-    This is a consistency guard, not a security boundary. Only the account that
-    owns this directory can plant or retarget the link, and that same account
-    could equally rename the real directory or delete the lock file. What it
-    buys is that an unusual layout fails loudly instead of quietly electing a
-    second browser owner.
+    What this cannot defend against is the path being *changed* underneath a
+    running owner, by retargeting a link or renaming a directory. Measured: a
+    second process then takes a lock on a different inode while the first still
+    holds its own. The existing profile lease has exactly the same property, for
+    the same reason, and no lock addressed by path can avoid it. The account
+    that could do this is the one whose browser is at stake.
     """
-    root = _account_home() / _APPLICATION_STATE_DIR / _DAEMON_DIR
-    for part in (root.parent, root):
-        if part.is_symlink():
-            raise DescriptorError(
-                f"{part} is a symbolic link. Daemon state has to sit at a real "
-                f"path, because a link that is retargeted between two starts "
-                f"would let two processes each own the browser. Replace it with "
-                f"a directory."
-            )
-    return root
+    return (_account_home() / _APPLICATION_STATE_DIR / _DAEMON_DIR).resolve()
 
 
 def _directory_identity(path: Path, *, label: str) -> tuple[int, int]:

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -249,7 +249,22 @@ def _auth_root_identity(auth_root: Path) -> bytes:
     profile inside it cannot, and :func:`profile_identity` says why.
     """
     canonical = auth_root.expanduser().resolve()
-    secure_mkdir(canonical, mode=0o700)
+    # Checked before creating, not after. secure_mkdir refuses an existing
+    # non-directory itself, with a NotADirectoryError that reaches the caller
+    # instead of the DescriptorError this module is read through, and the check
+    # below could then never run: measured, a file where the auth root belongs
+    # surfaced as NotADirectoryError.
+    if canonical.exists() and not canonical.is_dir():
+        raise DescriptorError(
+            f"The authentication root is not a directory: {canonical}"
+        )
+
+    try:
+        secure_mkdir(canonical, mode=0o700)
+    except OSError as exc:
+        raise DescriptorError(
+            f"The authentication root {canonical} could not be created: {exc}"
+        ) from exc
     info = canonical.stat()
 
     if not stat.S_ISDIR(info.st_mode):
@@ -307,13 +322,14 @@ def profile_identity(profile: Path) -> str:
     # matching its own profile. Measured, with the auth root non-empty so the
     # scan had something to walk: serves() went from True to False across the
     # login that created the directory.
-    # An exact match wins over a case-insensitive one, and that order is the
-    # whole point. On a case-insensitive volume the listing holds one spelling,
-    # so Profile and profile find each other and agree, which is what this is
-    # for. On a case-sensitive one they are two directories that both exist,
-    # and folding without preferring the exact name gave them the same identity:
-    # measured on a case-sensitive APFS volume, two distinct siblings both
-    # keyed as Profile, which would have handed a client the other's session.
+    # The name as the filesystem holds it, which is only a different name from
+    # the caller's where the filesystem says the two are one directory. Asking
+    # it directly rather than folding on principle: on a case-sensitive volume
+    # Profile and profile are two directories, and treating a fold match as the
+    # same entry there is wrong twice over. Measured on a case-sensitive APFS
+    # volume, once with both present and once with only the sibling: two
+    # distinct profiles shared an identity, which would have served a client
+    # the other one's logged-in session.
     wanted = canonical.name
     folded = wanted.casefold()
     try:
@@ -323,7 +339,19 @@ def profile_identity(profile: Path) -> str:
         # the caller gave still identifies it well enough to compare.
         entries = []
     if wanted not in entries:
-        wanted = next((name for name in entries if name.casefold() == folded), wanted)
+        for name in entries:
+            if name.casefold() != folded:
+                continue
+            # samefile answers what folding only guesses at, and it is safe to
+            # ask here: the candidate exists by definition, and the profile
+            # need not, which is the case that made an earlier version of this
+            # fall back to a path and change its answer at the first login.
+            try:
+                if canonical.parent.joinpath(name).samefile(canonical):
+                    wanted = name
+            except OSError:
+                pass
+            break
     return f"under\0{info.st_dev}\0{info.st_ino}\0{wanted}"
 
 
@@ -354,10 +382,12 @@ def token_path(auth_root: Path, instance_id: str) -> Path:
     and, following the discovery rules, call it corruption instead of a restart.
 
     The identifier is checked to be a UUID before it becomes part of a path.
-    It arrives from a file anything with write access to the auth root can
-    edit, and building a filename from it unchecked would let ``..`` walk out
-    of the daemon directory and turn any readable file into what this client
-    sends to the endpoint as its bearer token.
+    It arrives from a file, and a file is only ever as trustworthy as what can
+    write to it. The state directory is owner-only now, so that is this account
+    and whatever runs as it, but building a filename from the identifier
+    unchecked would let ``..`` walk out of the daemon directory and turn any
+    readable file into what this client sends to the endpoint as its bearer
+    token. The check costs one parse.
     """
     return daemon_dir(auth_root) / f"token-{_checked_instance_id(instance_id)}"
 
@@ -552,10 +582,13 @@ class DaemonDescriptor:
     def check_endpoint_is_local(self) -> None:
         """Refuse an endpoint that is not this machine, before sending a token.
 
-        The descriptor is a file on disk, so it can be edited. Reading a host
-        from it and posting a bearer token there without checking would turn any
-        write access to the auth root into a way to collect the token and,
-        through it, the LinkedIn session behind it.
+        The descriptor is a file on disk, so it says what was last written to
+        it rather than what this process believes. Reading a host from it and
+        posting a bearer token there unchecked would turn a corrupted or
+        stale file into a way to hand over the token and, through it, the
+        LinkedIn session behind it. The file lives in owner-only state, so this
+        is about what has gone wrong rather than about another account, and it
+        is cheap enough to check either way.
         """
         if not is_loopback_host(self.host):
             raise DescriptorError(
@@ -570,38 +603,44 @@ class DaemonDescriptor:
         if not self.path.startswith("/"):
             raise DescriptorError("The daemon descriptor has no usable path")
 
-        # A request line is one line. A control character in any of these ends
-        # up in the URL and, in the wrong place, would let a descriptor written
-        # by something else decide where one header stops and the next begins.
-        # urlsplit is happy to carry them, so they are refused here.
+        # A URL is printable ASCII. Stated as a rule rather than as a list of
+        # the characters that happened to come up: an earlier version banned
+        # CR, LF, tab and NUL by name and left thirty-six other code points
+        # that were accepted here and rejected by the client, which is exactly
+        # the shape of failure this check exists to move. Anything outside the
+        # printable range goes, whether it is a control character, a
+        # non-breaking space, or a lone surrogate.
         for name, value in (("host", self.host), ("path", self.path)):
-            if any(character in value for character in "\r\n\t\x00"):
+            if any(character < "\x21" or character > "\x7e" for character in value):
                 raise DescriptorError(
-                    f"The daemon descriptor's {name} contains a control "
-                    f"character, so it cannot name an endpoint"
+                    f"The daemon descriptor's {name} contains a character that "
+                    f"cannot appear in a URL, so it cannot name an endpoint"
                 )
 
         # The fields are individually plausible; whether they compose into
         # something a client can use is a separate question, and the only one
-        # that finally matters. is_loopback_host trims before classifying, for
-        # instance, so a host with whitespace around it is loopback by that
-        # measure and produces a URL that parses as a bad port. Measured
-        # accepting three such descriptors: "[::1] ", a bracketed IPv4, and a
-        # path with a newline, each failing later in the client rather than
-        # here where it could be explained as a descriptor this did not write.
+        # that finally matters. Measured accepting three such descriptors:
+        # "[::1] ", a bracketed IPv4, and a path with a newline, each failing
+        # later in the client rather than here where it could be explained as a
+        # descriptor this did not write.
         #
         # urlsplit rather than an HTTP client's parser: this has no business
-        # depending on which client the caller happens to use, and reading the
-        # port back is what catches a host that ran into it.
+        # depending on which client the caller happens to use.
         try:
             parsed = urlsplit(self.url)
-            reachable = parsed.port == self.port and parsed.scheme == "http"
+            port_survived = parsed.port == self.port
+            host_survived = (parsed.hostname or "") == self.host.strip("[]").lower()
         except ValueError as exc:
             raise DescriptorError(
                 f"The daemon descriptor describes an endpoint that cannot be "
                 f"used to reach anything: {exc}"
             ) from exc
-        if not reachable:
+        # The host is read back, not just the port. is_loopback_host was asked
+        # about the field; this asks about the string a client will actually
+        # connect to, and the two came apart: a space-padded address passed as
+        # loopback and produced a host of "%20127.0.0.1%20", so what was
+        # verified and what would be contacted were not the same name.
+        if not port_survived or not host_survived or parsed.scheme != "http":
             raise DescriptorError(
                 f"The daemon descriptor's host, port and path do not compose "
                 f"into a usable address: {self.url!r}"

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -175,12 +175,22 @@ def _canonical(value: object) -> str:
     )
 
 
+#: Fields where an empty string is a value rather than an absence. The proxy
+#: credentials are the case that matters: ``proxy_settings`` compares the
+#: password against None precisely so an empty one is still sent, so folding it
+#: into "unset" would report a match between two clients whose browsers launch
+#: with different options.
+_EMPTY_IS_MEANINGFUL = frozenset({"proxy_username", "proxy_password"})
+
+
 def _normalize(name: str, value: Any) -> Any:
     """Reduce a field to the form two processes should agree on.
 
     Only differences that would actually make the owner's browser wrong for a
-    client should count. Two spellings of the same path are the same profile,
-    and an unset optional string is the same as an empty one.
+    client should count. Two spellings of the same path are the same profile.
+    Erring towards a false difference is safe here: it costs a refusal that
+    names the field. Erring the other way hands a client a browser configured
+    differently from what it asked for.
     """
     if value is None:
         return None
@@ -194,7 +204,7 @@ def _normalize(name: str, value: Any) -> Any:
         # spacing changes which hosts bypass the proxy.
         hosts = sorted({host.strip().lower() for host in str(value).split(",")} - {""})
         return ",".join(hosts)
-    if isinstance(value, str) and not value:
+    if isinstance(value, str) and not value and name not in _EMPTY_IS_MEANINGFUL:
         return None
     return value
 

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -80,6 +80,9 @@ _APPLICATION_STATE_DIR = ".mcp-server-linkedin"
 # Enough that guessing is not a strategy. Read straight from the OS source.
 _TOKEN_BYTES = 32
 
+#: What a hex digest may contain, for checking one read from a file.
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
 #: Configuration a client must share with the owner to be served by it. Each of
 #: these either changes what the browser *is* (its fingerprint, its exit
 #: address, where its profile lives) or how long the owner keeps it. Anything
@@ -114,6 +117,25 @@ def _text(raw: Mapping[Any, Any], name: str) -> str:
     if not isinstance(value, str):
         raise DescriptorError(
             f"The daemon descriptor field {name} is missing or not text"
+        )
+    return value
+
+
+def _digest_text(raw: Mapping[Any, Any], name: str) -> str:
+    """Read a field that must be a SHA-256 digest, and check that it is one.
+
+    Both digests are compared with ``hmac.compare_digest``, which refuses a
+    string carrying anything outside ASCII and raises TypeError doing so.
+    Measured with an accented character: the descriptor was accepted here and
+    the comparison failed later with a TypeError, outside the DescriptorError
+    every caller of this module is written to expect. A digest has one shape,
+    so checking it costs nothing and keeps the failure where it can be
+    explained.
+    """
+    value = _text(raw, name)
+    if len(value) != 64 or any(character not in _HEX_DIGITS for character in value):
+        raise DescriptorError(
+            f"The daemon descriptor field {name} is not a SHA-256 digest"
         )
     return value
 
@@ -285,20 +307,23 @@ def profile_identity(profile: Path) -> str:
     # matching its own profile. Measured, with the auth root non-empty so the
     # scan had something to walk: serves() went from True to False across the
     # login that created the directory.
-    # casefold rather than normcase: normcase is a no-op on POSIX, while macOS
-    # is case-insensitive regardless, so Profile and profile name one directory
-    # there and the listing holds only one of the two spellings.
+    # An exact match wins over a case-insensitive one, and that order is the
+    # whole point. On a case-insensitive volume the listing holds one spelling,
+    # so Profile and profile find each other and agree, which is what this is
+    # for. On a case-sensitive one they are two directories that both exist,
+    # and folding without preferring the exact name gave them the same identity:
+    # measured on a case-sensitive APFS volume, two distinct siblings both
+    # keyed as Profile, which would have handed a client the other's session.
     wanted = canonical.name
     folded = wanted.casefold()
     try:
-        for entry in os.scandir(canonical.parent):
-            if entry.name == wanted or entry.name.casefold() == folded:
-                wanted = entry.name
-                break
+        entries = [entry.name for entry in os.scandir(canonical.parent)]
     except OSError:
         # The parent stopped being readable between the two calls. The spelling
         # the caller gave still identifies it well enough to compare.
-        pass
+        entries = []
+    if wanted not in entries:
+        wanted = next((name for name in entries if name.casefold() == folded), wanted)
     return f"under\0{info.st_dev}\0{info.st_ino}\0{wanted}"
 
 
@@ -515,8 +540,8 @@ class DaemonDescriptor:
             host=_text(raw, "host"),
             port=_number(raw, "port"),
             path=_text(raw, "path"),
-            token_sha256=_text(raw, "token_sha256"),
-            config_fingerprint=_text(raw, "config_fingerprint"),
+            token_sha256=_digest_text(raw, "token_sha256"),
+            config_fingerprint=_digest_text(raw, "config_fingerprint"),
             started_at=_text(raw, "started_at"),
             log_path=_text(raw, "log_path"),
             pid=_number(raw, "pid", default=0),

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -860,7 +860,13 @@ def read(auth_root: Path) -> DaemonDescriptor | None:
 
     try:
         parsed = json.loads(raw)
-    except json.JSONDecodeError as exc:
+    except ValueError as exc:
+        # ValueError rather than JSONDecodeError alone: a number with more
+        # digits than sys.int_max_str_digits allows raises a plain ValueError
+        # from inside the parser, and a file well under the size limit can
+        # carry one. Measured with a five thousand digit integer: it crossed
+        # the boundary as ValueError before anything could call it a bad
+        # descriptor. JSONDecodeError is a ValueError, so this covers both.
         raise DescriptorError(
             f"The daemon descriptor is not valid JSON: {exc}"
         ) from exc

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -402,6 +402,22 @@ def _read_own_file(
     ordinary first-start case; absence of a token beside a published descriptor
     is not, and *missing_message* is how that caller says why.
     """
+    # Windows has no O_NOFOLLOW, so the open there resolves a link and the
+    # check below then sees a perfectly ordinary regular file at the other end.
+    # Checking the entry itself is the only refusal available on that platform.
+    # It is a check-then-open rather than an atomic one, so a link planted in
+    # the gap still wins; closing that properly needs the Win32 reparse-point
+    # flag, which is worth doing when the daemon actually runs there.
+    if not hasattr(os, "O_NOFOLLOW"):  # pragma: no cover - Windows only
+        try:
+            if path.is_symlink():
+                raise DescriptorError(
+                    f"{path} is a symbolic link rather than a file this daemon "
+                    f"wrote. Remove it and start the server again."
+                )
+        except OSError as exc:
+            raise DescriptorError(f"{path} could not be read: {exc}") from exc
+
     # O_NOFOLLOW fails on a symlink rather than resolving it, so the check and
     # the read cannot disagree about which file they mean. O_NONBLOCK has no
     # effect on the regular file this expects.

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -8,11 +8,16 @@ configuration is compared through a fingerprint.
 
 Two fields exist because of measurements rather than tidiness:
 
-``profile_path`` and its filesystem identity
+``profile_path`` and ``profile_identity``
     ``auth_root_dir`` returns the profile's *parent*, so ``.../profile`` and
     ``.../profile2`` share one auth root and therefore one lock. The path is
-    retained for diagnostics, while device and inode decide identity so case or
-    Unicode aliases of one profile match without conflating sibling profiles.
+    retained for diagnostics; the identity is what is compared. It is built
+    from the parent's inode and the profile's own name rather than the
+    profile's inode, because the profile directory is replaced whenever a new
+    session is established: keyed by its inode, a descriptor would stop
+    matching its own profile at the first login. The parent's inode still
+    settles the case and Unicode aliases that a bare string comparison gets
+    wrong on an insensitive volume.
 
 ``config_fingerprint``
     Two clients that disagree about ``headless``, the user agent or the proxy
@@ -231,28 +236,48 @@ def _directory_identity(path: Path, *, label: str) -> tuple[int, int]:
     return info.st_dev, info.st_ino
 
 
-def _comparable_identity(path: Path) -> tuple[int, int] | str:
-    """Return an identity for *path* without creating or touching anything.
+def profile_identity(profile: Path) -> str:
+    """Return an identity for a browser profile, by location rather than inode.
 
-    Comparison must not have side effects. ``serves`` and ``mismatched_fields``
-    answer questions, and one of them runs while assembling a refusal message:
-    creating a browser profile directory in order to explain why a client was
-    turned away would be an odd thing for a client to discover afterwards.
+    Deliberately not the device and inode that address daemon state. A profile
+    directory is *replaced* in normal operation: every path that establishes a
+    new session rotates the old one into quarantine and Chromium creates a fresh
+    directory at the same place. Keyed by inode, a descriptor published before
+    the first login would stop matching its own profile the moment that login
+    happened, and the owner would keep the lock while no client could recognise
+    it. The auth root above it is not rotated, which is why the lock can use an
+    inode and this cannot.
 
-    A path that does not exist yet falls back to its spelling, which can never
-    equal a real device and inode pair. Two clients naming the same missing
-    directory still agree; a missing one and a real one do not. That errs
-    towards a refusal, which this module prefers over serving a client a browser
-    that is not the one it asked for.
+    Location, then, but not a bare string comparison: on a case-insensitive
+    volume ``resolve()`` keeps whichever spelling the caller used, so two names
+    for one profile would look like two profiles. The parent is identified by
+    its inode, and the final component is taken from the parent's own directory
+    listing rather than from the caller, which is what makes ``Profile`` and
+    ``profile`` land on the same answer where the filesystem says they are one
+    directory. ``normcase`` alone would not: it is a no-op on POSIX, and macOS
+    is case-insensitive all the same.
+
+    Creates nothing: this runs while assembling a refusal, and leaving a browser
+    profile behind to explain one would be a strange thing for a client to
+    discover afterwards.
     """
-    canonical = path.expanduser().resolve()
+    canonical = profile.expanduser().resolve()
+    spelled = f"path\0{os.path.normcase(str(canonical))}"
     try:
-        info = canonical.stat()
+        info = canonical.parent.stat()
+        if not stat.S_ISDIR(info.st_mode) or not info.st_ino:
+            return spelled
+        # The name as the filesystem holds it. scandir is one syscall over a
+        # directory this already resolved, and it is the only way to learn which
+        # spelling is the real one where several address one entry.
+        name = os.path.normcase(canonical.name)
+        for entry in os.scandir(canonical.parent):
+            if os.path.normcase(entry.name) == name or canonical.samefile(entry.path):
+                name = entry.name
+                break
     except OSError:
-        return f"path\0{os.path.normcase(str(canonical))}"
-    if not stat.S_ISDIR(info.st_mode) or not info.st_ino:
-        return f"path\0{os.path.normcase(str(canonical))}"
-    return info.st_dev, info.st_ino
+        return spelled
+    return f"under\0{info.st_dev}\0{info.st_ino}\0{name}"
 
 
 def _auth_root_identity(auth_root: Path) -> bytes:
@@ -359,7 +384,7 @@ def _normalize(name: str, value: Any) -> Any:
         # The profile is shared state, so compare the physical directory rather
         # than one spelling. macOS can preserve case and Unicode aliases in a
         # resolved path even when both names address the same directory.
-        return _comparable_identity(Path(str(value)))
+        return profile_identity(Path(str(value)))
     if name == "chrome_path":
         path = Path(str(value)).expanduser().resolve()
         return os.path.normcase(str(path))
@@ -420,8 +445,7 @@ class DaemonDescriptor:
     package_version: str
     runtime_id: str
     profile_path: str
-    profile_device: int
-    profile_inode: int
+    profile_identity: str
     host: str
     port: int
     path: str
@@ -470,8 +494,7 @@ class DaemonDescriptor:
             package_version=_text(raw, "package_version"),
             runtime_id=_text(raw, "runtime_id"),
             profile_path=_text(raw, "profile_path"),
-            profile_device=_number(raw, "profile_device"),
-            profile_inode=_number(raw, "profile_inode"),
+            profile_identity=_text(raw, "profile_identity"),
             host=_text(raw, "host"),
             port=_number(raw, "port"),
             path=_text(raw, "path"),
@@ -516,10 +539,7 @@ class DaemonDescriptor:
         Two directories side by side elect one owner between them, and a client
         that only checked the auth root would be served the wrong browser.
         """
-        return _comparable_identity(profile) == (
-            self.profile_device,
-            self.profile_inode,
-        )
+        return profile_identity(profile) == self.profile_identity
 
 
 def publish(
@@ -728,9 +748,6 @@ def build(
     log_path: Path,
 ) -> DaemonDescriptor:
     """Assemble a descriptor for a daemon that is already listening."""
-    profile_device, profile_inode = _directory_identity(
-        profile, label="browser profile"
-    )
     return DaemonDescriptor(
         instance_id=instance_id,
         schema_version=SCHEMA_VERSION,
@@ -738,8 +755,7 @@ def build(
         package_version=package_version,
         runtime_id=runtime_id,
         profile_path=str(profile.expanduser().resolve()),
-        profile_device=profile_device,
-        profile_inode=profile_inode,
+        profile_identity=profile_identity(profile),
         host=host,
         port=port,
         path=path,

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -35,6 +35,7 @@ import hmac
 import json
 import os
 import secrets
+import stat
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -421,19 +422,62 @@ def read(auth_root: Path) -> DaemonDescriptor | None:
             f"The daemon descriptor is version {descriptor.schema_version}, and "
             f"this client understands version {SCHEMA_VERSION}"
         )
+    # Enforced, not merely recorded. This is the field compatibility is meant
+    # to key on, and a client that attached across a protocol change would be
+    # speaking to an owner whose control routes, call metadata and ping
+    # contract it does not share.
+    if descriptor.protocol_version != PROTOCOL_VERSION:
+        raise DescriptorError(
+            f"The running daemon speaks protocol {descriptor.protocol_version} "
+            f"and this client speaks {PROTOCOL_VERSION}. Stop the running "
+            f"daemon to let a compatible one start."
+        )
     return descriptor
 
 
+#: A token is a few dozen characters. Reading is bounded anyway, so a file that
+#: turns out to be something else cannot pull an unbounded amount into memory
+#: before the checks below reject it.
+_MAX_TOKEN_BYTES = 4096
+
+
 def read_token(auth_root: Path, descriptor: DaemonDescriptor) -> str:
-    """Read the token belonging to *descriptor*, checking it is the right one."""
+    """Read the token belonging to *descriptor*, checking it is the right one.
+
+    Opened without following links and confirmed to be a regular file before a
+    byte is read. Confining the *filename* to the daemon directory, which the
+    UUID check does, is not enough on its own: a link sitting at that name
+    still points wherever it likes, and a special file there could block the
+    client before any of the checks ran.
+    """
     path = token_path(auth_root, descriptor.instance_id)
     try:
-        token = path.read_text(encoding="utf-8").strip()
+        # O_NOFOLLOW fails on a symlink rather than resolving it, so the check
+        # and the read cannot disagree about which file they mean. O_NONBLOCK
+        # is what stops a named pipe planted at this path from hanging the
+        # client inside open(), before any check has had a chance to run; it
+        # has no effect on the regular file this expects.
+        flags = (
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        )
+        fd = os.open(path, flags)
+        try:
+            info = os.fstat(fd)
+            if not stat.S_ISREG(info.st_mode):
+                raise DescriptorError(
+                    f"{path} is not a regular file, so it is not a token this "
+                    f"daemon wrote"
+                )
+            token = os.read(fd, _MAX_TOKEN_BYTES).decode("utf-8").strip()
+        finally:
+            os.close(fd)
     except FileNotFoundError as exc:
         raise DescriptorError(
             "The daemon is publishing a descriptor with no token beside it"
         ) from exc
     except OSError as exc:
+        # ELOOP lands here when the path is a symlink, which is never something
+        # this wrote and never something to follow.
         raise DescriptorError(f"The daemon token could not be read: {exc}") from exc
 
     if not descriptor.matches_token(token):

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -74,8 +74,16 @@ class DaemonLockError(RuntimeError):
 
 
 #: Every lock this process has built, so a fork can be cleaned up in the child.
-#: Weak, so holding a lock here never keeps a discarded one alive.
+#:
+#: Held strongly while a lock is *held* and weakly otherwise. A held lock owns a
+#: descriptor, and the descriptor is what the kernel lock hangs on, so letting
+#: the wrapper be collected would leave the lock held with nothing left to
+#: release it or to close it in a forked child. Measured: after dropping the
+#: last reference to a lock that had been acquired, the registry was empty and
+#: another process still could not take it. Unheld locks stay weak, so building
+#: one and never using it costs nothing.
 _live_locks: weakref.WeakSet[DaemonLock] = weakref.WeakSet()
+_held_locks: set[DaemonLock] = set()
 
 
 def _discard_inherited_locks() -> None:
@@ -90,7 +98,7 @@ def _discard_inherited_locks() -> None:
 
     Registered rather than polled, so it also covers a child that forks again.
     """
-    for lock in list(_live_locks):
+    for lock in [*_live_locks, *_held_locks]:
         lock._discard_if_forked()
 
 
@@ -155,6 +163,7 @@ class DaemonLock:
 
         self._fd = fd
         self._owner_pid = os.getpid()
+        _held_locks.add(self)
         logger.debug("Daemon lock acquired for %s", self._auth_root)
         return True
 
@@ -172,6 +181,7 @@ class DaemonLock:
             return
 
         fd, self._fd, self._owner_pid = self._fd, None, None
+        _held_locks.discard(self)
         try:
             os.close(fd)
         except OSError:
@@ -228,6 +238,7 @@ class DaemonLock:
         os.set_inheritable(fd, False)
         self._fd = fd
         self._owner_pid = os.getpid()
+        _held_locks.add(self)
         logger.debug("Adopted an inherited daemon lock for %s", self._auth_root)
 
     def hold(self) -> _DaemonLockScope:
@@ -242,6 +253,7 @@ class DaemonLock:
         if self._owner_pid is not None and self._owner_pid != os.getpid():
             logger.debug("Discarding a daemon lock inherited across a fork")
             inherited, self._fd, self._owner_pid = self._fd, None, None
+            _held_locks.discard(self)
             if inherited is not None:
                 # Closed, not unlocked, for the reason release() gives: the
                 # parent shares this open file description and still believes it

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -268,6 +268,21 @@ class DaemonLock:
                 "The inherited descriptor does not hold the daemon lock, so "
                 "adopting it would leave the browser unowned."
             )
+        # Checked again now that the lock is held, because the comparison above
+        # happened before it. An unlink and recreate in between leaves this
+        # holding a lock on an orphaned inode while the live path sits free for
+        # somebody else to take, which is two owners. st_nlink is what says the
+        # difference: zero means nothing refers to this inode any more.
+        # ``acquire_locked_fd`` guards its own acquisition the same way; it
+        # retries because it can, while adoption cannot re-lock a descriptor
+        # somebody else opened and has to refuse. Measured before this: adopter
+        # and contender each reported ownership, on two inodes.
+        if os.fstat(fd).st_nlink == 0:
+            raise DaemonLockError(
+                "The lock file was replaced while the inherited descriptor was "
+                "being adopted, so it now locks an inode nothing refers to. "
+                "Start the supervisor again."
+            )
         # Made non-inheritable again straight away. It was marked inheritable
         # for exactly one launch, and leaving it that way would let any later
         # child that inherits descriptors, a Chromium among them, keep the lock
@@ -324,28 +339,35 @@ if hasattr(os, "register_at_fork"):  # pragma: no branch - POSIX
 
 
 def daemon_is_running(auth_root: Path) -> bool:
-    """Whether some process currently owns the daemon for *auth_root*.
+    """Whether some process appeared to own the daemon for *auth_root*.
 
-    Answers the question that makes discovery cheap. A dead daemon leaves its
-    descriptor file behind, and probing that file over the network costs a
-    timeout on every cold start. The kernel already knows the answer for free:
-    if the lock can be taken, nobody owns the daemon, so whatever the descriptor
-    says is stale by definition and no connection needs attempting.
+    An observation, never a decision. Deciding whether to become the owner is
+    what :meth:`DaemonLock.try_acquire` is for, and asking this first would be
+    both slower and wrong: the answer can stop being true before the caller has
+    read it, and the attempt settles the question anyway.
 
-    Says nothing about whether a browser is still running. The kernel frees the
-    lock the moment the holder dies, and Chromium can outlive it.
+    The imprecision is not a shortcoming of this implementation, it is what
+    ``flock`` offers. There is no way to ask whether a lock is held without
+    taking one, so every probe contends with everything else touching the file.
+    Both directions were measured on this tree. Probing exclusively, 43 of 400
+    concurrent probes read a *sibling probe* as an owner. Probing shared fixes
+    that and costs the other half: 11 of 3000 concurrent elections failed
+    against a probe while no owner existed at all. Shared is the better trade,
+    because a probe that briefly delays an election is recoverable and a probe
+    that invents an owner is not, but neither is exact.
+
+    So: a False here means nobody held it a moment ago, which is worth acting
+    on only as a hint. A True may be an owner or may be another caller of this
+    function. Tests use it to observe ownership they established themselves,
+    where no such race exists.
+
+    Says nothing about whether a browser is still running either. The kernel
+    frees the lock the moment the holder dies, and Chromium can outlive it.
     """
     path = daemon_lock_path(auth_root)
     if not path.exists():
         return False
 
-    # Shared rather than exclusive, and that is not a detail. The owner holds
-    # the lock exclusively, so a shared request still fails against it and the
-    # answer stays correct. What it stops is two probes answering each other:
-    # with an exclusive request, one probe briefly holds the lock and the other
-    # reads its own sibling as a daemon. Measured before the change: 43 of 400
-    # concurrent probes reported a daemon that did not exist, which would have
-    # sent a cold-starting client looking for a descriptor rather than electing.
     fd = open_lock_file(path)
     try:
         if try_lock(fd, exclusive=False):

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -339,11 +339,16 @@ def daemon_is_running(auth_root: Path) -> bool:
     if not path.exists():
         return False
 
-    # Opened and probed rather than acquired and released: taking the lock for
-    # real would briefly exclude a supervisor that is starting up.
+    # Shared rather than exclusive, and that is not a detail. The owner holds
+    # the lock exclusively, so a shared request still fails against it and the
+    # answer stays correct. What it stops is two probes answering each other:
+    # with an exclusive request, one probe briefly holds the lock and the other
+    # reads its own sibling as a daemon. Measured before the change: 43 of 400
+    # concurrent probes reported a daemon that did not exist, which would have
+    # sent a cold-starting client looking for a descriptor rather than electing.
     fd = open_lock_file(path)
     try:
-        if try_lock(fd, exclusive=True):
+        if try_lock(fd, exclusive=False):
             return False
         return True
     finally:

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -32,7 +32,6 @@ them rather than share one path that is only true on one of them.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import os
 import weakref
@@ -318,8 +317,17 @@ class DaemonLock:
             # could not take the lock afterwards and only a manual close freed
             # it. Closing gives the lock up, which is the honest outcome of an
             # adoption that did not complete.
-            with contextlib.suppress(OSError):
+            #
+            # A failing close is logged rather than retried, and does not leave
+            # the descriptor behind. Linux and the BSDs release it early in the
+            # call and only then do the work that can fail, so the fd is gone
+            # whatever the return says; retrying would close whichever
+            # descriptor has since taken that number. POSIX.1-2024 standardised
+            # the opposite for EINTR, which Linux does not implement.
+            try:
                 os.close(fd)
+            except OSError:
+                logger.debug("Closing the adopted descriptor failed", exc_info=True)
             raise DaemonLockError(
                 f"The inherited descriptor could not be taken over: {exc}"
             ) from exc

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -229,17 +229,22 @@ class DaemonLock:
         """Take ownership of an inherited locked descriptor.
 
         POSIX only, like its counterpart, and for the measured reason above.
-        Called by a supervisor that was launched holding a copy. It does not
-        acquire anything: the lock is already held, and re-acquiring it against
-        our own copy would fail.
+        Called by a supervisor that was launched holding a copy.
 
-        The descriptor is checked to be this lock's own file and to actually
-        carry the lock, because adoption is the one path that takes a caller's
-        word for both. Measured with neither check: a descriptor belonging to
-        another auth root was adopted without complaint, so this process
-        reported it owned a browser nobody had elected it for while another
-        process took the real lock unopposed. An unlocked descriptor for the
-        right file did the same.
+        Adoption is the one path that would otherwise take a caller's word for
+        what it was handed, so the descriptor is checked to be this lock's own
+        file and then asked for the lock. Measured with neither check: a
+        descriptor belonging to another auth root was adopted without complaint,
+        so this process reported owning a browser nobody had elected it for
+        while another process took the real lock unopposed. An unlocked
+        descriptor for the right file did the same.
+
+        Asking for the lock is not a second acquisition. A process that already
+        holds it is granted it again against its own open file description, so
+        a genuine handover passes untouched; a descriptor that turns out to hold
+        nothing is turned into a real acquisition rather than a false claim.
+        Either way exactly one process ends up holding it, which is the whole
+        point of the exercise.
         """
         if not _INHERITED_LOCKS_TRANSFER:
             raise DaemonLockError(

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+import weakref
 from pathlib import Path
 from types import TracebackType
 
@@ -44,6 +45,27 @@ _DAEMON_LOCK_FILE = "daemon.lock"
 
 class DaemonLockError(RuntimeError):
     """The daemon lock could not be used, so ownership cannot be decided."""
+
+
+#: Every lock this process has built, so a fork can be cleaned up in the child.
+#: Weak, so holding a lock here never keeps a discarded one alive.
+_live_locks: weakref.WeakSet[DaemonLock] = weakref.WeakSet()
+
+
+def _discard_inherited_locks() -> None:
+    """Drop every lock the child inherited, immediately after a fork.
+
+    Waiting until the child touches a lock is not enough, and no check inside
+    an individual method could be: a child that never mentions the lock still
+    inherited the descriptor, and the kernel lock lives as long as any copy of
+    it is open. Measured: after the owner released and exited, an untouched
+    fork child kept the lock held, so every other process saw a daemon that was
+    no longer there and none of them could elect a replacement.
+
+    Registered rather than polled, so it also covers a child that forks again.
+    """
+    for lock in list(_live_locks):
+        lock._discard_if_forked()
 
 
 def daemon_lock_path(auth_root: Path) -> Path:
@@ -73,6 +95,7 @@ class DaemonLock:
         self._path = daemon_lock_path(self._auth_root)
         self._fd: int | None = None
         self._owner_pid: int | None = None
+        _live_locks.add(self)
 
     @property
     def path(self) -> Path:
@@ -139,6 +162,13 @@ class DaemonLock:
         and elect a second owner.
 
         The caller closes the copy once the supervisor confirms it has it.
+
+        How the copy reaches the child differs by platform, and the difference
+        is not small: ``subprocess`` passes descriptors through ``pass_fds`` on
+        POSIX and asserts outright that it is unsupported on Windows, where
+        inheriting a handle means naming it in the startup information instead.
+        Whoever launches the supervisor owns that difference; this returns a
+        descriptor that is merely eligible to be inherited.
         """
         if self._fd is None:
             raise DaemonLockError("Cannot hand over a lock this process does not hold")
@@ -196,6 +226,10 @@ class _DaemonLockScope:
         tb: TracebackType | None,
     ) -> None:
         self._lock.release()
+
+
+if hasattr(os, "register_at_fork"):  # pragma: no branch - POSIX
+    os.register_at_fork(after_in_child=_discard_inherited_locks)
 
 
 def daemon_is_running(auth_root: Path) -> bool:

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -13,14 +13,20 @@ one holder, no reference counting, released only on exit.
 
 Two things it must never do, both of which cost the lock silently:
 
-* It must not unlock before closing. ``flock`` belongs to the open file
-  description, which every inherited copy shares, so unlocking releases it for
-  the supervisor that inherited it too. Measured: unlock-then-close left the
-  lock free while the holder was alive and believed it held it.
+* It must not unlock before closing. The lock belongs to the open file
+  description, which every copy shares, so unlocking releases it for anything
+  else holding one. Measured on both POSIX and Windows: unlock-then-close left
+  the lock free while a live process believed it held it.
 * It must not treat a free lock as proof that nothing is running. Chromium
   outlives the process that started it, measured at over twenty seconds after a
   kill, and the kernel frees the lock at the instant of death. The two facts are
   true at the same time.
+
+Handing a held lock to another process works only on POSIX. Measured on
+Windows: a child that inherited the handle through the documented mechanism did
+not hold the lock once the parent closed its own, in 20 of 20 runs. The two
+platforms genuinely differ here, so startup has to differ with them rather than
+share one path that is only true on one of them.
 """
 
 from __future__ import annotations
@@ -41,6 +47,19 @@ from linkedin_mcp_server.profile_lease import (
 logger = logging.getLogger(__name__)
 
 _DAEMON_LOCK_FILE = "daemon.lock"
+
+#: Whether a held lock can be handed to another process by letting it inherit
+#: the descriptor. True on POSIX, where the lock belongs to the open file
+#: description that every copy shares.
+#:
+#: False on Windows, and this is measured rather than assumed. On a Windows
+#: runner, a child that received the handle through the documented
+#: ``STARTUPINFO`` handle list and kept it open did not hold the lock once the
+#: parent closed its own: a third process acquired the byte range in 20 of 20
+#: runs. Within one process a duplicate does keep the lock alive, which is why
+#: this is easy to get wrong from a single-process test. Ownership there has to
+#: be taken by the supervisor itself rather than passed to it.
+_INHERITED_LOCKS_TRANSFER = os.name != "nt"
 
 
 class DaemonLockError(RuntimeError):
@@ -155,6 +174,9 @@ class DaemonLock:
     def inheritable_copy(self) -> int:
         """Duplicate the descriptor so a launched supervisor can inherit it.
 
+        POSIX only, and refused elsewhere rather than quietly returning
+        something that does not mean what it says.
+
         The original is opened close-on-exec, so it would not survive the exec
         that starts the supervisor. Handing over a duplicate rather than
         releasing and letting the supervisor take the lock itself is what closes
@@ -162,14 +184,12 @@ class DaemonLock:
         and elect a second owner.
 
         The caller closes the copy once the supervisor confirms it has it.
-
-        How the copy reaches the child differs by platform, and the difference
-        is not small: ``subprocess`` passes descriptors through ``pass_fds`` on
-        POSIX and asserts outright that it is unsupported on Windows, where
-        inheriting a handle means naming it in the startup information instead.
-        Whoever launches the supervisor owns that difference; this returns a
-        descriptor that is merely eligible to be inherited.
         """
+        if not _INHERITED_LOCKS_TRANSFER:
+            raise DaemonLockError(
+                "Handing a held lock to another process is a POSIX mechanism. "
+                "On this platform the supervisor has to take the lock itself."
+            )
         if self._fd is None:
             raise DaemonLockError("Cannot hand over a lock this process does not hold")
         duplicate = os.dup(self._fd)
@@ -179,10 +199,16 @@ class DaemonLock:
     def adopt(self, fd: int) -> None:
         """Take ownership of an inherited locked descriptor.
 
+        POSIX only, like its counterpart, and for the measured reason above.
         Called by a supervisor that was launched holding a copy. It does not
         acquire anything: the lock is already held, and re-acquiring it against
-        our own copy would fail on POSIX and mean nothing on Windows.
+        our own copy would fail.
         """
+        if not _INHERITED_LOCKS_TRANSFER:
+            raise DaemonLockError(
+                "An inherited lock cannot be adopted on this platform. "
+                "The supervisor has to take the lock itself."
+            )
         self._discard_if_forked()
         if self._fd is not None:
             raise DaemonLockError("This process already holds the daemon lock")

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -13,10 +13,11 @@ one holder, no reference counting, released only on exit.
 
 Two things it must never do, both of which cost the lock silently:
 
-* It must not unlock before closing. The lock belongs to the open file
-  description, which every copy shares, so unlocking releases it for anything
-  else holding one. Measured on both POSIX and Windows: unlock-then-close left
-  the lock free while a live process believed it held it.
+* It must not unlock before closing. A duplicate of the descriptor shares the
+  lock rather than holding one of its own, so unlocking through any of them
+  releases it for all. Measured on both POSIX and Windows: unlock-then-close
+  left the lock free while a live process believed it held it. The kernel
+  bookkeeping behind that differs by platform, but the rule does not.
 * It must not treat a free lock as proof that nothing is running. Chromium
   outlives the process that started it, measured at over twenty seconds after a
   kill, and the kernel frees the lock at the instant of death. The two facts are
@@ -24,9 +25,9 @@ Two things it must never do, both of which cost the lock silently:
 
 Handing a held lock to another process works only on POSIX. Measured on
 Windows: a child that inherited the handle through the documented mechanism did
-not hold the lock once the parent closed its own, in 20 of 20 runs. The two
-platforms genuinely differ here, so startup has to differ with them rather than
-share one path that is only true on one of them.
+not hold the lock once the parent had closed its handles and exited, in 20 of 20
+runs. The two platforms genuinely differ here, so startup has to differ with
+them rather than share one path that is only true on one of them.
 """
 
 from __future__ import annotations
@@ -55,10 +56,16 @@ _DAEMON_LOCK_FILE = "daemon.lock"
 #: False on Windows, and this is measured rather than assumed. On a Windows
 #: runner, a child that received the handle through the documented
 #: ``STARTUPINFO`` handle list and kept it open did not hold the lock once the
-#: parent closed its own: a third process acquired the byte range in 20 of 20
-#: runs. Within one process a duplicate does keep the lock alive, which is why
-#: this is easy to get wrong from a single-process test. Ownership there has to
-#: be taken by the supervisor itself rather than passed to it.
+#: parent had closed its handles and exited: a third process acquired the byte
+#: range in 20 of 20 runs. Within one process a duplicate does keep the lock
+#: alive, which is why this is easy to get wrong from a single-process test.
+#: Ownership here has to be taken by the supervisor itself rather than passed
+#: to it.
+#:
+#: The measurement closed and exited together, so it does not say which of the
+#: two released the region. That distinction would matter for a design that
+#: kept the electing process alive as a lock broker; it does not matter for
+#: this one, where the elector always exits.
 _INHERITED_LOCKS_TRANSFER = os.name != "nt"
 
 

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -221,6 +221,14 @@ class DaemonLock:
         Called by a supervisor that was launched holding a copy. It does not
         acquire anything: the lock is already held, and re-acquiring it against
         our own copy would fail.
+
+        The descriptor is checked to be this lock's own file and to actually
+        carry the lock, because adoption is the one path that takes a caller's
+        word for both. Measured with neither check: a descriptor belonging to
+        another auth root was adopted without complaint, so this process
+        reported it owned a browser nobody had elected it for while another
+        process took the real lock unopposed. An unlocked descriptor for the
+        right file did the same.
         """
         if not _INHERITED_LOCKS_TRANSFER:
             raise DaemonLockError(
@@ -230,6 +238,36 @@ class DaemonLock:
         self._discard_if_forked()
         if self._fd is not None:
             raise DaemonLockError("This process already holds the daemon lock")
+
+        try:
+            inherited = os.fstat(fd)
+        except OSError as exc:
+            raise DaemonLockError(
+                f"The inherited descriptor cannot be used: {exc}"
+            ) from exc
+        try:
+            expected = self._path.stat()
+        except OSError as exc:
+            raise DaemonLockError(
+                f"There is no lock file at {self._path} for the inherited "
+                f"descriptor to belong to"
+            ) from exc
+        if (inherited.st_dev, inherited.st_ino) != (expected.st_dev, expected.st_ino):
+            raise DaemonLockError(
+                "The inherited descriptor is not this auth root's lock file. "
+                "Adopting it would report ownership of a browser this process "
+                "was never elected to hold."
+            )
+        # A descriptor for the right file that holds no lock is the same
+        # mistake wearing the right name: another process would take the lock
+        # while this one believed it already had it. Asking for the lock here
+        # is not acquiring it twice, because on POSIX a process that already
+        # holds it is granted it again against its own open file description.
+        if not try_lock(fd, exclusive=True):
+            raise DaemonLockError(
+                "The inherited descriptor does not hold the daemon lock, so "
+                "adopting it would leave the browser unowned."
+            )
         # Made non-inheritable again straight away. It was marked inheritable
         # for exactly one launch, and leaving it that way would let any later
         # child that inherits descriptors, a Chromium among them, keep the lock

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -41,6 +41,7 @@ from types import TracebackType
 from linkedin_mcp_server.daemon_descriptor import daemon_dir, daemon_state_root
 from linkedin_mcp_server.private_state import harden_directory
 from linkedin_mcp_server.profile_lease import (
+    is_still_at,
     acquire_locked_fd,
     open_lock_file,
     try_lock,
@@ -211,7 +212,17 @@ class DaemonLock:
         if self._fd is None:
             raise DaemonLockError("Cannot hand over a lock this process does not hold")
         duplicate = os.dup(self._fd)
-        os.set_inheritable(duplicate, True)
+        try:
+            os.set_inheritable(duplicate, True)
+        except OSError:
+            # The duplicate already shares the kernel lock, so leaking it here
+            # would hold the lock for this process's whole life with nothing
+            # left to release it: release() closes the original and the lock
+            # survives in the copy. Measured with the call made to fail: the
+            # daemon still read as running after release, and no other process
+            # could take over.
+            os.close(duplicate)
+            raise
         return duplicate
 
     def adopt(self, fd: int) -> None:
@@ -268,16 +279,19 @@ class DaemonLock:
                 "The inherited descriptor does not hold the daemon lock, so "
                 "adopting it would leave the browser unowned."
             )
-        # Checked again now that the lock is held, because the comparison above
-        # happened before it. An unlink and recreate in between leaves this
-        # holding a lock on an orphaned inode while the live path sits free for
-        # somebody else to take, which is two owners. st_nlink is what says the
-        # difference: zero means nothing refers to this inode any more.
-        # ``acquire_locked_fd`` guards its own acquisition the same way; it
-        # retries because it can, while adoption cannot re-lock a descriptor
-        # somebody else opened and has to refuse. Measured before this: adopter
-        # and contender each reported ownership, on two inodes.
-        if os.fstat(fd).st_nlink == 0:
+        # Compared again now that the lock is held, because the check above
+        # happened before it. Anything that replaces the file in between leaves
+        # this holding a lock on an inode the path no longer names, while the
+        # live path sits free for somebody else to take, which is two owners.
+        #
+        # By identity rather than link count. A count catches an unlink and
+        # misses a rename, where the inode keeps its one link and the name now
+        # refers to something else. Measured with a rename plus recreate: the
+        # count test passed and a contender locked the live path alongside the
+        # adopter. ``acquire_locked_fd`` makes the same comparison and retries;
+        # adoption cannot re-lock a descriptor another process opened, so it
+        # refuses instead.
+        if not is_still_at(fd, self._path):
             raise DaemonLockError(
                 "The lock file was replaced while the inherited descriptor was "
                 "being adopted, so it now locks an inode nothing refers to. "

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -1,0 +1,230 @@
+"""The lock that decides which process owns the shared browser.
+
+Held for a process lifetime rather than around an operation, which is what
+separates it from the profile lease next door. That difference is not
+cosmetic. The lease is reference counted so a tool call, the browser singleton
+and a destructive helper can each hold it at once, and it is released the moment
+the browser closes so ``--login`` can take it. A lock with those properties
+cannot decide ownership: it would be free every time the browser happened to be
+shut, and holding it for a whole process life would lock out every login.
+
+So this is a separate file with the same kernel primitives and different rules:
+one holder, no reference counting, released only on exit.
+
+Two things it must never do, both of which cost the lock silently:
+
+* It must not unlock before closing. ``flock`` belongs to the open file
+  description, which every inherited copy shares, so unlocking releases it for
+  the supervisor that inherited it too. Measured: unlock-then-close left the
+  lock free while the holder was alive and believed it held it.
+* It must not treat a free lock as proof that nothing is running. Chromium
+  outlives the process that started it, measured at over twenty seconds after a
+  kill, and the kernel frees the lock at the instant of death. The two facts are
+  true at the same time.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from types import TracebackType
+
+from linkedin_mcp_server.private_state import harden_directory
+from linkedin_mcp_server.profile_lease import (
+    acquire_locked_fd,
+    open_lock_file,
+    try_lock,
+)
+
+logger = logging.getLogger(__name__)
+
+_DAEMON_LOCK_FILE = "daemon.lock"
+
+
+class DaemonLockError(RuntimeError):
+    """The daemon lock could not be used, so ownership cannot be decided."""
+
+
+def daemon_lock_path(auth_root: Path) -> Path:
+    """Where the lock lives for *auth_root*.
+
+    At the auth root, not under the per-profile directory, and that placement is
+    load-bearing. The profile lease keys on the auth root too, because
+    ``auth_root_dir`` returns the profile's parent, so two profile directories
+    that sit side by side share one lease. An election scoped more narrowly than
+    that would let two owners start, each convinced it had won, and then compete
+    forever for a lease only one of them can hold.
+    """
+    return auth_root.expanduser().resolve() / _DAEMON_LOCK_FILE
+
+
+class DaemonLock:
+    """Exclusive ownership of one auth root's daemon, for as long as it is held.
+
+    Not a context manager by default, because the normal case is a supervisor
+    that takes it at startup and holds it until it has finished cleaning up. Use
+    :meth:`hold` when a scope really is the right shape, which is mainly tests
+    and the one-shot maintenance commands.
+    """
+
+    def __init__(self, auth_root: Path) -> None:
+        self._auth_root = auth_root.expanduser().resolve()
+        self._path = daemon_lock_path(self._auth_root)
+        self._fd: int | None = None
+        self._owner_pid: int | None = None
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def held(self) -> bool:
+        """Whether *this* process holds it.
+
+        A fork gives the child a copy of the descriptor, and with it a share of
+        the kernel lock, while none of the bookkeeping here belongs to it. Left
+        alone, such a child keeps its parent's lock alive after the parent dies
+        and locks every other process out with nothing to explain why.
+        """
+        self._discard_if_forked()
+        return self._fd is not None
+
+    def try_acquire(self) -> bool:
+        """Take the lock, or report that another process holds it."""
+        self._discard_if_forked()
+        if self._fd is not None:
+            # Deliberately not reference counted: a second acquire is a caller
+            # believing it is the first, and the lock's whole meaning is that
+            # exactly one holder exists.
+            raise DaemonLockError("This process already holds the daemon lock")
+
+        harden_directory(self._auth_root)
+        fd = acquire_locked_fd(self._path, exclusive=True)
+        if fd is None:
+            return False
+
+        self._fd = fd
+        self._owner_pid = os.getpid()
+        logger.debug("Daemon lock acquired for %s", self._auth_root)
+        return True
+
+    def release(self) -> None:
+        """Give up the lock by closing our descriptor, never by unlocking it.
+
+        Closing drops only this descriptor; the lock survives in any copy a
+        supervisor inherited. Unlocking would release it for all of them at
+        once, so a supervisor that had already adopted the handoff would lose
+        the lock without anything saying so, and the next client would elect a
+        second owner against a live browser.
+        """
+        self._discard_if_forked()
+        if self._fd is None:
+            return
+
+        fd, self._fd, self._owner_pid = self._fd, None, None
+        try:
+            os.close(fd)
+        except OSError:
+            logger.debug("Closing the daemon lock failed (ignored)", exc_info=True)
+        logger.debug("Daemon lock released for %s", self._auth_root)
+
+    def inheritable_copy(self) -> int:
+        """Duplicate the descriptor so a launched supervisor can inherit it.
+
+        The original is opened close-on-exec, so it would not survive the exec
+        that starts the supervisor. Handing over a duplicate rather than
+        releasing and letting the supervisor take the lock itself is what closes
+        the window in between, during which another client would see a free lock
+        and elect a second owner.
+
+        The caller closes the copy once the supervisor confirms it has it.
+        """
+        if self._fd is None:
+            raise DaemonLockError("Cannot hand over a lock this process does not hold")
+        duplicate = os.dup(self._fd)
+        os.set_inheritable(duplicate, True)
+        return duplicate
+
+    def adopt(self, fd: int) -> None:
+        """Take ownership of an inherited locked descriptor.
+
+        Called by a supervisor that was launched holding a copy. It does not
+        acquire anything: the lock is already held, and re-acquiring it against
+        our own copy would fail on POSIX and mean nothing on Windows.
+        """
+        self._discard_if_forked()
+        if self._fd is not None:
+            raise DaemonLockError("This process already holds the daemon lock")
+        self._fd = fd
+        self._owner_pid = os.getpid()
+        logger.debug("Adopted an inherited daemon lock for %s", self._auth_root)
+
+    def hold(self) -> _DaemonLockScope:
+        """Take the lock for a scope, raising when another process holds it."""
+        if not self.try_acquire():
+            raise DaemonLockError(
+                f"Another LinkedIn MCP process owns the browser for {self._auth_root}"
+            )
+        return _DaemonLockScope(self)
+
+    def _discard_if_forked(self) -> None:
+        if self._owner_pid is not None and self._owner_pid != os.getpid():
+            logger.debug("Discarding a daemon lock inherited across a fork")
+            inherited, self._fd, self._owner_pid = self._fd, None, None
+            if inherited is not None:
+                # Closed, not unlocked, for the reason release() gives: the
+                # parent shares this open file description and still believes it
+                # holds the lock.
+                try:
+                    os.close(inherited)
+                except OSError:
+                    logger.debug("Closing an inherited lock failed", exc_info=True)
+
+
+class _DaemonLockScope:
+    def __init__(self, lock: DaemonLock) -> None:
+        self._lock = lock
+
+    def __enter__(self) -> DaemonLock:
+        return self._lock
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self._lock.release()
+
+
+def daemon_is_running(auth_root: Path) -> bool:
+    """Whether some process currently owns the daemon for *auth_root*.
+
+    Answers the question that makes discovery cheap. A dead daemon leaves its
+    descriptor file behind, and probing that file over the network costs a
+    timeout on every cold start. The kernel already knows the answer for free:
+    if the lock can be taken, nobody owns the daemon, so whatever the descriptor
+    says is stale by definition and no connection needs attempting.
+
+    Says nothing about whether a browser is still running. The kernel frees the
+    lock the moment the holder dies, and Chromium can outlive it.
+    """
+    path = daemon_lock_path(auth_root)
+    if not path.exists():
+        return False
+
+    # Opened and probed rather than acquired and released: taking the lock for
+    # real would briefly exclude a supervisor that is starting up.
+    fd = open_lock_file(path)
+    try:
+        if try_lock(fd, exclusive=True):
+            return False
+        return True
+    finally:
+        # Closed without unlocking, which releases whatever this descriptor
+        # holds, and never touches a lock held through another one.
+        try:
+            os.close(fd)
+        except OSError:
+            logger.debug("Closing the probe descriptor failed", exc_info=True)

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -186,6 +186,13 @@ class DaemonLock:
         self._discard_if_forked()
         if self._fd is not None:
             raise DaemonLockError("This process already holds the daemon lock")
+        # Made non-inheritable again straight away. It was marked inheritable
+        # for exactly one launch, and leaving it that way would let any later
+        # child that inherits descriptors, a Chromium among them, keep the lock
+        # alive after this process exits. Measured: an unrelated child did
+        # exactly that, and every client afterwards saw a daemon that was no
+        # longer there.
+        os.set_inheritable(fd, False)
         self._fd = fd
         self._owner_pid = os.getpid()
         logger.debug("Adopted an inherited daemon lock for %s", self._auth_root)

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -32,6 +32,7 @@ them rather than share one path that is only true on one of them.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import weakref
@@ -308,7 +309,20 @@ class DaemonLock:
         # alive after this process exits. Measured: an unrelated child did
         # exactly that, and every client afterwards saw a daemon that was no
         # longer there.
-        os.set_inheritable(fd, False)
+        try:
+            os.set_inheritable(fd, False)
+        except OSError as exc:
+            # The lock is held through this descriptor by now, and nothing has
+            # recorded that yet, so failing here without closing it would leave
+            # it held with no object able to release it: measured, a contender
+            # could not take the lock afterwards and only a manual close freed
+            # it. Closing gives the lock up, which is the honest outcome of an
+            # adoption that did not complete.
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise DaemonLockError(
+                f"The inherited descriptor could not be taken over: {exc}"
+            ) from exc
         self._fd = fd
         self._owner_pid = os.getpid()
         _held_locks.add(self)

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -39,9 +39,9 @@ from pathlib import Path
 from types import TracebackType
 
 from linkedin_mcp_server.daemon_descriptor import daemon_dir, daemon_state_root
+from linkedin_mcp_server.common_utils import is_still_at
 from linkedin_mcp_server.private_state import harden_directory
 from linkedin_mcp_server.profile_lease import (
-    is_still_at,
     acquire_locked_fd,
     open_lock_file,
     try_lock,

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -38,6 +38,7 @@ import weakref
 from pathlib import Path
 from types import TracebackType
 
+from linkedin_mcp_server.daemon_descriptor import daemon_dir, daemon_state_root
 from linkedin_mcp_server.private_state import harden_directory
 from linkedin_mcp_server.profile_lease import (
     acquire_locked_fd,
@@ -105,14 +106,13 @@ def _discard_inherited_locks() -> None:
 def daemon_lock_path(auth_root: Path) -> Path:
     """Where the lock lives for *auth_root*.
 
-    At the auth root, not under the per-profile directory, and that placement is
-    load-bearing. The profile lease keys on the auth root too, because
-    ``auth_root_dir`` returns the profile's parent, so two profile directories
-    that sit side by side share one lease. An election scoped more narrowly than
-    that would let two owners start, each convinced it had won, and then compete
-    forever for a lease only one of them can hold.
+    The dedicated daemon directory is private state owned by this application,
+    unlike the configurable auth root, which must keep the user's permissions.
+    The path remains derived from the auth root rather than a profile directory,
+    so sibling profiles still share one election and cannot start two owners that
+    compete for the same profile lease.
     """
-    return auth_root.expanduser().resolve() / _DAEMON_LOCK_FILE
+    return daemon_dir(auth_root) / _DAEMON_LOCK_FILE
 
 
 class DaemonLock:
@@ -156,7 +156,8 @@ class DaemonLock:
             # exactly one holder exists.
             raise DaemonLockError("This process already holds the daemon lock")
 
-        harden_directory(self._auth_root)
+        harden_directory(daemon_state_root())
+        harden_directory(daemon_dir(self._auth_root))
         fd = acquire_locked_fd(self._path, exclusive=True)
         if fd is None:
             return False

--- a/linkedin_mcp_server/profile_lease.py
+++ b/linkedin_mcp_server/profile_lease.py
@@ -86,7 +86,7 @@ if not _HAS_FCNTL:  # pragma: no cover - Windows
         # Probed here rather than assumed: the block below binds kernel32 at
         # import time, and an ImportError or a missing symbol there would take
         # the whole server down with an obscure message instead of the explicit
-        # "no usable file locking" refusal that _try_lock raises.
+        # "no usable file locking" refusal that try_lock raises.
         _HAS_WINDOWS_LOCKS = hasattr(ctypes, "WinDLL")
     except ImportError:
         _HAS_WINDOWS_LOCKS = False
@@ -94,7 +94,7 @@ else:  # pragma: no cover - POSIX
     _HAS_WINDOWS_LOCKS = False
 
 
-def _try_lock(fd: int, *, exclusive: bool) -> bool:
+def try_lock(fd: int, *, exclusive: bool) -> bool:
     """Take a non-blocking lock on *fd*. Return whether it was granted.
 
     ``msvcrt.locking`` is deliberately not used on Windows: it offers only
@@ -244,7 +244,7 @@ if not _HAS_FCNTL and _HAS_WINDOWS_LOCKS:  # pragma: no cover - Windows
 # --------------------------------------------------------------------------- #
 
 
-def _open_lock_file(path: Path) -> int:
+def open_lock_file(path: Path) -> int:
     """Open *path* for locking, creating it with owner-only permissions."""
     secure_mkdir(path.parent)
     harden_linkedin_tree(path.parent)
@@ -255,7 +255,7 @@ def _open_lock_file(path: Path) -> int:
     return os.open(path, os.O_RDWR | os.O_CREAT | cloexec, 0o600)
 
 
-def _acquire_locked_fd(path: Path, *, exclusive: bool) -> int | None:
+def acquire_locked_fd(path: Path, *, exclusive: bool) -> int | None:
     """Open *path* and lock it, or return ``None`` if it is already held.
 
     Re-opens when the path was unlinked between open and lock. Without that
@@ -264,10 +264,10 @@ def _acquire_locked_fd(path: Path, *, exclusive: bool) -> int | None:
     against with the same ``st_nlink`` test.
     """
     for _ in range(3):
-        fd = _open_lock_file(path)
+        fd = open_lock_file(path)
         locked = False
         try:
-            if not _try_lock(fd, exclusive=exclusive):
+            if not try_lock(fd, exclusive=exclusive):
                 return None
             locked = True
             if os.fstat(fd).st_nlink > 0:
@@ -421,7 +421,7 @@ class ProfileLease:
             self._refs += 1
             return True
 
-        fd = _acquire_locked_fd(self._lease_path, exclusive=True)
+        fd = acquire_locked_fd(self._lease_path, exclusive=True)
         if fd is None:
             return False
 
@@ -492,7 +492,7 @@ class ProfileLease:
         waiter holds its shared lock.
         """
         try:
-            fd = _acquire_locked_fd(self._handoff_path, exclusive=True)
+            fd = acquire_locked_fd(self._handoff_path, exclusive=True)
         except ProfileLeaseUnavailableError:
             # A path that keeps being replaced tells us nothing; do not hand over
             # on the strength of a broken signal.
@@ -547,7 +547,7 @@ class _Announcement:
 
     def __enter__(self) -> _Announcement:
         try:
-            self._fd = _acquire_locked_fd(self._path, exclusive=False)
+            self._fd = acquire_locked_fd(self._path, exclusive=False)
         except ProfileLeaseUnavailableError:
             # Failing to announce only costs us a prompt handoff, so degrade to
             # waiting quietly rather than failing the caller's tool call.

--- a/linkedin_mcp_server/profile_lease.py
+++ b/linkedin_mcp_server/profile_lease.py
@@ -39,7 +39,11 @@ import time
 from pathlib import Path
 from types import TracebackType
 
-from linkedin_mcp_server.common_utils import harden_linkedin_tree, secure_mkdir
+from linkedin_mcp_server.common_utils import (
+    harden_linkedin_tree,
+    is_still_at,
+    secure_mkdir,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -327,21 +331,6 @@ def acquire_locked_fd(path: Path, *, exclusive: bool) -> int | None:
     raise ProfileLeaseUnavailableError(
         f"The lock file {path} keeps being replaced; refusing to continue."
     )
-
-
-def is_still_at(fd: int, path: Path) -> bool:
-    """Whether *fd* is still the file that *path* names.
-
-    Answered after the lock is taken, because that is the only order in which
-    the answer means anything: before it, the file can change immediately
-    afterwards. A path that has since vanished counts as changed.
-    """
-    held = os.fstat(fd)
-    try:
-        current = path.stat()
-    except OSError:
-        return False
-    return (held.st_dev, held.st_ino) == (current.st_dev, current.st_ino)
 
 
 def _release_locked_fd(fd: int) -> None:

--- a/linkedin_mcp_server/profile_lease.py
+++ b/linkedin_mcp_server/profile_lease.py
@@ -295,7 +295,15 @@ def acquire_locked_fd(path: Path, *, exclusive: bool) -> int | None:
         locked = False
         try:
             if not try_lock(fd, exclusive=exclusive):
-                return None
+                # Contention is only an answer about the file this opened. If
+                # the path has moved on since, the holder is holding something
+                # nobody else will consult, and reporting "busy" would refuse a
+                # lock that is free: measured, this returned None while the live
+                # path could be locked immediately. Retry against what is there
+                # now, exactly as a successful lock on a stale inode does.
+                if is_still_at(fd, path):
+                    return None
+                continue
             locked = True
             if is_still_at(fd, path):
                 keep = fd

--- a/linkedin_mcp_server/profile_lease.py
+++ b/linkedin_mcp_server/profile_lease.py
@@ -32,6 +32,7 @@ exclusion. It is also not a runtime dependency.
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import os
 import time
@@ -94,6 +95,12 @@ else:  # pragma: no cover - POSIX
     _HAS_WINDOWS_LOCKS = False
 
 
+#: The errnos a non-blocking lock request uses to say "somebody else holds it".
+#: POSIX allows either, and they are the same value on Linux while macOS keeps
+#: them distinct, so both are listed rather than assumed to coincide.
+_CONTENTION_ERRNOS = frozenset({errno.EAGAIN, errno.EWOULDBLOCK, errno.EACCES})
+
+
 def try_lock(fd: int, *, exclusive: bool) -> bool:
     """Take a non-blocking lock on *fd*. Return whether it was granted.
 
@@ -107,8 +114,22 @@ def try_lock(fd: int, *, exclusive: bool) -> bool:
         mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
         try:
             fcntl.flock(fd, mode | fcntl.LOCK_NB)
-        except OSError:
-            return False
+        except OSError as exc:
+            # Only contention means "somebody else holds it". Every other errno
+            # means the question could not be answered, and answering it with
+            # "busy" is the worst of the two wrong answers: on a filesystem
+            # without usable flock, every process would report a live owner
+            # forever, no owner could ever be elected, and the message would
+            # point at contention that does not exist. Measured with
+            # EOPNOTSUPP: reported as busy.
+            if exc.errno in _CONTENTION_ERRNOS:
+                return False
+            raise ProfileLeaseUnavailableError(
+                f"Could not lock the profile: {exc}. This filesystem may not "
+                f"support the locking that keeps two servers off one browser "
+                f"profile. Move the profile to a local disk, or run only one "
+                f"server process against it."
+            ) from exc
         return True
 
     if _HAS_WINDOWS_LOCKS:  # pragma: no cover - Windows

--- a/linkedin_mcp_server/profile_lease.py
+++ b/linkedin_mcp_server/profile_lease.py
@@ -279,10 +279,16 @@ def open_lock_file(path: Path) -> int:
 def acquire_locked_fd(path: Path, *, exclusive: bool) -> int | None:
     """Open *path* and lock it, or return ``None`` if it is already held.
 
-    Re-opens when the path was unlinked between open and lock. Without that
-    check two processes can hold locks on different inodes for the same path and
-    believe they hold the same logical lock — the failure mode Bazel guards
-    against with the same ``st_nlink`` test.
+    Re-opens when the file at the path changed between open and lock. Without
+    that check two processes can hold locks on different inodes for the same
+    path and each believe it holds the same logical lock.
+
+    The identity is compared, not merely the link count. Counting links catches
+    an unlink, which is the case Bazel's version of this guards against, and
+    misses a rename: the inode keeps its one link, so the count still says one
+    while the name now refers to something else. Measured: a rename plus
+    recreate passed the count test, and a second process locked the live path
+    alongside the first.
     """
     for _ in range(3):
         fd = open_lock_file(path)
@@ -291,7 +297,7 @@ def acquire_locked_fd(path: Path, *, exclusive: bool) -> int | None:
             if not try_lock(fd, exclusive=exclusive):
                 return None
             locked = True
-            if os.fstat(fd).st_nlink > 0:
+            if is_still_at(fd, path):
                 keep = fd
                 fd = -1  # handed to the caller; not ours to close below
                 return keep
@@ -307,11 +313,27 @@ def acquire_locked_fd(path: Path, *, exclusive: bool) -> int | None:
                     os.close(fd)
                 except OSError:
                     logger.debug("Closing lock descriptor failed", exc_info=True)
-        # The path was unlinked while we held the lock: our inode is orphaned
-        # and protects nothing. Retry against the live path.
+        # The file at the path changed while we held the lock: our inode no
+        # longer protects anything anyone else will look at. Retry against
+        # whatever is there now.
     raise ProfileLeaseUnavailableError(
         f"The lock file {path} keeps being replaced; refusing to continue."
     )
+
+
+def is_still_at(fd: int, path: Path) -> bool:
+    """Whether *fd* is still the file that *path* names.
+
+    Answered after the lock is taken, because that is the only order in which
+    the answer means anything: before it, the file can change immediately
+    afterwards. A path that has since vanished counts as changed.
+    """
+    held = os.fstat(fd)
+    try:
+        current = path.stat()
+    except OSError:
+        return False
+    return (held.st_dev, held.st_ino) == (current.st_dev, current.st_ino)
 
 
 def _release_locked_fd(fd: int) -> None:

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -22,8 +22,10 @@ from linkedin_mcp_server.daemon_descriptor import (
     DescriptorError,
     build,
     config_fingerprint,
+    daemon_dir,
     descriptor_path,
     mismatched_fields,
+    new_instance_id,
     new_token,
     publish,
     read,
@@ -178,6 +180,31 @@ class TestRefusals:
 
         with pytest.raises(DescriptorError, match="no token beside it"):
             read_token(tmp_path, loaded)
+
+
+class TestInstanceIdentity:
+    def test_an_instance_id_cannot_escape_the_daemon_directory(self, tmp_path: Path):
+        # The identifier becomes part of a filename, and it arrives from a file
+        # anything with write access to the auth root can edit. Unchecked, a
+        # descriptor naming ".." would turn some other readable file into what
+        # this client sends to the endpoint as its bearer token.
+        with pytest.raises(DescriptorError, match="not a UUID"):
+            token_path(tmp_path, "../../../../etc/hosts")
+
+    def test_a_descriptor_with_a_forged_instance_id_is_refused(self, tmp_path: Path):
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        raw = json.loads(descriptor_path(tmp_path).read_text())
+        raw["instance_id"] = "../../secrets"
+        descriptor_path(tmp_path).write_text(json.dumps(raw))
+
+        with pytest.raises(DescriptorError, match="not a UUID"):
+            read(tmp_path)
+
+    def test_a_generated_instance_id_is_accepted(self, tmp_path: Path):
+        # The identity the daemon actually publishes has to survive its own
+        # validation, which is easy to break by tightening the check.
+        assert token_path(tmp_path, new_instance_id()).parent == daemon_dir(tmp_path)
 
 
 class TestProfileIdentity:

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -217,6 +217,17 @@ class TestRefusals:
         with pytest.raises(DescriptorError, match="not something this daemon wrote"):
             read(tmp_path)
 
+    def test_an_oversized_descriptor_is_refused_as_oversized(self, tmp_path: Path):
+        # The read is bounded, so without a size check the caller would get a
+        # fragment, and a fragment of JSON reads as malformed. That sends
+        # whoever reads the message looking for a corrupt descriptor rather
+        # than for whatever wrote something this size.
+        descriptor_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+        descriptor_path(tmp_path).write_text(json.dumps({"pad": "x" * 200_000}))
+
+        with pytest.raises(DescriptorError, match="larger than anything"):
+            read(tmp_path)
+
     def test_bytes_that_are_not_text_are_refused_as_such(self, tmp_path: Path):
         # A caller telling absence from untrusted state through DescriptorError
         # would otherwise meet a decoding error, which says nothing about which

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -202,6 +202,41 @@ class TestRefusals:
         with pytest.raises(DescriptorError, match="symbolic link"):
             read(tmp_path)
 
+    @pytest.mark.skipif(
+        not hasattr(os, "mkfifo"), reason="named pipes are a POSIX mechanism"
+    )
+    def test_a_descriptor_that_is_not_a_regular_file_does_not_hang(
+        self, tmp_path: Path
+    ):
+        # Discovery runs on every cold start, so a named pipe left at this path
+        # would stall it inside open() with no timeout and no error, rather
+        # than being reported as something the daemon did not write.
+        descriptor_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+        os.mkfifo(descriptor_path(tmp_path))
+
+        with pytest.raises(DescriptorError, match="not something this daemon wrote"):
+            read(tmp_path)
+
+    def test_bytes_that_are_not_text_are_refused_as_such(self, tmp_path: Path):
+        # A caller telling absence from untrusted state through DescriptorError
+        # would otherwise meet a decoding error, which says nothing about which
+        # of the two it is looking at.
+        descriptor_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+        descriptor_path(tmp_path).write_bytes(b"\xff\xfe")
+
+        with pytest.raises(DescriptorError, match="not text this daemon wrote"):
+            read(tmp_path)
+
+    def test_a_token_that_is_not_text_is_refused_as_such(self, tmp_path: Path):
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        loaded = read(tmp_path)
+        assert loaded is not None
+        token_path(tmp_path, loaded.instance_id).write_bytes(b"\xff\xfe")
+
+        with pytest.raises(DescriptorError, match="not text this daemon wrote"):
+            read_token(tmp_path, loaded)
+
     def test_a_descriptor_from_another_protocol_is_refused(self, tmp_path: Path):
         # The field compatibility is meant to key on. Parsed but unenforced, a
         # client would attach to an owner whose control routes, call metadata

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -557,6 +557,24 @@ class TestProfileIdentity:
 
         assert descriptor.serves(tmp_path / "sub" / ".." / "profile")
 
+    def test_a_rotated_profile_is_still_served(self, tmp_path: Path):
+        # Every path that establishes a new session rotates the old profile into
+        # quarantine and Chromium creates a fresh directory in its place. Keyed
+        # by the profile's own inode, a descriptor stopped matching its own
+        # profile at the first login while its owner kept holding the lock.
+        profile = tmp_path / "profile"
+        profile.mkdir()
+        descriptor = _descriptor(tmp_path, new_token(), profile=profile)
+        before = profile.stat().st_ino
+
+        quarantine = tmp_path / "quarantine"
+        quarantine.mkdir()
+        profile.rename(quarantine / "profile")
+        profile.mkdir()
+
+        assert profile.stat().st_ino != before
+        assert descriptor.serves(profile)
+
     def test_asking_what_a_daemon_serves_creates_nothing(self, tmp_path: Path):
         # Comparison answers a question. Creating a browser profile in order to
         # explain why a client was turned away would be a surprising thing for

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -556,7 +556,45 @@ class TestEndpointSpelling:
         httpx.URL(descriptor.url)
 
 
+class TestDigestFields:
+    @pytest.mark.parametrize("field", ["token_sha256", "config_fingerprint"])
+    @pytest.mark.parametrize("value", ["é" * 64, "z" * 64, "abc", "a" * 63, "a" * 65])
+    def test_a_field_that_is_not_a_digest_is_refused(
+        self, tmp_path: Path, field: str, value: str
+    ):
+        # compare_digest refuses a string carrying anything outside ASCII and
+        # raises TypeError doing so. Measured with an accented character: the
+        # descriptor was accepted and the comparison failed later, outside the
+        # DescriptorError every caller of this module expects.
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        raw = json.loads(descriptor_path(tmp_path).read_text())
+        raw[field] = value
+        descriptor_path(tmp_path).write_text(json.dumps(raw))
+
+        with pytest.raises(DescriptorError, match="SHA-256 digest"):
+            read(tmp_path)
+
+
 class TestProfileIdentityStability:
+    def test_case_distinct_siblings_do_not_collide(self, tmp_path: Path):
+        # On a case-insensitive volume Profile and profile name one directory,
+        # which is what the fold is for. On a case-sensitive one they are two,
+        # and folding without preferring an exact match gave both the same
+        # identity: measured on a case-sensitive APFS volume, which would have
+        # handed a client the other profile's logged-in session.
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir()
+        upper = auth_root / "Profile"
+        lower = auth_root / "profile"
+        upper.mkdir()
+        try:
+            lower.mkdir()
+        except FileExistsError:
+            pytest.skip("this volume is case-insensitive, so these are one directory")
+
+        assert profile_identity(upper) != profile_identity(lower)
+
     def test_the_identity_survives_the_profile_being_created(self, tmp_path: Path):
         # The profile does not exist before the first login, so an identity
         # that changed when it appeared would leave a descriptor published

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -1,0 +1,285 @@
+"""What a daemon publishes, and what a client refuses to trust.
+
+A client that reads a descriptor is about to send a bearer token to the address
+it names and then drive a logged-in LinkedIn session through it. Most of these
+tests are about the cases where it must not.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon_descriptor import (
+    SCHEMA_VERSION,
+    DaemonDescriptor,
+    DescriptorError,
+    build,
+    config_fingerprint,
+    descriptor_path,
+    mismatched_fields,
+    new_token,
+    publish,
+    read,
+    read_token,
+    token_path,
+)
+
+posix_only = pytest.mark.skipif(
+    os.name == "nt", reason="POSIX permission bits do not exist on Windows"
+)
+
+
+def _config(**browser: object) -> AppConfig:
+    config = AppConfig()
+    for name, value in browser.items():
+        setattr(config.browser, name, value)
+    return config
+
+
+def _descriptor(tmp_path: Path, token: str, **overrides: object) -> DaemonDescriptor:
+    descriptor = build(
+        instance_id="11111111-2222-3333-4444-555555555555",
+        package_version="4.19.0",
+        runtime_id="macos-arm64-host",
+        profile=tmp_path / "profile",
+        host="127.0.0.1",
+        port=49152,
+        path="/mcp",
+        token=token,
+        config=_config(),
+        log_path=tmp_path / "daemon.log",
+    )
+    return replace(descriptor, **overrides) if overrides else descriptor
+
+
+class TestRoundTrip:
+    def test_a_published_descriptor_reads_back(self, tmp_path: Path):
+        token = new_token()
+
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        loaded = read(tmp_path)
+
+        assert loaded is not None
+        assert loaded.url == "http://127.0.0.1:49152/mcp"
+        assert read_token(tmp_path, loaded) == token
+
+    def test_no_descriptor_reads_as_absent_rather_than_failing(self, tmp_path: Path):
+        # Absence is the ordinary first-start case, not an error.
+        assert read(tmp_path) is None
+
+    @posix_only
+    def test_the_token_is_written_owner_only(self, tmp_path: Path):
+        token = new_token()
+
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+
+        file = token_path(tmp_path, "11111111-2222-3333-4444-555555555555")
+        assert stat.S_IMODE(file.stat().st_mode) == 0o600
+        assert stat.S_IMODE(file.parent.stat().st_mode) == 0o700
+
+    def test_the_token_is_not_in_the_descriptor(self, tmp_path: Path):
+        # The descriptor is the readable half of the pair on purpose, so the
+        # secret must not be in it. Only its digest is.
+        token = new_token()
+
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+
+        assert token not in descriptor_path(tmp_path).read_text()
+
+
+class TestRefusals:
+    def test_a_non_loopback_endpoint_is_refused(self, tmp_path: Path):
+        # The descriptor is a file, so anything that can write to the auth root
+        # could point it elsewhere. Sending the token there would hand over the
+        # LinkedIn session behind it.
+        token = new_token()
+        descriptor = _descriptor(tmp_path, token, host="203.0.113.5")
+
+        with pytest.raises(DescriptorError, match="not.*this machine"):
+            descriptor.check_endpoint_is_local()
+
+    def test_a_hostname_that_needs_dns_is_refused(self, tmp_path: Path):
+        # DNS can point anywhere, and can change between the check and the
+        # connection, so a name is never accepted as proof of locality.
+        token = new_token()
+        descriptor = _descriptor(tmp_path, token, host="daemon.example.test")
+
+        with pytest.raises(DescriptorError, match="not.*this machine"):
+            descriptor.check_endpoint_is_local()
+
+    def test_corrupt_json_is_refused_rather_than_ignored(self, tmp_path: Path):
+        # Refused, not treated as absent. A corrupt descriptor beside a held
+        # lock means a live daemon this client cannot talk to, and treating it
+        # as absent would elect a second owner against a running browser.
+        publish(tmp_path, _descriptor(tmp_path, new_token()), new_token())
+        descriptor_path(tmp_path).write_text("{ not json")
+
+        with pytest.raises(DescriptorError, match="not valid JSON"):
+            read(tmp_path)
+
+    def test_a_missing_field_is_refused(self, tmp_path: Path):
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        raw = json.loads(descriptor_path(tmp_path).read_text())
+        del raw["config_fingerprint"]
+        descriptor_path(tmp_path).write_text(json.dumps(raw))
+
+        with pytest.raises(DescriptorError, match="config_fingerprint"):
+            read(tmp_path)
+
+    def test_a_port_that_is_not_a_number_is_refused(self, tmp_path: Path):
+        # Read field by field rather than unpacked, so a wrong type fails here
+        # with something that names the field instead of much later.
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        raw = json.loads(descriptor_path(tmp_path).read_text())
+        raw["port"] = "49152"
+        descriptor_path(tmp_path).write_text(json.dumps(raw))
+
+        with pytest.raises(DescriptorError, match="port.*not a number"):
+            read(tmp_path)
+
+    def test_a_future_schema_is_refused(self, tmp_path: Path):
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        raw = json.loads(descriptor_path(tmp_path).read_text())
+        raw["schema_version"] = SCHEMA_VERSION + 1
+        descriptor_path(tmp_path).write_text(json.dumps(raw))
+
+        with pytest.raises(DescriptorError, match="version"):
+            read(tmp_path)
+
+    def test_a_token_from_another_generation_is_refused(self, tmp_path: Path):
+        # The pairing check. A token whose digest does not match the descriptor
+        # belongs to a different daemon, and using it would authenticate against
+        # something other than what the descriptor described.
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        loaded = read(tmp_path)
+        assert loaded is not None
+        token_path(tmp_path, loaded.instance_id).write_text(new_token())
+
+        with pytest.raises(DescriptorError, match="different daemon generations"):
+            read_token(tmp_path, loaded)
+
+    def test_a_descriptor_with_no_token_beside_it_is_refused(self, tmp_path: Path):
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        loaded = read(tmp_path)
+        assert loaded is not None
+        token_path(tmp_path, loaded.instance_id).unlink()
+
+        with pytest.raises(DescriptorError, match="no token beside it"):
+            read_token(tmp_path, loaded)
+
+
+class TestProfileIdentity:
+    def test_a_sibling_profile_is_not_served(self, tmp_path: Path):
+        # Measured: auth_root_dir returns the profile's parent, so profile and
+        # profile2 share one lock and therefore one election. Without an exact
+        # comparison a client configured for one silently gets the other's
+        # browser, complete with the wrong logged-in session.
+        descriptor = _descriptor(tmp_path, new_token())
+
+        assert descriptor.serves(tmp_path / "profile")
+        assert not descriptor.serves(tmp_path / "profile2")
+
+    def test_a_different_spelling_of_the_same_profile_is_served(self, tmp_path: Path):
+        # Same directory reached by a longer route is still the same browser.
+        descriptor = _descriptor(tmp_path, new_token())
+
+        assert descriptor.serves(tmp_path / "sub" / ".." / "profile")
+
+
+class TestConfigFingerprint:
+    def test_identical_configuration_matches(self):
+        token = new_token()
+
+        assert config_fingerprint(_config(), key=token) == config_fingerprint(
+            _config(), key=token
+        )
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("headless", False),
+            ("user_agent", "custom-agent"),
+            ("viewport_width", 1920),
+            ("proxy_server", "http://proxy.example:8080"),
+            ("proxy_password", "hunter2"),
+            ("slow_mo", 250),
+        ],
+    )
+    def test_configuration_that_changes_the_browser_does_not_match(
+        self, field: str, value: object
+    ):
+        # Each of these changes what the shared browser is, so a client that
+        # disagrees cannot be served by that owner.
+        token = new_token()
+
+        assert config_fingerprint(_config(), key=token) != config_fingerprint(
+            _config(**{field: value}), key=token
+        )
+
+    def test_configuration_that_only_affects_the_client_still_matches(self):
+        # These describe how one client behaves, not what the browser is, so
+        # they must not stop it attaching.
+        token = new_token()
+
+        assert config_fingerprint(_config(), key=token) == config_fingerprint(
+            _config(browser_wait_seconds=10.0, browser_min_hold_seconds=5.0),
+            key=token,
+        )
+
+    def test_the_fingerprint_is_keyed_to_the_daemon(self):
+        # Unkeyed, the digest would sit in a readable file covering a proxy
+        # password and otherwise guessable settings, which is an offline check
+        # for password guesses. Keyed, only a process that already has the token
+        # can compute it.
+        assert config_fingerprint(_config(), key=new_token()) != config_fingerprint(
+            _config(), key=new_token()
+        )
+
+    def test_the_same_profile_spelled_differently_matches(self, tmp_path: Path):
+        token = new_token()
+        direct = _config(user_data_dir=str(tmp_path / "profile"))
+        indirect = _config(user_data_dir=str(tmp_path / "sub" / ".." / "profile"))
+
+        assert config_fingerprint(direct, key=token) == config_fingerprint(
+            indirect, key=token
+        )
+
+    def test_reordered_proxy_bypass_hosts_match(self):
+        # The same hosts bypass the proxy either way, so the order is not a
+        # difference worth refusing over.
+        token = new_token()
+        one = _config(proxy_server="http://p.example:1", proxy_bypass="a.com, b.com")
+        other = _config(proxy_server="http://p.example:1", proxy_bypass="b.com,a.com")
+
+        assert config_fingerprint(one, key=token) == config_fingerprint(
+            other, key=token
+        )
+
+
+class TestMismatchReporting:
+    def test_mismatches_name_fields(self):
+        differing = mismatched_fields(_config(), _config(headless=False))
+
+        assert differing == ("headless",)
+
+    def test_a_mismatch_report_carries_no_values(self):
+        # What gets shown to a user. The values include a proxy password and the
+        # path to someone's browser profile, so the report names fields only.
+        differing = mismatched_fields(
+            _config(proxy_password="hunter2"), _config(proxy_password="letmein")
+        )
+
+        assert differing == ("proxy_password",)
+        assert "hunter2" not in str(differing)

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -421,22 +421,57 @@ class TestStateLocation:
     @pytest.mark.skipif(
         os.name == "nt", reason="creating directory symlinks needs extra privileges"
     )
-    @pytest.mark.parametrize("depth", ["daemon", "application"])
-    def test_a_linked_state_root_is_refused(self, tmp_path: Path, depth: str):
-        # Measured before the check: retargeting the link between two starts let
-        # a second process take a lock on another inode at the same path, so two
-        # owners each believed they held the one lock.
-        application = tmp_path / ".mcp-server-linkedin"
-        target = tmp_path / "elsewhere"
-        target.mkdir()
-        if depth == "application":
-            application.symlink_to(target, target_is_directory=True)
+    @pytest.mark.parametrize("depth", ["home", "application", "daemon"])
+    def test_state_reached_through_a_link_resolves_to_one_place(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, depth: str
+    ):
+        # A symlinked home is an ordinary POSIX layout, so it has to work rather
+        # than be refused. What matters is that two routes to it agree, which is
+        # what resolving gives: the lock is addressed by path, and two spellings
+        # would otherwise be two locks.
+        real = tmp_path / "real"
+        real.mkdir()
+        home = tmp_path / "home"
+        if depth == "home":
+            home.symlink_to(real, target_is_directory=True)
         else:
-            application.mkdir()
-            (application / "daemon").symlink_to(target, target_is_directory=True)
+            home.mkdir()
+            application = home / ".mcp-server-linkedin"
+            if depth == "application":
+                application.symlink_to(real, target_is_directory=True)
+            else:
+                application.mkdir()
+                (application / "daemon").symlink_to(real, target_is_directory=True)
+        monkeypatch.setattr(daemon_descriptor_module, "_account_home", lambda: home)
 
-        with pytest.raises(DescriptorError, match="symbolic link"):
+        root = daemon_state_root()
+
+        assert not root.is_symlink()
+        assert root == root.resolve()
+        assert real in (root, *root.parents)
+
+    def test_a_home_that_is_not_there_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        # Creating it would shadow a home that is merely not mounted yet, and
+        # the daemon that did so would key its state under that empty directory
+        # while everything started after the mount keys it under the real one.
+        missing = tmp_path / "not-mounted" / "user"
+        monkeypatch.setattr(
+            daemon_descriptor_module, "_account_home", _REAL_ACCOUNT_HOME
+        )
+        monkeypatch.setattr(os, "getuid", lambda: 424242, raising=False)
+
+        import pwd
+
+        entry = pwd.struct_passwd(
+            ("nobody", "x", 424242, 424242, "", str(missing), "/usr/bin/false")
+        )
+        monkeypatch.setattr(pwd, "getpwuid", lambda _uid: entry)
+
+        with pytest.raises(DescriptorError, match="does not exist"):
             daemon_state_root()
+        assert not missing.exists()
 
     def test_an_account_without_an_absolute_home_is_refused(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -550,6 +550,37 @@ class TestEndpointSpelling:
             descriptor.check_endpoint_is_local()
 
     @pytest.mark.parametrize(
+        "answers",
+        [
+            [("203.0.113.9", 49152)],
+            [("127.0.0.1", 49152), ("10.0.0.5", 49152)],
+        ],
+    )
+    def test_a_name_resolving_off_this_machine_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, answers: list
+    ):
+        # is_loopback_host accepts "localhost" by name, which says nothing
+        # about where the resolver on this machine sends it. Measured with the
+        # resolver answering 203.0.113.9: the descriptor was accepted, and the
+        # bearer token would have been posted off this machine. Every answer is
+        # checked, since one of several being loopback says nothing about the
+        # one a client picks.
+        import socket
+
+        descriptor = _descriptor(tmp_path, new_token(), host="localhost")
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *args, **kwargs: [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", answer)
+                for answer in answers
+            ],
+        )
+
+        with pytest.raises(DescriptorError, match="other than this machine"):
+            descriptor.check_endpoint_is_local()
+
+    @pytest.mark.parametrize(
         "host", ["127.0.0.1", "::1", "[::1]", "localhost", "::ffff:127.0.0.1"]
     )
     def test_every_spelling_a_daemon_publishes_is_accepted(

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -466,6 +466,28 @@ class TestConfigFingerprint:
             other, key=token
         )
 
+    def test_default_auto_import_matches_explicit_enabled(self):
+        # None is the enabled default, so spelling that default as True must not
+        # stop an otherwise compatible client from attaching.
+        token = new_token()
+        default = _config()
+        enabled = _config(auto_import_from_browser=True)
+
+        assert config_fingerprint(default, key=token) == config_fingerprint(
+            enabled, key=token
+        )
+        assert mismatched_fields(default, enabled) == ()
+
+    def test_disabled_auto_import_remains_a_difference(self):
+        token = new_token()
+        default = _config()
+        disabled = _config(auto_import_from_browser=False)
+
+        assert config_fingerprint(default, key=token) != config_fingerprint(
+            disabled, key=token
+        )
+        assert mismatched_fields(default, disabled) == ("auto_import_from_browser",)
+
 
 class TestMismatchReporting:
     def test_mismatches_name_fields(self):

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 import json
 import os
 import stat
+import sys
+import unicodedata
 from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
+import linkedin_mcp_server.daemon_descriptor as daemon_descriptor_module
 from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.daemon_descriptor import (
     PROTOCOL_VERSION,
@@ -24,6 +27,7 @@ from linkedin_mcp_server.daemon_descriptor import (
     build,
     config_fingerprint,
     daemon_dir,
+    daemon_state_root,
     descriptor_path,
     mismatched_fields,
     new_instance_id,
@@ -37,26 +41,40 @@ from linkedin_mcp_server.daemon_descriptor import (
 posix_only = pytest.mark.skipif(
     os.name == "nt", reason="POSIX permission bits do not exist on Windows"
 )
+_REAL_ACCOUNT_HOME = daemon_descriptor_module._account_home
+
+
+@pytest.fixture(autouse=True)
+def _isolate_daemon_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    # Production state lives under the user's private application directory.
+    # Isolate it per test rather than touching the real user directory.
+    monkeypatch.setattr(daemon_descriptor_module, "_account_home", lambda: tmp_path)
 
 
 def _config(**browser: object) -> AppConfig:
     config = AppConfig()
+    config.browser.user_data_dir = str(
+        daemon_descriptor_module._account_home() / ".linkedin-mcp" / "profile"
+    )
     for name, value in browser.items():
         setattr(config.browser, name, value)
     return config
 
 
-def _descriptor(tmp_path: Path, token: str, **overrides: object) -> DaemonDescriptor:
+def _descriptor(
+    tmp_path: Path, token: str, *, profile: Path | None = None, **overrides: object
+) -> DaemonDescriptor:
+    profile = profile or (tmp_path / "profile")
     descriptor = build(
         instance_id="11111111-2222-3333-4444-555555555555",
         package_version="4.19.0",
         runtime_id="macos-arm64-host",
-        profile=tmp_path / "profile",
+        profile=profile,
         host="127.0.0.1",
         port=49152,
         path="/mcp",
         token=token,
-        config=_config(),
+        config=_config(user_data_dir=str(profile)),
         log_path=tmp_path / "daemon.log",
     )
     return replace(descriptor, **overrides) if overrides else descriptor
@@ -337,6 +355,131 @@ class TestEndpointUrl:
         httpx.URL(descriptor.url)  # raises if a client could not use it
 
 
+class TestStateLocation:
+    def test_state_is_outside_the_configured_auth_root(self, tmp_path: Path):
+        # The auth root can be /tmp, a home directory, or another shared parent.
+        # Daemon state must not change it or trust entries planted inside it.
+        auth_root = tmp_path / "shared-parent"
+
+        assert daemon_dir(auth_root).parent == daemon_state_root()
+        assert auth_root not in daemon_dir(auth_root).parents
+
+    def test_equivalent_auth_roots_share_one_state_directory(self, tmp_path: Path):
+        direct = tmp_path / "shared-parent"
+        indirect = tmp_path / "sub" / ".." / "shared-parent"
+
+        assert daemon_dir(direct) == daemon_dir(indirect)
+
+    def test_different_auth_roots_have_different_state_directories(
+        self, tmp_path: Path
+    ):
+        one = tmp_path / "one"
+        two = tmp_path / "two"
+        one.mkdir()
+        two.mkdir()
+
+        assert daemon_dir(one) != daemon_dir(two)
+
+    def test_case_aliases_share_state_on_an_insensitive_volume(self, tmp_path: Path):
+        mixed = tmp_path / "MixedCase"
+        lower = tmp_path / "mixedcase"
+        mixed.mkdir()
+        if not lower.exists():
+            pytest.skip("the test volume is case-sensitive")
+
+        assert mixed.samefile(lower)
+        assert daemon_dir(mixed) == daemon_dir(lower)
+
+    def test_process_home_overrides_do_not_move_daemon_state(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        # Launchers and services can override these per process. Election scope
+        # follows the OS account, so the same absolute profile cannot split.
+        monkeypatch.setattr(
+            daemon_descriptor_module, "_account_home", _REAL_ACCOUNT_HOME
+        )
+        auth_root = tmp_path / "shared-parent"
+        auth_root.mkdir()
+        before = daemon_dir(auth_root)
+
+        monkeypatch.setenv("HOME", str(tmp_path / "other-home"))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path / "other-profile"))
+
+        assert daemon_dir(auth_root) == before
+
+    @pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="Linux filesystems accept non-UTF-8 byte names through surrogateescape",
+    )
+    def test_a_non_utf8_auth_root_spelling_can_be_keyed(self, tmp_path: Path):
+        raw = os.fsencode(tmp_path) + b"/missing-\xff"
+        path = Path(os.fsdecode(raw))
+
+        assert daemon_dir(path).parent == daemon_state_root()
+        assert path.is_dir()
+
+    @pytest.mark.skipif(
+        os.name == "nt", reason="creating directory symlinks needs extra privileges"
+    )
+    @pytest.mark.parametrize("depth", ["daemon", "application"])
+    def test_a_linked_state_root_is_refused(self, tmp_path: Path, depth: str):
+        # Measured before the check: retargeting the link between two starts let
+        # a second process take a lock on another inode at the same path, so two
+        # owners each believed they held the one lock.
+        application = tmp_path / ".mcp-server-linkedin"
+        target = tmp_path / "elsewhere"
+        target.mkdir()
+        if depth == "application":
+            application.symlink_to(target, target_is_directory=True)
+        else:
+            application.mkdir()
+            (application / "daemon").symlink_to(target, target_is_directory=True)
+
+        with pytest.raises(DescriptorError, match="symbolic link"):
+            daemon_state_root()
+
+    def test_an_account_without_an_absolute_home_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Path("") is ".", so an empty entry would key state under whichever
+        # directory the process happened to start in and split one account's
+        # election between them.
+        monkeypatch.setattr(
+            daemon_descriptor_module, "_account_home", _REAL_ACCOUNT_HOME
+        )
+        monkeypatch.setattr(os, "getuid", lambda: 424242, raising=False)
+
+        import pwd
+
+        entry = pwd.struct_passwd(
+            ("nobody", "x", 424242, 424242, "", "", "/usr/bin/false")
+        )
+        monkeypatch.setattr(pwd, "getpwuid", lambda _uid: entry)
+
+        with pytest.raises(DescriptorError, match="absolute home directory"):
+            daemon_state_root()
+
+    def test_a_filesystem_without_stable_ids_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        auth_root = tmp_path / "shared-parent"
+        auth_root.mkdir()
+        real_stat = os.stat
+
+        def stat_without_inode(path, *args, **kwargs):
+            result = real_stat(path, *args, **kwargs)
+            if Path(path) == auth_root:
+                fields = list(result)
+                fields[1] = 0
+                return os.stat_result(fields)
+            return result
+
+        monkeypatch.setattr(os, "stat", stat_without_inode)
+
+        with pytest.raises(DescriptorError, match="stable identity"):
+            daemon_dir(auth_root)
+
+
 class TestInstanceIdentity:
     def test_an_instance_id_cannot_escape_the_daemon_directory(self, tmp_path: Path):
         # The identifier becomes part of a filename, and it arrives from a file
@@ -378,6 +521,48 @@ class TestProfileIdentity:
         descriptor = _descriptor(tmp_path, new_token())
 
         assert descriptor.serves(tmp_path / "sub" / ".." / "profile")
+
+    def test_asking_what_a_daemon_serves_creates_nothing(self, tmp_path: Path):
+        # Comparison answers a question. Creating a browser profile in order to
+        # explain why a client was turned away would be a surprising thing for
+        # that client to find afterwards.
+        descriptor = _descriptor(tmp_path, new_token())
+        absent = tmp_path / "never-created"
+
+        assert not descriptor.serves(absent)
+        assert not absent.exists()
+
+    def test_reporting_a_mismatch_creates_nothing(self, tmp_path: Path):
+        absent = tmp_path / "also-never-created"
+
+        assert mismatched_fields(_config(), _config(user_data_dir=str(absent))) == (
+            "user_data_dir",
+        )
+        assert not absent.exists()
+
+    def test_a_case_alias_of_the_same_profile_is_served(self, tmp_path: Path):
+        profile = tmp_path / "MixedRoot" / "Profile"
+        profile.mkdir(parents=True)
+        alias = tmp_path / "mixedroot" / "profile"
+        if not alias.exists():
+            pytest.skip("the test volume is case-sensitive")
+        descriptor = _descriptor(tmp_path, new_token(), profile=profile)
+
+        assert profile.samefile(alias)
+        assert descriptor.serves(alias)
+
+    def test_a_unicode_alias_of_the_same_profile_is_served(self, tmp_path: Path):
+        composed = unicodedata.normalize("NFC", "é")
+        decomposed = unicodedata.normalize("NFD", "é")
+        profile = tmp_path / composed / "profile"
+        profile.mkdir(parents=True)
+        alias = tmp_path / decomposed / "profile"
+        if not alias.exists():
+            pytest.skip("the test volume preserves distinct Unicode spellings")
+        descriptor = _descriptor(tmp_path, new_token(), profile=profile)
+
+        assert profile.samefile(alias)
+        assert descriptor.serves(alias)
 
 
 class TestConfigFingerprint:
@@ -437,6 +622,32 @@ class TestConfigFingerprint:
         assert config_fingerprint(direct, key=token) == config_fingerprint(
             indirect, key=token
         )
+
+    def test_case_aliases_of_the_same_profile_match(self, tmp_path: Path):
+        profile = tmp_path / "MixedRoot" / "Profile"
+        profile.mkdir(parents=True)
+        alias = tmp_path / "mixedroot" / "profile"
+        if not alias.exists():
+            pytest.skip("the test volume is case-sensitive")
+        token = new_token()
+
+        assert config_fingerprint(
+            _config(user_data_dir=str(profile)), key=token
+        ) == config_fingerprint(_config(user_data_dir=str(alias)), key=token)
+
+    def test_unicode_aliases_of_the_same_profile_match(self, tmp_path: Path):
+        composed = unicodedata.normalize("NFC", "é")
+        decomposed = unicodedata.normalize("NFD", "é")
+        profile = tmp_path / composed / "profile"
+        profile.mkdir(parents=True)
+        alias = tmp_path / decomposed / "profile"
+        if not alias.exists():
+            pytest.skip("the test volume preserves distinct Unicode spellings")
+        token = new_token()
+
+        assert config_fingerprint(
+            _config(user_data_dir=str(profile)), key=token
+        ) == config_fingerprint(_config(user_data_dir=str(alias)), key=token)
 
     def test_an_empty_proxy_password_is_not_an_absent_one(self):
         # proxy_settings compares the password against None precisely so an

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -17,6 +17,7 @@ import pytest
 
 from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.daemon_descriptor import (
+    PROTOCOL_VERSION,
     SCHEMA_VERSION,
     DaemonDescriptor,
     DescriptorError,
@@ -200,6 +201,58 @@ class TestRefusals:
 
         with pytest.raises(DescriptorError, match="symbolic link"):
             read(tmp_path)
+
+    def test_a_descriptor_from_another_protocol_is_refused(self, tmp_path: Path):
+        # The field compatibility is meant to key on. Parsed but unenforced, a
+        # client would attach to an owner whose control routes, call metadata
+        # and ping contract it does not share.
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        raw = json.loads(descriptor_path(tmp_path).read_text())
+        raw["protocol_version"] = PROTOCOL_VERSION + 1
+        descriptor_path(tmp_path).write_text(json.dumps(raw))
+
+        with pytest.raises(DescriptorError, match="protocol"):
+            read(tmp_path)
+
+    @pytest.mark.skipif(
+        os.name == "nt", reason="symlinks need a privilege this test cannot assume"
+    )
+    def test_a_token_symlink_is_not_followed(self, tmp_path: Path):
+        # Confining the filename to the daemon directory is not enough on its
+        # own: a link sitting at that name still points wherever it likes, so
+        # a planted one whose target matched the digest would have been read
+        # and sent to the endpoint as this client's credential.
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        loaded = read(tmp_path)
+        assert loaded is not None
+        elsewhere = tmp_path / "planted"
+        elsewhere.write_text(token)
+        path = token_path(tmp_path, loaded.instance_id)
+        path.unlink()
+        path.symlink_to(elsewhere)
+
+        with pytest.raises(DescriptorError, match="could not be read"):
+            read_token(tmp_path, loaded)
+
+    @pytest.mark.skipif(
+        not hasattr(os, "mkfifo"), reason="named pipes are a POSIX mechanism"
+    )
+    def test_a_token_that_is_not_a_regular_file_is_refused(self, tmp_path: Path):
+        # A named pipe at that path would otherwise block the client inside
+        # open(), before any check could run, so the read is opened
+        # non-blocking and the file type is confirmed first.
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        loaded = read(tmp_path)
+        assert loaded is not None
+        path = token_path(tmp_path, loaded.instance_id)
+        path.unlink()
+        os.mkfifo(path)
+
+        with pytest.raises(DescriptorError, match="not a regular file"):
+            read_token(tmp_path, loaded)
 
     def test_a_descriptor_with_no_token_beside_it_is_refused(self, tmp_path: Path):
         token = new_token()

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -283,6 +283,23 @@ class TestConfigFingerprint:
             indirect, key=token
         )
 
+    def test_an_empty_proxy_password_is_not_an_absent_one(self):
+        # proxy_settings compares the password against None precisely so an
+        # empty one is still sent to Chromium. Measured before the fix: the two
+        # produced different launch options and an identical fingerprint, so a
+        # client would have been served a browser configured differently from
+        # what it asked for.
+        token = new_token()
+        absent = _config(proxy_server="http://p.example:1", proxy_username="u")
+        empty = _config(
+            proxy_server="http://p.example:1", proxy_username="u", proxy_password=""
+        )
+
+        assert absent.browser.proxy_settings() != empty.browser.proxy_settings()
+        assert config_fingerprint(absent, key=token) != config_fingerprint(
+            empty, key=token
+        )
+
     def test_reordered_proxy_bypass_hosts_match(self):
         # The same hosts bypass the proxy either way, so the order is not a
         # difference worth refusing over.

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -32,6 +32,7 @@ from linkedin_mcp_server.daemon_descriptor import (
     mismatched_fields,
     new_instance_id,
     new_token,
+    profile_identity,
     publish,
     read,
     read_token,
@@ -513,6 +514,35 @@ class TestStateLocation:
 
         with pytest.raises(DescriptorError, match="stable identity"):
             daemon_dir(auth_root)
+
+
+class TestEndpointSpelling:
+    def test_a_host_with_whitespace_is_refused(self, tmp_path: Path):
+        # is_loopback_host trims before classifying, so such a host passes as
+        # loopback and then produces a URL no client can parse. Measured:
+        # "[::1] " was accepted and failed later with "Invalid port".
+        descriptor = _descriptor(tmp_path, new_token(), host="[::1] ")
+
+        with pytest.raises(DescriptorError, match="whitespace"):
+            descriptor.check_endpoint_is_local()
+
+
+class TestProfileIdentityStability:
+    def test_the_identity_survives_the_profile_being_created(self, tmp_path: Path):
+        # The profile does not exist before the first login, so an identity
+        # that changed when it appeared would leave a descriptor published
+        # beforehand no longer matching its own profile. Measured with the auth
+        # root non-empty, which is the normal case since the lease files are
+        # never removed: serves() went from True to False across that login.
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir()
+        (auth_root / "profile.lock").touch()
+        profile = auth_root / "profile"
+
+        before = profile_identity(profile)
+        profile.mkdir()
+
+        assert profile_identity(profile) == before
 
 
 class TestInstanceIdentity:

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -622,6 +622,23 @@ class TestAuthRootShape:
             daemon_dir(occupied)
 
 
+class TestUnusablePaths:
+    @pytest.mark.parametrize(
+        "path",
+        [Path("~definitely-no-such-user-xyz/auth"), Path("/tmp/auth\x00x")],
+    )
+    def test_a_path_that_cannot_be_resolved_is_refused(self, path: Path):
+        # expanduser and resolve run before anything else and have failure
+        # modes of their own: an unknown user raises RuntimeError, an embedded
+        # NUL raises ValueError. Both come from type-correct configuration, so
+        # they are refusals rather than defects.
+        with pytest.raises(DescriptorError, match="not a usable path"):
+            daemon_dir(path)
+
+        with pytest.raises(DescriptorError, match="not a usable path"):
+            profile_identity(path)
+
+
 class TestDigestFields:
     @pytest.mark.parametrize("field", ["token_sha256", "config_fingerprint"])
     @pytest.mark.parametrize("value", ["é" * 64, "z" * 64, "abc", "a" * 63, "a" * 65])

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -531,6 +531,9 @@ class TestEndpointSpelling:
             ("127.0.0.1", "/mcp\ta"),
             ("127.0.0.1", "/mcp\x0b"),
             ("127.0.0.1", "/mcp\udcff"),
+            ("127.0.0.1.", "/mcp"),
+            ("127.0.0.1..", "/mcp"),
+            ("localhost..", "/mcp"),
         ],
     )
     def test_an_endpoint_that_composes_into_nothing_usable_is_refused(

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -517,14 +517,43 @@ class TestStateLocation:
 
 
 class TestEndpointSpelling:
-    def test_a_host_with_whitespace_is_refused(self, tmp_path: Path):
-        # is_loopback_host trims before classifying, so such a host passes as
-        # loopback and then produces a URL no client can parse. Measured:
-        # "[::1] " was accepted and failed later with "Invalid port".
-        descriptor = _descriptor(tmp_path, new_token(), host="[::1] ")
+    @pytest.mark.parametrize(
+        "host,path",
+        [
+            ("[::1] ", "/mcp"),
+            ("[127.0.0.1]", "/mcp"),
+            ("127.0.0.1\r", "/mcp"),
+            ("127.0.0.1", "/mcp\n"),
+            ("127.0.0.1", "/mcp\ta"),
+        ],
+    )
+    def test_an_endpoint_that_composes_into_nothing_usable_is_refused(
+        self, tmp_path: Path, host: str, path: str
+    ):
+        # Each field is plausible on its own. Whether they compose into an
+        # address a client can reach is the question that matters, and it used
+        # to be answered by the client, far from anything that could explain it
+        # as a descriptor this daemon did not write. Measured: "[::1] " passed
+        # as loopback because the check trims and the URL does not.
+        descriptor = _descriptor(tmp_path, new_token(), host=host, path=path)
 
-        with pytest.raises(DescriptorError, match="whitespace"):
+        with pytest.raises(DescriptorError):
             descriptor.check_endpoint_is_local()
+
+    @pytest.mark.parametrize(
+        "host", ["127.0.0.1", "::1", "[::1]", "localhost", "::ffff:127.0.0.1"]
+    )
+    def test_every_spelling_a_daemon_publishes_is_accepted(
+        self, tmp_path: Path, host: str
+    ):
+        # The other half: tightening this must not refuse an endpoint the
+        # daemon itself would write, which is easy to do by accident.
+        import httpx
+
+        descriptor = _descriptor(tmp_path, new_token(), host=host)
+
+        descriptor.check_endpoint_is_local()
+        httpx.URL(descriptor.url)
 
 
 class TestProfileIdentityStability:

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -146,6 +146,19 @@ class TestRefusals:
         with pytest.raises(DescriptorError, match="not valid JSON"):
             read(tmp_path)
 
+    def test_a_number_too_long_to_parse_is_refused(self, tmp_path: Path):
+        # Well under the size limit, and still unparseable: Python refuses an
+        # integer with more digits than sys.int_max_str_digits allows, and does
+        # it with a plain ValueError from inside the parser. Measured with five
+        # thousand digits: it crossed the boundary before anything could call
+        # it a bad descriptor.
+        token = new_token()
+        publish(tmp_path, _descriptor(tmp_path, token), token)
+        descriptor_path(tmp_path).write_text('{"port": ' + "9" * 5000 + "}")
+
+        with pytest.raises(DescriptorError, match="not valid JSON"):
+            read(tmp_path)
+
     def test_a_missing_field_is_refused(self, tmp_path: Path):
         token = new_token()
         publish(tmp_path, _descriptor(tmp_path, token), token)

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -652,6 +652,29 @@ class TestProfileIdentityStability:
         profile.mkdir()
         assert profile_identity(profile) == before
 
+    @pytest.mark.parametrize("variant", ["case", "unicode"])
+    def test_an_alias_of_the_profile_name_itself_matches(
+        self, tmp_path: Path, variant: str
+    ):
+        # The alias tests above vary a parent segment. This varies the profile's
+        # own name, which is the part the identity carries as text: measured, a
+        # decomposed and a composed accent named one directory and produced two
+        # identities, because casefold settles case and says nothing about
+        # composition.
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir()
+        if variant == "case":
+            first, second = "Profile", "profile"
+        else:
+            first = "profile" + unicodedata.normalize("NFC", "é")
+            second = "profile" + unicodedata.normalize("NFD", "é")
+        (auth_root / first).mkdir()
+        alias = auth_root / second
+        if not alias.exists():
+            pytest.skip("this volume keeps the two spellings apart")
+
+        assert profile_identity(auth_root / first) == profile_identity(alias)
+
     def test_case_distinct_siblings_do_not_collide(self, tmp_path: Path):
         # On a case-insensitive volume Profile and profile name one directory,
         # which is what the fold is for. On a case-sensitive one they are two,

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -690,9 +690,9 @@ class TestProfileIdentityStability:
 class TestInstanceIdentity:
     def test_an_instance_id_cannot_escape_the_daemon_directory(self, tmp_path: Path):
         # The identifier becomes part of a filename, and it arrives from a file
-        # anything with write access to the auth root can edit. Unchecked, a
-        # descriptor naming ".." would turn some other readable file into what
-        # this client sends to the endpoint as its bearer token.
+        # rather than from this process. Unchecked, a descriptor naming ".."
+        # would turn some other readable file into what this client sends to
+        # the endpoint as its bearer token.
         with pytest.raises(DescriptorError, match="not a UUID"):
             token_path(tmp_path, "../../../../etc/hosts")
 

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -521,10 +521,16 @@ class TestEndpointSpelling:
         "host,path",
         [
             ("[::1] ", "/mcp"),
+            (" 127.0.0.1 ", "/mcp"),
             ("[127.0.0.1]", "/mcp"),
             ("127.0.0.1\r", "/mcp"),
+            ("127.0.0.1\x01", "/mcp"),
+            ("127.0.0.1\x7f", "/mcp"),
+            ("127.0.0.1\xa0", "/mcp"),
             ("127.0.0.1", "/mcp\n"),
             ("127.0.0.1", "/mcp\ta"),
+            ("127.0.0.1", "/mcp\x0b"),
+            ("127.0.0.1", "/mcp\udcff"),
         ],
     )
     def test_an_endpoint_that_composes_into_nothing_usable_is_refused(
@@ -556,6 +562,19 @@ class TestEndpointSpelling:
         httpx.URL(descriptor.url)
 
 
+class TestAuthRootShape:
+    def test_a_file_where_the_auth_root_belongs_is_refused(self, tmp_path: Path):
+        # The check for this existed but sat after secure_mkdir, which refuses
+        # a non-directory itself with a NotADirectoryError that reaches the
+        # caller instead of the error this module is read through. Measured
+        # before the reorder: NotADirectoryError.
+        occupied = tmp_path / "auth"
+        occupied.write_text("a file, not a directory")
+
+        with pytest.raises(DescriptorError, match="not a directory"):
+            daemon_dir(occupied)
+
+
 class TestDigestFields:
     @pytest.mark.parametrize("field", ["token_sha256", "config_fingerprint"])
     @pytest.mark.parametrize("value", ["é" * 64, "z" * 64, "abc", "a" * 63, "a" * 65])
@@ -577,6 +596,28 @@ class TestDigestFields:
 
 
 class TestProfileIdentityStability:
+    def test_a_missing_profile_does_not_borrow_a_siblings_identity(
+        self, tmp_path: Path
+    ):
+        # The profile does not exist before the first login. Where a sibling
+        # differs only in case, folding onto it would give the two the same
+        # identity, and on a case-sensitive volume they really are two
+        # directories. Measured there: the identity collided before the login
+        # and then changed once the directory appeared.
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir()
+        sibling = auth_root / "Profile"
+        sibling.mkdir()
+        profile = auth_root / "profile"
+        if profile.exists():
+            pytest.skip("this volume is case-insensitive, so these are one directory")
+
+        before = profile_identity(profile)
+
+        assert before != profile_identity(sibling)
+        profile.mkdir()
+        assert profile_identity(profile) == before
+
     def test_case_distinct_siblings_do_not_collide(self, tmp_path: Path):
         # On a case-insensitive volume Profile and profile name one directory,
         # which is what the fold is for. On a case-sensitive one they are two,

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -171,6 +171,36 @@ class TestRefusals:
         with pytest.raises(DescriptorError, match="different daemon generations"):
             read_token(tmp_path, loaded)
 
+    @pytest.mark.skipif(
+        os.name == "nt", reason="symlinks need a privilege this test cannot assume"
+    )
+    def test_a_dangling_descriptor_symlink_is_not_read_as_absence(self, tmp_path: Path):
+        # Measured: a dead symlink made read() return None, so a client would
+        # have taken it for a first start and elected a second owner while the
+        # first was still running. Absence and untrustworthy have to stay
+        # distinguishable, because only one of them means "go ahead".
+        descriptor_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+        descriptor_path(tmp_path).symlink_to(tmp_path / "nowhere")
+
+        with pytest.raises(DescriptorError, match="symbolic link"):
+            read(tmp_path)
+
+    @pytest.mark.skipif(
+        os.name == "nt", reason="symlinks need a privilege this test cannot assume"
+    )
+    def test_a_descriptor_symlink_pointing_somewhere_real_is_refused(
+        self, tmp_path: Path
+    ):
+        # Following it would read a file this never published, chosen by
+        # whoever could write the link.
+        elsewhere = tmp_path / "planted.json"
+        elsewhere.write_text("{}")
+        descriptor_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+        descriptor_path(tmp_path).symlink_to(elsewhere)
+
+        with pytest.raises(DescriptorError, match="symbolic link"):
+            read(tmp_path)
+
     def test_a_descriptor_with_no_token_beside_it_is_refused(self, tmp_path: Path):
         token = new_token()
         publish(tmp_path, _descriptor(tmp_path, token), token)
@@ -180,6 +210,32 @@ class TestRefusals:
 
         with pytest.raises(DescriptorError, match="no token beside it"):
             read_token(tmp_path, loaded)
+
+
+class TestEndpointUrl:
+    @pytest.mark.parametrize(
+        "host,expected",
+        [
+            ("127.0.0.1", "http://127.0.0.1:49152/mcp"),
+            ("localhost", "http://localhost:49152/mcp"),
+            ("::1", "http://[::1]:49152/mcp"),
+            ("::ffff:127.0.0.1", "http://[::ffff:127.0.0.1]:49152/mcp"),
+            ("[::1]", "http://[::1]:49152/mcp"),
+        ],
+    )
+    def test_every_accepted_host_produces_a_usable_url(
+        self, tmp_path: Path, host: str, expected: str
+    ):
+        # An IPv6 literal that is accepted but unbracketed parses as a bad
+        # port. Measured: a valid ::1 endpoint produced a URL no client could
+        # use, so the daemon was unreachable through its own descriptor.
+        import httpx
+
+        descriptor = _descriptor(tmp_path, new_token(), host=host)
+        descriptor.check_endpoint_is_local()
+
+        assert descriptor.url == expected
+        httpx.URL(descriptor.url)  # raises if a client could not use it
 
 
 class TestInstanceIdentity:

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -33,6 +33,10 @@ def _run_child(source: str, *args: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
         env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+        # The child's working directory outranks PYTHONPATH on its import path,
+        # so running the suite from another checkout would have these children
+        # mix modules from both. Pinning it keeps them on the tree under test.
+        cwd=_REPO_ROOT,
         timeout=30,
     )
 
@@ -105,7 +109,14 @@ class TestScope:
             lock.release()
 
 
+posix_handoff = pytest.mark.skipif(
+    os.name == "nt",
+    reason="Measured on Windows: an inherited handle does not carry the lock",
+)
+
+
 class TestHandoff:
+    @posix_handoff
     def test_a_duplicate_survives_the_original_being_closed(self, tmp_path: Path):
         # How a supervisor is launched: it inherits a copy, and the process that
         # elected it lets go. If the lock did not survive that, another client
@@ -122,6 +133,7 @@ class TestHandoff:
 
         assert not daemon_is_running(tmp_path)
 
+    @posix_handoff
     def test_the_copy_is_inheritable(self, tmp_path: Path):
         # The original is opened close-on-exec so a launched Chromium cannot
         # hold the lock open. That same flag would stop a supervisor inheriting
@@ -137,10 +149,12 @@ class TestHandoff:
         finally:
             lock.release()
 
+    @posix_handoff
     def test_handing_over_a_lock_we_do_not_hold_refuses(self, tmp_path: Path):
         with pytest.raises(DaemonLockError, match="does not hold"):
             DaemonLock(tmp_path).inheritable_copy()
 
+    @posix_handoff
     def test_an_adopted_lock_is_held_without_reacquiring(self, tmp_path: Path):
         # A supervisor is launched already holding a copy. Acquiring again would
         # fail on POSIX, where the process already holds it, so adoption records
@@ -159,6 +173,25 @@ class TestHandoff:
             supervisor.release()
 
         assert not daemon_is_running(tmp_path)
+
+
+class TestPlatformDifference:
+    @pytest.mark.skipif(
+        os.name != "nt", reason="the refusal only applies where handoff cannot work"
+    )
+    def test_windows_refuses_to_hand_a_lock_over(self, tmp_path: Path):
+        # Measured on a Windows runner: a child holding the inherited handle
+        # did not hold the lock once the parent closed its own, in 20 of 20
+        # runs, while a third process took the byte range. Returning a
+        # descriptor that looks like a transferred lock and is not would put a
+        # second owner on a live browser, so it refuses instead.
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+        try:
+            with pytest.raises(DaemonLockError, match="POSIX mechanism"):
+                lock.inheritable_copy()
+        finally:
+            lock.release()
 
 
 class TestFork:
@@ -199,6 +232,7 @@ class TestFork:
 
 
 class TestAdoptedDescriptors:
+    @posix_handoff
     def test_an_adopted_lock_does_not_leak_to_later_children(self, tmp_path: Path):
         # The descriptor is marked inheritable for exactly one launch. Measured
         # before the fix: it stayed that way, so an unrelated child launched
@@ -226,6 +260,7 @@ class TestAdoptedDescriptors:
 
 
 class TestReleaseSemantics:
+    @posix_handoff
     def test_releasing_closes_rather_than_unlocks(self, tmp_path: Path):
         # The measured trap. flock belongs to the open file description, which
         # every inherited copy shares, so unlocking would release the lock for

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -198,6 +198,33 @@ class TestFork:
             os.waitpid(pid, 0)
 
 
+class TestAdoptedDescriptors:
+    def test_an_adopted_lock_does_not_leak_to_later_children(self, tmp_path: Path):
+        # The descriptor is marked inheritable for exactly one launch. Measured
+        # before the fix: it stayed that way, so an unrelated child launched
+        # afterwards inherited the lock and kept it held after the owner exited,
+        # leaving every client looking at a daemon that was no longer there.
+        original = DaemonLock(tmp_path)
+        assert original.try_acquire()
+        inherited = original.inheritable_copy()
+        original.release()
+
+        adopter = DaemonLock(tmp_path)
+        adopter.adopt(inherited)
+
+        # Launched the way a browser would be, inheriting open descriptors.
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(3)"], close_fds=False
+        )
+        try:
+            adopter.release()
+
+            assert not daemon_is_running(tmp_path)
+        finally:
+            child.kill()
+            child.wait()
+
+
 class TestReleaseSemantics:
     def test_releasing_closes_rather_than_unlocks(self, tmp_path: Path):
         # The measured trap. flock belongs to the open file description, which

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -8,6 +8,7 @@ behaviour that is easy to write correctly and just as easy to break later.
 from __future__ import annotations
 
 import os
+import stat
 import subprocess
 import sys
 import textwrap
@@ -16,6 +17,8 @@ from pathlib import Path
 
 import pytest
 
+import linkedin_mcp_server.daemon_descriptor as daemon_descriptor_module
+from linkedin_mcp_server.daemon_descriptor import daemon_dir, daemon_state_root
 from linkedin_mcp_server.daemon_lock import (
     DaemonLock,
     DaemonLockError,
@@ -24,6 +27,14 @@ from linkedin_mcp_server.daemon_lock import (
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_daemon_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    # The child interpreters inherit HOME and patch the account lookup below, so
+    # every process contends on the same state without touching the real user.
+    monkeypatch.setattr(daemon_descriptor_module, "_account_home", lambda: tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
 
 
 def _run_child(source: str, *args: str) -> subprocess.CompletedProcess[str]:
@@ -42,10 +53,13 @@ def _run_child(source: str, *args: str) -> subprocess.CompletedProcess[str]:
 
 
 _TRY_ACQUIRE = """
+    import os
     import sys
     from pathlib import Path
+    import linkedin_mcp_server.daemon_descriptor as daemon_descriptor
     from linkedin_mcp_server.daemon_lock import DaemonLock
 
+    daemon_descriptor._account_home = lambda: Path(os.environ["HOME"])
     lock = DaemonLock(Path(sys.argv[1]))
     print("ACQUIRED" if lock.try_acquire() else "BUSY")
 """
@@ -93,12 +107,82 @@ class TestOwnership:
 
 
 class TestScope:
-    def test_the_lock_covers_the_whole_auth_root(self, tmp_path: Path):
-        # Every profile under one auth root shares one browser lease, so the
-        # election has to be just as wide. Scoped per profile, two owners would
-        # both start and then compete forever for a lease only one can hold.
-        assert daemon_lock_path(tmp_path / "profile").parent != tmp_path
-        assert daemon_lock_path(tmp_path).parent == tmp_path
+    def test_the_lock_lives_in_private_daemon_state(self, tmp_path: Path):
+        # The path remains keyed by the auth root, so every profile under that
+        # root shares one election, while different roots cannot collide.
+        first = daemon_lock_path(tmp_path)
+        second = daemon_lock_path(tmp_path / "other-root")
+
+        assert first.parent == daemon_dir(tmp_path)
+        assert first.parent.parent == daemon_state_root()
+        assert second.parent.parent == daemon_state_root()
+        assert first != second
+
+    @pytest.mark.skipif(
+        os.name == "nt", reason="POSIX permission bits do not exist on Windows"
+    )
+    def test_acquiring_does_not_harden_the_configured_auth_root(self, tmp_path: Path):
+        # Measured before the fix: acquiring changed any existing auth root from
+        # 0755 to 0700. A custom profile directly under /tmp would try to chmod
+        # /tmp itself; under a home directory it would silently change the home.
+        auth_root = tmp_path / "shared-parent"
+        auth_root.mkdir(mode=0o755)
+        auth_root.chmod(0o755)
+        lock = DaemonLock(auth_root)
+
+        assert lock.try_acquire()
+        try:
+            assert stat.S_IMODE(auth_root.stat().st_mode) == 0o755
+            assert not (auth_root / "daemon").exists()
+            assert stat.S_IMODE(daemon_state_root().stat().st_mode) == 0o700
+            assert stat.S_IMODE(daemon_dir(auth_root).stat().st_mode) == 0o700
+        finally:
+            lock.release()
+
+    def test_a_fresh_auth_root_keeps_one_lock_identity(self, tmp_path: Path):
+        # Measured before the fix: the first wrapper cached a path-derived key,
+        # then acquisition created the auth root and every later lookup used its
+        # inode. The live lock appeared free and a second owner was elected.
+        auth_root = tmp_path / "fresh" / ".linkedin-mcp"
+        first = DaemonLock(auth_root)
+
+        assert first.try_acquire()
+        try:
+            assert daemon_is_running(auth_root)
+            second = DaemonLock(auth_root)
+            assert not second.try_acquire()
+            second.release()
+        finally:
+            first.release()
+
+    @pytest.mark.skipif(
+        os.name == "nt", reason="creating directory symlinks needs extra privileges"
+    )
+    def test_an_auth_root_symlink_cannot_split_the_election(self, tmp_path: Path):
+        # Measured before the fix: the default auth root also held daemon state,
+        # so retargeting its daemon link let another owner lock a second inode.
+        auth_root = tmp_path / ".linkedin-mcp"
+        first_target = tmp_path / "first-target"
+        second_target = tmp_path / "second-target"
+        auth_root.mkdir()
+        first_target.mkdir()
+        second_target.mkdir()
+        planted = auth_root / "daemon"
+        planted.symlink_to(first_target, target_is_directory=True)
+
+        first = DaemonLock(auth_root)
+        assert first.try_acquire()
+        planted.unlink()
+        planted.symlink_to(second_target, target_is_directory=True)
+
+        second = DaemonLock(auth_root)
+        try:
+            assert not second.try_acquire()
+            assert not (first_target / "daemon.lock").exists()
+            assert not (second_target / "daemon.lock").exists()
+        finally:
+            second.release()
+            first.release()
 
     def test_two_locks_on_one_root_are_the_same_lock(self, tmp_path: Path):
         lock = DaemonLock(tmp_path)
@@ -189,7 +273,9 @@ class TestRegistry:
         gc.collect()
 
         assert daemon_is_running(tmp_path)
-        held = [lock for lock in _held_locks if lock.path.parent == tmp_path]
+        held = [
+            lock for lock in _held_locks if lock.path.parent == daemon_dir(tmp_path)
+        ]
         assert held, "a held lock must stay reachable"
 
         for lock in held:

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -175,6 +175,40 @@ class TestHandoff:
         assert not daemon_is_running(tmp_path)
 
 
+class TestRegistry:
+    def test_a_held_lock_survives_losing_its_last_reference(self, tmp_path: Path):
+        # Measured before the fix: the registry was weak throughout, so a lock
+        # acquired and then dropped left the descriptor open with nothing left
+        # to close it. Another process could not take the lock, and no object
+        # remained through which to release it or clean it up after a fork.
+        import gc
+
+        from linkedin_mcp_server.daemon_lock import _held_locks
+
+        DaemonLock(tmp_path).try_acquire()
+        gc.collect()
+
+        assert daemon_is_running(tmp_path)
+        held = [lock for lock in _held_locks if lock.path.parent == tmp_path]
+        assert held, "a held lock must stay reachable"
+
+        for lock in held:
+            lock.release()
+        assert not daemon_is_running(tmp_path)
+
+    def test_an_unheld_lock_is_not_kept_alive(self, tmp_path: Path):
+        # Only held locks are worth pinning. One that was built and never used
+        # owns nothing, so keeping it would be a leak for no benefit.
+        import gc
+
+        from linkedin_mcp_server.daemon_lock import _held_locks
+
+        DaemonLock(tmp_path)
+        gc.collect()
+
+        assert not [lock for lock in _held_locks if lock.path.parent == tmp_path]
+
+
 class TestPlatformDifference:
     @pytest.mark.skipif(
         os.name != "nt", reason="the refusal only applies where handoff cannot work"

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -296,6 +296,60 @@ class TestHandoff:
             os.close(inherited)
 
     @posix_handoff
+    def test_a_lock_file_renamed_mid_adoption_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A rename keeps the inode's one link, so a link count still reads as
+        # one while the name now refers to something else. Measured with a
+        # count-based check: the rename passed and a contender locked the live
+        # path alongside the adopter.
+        seed = DaemonLock(tmp_path)
+        assert seed.try_acquire()
+        inherited = seed.inheritable_copy()
+        seed.release()
+        path = daemon_lock_path(tmp_path)
+        real = daemon_lock_module.try_lock
+
+        def rename_then_lock(fd: int, *, exclusive: bool) -> bool:
+            monkeypatch.setattr(daemon_lock_module, "try_lock", real)
+            path.rename(path.parent / "moved")
+            path.touch()
+            return real(fd, exclusive=exclusive)
+
+        monkeypatch.setattr(daemon_lock_module, "try_lock", rename_then_lock)
+
+        try:
+            with pytest.raises(DaemonLockError, match="was replaced"):
+                DaemonLock(tmp_path).adopt(inherited)
+        finally:
+            os.close(inherited)
+
+    @posix_handoff
+    def test_a_failed_handover_does_not_leak_the_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The duplicate already shares the kernel lock, so leaking it holds the
+        # lock for this process's whole life: release() closes the original and
+        # the lock survives in the copy. Measured before the fix: the daemon
+        # still read as running after release and nobody could take over.
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+
+        def refuse(*args: object, **kwargs: object) -> None:
+            raise OSError("cannot mark inheritable")
+
+        monkeypatch.setattr(os, "set_inheritable", refuse)
+        with pytest.raises(OSError):
+            lock.inheritable_copy()
+        monkeypatch.undo()
+
+        lock.release()
+
+        successor = DaemonLock(tmp_path)
+        assert successor.try_acquire(), "the duplicate leaked and kept the lock"
+        successor.release()
+
+    @posix_handoff
     def test_adopting_a_descriptor_that_holds_no_lock_still_excludes(
         self, tmp_path: Path
     ):

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -455,7 +455,14 @@ class TestAdoptedDescriptors:
         try:
             adopter.release()
 
-            assert not daemon_is_running(tmp_path)
+            # Asked by electing rather than by probing. daemon_is_running takes
+            # a lock to answer, so under a loaded parallel test run it competes
+            # with whatever else is touching this file and can report a holder
+            # that is really another probe. Election is the question that
+            # matters anyway: if the child still held the lock, this would fail.
+            successor = DaemonLock(tmp_path)
+            assert successor.try_acquire(), "the child kept the lock alive"
+            successor.release()
         finally:
             child.kill()
             child.wait()

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import sys
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -158,6 +159,43 @@ class TestHandoff:
             supervisor.release()
 
         assert not daemon_is_running(tmp_path)
+
+
+class TestFork:
+    @pytest.mark.skipif(
+        not hasattr(os, "fork"), reason="fork does not exist on Windows"
+    )
+    def test_a_child_that_never_touches_the_lock_does_not_hold_it(self, tmp_path: Path):
+        # Measured before the fix: an untouched fork child kept the lock held
+        # after the owner released, so every other process saw a daemon that
+        # was no longer there and none could elect a replacement. Checking
+        # inside the lock's own methods cannot catch this, because the child
+        # never calls one.
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+
+        # The child reports what it inherited rather than sleeping, so the
+        # assertion below cannot run before the child has finished discarding
+        # it. Timing the two against each other would make this flaky in
+        # whichever direction the scheduler happened to go.
+        read_fd, write_fd = os.pipe()
+        pid = os.fork()
+        if pid == 0:  # pragma: no cover - runs in the forked child
+            os.close(read_fd)
+            os.write(write_fd, b"x")
+            os.close(write_fd)
+            time.sleep(2)
+            os._exit(0)
+
+        os.close(write_fd)
+        try:
+            os.read(read_fd, 1)
+            lock.release()
+
+            assert not daemon_is_running(tmp_path)
+        finally:
+            os.close(read_fd)
+            os.waitpid(pid, 0)
 
 
 class TestReleaseSemantics:

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 
 import linkedin_mcp_server.daemon_descriptor as daemon_descriptor_module
+import linkedin_mcp_server.daemon_lock as daemon_lock_module
 from linkedin_mcp_server.daemon_descriptor import daemon_dir, daemon_state_root
 from linkedin_mcp_server.daemon_lock import (
     DaemonLock,
@@ -265,6 +266,36 @@ class TestHandoff:
             os.close(inherited)
 
     @posix_handoff
+    def test_a_lock_file_replaced_mid_adoption_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The descriptor is compared against the path before the lock is held,
+        # so an unlink and recreate in between leaves adoption holding an
+        # orphaned inode while the live path sits free. Measured before the
+        # check: adopter and contender each reported ownership, on two inodes.
+        seed = DaemonLock(tmp_path)
+        assert seed.try_acquire()
+        inherited = seed.inheritable_copy()
+        seed.release()
+        path = daemon_lock_path(tmp_path)
+
+        real = daemon_lock_module.try_lock
+
+        def replace_then_lock(fd: int, *, exclusive: bool) -> bool:
+            monkeypatch.setattr(daemon_lock_module, "try_lock", real)
+            path.unlink()
+            path.touch()
+            return real(fd, exclusive=exclusive)
+
+        monkeypatch.setattr(daemon_lock_module, "try_lock", replace_then_lock)
+
+        try:
+            with pytest.raises(DaemonLockError, match="was replaced"):
+                DaemonLock(tmp_path).adopt(inherited)
+        finally:
+            os.close(inherited)
+
+    @posix_handoff
     def test_adopting_a_descriptor_that_holds_no_lock_still_excludes(
         self, tmp_path: Path
     ):
@@ -467,12 +498,12 @@ class TestLiveness:
             lock.release()
 
     def test_concurrent_probes_do_not_see_each_other(self, tmp_path: Path):
-        # Measured before the probe became shared: 43 of 400 concurrent probes
-        # reported a daemon that did not exist, because an exclusive probe
-        # briefly holds the lock and the other probe reads its own sibling as an
-        # owner. A cold-starting client would then look for a descriptor rather
-        # than elect. Shared still fails against the owner's exclusive hold, so
-        # the answer stays right when there really is one.
+        # The half of the trade the shared probe buys. Measured with an
+        # exclusive probe: 43 of 400 concurrent probes reported a daemon that
+        # did not exist, because one briefly held the lock and the other read
+        # its own sibling as an owner. Inventing an owner is the unrecoverable
+        # direction, which is why shared is preferred despite the cost pinned
+        # in the test below.
         creator = DaemonLock(tmp_path)
         assert creator.try_acquire()
         creator.release()
@@ -491,6 +522,32 @@ class TestLiveness:
             thread.join()
 
         assert answers and not any(answers)
+
+    def test_the_probe_is_an_observation_not_a_decision(self, tmp_path: Path):
+        # The other half, and the reason the docstring calls this a hint. There
+        # is no way to ask flock whether a lock is held without taking one, so a
+        # probe contends with a concurrent election: measured, 11 of 3000
+        # elections failed against a probe while no owner existed. Ownership is
+        # therefore decided by try_acquire alone, never by asking this first.
+        creator = DaemonLock(tmp_path)
+        assert creator.try_acquire()
+        creator.release()
+
+        # An election is never wrong when nothing competes with it, which is
+        # the property callers may rely on.
+        for _ in range(50):
+            lock = DaemonLock(tmp_path)
+            assert lock.try_acquire()
+            lock.release()
+
+        # And the probe agrees with a settled state in both directions.
+        assert not daemon_is_running(tmp_path)
+        owner = DaemonLock(tmp_path)
+        assert owner.try_acquire()
+        try:
+            assert daemon_is_running(tmp_path)
+        finally:
+            owner.release()
 
     def test_a_stale_lock_file_does_not_look_alive(self, tmp_path: Path):
         # The file is never unlinked, so it outlives the daemon that made it.

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -180,11 +180,11 @@ class TestPlatformDifference:
         os.name != "nt", reason="the refusal only applies where handoff cannot work"
     )
     def test_windows_refuses_to_hand_a_lock_over(self, tmp_path: Path):
-        # Measured on a Windows runner: a child holding the inherited handle
-        # did not hold the lock once the parent closed its own, in 20 of 20
-        # runs, while a third process took the byte range. Returning a
-        # descriptor that looks like a transferred lock and is not would put a
-        # second owner on a live browser, so it refuses instead.
+        # Measured on a Windows runner: a child holding the inherited handle did
+        # not hold the lock once the parent had closed its handles and exited,
+        # in 20 of 20 runs, while a third process took the byte range.
+        # Returning a descriptor that looks like a transferred lock and is not
+        # would put a second owner on a live browser, so it refuses instead.
         lock = DaemonLock(tmp_path)
         assert lock.try_acquire()
         try:

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -1,0 +1,207 @@
+"""The lock that decides which process owns the shared browser.
+
+Mutual exclusion cannot be shown inside one interpreter, so the tests that
+matter here spawn real processes and let the kernel arbitrate. The rest pin
+behaviour that is easy to write correctly and just as easy to break later.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from linkedin_mcp_server.daemon_lock import (
+    DaemonLock,
+    DaemonLockError,
+    daemon_is_running,
+    daemon_lock_path,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_child(source: str, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run *source* in a separate interpreter, so the kernel decides."""
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source), *args],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+        timeout=30,
+    )
+
+
+_TRY_ACQUIRE = """
+    import sys
+    from pathlib import Path
+    from linkedin_mcp_server.daemon_lock import DaemonLock
+
+    lock = DaemonLock(Path(sys.argv[1]))
+    print("ACQUIRED" if lock.try_acquire() else "BUSY")
+"""
+
+
+class TestOwnership:
+    def test_one_process_at_a_time(self, tmp_path: Path):
+        # The whole point: a second process must not be able to start a second
+        # browser against a profile the first one already owns.
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+
+        result = _run_child(_TRY_ACQUIRE, str(tmp_path))
+
+        assert result.stdout.strip() == "BUSY", result.stderr
+        lock.release()
+
+    def test_the_lock_frees_when_the_holder_exits(self, tmp_path: Path):
+        # A crashed daemon must not lock everyone out forever. The kernel
+        # releases the lock on death, which is why this uses a file lock rather
+        # than a pid file that would need a liveness check nobody can do safely.
+        first = _run_child(_TRY_ACQUIRE, str(tmp_path))
+        assert first.stdout.strip() == "ACQUIRED", first.stderr
+
+        second = _run_child(_TRY_ACQUIRE, str(tmp_path))
+
+        assert second.stdout.strip() == "ACQUIRED", second.stderr
+
+    def test_acquiring_twice_in_one_process_is_a_mistake(self, tmp_path: Path):
+        # Not reference counted, unlike the profile lease. A second acquire is a
+        # caller that believes it is the first, and the lock means nothing if
+        # two parts of one process can each think they own the daemon.
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+
+        with pytest.raises(DaemonLockError, match="already holds"):
+            lock.try_acquire()
+
+        lock.release()
+
+    def test_releasing_without_holding_is_harmless(self, tmp_path: Path):
+        # Cleanup paths call this without always knowing whether the acquire
+        # got far enough, and raising there would mask the original failure.
+        DaemonLock(tmp_path).release()
+
+
+class TestScope:
+    def test_the_lock_covers_the_whole_auth_root(self, tmp_path: Path):
+        # Every profile under one auth root shares one browser lease, so the
+        # election has to be just as wide. Scoped per profile, two owners would
+        # both start and then compete forever for a lease only one can hold.
+        assert daemon_lock_path(tmp_path / "profile").parent != tmp_path
+        assert daemon_lock_path(tmp_path).parent == tmp_path
+
+    def test_two_locks_on_one_root_are_the_same_lock(self, tmp_path: Path):
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+        try:
+            assert not DaemonLock(tmp_path).try_acquire()
+        finally:
+            lock.release()
+
+
+class TestHandoff:
+    def test_a_duplicate_survives_the_original_being_closed(self, tmp_path: Path):
+        # How a supervisor is launched: it inherits a copy, and the process that
+        # elected it lets go. If the lock did not survive that, another client
+        # would see it free and elect a second owner against a live browser.
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+        inherited = lock.inheritable_copy()
+        lock.release()
+
+        try:
+            assert daemon_is_running(tmp_path)
+        finally:
+            os.close(inherited)
+
+        assert not daemon_is_running(tmp_path)
+
+    def test_the_copy_is_inheritable(self, tmp_path: Path):
+        # The original is opened close-on-exec so a launched Chromium cannot
+        # hold the lock open. That same flag would stop a supervisor inheriting
+        # it, so the duplicate has to clear it explicitly.
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+        try:
+            inherited = lock.inheritable_copy()
+            try:
+                assert os.get_inheritable(inherited)
+            finally:
+                os.close(inherited)
+        finally:
+            lock.release()
+
+    def test_handing_over_a_lock_we_do_not_hold_refuses(self, tmp_path: Path):
+        with pytest.raises(DaemonLockError, match="does not hold"):
+            DaemonLock(tmp_path).inheritable_copy()
+
+    def test_an_adopted_lock_is_held_without_reacquiring(self, tmp_path: Path):
+        # A supervisor is launched already holding a copy. Acquiring again would
+        # fail on POSIX, where the process already holds it, so adoption records
+        # ownership rather than taking it.
+        original = DaemonLock(tmp_path)
+        assert original.try_acquire()
+        inherited = original.inheritable_copy()
+        original.release()
+
+        supervisor = DaemonLock(tmp_path)
+        supervisor.adopt(inherited)
+        try:
+            assert supervisor.held
+            assert daemon_is_running(tmp_path)
+        finally:
+            supervisor.release()
+
+        assert not daemon_is_running(tmp_path)
+
+
+class TestReleaseSemantics:
+    def test_releasing_closes_rather_than_unlocks(self, tmp_path: Path):
+        # The measured trap. flock belongs to the open file description, which
+        # every inherited copy shares, so unlocking would release the lock for
+        # the supervisor too. Closing drops only this descriptor.
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+        inherited = lock.inheritable_copy()
+
+        lock.release()
+
+        try:
+            # Still held, through the copy. An unlock-then-close release would
+            # have freed it here and let a second owner start.
+            assert daemon_is_running(tmp_path)
+        finally:
+            os.close(inherited)
+
+
+class TestLiveness:
+    def test_no_lock_file_means_no_daemon(self, tmp_path: Path):
+        assert not daemon_is_running(tmp_path)
+
+    def test_probing_does_not_disturb_the_holder(self, tmp_path: Path):
+        # Discovery calls this on every cold start, so it must not briefly
+        # exclude a supervisor that is starting up.
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+        try:
+            assert daemon_is_running(tmp_path)
+            assert daemon_is_running(tmp_path)
+            assert lock.held
+        finally:
+            lock.release()
+
+    def test_a_stale_lock_file_does_not_look_alive(self, tmp_path: Path):
+        # The file is never unlinked, so it outlives the daemon that made it.
+        # Its presence must therefore mean nothing on its own: what counts is
+        # whether the lock inside it can be taken.
+        lock = DaemonLock(tmp_path)
+        assert lock.try_acquire()
+        lock.release()
+
+        assert daemon_lock_path(tmp_path).exists()
+        assert not daemon_is_running(tmp_path)

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import stat
 import subprocess
+import threading
 import sys
 import textwrap
 import time
@@ -464,6 +465,32 @@ class TestLiveness:
             assert lock.held
         finally:
             lock.release()
+
+    def test_concurrent_probes_do_not_see_each_other(self, tmp_path: Path):
+        # Measured before the probe became shared: 43 of 400 concurrent probes
+        # reported a daemon that did not exist, because an exclusive probe
+        # briefly holds the lock and the other probe reads its own sibling as an
+        # owner. A cold-starting client would then look for a descriptor rather
+        # than elect. Shared still fails against the owner's exclusive hold, so
+        # the answer stays right when there really is one.
+        creator = DaemonLock(tmp_path)
+        assert creator.try_acquire()
+        creator.release()
+
+        answers: list[bool] = []
+        start = threading.Barrier(2)
+
+        def probe() -> None:
+            start.wait()
+            answers.extend(daemon_is_running(tmp_path) for _ in range(200))
+
+        threads = [threading.Thread(target=probe) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert answers and not any(answers)
 
     def test_a_stale_lock_file_does_not_look_alive(self, tmp_path: Path):
         # The file is never unlinked, so it outlives the daemon that made it.

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -239,6 +239,56 @@ class TestHandoff:
             DaemonLock(tmp_path).inheritable_copy()
 
     @posix_handoff
+    def test_a_descriptor_for_another_auth_root_is_not_adopted(self, tmp_path: Path):
+        # Measured before the check: it was adopted without complaint, so this
+        # process reported it owned a browser nobody had elected it for, while
+        # another process took the real lock unopposed.
+        other = tmp_path / "other"
+        other.mkdir()
+        mine = tmp_path / "mine"
+        mine.mkdir()
+        elsewhere = DaemonLock(other)
+        assert elsewhere.try_acquire()
+        inherited = elsewhere.inheritable_copy()
+        elsewhere.release()
+        # Give this auth root a lock file of its own, so the refusal has to come
+        # from comparing the two rather than from one of them being absent.
+        own = DaemonLock(mine)
+        assert own.try_acquire()
+        own.release()
+
+        try:
+            with pytest.raises(DaemonLockError, match="not this auth root's"):
+                DaemonLock(mine).adopt(inherited)
+        finally:
+            os.close(inherited)
+
+    @posix_handoff
+    def test_adopting_a_descriptor_that_holds_no_lock_still_excludes(
+        self, tmp_path: Path
+    ):
+        # A supervisor launched with a descriptor that was never locked, or
+        # whose lock was already released. Measured before the fix: it reported
+        # ownership while daemon_is_running said no daemon was there and a
+        # contender took the lock alongside it. Adoption now asks for the lock,
+        # which is granted against our own open file description when we already
+        # hold it and takes it when it is free. Either way exactly one holder.
+        creator = DaemonLock(tmp_path)
+        assert creator.try_acquire()
+        creator.release()
+        unlocked = os.open(daemon_lock_path(tmp_path), os.O_RDWR)
+
+        adopter = DaemonLock(tmp_path)
+        adopter.adopt(unlocked)
+        try:
+            assert adopter.held
+            assert daemon_is_running(tmp_path)
+            contender = DaemonLock(tmp_path)
+            assert not contender.try_acquire()
+        finally:
+            adopter.release()
+
+    @posix_handoff
     def test_an_adopted_lock_is_held_without_reacquiring(self, tmp_path: Path):
         # A supervisor is launched already holding a copy. Acquiring again would
         # fail on POSIX, where the process already holds it, so adoption records

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -350,6 +350,31 @@ class TestHandoff:
         successor.release()
 
     @posix_handoff
+    def test_an_adoption_that_cannot_complete_gives_the_lock_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # By the time inheritance is cleared the lock is held through this
+        # descriptor, and nothing has recorded that yet. Measured before the
+        # cleanup: the failure left it held with no object able to release it,
+        # and only a manual close freed it.
+        elector = DaemonLock(tmp_path)
+        assert elector.try_acquire()
+        inherited = elector.inheritable_copy()
+        elector.release()
+
+        def refuse(*args: object, **kwargs: object) -> None:
+            raise OSError("cannot clear inheritance")
+
+        monkeypatch.setattr(os, "set_inheritable", refuse)
+        with pytest.raises(DaemonLockError, match="could not be taken over"):
+            DaemonLock(tmp_path).adopt(inherited)
+        monkeypatch.undo()
+
+        successor = DaemonLock(tmp_path)
+        assert successor.try_acquire(), "the lock was left held by nobody"
+        successor.release()
+
+    @posix_handoff
     def test_adopting_a_descriptor_that_holds_no_lock_still_excludes(
         self, tmp_path: Path
     ):

--- a/tests/test_profile_lease.py
+++ b/tests/test_profile_lease.py
@@ -170,6 +170,39 @@ class TestSingleProcess:
         finally:
             os.close(descriptor)
 
+    @_posix_unlink_race
+    def test_contention_on_a_stale_inode_retries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Being refused the old file says nothing about the current one.
+
+        Contention answers only about the file that was opened. If the path has
+        moved on since, the holder holds something nobody will consult, and
+        reporting busy refuses a lock that is free. Measured before the fix:
+        None came back while the live path could be locked immediately.
+        """
+        from linkedin_mcp_server import profile_lease
+
+        path = tmp_path / "profile.lock"
+        holder = profile_lease.open_lock_file(path)
+        assert profile_lease.try_lock(holder, exclusive=True)
+        real = profile_lease.try_lock
+
+        def rename_then_lock(fd: int, *, exclusive: bool) -> bool:
+            monkeypatch.setattr(profile_lease, "try_lock", real)
+            path.rename(tmp_path / "moved")
+            path.touch()
+            return real(fd, exclusive=exclusive)
+
+        monkeypatch.setattr(profile_lease, "try_lock", rename_then_lock)
+
+        try:
+            descriptor = profile_lease.acquire_locked_fd(path, exclusive=True)
+            assert descriptor is not None, "refused a lock nobody was holding"
+            os.close(descriptor)
+        finally:
+            os.close(holder)
+
     def test_lock_file_is_never_unlinked(self, tmp_path: Path) -> None:
         """Unlinking on release splits contenders across inodes.
 
@@ -709,8 +742,10 @@ class TestDegradedSignals:
     def test_an_unlinked_lock_file_is_reacquired(self, tmp_path: Path) -> None:
         """An orphaned inode protects nothing, so acquisition must retry.
 
-        Without the ``st_nlink`` check two processes end up holding locks on
+        Without the identity check two processes end up holding locks on
         different inodes for the same path and both believe they are the owner.
+        Unlinking is the easier half of that: it is also what a rename does,
+        which the test below covers and a link count cannot see.
         """
         from linkedin_mcp_server import profile_lease as module
 
@@ -735,7 +770,9 @@ class TestDegradedSignals:
 
         assert len(attempts) == 2, "the orphaned inode was accepted"
         assert lease._fd is not None
-        assert os.fstat(lease._fd).st_nlink > 0
+        # The descriptor is the file the path names, which is what the retry
+        # was for. A link count would also pass here and miss the rename case.
+        assert os.fstat(lease._fd).st_ino == lock_path.stat().st_ino
         assert lock_path.exists()
         lease.release()
 

--- a/tests/test_profile_lease.py
+++ b/tests/test_profile_lease.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import os
 import signal
 import subprocess
@@ -751,6 +752,52 @@ class TestDegradedSignals:
         from linkedin_mcp_server.profile_lease import _windows_failure_is_contention
 
         assert _windows_failure_is_contention(error_code) is is_contention
+
+    @pytest.mark.skipif(os.name == "nt", reason="flock is the POSIX backend")
+    @pytest.mark.parametrize(
+        "code,is_contention",
+        [
+            (errno.EAGAIN, True),
+            (errno.EWOULDBLOCK, True),
+            (errno.EACCES, True),
+            (errno.EOPNOTSUPP, False),
+            (errno.EIO, False),
+            (errno.EBADF, False),
+        ],
+    )
+    def test_posix_failures_are_classified(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        code: int,
+        is_contention: bool,
+    ) -> None:
+        """The POSIX half of the same question, and for the same reason.
+
+        Only contention means somebody else holds the lock. Measured with
+        EOPNOTSUPP before the fix: reported as busy, which on a filesystem
+        without usable flock would leave every process seeing an owner that does
+        not exist, no owner electable, and an error pointing at contention.
+        """
+        import fcntl
+
+        from linkedin_mcp_server.profile_lease import (
+            ProfileLeaseUnavailableError,
+            open_lock_file,
+            try_lock,
+        )
+
+        def failing(fd: int, operation: int) -> None:
+            raise OSError(code, os.strerror(code))
+
+        descriptor = open_lock_file(tmp_path / "probe.lock")
+        monkeypatch.setattr(fcntl, "flock", failing)
+
+        if is_contention:
+            assert try_lock(descriptor, exclusive=True) is False
+        else:
+            with pytest.raises(ProfileLeaseUnavailableError, match="Could not lock"):
+                try_lock(descriptor, exclusive=True)
 
     def test_a_failing_backend_does_not_leak_descriptors(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_profile_lease.py
+++ b/tests/test_profile_lease.py
@@ -140,6 +140,36 @@ class TestSingleProcess:
             holder.kill()
             holder.wait(timeout=10)
 
+    @_posix_unlink_race
+    def test_a_renamed_lock_file_is_not_accepted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A rename keeps the link count, so counting links cannot see it.
+
+        The inode holds its one link while the name comes to mean a different
+        file, so a count-based check passes and two processes end up locking
+        two inodes for one path. Comparing identity is what catches it.
+        """
+        from linkedin_mcp_server import profile_lease
+
+        path = tmp_path / "profile.lock"
+        real = profile_lease.try_lock
+
+        def rename_then_lock(fd: int, *, exclusive: bool) -> bool:
+            monkeypatch.setattr(profile_lease, "try_lock", real)
+            path.rename(tmp_path / "moved")
+            path.touch()
+            return real(fd, exclusive=exclusive)
+
+        monkeypatch.setattr(profile_lease, "try_lock", rename_then_lock)
+
+        descriptor = profile_lease.acquire_locked_fd(path, exclusive=True)
+        assert descriptor is not None
+        try:
+            assert os.fstat(descriptor).st_ino == path.stat().st_ino
+        finally:
+            os.close(descriptor)
+
     def test_lock_file_is_never_unlinked(self, tmp_path: Path) -> None:
         """Unlinking on release splits contenders across inodes.
 

--- a/tests/test_profile_lease.py
+++ b/tests/test_profile_lease.py
@@ -685,7 +685,7 @@ class TestDegradedSignals:
 
         lease = ProfileLease(tmp_path)
         lock_path = tmp_path / "profile.lock"
-        real_open = module._open_lock_file
+        real_open = module.open_lock_file
         attempts: list[int] = []
 
         def unlink_once(path: Path) -> int:
@@ -699,7 +699,7 @@ class TestDegradedSignals:
         # would also revert the autouse profile-directory patches in conftest,
         # silently unpinning this test from its tmp_path for the rest of the run.
         with pytest.MonkeyPatch.context() as patch:
-            patch.setattr(module, "_open_lock_file", unlink_once)
+            patch.setattr(module, "open_lock_file", unlink_once)
             assert lease.try_acquire()
 
         assert len(attempts) == 2, "the orphaned inode was accepted"
@@ -715,14 +715,14 @@ class TestDegradedSignals:
         """Retrying forever would hang a tool call; refuse instead."""
         from linkedin_mcp_server import profile_lease as module
 
-        real_open = module._open_lock_file
+        real_open = module.open_lock_file
 
         def always_unlink(path: Path) -> int:
             fd = real_open(path)
             path.unlink()
             return fd
 
-        monkeypatch.setattr(module, "_open_lock_file", always_unlink)
+        monkeypatch.setattr(module, "open_lock_file", always_unlink)
         with pytest.raises(ProfileLeaseUnavailableError, match="keeps being"):
             ProfileLease(tmp_path).try_acquire()
 
@@ -765,7 +765,7 @@ class TestDegradedSignals:
         from linkedin_mcp_server import profile_lease as module
 
         opened: list[int] = []
-        real_open = module._open_lock_file
+        real_open = module.open_lock_file
 
         def spy(path: Path) -> int:
             fd = real_open(path)
@@ -775,12 +775,12 @@ class TestDegradedSignals:
         def refuse(fd: int, *, exclusive: bool) -> bool:
             raise ProfileLeaseUnavailableError("backend unavailable")
 
-        monkeypatch.setattr(module, "_open_lock_file", spy)
-        monkeypatch.setattr(module, "_try_lock", refuse)
+        monkeypatch.setattr(module, "open_lock_file", spy)
+        monkeypatch.setattr(module, "try_lock", refuse)
 
         for _ in range(3):
             with pytest.raises(ProfileLeaseUnavailableError):
-                module._acquire_locked_fd(tmp_path / "probe.lock", exclusive=True)
+                module.acquire_locked_fd(tmp_path / "probe.lock", exclusive=True)
 
         assert opened, "the spy never ran, so this proves nothing"
         for fd in set(opened):
@@ -797,10 +797,10 @@ class TestDegradedSignals:
             os.close(fd)  # as if something else had already reclaimed it
             raise ProfileLeaseUnavailableError("backend unavailable")
 
-        monkeypatch.setattr(module, "_try_lock", close_then_refuse)
+        monkeypatch.setattr(module, "try_lock", close_then_refuse)
 
         with pytest.raises(ProfileLeaseUnavailableError, match="backend unavailable"):
-            module._acquire_locked_fd(tmp_path / "probe.lock", exclusive=True)
+            module.acquire_locked_fd(tmp_path / "probe.lock", exclusive=True)
 
     def test_an_inconclusive_probe_does_not_hand_the_profile_over(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -817,7 +817,7 @@ class TestDegradedSignals:
         def refuse(path: Path, *, exclusive: bool) -> int | None:
             raise ProfileLeaseUnavailableError("signal unreadable")
 
-        monkeypatch.setattr(module, "_acquire_locked_fd", refuse)
+        monkeypatch.setattr(module, "acquire_locked_fd", refuse)
         assert lease.handoff_requested() is False
 
     def test_a_failed_announcement_degrades_to_waiting_quietly(
@@ -831,7 +831,7 @@ class TestDegradedSignals:
         def refuse(path: Path, *, exclusive: bool) -> int | None:
             raise ProfileLeaseUnavailableError("signal unreadable")
 
-        monkeypatch.setattr(module, "_acquire_locked_fd", refuse)
+        monkeypatch.setattr(module, "acquire_locked_fd", refuse)
         with lease.announce() as announcement:
             assert announcement.holds_lock is False
 
@@ -852,7 +852,7 @@ class TestDegradedSignals:
             with pytest.raises(
                 ProfileLeaseUnavailableError, match="no usable file locking"
             ):
-                module._try_lock(fd, exclusive=True)
+                module.try_lock(fd, exclusive=True)
             # Unlocking has nothing to undo and must stay silent, or a cleanup
             # path would raise on top of the original failure.
             module._unlock(fd)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -42,9 +42,13 @@ class TestServerRoles:
         # this would corrupt the session rather than merely run slowly.
         for role in ServerRole:
             mcp = create_mcp_server(role=role)
+            serializes = _has_middleware(mcp, SequentialToolExecutionMiddleware)
 
-            assert role.drives_browser
-            assert _has_middleware(mcp, SequentialToolExecutionMiddleware), role
+            # Stated as the conditional it is. Asserting that every role drives
+            # a browser would pass today and fail the moment the forwarding
+            # role arrives, for the entirely legitimate reason that one does
+            # not, which is a test failing at the wrong thing.
+            assert serializes == role.drives_browser, role
 
     def test_the_update_notice_goes_only_where_a_user_reads_it(self):
         # Appended to one tool result per process. On a server shared by many


### PR DESCRIPTION
Closes #609

For one process to hold the browser on behalf of the others (#606), two things have to exist first: something deciding which process that is, and something a client can read to find it and check it is the right one to attach to.

The profile lease (#598) cannot do the first job. It is reference counted so several callers in one process can hold it at once, and released the moment the browser closes so `--login` can take it. Ownership held that way would lapse whenever the browser happened to be shut, and holding it for a process lifetime would lock out every login.

So this adds a separate lock with the same kernel primitives and different rules: one holder, no reference counting, released only on exit. It lives at the auth root because `auth_root_dir()` returns the profile's parent, so sibling profile directories already share one lease; an election scoped more narrowly would let two owners start and then compete forever for a lease only one can hold.

Three properties come from measurements rather than reasoning.

The lock is released by closing the descriptor, never by unlocking it. A duplicate shares the lock rather than holding one of its own, so unlocking through any of them releases it for all. Measured on both platforms: unlock-then-close left the lock free while a live process believed it held it.

A free lock is never read as proof the profile is idle. A persistent headless Chromium survived a kill of its Python parent by over 20 seconds, while the kernel frees the lock at the instant of death.

Handing a held lock to a launched process works only on POSIX. Measured on a Windows runner: a child that received the handle through the documented `STARTUPINFO` mechanism and kept it open did not hold the lock once the parent had closed its handles and exited, and a third process took the byte range in 20 of 20 runs. Within one process a duplicate does keep it alive, which is why a single-process test agrees and the cross-process case does not. Both handoff entry points refuse on Windows and say the supervisor has to take the lock itself.

Alongside it, a descriptor the owner publishes and a client verifies rather than trusts, since anything that can write to the auth root can edit it. The endpoint must be loopback before a token is sent anywhere, and IPv6 literals are bracketed so an accepted endpoint is also a reachable one. The profile path is compared exactly, because sibling profiles share one auth root and a client configured for one would otherwise be handed the other's logged-in session. The instance identifier must be a UUID before it becomes a filename, and the token is opened without following links and confirmed to be a regular file, so neither the name nor a link at that name can redirect the read. The protocol version is compared, not merely recorded. Configuration deciding what the shared browser is must match, through a digest keyed to the daemon token: unkeyed it would cover the proxy password alongside otherwise guessable settings, which is an offline check for password guesses. Mismatches name fields, never values.

Three lock helpers in `profile_lease.py` become public so both callers share one implementation rather than duplicating it. Rename only, verified by diff.

Verified with 1299 tests, 144 of them new. Mutual exclusion, crash release, fork inheritance and the POSIX handoff are exercised with real subprocesses, since none of it can be shown inside one interpreter. The state directory, the identity it is keyed by and the aliases that must resolve to one browser were each reproduced as a split owner before being closed.

## Synthetic prompt

> Add the lock that decides which process owns the shared browser, and the descriptor a client reads to find and validate that owner. The profile lease cannot serve as the election lock, so build a separate one on the same primitives with one holder and no reference counting. Release it by closing rather than unlocking, never treat a free lock as proof no browser is running, and check on a real Windows runner whether an inherited handle actually carries the lock. Make the descriptor carry the exact profile path, a keyed configuration fingerprint and a token in its own instance-named file, and refuse anything that cannot be verified, including planted links and endpoints that are accepted but unreachable. Test mutual exclusion with real processes.














Supersedes #612, which GitHub closed when the branch below it merged and its base was deleted. Same branch, same commits, retargeted at main.
