### PR TITLE
fix(release): Show versions in release list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
-          name: "LinkedIn MCP Server v${{ env.VERSION }}"
+          name: "v${{ env.VERSION }}"
           body_path: RELEASE_NOTES.md
 
       - name: Summary


### PR DESCRIPTION
Closes #626

GitHub truncates the current release titles before their versions, making every entry in the release sidebar look identical.

Use each version tag as its release title so future releases remain distinguishable at a glance. Existing releases will be renamed to match after this lands.

Verified with the repository pre-commit checks for the changed workflow.

## Synthetic prompt

> Use version tags as GitHub release titles so release sidebar entries remain distinguishable.