### PR TITLE
feat(daemon): Find a running owner worth attaching to

### DIFF
--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -117,6 +117,7 @@ class EnvironmentKeys:
     IMPORT_FROM_BROWSER = "IMPORT_FROM_BROWSER"
     AUTO_IMPORT_FROM_BROWSER = "AUTO_IMPORT_FROM_BROWSER"
     EAGER_FULL_CHROMIUM = "EAGER_FULL_CHROMIUM"
+    DAEMON_ENABLED = "DAEMON_ENABLED"
 
 
 def is_interactive_environment() -> bool:
@@ -323,6 +324,14 @@ def load_from_env(config: AppConfig) -> AppConfig:
             config.browser.eager_full_chromium = False
         elif eager_full_value in TRUTHY_VALUES:
             config.browser.eager_full_chromium = True
+
+    # Share one browser-owning process across stdio clients.
+    if daemon_env := os.environ.get(EnvironmentKeys.DAEMON_ENABLED):
+        daemon_value = _normalize_env(daemon_env)
+        if daemon_value in FALSY_VALUES:
+            config.server.daemon_enabled = False
+        elif daemon_value in TRUTHY_VALUES:
+            config.server.daemon_enabled = True
 
     return config
 
@@ -591,6 +600,25 @@ def load_from_args(config: AppConfig) -> AppConfig:
         ),
     )
 
+    daemon_group = parser.add_mutually_exclusive_group()
+    daemon_group.add_argument(
+        "--daemon",
+        dest="daemon_enabled",
+        action="store_true",
+        default=None,
+        help=(
+            "Serve every stdio client from one browser-owning process instead "
+            "of giving each its own (experimental)."
+        ),
+    )
+    daemon_group.add_argument(
+        "--no-daemon",
+        dest="daemon_enabled",
+        action="store_false",
+        default=None,
+        help="Give every stdio client its own browser (default; overrides DAEMON_ENABLED=true).",
+    )
+
     args = parser.parse_args()
 
     # Update configuration with parsed arguments
@@ -687,6 +715,9 @@ def load_from_args(config: AppConfig) -> AppConfig:
 
     if args.eager_full_chromium is not None:
         config.browser.eager_full_chromium = args.eager_full_chromium
+
+    if args.daemon_enabled is not None:
+        config.server.daemon_enabled = args.daemon_enabled
 
     return config
 

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -374,6 +374,12 @@ class ServerConfig:
     port: int = 8000
     path: str = "/mcp"
     tool_timeout_seconds: float = DEFAULT_TOOL_TIMEOUT_SECONDS
+    # Serve every stdio client from one browser-owning process instead of
+    # giving each its own. Off while the supervision and liveness work is
+    # unfinished: an owner that outlives its client must be provably unable to
+    # keep scraping, and until then this stays something you opt into. Only
+    # applies to stdio; an explicit HTTP bind is already a single server.
+    daemon_enabled: bool = False
 
     def validate(self) -> None:
         """Validate server configuration values."""

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -1,0 +1,139 @@
+"""Decide whether this process attaches to a daemon, owns one, or goes it alone.
+
+A stdio server is spawned per MCP client, and #598 made several of them safe on
+one profile by passing the browser between them. Safe, but not cheap: ownership
+moves on nearly every call, and every move reopens Chromium and revalidates the
+session against ``/feed/``. One long-lived owner removes that traffic entirely.
+
+This module is only the discovery half: it answers "is there an owner I should
+be talking to, and may I trust it with a token". Electing an owner, forwarding
+to it and supervising it build on this and land with the code that forwards.
+
+Finding an owner takes a wait rather than a single read, because the interesting
+case is neither "an owner exists" nor "none does", but the window in between. An
+owner takes the lock first and publishes its descriptor only once it is actually
+listening, so a client arriving in that gap sees no descriptor *and* loses the
+lock race. Reading that as "no daemon" is the one wrong answer: the process
+would drive its own browser against the same profile for its whole life, which
+is exactly the per-call handoff this feature exists to remove, and it is what
+two clients starting together would normally hit.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from linkedin_mcp_server import daemon_descriptor
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon_descriptor import DaemonDescriptor, DescriptorError
+from linkedin_mcp_server.session_state import get_runtime_id
+
+logger = logging.getLogger(__name__)
+
+#: How long to keep re-reading while an owner is starting up. It covers the gap
+#: between a lock being taken and the descriptor being published, which is a
+#: bind plus a server start, so this is generous rather than tuned. Waiting too
+#: long costs a slow first call; giving up too early costs a redundant browser
+#: for the life of the process.
+_ATTACH_WAIT_SECONDS = 10.0
+
+#: Re-read this often while waiting. Short enough that the common case (an owner
+#: that is nearly ready) does not feel like a stall.
+_ATTACH_POLL_SECONDS = 0.1
+
+
+@dataclass(frozen=True)
+class Attachment:
+    """An owner worth talking to, and the credential for doing so."""
+
+    descriptor: DaemonDescriptor
+    token: str
+
+
+def _usable_attachment(
+    auth_root: Path, profile: Path, config: AppConfig
+) -> Attachment | None:
+    """Whether the published descriptor describes a daemon we may attach to.
+
+    Order matters. The cheap, local checks come first and the ones that touch
+    the endpoint come last, so a descriptor that is merely stale is rejected
+    without a connection attempt.
+    """
+    descriptor = daemon_descriptor.read(auth_root)
+    if descriptor is None:
+        return None
+
+    # Not enforced by read(), deliberately: it is the caller who knows which
+    # runtime it belongs to. A host attaching to a container's daemon would be
+    # handed a browser in a different filesystem namespace.
+    if descriptor.runtime_id != get_runtime_id():
+        logger.debug("Daemon belongs to another runtime; not attaching")
+        return None
+
+    # The lock is per auth root, but a profile is what a browser opens. Two
+    # profiles side by side elect one owner between them, so an owner exists
+    # that is not *our* owner.
+    if not descriptor.serves(profile):
+        logger.debug("Daemon serves a different profile; not attaching")
+        return None
+
+    # No endpoint check here: `from_mapping` already refuses a non-local host
+    # while parsing, so `read` above cannot return one. Repeating it would read
+    # as the safeguard when it is really a second copy of one, and a second
+    # copy is what rots when the first moves.
+    token = daemon_descriptor.read_token(auth_root, descriptor)
+
+    # Keyed with the token, so this can only run once the token is in hand.
+    if descriptor.config_fingerprint != daemon_descriptor.config_fingerprint(
+        config, key=token
+    ):
+        logger.debug("Daemon runs a different configuration; not attaching")
+        return None
+
+    return Attachment(descriptor=descriptor, token=token)
+
+
+def find_owner(
+    auth_root: Path,
+    profile: Path,
+    config: AppConfig,
+    *,
+    wait_seconds: float = 0.0,
+) -> Attachment | None:
+    """Find an owner to attach to, optionally waiting for one to finish starting.
+
+    A :class:`DescriptorError` is not an absence. A descriptor that exists but
+    cannot be trusted, sitting beside a held lock, means a live daemon this
+    client cannot talk to, and treating that as "nobody is there" would start a
+    second browser on the profile the daemon is using.
+    """
+    deadline = time.monotonic() + max(wait_seconds, 0.0)
+    while True:
+        try:
+            attachment = _usable_attachment(auth_root, profile, config)
+        except DescriptorError as exc:
+            logger.info("Not attaching to the running daemon: %s", exc)
+            return None
+
+        if attachment is not None:
+            return attachment
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(_ATTACH_POLL_SECONDS)
+
+
+def daemon_would_be_used(config: AppConfig) -> bool:
+    """Whether this process is even a candidate for sharing a browser.
+
+    Separate from finding an owner, because it depends on nothing outside the
+    configuration and rules out the two cases where the question is moot.
+    """
+    if not config.server.daemon_enabled:
+        return False
+    # An explicit HTTP bind is already one server for many clients, so there is
+    # nothing for a daemon to deduplicate. Only stdio spawns a process per
+    # client, which is the whole reason this exists.
+    return config.server.transport == "stdio"

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -20,8 +20,16 @@ per-call handoff this feature exists to remove, and it is what two clients
 starting together would normally hit.
 
 One rule underpins the whole module: a file says nothing about whether the
-process that wrote it still exists. Only :meth:`DaemonLock.try_acquire` answers
-that. Every place this module was wrong before, it was wrong by forgetting it.
+process that wrote it still exists. Only :meth:`DaemonLock.try_acquire` settles
+who owns the browser, and only connecting settles whether anything is listening.
+Every place this module was wrong before, it was wrong by forgetting that — most
+recently about ``ATTACHABLE`` itself, which an owner leaves behind intact when it
+crashes after publishing.
+
+That is also why the only entry point returns an :class:`OwnerLookup` rather
+than an optional attachment. A convenience wrapper that handed back just the
+attachment existed here and was removed: it let a caller act on "there is a
+daemon" without the state that says how much that is worth.
 """
 
 from __future__ import annotations
@@ -225,31 +233,13 @@ def look_up_owner(
         # asked to stay near fail-fast. Measured before this clamp existed.
         remaining = deadline - time.monotonic()
         if remaining <= 0:
+            # The state at INFO, the detail at DEBUG. A reason can quote a path
+            # or host out of the descriptor, and "nothing usable was published"
+            # is the part that belongs in a log a user pastes into a report.
+            logger.info("No daemon to attach to (%s)", lookup.state.value)
+            logger.debug("Daemon lookup detail: %s", lookup.reason)
             return lookup
         time.sleep(min(_ATTACH_POLL_SECONDS, remaining))
-
-
-def find_owner(
-    auth_root: Path,
-    profile: Path,
-    config: AppConfig,
-    *,
-    wait_seconds: float = 0.0,
-) -> Attachment | None:
-    """The attachment alone, for callers that only want to talk to an owner.
-
-    Callers deciding what this process should *be* want
-    :func:`look_up_owner`: the reason there is no attachment governs what they
-    may do next, and it is lost here.
-    """
-    lookup = look_up_owner(auth_root, profile, config, wait_seconds=wait_seconds)
-    if lookup.state is not OwnerState.ATTACHABLE:
-        # The state at INFO, the detail at DEBUG. A reason can quote a path or
-        # host out of the descriptor, and "no daemon was usable" is the part
-        # that belongs in a log a user pastes into an issue report.
-        logger.info("Not attaching to a daemon (%s)", lookup.state.value)
-        logger.debug("Daemon lookup detail: %s", lookup.reason)
-    return lookup.attachment
 
 
 def daemon_would_be_used(config: AppConfig) -> bool:

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -49,11 +49,10 @@ _ATTACH_POLL_SECONDS = 0.1
 class OwnerState(enum.Enum):
     """What the published descriptor says, in the terms a caller must act on.
 
-    One verdict rather than "an owner or not", because the right response
-    differs and some of these are permanent. A client that reduced them all to
-    "nobody to attach to" would treat "an owner is starting" and "an owner is
-    running that I may not use" the same way, and only one of those is a reason
-    to open a second browser.
+    Strictly a reading of one file. None of these states knows whether the
+    process that wrote it still exists, which is why none of them decides who
+    owns the browser; they decide whether there is someone to *talk* to, and
+    what to say when there is not.
     """
 
     #: Nothing published. The ordinary first start.
@@ -62,11 +61,11 @@ class OwnerState(enum.Enum):
     #: Published and usable. Attach.
     ATTACHABLE = "attachable"
 
-    #: An owner exists and is running, but not for us: it serves a different
-    #: profile, or a configuration this client did not ask for. Permanent, not
-    #: a phase — the lock is per auth root, so sibling profiles share one
-    #: election and this client can neither attach nor elect itself.
-    LIVE_INCOMPATIBLE = "live_incompatible"
+    #: A descriptor we may not use: it names a different profile, runtime, or
+    #: configuration. Says nothing about whether that daemon is still running.
+    #: A crashed owner leaves a perfectly valid descriptor behind, so this is
+    #: "not for us", never "in use".
+    INCOMPATIBLE = "incompatible"
 
     #: A descriptor exists that cannot be trusted. Distinct from absence
     #: because it must not be *deleted* or explained away: beside a held lock
@@ -94,26 +93,29 @@ class OwnerLookup:
 
     @property
     def worth_attempting_election(self) -> bool:
-        """Whether becoming the owner is worth *trying*, never whether it is free.
+        """Whether to try the lock: true whenever there is nothing to attach to.
 
-        Nothing here can answer that. The descriptor and the lock are separate
-        artifacts that go out of step in both directions, and both directions
-        were reproduced on this tree:
+        Every state other than :attr:`OwnerState.ATTACHABLE` gets an attempt,
+        because none of them can tell whether the position is actually free.
+        The descriptor and the lock are separate artifacts that go out of step
+        in both directions, and each case below was reproduced on this tree:
 
         * lock held, nothing published yet — the ordinary startup window. Reads
-          as ``ABSENT``, and taking that for "the position is free" would put a
-          second browser on the profile.
+          as ``ABSENT``, so a "free" reading here would start a second browser.
         * lock free, a corrupt descriptor left by a crashed owner. Reads as
-          ``UNTRUSTED`` while ``try_acquire`` succeeds, and refusing on that
-          basis would strand the profile until someone deleted the file by hand.
+          ``UNTRUSTED`` while ``try_acquire`` succeeds.
+        * lock free, a *valid* descriptor left by a crashed owner that served a
+          sibling profile. Reads as ``INCOMPATIBLE`` while ``try_acquire``
+          succeeds. Nothing about a descriptor says its writer is alive.
 
-        So this only says the descriptor gives no reason *not* to try;
-        :meth:`DaemonLock.try_acquire` settles it, which is what its own
-        docstring says of the matching probe (``daemon_lock.py:382-407``).
-        A caller must attempt the lock and treat this state as the explanation
-        for what to do when the attempt fails, not as permission before it.
+        Refusing on any of those readings strands the profile until someone
+        deletes a file by hand. So this says only that there is no owner to
+        talk to; :meth:`DaemonLock.try_acquire` settles who owns, which is what
+        its own docstring says of the matching probe
+        (``daemon_lock.py:382-407``). The state is the explanation for a failed
+        attempt, never permission granted before one.
         """
-        return self.state in (OwnerState.ABSENT, OwnerState.UNTRUSTED)
+        return self.state is not OwnerState.ATTACHABLE
 
 
 def _inspect(auth_root: Path, profile: Path, config: AppConfig) -> OwnerLookup:
@@ -129,23 +131,19 @@ def _inspect(auth_root: Path, profile: Path, config: AppConfig) -> OwnerLookup:
     # Not enforced by read(), deliberately: it is the caller who knows which
     # runtime it belongs to. A host attaching to a container's daemon would be
     # handed a browser in a different filesystem namespace.
-    #
-    # Incompatible rather than absent, and that distinction is the point: the
-    # container's daemon holds the lock on the shared auth root, so this client
-    # cannot take the position either.
     if descriptor.runtime_id != get_runtime_id():
         return OwnerLookup(
-            state=OwnerState.LIVE_INCOMPATIBLE,
-            reason="the running daemon belongs to another runtime",
+            state=OwnerState.INCOMPATIBLE,
+            reason="the published daemon belongs to another runtime",
         )
 
     # The lock is per auth root, but a profile is what a browser opens. Two
-    # profiles side by side elect one owner between them, so an owner exists
-    # that is not *our* owner — permanently, not while it starts up.
+    # profiles side by side elect one owner between them, so a published owner
+    # can be one this client may not use.
     if not descriptor.serves(profile):
         return OwnerLookup(
-            state=OwnerState.LIVE_INCOMPATIBLE,
-            reason="the running daemon serves a different profile",
+            state=OwnerState.INCOMPATIBLE,
+            reason="the published daemon serves a different profile",
         )
 
     # No endpoint check here: `from_mapping` already refuses a non-local host
@@ -159,10 +157,10 @@ def _inspect(auth_root: Path, profile: Path, config: AppConfig) -> OwnerLookup:
         config, key=token
     ):
         return OwnerLookup(
-            state=OwnerState.LIVE_INCOMPATIBLE,
+            state=OwnerState.INCOMPATIBLE,
             # Names no values: the shared fields include a proxy password and
             # the path to someone's profile.
-            reason="the running daemon uses a different configuration",
+            reason="the published daemon uses a different configuration",
         )
 
     return OwnerLookup(
@@ -181,20 +179,22 @@ def look_up_owner(
 ) -> OwnerLookup:
     """Say what owner is out there, waiting only while that could still change.
 
-    Waiting is for exactly one state. ABSENT can become ATTACHABLE, because an
-    owner publishes only once it is listening and a client can arrive in that
-    window. LIVE_INCOMPATIBLE cannot: the lock is per auth root, so a daemon
-    serving another profile or configuration is not a phase this client can
-    wait out. Polling it would only delay an answer that will not change.
+    Waiting is for ``ABSENT`` alone, because that is the one reading a starting
+    owner produces: it publishes only once it is listening, so a client can
+    arrive after the lock was taken and before the file exists. The other
+    states are already answers. A descriptor that names another profile or a
+    configuration this client did not ask for will still name it in ten
+    seconds, and polling would only postpone the same verdict.
     """
     deadline = time.monotonic() + max(wait_seconds, 0.0)
     while True:
         try:
             lookup = _inspect(auth_root, profile, config)
         except DescriptorError as exc:
-            # Not an absence. Beside a held lock this is a live daemon this
-            # client cannot talk to, so the caller must not read it as licence
-            # to open a browser on the profile.
+            # Distinct from absence so the file is preserved rather than
+            # cleaned up: beside a held lock it belongs to a live daemon. It
+            # says nothing about whether the position is free, which is why
+            # this state still allows an election attempt.
             return OwnerLookup(state=OwnerState.UNTRUSTED, reason=str(exc))
 
         if lookup.state is not OwnerState.ABSENT:

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -68,9 +68,10 @@ class OwnerState(enum.Enum):
     #: election and this client can neither attach nor elect itself.
     LIVE_INCOMPATIBLE = "live_incompatible"
 
-    #: A descriptor exists that cannot be trusted. Never an absence: beside a
-    #: held lock it means a live daemon this client cannot talk to, and opening
-    #: a browser on that assumption is the corruption the lease exists to stop.
+    #: A descriptor exists that cannot be trusted. Distinct from absence
+    #: because it must not be *deleted* or explained away: beside a held lock
+    #: it is a live daemon this client cannot talk to. Whether the position is
+    #: actually free is still the lock's answer, not this one.
     UNTRUSTED = "untrusted"
 
 
@@ -92,14 +93,27 @@ class OwnerLookup:
     reason: str = ""
 
     @property
-    def may_elect_itself(self) -> bool:
-        """Whether this client is free to become the owner.
+    def worth_attempting_election(self) -> bool:
+        """Whether becoming the owner is worth *trying*, never whether it is free.
 
-        Only true when nobody holds the position. An untrusted descriptor is
-        deliberately excluded: it may be sitting beside a held lock, and the
-        election attempt itself is what settles that safely.
+        Nothing here can answer that. The descriptor and the lock are separate
+        artifacts that go out of step in both directions, and both directions
+        were reproduced on this tree:
+
+        * lock held, nothing published yet — the ordinary startup window. Reads
+          as ``ABSENT``, and taking that for "the position is free" would put a
+          second browser on the profile.
+        * lock free, a corrupt descriptor left by a crashed owner. Reads as
+          ``UNTRUSTED`` while ``try_acquire`` succeeds, and refusing on that
+          basis would strand the profile until someone deleted the file by hand.
+
+        So this only says the descriptor gives no reason *not* to try;
+        :meth:`DaemonLock.try_acquire` settles it, which is what its own
+        docstring says of the matching probe (``daemon_lock.py:382-407``).
+        A caller must attempt the lock and treat this state as the explanation
+        for what to do when the attempt fails, not as permission before it.
         """
-        return self.state is OwnerState.ABSENT
+        return self.state in (OwnerState.ABSENT, OwnerState.UNTRUSTED)
 
 
 def _inspect(auth_root: Path, profile: Path, config: AppConfig) -> OwnerLookup:

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import enum
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from linkedin_mcp_server import daemon_descriptor
@@ -79,7 +79,11 @@ class Attachment:
     """An owner worth talking to, and the credential for doing so."""
 
     descriptor: DaemonDescriptor
-    token: str
+    #: Kept out of the repr, as the proxy credentials are
+    #: (``config/schema.py:116-117``). This is a bearer token for a server that
+    #: drives a logged-in LinkedIn session, and the surrounding code logs whole
+    #: objects at DEBUG while users paste those logs into issue reports.
+    token: str = field(repr=False)
 
 
 @dataclass(frozen=True)

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -58,7 +58,10 @@ class OwnerState(enum.Enum):
     #: Nothing published. The ordinary first start.
     ABSENT = "absent"
 
-    #: Published and usable. Attach.
+    #: A descriptor this client may use, with a token to match. Says the file
+    #: is *compatible*, never that anyone is listening: an owner that crashes
+    #: after publishing leaves exactly this behind. Whether the endpoint
+    #: answers is settled by connecting, and who owns the browser by the lock.
     ATTACHABLE = "attachable"
 
     #: A descriptor we may not use: it names a different profile, runtime, or
@@ -92,34 +95,23 @@ class OwnerLookup:
 
     state: OwnerState
     attachment: Attachment | None = None
-    #: Why, in words worth logging. Never carries a token or a config value.
+    #: Why, for a log line. Never a token, and never a value read from the
+    #: configuration. It *can* name a path or host taken from the descriptor
+    #: when that is the diagnosis — an unusable profile path is only
+    #: actionable if you can see which path — so it is DEBUG-grade detail and
+    #: the callers here log it accordingly.
     reason: str = ""
 
     @property
-    def worth_attempting_election(self) -> bool:
-        """Whether to try the lock: true whenever there is nothing to attach to.
+    def worth_connecting(self) -> bool:
+        """Whether there is a compatible endpoint to try talking to.
 
-        Every state other than :attr:`OwnerState.ATTACHABLE` gets an attempt,
-        because none of them can tell whether the position is actually free.
-        The descriptor and the lock are separate artifacts that go out of step
-        in both directions, and each case below was reproduced on this tree:
-
-        * lock held, nothing published yet — the ordinary startup window. Reads
-          as ``ABSENT``, so a "free" reading here would start a second browser.
-        * lock free, a corrupt descriptor left by a crashed owner. Reads as
-          ``UNTRUSTED`` while ``try_acquire`` succeeds.
-        * lock free, a *valid* descriptor left by a crashed owner that served a
-          sibling profile. Reads as ``INCOMPATIBLE`` while ``try_acquire``
-          succeeds. Nothing about a descriptor says its writer is alive.
-
-        Refusing on any of those readings strands the profile until someone
-        deletes a file by hand. So this says only that there is no owner to
-        talk to; :meth:`DaemonLock.try_acquire` settles who owns, which is what
-        its own docstring says of the matching probe
-        (``daemon_lock.py:382-407``). The state is the explanation for a failed
-        attempt, never permission granted before one.
+        Deliberately not "an owner is running". Connecting is what establishes
+        that, and a caller whose connection is refused is looking at a crashed
+        owner's leftovers, not at a daemon. It must fall through to the lock
+        exactly as if nothing had been published.
         """
-        return self.state is not OwnerState.ATTACHABLE
+        return self.state is OwnerState.ATTACHABLE
 
 
 def _inspect(auth_root: Path, profile: Path, config: AppConfig) -> OwnerLookup:
@@ -170,7 +162,10 @@ def _inspect(auth_root: Path, profile: Path, config: AppConfig) -> OwnerLookup:
     return OwnerLookup(
         state=OwnerState.ATTACHABLE,
         attachment=Attachment(descriptor=descriptor, token=token),
-        reason="attached to the running daemon",
+        # Says what the file is, not what any process is doing. "attached to
+        # the running daemon" was the earlier wording and it was wrong twice
+        # over: nothing has attached yet, and the writer may be long dead.
+        reason="the published daemon is compatible with this client",
     )
 
 
@@ -181,21 +176,24 @@ def look_up_owner(
     *,
     wait_seconds: float = 0.0,
 ) -> OwnerLookup:
-    """Say what owner is out there, re-reading until one is usable or time runs out.
+    """Read the descriptor until it is compatible or the budget runs out.
 
-    Every unusable state is waited out, not just ``ABSENT``. The tempting rule
-    is that only ``ABSENT`` can turn into ``ATTACHABLE``, since a starting owner
-    publishes late. It is wrong for the same reason the election rule was: a
-    descriptor left by a *previous* owner survives that owner's death, so a
-    fresh owner starting right now is seen through the dead one's file.
-    Reproduced on this tree — an owner that crashed serving a sibling profile
-    reads as ``INCOMPATIBLE`` while its replacement is mid-startup, and
-    returning that immediately hands the caller a verdict about a process that
-    no longer exists.
+    Every state but ``ATTACHABLE`` is waited out, not just ``ABSENT``. The
+    tempting rule is that only ``ABSENT`` can turn into ``ATTACHABLE``, since a
+    starting owner publishes late. It is wrong for the same reason every other
+    mistake in this module was: a descriptor outlives the owner that wrote it,
+    so a fresh owner mid-startup is read through the dead one's file. Measured
+    on this tree — an owner that crashed serving a sibling profile reads as
+    ``INCOMPATIBLE`` while its replacement is coming up.
 
-    Callers pass a wait only when they have reason to think that is happening,
-    which in practice means having just lost the lock race: somebody holds it,
-    so somebody is starting. With the default of no wait this is a single read.
+    Stopping at ``ATTACHABLE`` is not the same claim. It says a compatible file
+    is on disk, which is all a re-read can ever establish; the process that
+    wrote it may be gone. A caller whose connection to that endpoint fails must
+    go to the lock rather than conclude a daemon exists.
+
+    Callers pass a wait only when they have reason to think an owner is
+    starting, which in practice means having just lost the lock race. With the
+    default of no wait this is a single read.
 
     Raises:
         ValueError: *wait_seconds* is not finite.
@@ -221,9 +219,14 @@ def look_up_owner(
 
         if lookup.state is OwnerState.ATTACHABLE:
             return lookup
-        if time.monotonic() >= deadline:
+
+        # Never sleep past the deadline. A flat poll interval turned a 1 ms
+        # budget into 101 ms, which is a hundredfold overrun for a caller that
+        # asked to stay near fail-fast. Measured before this clamp existed.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             return lookup
-        time.sleep(_ATTACH_POLL_SECONDS)
+        time.sleep(min(_ATTACH_POLL_SECONDS, remaining))
 
 
 def find_owner(
@@ -241,7 +244,11 @@ def find_owner(
     """
     lookup = look_up_owner(auth_root, profile, config, wait_seconds=wait_seconds)
     if lookup.state is not OwnerState.ATTACHABLE:
-        logger.info("Not attaching to a daemon: %s", lookup.reason)
+        # The state at INFO, the detail at DEBUG. A reason can quote a path or
+        # host out of the descriptor, and "no daemon was usable" is the part
+        # that belongs in a log a user pastes into an issue report.
+        logger.info("Not attaching to a daemon (%s)", lookup.state.value)
+        logger.debug("Daemon lookup detail: %s", lookup.reason)
     return lookup.attachment
 
 

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -6,8 +6,8 @@ moves on nearly every call, and every move reopens Chromium and revalidates the
 session against ``/feed/``. One long-lived owner removes that traffic entirely.
 
 This module is only the discovery half: it answers "is there an owner I should
-be talking to, and may I trust it with a token". Electing an owner, forwarding
-to it and supervising it build on this and land with the code that forwards.
+be talking to, and may I trust it with a token". Electing one, spawning it and
+forwarding to it build on this and land with the code that does them.
 
 Finding an owner takes a wait rather than a single read, because the interesting
 case is neither "an owner exists" nor "none does", but the window in between. An

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import math
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -195,7 +196,18 @@ def look_up_owner(
     Callers pass a wait only when they have reason to think that is happening,
     which in practice means having just lost the lock race: somebody holds it,
     so somebody is starting. With the default of no wait this is a single read.
+
+    Raises:
+        ValueError: *wait_seconds* is not finite.
     """
+    # A NaN or infinite budget makes `monotonic() >= deadline` false forever,
+    # so the stdio process would never finish starting. Refused rather than
+    # clamped: an infinite wait is a plausible thing for a caller to mean and a
+    # ruinous thing to grant, and the configuration parsers refuse non-finite
+    # timeouts on the same grounds. A negative wait is merely no wait.
+    if not math.isfinite(wait_seconds):
+        raise ValueError(f"wait_seconds must be a finite number, got {wait_seconds}")
+
     deadline = time.monotonic() + max(wait_seconds, 0.0)
     while True:
         try:

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -12,11 +12,16 @@ to it and supervising it build on this and land with the code that forwards.
 Finding an owner takes a wait rather than a single read, because the interesting
 case is neither "an owner exists" nor "none does", but the window in between. An
 owner takes the lock first and publishes its descriptor only once it is actually
-listening, so a client arriving in that gap sees no descriptor *and* loses the
-lock race. Reading that as "no daemon" is the one wrong answer: the process
-would drive its own browser against the same profile for its whole life, which
-is exactly the per-call handoff this feature exists to remove, and it is what
-two clients starting together would normally hit.
+listening, so a client arriving in that gap loses the lock race while the file
+still says whatever the *last* owner left there — nothing, or a descriptor that
+outlived its writer. Settling on either reading is how a process ends up driving
+its own browser against the same profile for its whole life, which is the
+per-call handoff this feature exists to remove, and it is what two clients
+starting together would normally hit.
+
+One rule underpins the whole module: a file says nothing about whether the
+process that wrote it still exists. Only :meth:`DaemonLock.try_acquire` answers
+that. Every place this module was wrong before, it was wrong by forgetting it.
 """
 
 from __future__ import annotations
@@ -34,15 +39,9 @@ from linkedin_mcp_server.session_state import get_runtime_id
 
 logger = logging.getLogger(__name__)
 
-#: How long to keep re-reading while an owner is starting up. It covers the gap
-#: between a lock being taken and the descriptor being published, which is a
-#: bind plus a server start, so this is generous rather than tuned. Waiting too
-#: long costs a slow first call; giving up too early costs a redundant browser
-#: for the life of the process.
-_ATTACH_WAIT_SECONDS = 10.0
-
 #: Re-read this often while waiting. Short enough that the common case (an owner
-#: that is nearly ready) does not feel like a stall.
+#: that is nearly ready) does not feel like a stall. How *long* to wait belongs
+#: to the caller that lost the lock race, not here.
 _ATTACH_POLL_SECONDS = 0.1
 
 
@@ -181,14 +180,21 @@ def look_up_owner(
     *,
     wait_seconds: float = 0.0,
 ) -> OwnerLookup:
-    """Say what owner is out there, waiting only while that could still change.
+    """Say what owner is out there, re-reading until one is usable or time runs out.
 
-    Waiting is for ``ABSENT`` alone, because that is the one reading a starting
-    owner produces: it publishes only once it is listening, so a client can
-    arrive after the lock was taken and before the file exists. The other
-    states are already answers. A descriptor that names another profile or a
-    configuration this client did not ask for will still name it in ten
-    seconds, and polling would only postpone the same verdict.
+    Every unusable state is waited out, not just ``ABSENT``. The tempting rule
+    is that only ``ABSENT`` can turn into ``ATTACHABLE``, since a starting owner
+    publishes late. It is wrong for the same reason the election rule was: a
+    descriptor left by a *previous* owner survives that owner's death, so a
+    fresh owner starting right now is seen through the dead one's file.
+    Reproduced on this tree — an owner that crashed serving a sibling profile
+    reads as ``INCOMPATIBLE`` while its replacement is mid-startup, and
+    returning that immediately hands the caller a verdict about a process that
+    no longer exists.
+
+    Callers pass a wait only when they have reason to think that is happening,
+    which in practice means having just lost the lock race: somebody holds it,
+    so somebody is starting. With the default of no wait this is a single read.
     """
     deadline = time.monotonic() + max(wait_seconds, 0.0)
     while True:
@@ -199,9 +205,9 @@ def look_up_owner(
             # cleaned up: beside a held lock it belongs to a live daemon. It
             # says nothing about whether the position is free, which is why
             # this state still allows an election attempt.
-            return OwnerLookup(state=OwnerState.UNTRUSTED, reason=str(exc))
+            lookup = OwnerLookup(state=OwnerState.UNTRUSTED, reason=str(exc))
 
-        if lookup.state is not OwnerState.ABSENT:
+        if lookup.state is OwnerState.ATTACHABLE:
             return lookup
         if time.monotonic() >= deadline:
             return lookup

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -21,6 +21,7 @@ two clients starting together would normally hit.
 
 from __future__ import annotations
 
+import enum
 import logging
 import time
 from dataclasses import dataclass
@@ -45,6 +46,34 @@ _ATTACH_WAIT_SECONDS = 10.0
 _ATTACH_POLL_SECONDS = 0.1
 
 
+class OwnerState(enum.Enum):
+    """What the published descriptor says, in the terms a caller must act on.
+
+    One verdict rather than "an owner or not", because the right response
+    differs and some of these are permanent. A client that reduced them all to
+    "nobody to attach to" would treat "an owner is starting" and "an owner is
+    running that I may not use" the same way, and only one of those is a reason
+    to open a second browser.
+    """
+
+    #: Nothing published. The ordinary first start.
+    ABSENT = "absent"
+
+    #: Published and usable. Attach.
+    ATTACHABLE = "attachable"
+
+    #: An owner exists and is running, but not for us: it serves a different
+    #: profile, or a configuration this client did not ask for. Permanent, not
+    #: a phase — the lock is per auth root, so sibling profiles share one
+    #: election and this client can neither attach nor elect itself.
+    LIVE_INCOMPATIBLE = "live_incompatible"
+
+    #: A descriptor exists that cannot be trusted. Never an absence: beside a
+    #: held lock it means a live daemon this client cannot talk to, and opening
+    #: a browser on that assumption is the corruption the lease exists to stop.
+    UNTRUSTED = "untrusted"
+
+
 @dataclass(frozen=True)
 class Attachment:
     """An owner worth talking to, and the credential for doing so."""
@@ -53,32 +82,57 @@ class Attachment:
     token: str
 
 
-def _usable_attachment(
-    auth_root: Path, profile: Path, config: AppConfig
-) -> Attachment | None:
-    """Whether the published descriptor describes a daemon we may attach to.
+@dataclass(frozen=True)
+class OwnerLookup:
+    """The verdict, and the attachment when there is one."""
 
-    Order matters. The cheap, local checks come first and the ones that touch
-    the endpoint come last, so a descriptor that is merely stale is rejected
-    without a connection attempt.
+    state: OwnerState
+    attachment: Attachment | None = None
+    #: Why, in words worth logging. Never carries a token or a config value.
+    reason: str = ""
+
+    @property
+    def may_elect_itself(self) -> bool:
+        """Whether this client is free to become the owner.
+
+        Only true when nobody holds the position. An untrusted descriptor is
+        deliberately excluded: it may be sitting beside a held lock, and the
+        election attempt itself is what settles that safely.
+        """
+        return self.state is OwnerState.ABSENT
+
+
+def _inspect(auth_root: Path, profile: Path, config: AppConfig) -> OwnerLookup:
+    """Read the descriptor once and say what it means.
+
+    Order matters. The cheap, local checks come first, so a descriptor that
+    already disqualifies itself is rejected before the token is read.
     """
     descriptor = daemon_descriptor.read(auth_root)
     if descriptor is None:
-        return None
+        return OwnerLookup(state=OwnerState.ABSENT, reason="no daemon is published")
 
     # Not enforced by read(), deliberately: it is the caller who knows which
     # runtime it belongs to. A host attaching to a container's daemon would be
     # handed a browser in a different filesystem namespace.
+    #
+    # Incompatible rather than absent, and that distinction is the point: the
+    # container's daemon holds the lock on the shared auth root, so this client
+    # cannot take the position either.
     if descriptor.runtime_id != get_runtime_id():
-        logger.debug("Daemon belongs to another runtime; not attaching")
-        return None
+        return OwnerLookup(
+            state=OwnerState.LIVE_INCOMPATIBLE,
+            reason="the running daemon belongs to another runtime",
+        )
 
     # The lock is per auth root, but a profile is what a browser opens. Two
     # profiles side by side elect one owner between them, so an owner exists
-    # that is not *our* owner.
+    # that is not *our* owner — permanently, not while it starts up.
     if not descriptor.serves(profile):
-        logger.debug("Daemon serves a different profile; not attaching")
-        return None
+        return OwnerLookup(
+            state=OwnerState.LIVE_INCOMPATIBLE,
+            reason="the running daemon serves a different profile",
+        )
 
     # No endpoint check here: `from_mapping` already refuses a non-local host
     # while parsing, so `read` above cannot return one. Repeating it would read
@@ -90,10 +144,50 @@ def _usable_attachment(
     if descriptor.config_fingerprint != daemon_descriptor.config_fingerprint(
         config, key=token
     ):
-        logger.debug("Daemon runs a different configuration; not attaching")
-        return None
+        return OwnerLookup(
+            state=OwnerState.LIVE_INCOMPATIBLE,
+            # Names no values: the shared fields include a proxy password and
+            # the path to someone's profile.
+            reason="the running daemon uses a different configuration",
+        )
 
-    return Attachment(descriptor=descriptor, token=token)
+    return OwnerLookup(
+        state=OwnerState.ATTACHABLE,
+        attachment=Attachment(descriptor=descriptor, token=token),
+        reason="attached to the running daemon",
+    )
+
+
+def look_up_owner(
+    auth_root: Path,
+    profile: Path,
+    config: AppConfig,
+    *,
+    wait_seconds: float = 0.0,
+) -> OwnerLookup:
+    """Say what owner is out there, waiting only while that could still change.
+
+    Waiting is for exactly one state. ABSENT can become ATTACHABLE, because an
+    owner publishes only once it is listening and a client can arrive in that
+    window. LIVE_INCOMPATIBLE cannot: the lock is per auth root, so a daemon
+    serving another profile or configuration is not a phase this client can
+    wait out. Polling it would only delay an answer that will not change.
+    """
+    deadline = time.monotonic() + max(wait_seconds, 0.0)
+    while True:
+        try:
+            lookup = _inspect(auth_root, profile, config)
+        except DescriptorError as exc:
+            # Not an absence. Beside a held lock this is a live daemon this
+            # client cannot talk to, so the caller must not read it as licence
+            # to open a browser on the profile.
+            return OwnerLookup(state=OwnerState.UNTRUSTED, reason=str(exc))
+
+        if lookup.state is not OwnerState.ABSENT:
+            return lookup
+        if time.monotonic() >= deadline:
+            return lookup
+        time.sleep(_ATTACH_POLL_SECONDS)
 
 
 def find_owner(
@@ -103,26 +197,16 @@ def find_owner(
     *,
     wait_seconds: float = 0.0,
 ) -> Attachment | None:
-    """Find an owner to attach to, optionally waiting for one to finish starting.
+    """The attachment alone, for callers that only want to talk to an owner.
 
-    A :class:`DescriptorError` is not an absence. A descriptor that exists but
-    cannot be trusted, sitting beside a held lock, means a live daemon this
-    client cannot talk to, and treating that as "nobody is there" would start a
-    second browser on the profile the daemon is using.
+    Callers deciding what this process should *be* want
+    :func:`look_up_owner`: the reason there is no attachment governs what they
+    may do next, and it is lost here.
     """
-    deadline = time.monotonic() + max(wait_seconds, 0.0)
-    while True:
-        try:
-            attachment = _usable_attachment(auth_root, profile, config)
-        except DescriptorError as exc:
-            logger.info("Not attaching to the running daemon: %s", exc)
-            return None
-
-        if attachment is not None:
-            return attachment
-        if time.monotonic() >= deadline:
-            return None
-        time.sleep(_ATTACH_POLL_SECONDS)
+    lookup = look_up_owner(auth_root, profile, config, wait_seconds=wait_seconds)
+    if lookup.state is not OwnerState.ATTACHABLE:
+        logger.info("Not attaching to a daemon: %s", lookup.reason)
+    return lookup.attachment
 
 
 def daemon_would_be_used(config: AppConfig) -> bool:

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -6,7 +6,6 @@ person profiles, company data, job information, and session management capabilit
 """
 
 import asyncio
-import enum
 import logging
 from typing import Any, AsyncIterator
 
@@ -28,6 +27,7 @@ from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
+from linkedin_mcp_server.server_role import ServerRole
 from linkedin_mcp_server.update_check import UpdateNoticeMiddleware
 from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.feed import register_feed_tools
@@ -37,39 +37,6 @@ from linkedin_mcp_server.tools.person import register_person_tools
 from linkedin_mcp_server.tools.post import register_post_tools
 
 logger = logging.getLogger(__name__)
-
-
-class ServerRole(enum.Enum):
-    """Which job a server process does for the shared LinkedIn profile.
-
-    One process per MCP client is the transport's doing, not a choice: a stdio
-    server is spawned per client instance. That makes "who drives Chromium" a
-    property of the process rather than of the code, and every difference below
-    follows from it.
-    """
-
-    #: Drives its own browser and talks to its own client. The historical
-    #: behaviour, and still what an explicit HTTP bind or an embedder gets.
-    DIRECT = "direct"
-
-    #: Drives the browser on behalf of other processes over loopback HTTP.
-    #: Never speaks to an end client, so nothing user-facing belongs here.
-    OWNER = "owner"
-
-    # A forwarding role belongs here too, but only once something actually
-    # forwards. Adding it now would mean a server that registers the local
-    # browser-backed tools and then declines to serialize them, which is a
-    # worse starting point than not having the role at all.
-
-    @property
-    def drives_browser(self) -> bool:
-        """Whether this role launches Chromium against the shared profile."""
-        return self in (ServerRole.DIRECT, ServerRole.OWNER)
-
-    @property
-    def faces_a_client(self) -> bool:
-        """Whether an end user reads this server's tool results."""
-        return self is ServerRole.DIRECT
 
 
 @lifespan

--- a/linkedin_mcp_server/server_role.py
+++ b/linkedin_mcp_server/server_role.py
@@ -1,0 +1,44 @@
+"""What job a server process does for the shared LinkedIn profile.
+
+Its own module, and deliberately free of imports from the rest of the package.
+The role decides how far down the stack behaviour differs — an owner must not
+open a login window, a proxy must not take the profile lease — so the modules
+that answer those questions need to read it. ``dependencies`` is one of them,
+and it cannot import from ``server``: ``server`` imports the tool modules, and
+those import ``dependencies``, so the edge would close the cycle.
+"""
+
+import enum
+
+
+class ServerRole(enum.Enum):
+    """Which job a server process does for the shared LinkedIn profile.
+
+    One process per MCP client is the transport's doing, not a choice: a stdio
+    server is spawned per client instance. That makes "who drives Chromium" a
+    property of the process rather than of the code, and every difference below
+    follows from it.
+    """
+
+    #: Drives its own browser and talks to its own client. The historical
+    #: behaviour, and still what an explicit HTTP bind or an embedder gets.
+    DIRECT = "direct"
+
+    #: Drives the browser on behalf of other processes over loopback HTTP.
+    #: Never speaks to an end client, so nothing user-facing belongs here.
+    OWNER = "owner"
+
+    # A forwarding role belongs here too, but only once something actually
+    # forwards. Adding it now would mean a server that registers the local
+    # browser-backed tools and then declines to serialize them, which is a
+    # worse starting point than not having the role at all.
+
+    @property
+    def drives_browser(self) -> bool:
+        """Whether this role launches Chromium against the shared profile."""
+        return self in (ServerRole.DIRECT, ServerRole.OWNER)
+
+    @property
+    def faces_a_client(self) -> bool:
+        """Whether an end user reads this server's tool results."""
+        return self is ServerRole.DIRECT

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -737,6 +737,56 @@ class TestLoaders:
         config = load_config()
         assert config.browser.eager_full_chromium is False
 
+    def test_daemon_enabled_default_is_false(self):
+        # Supervision and liveness are unfinished, so a shared browser-owning
+        # process is something you ask for, never something you get.
+        assert ServerConfig().daemon_enabled is False
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("false", False), ("true", True), ("0", False), ("1", True)],
+    )
+    def test_load_from_env_daemon_enabled(self, monkeypatch, value, expected):
+        monkeypatch.setenv("DAEMON_ENABLED", value)
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.server.daemon_enabled is expected
+
+    def test_load_from_args_daemon(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", "--daemon"])
+        from linkedin_mcp_server.config.loaders import load_from_args
+
+        config = load_from_args(AppConfig())
+        assert config.server.daemon_enabled is True
+
+    def test_load_from_args_no_daemon(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", "--no-daemon"])
+        from linkedin_mcp_server.config.loaders import load_from_args
+
+        config = AppConfig()
+        config.server.daemon_enabled = True
+        config = load_from_args(config)
+        assert config.server.daemon_enabled is False
+
+    def test_no_daemon_flag_overrides_env_true(self, monkeypatch):
+        # The way out for someone whose environment enables the daemon and who
+        # needs one process back on its own browser.
+        monkeypatch.setenv("DAEMON_ENABLED", "true")
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", "--no-daemon"])
+        from linkedin_mcp_server.config import load_config
+
+        config = load_config()
+        assert config.server.daemon_enabled is False
+
+    def test_daemon_enabled_absent_keeps_default(self, monkeypatch):
+        monkeypatch.delenv("DAEMON_ENABLED", raising=False)
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
+        from linkedin_mcp_server.config import load_config
+
+        config = load_config()
+        assert config.server.daemon_enabled is False
+
     def test_load_from_env_port(self, monkeypatch):
         monkeypatch.setenv("PORT", "9000")
         from linkedin_mcp_server.config.loaders import load_from_env

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -18,8 +18,10 @@ import linkedin_mcp_server.daemon as daemon_module
 import linkedin_mcp_server.daemon_descriptor as daemon_descriptor_module
 from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.daemon import (
+    OwnerState,
     daemon_would_be_used,
     find_owner,
+    look_up_owner,
 )
 from linkedin_mcp_server.daemon_descriptor import (
     build,
@@ -227,6 +229,89 @@ class TestWaitingForAStartingOwner:
         find_owner(tmp_path, profile, _config(profile))
 
         assert time.monotonic() - started < 0.2
+
+
+class TestTellingTheRefusalsApart:
+    """Why one verdict is not enough.
+
+    "No attachment" covers a first start, an owner still binding, an owner
+    running for someone else, and a descriptor that cannot be trusted. Only the
+    first of those is licence to open a browser on the profile, so collapsing
+    them is how a second Chromium ends up on a live session.
+    """
+
+    def test_nothing_published_is_the_only_case_that_may_elect_itself(
+        self, tmp_path: Path
+    ):
+        profile = tmp_path / "profile"
+        profile.mkdir()
+
+        lookup = look_up_owner(tmp_path, profile, _config(profile))
+
+        assert lookup.state is OwnerState.ABSENT
+        assert lookup.may_elect_itself
+
+    def test_a_live_incompatible_owner_may_not_be_displaced(self, tmp_path: Path):
+        # The lock is per auth root, so this client cannot take the position
+        # either. Electing itself would put a second browser on the auth root
+        # the running daemon owns.
+        theirs = tmp_path / "their-profile"
+        ours = tmp_path / "our-profile"
+        ours.mkdir()
+        _publish_owner(tmp_path, theirs, config=_config(ours))
+
+        lookup = look_up_owner(tmp_path, ours, _config(ours))
+
+        assert lookup.state is OwnerState.LIVE_INCOMPATIBLE
+        assert not lookup.may_elect_itself
+
+    def test_an_untrusted_descriptor_may_not_be_displaced(self, tmp_path: Path):
+        # Beside a held lock this is a live daemon we cannot talk to. Treating
+        # it as absence is the reading that opens a browser on a profile
+        # someone else is driving.
+        profile = tmp_path / "profile"
+        _publish_owner(tmp_path, profile)
+        descriptor_path(tmp_path).write_text("{not json", encoding="utf-8")
+
+        lookup = look_up_owner(tmp_path, profile, _config(profile))
+
+        assert lookup.state is OwnerState.UNTRUSTED
+        assert not lookup.may_elect_itself
+
+    def test_an_incompatible_owner_is_not_waited_out(self, tmp_path: Path):
+        # Waiting is for an owner that is still starting. A daemon serving
+        # another profile is not a phase, so polling would only stall a client
+        # for an answer that cannot change.
+        theirs = tmp_path / "their-profile"
+        ours = tmp_path / "our-profile"
+        ours.mkdir()
+        _publish_owner(tmp_path, theirs, config=_config(ours))
+
+        started = time.monotonic()
+        lookup = look_up_owner(tmp_path, ours, _config(ours), wait_seconds=5.0)
+
+        assert lookup.state is OwnerState.LIVE_INCOMPATIBLE
+        assert time.monotonic() - started < 1.0
+
+    def test_the_refusal_reason_carries_no_secret(self, tmp_path: Path):
+        # The shared configuration includes a proxy password. A mismatch has to
+        # say enough to act on and nothing more.
+        profile = tmp_path / "profile"
+        _publish_owner(
+            tmp_path,
+            profile,
+            config=_config(
+                profile,
+                proxy_server="http://proxy.example:8080",
+                proxy_password="hunter2-not-in-logs",
+            ),
+        )
+
+        lookup = look_up_owner(tmp_path, profile, _config(profile))
+
+        assert lookup.state is OwnerState.LIVE_INCOMPATIBLE
+        assert "hunter2-not-in-logs" not in lookup.reason
+        assert "proxy.example" not in lookup.reason
 
 
 class TestWhetherTheDaemonAppliesAtAll:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -334,20 +334,48 @@ class TestTellingTheRefusalsApart:
             contender.release()
         assert after_a_crash.state is OwnerState.UNTRUSTED
 
-    def test_an_incompatible_owner_is_not_waited_out(self, tmp_path: Path):
-        # Waiting is for an owner that is still starting. A daemon serving
-        # another profile is not a phase, so polling would only stall a client
-        # for an answer that cannot change.
+    def test_a_replacement_owner_is_seen_through_a_dead_descriptor(
+        self, tmp_path: Path
+    ):
+        # The tempting rule is that only ABSENT can become ATTACHABLE, because
+        # a starting owner publishes late. It is wrong: a descriptor outlives
+        # the owner that wrote it, so a fresh owner starting right now is read
+        # through the dead one's file. Returning that at once answers a
+        # question about a process that no longer exists.
+        theirs = tmp_path / "their-profile"
+        ours = tmp_path / "our-profile"
+        ours.mkdir()
+        _publish_owner(tmp_path, theirs, config=_config(ours))
+        replaced = threading.Event()
+
+        def replace_after_a_moment() -> None:
+            time.sleep(0.3)
+            _publish_owner(tmp_path, ours)
+            replaced.set()
+
+        starter = threading.Thread(target=replace_after_a_moment)
+        starter.start()
+        try:
+            lookup = look_up_owner(tmp_path, ours, _config(ours), wait_seconds=5.0)
+        finally:
+            starter.join()
+
+        assert replaced.is_set()
+        assert lookup.state is OwnerState.ATTACHABLE
+
+    def test_an_incompatible_descriptor_still_bounds_the_wait(self, tmp_path: Path):
+        # Nothing replaces it, so the caller has to get its answer. A client
+        # blocked here is a client whose first tool call never returns.
         theirs = tmp_path / "their-profile"
         ours = tmp_path / "our-profile"
         ours.mkdir()
         _publish_owner(tmp_path, theirs, config=_config(ours))
 
         started = time.monotonic()
-        lookup = look_up_owner(tmp_path, ours, _config(ours), wait_seconds=5.0)
+        lookup = look_up_owner(tmp_path, ours, _config(ours), wait_seconds=0.3)
 
         assert lookup.state is OwnerState.INCOMPATIBLE
-        assert time.monotonic() - started < 1.0
+        assert time.monotonic() - started >= 0.3
 
     def test_the_refusal_reason_carries_no_secret(self, tmp_path: Path):
         # The shared configuration includes a proxy password. A mismatch has to

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -98,6 +98,21 @@ class TestAttaching:
 
         assert find_owner(tmp_path, profile, _config(profile)) is None
 
+    def test_the_token_stays_out_of_the_repr(self, tmp_path: Path):
+        # This is a bearer token for a server driving a logged-in LinkedIn
+        # session. Surrounding code logs whole objects at DEBUG and users paste
+        # those logs into issue reports, so a default dataclass repr is how the
+        # credential leaves the machine.
+        profile = tmp_path / "profile"
+        token = _publish_owner(tmp_path, profile)
+
+        lookup = look_up_owner(tmp_path, profile, _config(profile))
+
+        assert lookup.attachment is not None
+        assert lookup.attachment.token == token
+        assert token not in repr(lookup.attachment)
+        assert token not in repr(lookup)
+
 
 class TestRefusing:
     def test_a_daemon_from_another_runtime_is_refused(self, tmp_path: Path):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -30,6 +30,7 @@ from linkedin_mcp_server.daemon_descriptor import (
     new_token,
     publish,
 )
+from linkedin_mcp_server.daemon_lock import DaemonLock
 
 _RUNTIME = "macos-arm64-host"
 
@@ -240,21 +241,19 @@ class TestTellingTheRefusalsApart:
     them is how a second Chromium ends up on a live session.
     """
 
-    def test_nothing_published_is_the_only_case_that_may_elect_itself(
-        self, tmp_path: Path
-    ):
+    def test_nothing_published_is_worth_an_election_attempt(self, tmp_path: Path):
         profile = tmp_path / "profile"
         profile.mkdir()
 
         lookup = look_up_owner(tmp_path, profile, _config(profile))
 
         assert lookup.state is OwnerState.ABSENT
-        assert lookup.may_elect_itself
+        assert lookup.worth_attempting_election
 
-    def test_a_live_incompatible_owner_may_not_be_displaced(self, tmp_path: Path):
+    def test_a_live_incompatible_owner_is_not_worth_displacing(self, tmp_path: Path):
         # The lock is per auth root, so this client cannot take the position
-        # either. Electing itself would put a second browser on the auth root
-        # the running daemon owns.
+        # either. Trying would put a second browser on the auth root the
+        # running daemon owns.
         theirs = tmp_path / "their-profile"
         ours = tmp_path / "our-profile"
         ours.mkdir()
@@ -263,12 +262,15 @@ class TestTellingTheRefusalsApart:
         lookup = look_up_owner(tmp_path, ours, _config(ours))
 
         assert lookup.state is OwnerState.LIVE_INCOMPATIBLE
-        assert not lookup.may_elect_itself
+        assert not lookup.worth_attempting_election
 
-    def test_an_untrusted_descriptor_may_not_be_displaced(self, tmp_path: Path):
-        # Beside a held lock this is a live daemon we cannot talk to. Treating
-        # it as absence is the reading that opens a browser on a profile
-        # someone else is driving.
+    def test_an_untrusted_descriptor_is_kept_but_does_not_block_an_attempt(
+        self, tmp_path: Path
+    ):
+        # Two things that look alike and are not. The file must survive — beside
+        # a held lock it belongs to a live daemon. But a crashed owner leaves
+        # exactly this file behind with the lock free, so refusing to even try
+        # would strand the profile until someone deleted it by hand.
         profile = tmp_path / "profile"
         _publish_owner(tmp_path, profile)
         descriptor_path(tmp_path).write_text("{not json", encoding="utf-8")
@@ -276,7 +278,36 @@ class TestTellingTheRefusalsApart:
         lookup = look_up_owner(tmp_path, profile, _config(profile))
 
         assert lookup.state is OwnerState.UNTRUSTED
-        assert not lookup.may_elect_itself
+        assert lookup.attachment is None
+        assert descriptor_path(tmp_path).exists()
+        assert lookup.worth_attempting_election
+
+    def test_the_descriptor_never_answers_who_holds_the_lock(self, tmp_path: Path):
+        # The artifacts go out of step in both directions, so no reading of one
+        # settles the other. Both halves reproduced here; the lock is the only
+        # authority, and taking it is what asks.
+        profile = tmp_path / "profile"
+        profile.mkdir()
+
+        # Held, nothing published: the ordinary startup window.
+        holder = DaemonLock(tmp_path)
+        assert holder.try_acquire()
+        try:
+            during_startup = look_up_owner(tmp_path, profile, _config(profile))
+        finally:
+            holder.release()
+        assert during_startup.state is OwnerState.ABSENT
+
+        # Free, a corrupt descriptor left behind by a crash.
+        _publish_owner(tmp_path, profile)
+        descriptor_path(tmp_path).write_text("{not json", encoding="utf-8")
+        after_a_crash = look_up_owner(tmp_path, profile, _config(profile))
+        contender = DaemonLock(tmp_path)
+        try:
+            assert contender.try_acquire(), "the lock is free despite the descriptor"
+        finally:
+            contender.release()
+        assert after_a_crash.state is OwnerState.UNTRUSTED
 
     def test_an_incompatible_owner_is_not_waited_out(self, tmp_path: Path):
         # Waiting is for an owner that is still starting. A daemon serving

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -273,22 +273,34 @@ class TestWaitingForAStartingOwner:
 
     @pytest.mark.parametrize("budget", [0.001, 0.01])
     def test_a_small_budget_is_not_rounded_up_to_a_poll(
-        self, tmp_path: Path, budget: float
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, budget: float
     ):
         # A flat poll interval turned a 1 ms budget into 101 ms: a caller who
-        # asked to stay near fail-fast paid a hundredfold. The lower bound was
-        # the only thing asserted before, which cannot see this.
+        # asked to stay near fail-fast paid a hundredfold.
+        #
+        # Asserts what the code *asks for*, not what the clock shows. An upper
+        # bound on elapsed time fails on a descheduled runner even when the
+        # request was correct — reproduced: a 0.8 ms sleep request measured
+        # 66 ms of wall time. That is a test failing at the machine rather than
+        # at the code, and in CI it would be indistinguishable from a real bug.
         profile = tmp_path / "profile"
         profile.mkdir()
 
+        requested: list[float] = []
+        real_sleep = time.sleep
+
+        def record(duration: float) -> None:
+            requested.append(duration)
+            real_sleep(duration)
+
+        monkeypatch.setattr(daemon_module.time, "sleep", record)
+
         started = time.monotonic()
         look_up_owner(tmp_path, profile, _config(profile), wait_seconds=budget)
-        elapsed = time.monotonic() - started
 
-        assert elapsed >= budget
-        # Generous, because a loaded machine can stretch any wall-clock bound.
-        # Even so it fails by a wide margin against a full unclamped poll.
-        assert elapsed < budget + 0.05
+        assert time.monotonic() - started >= budget
+        assert requested, "a positive budget has to poll at least once"
+        assert max(requested) <= budget
 
     def test_a_negative_wait_is_simply_no_wait(self, tmp_path: Path):
         # Unlike a non-finite budget, this one has an obvious reading.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -170,12 +170,13 @@ class TestRefusing:
         profile = tmp_path / "profile"
         token = _publish_owner(tmp_path, profile, host="198.51.100.7")
 
-        with caplog.at_level("INFO", logger="linkedin_mcp_server.daemon"):
+        with caplog.at_level("DEBUG", logger="linkedin_mcp_server.daemon"):
             assert find_owner(tmp_path, profile, _config(profile)) is None
 
-        # Refused for the right reason, and loudly: a silent None here reads
-        # like an ordinary first start rather than a descriptor pointing off
-        # the machine.
+        # Refused for the right reason, and it says so: a silent None here
+        # reads like an ordinary first start rather than a descriptor pointing
+        # off the machine. The address is DEBUG-grade, because a reason can
+        # quote a path or host out of the descriptor.
         assert "198.51.100.7" in caplog.text
         # And the token itself never appears in what we log about the refusal.
         assert token not in caplog.text
@@ -271,6 +272,25 @@ class TestWaitingForAStartingOwner:
         with pytest.raises(ValueError):
             look_up_owner(tmp_path, profile, _config(profile), wait_seconds=budget)
 
+    @pytest.mark.parametrize("budget", [0.001, 0.01])
+    def test_a_small_budget_is_not_rounded_up_to_a_poll(
+        self, tmp_path: Path, budget: float
+    ):
+        # A flat poll interval turned a 1 ms budget into 101 ms: a caller who
+        # asked to stay near fail-fast paid a hundredfold. The lower bound was
+        # the only thing asserted before, which cannot see this.
+        profile = tmp_path / "profile"
+        profile.mkdir()
+
+        started = time.monotonic()
+        look_up_owner(tmp_path, profile, _config(profile), wait_seconds=budget)
+        elapsed = time.monotonic() - started
+
+        assert elapsed >= budget
+        # Generous, because a loaded machine can stretch any wall-clock bound.
+        # Even so it fails by a wide margin against a full unclamped poll.
+        assert elapsed < budget + 0.05
+
     def test_a_negative_wait_is_simply_no_wait(self, tmp_path: Path):
         # Unlike a non-finite budget, this one has an obvious reading.
         profile = tmp_path / "profile"
@@ -310,7 +330,7 @@ class TestTellingTheRefusalsApart:
         lookup = look_up_owner(tmp_path, profile, _config(profile))
 
         assert lookup.state is OwnerState.ABSENT
-        assert lookup.worth_attempting_election
+        assert not lookup.worth_connecting
 
     def test_an_incompatible_descriptor_does_not_block_an_attempt_either(
         self, tmp_path: Path
@@ -334,7 +354,7 @@ class TestTellingTheRefusalsApart:
         assert lookup.state is OwnerState.INCOMPATIBLE
         assert lookup.attachment is None
         assert lock_is_free, "a crashed owner leaves the descriptor, not the lock"
-        assert lookup.worth_attempting_election
+        assert not lookup.worth_connecting
 
     def test_an_untrusted_descriptor_is_kept_but_does_not_block_an_attempt(
         self, tmp_path: Path
@@ -352,7 +372,7 @@ class TestTellingTheRefusalsApart:
         assert lookup.state is OwnerState.UNTRUSTED
         assert lookup.attachment is None
         assert descriptor_path(tmp_path).exists()
-        assert lookup.worth_attempting_election
+        assert not lookup.worth_connecting
 
     def test_the_descriptor_never_answers_who_holds_the_lock(self, tmp_path: Path):
         # The artifacts go out of step in both directions, so no reading of one
@@ -424,6 +444,31 @@ class TestTellingTheRefusalsApart:
         assert lookup.state is OwnerState.INCOMPATIBLE
         assert time.monotonic() - started >= 0.3
 
+    def test_a_matching_descriptor_from_a_dead_owner_is_still_only_a_file(
+        self, tmp_path: Path
+    ):
+        # The state this module was most likely to over-read. An owner that
+        # crashes *after* publishing leaves a descriptor and token that pass
+        # every check, so the reading is ATTACHABLE while the lock is free and
+        # nothing is listening. Connecting is what finds that out; a caller
+        # whose connection fails has to fall through to the lock rather than
+        # conclude a daemon exists.
+        profile = tmp_path / "profile"
+        _publish_owner(tmp_path, profile)
+
+        lookup = look_up_owner(tmp_path, profile, _config(profile))
+        contender = DaemonLock(tmp_path)
+        try:
+            lock_is_free = contender.try_acquire()
+        finally:
+            contender.release()
+
+        assert lookup.state is OwnerState.ATTACHABLE
+        assert lock_is_free, "the owner is dead; only its file remains"
+        # Says what the file is, never that anything is running or attached.
+        assert "running" not in lookup.reason
+        assert "attached" not in lookup.reason
+
     def test_the_refusal_reason_carries_no_secret(self, tmp_path: Path):
         # The shared configuration includes a proxy password. A mismatch has to
         # say enough to act on and nothing more.
@@ -443,6 +488,23 @@ class TestTellingTheRefusalsApart:
         assert lookup.state is OwnerState.INCOMPATIBLE
         assert "hunter2-not-in-logs" not in lookup.reason
         assert "proxy.example" not in lookup.reason
+
+    def test_a_path_in_a_reason_stays_out_of_the_info_log(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        # A reason can quote a path out of the descriptor, because an unusable
+        # profile path is only actionable if you can see which one. INFO is
+        # what users paste into issue reports, so the detail belongs a level
+        # down and only the state stays up.
+        profile = tmp_path / "profile"
+        _publish_owner(tmp_path, profile)
+        descriptor_path(tmp_path).write_text("{not json", encoding="utf-8")
+
+        with caplog.at_level("INFO", logger="linkedin_mcp_server.daemon"):
+            find_owner(tmp_path, profile, _config(profile))
+
+        assert "untrusted" in caplog.text
+        assert "not valid JSON" not in caplog.text
 
 
 class TestWhetherTheDaemonAppliesAtAll:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -29,6 +29,8 @@ from linkedin_mcp_server.daemon_descriptor import (
     new_instance_id,
     new_token,
     publish,
+    read,
+    token_path,
 )
 from linkedin_mcp_server.daemon_lock import DaemonLock
 
@@ -177,6 +179,28 @@ class TestRefusing:
         assert "198.51.100.7" in caplog.text
         # And the token itself never appears in what we log about the refusal.
         assert token not in caplog.text
+
+    def test_a_descriptor_with_no_token_beside_it_is_untrusted(self, tmp_path: Path):
+        # The pair can come apart: a half-finished publish, or a token file
+        # removed under a descriptor that stays. There is nothing to
+        # authenticate with, and inventing a fallback would mean talking to a
+        # daemon we cannot prove is ours.
+        #
+        # Two independent refusals cover this, which is why the test asserts
+        # the outcome rather than one mechanism: the token read treats absence
+        # as an error, and the digest comparison that follows would reject a
+        # missing token anyway. Verified by disabling the first — the second
+        # still refuses.
+        profile = tmp_path / "profile"
+        _publish_owner(tmp_path, profile)
+        published = read(tmp_path)
+        assert published is not None
+        token_path(tmp_path, published.instance_id).unlink()
+
+        lookup = look_up_owner(tmp_path, profile, _config(profile))
+
+        assert lookup.state is OwnerState.UNTRUSTED
+        assert lookup.attachment is None
 
     def test_an_unreadable_descriptor_is_not_read_as_absence(self, tmp_path: Path):
         # This is the dangerous confusion. A corrupt descriptor beside a held

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,252 @@
+"""When a client attaches to a running daemon, and when it must not.
+
+Attaching means sending a bearer token to an address read from a file and then
+driving a logged-in LinkedIn session through whatever answers. Most of these
+tests pin a case where that must not happen; the rest pin the one window where
+refusing is just as wrong as attaching.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import linkedin_mcp_server.daemon as daemon_module
+import linkedin_mcp_server.daemon_descriptor as daemon_descriptor_module
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon import (
+    daemon_would_be_used,
+    find_owner,
+)
+from linkedin_mcp_server.daemon_descriptor import (
+    build,
+    descriptor_path,
+    new_instance_id,
+    new_token,
+    publish,
+)
+
+_RUNTIME = "macos-arm64-host"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_daemon_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    # Production state lives under the user's private application directory.
+    monkeypatch.setattr(daemon_descriptor_module, "_account_home", lambda: tmp_path)
+    monkeypatch.setattr(daemon_module, "get_runtime_id", lambda: _RUNTIME)
+
+
+def _config(profile: Path, **browser: object) -> AppConfig:
+    config = AppConfig()
+    config.browser.user_data_dir = str(profile)
+    for name, value in browser.items():
+        setattr(config.browser, name, value)
+    return config
+
+
+def _publish_owner(
+    auth_root: Path,
+    profile: Path,
+    *,
+    config: AppConfig | None = None,
+    runtime_id: str = _RUNTIME,
+    host: str = "127.0.0.1",
+) -> str:
+    """Publish a descriptor as a live owner would, and return its token."""
+    profile.mkdir(parents=True, exist_ok=True)
+    token = new_token()
+    publish(
+        auth_root,
+        build(
+            instance_id=new_instance_id(),
+            package_version="4.20.0",
+            runtime_id=runtime_id,
+            profile=profile,
+            host=host,
+            port=49152,
+            path="/mcp",
+            token=token,
+            config=config or _config(profile),
+            log_path=auth_root / "daemon.log",
+        ),
+        token,
+    )
+    return token
+
+
+class TestAttaching:
+    def test_a_matching_owner_is_attached_to(self, tmp_path: Path):
+        profile = tmp_path / "profile"
+        token = _publish_owner(tmp_path, profile)
+
+        attachment = find_owner(tmp_path, profile, _config(profile))
+
+        assert attachment is not None
+        assert attachment.token == token
+        assert attachment.descriptor.url == "http://127.0.0.1:49152/mcp"
+
+    def test_no_daemon_is_not_an_error(self, tmp_path: Path):
+        # The ordinary first-start case. Nothing published, nobody to talk to.
+        profile = tmp_path / "profile"
+        profile.mkdir()
+
+        assert find_owner(tmp_path, profile, _config(profile)) is None
+
+
+class TestRefusing:
+    def test_a_daemon_from_another_runtime_is_refused(self, tmp_path: Path):
+        # A host and a container share the mounted auth root but not their
+        # filesystems. Attaching across that boundary hands back a browser
+        # running against a profile in a different namespace.
+        profile = tmp_path / "profile"
+        _publish_owner(tmp_path, profile, runtime_id="docker-abc123")
+
+        assert find_owner(tmp_path, profile, _config(profile)) is None
+
+    def test_a_daemon_serving_another_profile_is_refused(self, tmp_path: Path):
+        # The lock is per auth root, but a browser opens a profile. Sibling
+        # profiles elect one owner between them, so an owner can exist that is
+        # not this client's owner.
+        theirs = tmp_path / "their-profile"
+        ours = tmp_path / "our-profile"
+        ours.mkdir()
+
+        # Published with our configuration, not theirs. Otherwise the profile
+        # path reaches the fingerprint too and that check does the refusing,
+        # leaving this one passing whether or not the profile is compared.
+        # Verified by removing the check: the test still passed.
+        _publish_owner(tmp_path, theirs, config=_config(ours))
+
+        assert find_owner(tmp_path, ours, _config(ours)) is None
+
+    def test_a_daemon_with_a_different_configuration_is_refused(self, tmp_path: Path):
+        # Attaching anyway would silently give the client a browser configured
+        # differently from the one it asked for — a different proxy, in this
+        # case, which is the difference between traffic leaving the machine one
+        # way or another.
+        profile = tmp_path / "profile"
+        _publish_owner(
+            tmp_path,
+            profile,
+            config=_config(profile, proxy_server="http://proxy.example:8080"),
+        )
+
+        assert find_owner(tmp_path, profile, _config(profile)) is None
+
+    def test_an_off_machine_endpoint_is_refused_before_the_token_is_sent(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        # The descriptor is a file, so its host is whatever was last written
+        # there. Posting a bearer token to it unchecked would turn a corrupted
+        # file into a way to hand the session to another machine.
+        #
+        # The refusal happens while parsing, in `from_mapping`, so it is in
+        # force before anything here can act on the host. This test pins the
+        # behaviour at the boundary a client actually calls, so that moving the
+        # check would surface here rather than silently going missing.
+        profile = tmp_path / "profile"
+        token = _publish_owner(tmp_path, profile, host="198.51.100.7")
+
+        with caplog.at_level("INFO", logger="linkedin_mcp_server.daemon"):
+            assert find_owner(tmp_path, profile, _config(profile)) is None
+
+        # Refused for the right reason, and loudly: a silent None here reads
+        # like an ordinary first start rather than a descriptor pointing off
+        # the machine.
+        assert "198.51.100.7" in caplog.text
+        # And the token itself never appears in what we log about the refusal.
+        assert token not in caplog.text
+
+    def test_an_unreadable_descriptor_is_not_read_as_absence(self, tmp_path: Path):
+        # This is the dangerous confusion. A corrupt descriptor beside a held
+        # lock means a live daemon this client cannot talk to. Returning None
+        # says "attach to nobody", which is correct; what must never happen is
+        # deleting it or concluding the profile is free.
+        profile = tmp_path / "profile"
+        _publish_owner(tmp_path, profile)
+        descriptor_path(tmp_path).write_text("{not json", encoding="utf-8")
+
+        assert find_owner(tmp_path, profile, _config(profile)) is None
+        assert descriptor_path(tmp_path).exists()
+
+
+class TestWaitingForAStartingOwner:
+    """The window between a lock being taken and a descriptor being published.
+
+    An owner binds and starts serving before it publishes, so a client that
+    arrives in between sees no descriptor and also cannot take the lock. That is
+    the normal two-client startup, and treating it as "no daemon" would leave
+    this process driving its own browser against the same profile for its whole
+    life — the per-call handoff the daemon exists to remove.
+    """
+
+    def test_an_owner_that_publishes_late_is_still_found(self, tmp_path: Path):
+        profile = tmp_path / "profile"
+        profile.mkdir()
+        published = threading.Event()
+
+        def publish_after_a_moment() -> None:
+            time.sleep(0.3)
+            _publish_owner(tmp_path, profile)
+            published.set()
+
+        starter = threading.Thread(target=publish_after_a_moment)
+        starter.start()
+        try:
+            attachment = find_owner(
+                tmp_path, profile, _config(profile), wait_seconds=5.0
+            )
+        finally:
+            starter.join()
+
+        assert published.is_set()
+        assert attachment is not None
+
+    def test_waiting_gives_up_rather_than_hanging(self, tmp_path: Path):
+        # Nothing ever publishes. The caller has to get an answer, because a
+        # client blocked here is a client whose first tool call never returns.
+        profile = tmp_path / "profile"
+        profile.mkdir()
+
+        started = time.monotonic()
+        attachment = find_owner(tmp_path, profile, _config(profile), wait_seconds=0.3)
+
+        assert attachment is None
+        assert time.monotonic() - started >= 0.3
+
+    def test_not_waiting_is_the_default(self, tmp_path: Path):
+        # Callers that only want to know the current state must not pay for a
+        # wait they did not ask for.
+        profile = tmp_path / "profile"
+        profile.mkdir()
+
+        started = time.monotonic()
+        find_owner(tmp_path, profile, _config(profile))
+
+        assert time.monotonic() - started < 0.2
+
+
+class TestWhetherTheDaemonAppliesAtAll:
+    def test_the_daemon_is_off_by_default(self):
+        # Supervision and liveness are unfinished, so nobody gets this without
+        # asking for it.
+        assert daemon_would_be_used(AppConfig()) is False
+
+    def test_an_explicit_http_bind_does_not_use_a_daemon(self):
+        # HTTP already serves every client from one process, so there is
+        # nothing to deduplicate and a second listener would only add a hop.
+        config = AppConfig()
+        config.server.daemon_enabled = True
+        config.server.transport = "streamable-http"
+
+        assert daemon_would_be_used(config) is False
+
+    def test_stdio_with_the_flag_on_uses_a_daemon(self):
+        config = AppConfig()
+        config.server.daemon_enabled = True
+
+        assert config.server.transport == "stdio"
+        assert daemon_would_be_used(config) is True

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -250,19 +250,29 @@ class TestTellingTheRefusalsApart:
         assert lookup.state is OwnerState.ABSENT
         assert lookup.worth_attempting_election
 
-    def test_a_live_incompatible_owner_is_not_worth_displacing(self, tmp_path: Path):
-        # The lock is per auth root, so this client cannot take the position
-        # either. Trying would put a second browser on the auth root the
-        # running daemon owns.
+    def test_an_incompatible_descriptor_does_not_block_an_attempt_either(
+        self, tmp_path: Path
+    ):
+        # A valid descriptor is no more proof of a living owner than a corrupt
+        # one. An owner for a sibling profile that crashed leaves exactly this
+        # behind with the lock free, so refusing here strands the profile for
+        # good — nothing would ever clean the file up.
         theirs = tmp_path / "their-profile"
         ours = tmp_path / "our-profile"
         ours.mkdir()
         _publish_owner(tmp_path, theirs, config=_config(ours))
 
         lookup = look_up_owner(tmp_path, ours, _config(ours))
+        contender = DaemonLock(tmp_path)
+        try:
+            lock_is_free = contender.try_acquire()
+        finally:
+            contender.release()
 
-        assert lookup.state is OwnerState.LIVE_INCOMPATIBLE
-        assert not lookup.worth_attempting_election
+        assert lookup.state is OwnerState.INCOMPATIBLE
+        assert lookup.attachment is None
+        assert lock_is_free, "a crashed owner leaves the descriptor, not the lock"
+        assert lookup.worth_attempting_election
 
     def test_an_untrusted_descriptor_is_kept_but_does_not_block_an_attempt(
         self, tmp_path: Path
@@ -321,7 +331,7 @@ class TestTellingTheRefusalsApart:
         started = time.monotonic()
         lookup = look_up_owner(tmp_path, ours, _config(ours), wait_seconds=5.0)
 
-        assert lookup.state is OwnerState.LIVE_INCOMPATIBLE
+        assert lookup.state is OwnerState.INCOMPATIBLE
         assert time.monotonic() - started < 1.0
 
     def test_the_refusal_reason_carries_no_secret(self, tmp_path: Path):
@@ -340,7 +350,7 @@ class TestTellingTheRefusalsApart:
 
         lookup = look_up_owner(tmp_path, profile, _config(profile))
 
-        assert lookup.state is OwnerState.LIVE_INCOMPATIBLE
+        assert lookup.state is OwnerState.INCOMPATIBLE
         assert "hunter2-not-in-logs" not in lookup.reason
         assert "proxy.example" not in lookup.reason
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -235,6 +235,29 @@ class TestWaitingForAStartingOwner:
         assert attachment is None
         assert time.monotonic() - started >= 0.3
 
+    @pytest.mark.parametrize("budget", [float("nan"), float("inf")])
+    def test_a_wait_that_never_ends_is_refused(self, tmp_path: Path, budget: float):
+        # `monotonic() >= nan` is false forever and so is `>= inf`, so either
+        # one turns the poll into a process that never finishes starting.
+        # Refused rather than clamped: an unbounded wait is a plausible thing
+        # to mean and a ruinous thing to grant.
+        profile = tmp_path / "profile"
+        profile.mkdir()
+
+        with pytest.raises(ValueError):
+            look_up_owner(tmp_path, profile, _config(profile), wait_seconds=budget)
+
+    def test_a_negative_wait_is_simply_no_wait(self, tmp_path: Path):
+        # Unlike a non-finite budget, this one has an obvious reading.
+        profile = tmp_path / "profile"
+        profile.mkdir()
+
+        started = time.monotonic()
+        lookup = look_up_owner(tmp_path, profile, _config(profile), wait_seconds=-5.0)
+
+        assert lookup.state is OwnerState.ABSENT
+        assert time.monotonic() - started < 0.2
+
     def test_not_waiting_is_the_default(self, tmp_path: Path):
         # Callers that only want to know the current state must not pay for a
         # wait they did not ask for.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -20,7 +20,6 @@ from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.daemon import (
     OwnerState,
     daemon_would_be_used,
-    find_owner,
     look_up_owner,
 )
 from linkedin_mcp_server.daemon_descriptor import (
@@ -87,7 +86,7 @@ class TestAttaching:
         profile = tmp_path / "profile"
         token = _publish_owner(tmp_path, profile)
 
-        attachment = find_owner(tmp_path, profile, _config(profile))
+        attachment = look_up_owner(tmp_path, profile, _config(profile)).attachment
 
         assert attachment is not None
         assert attachment.token == token
@@ -98,7 +97,7 @@ class TestAttaching:
         profile = tmp_path / "profile"
         profile.mkdir()
 
-        assert find_owner(tmp_path, profile, _config(profile)) is None
+        assert look_up_owner(tmp_path, profile, _config(profile)).attachment is None
 
     def test_the_token_stays_out_of_the_repr(self, tmp_path: Path):
         # This is a bearer token for a server driving a logged-in LinkedIn
@@ -124,7 +123,7 @@ class TestRefusing:
         profile = tmp_path / "profile"
         _publish_owner(tmp_path, profile, runtime_id="docker-abc123")
 
-        assert find_owner(tmp_path, profile, _config(profile)) is None
+        assert look_up_owner(tmp_path, profile, _config(profile)).attachment is None
 
     def test_a_daemon_serving_another_profile_is_refused(self, tmp_path: Path):
         # The lock is per auth root, but a browser opens a profile. Sibling
@@ -140,7 +139,7 @@ class TestRefusing:
         # Verified by removing the check: the test still passed.
         _publish_owner(tmp_path, theirs, config=_config(ours))
 
-        assert find_owner(tmp_path, ours, _config(ours)) is None
+        assert look_up_owner(tmp_path, ours, _config(ours)).attachment is None
 
     def test_a_daemon_with_a_different_configuration_is_refused(self, tmp_path: Path):
         # Attaching anyway would silently give the client a browser configured
@@ -154,7 +153,7 @@ class TestRefusing:
             config=_config(profile, proxy_server="http://proxy.example:8080"),
         )
 
-        assert find_owner(tmp_path, profile, _config(profile)) is None
+        assert look_up_owner(tmp_path, profile, _config(profile)).attachment is None
 
     def test_an_off_machine_endpoint_is_refused_before_the_token_is_sent(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -171,7 +170,7 @@ class TestRefusing:
         token = _publish_owner(tmp_path, profile, host="198.51.100.7")
 
         with caplog.at_level("DEBUG", logger="linkedin_mcp_server.daemon"):
-            assert find_owner(tmp_path, profile, _config(profile)) is None
+            assert look_up_owner(tmp_path, profile, _config(profile)).attachment is None
 
         # Refused for the right reason, and it says so: a silent None here
         # reads like an ordinary first start rather than a descriptor pointing
@@ -212,7 +211,7 @@ class TestRefusing:
         _publish_owner(tmp_path, profile)
         descriptor_path(tmp_path).write_text("{not json", encoding="utf-8")
 
-        assert find_owner(tmp_path, profile, _config(profile)) is None
+        assert look_up_owner(tmp_path, profile, _config(profile)).attachment is None
         assert descriptor_path(tmp_path).exists()
 
 
@@ -239,14 +238,14 @@ class TestWaitingForAStartingOwner:
         starter = threading.Thread(target=publish_after_a_moment)
         starter.start()
         try:
-            attachment = find_owner(
+            lookup = look_up_owner(
                 tmp_path, profile, _config(profile), wait_seconds=5.0
             )
         finally:
             starter.join()
 
         assert published.is_set()
-        assert attachment is not None
+        assert lookup.attachment is not None
 
     def test_waiting_gives_up_rather_than_hanging(self, tmp_path: Path):
         # Nothing ever publishes. The caller has to get an answer, because a
@@ -255,9 +254,9 @@ class TestWaitingForAStartingOwner:
         profile.mkdir()
 
         started = time.monotonic()
-        attachment = find_owner(tmp_path, profile, _config(profile), wait_seconds=0.3)
+        lookup = look_up_owner(tmp_path, profile, _config(profile), wait_seconds=0.3)
 
-        assert attachment is None
+        assert lookup.attachment is None
         assert time.monotonic() - started >= 0.3
 
     @pytest.mark.parametrize("budget", [float("nan"), float("inf")])
@@ -309,7 +308,7 @@ class TestWaitingForAStartingOwner:
         profile.mkdir()
 
         started = time.monotonic()
-        find_owner(tmp_path, profile, _config(profile))
+        look_up_owner(tmp_path, profile, _config(profile)).attachment
 
         assert time.monotonic() - started < 0.2
 
@@ -501,7 +500,7 @@ class TestTellingTheRefusalsApart:
         descriptor_path(tmp_path).write_text("{not json", encoding="utf-8")
 
         with caplog.at_level("INFO", logger="linkedin_mcp_server.daemon"):
-            find_owner(tmp_path, profile, _config(profile))
+            look_up_owner(tmp_path, profile, _config(profile)).attachment
 
         assert "untrusted" in caplog.text
         assert "not valid JSON" not in caplog.text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,6 @@
 import asyncio
+import subprocess
+import sys
 from unittest.mock import AsyncMock, MagicMock, call
 
 import mcp.types as mt
@@ -6,6 +8,7 @@ import pytest
 from fastmcp import FastMCP
 from fastmcp.server.middleware import MiddlewareContext
 
+import linkedin_mcp_server.server as server_module
 from linkedin_mcp_server import __version__
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
@@ -69,6 +72,31 @@ class TestServerRoles:
 
         assert len(set(map(frozenset, served.values()))) == 1
         assert "get_person_profile" in served[ServerRole.DIRECT]
+
+    def test_the_role_is_readable_without_importing_the_server(self):
+        # The reason the enum lives in its own module. Behaviour has to differ
+        # by role well below the server — an owner must not open a login
+        # window, and that decision is made in `dependencies`, which `server`
+        # reaches only through the tool modules. Importing back the other way
+        # would close the cycle, so the enum has to be reachable on its own.
+        probe = (
+            "import linkedin_mcp_server.server_role, sys;"
+            "print(any(name.startswith('linkedin_mcp_server.tools') for name in sys.modules)"
+            " or 'linkedin_mcp_server.server' in sys.modules)"
+        )
+        pulled_in_the_server_graph = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        assert pulled_in_the_server_graph == "False"
+
+    def test_the_enum_stays_importable_from_the_server(self):
+        # Moving it must not break an embedder that already imports it from
+        # where it used to live.
+        assert server_module.ServerRole is ServerRole
 
 
 class TestSequentialToolExecutionMiddleware:


### PR DESCRIPTION
Running several MCP clients at once means several server processes on one Chromium profile. #598 made that safe with a file lease, but ownership moves on nearly every call, and each move closes and reopens the browser, which revalidates the session against `/feed/`. The steady state is one extra LinkedIn request per tool call. Fixing it means one long-lived process owning the browser and serving the others over authenticated loopback HTTP, which is #606.

This is the first piece: reading the descriptor a daemon publishes and deciding whether this client may talk to it. It elects nobody, spawns nothing, takes no lock and forwards no calls, so with `daemon_enabled` off it changes nothing for anyone.

The result is a typed state rather than an optional attachment, because "no owner to attach to" covers four situations that call for different responses: nothing published, a descriptor for another runtime or profile or configuration, one that cannot be trusted, and one that is usable. Collapsing them is how a second Chromium ends up on a live profile. The single rule underneath is that a file says nothing about whether the process that wrote it still exists: only the lock settles who owns the browser, and only connecting settles whether anything is listening. A descriptor that passes every check is still just a file an owner may have left behind when it crashed.

`ServerRole` moves to its own module. Role has to decide behaviour down in `dependencies`, which `server` reaches only through the tool modules, so importing it back would close a cycle.

Verified with the full suite plus mutation checks on each refusal, confirming the test fails when the corresponding check is removed.
