### PR TITLE
chore: Bump version to 4.20.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-linkedin"
-version = "4.20.0"
+version = "4.20.1"
 description = "MCP server that gives AI assistants like Claude access to LinkedIn profiles, companies, and job postings through the user's own browser session."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-linkedin"
-version = "4.20.0"
+version = "4.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Patch release for #621: container detection classified any Linux host running a Docker daemon as a container, which answered every tool call with "run --login on the host machine" while a valid session sat on disk, with no way out short of editing installed source.

Shipping this separately from the daemon work in #606 so the fix reaches affected users now rather than waiting on a release whose scope is still open.
