### PR TITLE
docs: Say how to merge a stack without losing the top PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,22 @@ Always read [`CONTRIBUTING.md`](CONTRIBUTING.md) before filing an issue or worki
   5. Create a draft PR; only convert to regular PR when ready to merge
   6. Review with AI agents first, then manual review. PRs are squash-merged into `main` (one commit per PR), so keep the PR title as the conventional-commit subject; commits within a PR are for review only.
 
+### Merging a stack
+
+Use `gt merge`, which merges every PR from `main` up to the current branch in
+one operation. Do not merge a stack one PR at a time with `gh pr merge`.
+
+The repository deletes the head branch on merge, and that races GitHub's
+retargeting of the PR above. Measured twice, both times two seconds apart:
+merging the middle PR deleted its branch, and the PR on top of it was closed
+before its base could be moved to `main`. A PR closed that way cannot be
+reopened or retargeted, so the only way back is to recreate it, which loses its
+review history.
+
+If a stacked PR does get closed this way, rebase its branch onto `main`,
+force-push with a lease, open a replacement, and leave a comment on the closed
+one pointing at it.
+
 ## PR Reviews
 
 Greptile posts initial reviews as PR review comments, but follow-ups as **issue comments**. Always check both.


### PR DESCRIPTION
Merging a stack one pull request at a time closes the one above. The
repository deletes the head branch on merge, and that races GitHub's
retargeting: measured twice, both times two seconds between the merge
and base_ref_deleted plus closed. A pull request closed that way cannot
be reopened or retargeted, so it has to be recreated and loses its
review history.

gt merge does the whole stack in one operation and was there all along.
Nothing in this file mentioned it, which is why the manual route was
taken twice.