### PR TITLE
feat(daemon): Elect one owner and serve it over loopback

### DIFF
--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -14,6 +14,7 @@ from linkedin_mcp_server.bootstrap import (
 from linkedin_mcp_server.core import AuthenticationError
 from linkedin_mcp_server.authentication import clear_auth_state
 from linkedin_mcp_server.config import get_config
+from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.drivers.browser import (
     experimental_persist_derived_runtime,
     close_browser,
@@ -282,6 +283,48 @@ def profile_info_and_exit() -> None:
     sys.exit(1)
 
 
+def _elect_daemon_owner_if_enabled(config: AppConfig) -> None:
+    """Make sure one shared owner is running, when the daemon is switched on.
+
+    Off by default, and inert when off. What it establishes when on is the half
+    of the daemon that has to work before forwarding can be built: exactly one
+    owner process per profile, reachable, with the lock held by the process that
+    actually serves.
+
+    This process still runs its own tools. Until the forwarding role exists, an
+    enabled daemon therefore costs an idle owner beside the ordinary server and
+    buys nothing, which is why the flag stays experimental and off. Nothing here
+    can make things worse for a user who leaves it alone.
+
+    Never fatal. Every failure inside is a reason to serve this client the way
+    the server always has, and a client that could not start because a shared
+    browser could not be elected would be a worse outcome than not sharing one.
+    """
+    from linkedin_mcp_server.daemon import daemon_would_be_used
+
+    if not daemon_would_be_used(config):
+        return
+
+    try:
+        from linkedin_mcp_server.daemon_election import obtain_owner
+        from linkedin_mcp_server.session_state import auth_root_dir
+
+        profile = get_profile_dir()
+        outcome = obtain_owner(auth_root_dir(profile), profile, config)
+    except Exception:
+        logger.warning("The shared browser owner is unavailable", exc_info=True)
+        return
+
+    if outcome.worth_connecting:
+        logger.info("A shared browser owner is running")
+    else:
+        logger.warning(
+            "No shared browser owner could be started (%s); this server will "
+            "drive its own browser",
+            outcome.attachment_lookup.state.value,
+        )
+
+
 def get_version() -> str:
     """Get version from installed metadata with a source fallback."""
     try:
@@ -384,6 +427,13 @@ def main() -> None:
                 # rules that were skipped when the value said stdio.
                 config.server.transport = transport
                 config.validate()
+
+            # Get a shared owner running before building this process's server.
+            # Nothing downstream depends on the result yet: the frontend still
+            # runs its own tools. What this establishes is that exactly one
+            # owner exists per profile and that a client can reach it, which is
+            # what the forwarding half will attach to.
+            _elect_daemon_owner_if_enabled(config)
 
             # Create and run the MCP server
             mcp = create_mcp_server(tool_timeout=config.server.tool_timeout_seconds)

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -291,14 +291,23 @@ def _elect_daemon_owner_if_enabled(config: AppConfig) -> None:
     owner process per profile, reachable, with the lock held by the process that
     actually serves.
 
-    This process still runs its own tools. Until the forwarding role exists, an
-    enabled daemon therefore costs an idle owner beside the ordinary server and
-    buys nothing, which is why the flag stays experimental and off. Nothing here
-    can make things worse for a user who leaves it alone.
+    This process still runs its own tools, because the forwarding role does not
+    exist yet. So an enabled daemon costs an idle owner beside the ordinary
+    server and buys nothing, which is why the flag stays experimental and off.
+
+    That also means two processes can reach the same profile while the flag is
+    on, and what keeps them off each other is the profile lease from #598, not
+    anything here: the owner takes it when it opens Chromium and hands it over
+    when another process announces itself
+    (``drivers/browser.py:881-901``). The daemon lock decides who *owns* the
+    browser; the lease decides who is driving it right now, and only the second
+    question is being asked while this server still runs its own tools.
 
     Never fatal. Every failure inside is a reason to serve this client the way
     the server always has, and a client that could not start because a shared
     browser could not be elected would be a worse outcome than not sharing one.
+    Once forwarding lands, a failed election stops being survivable this way and
+    the decision moves with it.
     """
     from linkedin_mcp_server.daemon import daemon_would_be_used
 

--- a/linkedin_mcp_server/config/__init__.py
+++ b/linkedin_mcp_server/config/__init__.py
@@ -25,6 +25,25 @@ def get_config() -> AppConfig:
     return _config
 
 
+def set_config(config: AppConfig) -> None:
+    """Install *config* as the configuration this process runs on.
+
+    For the detached daemon owner, which is handed its settings rather than
+    parsing them. Half of what decides which browser opens arrives on the
+    command line of the process the MCP client spawned, and that is the
+    frontend: an owner that called ``load_config`` would see only the
+    environment, come up with a different browser, and be refused by the very
+    client that started it, because ``config_fingerprint`` compares exactly
+    those fields.
+
+    Called before anything reads the configuration. Nothing here unwinds
+    decisions already made from an earlier value.
+    """
+    global _config
+    _config = config
+    logger.debug("Configuration installed")
+
+
 def reset_config() -> None:
     """Reset the configuration to force reloading."""
     global _config
@@ -38,4 +57,5 @@ __all__ = [
     "ServerConfig",
     "get_config",
     "reset_config",
+    "set_config",
 ]

--- a/linkedin_mcp_server/daemon_config.py
+++ b/linkedin_mcp_server/daemon_config.py
@@ -1,0 +1,155 @@
+"""The configuration a frontend hands to the owner it starts.
+
+The owner cannot simply reload the configuration for itself. Half of it arrives
+on the command line of the process the MCP client spawned, and that process is
+the frontend, not the owner. An owner that re-read only the environment would
+come up with a different browser than the client asked for, and the frontend
+would then refuse to attach to it: ``config_fingerprint`` compares exactly the
+fields that would differ. The result is not a wrong browser but a client that
+elects an owner and then declines to use it, forever.
+
+So the resolved configuration is handed over explicitly, on the child's standard
+input. Not the environment and not the command line, because both are readable
+by anything running as this account — ``/proc/<pid>/environ`` and ``ps`` — and
+what travels here includes ``proxy_password``. A pipe is read once by one
+process and never lands anywhere.
+
+Both ends are the same installation: the frontend starts the owner with its own
+interpreter and its own package, so this codec never crosses versions. It is
+still a parse of untrusted-shaped input rather than a restore, because the thing
+being reconstructed decides which browser opens against a logged-in session.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+from types import UnionType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+from linkedin_mcp_server.config.schema import AppConfig
+
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
+
+#: Server settings an owner needs. Deliberately a short list rather than the
+#: whole section: transport, host, port and the one-shot flags all describe the
+#: *frontend's* invocation, and an owner that adopted them would try to run the
+#: client's transport or re-run its ``--login``.
+_SERVER_FIELDS = ("tool_timeout_seconds", "log_level")
+
+
+def encode(config: AppConfig) -> str:
+    """Serialise the parts of *config* that an owner has to agree on."""
+    return json.dumps(
+        {
+            # Every browser field, not just the fingerprinted ones. The
+            # fingerprint says which differences make two clients unable to
+            # share an owner; it does not say which settings the owner needs to
+            # do its job. Handing over only the shared subset would leave the
+            # owner on default handoff and idle timings while the user had
+            # configured others.
+            "browser": {
+                field.name: getattr(config.browser, field.name)
+                for field in fields(config.browser)
+            },
+            "server": {name: getattr(config.server, name) for name in _SERVER_FIELDS},
+        }
+    )
+
+
+def decode(raw: str) -> AppConfig:
+    """Rebuild the configuration an owner was started with.
+
+    Unknown names are refused rather than skipped. The two ends are one
+    installation, so a name this does not recognise is not a version difference
+    but a blob that did not come from :func:`encode`, and the quiet reading of
+    it would be an owner running on settings nobody chose.
+    """
+    try:
+        parsed = json.loads(raw)
+    except ValueError as exc:
+        raise ValueError(f"The owner configuration is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("The owner configuration is not an object")
+
+    config = AppConfig()
+    _apply(config.browser, parsed.get("browser"), "browser")
+    _apply(config.server, parsed.get("server"), "server", allowed=_SERVER_FIELDS)
+    # The same validation the frontend's own configuration went through. An
+    # owner is the process that opens the browser, so a value that would be
+    # refused there must be refused here rather than reaching Chromium by the
+    # back door.
+    config.validate()
+    return config
+
+
+def _apply(
+    section: DataclassInstance,
+    values: object,
+    label: str,
+    *,
+    allowed: tuple[str, ...] | None = None,
+) -> None:
+    if not isinstance(values, dict):
+        raise ValueError(f"The owner configuration has no {label} section")
+
+    declared = get_type_hints(type(section))
+    known = {field.name for field in fields(section)}
+    if allowed is not None:
+        known &= set(allowed)
+
+    for name, value in values.items():
+        if not isinstance(name, str) or name not in known:
+            raise ValueError(
+                f"The owner configuration names an unknown {label} setting"
+            )
+        if not _matches(value, declared[name]):
+            # Named without its value: this section carries proxy_password and
+            # the path to someone's browser profile, and the failure is
+            # diagnosable from the field alone.
+            raise ValueError(
+                f"The owner configuration gives {label}.{name} the wrong type"
+            )
+        setattr(section, name, value)
+
+
+def _matches(value: object, declared: Any) -> bool:
+    """Whether *value* is usable where something of type *declared* belongs.
+
+    Checked against the declared type rather than against the default's runtime
+    type, because the optional settings default to ``None`` and every value
+    would look wrong beside one. JSON is the other half of the reason: it cannot
+    tell seconds from a count, so a string where a float belongs would otherwise
+    surface deep inside a browser launch rather than here.
+    """
+    origin = get_origin(declared)
+    if origin is Literal:
+        # An exact member, so a log level or transport that this build does not
+        # know is refused here rather than at whatever reads it later.
+        return value in get_args(declared)
+    if origin in (Union, UnionType):
+        return any(_matches(value, member) for member in get_args(declared))
+    if declared is type(None):
+        return value is None
+    if declared is float:
+        # JSON writes 0 for 0.0, so an int has to be accepted where a float is
+        # declared. bool is excluded explicitly: it is a subclass of int, and
+        # accepting True as a timeout is exactly the silent nonsense this
+        # function exists to stop.
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if declared is int:
+        return isinstance(value, int) and not isinstance(value, bool)
+    if isinstance(declared, type):
+        return isinstance(value, declared)
+    # An annotation this does not understand. Refusing is the safe direction:
+    # the alternative is a value nothing checked reaching a browser launch.
+    return False

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -554,9 +554,15 @@ def _spawn(
             # only ever handed over where that works.
             pass_fds=() if lock_fd is None else (lock_fd,),
             # Its own session, so a signal aimed at the client's process group
-            # does not take the owner with it.
+            # does not take the owner with it. POSIX-only, which is why the
+            # Windows equivalent is passed separately below rather than assumed.
             start_new_session=True,
             close_fds=True,
+            # Zero on POSIX, where `subprocess` ignores it, and the real
+            # detachment on Windows, where `start_new_session` is what gets
+            # ignored. Passed positionally rather than unpacked from a mapping,
+            # which would defeat the overload the type checker resolves against.
+            creationflags=_detachment_flags(),
         )
 
     try:
@@ -567,6 +573,32 @@ def _spawn(
     finally:
         _release_handshake(child)
         _reap(child)
+
+
+def _detachment_flags() -> int:
+    """What it takes on this platform to survive the client that started us.
+
+    ``start_new_session`` is POSIX-only. CPython's Windows implementation names
+    the parameter ``unused_start_new_session`` and ignores it outright
+    (``subprocess.py:1461``), so passing it there detaches nothing: a console
+    ``Ctrl+C``, or a client that cleans up its process tree, would take the
+    owner down with it — the opposite of what the owner is for.
+
+    The Windows equivalent is a creation flag. ``CREATE_NEW_PROCESS_GROUP``
+    removes the child from the console group that receives ``Ctrl+C`` and
+    ``Ctrl+Break``, and ``DETACHED_PROCESS`` gives it no console at all, which
+    is right for a process whose output already goes to a log file.
+
+    Unmeasured, unlike the POSIX side, and said so where it matters: nothing in
+    this repository runs Windows outside CI, and a job object that kills its
+    tree ignores both flags. This is the documented mechanism rather than a
+    verified outcome.
+    """
+    if os.name != "nt":
+        return 0
+    return (  # pragma: no cover - exercised on the Windows runner
+        subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+    )
 
 
 def _release_handshake(child: subprocess.Popen[bytes]) -> None:

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -195,22 +195,21 @@ def obtain_owner(
         # A started owner has already published by the time it reports ready, so
         # this re-read normally succeeds at once. The wait is for the other
         # branch: this process lost the lock race, so somebody else is coming up
-        # and the descriptor is not there yet. Bounded by the shared deadline,
-        # so a winner that dies silently does not hold the client here forever.
+        # and the descriptor is not there yet.
+        #
+        # Bounded per pass rather than by the whole remaining budget, and that is
+        # not a detail. Waiting out the full budget here consumes it inside a
+        # single read, so the loop's own deadline check fires on the way back and
+        # the lock is attempted exactly once — measured: one attempt against a
+        # one second budget, in the case this loop exists to keep retrying. The
+        # holder may also release without ever publishing, which only another
+        # lock attempt can discover.
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return ElectionOutcome(look(), started_owner=started)
-        lookup = look(remaining)
+        lookup = look(min(_RETRY_SECONDS, remaining))
         if lookup.worth_connecting or time.monotonic() >= deadline:
             return ElectionOutcome(lookup, started_owner=started)
-
-        # Pause before going round again. The wait above only sleeps while the
-        # descriptor is unreadable, and the case that brought this loop back here
-        # is the opposite one: a descriptor that is perfectly readable and known
-        # unusable, belonging to an owner that is on its way out. Without a pause
-        # this spins at full speed on the lock until that owner has finished
-        # closing its browser.
-        time.sleep(min(_RETRY_SECONDS, max(deadline - time.monotonic(), 0.0)))
 
 
 def _live_lookup(
@@ -390,6 +389,25 @@ def _log_hint(auth_root: Path) -> Path:
     return daemon_owner.daemon_log_path(auth_root)
 
 
+class _Started(enum.Enum):
+    """What the startup handshake said, in the three ways it can end.
+
+    Silence is its own answer and must not be folded into failure. A child that
+    has neither answered nor exited is still coming up and still holds the lock
+    it adopted; calling that a failure sends the caller off to drive its own
+    browser against the profile that child is about to open.
+    """
+
+    #: The endpoint answered and the descriptor is published.
+    YES = "yes"
+
+    #: The child said it could not serve, or died trying.
+    NO = "no"
+
+    #: Neither, within the budget. It may still succeed.
+    STILL_TRYING = "still_trying"
+
+
 class _Attempt(enum.Enum):
     """What came of trying to start an owner, in the three ways it can end.
 
@@ -402,11 +420,12 @@ class _Attempt(enum.Enum):
     #: An owner is up and has published. Ready to attach.
     STARTED = "started"
 
-    #: Another process holds the lock, so somebody else is starting. Wait.
+    #: Somebody is starting: another process holds the lock, or the child this
+    #: process started has not answered yet and is still holding one. Wait.
     CONTENDED = "contended"
 
-    #: This process was the one that may, and the child could not serve. Nobody
-    #: else is coming, so waiting is pure delay.
+    #: The child this process started said it could not serve. Nothing is
+    #: holding the lock on its behalf, so waiting on it specifically is delay.
     FAILED = "failed"
 
 
@@ -443,8 +462,14 @@ def _start_holding_the_lock(
     try:
         duplicate = lock.inheritable_copy()
         try:
-            if _spawn(auth_root, config, lock_fd=duplicate, timeout=timeout):
+            started = _spawn(auth_root, config, lock_fd=duplicate, timeout=timeout)
+            if started is _Started.YES:
                 outcome = _Attempt.STARTED
+            elif started is _Started.STILL_TRYING:
+                # The child is alive and holds the lock this process is about to
+                # let go of, so from here it is indistinguishable from any other
+                # owner coming up: wait for it rather than conclude anything.
+                outcome = _Attempt.CONTENDED
         finally:
             # Closed whether or not the child got going. It shares the kernel
             # lock, so a leaked copy would hold the daemon lock for this
@@ -474,14 +499,14 @@ def _start_contending_for_the_lock(
     coming and avoids giving up while a rival owner is still starting. The
     frontend on this platform has no better information to act on.
     """
-    if _spawn(auth_root, config, lock_fd=None, timeout=timeout):
+    if _spawn(auth_root, config, lock_fd=None, timeout=timeout) is _Started.YES:
         return _Attempt.STARTED
     return _Attempt.CONTENDED
 
 
 def _spawn(
     auth_root: Path, config: AppConfig, *, lock_fd: int | None, timeout: float
-) -> bool:
+) -> _Started:
     """Start the detached owner and wait for its ready handshake.
 
     The owner has to outlive the client that caused it to start, or the whole
@@ -563,7 +588,7 @@ def _reap(child: subprocess.Popen[bytes]) -> None:
         child.poll()
 
 
-def _await_ready(child: subprocess.Popen[bytes], *, timeout: float) -> bool:
+def _await_ready(child: subprocess.Popen[bytes], *, timeout: float) -> _Started:
     """Wait for the child's verdict, or for it to die trying.
 
     Three outcomes, and the third is why this is a pipe rather than a file.
@@ -617,13 +642,20 @@ def _await_ready(child: subprocess.Popen[bytes], *, timeout: float) -> bool:
     try:
         verdict = verdicts.get(timeout=max(timeout, 0.0))
     except queue.Empty:
-        logger.warning("The daemon did not finish starting in time")
-        return False
+        # Not a failure, and the difference matters. The child said nothing and
+        # did not exit, so it is still starting and still holds the lock it
+        # adopted. Reporting this as "the child could not serve" would send the
+        # caller off to drive its own browser against the profile the child is
+        # about to open — two browsers, from a slow machine rather than a bug.
+        logger.warning(
+            "The daemon has not finished starting; leaving it to come up on its own"
+        )
+        return _Started.STILL_TRYING
 
     if verdict is None:
         logger.info("The daemon exited before it was ready")
-        return False
+        return _Started.NO
     if verdict == daemon_owner.FAILED:
         logger.info("The daemon reported that it could not start")
-        return False
-    return True
+        return _Started.NO
+    return _Started.YES

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -566,12 +566,70 @@ def _spawn(
 
     try:
         assert child.stdin is not None and child.stdout is not None
-        with child.stdin as handed:
-            handed.write(daemon_config.encode(config).encode())
-        return _await_ready(child, timeout=timeout)
+        started = time.monotonic()
+        try:
+            _hand_over_config(child, config, timeout=timeout)
+        except TimeoutError:
+            # The same verdict a silent handshake gets, and for the same reason:
+            # the child is alive and holds the lock, so it may yet come up. It
+            # simply has not read its configuration, which is what a machine
+            # under load looks like from here.
+            logger.warning("The daemon has not read its configuration yet")
+            return _Started.STILL_TRYING
+        # One budget across both halves. Handing the configuration over and
+        # waiting for the verdict are two ways of waiting on the same child, and
+        # giving each the full budget would let a slow one spend twice what the
+        # caller allowed.
+        return _await_ready(child, timeout=timeout - (time.monotonic() - started))
     finally:
         _release_handshake(child)
         _reap(child)
+
+
+def _hand_over_config(
+    child: subprocess.Popen[bytes], config: AppConfig, *, timeout: float
+) -> None:
+    """Write the configuration to the child, without waiting on it forever.
+
+    The obvious ``child.stdin.write(...)`` blocks once the pipe buffer is full,
+    and the buffer is small — 64 KiB on Linux, less on some platforms — while
+    the configuration has no size limit at all: ``user_agent``, ``proxy_bypass``
+    and the paths are free-form strings. A child that neither reads nor exits
+    therefore blocks this write indefinitely, *before* the handshake timeout is
+    ever reached. Reproduced with a 10 MiB user agent and a child that only
+    sleeps: the outer process timeout fired and the wait below was never
+    entered. Both processes hold the daemon lock while that happens.
+
+    Written on a thread for the same reason the verdict is read on one: it is
+    the one mechanism that bounds a blocking pipe operation on every platform.
+    The thread is a daemon, so a write that never completes cannot keep the
+    frontend from exiting, and the descriptor it holds is closed by the caller.
+    """
+    stream = child.stdin
+    assert stream is not None
+    payload = daemon_config.encode(config).encode()
+
+    done: queue.Queue[BaseException | None] = queue.Queue()
+
+    def hand_over() -> None:
+        try:
+            with stream:
+                stream.write(payload)
+        except BaseException as exc:  # noqa: BLE001 - reported to the caller
+            done.put(exc)
+        else:
+            done.put(None)
+
+    writer = threading.Thread(target=hand_over, name="daemon-config", daemon=True)
+    writer.start()
+    try:
+        failure = done.get(timeout=max(timeout, 0.0))
+    except queue.Empty:
+        raise TimeoutError(
+            "The daemon did not read its configuration in time"
+        ) from None
+    if failure is not None:
+        raise failure
 
 
 def _spawn_command(*, lock_fd: int | None) -> list[str]:

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -484,11 +484,21 @@ def _spawn(
 ) -> bool:
     """Start the detached owner and wait for its ready handshake.
 
-    Detached deliberately, and this is the one piece of the issue's process-model
-    advice that survived measurement: a child started with ``start_new_session``
-    alone is still killed when the MCP client shuts down, and only a
-    double-forked child survives. An owner that dies with its first client would
-    reduce this whole feature to a slower version of what it replaces.
+    The owner has to outlive the client that caused it to start, or the whole
+    feature degrades to a slower version of what it replaces. ``start_new_session``
+    is what buys that: the child leads its own session and process group, so a
+    signal aimed at the client's group does not reach it.
+
+    Measured on this tree rather than assumed, because the issue claims otherwise
+    — that only a double-forked child survives and ``start_new_session`` is not
+    enough. On macOS it is: after ``SIGKILL`` to the frontend's entire process
+    group, the owner was still running and had reparented to pid 1. A double fork
+    would add a layer whose only job is to be exited, so it is not done here.
+
+    Not measured: Windows, and Linux under a supervisor that kills a whole
+    cgroup rather than a process group. The second is the one that could still
+    take the owner down, and it is worth revisiting if a Linux user reports the
+    daemon dying with their client.
     """
     log_path = daemon_owner.daemon_log_path(auth_root)
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -532,6 +542,25 @@ def _spawn(
         # this cannot cost it a broken pipe.
         if child.stdout is not None:
             child.stdout.close()
+        _reap(child)
+
+
+def _reap(child: subprocess.Popen[bytes]) -> None:
+    """Collect a child that has already exited, without waiting for one that has not.
+
+    A successful election leaves a *running* owner, and this process must never
+    wait for it: outliving this process is the point. The other outcomes leave a
+    child that has exited, and ``poll`` collects exactly those.
+
+    Belt and braces rather than a fix for something observed. ``subprocess``
+    keeps its own registry of abandoned children and reaps them when the next one
+    is created, and a failed election measured here left no zombie with this call
+    removed. It is kept because that behaviour is an implementation detail of the
+    standard library, and this is the one place that knowingly walks away from a
+    child.
+    """
+    with contextlib.suppress(OSError, ValueError):
+        child.poll()
 
 
 def _await_ready(child: subprocess.Popen[bytes], *, timeout: float) -> bool:

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -61,10 +61,16 @@ from linkedin_mcp_server.daemon_lock import DaemonLock, DaemonLockError
 logger = logging.getLogger(__name__)
 
 #: How long a frontend waits for an owner to become attachable before giving up
-#: and reporting what it last saw. Covers a cold start of the whole server graph
-#: plus the owner's own startup probe, and is what bounds the delay a user sees
-#: when something goes wrong rather than when it goes right.
-DEFAULT_ELECTION_SECONDS = 45.0
+#: and reporting what it last saw. It is what bounds the delay a user sees when
+#: something goes wrong rather than when it goes right.
+#:
+#: Comfortably more than twice the owner's own startup allowance
+#: (``daemon_owner._STARTUP_PROBE_SECONDS``), and that ordering is enforced by a
+#: test. A frontend now stops a child that has said nothing by the time this
+#: runs out, so an owner permitted to take longer would be killed on a slow
+#: machine while still inside its own rules. The remainder covers handing the
+#: configuration over and the lock attempts before the owner's clock starts.
+DEFAULT_ELECTION_SECONDS = 90.0
 
 #: How long a published owner has to answer before it is treated as leftovers.
 #: This is a loopback request to a process that is either serving or gone, so
@@ -393,21 +399,24 @@ def _log_hint(auth_root: Path) -> Path:
 
 
 class _Started(enum.Enum):
-    """What the startup handshake said, in the three ways it can end.
+    """What the startup handshake said.
 
-    Silence is its own answer and must not be folded into failure. A child that
-    has neither answered nor exited is still coming up and still holds the lock
-    it adopted; calling that a failure sends the caller off to drive its own
-    browser against the profile that child is about to open.
+    Silence is a third answer while the wait is running, and ``_spawn`` resolves
+    it rather than passing it on: a child that has said nothing by the end of
+    the budget is stopped, so what reaches the caller is only ever "it serves"
+    or "it does not". Leaving silence as an outcome is what let a child keep the
+    inherited lock while never serving.
     """
 
     #: The endpoint answered and the descriptor is published.
     YES = "yes"
 
-    #: The child said it could not serve, or died trying.
+    #: The child could not serve, said so, died trying, or was stopped for
+    #: having said nothing at all.
     NO = "no"
 
-    #: Neither, within the budget. It may still succeed.
+    #: Neither, within the budget — used only inside ``_spawn``, which decides
+    #: what to do about it before returning.
     STILL_TRYING = "still_trying"
 
 
@@ -465,14 +474,10 @@ def _start_holding_the_lock(
     try:
         duplicate = lock.inheritable_copy()
         try:
-            started = _spawn(auth_root, config, lock_fd=duplicate, timeout=timeout)
-            if started is _Started.YES:
+            if _spawn(auth_root, config, lock_fd=duplicate, timeout=timeout) is (
+                _Started.YES
+            ):
                 outcome = _Attempt.STARTED
-            elif started is _Started.STILL_TRYING:
-                # The child is alive and holds the lock this process is about to
-                # let go of, so from here it is indistinguishable from any other
-                # owner coming up: wait for it rather than conclude anything.
-                outcome = _Attempt.CONTENDED
         finally:
             # Closed whether or not the child got going. It shares the kernel
             # lock, so a leaked copy would hold the daemon lock for this
@@ -593,7 +598,32 @@ def _spawn(
         # waiting for the verdict are two ways of waiting on the same child, and
         # giving each the full budget would let a slow one spend twice what the
         # caller allowed.
-        return _await_ready(child, timeout=timeout - (time.monotonic() - started))
+        verdict = _await_ready(child, timeout=timeout - (time.monotonic() - started))
+        if verdict is _Started.STILL_TRYING:
+            # Stopped, not left to itself, and this is the last of the lock
+            # wedges. "Still trying" reads as generous — the child may yet come
+            # up — but by now it has had the whole budget and said nothing, and
+            # on POSIX it holds the inherited lock descriptor. Left alone it
+            # keeps that lock while never serving, and every later election
+            # contends against a process that will never publish.
+            #
+            # Measured with an ordinary configuration and a child that only
+            # sleeps: the lock was still held afterwards. The kill path added
+            # for the configuration timeout only covered the case where the
+            # *write* blocked, which needs a configuration large enough to fill
+            # a pipe; this is the same wedge reached by the ordinary route.
+            #
+            # Safe for the same reason: an owner opens no browser before it
+            # answers, so nothing is interrupted mid-flight. And on POSIX the
+            # frontend still holds its own lock until this returns, so the
+            # position cannot be taken by anyone else in between.
+            logger.warning(
+                "The daemon did not finish starting; stopping it so the lock is "
+                "not held by a process that never served"
+            )
+            _stop_child(child)
+            return _Started.NO
+        return verdict
     finally:
         _release_handshake(child)
         _reap(child)

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -531,15 +531,14 @@ def _spawn(
     log_path = daemon_owner.daemon_log_path(auth_root)
     log_path.parent.mkdir(parents=True, exist_ok=True)
 
-    command = [sys.executable, "-m", "linkedin_mcp_server.daemon_owner"]
-    if lock_fd is not None:
-        command += ["--lock-fd", str(lock_fd)]
+    command = _spawn_command(lock_fd=lock_fd)
 
     # Opened append, so a restart adds to the record rather than erasing the
     # reason the last owner died.
     with open(log_path, "a", encoding="utf-8") as log:
         child = subprocess.Popen(
             command,
+            env=_owner_environment(),
             stdin=subprocess.PIPE,
             # The handshake channel. Not a separate inherited descriptor,
             # because ``pass_fds`` is POSIX-only (``subprocess.py:1464``) and
@@ -573,6 +572,54 @@ def _spawn(
     finally:
         _release_handshake(child)
         _reap(child)
+
+
+def _spawn_command(*, lock_fd: int | None) -> list[str]:
+    """How the owner is invoked.
+
+    ``-P`` keeps the working directory off ``sys.path``. Without it, a directory
+    containing ``linkedin_mcp_server/daemon_owner.py`` is imported in preference
+    to the installed package, and an MCP client started in such a workspace
+    would hand that code the inherited lock descriptor and the whole
+    configuration on standard input, ``proxy_password`` included. Reproduced
+    with this project's own interpreter from a temporary directory: the local
+    file ran instead of the installed module.
+
+    That is also what makes ``daemon_config``'s "both ends are the same
+    installation" true rather than hopeful.
+    """
+    command = [sys.executable, "-P", "-m", "linkedin_mcp_server.daemon_owner"]
+    if lock_fd is not None:
+        command += ["--lock-fd", str(lock_fd)]
+    return command
+
+
+#: Environment variables carrying a secret that the owner has no use for. It
+#: receives every setting it needs on standard input, so keeping these would be
+#: the exposure the stdin channel exists to avoid, held for the owner's whole
+#: lifetime rather than the frontend's. ``/proc/<pid>/environ`` is readable by
+#: this account, and ``ps e`` shows it on the BSDs.
+_SECRETS_TO_DROP = ("PROXY_PASSWORD", "PROXY_USERNAME")
+
+
+def _owner_environment() -> dict[str, str]:
+    """The environment to start the owner in, minus what it must not keep.
+
+    ``daemon_config`` hands the configuration over on standard input precisely
+    so that a password does not sit in a readable environment. That is only half
+    the job while the child inherits the frontend's environment unchanged: the
+    documented way to configure a proxy is ``PROXY_PASSWORD``
+    (``config/loaders.py:107-108``), so the owner would hold the raw value for
+    as long as it runs, which is far longer than the process it came from.
+
+    Dropped rather than emptied. An empty ``PROXY_USERNAME`` is meaningful to
+    the configuration parser (``daemon_descriptor.py:480``), and the owner is
+    told the real values through the channel that was built for them.
+    """
+    environment = dict(os.environ)
+    for name in _SECRETS_TO_DROP:
+        environment.pop(name, None)
+    return environment
 
 
 def _detachment_flags() -> int:

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -320,16 +320,15 @@ def _ask_to_stand_down(attachment: Attachment) -> None:
     Whether the owner *complied* is never assumed. The lock is what says the
     browser is free, and this function never claims otherwise.
     """
-    import httpx
 
     descriptor = attachment.descriptor
     url = f"http://{descriptor.host if ':' not in descriptor.host else f'[{descriptor.host}]'}:{descriptor.port}{daemon_owner.STAND_DOWN_PATH}"
     try:
-        response = httpx.post(
-            url,
-            headers={"Authorization": f"Bearer {attachment.token}"},
-            timeout=_STAND_DOWN_SECONDS,
-        )
+        with daemon_owner.direct_http_client(timeout=_STAND_DOWN_SECONDS) as client:
+            response = client.post(
+                url,
+                headers={"Authorization": f"Bearer {attachment.token}"},
+            )
     except Exception:
         logger.debug("The stale daemon could not be asked to stand down", exc_info=True)
         return
@@ -362,7 +361,11 @@ def _reachable(attachment: Attachment) -> bool:
         try:
             async with Client(
                 StreamableHttpTransport(
-                    attachment.descriptor.url, auth=attachment.token
+                    attachment.descriptor.url,
+                    auth=attachment.token,
+                    # Never through a proxy: this is a loopback hop carrying the
+                    # token to a logged-in session. See ``direct_http_client``.
+                    httpx_client_factory=daemon_owner.direct_async_http_client,
                 )
             ) as client:
                 await client.ping()
@@ -562,12 +565,44 @@ def _spawn(
             handed.write(daemon_config.encode(config).encode())
         return _await_ready(child, timeout=timeout)
     finally:
-        # Closed once the verdict is in. The child has redirected its own
-        # standard output to the log by then and writes nothing more here, so
-        # this cannot cost it a broken pipe.
-        if child.stdout is not None:
-            child.stdout.close()
+        _release_handshake(child)
         _reap(child)
+
+
+def _release_handshake(child: subprocess.Popen[bytes]) -> None:
+    """Stop listening to the child, without waiting for it to stop talking.
+
+    ``child.stdout.close()`` is the obvious call and it is a trap. The reader
+    thread is parked inside iteration holding the buffered reader's I/O lock,
+    and ``BufferedReader.close()`` waits for that lock — so closing here blocks
+    for exactly as long as the child stays silent. Measured: a child that said
+    nothing for thirty seconds made this call block 29.27 of them, and one that
+    neither answers nor exits would block forever. That is the timeout above
+    being handed straight back, in the one case it exists for.
+
+    So the *descriptor* is closed instead. That is not held by the reader
+    thread: the pending read fails, the thread unwinds, and the caller is free.
+
+    ``detach()`` first, so the buffer gives up the descriptor instead of trying
+    to close it again later, and then close the raw file object it hands back
+    rather than the bare number. Closing the number directly leaves that raw
+    object owning a descriptor that no longer exists, and its finalizer prints
+    ``Bad file descriptor`` from a context nothing can catch. Both variants were
+    tried; this is the one that is quiet.
+    """
+    stream, child.stdout = child.stdout, None
+    if stream is None:
+        return
+    # `Popen.stdout` is declared as a plain `IO`, which has no `detach`; the
+    # object is a BufferedReader in practice, and the fallback covers a caller
+    # that handed us something else rather than assuming.
+    detach = getattr(stream, "detach", None)
+    try:
+        raw = detach() if callable(detach) else stream
+        raw.close()
+    except (OSError, ValueError):
+        # Already gone, which is the ordinary case for a child that exited.
+        logger.debug("The handshake pipe was already closed", exc_info=True)
 
 
 def _reap(child: subprocess.Popen[bytes]) -> None:

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -570,12 +570,25 @@ def _spawn(
         try:
             _hand_over_config(child, config, timeout=timeout)
         except TimeoutError:
-            # The same verdict a silent handshake gets, and for the same reason:
-            # the child is alive and holds the lock, so it may yet come up. It
-            # simply has not read its configuration, which is what a machine
-            # under load looks like from here.
-            logger.warning("The daemon has not read its configuration yet")
-            return _Started.STILL_TRYING
+            # Killed rather than left to itself, and the difference is a wedge
+            # that never heals. A child still waiting on its configuration is
+            # inside ``sys.stdin.read()``, which comes *before* it adopts the
+            # lock — but on POSIX it already inherited the descriptor, so the
+            # kernel lock is alive through it. Walking away leaves that child
+            # holding the daemon lock forever while never serving anything, and
+            # every later election contends against it.
+            #
+            # Safe precisely because of that ordering: a child that has not
+            # finished reading cannot have reached ``_take_lock``, so nothing is
+            # being interrupted mid-adoption. Waiting longer is not an option
+            # either, since the thing being waited on is a process that is not
+            # reading.
+            logger.warning(
+                "The daemon never read its configuration; stopping it so the "
+                "lock is not held by a process that cannot serve"
+            )
+            _stop_child(child)
+            return _Started.NO
         # One budget across both halves. Handing the configuration over and
         # waiting for the verdict are two ways of waiting on the same child, and
         # giving each the full budget would let a slow one spend twice what the
@@ -584,6 +597,33 @@ def _spawn(
     finally:
         _release_handshake(child)
         _reap(child)
+
+
+#: How long a child gets to notice it has been asked to stop before it is killed
+#: outright. It has not read its configuration at this point, so there is
+#: nothing for it to clean up and nothing to preserve.
+_STOP_CHILD_SECONDS = 5.0
+
+
+def _stop_child(child: subprocess.Popen[bytes]) -> None:
+    """End a child that never took its configuration, and collect it.
+
+    Terminate first, kill if that is ignored, and wait either way: an
+    uncollected child is a zombie, and one that is merely signalled has not
+    necessarily let go of the lock descriptor it inherited. The wait is what
+    makes "the lock is free" true before this returns.
+    """
+    with contextlib.suppress(OSError):
+        child.terminate()
+    try:
+        child.wait(timeout=_STOP_CHILD_SECONDS)
+        return
+    except subprocess.TimeoutExpired:
+        logger.warning("The daemon ignored the request to stop; killing it")
+    with contextlib.suppress(OSError):
+        child.kill()
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        child.wait(timeout=_STOP_CHILD_SECONDS)
 
 
 def _hand_over_config(

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -577,18 +577,27 @@ def _spawn(
 def _spawn_command(*, lock_fd: int | None) -> list[str]:
     """How the owner is invoked.
 
-    ``-P`` keeps the working directory off ``sys.path``. Without it, a directory
-    containing ``linkedin_mcp_server/daemon_owner.py`` is imported in preference
-    to the installed package, and an MCP client started in such a workspace
-    would hand that code the inherited lock descriptor and the whole
-    configuration on standard input, ``proxy_password`` included. Reproduced
-    with this project's own interpreter from a temporary directory: the local
-    file ran instead of the installed module.
+    ``-I`` is isolated mode: it keeps the working directory *and* ``PYTHONPATH``
+    off ``sys.path``. Without it, a directory containing
+    ``linkedin_mcp_server/daemon_owner.py`` is imported in preference to the
+    installed package, and an MCP client started in such a workspace would hand
+    that code the inherited lock descriptor and the whole configuration on
+    standard input, ``proxy_password`` included.
+
+    ``-P`` alone is not enough, which is worth stating because it is the obvious
+    choice and it looks sufficient: it drops the implicit working directory and
+    leaves ``PYTHONPATH`` in force, so the very common ``PYTHONPATH=.`` puts the
+    workspace back at the front. Both were measured from a prepared directory
+    with this project's own interpreter — ``-P`` loaded the local file, ``-I``
+    loaded the installed module.
 
     That is also what makes ``daemon_config``'s "both ends are the same
-    installation" true rather than hopeful.
+    installation" true rather than hopeful. Isolated mode is safe for the owner
+    because it needs nothing from the environment's import configuration: it is
+    the same interpreter and the same installation, and everything it is
+    configured with arrives on standard input.
     """
-    command = [sys.executable, "-P", "-m", "linkedin_mcp_server.daemon_owner"]
+    command = [sys.executable, "-I", "-m", "linkedin_mcp_server.daemon_owner"]
     if lock_fd is not None:
         command += ["--lock-fd", str(lock_fd)]
     return command
@@ -599,7 +608,13 @@ def _spawn_command(*, lock_fd: int | None) -> list[str]:
 #: the exposure the stdin channel exists to avoid, held for the owner's whole
 #: lifetime rather than the frontend's. ``/proc/<pid>/environ`` is readable by
 #: this account, and ``ps e`` shows it on the BSDs.
-_SECRETS_TO_DROP = ("PROXY_PASSWORD", "PROXY_USERNAME")
+#:
+#: ``PROXY_SERVER`` belongs here despite its name. The documented form accepts
+#: embedded credentials — ``http://user:password@host:port`` — which
+#: ``BrowserConfig.validate`` splits out into the separate fields
+#: (``config/schema.py:242-253``). It splits them out of the *configuration*; the
+#: environment variable still holds the original string.
+_SECRETS_TO_DROP = ("PROXY_PASSWORD", "PROXY_USERNAME", "PROXY_SERVER")
 
 
 def _owner_environment() -> dict[str, str]:

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -599,31 +599,42 @@ def _spawn(
         _reap(child)
 
 
-#: How long a child gets to notice it has been asked to stop before it is killed
-#: outright. It has not read its configuration at this point, so there is
-#: nothing for it to clean up and nothing to preserve.
-_STOP_CHILD_SECONDS = 5.0
+#: How long to wait for a killed child to be collected. Short by design: this
+#: follows ``SIGKILL``, which the process cannot decline, so anything but a
+#: prompt exit means the process is stuck in the kernel and no amount of waiting
+#: here will change that.
+_STOP_CHILD_SECONDS = 2.0
 
 
 def _stop_child(child: subprocess.Popen[bytes]) -> None:
     """End a child that never took its configuration, and collect it.
 
-    Terminate first, kill if that is ignored, and wait either way: an
-    uncollected child is a zombie, and one that is merely signalled has not
-    necessarily let go of the lock descriptor it inherited. The wait is what
-    makes "the lock is free" true before this returns.
+    Killed outright rather than asked politely first. The usual courtesy buys a
+    process time to clean up, and this one has nothing to clean up: it never
+    read its configuration, so it has opened no browser and holds no state
+    beyond the lock descriptor it inherited and must give back.
+
+    The courtesy is not free either. A ``SIGTERM`` grace period is time added
+    *after* the caller's budget is already spent, so a child that ignores the
+    signal turns a half-second election into five and a half, and the documented
+    ceiling stops being a ceiling.
+
+    The wait is what makes "the lock is free" true before this returns: a
+    signalled process has not necessarily been reaped, and until it is, the
+    descriptor may still be open.
     """
     with contextlib.suppress(OSError):
-        child.terminate()
+        child.kill()
     try:
         child.wait(timeout=_STOP_CHILD_SECONDS)
-        return
     except subprocess.TimeoutExpired:
-        logger.warning("The daemon ignored the request to stop; killing it")
-    with contextlib.suppress(OSError):
-        child.kill()
-    with contextlib.suppress(subprocess.TimeoutExpired):
-        child.wait(timeout=_STOP_CHILD_SECONDS)
+        # Uninterruptible sleep, or a kernel that has not finished with it.
+        # Reported rather than waited out, since the caller has a deadline and
+        # this is not something a longer wait resolves.
+        logger.warning(
+            "The daemon has not exited after being killed; the profile may stay "
+            "locked until it does"
+        )
 
 
 def _hand_over_config(

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -64,12 +64,12 @@ logger = logging.getLogger(__name__)
 #: and reporting what it last saw. It is what bounds the delay a user sees when
 #: something goes wrong rather than when it goes right.
 #:
-#: Comfortably more than twice the owner's own startup allowance
-#: (``daemon_owner._STARTUP_PROBE_SECONDS``), and that ordering is enforced by a
-#: test. A frontend now stops a child that has said nothing by the time this
-#: runs out, so an owner permitted to take longer would be killed on a slow
-#: machine while still inside its own rules. The remainder covers handing the
-#: configuration over and the lock attempts before the owner's clock starts.
+#: At least twice the owner's own startup allowance
+#: (``daemon_owner._STARTUP_PROBE_SECONDS``), which a test enforces. A frontend
+#: stops a child that has said nothing by the time this runs out, so an owner
+#: permitted to take longer would be killed on a slow machine while still inside
+#: its own rules. The remainder covers what is spent before the owner's clock
+#: starts: handing the configuration over, and the lock attempts before that.
 DEFAULT_ELECTION_SECONDS = 90.0
 
 #: How long a published owner has to answer before it is treated as leftovers.

--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -1,0 +1,600 @@
+"""Getting an owner started, from the side of the process that wants one.
+
+The counterpart to :mod:`linkedin_mcp_server.daemon`, which only reads. This is
+where a process acts: it takes the lock, starts a detached owner, and waits for
+the endpoint to exist. It never becomes the owner itself, because it cannot —
+``cli_main`` runs the stdio server blocking, so a process that served the owner's
+HTTP could not also serve its own client.
+
+**Election is two sides, and one function cannot be both.** The process that wins
+the lock is not the process that serves. What that means splits by platform, and
+the split is measured rather than stylistic:
+
+*POSIX.* The frontend takes the lock first, then hands the descriptor to the
+child (``DaemonLock.inheritable_copy``). Taking it first is what removes the
+window: between releasing a lock and a child taking it, another client would see
+the position free and start a second browser against the same profile.
+
+*Windows.* A held lock cannot be handed over there at all — measured, 20 of 20
+(``daemon_lock.py:54-71``) — so the frontend takes no lock and the child competes
+for it. Every frontend then waits for whoever wins to publish. Trying to hand a
+lock over anyway would produce a child that believes it owns a browser while the
+lock sits free behind it.
+
+**The parent must let go of the lock before it serves anything.** Both
+descriptors refer to one locked open file description, so the lock lives as long
+as *either* is open. A frontend that kept its original would keep the daemon lock
+alive after the owner died, and every recovery afterwards would be locked out by
+a process that is not the owner and does not know it is holding anything.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import enum
+import logging
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from linkedin_mcp_server import (
+    __version__,
+    daemon_config,
+    daemon_owner,
+    daemon_version,
+)
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon import (
+    Attachment,
+    OwnerLookup,
+    OwnerState,
+    look_up_owner,
+)
+from linkedin_mcp_server.daemon_lock import DaemonLock, DaemonLockError
+
+logger = logging.getLogger(__name__)
+
+#: How long a frontend waits for an owner to become attachable before giving up
+#: and reporting what it last saw. Covers a cold start of the whole server graph
+#: plus the owner's own startup probe, and is what bounds the delay a user sees
+#: when something goes wrong rather than when it goes right.
+DEFAULT_ELECTION_SECONDS = 45.0
+
+#: How long a published owner has to answer before it is treated as leftovers.
+#: This is a loopback request to a process that is either serving or gone, so
+#: the only thing a longer budget buys is a longer stall on a dead descriptor.
+_REACHABLE_SECONDS = 5.0
+
+#: How long a superseded owner has to acknowledge a stand-down request. Short:
+#: the reply says only that the request arrived, and whether the browser is
+#: actually free is settled by the lock afterwards, not by this.
+_STAND_DOWN_SECONDS = 5.0
+
+#: How long to pause before attempting the lock again, when the descriptor on
+#: disk is readable but known unusable. Short, because the thing being waited for
+#: is an owner finishing its shutdown, and long enough not to spin.
+_RETRY_SECONDS = 0.2
+
+#: Proves a published endpoint is live. Injectable so the election can be tested
+#: without a real server; production passes nothing and gets a real round trip.
+Reachable = Callable[[Attachment], bool]
+
+
+@dataclass(frozen=True)
+class ElectionOutcome:
+    """What came of trying to get an owner running."""
+
+    attachment_lookup: OwnerLookup
+    #: Whether this process started the owner. Diagnostics only: an attachment
+    #: is worth exactly the same either way.
+    started_owner: bool = False
+
+    @property
+    def worth_connecting(self) -> bool:
+        return self.attachment_lookup.worth_connecting
+
+
+def obtain_owner(
+    auth_root: Path,
+    profile: Path,
+    config: AppConfig,
+    *,
+    deadline_seconds: float = DEFAULT_ELECTION_SECONDS,
+    connect: Reachable | None = None,
+) -> ElectionOutcome:
+    """Return an owner to talk to, starting one if nobody else has.
+
+    The loop, and why it is a loop rather than "attach, else own, else give up":
+
+    A frontend that loses the lock race has learned that *somebody is starting*,
+    which is a reason to wait rather than to conclude anything. The tempting
+    shortcut is to fall back to driving a browser in-process, and it is wrong in
+    the ordinary case: two clients starting together is not an edge, and the one
+    that lost would then drive its own Chromium against the same profile for its
+    whole life. That is precisely the per-call handoff this feature exists to
+    remove.
+
+    Equally, winning the lock is not permission to keep it. This process cannot
+    serve, so winning means starting a child and handing the lock over.
+
+    *connect* is what settles liveness, and it is not optional. ``ATTACHABLE``
+    is a statement about a *file*: an owner that dies after publishing leaves a
+    descriptor and a token that pass every check there is. Reproduced on this
+    tree — an owner was killed and the very next election read its leftovers as
+    attachable and handed back the dead process's endpoint. Only a request that
+    is answered establishes that anything is listening.
+    """
+    deadline = time.monotonic() + max(deadline_seconds, 0.0)
+    started = False
+    reach = connect or _reachable
+    # Instances proved dead, so a corpse is not handed back a second time. The
+    # descriptor stays on disk until a live owner overwrites it, and without
+    # this the loop would re-read it, probe it again, and spin.
+    buried: set[str] = set()
+    # A turnover is asked for at most once per election, and the bound is not
+    # decoration. A newer frontend replaces a stale owner and then reads the
+    # replacement, and if that one still looked stale it would be asked to stand
+    # down as well, and so on for the whole budget. Reproduced while testing the
+    # turnover with a version override: every owner elected was immediately told
+    # to hand over, and the run ended with no owner at all. One request settles
+    # the case it exists for, and anything past that is a disagreement no amount
+    # of restarting resolves.
+    asked_for_turnover = False
+
+    def look(wait_seconds: float = 0.0) -> OwnerLookup:
+        nonlocal asked_for_turnover
+        found, asked = _live_lookup(
+            auth_root,
+            profile,
+            config,
+            reach,
+            buried,
+            may_ask_for_turnover=not asked_for_turnover,
+            wait_seconds=wait_seconds,
+        )
+        asked_for_turnover = asked_for_turnover or asked
+        return found
+
+    while True:
+        lookup = look()
+        if lookup.worth_connecting:
+            return ElectionOutcome(lookup, started_owner=started)
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return ElectionOutcome(lookup, started_owner=started)
+
+        try:
+            attempt = _start_owner(auth_root, profile, config, timeout=remaining)
+        except DaemonLockError:
+            # The lock could not be used at all, which is not contention: a
+            # filesystem without usable locking, or state this account cannot
+            # write. Waiting would never resolve it.
+            logger.warning("The daemon lock is unusable", exc_info=True)
+            return ElectionOutcome(lookup, started_owner=started)
+        except OSError:
+            logger.warning("The daemon could not be started", exc_info=True)
+            return ElectionOutcome(lookup, started_owner=started)
+
+        if attempt is _Attempt.FAILED:
+            # This process held the lock, started a child, and the child said it
+            # could not serve. Nobody else is coming: the lock is free again and
+            # a fresh attempt would fail the same way. Waiting out the deadline
+            # here is what turned a broken owner into a client that hangs for
+            # the better part of a minute before reporting nothing at all.
+            logger.warning("The daemon could not start; see %s", _log_hint(auth_root))
+            return ElectionOutcome(look(), started_owner=started)
+        started = started or attempt is _Attempt.STARTED
+
+        # A started owner has already published by the time it reports ready, so
+        # this re-read normally succeeds at once. The wait is for the other
+        # branch: this process lost the lock race, so somebody else is coming up
+        # and the descriptor is not there yet. Bounded by the shared deadline,
+        # so a winner that dies silently does not hold the client here forever.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return ElectionOutcome(look(), started_owner=started)
+        lookup = look(remaining)
+        if lookup.worth_connecting or time.monotonic() >= deadline:
+            return ElectionOutcome(lookup, started_owner=started)
+
+        # Pause before going round again. The wait above only sleeps while the
+        # descriptor is unreadable, and the case that brought this loop back here
+        # is the opposite one: a descriptor that is perfectly readable and known
+        # unusable, belonging to an owner that is on its way out. Without a pause
+        # this spins at full speed on the lock until that owner has finished
+        # closing its browser.
+        time.sleep(min(_RETRY_SECONDS, max(deadline - time.monotonic(), 0.0)))
+
+
+def _live_lookup(
+    auth_root: Path,
+    profile: Path,
+    config: AppConfig,
+    reach: Reachable,
+    buried: set[str],
+    *,
+    may_ask_for_turnover: bool = True,
+    wait_seconds: float = 0.0,
+) -> tuple[OwnerLookup, bool]:
+    """Find an owner and prove it answers, or report it as leftovers.
+
+    The one place ``ATTACHABLE`` is turned from a claim about a file into a
+    claim about a process. Everything in :mod:`linkedin_mcp_server.daemon` reads
+    disk; this connects.
+
+    A descriptor that fails the probe is downgraded rather than deleted, and the
+    distinction matters: a live owner this client merely cannot reach right now
+    would be stranded by a deletion, along with every other client attached to
+    it. The file is left alone and the *lock* decides what happens next, which
+    is the rule the whole module is built on.
+
+    Every path here answers on the first readable descriptor, and the waiting
+    happens inside :func:`look_up_owner` alone. That split is measured rather
+    than tidy: an earlier version looped, and because nothing rewrites a
+    descriptor except a *new* owner publishing, an unusable one was simply
+    re-read until the budget ran out. After a version turnover that cost ninety
+    seconds and produced no owner, while the lock the departing owner had freed
+    sat there untouched, because taking it is the caller's job and this function
+    never returned to let it.
+
+    Returns the reading and whether a turnover was requested. The caller counts
+    those, because asking twice in one election means telling a freshly elected
+    owner to stand down as well, and that does not terminate.
+    """
+    lookup = look_up_owner(auth_root, profile, config, wait_seconds=wait_seconds)
+    if not lookup.worth_connecting:
+        return lookup, False
+
+    attachment = lookup.attachment
+    assert attachment is not None  # worth_connecting implies one
+    instance = attachment.descriptor.instance_id
+    if instance in buried:
+        return (
+            OwnerLookup(
+                state=OwnerState.INCOMPATIBLE,
+                reason="the published daemon was already found unusable",
+            ),
+            False,
+        )
+
+    if (
+        may_ask_for_turnover
+        and daemon_version.compare(
+            owner=attachment.descriptor.package_version, frontend=__version__
+        )
+        is daemon_version.Skew.OWNER_IS_STALE
+    ):
+        # A newer frontend does not attach to an older owner, and it does not
+        # merely refuse either: refusing without asking would leave it unable to
+        # proceed at all, since it cannot take a lock the owner holds. So it
+        # asks, and the replacement is elected from the ordinary path once the
+        # lock comes free.
+        logger.info(
+            "The running daemon is version %s and this build is %s; asking it to "
+            "hand the browser over",
+            attachment.descriptor.package_version,
+            __version__,
+        )
+        _ask_to_stand_down(attachment)
+        buried.add(instance)
+        return (
+            OwnerLookup(
+                state=OwnerState.INCOMPATIBLE,
+                reason="the running daemon is older than this build",
+            ),
+            True,
+        )
+
+    if reach(attachment):
+        return lookup, False
+
+    buried.add(instance)
+    logger.info("The published daemon is not answering; electing a new one")
+    # Deliberately not ABSENT. The file is still there, and calling it absent
+    # invites a caller to clean it up; this says "not for us", which is what both
+    # a corpse's descriptor and a superseded owner's are.
+    return (
+        OwnerLookup(
+            state=OwnerState.INCOMPATIBLE,
+            reason="the published daemon did not answer, so it is leftovers",
+        ),
+        False,
+    )
+
+
+def _ask_to_stand_down(attachment: Attachment) -> None:
+    """Ask a superseded owner to give up the browser.
+
+    Best effort, and deliberately so. The owner may already be gone, may be an
+    older build with no such route, or may be busy finishing a call. In every one
+    of those cases the caller's next step is the same: try the lock, and wait if
+    somebody still holds it. Raising here would turn a routine upgrade into a
+    client that fails to start.
+
+    Whether the owner *complied* is never assumed. The lock is what says the
+    browser is free, and this function never claims otherwise.
+    """
+    import httpx
+
+    descriptor = attachment.descriptor
+    url = f"http://{descriptor.host if ':' not in descriptor.host else f'[{descriptor.host}]'}:{descriptor.port}{daemon_owner.STAND_DOWN_PATH}"
+    try:
+        response = httpx.post(
+            url,
+            headers={"Authorization": f"Bearer {attachment.token}"},
+            timeout=_STAND_DOWN_SECONDS,
+        )
+    except Exception:
+        logger.debug("The stale daemon could not be asked to stand down", exc_info=True)
+        return
+    if response.status_code == 404:
+        # An owner from before this route existed. It will not hand over on
+        # request, so the honest outcome is that the upgrade takes effect when
+        # that owner exits for its own reasons.
+        logger.info(
+            "The running daemon is too old to hand the browser over on request; "
+            "it will be replaced when it stops"
+        )
+        return
+    logger.debug("Stand-down request answered with %s", response.status_code)
+
+
+def _reachable(attachment: Attachment) -> bool:
+    """Whether the published endpoint answers this token.
+
+    An authenticated round trip rather than a TCP connect. A connect succeeds
+    against any listener that happens to hold the port, including one the
+    operating system handed to something else after the owner died, and against
+    an owner whose token no longer matches the file this client just read.
+    """
+    import asyncio
+
+    async def ask() -> bool:
+        from fastmcp import Client
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        try:
+            async with Client(
+                StreamableHttpTransport(
+                    attachment.descriptor.url, auth=attachment.token
+                )
+            ) as client:
+                await client.ping()
+        except Exception:
+            logger.debug("The published daemon did not answer", exc_info=True)
+            return False
+        return True
+
+    try:
+        return asyncio.run(asyncio.wait_for(ask(), _REACHABLE_SECONDS))
+    except Exception:
+        # Includes the timeout, and a caller that is already inside a running
+        # loop. Both mean the same thing here: no proof the owner is alive.
+        logger.debug("The daemon reachability check failed", exc_info=True)
+        return False
+
+
+def _log_hint(auth_root: Path) -> Path:
+    """Where a user should look when an owner refused to start.
+
+    The owner is detached, so its failure is not on anyone's terminal. Without
+    this the whole diagnosis a user gets is that nothing happened.
+    """
+    return daemon_owner.daemon_log_path(auth_root)
+
+
+class _Attempt(enum.Enum):
+    """What came of trying to start an owner, in the three ways it can end.
+
+    A boolean cannot carry this, and collapsing it was measured to cost a
+    minute: a child that reported it could not serve read as "somebody is
+    starting", so the caller waited out its whole deadline for a descriptor
+    nothing was going to write.
+    """
+
+    #: An owner is up and has published. Ready to attach.
+    STARTED = "started"
+
+    #: Another process holds the lock, so somebody else is starting. Wait.
+    CONTENDED = "contended"
+
+    #: This process was the one that may, and the child could not serve. Nobody
+    #: else is coming, so waiting is pure delay.
+    FAILED = "failed"
+
+
+def _start_owner(
+    auth_root: Path, profile: Path, config: AppConfig, *, timeout: float
+) -> _Attempt:
+    """Get an owner running, if this process is the one that may."""
+    del profile  # the owner derives it from the configuration it is handed
+    if _hands_over_locks():
+        return _start_holding_the_lock(auth_root, config, timeout=timeout)
+    return _start_contending_for_the_lock(auth_root, config, timeout=timeout)
+
+
+def _hands_over_locks() -> bool:
+    """Whether a held lock can be given to a child on this platform.
+
+    Read from the lock module rather than from ``os.name`` again, so the
+    measurement that established it lives in one place.
+    """
+    from linkedin_mcp_server import daemon_lock
+
+    return daemon_lock._INHERITED_LOCKS_TRANSFER
+
+
+def _start_holding_the_lock(
+    auth_root: Path, config: AppConfig, *, timeout: float
+) -> _Attempt:
+    """POSIX: take the lock, hand it over, then let go of it entirely."""
+    lock = DaemonLock(auth_root)
+    if not lock.try_acquire():
+        return _Attempt.CONTENDED
+
+    outcome = _Attempt.FAILED
+    try:
+        duplicate = lock.inheritable_copy()
+        try:
+            if _spawn(auth_root, config, lock_fd=duplicate, timeout=timeout):
+                outcome = _Attempt.STARTED
+        finally:
+            # Closed whether or not the child got going. It shares the kernel
+            # lock, so a leaked copy would hold the daemon lock for this
+            # frontend's whole life with nothing able to release it.
+            with contextlib.suppress(OSError):
+                os.close(duplicate)
+    finally:
+        # Released in every case, and this is the load-bearing line. The child
+        # holds the lock through its own copy by now; this descriptor is the
+        # parent's share of the same open file description, and keeping it would
+        # mean the lock outlives the owner. Measured on this tree: with the
+        # parent's copy left open, killing the owner freed nothing and no
+        # replacement could be elected until the frontend exited too.
+        lock.release()
+
+    return outcome
+
+
+def _start_contending_for_the_lock(
+    auth_root: Path, config: AppConfig, *, timeout: float
+) -> _Attempt:
+    """Windows: start a child that competes for the lock itself.
+
+    The frontend takes no lock here, so it cannot tell "my child lost the race"
+    from "my child could not serve": both arrive as a failed handshake. So a
+    failure here is reported as contention, which costs a wait when nothing is
+    coming and avoids giving up while a rival owner is still starting. The
+    frontend on this platform has no better information to act on.
+    """
+    if _spawn(auth_root, config, lock_fd=None, timeout=timeout):
+        return _Attempt.STARTED
+    return _Attempt.CONTENDED
+
+
+def _spawn(
+    auth_root: Path, config: AppConfig, *, lock_fd: int | None, timeout: float
+) -> bool:
+    """Start the detached owner and wait for its ready handshake.
+
+    Detached deliberately, and this is the one piece of the issue's process-model
+    advice that survived measurement: a child started with ``start_new_session``
+    alone is still killed when the MCP client shuts down, and only a
+    double-forked child survives. An owner that dies with its first client would
+    reduce this whole feature to a slower version of what it replaces.
+    """
+    log_path = daemon_owner.daemon_log_path(auth_root)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    command = [sys.executable, "-m", "linkedin_mcp_server.daemon_owner"]
+    if lock_fd is not None:
+        command += ["--lock-fd", str(lock_fd)]
+
+    # Opened append, so a restart adds to the record rather than erasing the
+    # reason the last owner died.
+    with open(log_path, "a", encoding="utf-8") as log:
+        child = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            # The handshake channel. Not a separate inherited descriptor,
+            # because ``pass_fds`` is POSIX-only (``subprocess.py:1464``) and
+            # this path has to work on Windows, where the child competes for the
+            # lock and the frontend has nothing *but* the handshake to go on.
+            stdout=subprocess.PIPE,
+            # To the log file from the first instruction, so an interpreter that
+            # dies during imports still leaves its traceback somewhere. A
+            # detached process has no terminal to write it to.
+            stderr=log,
+            # Empty on Windows, which refuses the argument outright. The lock is
+            # only ever handed over where that works.
+            pass_fds=() if lock_fd is None else (lock_fd,),
+            # Its own session, so a signal aimed at the client's process group
+            # does not take the owner with it.
+            start_new_session=True,
+            close_fds=True,
+        )
+
+    try:
+        assert child.stdin is not None and child.stdout is not None
+        with child.stdin as handed:
+            handed.write(daemon_config.encode(config).encode())
+        return _await_ready(child, timeout=timeout)
+    finally:
+        # Closed once the verdict is in. The child has redirected its own
+        # standard output to the log by then and writes nothing more here, so
+        # this cannot cost it a broken pipe.
+        if child.stdout is not None:
+            child.stdout.close()
+
+
+def _await_ready(child: subprocess.Popen[bytes], *, timeout: float) -> bool:
+    """Wait for the child's verdict, or for it to die trying.
+
+    Three outcomes, and the third is why this is a pipe rather than a file.
+    ``ready`` means the endpoint answered a real request and the descriptor is
+    on disk. ``failed`` means the child said so. End of file with neither means
+    the child is gone, which covers a crash during imports and a kill from
+    outside, and it arrives at once instead of after the timeout.
+
+    Lines are scanned rather than only the first one read. The child redirects
+    its standard output away as soon as it can, but that is not the very first
+    thing it does, and a library that greets the terminal on import would
+    otherwise turn a healthy owner into a failed election.
+
+    Read on a thread rather than with a readiness check on the descriptor.
+    ``select`` accepts only sockets on Windows, so the obvious portable-looking
+    loop would block inside ``readline`` well past the deadline on exactly the
+    platform where this handshake is the *only* thing the frontend has to go on.
+    A thread bounds the wait everywhere with one mechanism.
+    """
+    stream = child.stdout
+    assert stream is not None
+
+    verdicts: queue.Queue[str | None] = queue.Queue()
+
+    def collect() -> None:
+        try:
+            seen = 0
+            for line in stream:
+                verdict = line.decode("utf-8", "replace").strip()
+                if verdict in (daemon_owner.READY, daemon_owner.FAILED):
+                    verdicts.put(verdict)
+                    return
+                # Bounded, so a child stuck printing cannot keep this thread
+                # alive for the owner's whole lifetime.
+                seen += len(line)
+                if seen > 4096:
+                    break
+        except OSError:  # pragma: no cover - the stream closed under us
+            pass
+        finally:
+            # End of file, or a child that talked without ever answering. Either
+            # way the caller must stop waiting, so absence is a message too.
+            verdicts.put(None)
+
+    # A daemon thread: if the child neither answers nor exits, the frontend must
+    # still be able to shut down. It holds only this pipe, which the caller
+    # closes.
+    reader = threading.Thread(target=collect, name="daemon-handshake", daemon=True)
+    reader.start()
+
+    try:
+        verdict = verdicts.get(timeout=max(timeout, 0.0))
+    except queue.Empty:
+        logger.warning("The daemon did not finish starting in time")
+        return False
+
+    if verdict is None:
+        logger.info("The daemon exited before it was ready")
+        return False
+    if verdict == daemon_owner.FAILED:
+        logger.info("The daemon reported that it could not start")
+        return False
+    return True

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -18,10 +18,21 @@ Two things it must never do, both of which cost the lock silently:
   releases it for all. Measured on both POSIX and Windows: unlock-then-close
   left the lock free while a live process believed it held it. The kernel
   bookkeeping behind that differs by platform, but the rule does not.
-* It must not treat a free lock as proof that nothing is running. Chromium
-  outlives the process that started it, measured at over twenty seconds after a
-  kill, and the kernel frees the lock at the instant of death. The two facts are
-  true at the same time.
+* It must not treat a free lock as proof that nothing is running. The kernel
+  frees the lock at the instant of death, and Chromium can still be shutting
+  down. The margin is much smaller than an earlier note here claimed: that said
+  "over twenty seconds", and re-measuring found 13-38 ms on this machine and
+  11-103 ms independently, because Chromium is wired to its driver by
+  ``--remote-debugging-pipe`` and exits when the pipe breaks. A direct collision
+  test, five rounds with a successor pre-armed and spinning, produced no round
+  with two live browsers on one profile.
+
+  The rule stands regardless of the number, because it is about which question a
+  lock answers: ownership and profile-idleness are separate, and what actually
+  keeps two processes off one profile is the lease next door. The old figure is
+  recorded here because it was load-bearing in the design that produced this
+  file, and leaving it unqualified invites conclusions the measurement does not
+  support.
 
 Handing a held lock to another process works only on POSIX. Measured on
 Windows: a child that inherited the handle through the documented mechanism did

--- a/linkedin_mcp_server/daemon_lock.py
+++ b/linkedin_mcp_server/daemon_lock.py
@@ -61,8 +61,8 @@ _DAEMON_LOCK_FILE = "daemon.lock"
 #: parent had closed its handles and exited: a third process acquired the byte
 #: range in 20 of 20 runs. Within one process a duplicate does keep the lock
 #: alive, which is why this is easy to get wrong from a single-process test.
-#: Ownership here has to be taken by the supervisor itself rather than passed
-#: to it.
+#: So on Windows the elected process has to take the lock itself rather than be
+#: handed one.
 #:
 #: The measurement closed and exited together, so it does not say which of the
 #: two released the region. That distinction would matter for a design that
@@ -119,7 +119,7 @@ def daemon_lock_path(auth_root: Path) -> Path:
 class DaemonLock:
     """Exclusive ownership of one auth root's daemon, for as long as it is held.
 
-    Not a context manager by default, because the normal case is a supervisor
+    Not a context manager by default, because the normal case is a daemon owner
     that takes it at startup and holds it until it has finished cleaning up. Use
     :meth:`hold` when a scope really is the right shape, which is mainly tests
     and the one-shot maintenance commands.
@@ -173,8 +173,8 @@ class DaemonLock:
         """Give up the lock by closing our descriptor, never by unlocking it.
 
         Closing drops only this descriptor; the lock survives in any copy a
-        supervisor inherited. Unlocking would release it for all of them at
-        once, so a supervisor that had already adopted the handoff would lose
+        owner inherited. Unlocking would release it for all of them at
+        once, so an owner that had already adopted the handoff would lose
         the lock without anything saying so, and the next client would elect a
         second owner against a live browser.
         """
@@ -191,23 +191,23 @@ class DaemonLock:
         logger.debug("Daemon lock released for %s", self._auth_root)
 
     def inheritable_copy(self) -> int:
-        """Duplicate the descriptor so a launched supervisor can inherit it.
+        """Duplicate the descriptor so a launched owner can inherit it.
 
         POSIX only, and refused elsewhere rather than quietly returning
         something that does not mean what it says.
 
         The original is opened close-on-exec, so it would not survive the exec
-        that starts the supervisor. Handing over a duplicate rather than
-        releasing and letting the supervisor take the lock itself is what closes
+        that starts the owner. Handing over a duplicate rather than
+        releasing and letting the owner take the lock itself is what closes
         the window in between, during which another client would see a free lock
         and elect a second owner.
 
-        The caller closes the copy once the supervisor confirms it has it.
+        The caller closes the copy once the owner confirms it has it.
         """
         if not _INHERITED_LOCKS_TRANSFER:
             raise DaemonLockError(
                 "Handing a held lock to another process is a POSIX mechanism. "
-                "On this platform the supervisor has to take the lock itself."
+                "On this platform the owner has to take the lock itself."
             )
         if self._fd is None:
             raise DaemonLockError("Cannot hand over a lock this process does not hold")
@@ -229,7 +229,7 @@ class DaemonLock:
         """Take ownership of an inherited locked descriptor.
 
         POSIX only, like its counterpart, and for the measured reason above.
-        Called by a supervisor that was launched holding a copy.
+        Called by an owner that was launched holding a copy.
 
         Adoption is the one path that would otherwise take a caller's word for
         what it was handed, so the descriptor is checked to be this lock's own
@@ -249,7 +249,7 @@ class DaemonLock:
         if not _INHERITED_LOCKS_TRANSFER:
             raise DaemonLockError(
                 "An inherited lock cannot be adopted on this platform. "
-                "The supervisor has to take the lock itself."
+                "The owner has to take the lock itself."
             )
         self._discard_if_forked()
         if self._fd is not None:
@@ -300,7 +300,7 @@ class DaemonLock:
             raise DaemonLockError(
                 "The lock file was replaced while the inherited descriptor was "
                 "being adopted, so it now locks an inode nothing refers to. "
-                "Start the supervisor again."
+                "Start the owner again."
             )
         # Made non-inheritable again straight away. It was marked inheritable
         # for exactly one launch, and leaving it that way would let any later

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -59,6 +59,7 @@ from linkedin_mcp_server import __version__, daemon_config, daemon_descriptor
 from linkedin_mcp_server.config import set_config
 from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.daemon_lock import DaemonLock, DaemonLockError
+from linkedin_mcp_server.drivers.browser import set_headless
 from linkedin_mcp_server.logging_config import configure_logging
 from linkedin_mcp_server.server_role import ServerRole
 from linkedin_mcp_server.session_state import auth_root_dir, get_runtime_id
@@ -664,6 +665,17 @@ def main(argv: list[str] | None = None) -> int:
         raise
 
     set_config(config)
+    # Installing the configuration is not enough: the browser mode lives in a
+    # module global that defaults to headless (``drivers/browser.py:63``), and
+    # ``_make_browser`` reads that global rather than the configuration
+    # (``drivers/browser.py:265-283``). The frontend's own entry point sets it
+    # explicitly for the same reason (``cli_main.py:391``).
+    #
+    # Without this, an owner started with ``--no-headless`` publishes a
+    # fingerprint that says so — the frontend compares it and attaches happily —
+    # and then opens headless anyway. A user who asked to watch the browser
+    # would get no window and no error.
+    set_headless(config.browser.headless)
     configure_logging(log_level=config.server.log_level, json_format=True)
 
     profile = Path(config.browser.user_data_dir).expanduser().resolve()

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -80,11 +80,13 @@ MCP_PATH = "/mcp"
 #: both stages together. Generous, because it covers the first import of the
 #: whole server graph on a cold page cache.
 #:
-#: It must stay comfortably below the frontend's own election budget
-#: (``daemon_election.DEFAULT_ELECTION_SECONDS``), and a test enforces that. The
-#: frontend stops a child that has said nothing by the time its budget runs out,
-#: so an owner allowed to take longer would be killed on a slow machine while
-#: still inside its own rules.
+#: At most half the frontend's own election budget
+#: (``daemon_election.DEFAULT_ELECTION_SECONDS``), which is what the test
+#: enforces. The frontend stops a child that has said nothing by the time its
+#: budget runs out, so an owner allowed to take longer would be killed on a slow
+#: machine while still inside its own rules. The margin covers what the frontend
+#: spends before this clock even starts: handing the configuration over, and any
+#: lock attempts before that.
 _STARTUP_PROBE_SECONDS = 30.0
 
 _LOG_FILE = "daemon.log"

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -52,6 +52,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Protocol, TextIO
 
+import httpx
+
 from linkedin_mcp_server import __version__, daemon_config, daemon_descriptor
 from linkedin_mcp_server.config import set_config
 from linkedin_mcp_server.config.schema import AppConfig
@@ -140,6 +142,57 @@ def _endpoint_host(sock: socket.socket) -> str:
     return str(address)
 
 
+def direct_http_client(*, timeout: float) -> httpx.Client:
+    """An HTTP client that talks to this machine and nowhere else.
+
+    Every request the daemon makes carries the bearer token for a server driving
+    a logged-in LinkedIn session, and every one of them is addressed to
+    loopback. httpx honours ``HTTP_PROXY`` by default, and it does so even for
+    ``127.0.0.1`` unless ``NO_PROXY`` happens to say otherwise. Reproduced
+    against a capture proxy: a request to ``http://127.0.0.1:9/...`` arrived at
+    the proxy complete with ``Authorization: Bearer <token>``.
+
+    So proxies are refused rather than avoided by hoping the environment is
+    configured well. ``trust_env=False`` also drops ``.netrc`` and environment
+    certificate settings, none of which have any business on a loopback hop.
+
+    This is the same distinction the browser configuration already draws: the
+    user's proxy is for LinkedIn's traffic, not for the server's own
+    (``config/schema.py:105-107``).
+    """
+    return httpx.Client(trust_env=False, timeout=timeout)
+
+
+def direct_async_http_client(
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+    **extra: Any,
+) -> httpx.AsyncClient:
+    """The asynchronous counterpart, shaped as FastMCP's client factory.
+
+    The three named parameters are the ``McpHttpClientFactory`` protocol
+    (``mcp/shared/_httpx_utils.py``). ``**extra`` is there because the protocol
+    is not the whole contract: FastMCP's own transport passes
+    ``follow_redirects`` on top of it and marks the call ``type: ignore``
+    itself (``fastmcp/client/transports/http.py:176-181``), while the SDK's path
+    passes exactly the three. A factory that accepted only the documented
+    signature failed at connect time with an unexpected keyword — measured, and
+    it took every real-owner test with it.
+
+    ``trust_env`` is the one thing a caller may not override, so it is set after
+    the passthrough rather than merged into it.
+    """
+    extra.pop("trust_env", None)
+    return httpx.AsyncClient(
+        headers=headers,
+        timeout=timeout if timeout is not None else httpx.Timeout(30.0),
+        auth=auth,
+        trust_env=False,
+        **extra,
+    )
+
+
 async def _probe(url: str, token: str) -> None:
     """Prove the endpoint answers this token before anything is published.
 
@@ -152,7 +205,11 @@ async def _probe(url: str, token: str) -> None:
     from fastmcp import Client
     from fastmcp.client.transports import StreamableHttpTransport
 
-    async with Client(StreamableHttpTransport(url, auth=token)) as client:
+    async with Client(
+        StreamableHttpTransport(
+            url, auth=token, httpx_client_factory=direct_async_http_client
+        )
+    ) as client:
         await client.ping()
 
 

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -1,0 +1,545 @@
+"""The process that holds the browser and serves it over loopback.
+
+Started detached by a frontend that has just won the election, and from then on
+independent of it: it holds the daemon lock for its lifetime, listens on an
+ephemeral loopback port, and drives the one Chromium every client shares.
+
+Three orderings in here are load-bearing, and each of them is a way the daemon
+would otherwise wedge:
+
+*Listen, prove, then publish.* The descriptor is what makes the daemon
+discoverable, so writing it before the endpoint answers advertises a server that
+refuses tokens. The endpoint is proved by an authenticated request against the
+socket, not by the absence of an exception during startup.
+
+*Bind before publishing, and publish the bound port.* The port is chosen by the
+kernel, so it does not exist until the socket is bound. Binding here rather than
+letting uvicorn do it is what makes the published port the one being served.
+
+*Signal ready last.* The frontend is waiting on a pipe, and everything it does
+next assumes the descriptor is readable. Signalling earlier turns a rare startup
+loss into an attach against a file that is not there yet.
+
+The lock arrives one of two ways, and the split is a platform fact rather than a
+preference. On POSIX the frontend takes the lock first and hands the descriptor
+over, so no window exists in which the position looks free. Windows cannot do
+that (``daemon_lock.py:54-71``, measured), so the frontend takes no lock at all
+and this process competes for it. Losing that race is an ordinary outcome there:
+another owner is starting, and the frontend waits for whoever wins.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import errno
+import hmac
+import logging
+import os
+import socket
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Protocol, TextIO
+
+from linkedin_mcp_server import __version__, daemon_config, daemon_descriptor
+from linkedin_mcp_server.config import set_config
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon_lock import DaemonLock, DaemonLockError
+from linkedin_mcp_server.logging_config import configure_logging
+from linkedin_mcp_server.server_role import ServerRole
+from linkedin_mcp_server.session_state import auth_root_dir, get_runtime_id
+
+logger = logging.getLogger(__name__)
+
+#: What the frontend reads from the handshake pipe. One line, so a partially
+#: written message cannot be mistaken for a complete one.
+READY = "ready"
+FAILED = "failed"
+
+#: Where the owner serves MCP. Fixed rather than configurable: the frontend
+#: reads it out of the descriptor, and the only thing a second value would do is
+#: give two installations a way to disagree.
+MCP_PATH = "/mcp"
+
+#: How long the startup probe may take before the owner gives up and reports a
+#: failed election. Generous, because it covers the first import of the whole
+#: server graph on a cold page cache, and bounded because the frontend is
+#: blocked on the handshake for exactly this long.
+_STARTUP_PROBE_SECONDS = 30.0
+
+_LOG_FILE = "daemon.log"
+
+
+def daemon_log_path(auth_root: Path) -> Path:
+    """Where a detached owner's output goes.
+
+    A detached process has no terminal, so anything it writes to standard error
+    is lost. That includes the traceback of a failure before logging is
+    configured, which is exactly the failure a user would need to see. The
+    frontend opens this file and hands it to the child as both streams, so even
+    an interpreter that dies during imports leaves its reason behind.
+
+    Both sides derive the path from the auth root rather than passing it, so
+    they cannot disagree about which file the descriptor names.
+    """
+    return daemon_descriptor.daemon_dir(auth_root) / _LOG_FILE
+
+
+def _bind_loopback() -> socket.socket:
+    """Bind an ephemeral loopback port, and return the listening socket.
+
+    Bound here rather than by uvicorn because the port has to be known before
+    the descriptor is written, and with port 0 the kernel only settles it at
+    bind time. Uvicorn accepts an already-bound socket and serves it as is.
+
+    IPv6 first, falling back to IPv4. A host with IPv6 disabled is ordinary
+    enough that failing there would be a daemon that cannot start for reasons
+    the user did not choose.
+    """
+    for family, host in ((socket.AF_INET6, "::1"), (socket.AF_INET, "127.0.0.1")):
+        sock = socket.socket(family, socket.SOCK_STREAM)
+        try:
+            # Deliberately no SO_REUSEADDR. On an ephemeral port there is
+            # nothing to reuse, and on the BSDs, macOS among them, it would let
+            # a second bind succeed against a live listener on some
+            # configurations. A port the kernel just handed out is unused.
+            sock.bind((host, 0))
+            sock.listen(128)
+        except OSError as exc:
+            sock.close()
+            if family is socket.AF_INET6 and exc.errno in (
+                errno.EAFNOSUPPORT,
+                errno.EADDRNOTAVAIL,
+                errno.EPROTONOSUPPORT,
+            ):
+                continue
+            raise
+        return sock
+    raise OSError("No loopback address could be bound for the daemon endpoint")
+
+
+def _endpoint_host(sock: socket.socket) -> str:
+    """The address to publish for *sock*, unbracketed.
+
+    The descriptor stores a bare host and brackets it when it builds a URL
+    (``daemon_descriptor.py:576-585``), so bracketing here would produce
+    ``[[::1]]``.
+    """
+    address = sock.getsockname()[0]
+    return str(address)
+
+
+async def _probe(url: str, token: str) -> None:
+    """Prove the endpoint answers this token before anything is published.
+
+    An initialize round trip rather than a bare connection. A TCP connect
+    succeeds the moment the socket is listening, which it is before uvicorn has
+    a single route mounted, and a token that is not accepted would then only
+    surface at the first real tool call, in a different process, as a failure
+    nobody can place.
+    """
+    from fastmcp import Client
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    async with Client(StreamableHttpTransport(url, auth=token)) as client:
+        await client.ping()
+
+
+#: The route a newer frontend uses to ask a stale owner to stand down. Part of
+#: the daemon's own protocol, so a change here is a ``PROTOCOL_VERSION`` bump.
+STAND_DOWN_PATH = "/control/stand-down"
+
+
+def create_owner_server(
+    *,
+    config: AppConfig,
+    token: str,
+    host: str,
+    port: int,
+    stand_down: Callable[[], None] | None = None,
+) -> Any:
+    """Build the authenticated HTTP server the owner runs.
+
+    Uvicorn directly rather than ``FastMCP.run_http_async``, which would
+    otherwise be the obvious call. It builds its own server, binds its own port
+    and blocks with no handle to stop it (``fastmcp/server/mixins/transport.py``,
+    the ``server.serve`` at the end of ``run_http_async``). This process needs
+    all three: the port before it can publish, the started flag before it can
+    probe, and a way to shut down for the idle exit that follows. Verified
+    against the installed 3.4.4, including that a lifespan still runs both ways
+    round when driving uvicorn like this.
+    """
+    import uvicorn
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+
+    from linkedin_mcp_server.server import create_mcp_server
+
+    mcp = create_mcp_server(
+        tool_timeout=config.server.tool_timeout_seconds,
+        role=ServerRole.OWNER,
+        auth_token=token,
+    )
+
+    if stand_down is not None:
+
+        @mcp.custom_route(STAND_DOWN_PATH, methods=["POST"])
+        async def stand_down_route(request: Request) -> JSONResponse:
+            """Give up the browser so a newer build can take over.
+
+            The token is checked here rather than left to the server's auth
+            provider. Measured on 3.4.4: a custom route is mounted outside the
+            authentication middleware, so an unauthenticated POST to this path
+            was served. Without this check any process on the machine, and any
+            page the user's browser visits, could stop the shared browser at
+            will.
+            """
+            header = request.headers.get("authorization", "")
+            scheme, _, presented = header.partition(" ")
+            if scheme.lower() != "bearer" or not hmac.compare_digest(
+                presented.strip(), token
+            ):
+                return JSONResponse({"error": "unauthorized"}, status_code=401)
+            stand_down()
+            return JSONResponse({"standing_down": True})
+
+    app = mcp.http_app(
+        path=MCP_PATH,
+        transport="http",
+        # The same defence the documented HTTP bind gets. A loopback listener is
+        # reachable from every process on the machine, and from a browser the
+        # user merely points at a page: a website could otherwise drive this
+        # server through the user's own browser, from inside the network where a
+        # firewall does not help. The token is the real barrier, and a Host this
+        # server does not answer to is still worth refusing before it is checked.
+        host_origin_protection=True,
+        allowed_hosts=[host, f"{host}:{port}", f"[{host}]", f"[{host}]:{port}"],
+    )
+    return uvicorn.Server(
+        uvicorn.Config(
+            app,
+            log_level=config.server.log_level.lower(),
+            lifespan="on",
+            timeout_graceful_shutdown=5,
+        )
+    )
+
+
+async def _serve(
+    *,
+    lock: DaemonLock,
+    auth_root: Path,
+    profile: Path,
+    config: AppConfig,
+    log_path: Path,
+    ready: Handshake,
+) -> int:
+    """Run the endpoint, publish it, and hold it until shutdown."""
+    instance_id = daemon_descriptor.new_instance_id()
+    token = daemon_descriptor.new_token()
+
+    sock = _bind_loopback()
+    host, port = _endpoint_host(sock), sock.getsockname()[1]
+
+    # A list so the route can reach it before the server it belongs to exists.
+    turnover: list[str] = []
+
+    def stand_down() -> None:
+        turnover.append("asked")
+
+    server = create_owner_server(
+        config=config, token=token, host=host, port=port, stand_down=stand_down
+    )
+
+    descriptor = daemon_descriptor.build(
+        instance_id=instance_id,
+        package_version=__version__,
+        runtime_id=get_runtime_id(),
+        profile=profile,
+        host=host,
+        port=port,
+        path=MCP_PATH,
+        token=token,
+        config=config,
+        log_path=log_path,
+    )
+
+    serving = asyncio.create_task(server.serve(sockets=[sock]), name="daemon-endpoint")
+    try:
+        await _await_started(server, serving)
+        # Built before it is proved, and proved through its own ``url``: a probe
+        # against a URL assembled here would pass while the one clients actually
+        # use was malformed. An IPv6 endpoint is exactly that case, since the
+        # literal has to be bracketed.
+        await asyncio.wait_for(_probe(descriptor.url, token), _STARTUP_PROBE_SECONDS)
+
+        daemon_descriptor.publish(auth_root, descriptor, token)
+        # Only now, and only while the lock is held: a token file that is not
+        # this generation's belongs to an owner that is gone, because a live one
+        # would be holding the lock this process has.
+        _forget_superseded_tokens(auth_root, keeping=instance_id)
+        logger.info("Daemon listening on %s", descriptor.url)
+        ready.succeed()
+    except BaseException:
+        server.should_exit = True
+        with contextlib.suppress(BaseException):
+            await asyncio.wait_for(serving, timeout=10)
+        raise
+
+    del lock  # held for the process lifetime; named to say so
+    await _serve_until_stopped(server, serving, turnover)
+    return 0
+
+
+#: How often the owner checks whether it has been asked to stand down. A
+#: turnover happens once per upgrade, so a leisurely poll costs a user nothing
+#: and keeps the request itself free of any dependency on the serving loop.
+_STAND_DOWN_POLL_SECONDS = 0.1
+
+
+async def _serve_until_stopped(
+    server: Any, serving: asyncio.Task[None], turnover: list[str]
+) -> None:
+    """Hold the endpoint open until it stops, or until a newer build asks.
+
+    The stand-down request is noticed here rather than acted on inside the
+    route, so the asking frontend gets its reply before this process goes away.
+    Stopping mid-request would leave it unable to tell a completed turnover from
+    a refusal, and it would then wait for a lock this process had not yet freed.
+    """
+    while not serving.done():
+        if turnover:
+            logger.info("A newer build asked for the browser; standing down")
+            server.should_exit = True
+            # Graceful: uvicorn finishes the requests in flight, the lifespan
+            # runs, and the browser is closed on the way out. Only after that
+            # does this process exit and the kernel free the daemon lock, which
+            # is what lets the replacement start without ever overlapping.
+            await serving
+            return
+        await asyncio.sleep(_STAND_DOWN_POLL_SECONDS)
+    await serving
+
+
+async def _await_started(server: object, serving: asyncio.Task[None]) -> None:
+    """Wait until uvicorn reports it is serving, or until it gives up.
+
+    Polled rather than awaited on an event, because uvicorn exposes only the
+    flag. Watching the serving task alongside it is what turns a server that
+    died during startup into an error instead of a wait that never ends.
+    """
+    while not getattr(server, "started", False):
+        if serving.done():
+            # Re-raises whatever killed it, or reports the silent exit.
+            await serving
+            raise RuntimeError("The daemon endpoint stopped before it started serving")
+        await asyncio.sleep(0.02)
+
+
+def _forget_superseded_tokens(auth_root: Path, *, keeping: str) -> None:
+    """Remove token files from earlier generations of this daemon.
+
+    ``publish`` writes one per instance and removes none
+    (``daemon_descriptor.py:754-790``), so without this every restart leaves
+    another credential file behind. Safe only here: the caller holds the lock,
+    so no other owner exists, and the descriptor for *keeping* is already
+    published, so no client is about to read one of these.
+    """
+    directory = daemon_descriptor.daemon_dir(auth_root)
+    keep = daemon_descriptor.token_path(auth_root, keeping).name
+    try:
+        entries = list(directory.iterdir())
+    except OSError:
+        logger.debug("Could not list the daemon directory", exc_info=True)
+        return
+    for entry in entries:
+        if entry.name.startswith("token-") and entry.name != keep:
+            with contextlib.suppress(OSError):
+                entry.unlink()
+
+
+class Handshake(Protocol):
+    """How this process tells the frontend how startup went.
+
+    Stated as a protocol because the ordering it participates in is the thing
+    worth testing — ready must come after the descriptor is on disk — and a test
+    that can observe when it is called does not need a pipe to do it.
+    """
+
+    def succeed(self) -> None: ...
+
+    def fail(self) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class _Handshake:
+    """The pipe the frontend waits on, and the one message that goes through it.
+
+    Standard output, taken over at startup and closed after the verdict. Not an
+    inherited descriptor of its own: ``pass_fds`` is POSIX-only
+    (``subprocess.py:1464``), and the platform without it is precisely the one
+    where the frontend has nothing else to go on, because it cannot hand over a
+    lock either and so cannot know whether this child won.
+
+    A pipe rather than a file, because the interesting failure is silence. When
+    this process dies the frontend's read ends at once, so an owner that never
+    reaches a verdict is reported as a failed election rather than waited out.
+    """
+
+    def __init__(self, stream: TextIO | None) -> None:
+        self._stream = stream
+
+    def succeed(self) -> None:
+        self._write(READY)
+
+    def fail(self) -> None:
+        self._write(FAILED)
+
+    def _write(self, message: str) -> None:
+        stream, self._stream = self._stream, None
+        if stream is None:
+            return
+        try:
+            stream.write(f"{message}\n")
+            stream.flush()
+        except (OSError, ValueError):
+            logger.debug("The startup handshake could not be written", exc_info=True)
+        finally:
+            with contextlib.suppress(OSError, ValueError):
+                stream.close()
+
+    def close(self) -> None:
+        """Close without a verdict, so the frontend sees the pipe end."""
+        stream, self._stream = self._stream, None
+        if stream is None:
+            return
+        with contextlib.suppress(OSError, ValueError):
+            stream.close()
+
+
+def _claim_handshake_stream() -> TextIO | None:
+    """Take standard output for the handshake, and point everything else away.
+
+    Two things at once, and both matter. The frontend reads this pipe for one
+    line, so anything else written to it would be read as a verdict. And the
+    pipe stops being read the moment the frontend has its answer, so a process
+    that kept writing there would eventually block on a full buffer or die of a
+    broken pipe — for a daemon that outlives its starter by design, that is a
+    hang with no visible cause.
+
+    So the descriptor is duplicated for this module's use and the original is
+    replaced by the log file, which the frontend opened as standard error. Every
+    later ``print``, every library that greets the terminal, and every logging
+    handler built afterwards goes to the log instead.
+    """
+    try:
+        sys.stdout.flush()
+        duplicate = os.dup(sys.stdout.fileno())
+    except (OSError, ValueError, AttributeError):
+        # No usable standard output, which means nobody is waiting on a
+        # handshake either: this was started by hand rather than by a frontend.
+        # Running on without one is the right outcome, since the endpoint and
+        # the descriptor do not depend on it.
+        logger.debug("No handshake stream to claim", exc_info=True)
+        return None
+    try:
+        # Onto the log the frontend already gave us, so nothing is lost and
+        # nothing else reaches the handshake pipe.
+        os.dup2(sys.stderr.fileno(), sys.stdout.fileno())
+    except (OSError, ValueError, AttributeError):
+        os.close(duplicate)
+        logger.debug("Standard output could not be redirected", exc_info=True)
+        return None
+    return os.fdopen(duplicate, "w", encoding="utf-8")
+
+
+def _take_lock(auth_root: Path, inherited_fd: int | None) -> DaemonLock | None:
+    """Hold the daemon lock, by adoption on POSIX or by contest on Windows."""
+    lock = DaemonLock(auth_root)
+    if inherited_fd is not None:
+        lock.adopt(inherited_fd)
+        return lock
+    # Windows, where the frontend cannot hand a lock over. Losing here is not a
+    # defect: another owner is coming up, and the frontend waits for it.
+    if not lock.try_acquire():
+        return None
+    return lock
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run as the detached owner. Returns a process exit status."""
+    parser = argparse.ArgumentParser(
+        prog="linkedin-mcp-daemon",
+        description="Serve one shared LinkedIn browser to local MCP clients.",
+    )
+    parser.add_argument("--lock-fd", type=int, default=None)
+    args = parser.parse_args(argv)
+
+    # Before anything else can write to it.
+    handshake = _Handshake(_claim_handshake_stream())
+    try:
+        # Read before anything else touches the configuration: the frontend
+        # holds the pipe open only until it has written, and the settings decide
+        # how this process logs.
+        config = _read_config()
+    except BaseException:
+        handshake.fail()
+        raise
+
+    set_config(config)
+    configure_logging(log_level=config.server.log_level, json_format=True)
+
+    profile = Path(config.browser.user_data_dir).expanduser().resolve()
+    auth_root = auth_root_dir(profile)
+
+    lock: DaemonLock | None = None
+    try:
+        lock = _take_lock(auth_root, args.lock_fd)
+        if lock is None:
+            logger.info("Another process won the daemon election")
+            handshake.fail()
+            return 0
+        return asyncio.run(
+            _serve(
+                lock=lock,
+                auth_root=auth_root,
+                profile=profile,
+                config=config,
+                log_path=daemon_log_path(auth_root),
+                ready=handshake,
+            )
+        )
+    except DaemonLockError:
+        logger.exception("The daemon could not take ownership")
+        handshake.fail()
+        return 1
+    except Exception:
+        logger.exception("The daemon stopped with an error")
+        handshake.fail()
+        return 1
+    finally:
+        # After the verdict either way, so a frontend blocked on the pipe is
+        # released even by a path that forgot to answer.
+        handshake.close()
+        if lock is not None:
+            lock.release()
+
+
+def _read_config() -> AppConfig:
+    """Read the handed-over configuration from standard input.
+
+    Read to end of file rather than one line, and the frontend closes its end
+    once written. That is the whole framing: a short read cannot be mistaken for
+    a complete message because a truncated JSON object does not parse.
+    """
+    raw = sys.stdin.read()
+    if not raw.strip():
+        raise ValueError("The daemon was started without a configuration")
+    return daemon_config.decode(raw)
+
+
+if __name__ == "__main__":  # pragma: no cover - process entry point
+    sys.exit(main())

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -76,10 +76,15 @@ FAILED = "failed"
 #: give two installations a way to disagree.
 MCP_PATH = "/mcp"
 
-#: How long the startup probe may take before the owner gives up and reports a
-#: failed election. Generous, because it covers the first import of the whole
-#: server graph on a cold page cache, and bounded because the frontend is
-#: blocked on the handshake for exactly this long.
+#: How long the owner has to get from a bound socket to a proved endpoint, for
+#: both stages together. Generous, because it covers the first import of the
+#: whole server graph on a cold page cache.
+#:
+#: It must stay comfortably below the frontend's own election budget
+#: (``daemon_election.DEFAULT_ELECTION_SECONDS``), and a test enforces that. The
+#: frontend stops a child that has said nothing by the time its budget runs out,
+#: so an owner allowed to take longer would be killed on a slow machine while
+#: still inside its own rules.
 _STARTUP_PROBE_SECONDS = 30.0
 
 _LOG_FILE = "daemon.log"
@@ -355,12 +360,20 @@ async def _serve(
 
     serving = asyncio.create_task(server.serve(sockets=[sock]), name="daemon-endpoint")
     try:
-        await _await_started(server, serving)
+        # One budget across both halves of startup, not one each. They are two
+        # stages of the same thing from the frontend's side, and it waits on the
+        # total: an allowance each let an owner take twice what the frontend
+        # would ever wait for, so it could be following its own rules and still
+        # be written off as silent and stopped.
+        deadline = time.monotonic() + _STARTUP_PROBE_SECONDS
+        await _await_started(server, serving, timeout=_STARTUP_PROBE_SECONDS)
         # Built before it is proved, and proved through its own ``url``: a probe
         # against a URL assembled here would pass while the one clients actually
         # use was malformed. An IPv6 endpoint is exactly that case, since the
         # literal has to be bracketed.
-        await asyncio.wait_for(_probe(descriptor.url, token), _STARTUP_PROBE_SECONDS)
+        await asyncio.wait_for(
+            _probe(descriptor.url, token), max(deadline - time.monotonic(), 0.0)
+        )
 
         daemon_descriptor.publish(auth_root, descriptor, token)
         # Only now, and only while the lock is held: a token file that is not

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -34,6 +34,7 @@ import argparse
 import asyncio
 import contextlib
 import errno
+import hashlib
 import hmac
 import logging
 import os
@@ -152,6 +153,26 @@ async def _probe(url: str, token: str) -> None:
 STAND_DOWN_PATH = "/control/stand-down"
 
 
+def _matches_token(presented: str, expected: str) -> bool:
+    """Whether a presented bearer token is the expected one.
+
+    Through digests rather than by comparing the strings directly, and that is
+    not belt and braces. ``hmac.compare_digest`` refuses two *strings* when
+    either contains a non-ASCII character, and the presented one arrives in an
+    HTTP header from anything that can reach the port. Compared directly, a
+    header of ``Bearer töken`` raises ``TypeError`` inside the route and the
+    caller gets a 500 where it should get a 401 — an unauthenticated request
+    turned into a way to provoke an error. Found by trying it.
+
+    Digesting first also makes the comparison length-independent, so nothing
+    about the real token's length is observable.
+    """
+    return hmac.compare_digest(
+        hashlib.sha256(presented.strip().encode("utf-8", "surrogatepass")).digest(),
+        hashlib.sha256(expected.encode("utf-8")).digest(),
+    )
+
+
 def create_owner_server(
     *,
     config: AppConfig,
@@ -198,9 +219,7 @@ def create_owner_server(
             """
             header = request.headers.get("authorization", "")
             scheme, _, presented = header.partition(" ")
-            if scheme.lower() != "bearer" or not hmac.compare_digest(
-                presented.strip(), token
-            ):
+            if scheme.lower() != "bearer" or not _matches_token(presented, token):
                 return JSONResponse({"error": "unauthorized"}, status_code=401)
             stand_down()
             return JSONResponse({"standing_down": True})

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -48,6 +48,7 @@ import logging
 import os
 import socket
 import sys
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Protocol, TextIO
@@ -383,6 +384,12 @@ async def _serve(
 #: and keeps the request itself free of any dependency on the serving loop.
 _STAND_DOWN_POLL_SECONDS = 0.1
 
+#: How long a standing-down owner may take to shut down before it exits anyway.
+#: Comfortably past uvicorn's own five second connection grace, so an ordinary
+#: shutdown is never cut short, and short enough that a hung one does not hold
+#: the lock for a user's whole session.
+_STAND_DOWN_SHUTDOWN_SECONDS = 30.0
+
 
 async def _serve_until_stopped(
     server: Any, serving: asyncio.Task[None], turnover: list[str]
@@ -398,28 +405,67 @@ async def _serve_until_stopped(
         if turnover:
             logger.info("A newer build asked for the browser; standing down")
             server.should_exit = True
-            # Graceful: uvicorn finishes the requests in flight, the lifespan
-            # runs, and the browser is closed on the way out. Only after that
-            # does this process exit and the kernel free the daemon lock, which
-            # is what lets the replacement start without ever overlapping.
-            await serving
+            # Graceful, but not unconditionally. Uvicorn finishes the requests
+            # in flight and runs the lifespan, which closes the browser, and
+            # only then does this process exit and the kernel free the lock.
+            #
+            # Bounded, because that shutdown is not guaranteed to finish:
+            # ``timeout_graceful_shutdown`` bounds the connection tasks and
+            # nothing bounds the lifespan behind them. An owner stuck there
+            # would hold the daemon lock forever, having already promised a
+            # frontend that it was standing down — every later election would
+            # find the position occupied by a process that is no longer serving.
+            # Giving up the wait and exiting is the lesser harm: the lock is
+            # freed by the exit either way.
+            await _stop_within(serving, _STAND_DOWN_SHUTDOWN_SECONDS)
             return
         await asyncio.sleep(_STAND_DOWN_POLL_SECONDS)
     await serving
 
 
-async def _await_started(server: object, serving: asyncio.Task[None]) -> None:
+async def _stop_within(serving: asyncio.Task[None], seconds: float) -> None:
+    """Let the server finish shutting down, and stop waiting if it will not."""
+    try:
+        await asyncio.wait_for(asyncio.shield(serving), seconds)
+    except TimeoutError:
+        logger.warning(
+            "The daemon did not finish shutting down in %.0fs; exiting anyway so "
+            "the lock is released",
+            seconds,
+        )
+    except Exception:
+        logger.warning("The daemon endpoint stopped with an error", exc_info=True)
+
+
+async def _await_started(
+    server: object,
+    serving: asyncio.Task[None],
+    *,
+    timeout: float = _STARTUP_PROBE_SECONDS,
+) -> None:
     """Wait until uvicorn reports it is serving, or until it gives up.
 
     Polled rather than awaited on an event, because uvicorn exposes only the
     flag. Watching the serving task alongside it is what turns a server that
     died during startup into an error instead of a wait that never ends.
+
+    Bounded as well, because "died" is not the only way startup fails. An ASGI
+    lifespan that hangs leaves the task pending and the flag false forever, and
+    by this point the child already holds the daemon lock: the frontend would
+    time out and move on while this process kept the position occupied without
+    ever serving anything. Raising here runs the failure path, which stops the
+    server and lets the process exit, and the kernel frees the lock with it.
     """
+    deadline = time.monotonic() + timeout
     while not getattr(server, "started", False):
         if serving.done():
             # Re-raises whatever killed it, or reports the silent exit.
             await serving
             raise RuntimeError("The daemon endpoint stopped before it started serving")
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"The daemon endpoint did not start within {timeout:.0f}s"
+            )
         await asyncio.sleep(0.02)
 
 

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -1,8 +1,16 @@
 """The process that holds the browser and serves it over loopback.
 
-Started detached by a frontend that has just won the election, and from then on
-independent of it: it holds the daemon lock for its lifetime, listens on an
-ephemeral loopback port, and drives the one Chromium every client shares.
+Started by a frontend that wants a shared browser, and from then on independent
+of it: it holds the daemon lock for its lifetime, listens on an ephemeral
+loopback port, and drives the one Chromium every client shares.
+
+"Independent" is a POSIX measurement, not a promise on every platform. There the
+child leads its own session, and after ``SIGKILL`` to the frontend's whole
+process group it was still running and had reparented to pid 1. Windows has no
+equivalent in this code: ``start_new_session`` is POSIX-only
+(``subprocess.py:795``), so nothing there detaches the child from a job object
+that takes its parent down. That is worth revisiting before the flag is turned
+on by default, and it is not a regression today, since the feature is opt-in.
 
 Three orderings in here are load-bearing, and each of them is a way the daemon
 would otherwise wedge:
@@ -188,9 +196,10 @@ def create_owner_server(
     and blocks with no handle to stop it (``fastmcp/server/mixins/transport.py``,
     the ``server.serve`` at the end of ``run_http_async``). This process needs
     all three: the port before it can publish, the started flag before it can
-    probe, and a way to shut down for the idle exit that follows. Verified
-    against the installed 3.4.4, including that a lifespan still runs both ways
-    round when driving uvicorn like this.
+    probe, and a handle to stop with — used here by the stand-down turnover, and
+    by the idle exit when that is built. Verified against the installed 3.4.4,
+    including that a lifespan still runs both ways round when driving uvicorn
+    like this.
     """
     import uvicorn
     from starlette.requests import Request

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -370,8 +370,13 @@ async def _serve(
         ready.succeed()
     except BaseException:
         server.should_exit = True
-        with contextlib.suppress(BaseException):
-            await asyncio.wait_for(serving, timeout=10)
+        # Through the same bounded stop as the stand-down path, and for the same
+        # reason: `wait_for` waits for the cancellation it requested to finish,
+        # so a task that suppresses cancellation makes this line unbounded no
+        # matter what timeout it is given. `suppress` only helps once the await
+        # returns. This process holds the daemon lock by now, so a failed
+        # startup that never exits is a profile nothing can elect an owner for.
+        await _stop_within(serving, _FAILED_STARTUP_SHUTDOWN_SECONDS)
         raise
 
     del lock  # held for the process lifetime; named to say so
@@ -389,6 +394,11 @@ _STAND_DOWN_POLL_SECONDS = 0.1
 #: shutdown is never cut short, and short enough that a hung one does not hold
 #: the lock for a user's whole session.
 _STAND_DOWN_SHUTDOWN_SECONDS = 30.0
+
+#: The same bound for a startup that failed. Shorter, because nothing is being
+#: preserved: no client was ever told this owner existed, and the descriptor was
+#: never published.
+_FAILED_STARTUP_SHUTDOWN_SECONDS = 10.0
 
 
 async def _serve_until_stopped(
@@ -424,17 +434,50 @@ async def _serve_until_stopped(
 
 
 async def _stop_within(serving: asyncio.Task[None], seconds: float) -> None:
-    """Let the server finish shutting down, and stop waiting if it will not."""
+    """Let the server finish shutting down, and stop the process if it will not.
+
+    Ending the *wait* is not the same as ending the process, and the difference
+    is the whole point here. Returning from this leaves the serving task pending;
+    ``asyncio.run`` then cancels it on the way out and waits, without any bound,
+    for that cancellation to complete. A task that suppresses cancellation
+    therefore keeps the interpreter alive, holding the daemon lock, after every
+    timeout above it has already fired.
+
+    That is not a hypothetical shape. ``close_browser`` deliberately holds
+    cancellation back until teardown finishes (``drivers/browser.py:736-757``),
+    because interrupting it half way leaves a Chromium nobody owns, and the
+    export it waits on first is itself unbounded. An unresponsive browser is
+    exactly the case where a stand-down must still end.
+
+    So the last resort is a hard exit. It skips interpreter cleanup, which here
+    means skipping the very teardown that is already stuck; the kernel closes
+    the descriptors and frees the lock, which is what the next election needs.
+    Measured before this existed: the helper returned on time and the process
+    never came out of ``asyncio.run``.
+    """
     try:
         await asyncio.wait_for(asyncio.shield(serving), seconds)
+        return
     except TimeoutError:
-        logger.warning(
-            "The daemon did not finish shutting down in %.0fs; exiting anyway so "
-            "the lock is released",
+        logger.error(
+            "The daemon did not finish shutting down in %.0fs; exiting hard so "
+            "the lock is released for the next owner",
             seconds,
         )
     except Exception:
         logger.warning("The daemon endpoint stopped with an error", exc_info=True)
+        return
+
+    _exit_hard()
+
+
+def _exit_hard() -> int:  # pragma: no cover - the process does not come back
+    """Leave immediately, without running interpreter cleanup.
+
+    Separated so a test can substitute it. Nothing after this returns.
+    """
+    logging.shutdown()  # flush the log file; the traceback above is the record
+    os._exit(1)
 
 
 async def _await_started(

--- a/linkedin_mcp_server/daemon_version.py
+++ b/linkedin_mcp_server/daemon_version.py
@@ -1,0 +1,68 @@
+"""Whether a frontend may be served by the owner it found, version-wise.
+
+``@latest`` is the documented install (README.md), so a machine can easily hold
+two versions at once: a long-lived owner from last week and a frontend that was
+downloaded a minute ago. Something has to give, and both obvious answers are
+wrong on their own.
+
+*Attach anyway* is what the shipped code did, because ``package_version`` was
+published and never compared. A months-old owner then serves its own tools to
+every new frontend indefinitely, which is exactly the "a pinned version quietly
+rots" failure the README warns users about — except invisible, because the user
+did update.
+
+*Refuse* wedges the client. A frontend that declines an incompatible owner and
+stops has no way forward: it cannot take the lock, so it cannot start a
+replacement, and the owner it refused will still be there next time.
+
+So the rule is neither. A **newer** frontend asks the owner to stand down and
+elects a replacement; an **older** one attaches, because the owner it found is
+at least as new as it is and downgrading a shared browser to satisfy one stale
+client would be the worse trade. Same version, obviously, attaches.
+
+``protocol_version`` stays a separate and stricter thing (``daemon_descriptor``
+enforces equality on it). That is for the wire contract, where disagreement means
+two processes cannot talk. This is for behaviour, where they can talk perfectly
+well and one of them is simply out of date.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+
+from packaging.version import InvalidVersion, Version
+
+logger = logging.getLogger(__name__)
+
+
+class Skew(enum.Enum):
+    """How a published owner's version relates to this frontend's."""
+
+    #: Same version, or the owner is newer. Attach.
+    SERVICEABLE = "serviceable"
+
+    #: This frontend is newer. Ask the owner to stand down, then elect.
+    OWNER_IS_STALE = "owner_is_stale"
+
+
+def compare(*, owner: str, frontend: str) -> Skew:
+    """Say whether *frontend* should be served by an owner running *owner*.
+
+    An unparseable version on either side is treated as serviceable. Both come
+    from installed package metadata, so a value neither ``packaging`` nor this
+    understands is a local build or an editable install rather than a skew, and
+    turning that into a forced restart on every single launch would make the
+    daemon useless exactly where it is being worked on.
+    """
+    try:
+        published, ours = Version(owner), Version(frontend)
+    except InvalidVersion:
+        logger.debug(
+            "Cannot compare daemon versions (%s against %s); attaching", owner, frontend
+        )
+        return Skew.SERVICEABLE
+
+    if ours > published:
+        return Skew.OWNER_IS_STALE
+    return Skew.SERVICEABLE

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -58,8 +58,15 @@ class _StaticTokenAuth(TokenVerifier):
 
     def __init__(self, token: str) -> None:
         super().__init__()
-        # Kept as a digest rather than the token, so a process dump or a repr
-        # of the running server does not carry the credential itself.
+        # A digest rather than the token, so the verifier's own repr does not
+        # carry the credential — the surrounding code logs whole objects at
+        # DEBUG and users paste those logs into issue reports.
+        #
+        # Deliberately not claimed: that this keeps the token out of the
+        # process. It does not. The owner holds it to serve the stand-down
+        # route, and every accepted request builds an AccessToken around it.
+        # Anything able to read this process's memory has already won, and the
+        # token is the least of what it finds there.
         self._expected = hashlib.sha256(token.encode()).digest()
 
     async def verify_token(self, token: str) -> AccessToken | None:

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -6,10 +6,17 @@ person profiles, company data, job information, and session management capabilit
 """
 
 import asyncio
+import hashlib
+import hmac
 import logging
 from typing import Any, AsyncIterator
 
 from fastmcp import FastMCP
+
+# fastmcp's own AccessToken, not the SDK's: it subclasses it to carry the JWT
+# claims (`fastmcp/server/auth/auth.py:54`), and returning the base class from
+# an override narrows what every caller downstream was promised.
+from fastmcp.server.auth.auth import AccessToken, TokenVerifier
 from fastmcp.server.lifespan import lifespan
 
 from linkedin_mcp_server import __version__
@@ -37,6 +44,30 @@ from linkedin_mcp_server.tools.person import register_person_tools
 from linkedin_mcp_server.tools.post import register_post_tools
 
 logger = logging.getLogger(__name__)
+
+
+class _StaticTokenAuth(TokenVerifier):
+    """Accepts exactly the one token the owner published, and nothing else.
+
+    A whole OAuth flow would be ceremony here: both ends are this installation,
+    the token is minted at startup, never reused, and written to a file only
+    this account can read. What it has to be is unguessable and compared without
+    leaking where two tokens diverge, which is what the digest comparison below
+    is for.
+    """
+
+    def __init__(self, token: str) -> None:
+        super().__init__()
+        # Kept as a digest rather than the token, so a process dump or a repr
+        # of the running server does not carry the credential itself.
+        self._expected = hashlib.sha256(token.encode()).digest()
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if not hmac.compare_digest(
+            self._expected, hashlib.sha256(token.encode()).digest()
+        ):
+            return None
+        return AccessToken(token=token, client_id="linkedin-mcp-frontend", scopes=[])
 
 
 @lifespan
@@ -91,18 +122,33 @@ def create_mcp_server(
     *,
     tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS,
     role: ServerRole = ServerRole.DIRECT,
+    auth_token: str | None = None,
 ) -> FastMCP:
     """Create and configure the MCP server with all LinkedIn tools.
 
     *role* selects which parts belong to this process. It defaults to
     :attr:`ServerRole.DIRECT`, which is exactly the historical server, so every
     existing caller keeps what it had.
+
+    *auth_token* is the bearer token a daemon owner requires. Only an owner has
+    one: it listens on a loopback port that every process on the machine can
+    reach, and a browser the user merely points at a page can reach it too.
     """
+    if auth_token is not None and role is not ServerRole.OWNER:
+        # A token on a stdio server protects nothing — there is no port to
+        # protect — and passing one is a caller that believes it built the
+        # owner. Refused rather than ignored, because the mistake it describes
+        # is an endpoint that was meant to be authenticated.
+        raise ValueError(
+            f"Only a daemon owner authenticates requests, not {role.value}"
+        )
+
     mcp = FastMCP(
         "mcp-server-linkedin",
         version=__version__,
         lifespan=browser_lifespan,
         mask_error_details=True,
+        auth=_StaticTokenAuth(auth_token) if auth_token is not None else None,
     )
     # Profile ownership belongs to whoever launches Chromium. A process that
     # only forwards calls must not take the lease: it would either block itself

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ asyncio_default_fixture_loop_scope = function
 addopts = -v --strict-markers -ra
 markers =
     browser_dom: evaluates extractor JS against a real chromium DOM; skipped when no browser is installed
+    slow: spawns real server processes; each case starts the full server graph

--- a/tests/test_daemon_config.py
+++ b/tests/test_daemon_config.py
@@ -158,6 +158,27 @@ class TestRefusing:
                 json.dumps({"browser": {}, "server": {"tool_timeout_seconds": -1.0}})
             )
 
+    def test_the_owner_refuses_to_start_without_a_configuration(self):
+        # The owner reads its settings from standard input and must not fall
+        # back to parsing its own command line: `load_config` would then see the
+        # daemon's argv, and the browser it opened would be configured by
+        # accident rather than by the client that asked for it.
+        #
+        # Exercised through `main`, which is otherwise reached only inside a
+        # spawned process where coverage cannot see it.
+        import io
+        import sys
+
+        from linkedin_mcp_server import daemon_owner
+
+        original = sys.stdin
+        sys.stdin = io.StringIO("   \n")
+        try:
+            with pytest.raises(ValueError, match="without a configuration"):
+                daemon_owner.main([])
+        finally:
+            sys.stdin = original
+
     def test_something_that_is_not_a_configuration_is_refused(self):
         with pytest.raises(ValueError, match="not valid JSON"):
             daemon_config.decode("not json at all")

--- a/tests/test_daemon_config.py
+++ b/tests/test_daemon_config.py
@@ -1,0 +1,169 @@
+"""Handing an owner the configuration it has to agree on.
+
+The owner is a separate process that opens a browser against a logged-in
+session, and it cannot work out its own settings: half of them arrived on the
+command line of the *frontend*. Get this wrong in the quiet direction and the
+result is not a visible error but a client that elects an owner and then refuses
+to use it, because the fingerprint it compares covers exactly these fields.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from linkedin_mcp_server import daemon_config
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon_descriptor import config_fingerprint
+
+
+def _config(**browser: object) -> AppConfig:
+    config = AppConfig()
+    config.browser.user_data_dir = "~/somewhere/profile"
+    for name, value in browser.items():
+        setattr(config.browser, name, value)
+    return config
+
+
+class TestRoundTrip:
+    def test_the_owner_agrees_with_the_frontend_that_started_it(self):
+        # The property that matters, stated the way the daemon uses it: the
+        # fingerprint is what a client compares before attaching, so an owner
+        # rebuilt from this must produce the same one. Anything dropped in
+        # transit shows up here as a client that will not talk to the owner it
+        # just started.
+        original = _config(
+            headless=False,
+            user_agent="Mozilla/5.0 (test)",
+            proxy_server="http://proxy.example:8080",
+            proxy_username="user",
+            proxy_password="secret",
+            viewport_width=1920,
+            login_timeout_seconds=900.0,
+        )
+
+        restored = daemon_config.decode(daemon_config.encode(original))
+
+        key = "a-token"
+        assert config_fingerprint(restored, key=key) == config_fingerprint(
+            original, key=key
+        )
+
+    def test_settings_outside_the_fingerprint_survive_too(self):
+        # The fingerprint says which differences stop two clients sharing an
+        # owner. It does not say which settings the owner needs to do its job:
+        # the handoff and wait timings are not in it, and an owner left on
+        # defaults would hand the browser around on a schedule the user did not
+        # choose.
+        # Values that survive validate() untouched, so this pins the transport
+        # rather than the clamping. The wait has a 45 second ceiling and the
+        # minimum hold has to leave room inside it, and both clamps are correct:
+        # picking values they act on would make this a test of the validator.
+        original = _config(
+            browser_wait_seconds=30.0,
+            browser_min_hold_seconds=5.0,
+            browser_idle_timeout_seconds=120.0,
+        )
+
+        restored = daemon_config.decode(daemon_config.encode(original))
+
+        assert restored.browser.browser_wait_seconds == 30.0
+        assert restored.browser.browser_min_hold_seconds == 5.0
+        assert restored.browser.browser_idle_timeout_seconds == 120.0
+
+    def test_the_tool_timeout_crosses_because_the_owner_enforces_it(self):
+        original = AppConfig()
+        original.browser.user_data_dir = "~/p/profile"
+        original.server.tool_timeout_seconds = 42.5
+
+        restored = daemon_config.decode(daemon_config.encode(original))
+
+        assert restored.server.tool_timeout_seconds == 42.5
+
+
+class TestRefusing:
+    def test_the_frontends_own_invocation_does_not_cross(self):
+        # An owner that adopted the frontend's transport would try to serve
+        # stdio, and one that adopted its one-shot flags would re-run the
+        # client's --login. Those describe how *that* process was started.
+        original = AppConfig()
+        original.browser.user_data_dir = "~/p/profile"
+        original.server.login = True
+        original.server.transport = "streamable-http"
+        original.server.port = 9999
+
+        carried = json.loads(daemon_config.encode(original))
+
+        assert "login" not in carried["server"]
+        assert "transport" not in carried["server"]
+        assert "port" not in carried["server"]
+
+    def test_an_unknown_setting_is_refused_rather_than_skipped(self):
+        # Both ends are one installation, so a name this does not recognise did
+        # not come from encode(). Skipping it quietly would be an owner running
+        # on settings nobody chose.
+        with pytest.raises(ValueError, match="unknown"):
+            daemon_config.decode(json.dumps({"browser": {"nonsense": 1}, "server": {}}))
+
+    def test_a_frontend_setting_smuggled_into_the_server_section_is_refused(self):
+        # The allowed list is enforced on the way in, not only on the way out.
+        with pytest.raises(ValueError, match="unknown"):
+            daemon_config.decode(json.dumps({"browser": {}, "server": {"login": True}}))
+
+    def test_a_value_of_the_wrong_type_is_refused_before_it_reaches_a_browser(self):
+        # JSON cannot tell seconds from a count. Left unchecked this surfaces
+        # deep inside a browser launch, in a detached process, as an error
+        # nobody can trace back to here.
+        with pytest.raises(ValueError, match="wrong type"):
+            daemon_config.decode(
+                json.dumps({"browser": {"slow_mo": "quickly"}, "server": {}})
+            )
+
+    def test_a_boolean_is_not_accepted_where_a_number_belongs(self):
+        # bool is a subclass of int, so an isinstance check alone accepts True
+        # as a timeout. That is exactly the silent nonsense this refuses.
+        with pytest.raises(ValueError, match="wrong type"):
+            daemon_config.decode(
+                json.dumps({"browser": {"slow_mo": True}, "server": {}})
+            )
+
+    def test_an_integer_is_accepted_where_a_float_belongs(self):
+        # The other direction, and it has to work: JSON writes 0 for 0.0, so
+        # refusing would make an ordinary configuration untransportable.
+        restored = daemon_config.decode(
+            json.dumps({"browser": {"login_timeout_seconds": 0}, "server": {}})
+        )
+
+        assert restored.browser.login_timeout_seconds == 0
+
+    def test_an_optional_setting_may_be_unset(self):
+        restored = daemon_config.decode(
+            json.dumps({"browser": {"user_agent": None}, "server": {}})
+        )
+
+        assert restored.browser.user_agent is None
+
+    def test_a_log_level_outside_the_supported_set_is_refused(self):
+        with pytest.raises(ValueError, match="wrong type"):
+            daemon_config.decode(
+                json.dumps({"browser": {}, "server": {"log_level": "CHATTY"}})
+            )
+
+    def test_a_configuration_the_frontend_would_reject_is_rejected_here_too(self):
+        # The owner is the process that opens the browser, so a value refused at
+        # the frontend must not reach Chromium through this back door.
+        with pytest.raises(Exception):
+            daemon_config.decode(
+                json.dumps({"browser": {}, "server": {"tool_timeout_seconds": -1.0}})
+            )
+
+    def test_something_that_is_not_a_configuration_is_refused(self):
+        with pytest.raises(ValueError, match="not valid JSON"):
+            daemon_config.decode("not json at all")
+
+        with pytest.raises(ValueError, match="not an object"):
+            daemon_config.decode("[1, 2, 3]")
+
+        with pytest.raises(ValueError, match="no browser section"):
+            daemon_config.decode(json.dumps({"server": {}}))

--- a/tests/test_daemon_config.py
+++ b/tests/test_daemon_config.py
@@ -10,6 +10,7 @@ to use it, because the fingerprint it compares covers exactly these fields.
 from __future__ import annotations
 
 import json
+from dataclasses import fields
 
 import pytest
 
@@ -76,9 +77,18 @@ class TestRoundTrip:
             eager_full_chromium=True,
         )
 
-        restored = daemon_config.decode(daemon_config.encode(original))
+        carried = daemon_config.encode(original)
+        restored = daemon_config.decode(carried)
 
         assert restored.browser == original.browser
+        # And every field was actually sent, not merely restored to a default
+        # that happened to match. The comparison above cannot tell those apart
+        # for any field left at its default — `chrome_path` is one, and so is
+        # every field added in future. Checking the serialised keys against the
+        # dataclass is what makes the name of this test true.
+        assert set(json.loads(carried)["browser"]) == {
+            field.name for field in fields(original.browser)
+        }
 
     def test_settings_outside_the_fingerprint_survive_too(self):
         # The fingerprint says which differences stop two clients sharing an

--- a/tests/test_daemon_config.py
+++ b/tests/test_daemon_config.py
@@ -207,6 +207,47 @@ class TestRefusing:
                 json.dumps({"browser": {}, "server": {"tool_timeout_seconds": -1.0}})
             )
 
+    def test_the_owner_applies_the_browser_mode_it_was_handed(self):
+        # Installing the configuration is not enough. The browser mode lives in
+        # a module global that defaults to headless, and `_make_browser` reads
+        # that global rather than the configuration — the frontend's own entry
+        # point sets it explicitly for exactly this reason.
+        #
+        # Without it, an owner started with `--no-headless` publishes a
+        # fingerprint saying so, the frontend compares it and attaches happily,
+        # and the browser opens headless anyway: no window, no error, and a user
+        # who asked to watch it left wondering.
+        #
+        # Driven through `main`, and asserted against the global the launcher
+        # actually reads. Calling `set_headless` directly here would only prove
+        # that setter works; what was broken is that the owner never called it.
+        import io
+        import sys
+
+        import linkedin_mcp_server.drivers.browser as browser_module
+        from linkedin_mcp_server import daemon_owner
+
+        visible = AppConfig()
+        visible.browser.user_data_dir = "~/p/profile"
+        visible.browser.headless = False
+
+        original = browser_module.current_headless()
+        stdin = sys.stdin
+        browser_module.set_headless(True)
+        sys.stdin = io.StringIO(daemon_config.encode(visible))
+        try:
+            # It gets as far as taking the lock, which fails on the deliberately
+            # invalid descriptor and is reported rather than raised. That is
+            # well past the point where the browser mode is settled.
+            assert daemon_owner.main(["--lock-fd", "-1"]) == 1
+
+            assert browser_module.current_headless() is False, (
+                "the owner ignored the browser mode it was handed"
+            )
+        finally:
+            sys.stdin = stdin
+            browser_module.set_headless(original)
+
     def test_the_owner_refuses_to_start_without_a_configuration(self):
         # The owner reads its settings from standard input and must not fall
         # back to parsing its own command line: `load_config` would then see the

--- a/tests/test_daemon_config.py
+++ b/tests/test_daemon_config.py
@@ -50,16 +50,49 @@ class TestRoundTrip:
             original, key=key
         )
 
+    def test_every_browser_setting_crosses_unchanged(self):
+        # The fingerprint check above is necessary and not sufficient: it only
+        # covers SHARED_CONFIG_FIELDS, and a field left at its default produces
+        # the same digest whether it crossed or was dropped. So the whole
+        # section is compared field by field, which is what would actually
+        # notice a setting quietly going missing from the codec.
+        original = _config(
+            headless=False,
+            slow_mo=25,
+            user_agent="Mozilla/5.0 (test)",
+            viewport_width=1920,
+            viewport_height=1080,
+            default_timeout=9000,
+            proxy_server="http://proxy.example:8080",
+            proxy_username="user",
+            proxy_password="secret",
+            proxy_bypass="localhost",
+            login_timeout_seconds=900.0,
+            login_inline_wait_seconds=10.0,
+            browser_wait_seconds=30.0,
+            browser_min_hold_seconds=5.0,
+            browser_idle_timeout_seconds=120.0,
+            auto_import_from_browser=False,
+            eager_full_chromium=True,
+        )
+
+        restored = daemon_config.decode(daemon_config.encode(original))
+
+        assert restored.browser == original.browser
+
     def test_settings_outside_the_fingerprint_survive_too(self):
         # The fingerprint says which differences stop two clients sharing an
         # owner. It does not say which settings the owner needs to do its job:
-        # the handoff and wait timings are not in it, and an owner left on
-        # defaults would hand the browser around on a schedule the user did not
-        # choose.
-        # Values that survive validate() untouched, so this pins the transport
-        # rather than the clamping. The wait has a 45 second ceiling and the
-        # minimum hold has to leave room inside it, and both clamps are correct:
-        # picking values they act on would make this a test of the validator.
+        # `browser_wait_seconds` and `browser_min_hold_seconds` are not in
+        # SHARED_CONFIG_FIELDS at all, so an owner left on their defaults would
+        # hand the browser around on a schedule the user did not choose while
+        # every fingerprint still matched. (`browser_idle_timeout_seconds` *is*
+        # in that list and is included here only as a third value to carry.)
+        #
+        # The values chosen survive validate() untouched, so this pins the
+        # transport rather than the clamping: the wait has a 45 second ceiling
+        # and the minimum hold has to leave room inside it, and picking values
+        # those clamps act on would make this a test of the validator.
         original = _config(
             browser_wait_seconds=30.0,
             browser_min_hold_seconds=5.0,
@@ -153,7 +186,13 @@ class TestRefusing:
     def test_a_configuration_the_frontend_would_reject_is_rejected_here_too(self):
         # The owner is the process that opens the browser, so a value refused at
         # the frontend must not reach Chromium through this back door.
-        with pytest.raises(Exception):
+        #
+        # The specific error, not a bare Exception: this is asserting that
+        # `validate()` ran, and any decoder bug at all would satisfy a looser
+        # check while the validation it names had quietly stopped happening.
+        from linkedin_mcp_server.config.schema import ConfigurationError
+
+        with pytest.raises(ConfigurationError, match="tool_timeout_seconds"):
             daemon_config.decode(
                 json.dumps({"browser": {}, "server": {"tool_timeout_seconds": -1.0}})
             )

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -376,26 +376,36 @@ class TestFailingFast:
                     sleeper.kill()
                     sleeper.wait(timeout=30)
 
-    def test_a_child_that_is_merely_slow_is_not_called_a_failure(
+    def test_a_child_that_says_nothing_does_not_keep_the_lock(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        # Silence is not failure, and conflating the two is the worst outcome
-        # this module can produce. A child that has neither answered nor exited
-        # is still coming up and still holds the lock it adopted. Reported as
-        # "could not serve", the caller concludes nobody is coming and goes off
-        # to drive its own browser against the profile that child is about to
-        # open — two browsers on one profile, caused by a slow machine.
+        # A child that has neither answered nor exited by the end of the budget
+        # is stopped, and the reasoning took two passes to get right.
+        #
+        # The first version called this "still trying" and left the child alone,
+        # on the grounds that it might yet come up and that killing it could
+        # leave the caller driving a second browser. The first half is true and
+        # the second is not: an owner opens no browser before it answers, and on
+        # POSIX the frontend holds its own lock until the spawn returns. What
+        # the leniency actually bought was a child holding the inherited lock
+        # while never serving — measured, the lock was still held afterwards,
+        # and every later election would contend against it forever.
+        #
+        # This test asserted the lenient behaviour and then killed the child in
+        # its own teardown, with a comment saying the lock would otherwise be
+        # held for the rest of the run. That comment was the bug report.
         profile = _profile(tmp_path)
         config = _config(profile)
         auth_root = profile.parent
 
-        # A child that starts and then says nothing at all, which is exactly
-        # what a cold interpreter on a loaded machine looks like.
+        # An ordinary configuration, so the handover succeeds and the silence
+        # happens at the handshake. The large-configuration case reaches the
+        # same wedge by blocking the write instead, and is covered separately.
         real = subprocess.Popen
         started: list[subprocess.Popen[Any]] = []
 
         def mute(command: list[str], **kwargs: Any) -> subprocess.Popen[Any]:
-            child = real([command[0], "-c", "import time; time.sleep(30)"], **kwargs)
+            child = real([command[0], "-c", "import time; time.sleep(600)"], **kwargs)
             started.append(child)
             return child
 
@@ -406,22 +416,27 @@ class TestFailingFast:
         elapsed = time.monotonic() - began
 
         try:
-            assert attempt is _Attempt.CONTENDED, (
-                "a child that is still starting was reported as a failure"
+            assert attempt is _Attempt.FAILED
+
+            # The half that matters. Nothing in production kills this child for
+            # us, which is exactly what the old teardown was standing in for.
+            probe = DaemonLock(auth_root)
+            assert probe.try_acquire(), (
+                "the silent child kept the daemon lock for this profile"
             )
-            # And it came back on time. The timeout above bounds the *wait*, and
-            # the cleanup after it used to hand that bound straight back:
-            # `child.stdout.close()` waits on the reader thread's I/O lock, so
-            # it blocked for exactly as long as the child stayed silent.
-            # Measured at 29.27s against a 30s sleeper, and forever against a
-            # child that never speaks or exits.
+            probe.release()
+            assert all(child.poll() is not None for child in started)
+
+            # And on time. The timeout bounds the *wait*, and the cleanup after
+            # it used to hand that bound straight back: `child.stdout.close()`
+            # waits on the reader thread's I/O lock, so it blocked for as long
+            # as the child stayed silent — 29.27s against a 30s sleeper.
             assert elapsed < 5, f"the bounded wait took {elapsed:.1f}s"
         finally:
-            # It sleeps for half a minute by design, so leaving it behind would
-            # hold the daemon lock it inherited for the rest of the run.
             for child in started:
-                child.kill()
-                child.wait(timeout=30)
+                if child.poll() is None:  # pragma: no cover - the stop worked
+                    child.kill()
+                    child.wait(timeout=30)
 
     def test_losing_the_lock_race_waits_instead_of_giving_up(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1360,6 +1375,33 @@ class TestVersionSkew:
         assert not _matches_token("\udcff", "the-token")
         assert _matches_token("the-token", "the-token")
         assert _matches_token("  the-token  ", "the-token")
+
+
+class TestBudgets:
+    def test_the_owner_may_not_take_longer_than_the_frontend_will_wait(self):
+        # The frontend now stops a child that has said nothing by the end of its
+        # budget, which makes the relationship between the two numbers load
+        # bearing rather than cosmetic: an owner allowed to take longer would be
+        # killed while still following its own rules, on a slow machine, and the
+        # user would see an election that never succeeds.
+        #
+        # They were out of step. The owner spent its full allowance twice, once
+        # waiting for uvicorn and again probing, so it could legitimately answer
+        # at 60s while the frontend gave up at 45. The two stages share one
+        # deadline now, and this pins the remaining margin.
+        from linkedin_mcp_server import daemon_owner
+
+        assert (
+            daemon_owner._STARTUP_PROBE_SECONDS
+            < election_module.DEFAULT_ELECTION_SECONDS
+        ), "an owner can now outlast the frontend that is waiting for it"
+
+        # With room to spare, because the frontend spends part of its budget on
+        # the configuration handover and on lock attempts before the owner's
+        # clock even starts.
+        assert daemon_owner._STARTUP_PROBE_SECONDS <= (
+            election_module.DEFAULT_ELECTION_SECONDS / 2
+        )
 
 
 class TestNotHoldingTheLockForever:

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -564,6 +564,50 @@ class TestRealOwner:
         finally:
             _stop(second.get("pid"))
 
+    @_POSIX_ONLY
+    def test_the_owner_outlives_the_client_that_started_it(self, real_state_root: Path):
+        # The premise of the whole feature. An owner that died with its first
+        # client would give every later client a cold start plus a fresh
+        # ``/feed/`` validation, which is the traffic this exists to remove.
+        #
+        # Killed by process *group*, not by pid, because that is how a client
+        # shutdown reaches a server it spawned — and a child that merely had its
+        # own pid would still be caught by it. ``start_new_session`` is what puts
+        # the owner in a group of its own.
+        import json
+
+        profile = real_state_root
+
+        frontend = subprocess.Popen(
+            [sys.executable, "-c", _LINGERING_FRONTEND, str(profile)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+            cwd=_REPO_ROOT,
+            # The test process needs a group of its own too, or the killpg below
+            # takes pytest with it. Found the direct way.
+            start_new_session=True,
+        )
+        owner_pid = None
+        try:
+            assert frontend.stdout is not None
+            owner_pid = json.loads(frontend.stdout.readline())["pid"]
+            assert isinstance(owner_pid, int), "no owner was elected"
+
+            os.killpg(os.getpgid(frontend.pid), signal.SIGKILL)
+            frontend.wait(timeout=30)
+
+            # Given a moment, because a group signal is not instantaneous and a
+            # check that raced it would pass for the wrong reason.
+            time.sleep(1.0)
+            assert _alive(owner_pid), "the owner died with the client that started it"
+        finally:
+            _stop(owner_pid)
+            if frontend.poll() is None:  # pragma: no cover - the kill worked
+                frontend.kill()
+                frontend.wait(timeout=30)
+
     def test_an_older_owner_hands_over_to_a_newer_build(self, real_state_root: Path):
         # The turnover, end to end against a live owner rather than a mock. Both
         # halves have to hold: the old process actually exits, and a replacement

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -332,13 +332,30 @@ class TestFailingFast:
 
         try:
             assert elapsed < 10, f"the spawn blocked for {elapsed:.1f}s"
-            # Alive and holding the lock, so it may still come up: the same
-            # verdict a silent handshake gets.
-            assert attempt is _Attempt.CONTENDED
+            # Reported as a failure, not as "somebody is starting". A child that
+            # never took its configuration is not coming up, and on POSIX it
+            # already holds the inherited lock descriptor — so it is stopped
+            # rather than left alone.
+            assert attempt is _Attempt.FAILED
+
+            # And the lock it inherited is free. This is the half that matters:
+            # measured with the child merely abandoned, the lock stayed held
+            # forever by a process that could never serve, and every later
+            # election contended against it.
+            probe = DaemonLock(auth_root)
+            assert probe.try_acquire(), (
+                "the abandoned child kept the daemon lock for this profile"
+            )
+            probe.release()
+
+            assert all(sleeper.poll() is not None for sleeper in sleepers), (
+                "the child that could not serve was left running"
+            )
         finally:
             for sleeper in sleepers:
-                sleeper.kill()
-                sleeper.wait(timeout=30)
+                if sleeper.poll() is None:  # pragma: no cover - the stop worked
+                    sleeper.kill()
+                    sleeper.wait(timeout=30)
 
     def test_a_child_that_is_merely_slow_is_not_called_a_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1,0 +1,991 @@
+"""Getting one owner started, and never two.
+
+The properties here are about process lifetime, file descriptor inheritance and
+the kernel's arbitration, so most of these spawn real processes. A test that
+stayed inside one interpreter could show the code takes the branches it means to
+and would not show the thing that matters: that exactly one browser-owning
+process exists, and that the lock dies with it.
+
+Three of these pin defects that were live in this code and found by running it:
+a failed child read as "somebody is starting" and cost a full deadline, a
+crashed owner's descriptor was handed back as attachable, and the parent's copy
+of the lock outliving the owner would have wedged every recovery.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+import linkedin_mcp_server.daemon as daemon_module
+import linkedin_mcp_server.daemon_descriptor as daemon_descriptor_module
+import linkedin_mcp_server.daemon_election as election_module
+from linkedin_mcp_server import __version__
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon import Attachment, OwnerState
+from linkedin_mcp_server.daemon_election import (
+    _Attempt,
+    ElectionOutcome,
+    obtain_owner,
+)
+from linkedin_mcp_server.daemon_descriptor import (
+    build,
+    new_instance_id,
+    new_token,
+    publish,
+)
+from linkedin_mcp_server.daemon_lock import DaemonLock, daemon_is_running
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_RUNTIME = "test-runtime"
+
+_POSIX_ONLY = pytest.mark.skipif(
+    os.name == "nt", reason="the lock is handed to the child only on POSIX"
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_daemon_state(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Keep in-process tests off the account's real daemon state.
+
+    Skipped for the tests that spawn real owners. Those cannot use a redirected
+    root, because the owner is started by production code and derives its own
+    state from the account rather than from anything a test can hand it. They
+    take the ``real_state_root`` fixture instead, which isolates by auth root
+    and cleans up after itself.
+    """
+    if "real_state_root" in request.fixturenames:
+        return
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(daemon_descriptor_module, "_account_home", lambda: home)
+    monkeypatch.setattr(daemon_module, "get_runtime_id", lambda: _RUNTIME)
+    monkeypatch.setenv("HOME", str(home))
+
+
+def _config(profile: Path) -> AppConfig:
+    config = AppConfig()
+    config.browser.user_data_dir = str(profile)
+    config.server.daemon_enabled = True
+    return config
+
+
+def _profile(tmp_path: Path) -> Path:
+    profile = tmp_path / "auth" / "profile"
+    profile.mkdir(parents=True, exist_ok=True)
+    return profile
+
+
+def _publish_stale_owner(
+    auth_root: Path,
+    profile: Path,
+    config: AppConfig,
+    *,
+    package_version: str = __version__,
+) -> str:
+    """Publish a descriptor for an owner that is not running.
+
+    Exactly what a crash after publishing leaves behind: every field is valid,
+    the token matches, and nothing is listening.
+    """
+    token = new_token()
+    descriptor = build(
+        instance_id=new_instance_id(),
+        package_version=package_version,
+        runtime_id=_RUNTIME,
+        profile=profile,
+        host="127.0.0.1",
+        port=49152,
+        path="/mcp",
+        token=token,
+        config=config,
+        log_path=auth_root / "daemon.log",
+    )
+    publish(auth_root, descriptor, token)
+    return descriptor.instance_id
+
+
+class TestLiveness:
+    """A descriptor is a file. Only a request that is answered is a process."""
+
+    def test_a_crashed_owners_descriptor_is_not_handed_back(self, tmp_path: Path):
+        # Reproduced against a real owner before this was fixed: the process was
+        # killed, and the next election read its leftovers as attachable and
+        # returned the dead endpoint. Every check passes on that file, because
+        # the owner wrote it while it was healthy.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(auth_root, profile, config)
+
+        outcome = obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=0,
+            connect=lambda attachment: False,
+        )
+
+        assert not outcome.worth_connecting
+        assert outcome.attachment_lookup.state is OwnerState.INCOMPATIBLE
+
+    def test_an_unreachable_descriptor_is_kept_rather_than_deleted(
+        self, tmp_path: Path
+    ):
+        # Downgrading is not the same as cleaning up. A live owner this client
+        # cannot reach for a moment would be stranded by a deletion, and so
+        # would every other client attached to it. The lock decides what happens
+        # next, not this reading.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(auth_root, profile, config)
+        descriptor_file = daemon_descriptor_module.descriptor_path(auth_root)
+
+        obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=0,
+            connect=lambda attachment: False,
+        )
+
+        assert descriptor_file.exists()
+
+    def test_a_reachable_owner_is_attached_to_without_starting_anything(
+        self, tmp_path: Path
+    ):
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(auth_root, profile, config)
+
+        outcome = obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=0,
+            connect=lambda attachment: True,
+        )
+
+        assert outcome.worth_connecting
+        assert not outcome.started_owner
+
+    def test_a_corpse_is_not_probed_over_and_over(self, tmp_path: Path):
+        # The descriptor stays on disk until a live owner overwrites it, so a
+        # loop that re-read it would probe the same dead endpoint every pass.
+        # Each probe is a network timeout, which is how a fail-fast path turns
+        # into a stall.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(auth_root, profile, config)
+
+        probes: list[Attachment] = []
+
+        def never_answers(attachment: Attachment) -> bool:
+            probes.append(attachment)
+            return False
+
+        obtain_owner(
+            auth_root, profile, config, deadline_seconds=1.0, connect=never_answers
+        )
+
+        # Once for the corpse. Anything more means the same instance was tried
+        # again after being proved dead.
+        instances = {attachment.descriptor.instance_id for attachment in probes}
+        assert len(probes) == len(instances)
+
+
+class TestFailingFast:
+    def test_a_child_that_cannot_serve_does_not_cost_the_whole_deadline(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Measured before this was fixed: a failed child was indistinguishable
+        # from "somebody else is starting", so the caller waited out its full
+        # budget for a descriptor nothing was going to write. Sixty seconds of
+        # a client apparently hanging, ending in no diagnosis at all.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+
+        monkeypatch.setattr(
+            election_module,
+            "_start_owner",
+            lambda *args, **kwargs: _Attempt.FAILED,
+        )
+
+        started = time.monotonic()
+        outcome = obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=30,
+            connect=lambda attachment: False,
+        )
+        elapsed = time.monotonic() - started
+
+        assert not outcome.worth_connecting
+        # Generously bounded: the point is that it returns rather than waiting
+        # out the budget, not that it returns in any particular millisecond.
+        assert elapsed < 5, elapsed
+
+    def test_losing_the_lock_race_waits_instead_of_giving_up(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The opposite case, and the reason the two cannot share a return value.
+        # Somebody else holds the lock, so an owner *is* coming: giving up here
+        # would leave this client driving its own browser against the same
+        # profile for its whole life, which is the per-call handoff the daemon
+        # exists to remove.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        attempts = 0
+
+        def contended(*args: object, **kwargs: object) -> _Attempt:
+            nonlocal attempts
+            attempts += 1
+            return _Attempt.CONTENDED
+
+        monkeypatch.setattr(election_module, "_start_owner", contended)
+
+        obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=0.3,
+            connect=lambda attachment: False,
+        )
+
+        assert attempts >= 1
+
+
+# Deliberately unindented, and run as it stands rather than through
+# textwrap.dedent. An indented block here reads as a nicely nested string and is
+# one formatter pass away from being reindented into a different program:
+# `ruff format` did exactly that to an earlier version of this file and every
+# process test failed with an IndentationError from the child.
+_INSPECT_OWNER = """
+import json
+import sys
+from pathlib import Path
+
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon_election import obtain_owner
+from linkedin_mcp_server.daemon_lock import DaemonLock
+
+profile = Path(sys.argv[1])
+auth_root = profile.parent
+config = AppConfig()
+config.browser.user_data_dir = str(profile)
+
+outcome = obtain_owner(auth_root, profile, config, deadline_seconds=90)
+attachment = outcome.attachment_lookup.attachment
+# Asked from *this* process, which is the frontend: it must not hold the lock it
+# handed over.
+print(json.dumps({
+    "state": outcome.attachment_lookup.state.value,
+    "started": outcome.started_owner,
+    "pid": attachment.descriptor.pid if attachment else None,
+    "url": attachment.descriptor.url if attachment else None,
+    "frontend_holds_lock": DaemonLock(auth_root).try_acquire(),
+}))
+"""
+
+
+#: A frontend that elects an owner and then *stays alive*, which is what a real
+#: stdio server does for as long as its client is connected. It reports the
+#: owner's pid and then waits, so the test can kill the owner while this process
+#: still exists and ask whether the lock came free.
+#:
+#: Without a frontend that outlives the owner, the lock always frees: the
+#: operating system closes the frontend's descriptors when it exits, so a leaked
+#: copy is indistinguishable from a released one. Verified by mutation — with the
+#: release removed, every other test here still passed.
+_LINGERING_FRONTEND = """
+import json
+import sys
+import time
+from pathlib import Path
+
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon_election import obtain_owner
+
+profile = Path(sys.argv[1])
+config = AppConfig()
+config.browser.user_data_dir = str(profile)
+
+outcome = obtain_owner(profile.parent, profile, config, deadline_seconds=90)
+attachment = outcome.attachment_lookup.attachment
+print(json.dumps({"pid": attachment.descriptor.pid if attachment else None}))
+sys.stdout.flush()
+# Long enough for the caller to kill the owner and watch the lock, short enough
+# that a failure cannot leave this process behind.
+time.sleep(30)
+"""
+
+
+@pytest.fixture
+def real_state_root(tmp_path: Path):
+    """Let the spawned processes use the account's real daemon state root.
+
+    The unit tests above redirect that root, and the process tests cannot:
+    ``_account_home`` reads the account's passwd entry and deliberately ignores
+    ``HOME`` (``daemon_descriptor.py:161-190``), precisely so that a launcher
+    overriding the environment for one process cannot split an account's
+    election in two. The owner is started by production code, so there is
+    nowhere to inject a redirection into it, and faking one would test a path
+    users never take.
+
+    So these run against the real root, keyed by a unique auth root under
+    ``tmp_path``. The daemon directory is a hash of that auth root, so nothing
+    here can collide with the user's own state or with a parallel test, and the
+    same derivation gives cleanup an exact target.
+    """
+    profile = tmp_path / "auth" / "profile"
+    profile.mkdir(parents=True, exist_ok=True)
+    yield profile
+
+    # Owners are detached, so an assertion that fails before its stop() would
+    # otherwise leave a server running against the developer's machine.
+    directory = daemon_descriptor_module.daemon_dir(profile.parent)
+    descriptor = daemon_descriptor_module.descriptor_path(profile.parent)
+    try:
+        published = daemon_descriptor_module.read(profile.parent)
+    except Exception:
+        published = None
+    if published is not None:
+        _stop(published.pid)
+    if directory.exists():
+        import shutil
+
+        shutil.rmtree(directory, ignore_errors=True)
+    assert not descriptor.exists()
+
+
+def _run_frontend(profile: Path) -> dict[str, object]:
+    """Elect an owner from a separate interpreter, as a real client would."""
+    import json
+
+    result = subprocess.run(
+        [sys.executable, "-c", _INSPECT_OWNER, str(profile)],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+        cwd=_REPO_ROOT,
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def _alive(pid: int) -> bool:
+    """Whether a process still exists. Signal 0 checks without delivering one."""
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _stop(pid: object) -> None:
+    """Kill an owner, taking the pid as it comes out of the child's JSON.
+
+    Untyped on purpose: every caller has just read this out of a subprocess's
+    output, and threading a cast through each of them would add noise to the
+    cleanup path without making anything safer. A pid that is not an integer is
+    nothing to kill.
+    """
+    if not isinstance(pid, int):
+        return
+    with contextlib.suppress(OSError):
+        os.kill(pid, signal.SIGKILL)
+
+
+@pytest.mark.slow
+class TestRealOwner:
+    """The whole thing, with a real detached process on the other end.
+
+    Slow, and worth it: everything these assert is invisible to a test that
+    stays in one interpreter. Each spawn starts the full server graph.
+    """
+
+    def test_an_owner_is_started_and_answers(self, real_state_root: Path):
+        profile = real_state_root
+
+        result = _run_frontend(profile)
+        try:
+            assert result["state"] == OwnerState.ATTACHABLE.value, result
+            assert result["started"] is True
+            assert result["pid"] and result["pid"] != os.getpid()
+        finally:
+            _stop(result.get("pid"))
+
+    def test_the_frontend_lets_go_of_the_lock_it_handed_over(
+        self, real_state_root: Path
+    ):
+        # The load-bearing one. Both descriptors refer to one locked open file
+        # description, so a frontend that kept its copy would keep the daemon
+        # lock alive after the owner died — and every recovery afterwards would
+        # be locked out by a process that is not the owner and does not know it
+        # holds anything.
+        profile = real_state_root
+
+        result = _run_frontend(profile)
+        try:
+            # Asked inside the frontend, before it exited: the lock is held by
+            # the owner, and the frontend could not take it.
+            assert result["frontend_holds_lock"] is False, result
+        finally:
+            _stop(result.get("pid"))
+
+    def test_the_lock_frees_while_the_frontend_is_still_running(
+        self, real_state_root: Path
+    ):
+        # The one that actually proves the release, and the reason it has to be
+        # written this way. Both descriptors refer to one locked open file
+        # description, so the lock lives as long as either is open. Every other
+        # test here lets the frontend exit first, which closes its copy whether
+        # the code released it or not — verified by mutation: with the release
+        # removed, all of them still passed and this one fails.
+        #
+        # A frontend that leaked its copy would keep the daemon lock held after
+        # the owner died, so no replacement could ever be elected while that
+        # client stayed connected. That is a wedge with no visible cause.
+        import json
+
+        profile = real_state_root
+        auth_root = profile.parent
+
+        frontend = subprocess.Popen(
+            [sys.executable, "-c", _LINGERING_FRONTEND, str(profile)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+            cwd=_REPO_ROOT,
+        )
+        try:
+            assert frontend.stdout is not None
+            owner_pid = json.loads(frontend.stdout.readline())["pid"]
+            assert isinstance(owner_pid, int), "no owner was elected"
+            assert frontend.poll() is None, "the frontend exited too early"
+
+            _stop(owner_pid)
+
+            freed = False
+            for _ in range(500):
+                time.sleep(0.01)
+                probe = DaemonLock(auth_root)
+                if probe.try_acquire():
+                    probe.release()
+                    freed = True
+                    break
+            assert freed, (
+                "the daemon lock is still held after the owner died, so the "
+                "frontend kept its copy of it"
+            )
+        finally:
+            frontend.kill()
+            frontend.wait(timeout=30)
+
+    def test_the_lock_frees_when_the_owner_dies(self, real_state_root: Path):
+        # The other half of the same property. The frontend has exited by now,
+        # so if it had leaked its copy the lock would still be held here even
+        # though the owner is gone. Measured at 10 ms on this tree.
+        profile = real_state_root
+        auth_root = profile.parent
+
+        result = _run_frontend(profile)
+        pid = result["pid"]
+        assert isinstance(pid, int)
+        assert daemon_is_running(auth_root)
+
+        _stop(pid)
+
+        freed = False
+        for _ in range(300):
+            time.sleep(0.01)
+            probe = DaemonLock(auth_root)
+            if probe.try_acquire():
+                probe.release()
+                freed = True
+                break
+        assert freed, "the daemon lock outlived the owner that held it"
+
+    def test_a_second_frontend_attaches_instead_of_starting_another_owner(
+        self, real_state_root: Path
+    ):
+        # The point of the whole feature: one browser, however many clients.
+        profile = real_state_root
+
+        first = _run_frontend(profile)
+        try:
+            assert first["started"] is True
+            second = _run_frontend(profile)
+
+            assert second["state"] == OwnerState.ATTACHABLE.value, second
+            assert second["started"] is False, "a second owner was started"
+            assert second["pid"] == first["pid"]
+        finally:
+            _stop(first.get("pid"))
+
+    def test_a_crashed_owner_is_replaced(self, real_state_root: Path):
+        # The descriptor survives the process that wrote it, so the next client
+        # must prove the endpoint before trusting it and elect a replacement
+        # when it does not answer.
+        profile = real_state_root
+
+        first = _run_frontend(profile)
+        dead = first["pid"]
+        assert isinstance(dead, int)
+        _stop(dead)
+        # The kernel frees the lock at death; wait for it rather than assuming.
+        for _ in range(300):
+            if not daemon_is_running(profile.parent):
+                break
+            time.sleep(0.01)
+
+        second = _run_frontend(profile)
+        try:
+            assert second["state"] == OwnerState.ATTACHABLE.value, second
+            assert second["started"] is True, "the corpse was attached to"
+            assert second["pid"] != dead
+        finally:
+            _stop(second.get("pid"))
+
+    def test_an_older_owner_hands_over_to_a_newer_build(self, real_state_root: Path):
+        # The turnover, end to end against a live owner rather than a mock. Both
+        # halves have to hold: the old process actually exits, and a replacement
+        # is elected. Getting only the first is worse than doing nothing, and it
+        # is what happened here twice while this was being built — the owner
+        # stood down, and the frontend then spent its whole budget re-reading
+        # the descriptor it had already rejected rather than taking the lock the
+        # departing owner had just freed.
+        #
+        # The running owner is made to *claim* an old version by rewriting the
+        # published descriptor. `package_version` is covered by neither the token
+        # digest nor the configuration fingerprint, so the file stays valid in
+        # every other respect and the process behind it is genuinely serving.
+        import json
+
+        profile = real_state_root
+        auth_root = profile.parent
+
+        first = _run_frontend(profile)
+        old_pid = first["pid"]
+        assert isinstance(old_pid, int)
+
+        descriptor_file = daemon_descriptor_module.descriptor_path(auth_root)
+        published = json.loads(descriptor_file.read_text())
+        published["package_version"] = "1.0.0"
+        descriptor_file.write_text(json.dumps(published, indent=2, sort_keys=True))
+
+        started = time.monotonic()
+        second = _run_frontend(profile)
+        elapsed = time.monotonic() - started
+        try:
+            assert second["state"] == OwnerState.ATTACHABLE.value, second
+            assert second["started"] is True, "no replacement owner was elected"
+            assert second["pid"] != old_pid, "the stale owner is still serving"
+
+            for _ in range(500):
+                if not _alive(old_pid):
+                    break
+                time.sleep(0.01)
+            assert not _alive(old_pid), "the stale owner never stood down"
+
+            # And it has to be quick, because this happens on the launch after
+            # every upgrade and the user is waiting for their client to come up.
+            # Asserted separately from correctness because the two failed
+            # separately: with the post-turnover wait reinstated the outcome was
+            # still right and it took a minute and a quarter instead of three
+            # seconds. Measured at 2.1s here, so the bound is generous enough for
+            # a loaded CI machine and far below the stall it guards against.
+            assert elapsed < 30, f"the upgrade took {elapsed:.1f}s"
+        finally:
+            _stop(second.get("pid"))
+            _stop(old_pid)
+
+    def test_the_owner_requires_its_token(self, real_state_root: Path):
+        # The endpoint is loopback, which every process on the machine can
+        # reach, and a website the user merely visits can reach through their
+        # own browser. The token is what stands between that and a logged-in
+        # LinkedIn session.
+        import asyncio
+
+        from fastmcp import Client
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        profile = real_state_root
+        result = _run_frontend(profile)
+        url = result["url"]
+        assert isinstance(url, str)
+
+        try:
+
+            async def unauthenticated() -> None:
+                async with Client(StreamableHttpTransport(url, auth="wrong")) as client:
+                    await client.ping()
+
+            with pytest.raises(Exception):
+                asyncio.run(unauthenticated())
+        finally:
+            _stop(result.get("pid"))
+
+    def test_only_the_current_generations_token_stays_on_disk(
+        self, real_state_root: Path
+    ):
+        # `publish` writes one token file per instance and removes none, so
+        # without cleanup every restart leaves another credential behind.
+        profile = real_state_root
+        auth_root = profile.parent
+
+        first = _run_frontend(profile)
+        _stop(first["pid"])
+        for _ in range(300):
+            if not daemon_is_running(auth_root):
+                break
+            time.sleep(0.01)
+        second = _run_frontend(profile)
+
+        try:
+            directory = daemon_descriptor_module.daemon_dir(auth_root)
+            tokens = sorted(p.name for p in directory.glob("token-*"))
+            assert len(tokens) == 1, tokens
+            assert second["state"] == OwnerState.ATTACHABLE.value
+        finally:
+            _stop(second.get("pid"))
+
+
+class TestVersionSkew:
+    """``@latest`` means two versions can be on one machine at the same time."""
+
+    def test_an_older_owner_is_asked_to_hand_the_browser_over(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The shipped code published `package_version` and never compared it, so
+        # a months-old owner would serve its own tools to every freshly updated
+        # frontend indefinitely. That is the "a pinned version quietly rots"
+        # failure the README warns about, except the user *did* update.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(auth_root, profile, config, package_version="1.0.0")
+
+        asked: list[object] = []
+        monkeypatch.setattr(
+            election_module, "_ask_to_stand_down", lambda attachment: asked.append(1)
+        )
+
+        outcome = obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=0,
+            # Would attach if version were not consulted, which is what makes
+            # this test about the version rather than about reachability.
+            connect=lambda attachment: True,
+        )
+
+        assert asked, "the stale owner was never asked to stand down"
+        assert not outcome.worth_connecting
+
+    def test_a_newer_owner_is_used_rather_than_downgraded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The other direction, and it must not be symmetric. An older frontend
+        # meeting a newer owner has found something at least as new as itself;
+        # restarting the shared browser to satisfy one stale client would be the
+        # worse trade, and it would also thrash whenever two versions coexist.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(auth_root, profile, config, package_version="99.0.0")
+
+        asked: list[object] = []
+        monkeypatch.setattr(
+            election_module, "_ask_to_stand_down", lambda attachment: asked.append(1)
+        )
+
+        outcome = obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=0,
+            connect=lambda attachment: True,
+        )
+
+        assert not asked
+        assert outcome.worth_connecting
+
+    def test_an_unrecognisable_version_is_served_rather_than_replaced(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A local or editable install has a version neither side can order.
+        # Treating that as a skew would force a restart on every single launch,
+        # which is exactly where somebody is working on this code.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(
+            auth_root, profile, config, package_version="not-a-version"
+        )
+
+        asked: list[object] = []
+        monkeypatch.setattr(
+            election_module, "_ask_to_stand_down", lambda attachment: asked.append(1)
+        )
+
+        outcome = obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=0,
+            connect=lambda attachment: True,
+        )
+
+        assert not asked
+        assert outcome.worth_connecting
+
+    def test_a_stand_down_request_needs_the_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The control route is mounted outside fastmcp's authentication
+        # middleware — measured on 3.4.4, an unauthenticated POST to a custom
+        # route is served — so it checks the token itself. Without that, any
+        # process on the machine, and any page the user's browser visits, could
+        # stop the shared browser at will.
+        import asyncio
+        import socket
+
+        import httpx
+        import uvicorn
+
+        from linkedin_mcp_server import config as config_module
+        from linkedin_mcp_server import daemon_owner
+
+        config = _config(_profile(tmp_path))
+        # The owner installs its handed-over configuration before it serves, and
+        # the lifespan depends on that: `get_config()` would otherwise parse this
+        # process's command line, which under pytest means argparse exits and
+        # startup fails. Found by writing this test without it.
+        #
+        # Set through monkeypatch rather than `set_config`, which is a module
+        # global that would then leak into every test that ran afterwards.
+        monkeypatch.setattr(config_module, "_config", config)
+
+        stopped: list[str] = []
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(16)
+        port = sock.getsockname()[1]
+        server = daemon_owner.create_owner_server(
+            config=config,
+            token="the-token",
+            host="127.0.0.1",
+            port=port,
+            stand_down=lambda: stopped.append("asked"),
+        )
+        assert isinstance(server, uvicorn.Server)
+        url = f"http://127.0.0.1:{port}{daemon_owner.STAND_DOWN_PATH}"
+
+        async def exercise() -> tuple[int, int]:
+            serving = asyncio.create_task(server.serve(sockets=[sock]))
+            try:
+                # Through the production wait, which watches the serving task
+                # alongside the flag. A bare `while not server.started` loop
+                # never ends when startup fails, which is how this test hung
+                # before it was written this way.
+                await daemon_owner._await_started(server, serving)
+                async with httpx.AsyncClient() as client:
+                    without = await client.post(url)
+                    wrong = await client.post(
+                        url, headers={"Authorization": "Bearer nope"}
+                    )
+                    assert not stopped, "an unauthenticated caller stopped the daemon"
+                    good = await client.post(
+                        url, headers={"Authorization": "Bearer the-token"}
+                    )
+                    assert good.status_code == 200
+                return without.status_code, wrong.status_code
+            finally:
+                server.should_exit = True
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(serving, timeout=15)
+
+        without_status, wrong_status = asyncio.run(exercise())
+
+        assert without_status == 401
+        assert wrong_status == 401
+        assert stopped == ["asked"]
+
+
+class TestPublishingLast:
+    """Nothing is discoverable until it has been proved to work."""
+
+    def test_a_descriptor_is_published_only_after_the_endpoint_answers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The ordering is the whole point of the startup handshake, and it is
+        # invisible from the outside once startup has succeeded: both orders end
+        # with a published descriptor and a working endpoint. What separates them
+        # is the failure case — published first, a client can find and attach to
+        # an endpoint that refuses its token, and the diagnosis lands in a
+        # different process from the cause.
+        #
+        # Verified by mutation: with publish moved ahead of the probe, every
+        # other test in this file still passed.
+        import asyncio
+
+        from linkedin_mcp_server import daemon_owner
+
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        order: list[str] = []
+
+        async def probe(url: str, token: str) -> None:
+            order.append("probe")
+
+        def publish_spy(root: Path, descriptor: object, token: str):
+            order.append("publish")
+            return Path("descriptor"), Path("token")
+
+        monkeypatch.setattr(daemon_owner, "_probe", probe)
+        monkeypatch.setattr(
+            daemon_owner.daemon_descriptor, "publish", publish_spy, raising=True
+        )
+        monkeypatch.setattr(
+            daemon_owner, "_forget_superseded_tokens", lambda *a, **k: None
+        )
+
+        class _StoppedServer:
+            """Serves nothing and stops at once, so only the order is observed."""
+
+            started = True
+            should_exit = False
+
+            async def serve(self, sockets: object = None) -> None:
+                return None
+
+        monkeypatch.setattr(
+            daemon_owner, "_bind_loopback", lambda: _FakeSocket(("127.0.0.1", 49152))
+        )
+        monkeypatch.setattr(
+            daemon_owner, "create_owner_server", lambda **kwargs: _StoppedServer()
+        )
+
+        handshake = daemon_owner._Handshake(None)
+        asyncio.run(
+            daemon_owner._serve(
+                lock=DaemonLock(auth_root),
+                auth_root=auth_root,
+                profile=profile,
+                config=config,
+                log_path=auth_root / "daemon.log",
+                ready=handshake,
+            )
+        )
+
+        assert order == ["probe", "publish"], order
+
+    def test_ready_is_signalled_only_after_the_descriptor_is_readable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The frontend treats "ready" as permission to go and read the
+        # descriptor, so signalling before writing it turns a rare scheduling
+        # order into a client that looks for a file that is not there yet and
+        # elects a second owner. Verified by mutation: with the signal moved
+        # ahead of the publish, nothing else in this suite noticed.
+        import asyncio
+
+        from linkedin_mcp_server import daemon_owner
+
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        order: list[str] = []
+
+        class _Recording:
+            started = True
+            should_exit = False
+
+            async def serve(self, sockets: object = None) -> None:
+                return None
+
+        class _RecordingHandshake:
+            def succeed(self) -> None:
+                order.append("ready")
+
+            def fail(self) -> None:  # pragma: no cover - not reached here
+                order.append("failed")
+
+            def close(self) -> None:
+                return None
+
+        async def probe(url: str, token: str) -> None:
+            return None
+
+        monkeypatch.setattr(daemon_owner, "_probe", probe)
+        monkeypatch.setattr(
+            daemon_owner.daemon_descriptor,
+            "publish",
+            lambda *a, **k: (order.append("publish"), (Path("d"), Path("t")))[1],
+        )
+        monkeypatch.setattr(
+            daemon_owner, "_forget_superseded_tokens", lambda *a, **k: None
+        )
+        monkeypatch.setattr(
+            daemon_owner, "_bind_loopback", lambda: _FakeSocket(("127.0.0.1", 49152))
+        )
+        monkeypatch.setattr(
+            daemon_owner, "create_owner_server", lambda **kwargs: _Recording()
+        )
+
+        asyncio.run(
+            daemon_owner._serve(
+                lock=DaemonLock(auth_root),
+                auth_root=auth_root,
+                profile=profile,
+                config=config,
+                log_path=auth_root / "daemon.log",
+                ready=_RecordingHandshake(),
+            )
+        )
+
+        assert order == ["publish", "ready"], order
+
+
+class _FakeSocket:
+    """Stands in for the bound listening socket, which nothing here serves."""
+
+    def __init__(self, address: tuple[str, int]) -> None:
+        self._address = address
+
+    def getsockname(self) -> tuple[str, int]:
+        return self._address
+
+    def close(self) -> None:
+        return None
+
+
+class TestOutcome:
+    def test_the_outcome_reports_what_the_lookup_says(self, tmp_path: Path):
+        # A thin wrapper, pinned because callers branch on it and the two
+        # answers must not be able to disagree.
+        from linkedin_mcp_server.daemon import OwnerLookup
+
+        absent = ElectionOutcome(OwnerLookup(state=OwnerState.ABSENT))
+
+        assert not absent.worth_connecting

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -571,13 +571,22 @@ class TestRealOwner:
         # The worst interleaving in the whole handoff. The frontend takes the
         # lock, hands a duplicate to the child, and releases its own copy the
         # moment the child has it — so from then on the lock exists *only* in a
-        # process that has not yet proved it can serve. If that process dies
-        # there, the lock has to come free on its own, because nothing else is
-        # holding a reference that could release it.
+        # process that has not yet proved it can serve. A child that dies there
+        # must leave the profile electable, or the daemon is permanently wedged
+        # by a single bad start.
         #
         # Exercised with a child that really adopts and then exits, rather than
         # one that fails earlier: a child that never got as far as `adopt` would
-        # pass this test while proving nothing about the case it is named for.
+        # pass this test while proving nothing about the case it is named for,
+        # which is why the marker is asserted.
+        #
+        # What this cannot fail on: the kernel reclaims a dead process's
+        # descriptors whatever the code did, so no mutation to `adopt` or
+        # `release` makes it go red — both were tried. It is an end-to-end
+        # statement that this sequence leaves a usable profile, not a test of
+        # the release logic, and it earns its place by covering the composition
+        # (adopt, die, elect again) that the unit-level tests each cover only
+        # half of.
         child = tmp_path / "adopting_child.py"
         marker = tmp_path / "adopted"
         child.write_text(
@@ -592,12 +601,21 @@ class TestRealOwner:
 
         profile = real_state_root
         auth_root = profile.parent
+        # The substitution only rewrites the daemon's own command line and
+        # forwards everything else untouched. Replacing `subprocess.Popen`
+        # outright looks equivalent and is not: on Linux `ctypes.util
+        # .find_library` shells out to `ldconfig` from deep inside the private
+        # state hardening this very call performs, so an unconditional rewrite
+        # tried to turn *that* into the daemon and failed the test on CI while
+        # passing on macOS, where find_library takes another route.
         frontend = (
             "import sys\n"
             "from pathlib import Path\n"
             "import linkedin_mcp_server.daemon_election as election\n"
             "real = election.subprocess.Popen\n"
             "def substitute(command, **kwargs):\n"
+            "    if '--lock-fd' not in command:\n"
+            "        return real(command, **kwargs)\n"
             "    fd = command[command.index('--lock-fd') + 1]\n"
             "    return real(\n"
             "        [command[0], sys.argv[2], fd, sys.argv[3], sys.argv[4]],\n"
@@ -637,6 +655,14 @@ class TestRealOwner:
             "elect an owner for this profile again"
         )
         probe.release()
+        # What this does *not* establish: that the frontend released its own
+        # copy. The frontend here is a subprocess that has exited by now, so the
+        # kernel closed its descriptors whatever the code did — verified by
+        # mutation, with `lock.release()` removed this still passed.
+        # `test_the_lock_frees_while_the_frontend_is_still_running` is the one
+        # that pins the release, by keeping the frontend alive across the kill.
+        # This test's own subject is the child: adopting the lock and then dying
+        # must not strand it.
 
         # And an ordinary election works afterwards, which is the outcome the
         # user actually needs.

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1228,7 +1228,12 @@ class TestVersionSkew:
             capture_output=True,
             text=True,
             cwd=workspace,
-            env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+            # `PYTHONPATH=.` on purpose, and it is the whole point of the test.
+            # `-P` alone drops only the *implicit* working directory and leaves
+            # PYTHONPATH in force, so this very common setting puts the
+            # workspace back at the front — measured, it loaded the local file.
+            # Isolated mode is what refuses both.
+            env={**os.environ, "PYTHONPATH": "."},
             timeout=60,
         )
 
@@ -1336,6 +1341,12 @@ class TestNotHoldingTheLockForever:
                 await asyncio.sleep(3600)
 
         monkeypatch.setattr(daemon_owner, "_STAND_DOWN_SHUTDOWN_SECONDS", 0.5)
+        # The real one calls `os._exit`, which would take this test runner with
+        # it. Substituted so the *wait* can be observed here; that it really
+        # ends the process is the separate real-process test below, which is the
+        # only way to see that at all.
+        exited: list[bool] = []
+        monkeypatch.setattr(daemon_owner, "_exit_hard", lambda: exited.append(True))
 
         async def exercise() -> float:
             server = NeverStops()
@@ -1352,6 +1363,76 @@ class TestNotHoldingTheLockForever:
         elapsed = asyncio.run(exercise())
 
         assert elapsed < 5, f"the stand-down wait took {elapsed:.1f}s"
+        assert exited, "the wait ended without asking the process to end"
+
+    def test_a_shutdown_that_resists_cancellation_still_ends_the_process(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Ending the *wait* is not ending the process, and only the second frees
+        # the lock. Returning from the bounded wait leaves the serving task
+        # pending; `asyncio.run` then cancels it and waits, unbounded, for that
+        # cancellation to finish. A task that suppresses cancellation therefore
+        # keeps the interpreter alive after every timeout above it has fired.
+        #
+        # Not a hypothetical shape: `close_browser` holds cancellation back
+        # until teardown finishes by design, and the export it waits on first is
+        # unbounded, so an unresponsive Chromium produces exactly this.
+        #
+        # Run as a real process, because what is being tested is that the
+        # process ends — which is precisely what an in-process test cannot see.
+        # Not `tmp_path / "home"`, which the isolation fixture already made.
+        home = tmp_path / "child-home"
+        home.mkdir()
+        auth_root = tmp_path / "child-auth"
+        auth_root.mkdir()
+
+        script = tmp_path / "wedged_owner.py"
+        script.write_text(
+            "import asyncio, os, sys\n"
+            "from pathlib import Path\n"
+            "import linkedin_mcp_server.daemon_descriptor as descriptor\n"
+            "descriptor._account_home = lambda: Path(sys.argv[1])\n"
+            "from linkedin_mcp_server import daemon_owner\n"
+            "from linkedin_mcp_server.daemon_lock import DaemonLock\n"
+            "lock = DaemonLock(Path(sys.argv[2]))\n"
+            "assert lock.try_acquire()\n"
+            "daemon_owner._STAND_DOWN_SHUTDOWN_SECONDS = 0.5\n"
+            "class Stubborn:\n"
+            "    started = True\n"
+            "    should_exit = False\n"
+            "    async def serve(self, sockets=None):\n"
+            "        try:\n"
+            "            await asyncio.sleep(3600)\n"
+            "        except asyncio.CancelledError:\n"
+            "            await asyncio.sleep(3600)\n"
+            "async def main():\n"
+            "    server = Stubborn()\n"
+            "    serving = asyncio.create_task(server.serve())\n"
+            "    await daemon_owner._serve_until_stopped(server, serving, ['asked'])\n"
+            "asyncio.run(main())\n"
+            "print('THE PROCESS SURVIVED')\n"
+        )
+
+        result = subprocess.run(
+            [sys.executable, str(script), str(home), str(auth_root)],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+            # Generous next to the half-second grace the child is given, and far
+            # below the forever this guards against.
+            timeout=60,
+        )
+
+        assert "THE PROCESS SURVIVED" not in result.stdout, (
+            "the interpreter outlived a shutdown it had already given up on"
+        )
+        # And the lock it held is free, which is the outcome the next election
+        # depends on. Asked with the child's own state root, which is where the
+        # lock file it took actually lives.
+        monkeypatch.setattr(daemon_descriptor_module, "_account_home", lambda: home)
+        probe = DaemonLock(auth_root)
+        assert probe.try_acquire(), "the wedged owner kept the lock"
+        probe.release()
 
 
 class TestPublishingLast:

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -267,12 +267,21 @@ class TestFailingFast:
 
         monkeypatch.setattr(election_module.subprocess, "Popen", mute)
 
+        began = time.monotonic()
         attempt = election_module._start_owner(auth_root, profile, config, timeout=0.5)
+        elapsed = time.monotonic() - began
 
         try:
             assert attempt is _Attempt.CONTENDED, (
                 "a child that is still starting was reported as a failure"
             )
+            # And it came back on time. The timeout above bounds the *wait*, and
+            # the cleanup after it used to hand that bound straight back:
+            # `child.stdout.close()` waits on the reader thread's I/O lock, so
+            # it blocked for exactly as long as the child stayed silent.
+            # Measured at 29.27s against a 30s sleeper, and forever against a
+            # child that never speaks or exits.
+            assert elapsed < 5, f"the bounded wait took {elapsed:.1f}s"
         finally:
             # It sleeps for half a minute by design, so leaving it behind would
             # hold the daemon lock it inherited for the rest of the run.
@@ -1076,6 +1085,61 @@ class TestVersionSkew:
         assert without_status == 401
         assert wrong_status == 401
         assert stopped == ["asked"]
+
+    def test_the_token_never_goes_through_a_configured_proxy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Every request the daemon makes carries the bearer token for a server
+        # driving a logged-in LinkedIn session, and every one is addressed to
+        # loopback. httpx honours HTTP_PROXY by default and does so even for
+        # 127.0.0.1 unless NO_PROXY happens to say otherwise — reproduced
+        # against a capture proxy, which received the absolute loopback URL and
+        # `Authorization: Bearer <token>` in full.
+        #
+        # A user with a corporate proxy configured is the ordinary case, not an
+        # exotic one, and the browser's own proxy setting is deliberately about
+        # LinkedIn's traffic rather than the server's.
+        import socket
+        import threading
+
+        from linkedin_mcp_server import daemon_owner
+
+        received: list[bytes] = []
+        listener = socket.socket()
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        listener.settimeout(5)
+        proxy_port = listener.getsockname()[1]
+
+        def capture() -> None:
+            with contextlib.suppress(OSError):
+                connection, _ = listener.accept()
+                received.append(connection.recv(4096))
+                connection.close()
+
+        watcher = threading.Thread(target=capture, daemon=True)
+        watcher.start()
+
+        monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{proxy_port}")
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        try:
+            # Port 9 is discard: nothing listens, so this fails either way. What
+            # is being tested is *where* it was addressed.
+            with daemon_owner.direct_http_client(timeout=2) as client:
+                with contextlib.suppress(Exception):
+                    client.post(
+                        "http://127.0.0.1:9/control/stand-down",
+                        headers={"Authorization": "Bearer SUPERSECRET"},
+                    )
+            watcher.join(timeout=3)
+        finally:
+            listener.close()
+
+        assert not received, "the request was routed through the proxy"
+        assert not any(b"SUPERSECRET" in seen for seen in received)
 
     def test_a_non_ascii_token_is_refused_rather_than_raising(self):
         # `hmac.compare_digest` raises TypeError when either *string* holds a

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -200,10 +201,12 @@ class TestLiveness:
             auth_root, profile, config, deadline_seconds=1.0, connect=never_answers
         )
 
-        # Once for the corpse. Anything more means the same instance was tried
-        # again after being proved dead.
-        instances = {attachment.descriptor.instance_id for attachment in probes}
-        assert len(probes) == len(instances)
+        # Exactly once for the corpse. Stated as a count rather than as
+        # "no instance appears twice", which is the weaker claim it started as:
+        # that version also passed when the probe was never called at all, so an
+        # implementation that skipped reachability entirely would have looked
+        # correct here.
+        assert len(probes) == 1, [p.descriptor.instance_id for p in probes]
 
 
 class TestFailingFast:
@@ -239,6 +242,44 @@ class TestFailingFast:
         # out the budget, not that it returns in any particular millisecond.
         assert elapsed < 5, elapsed
 
+    def test_a_child_that_is_merely_slow_is_not_called_a_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Silence is not failure, and conflating the two is the worst outcome
+        # this module can produce. A child that has neither answered nor exited
+        # is still coming up and still holds the lock it adopted. Reported as
+        # "could not serve", the caller concludes nobody is coming and goes off
+        # to drive its own browser against the profile that child is about to
+        # open — two browsers on one profile, caused by a slow machine.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+
+        # A child that starts and then says nothing at all, which is exactly
+        # what a cold interpreter on a loaded machine looks like.
+        real = subprocess.Popen
+        started: list[subprocess.Popen[Any]] = []
+
+        def mute(command: list[str], **kwargs: Any) -> subprocess.Popen[Any]:
+            child = real([command[0], "-c", "import time; time.sleep(30)"], **kwargs)
+            started.append(child)
+            return child
+
+        monkeypatch.setattr(election_module.subprocess, "Popen", mute)
+
+        attempt = election_module._start_owner(auth_root, profile, config, timeout=0.5)
+
+        try:
+            assert attempt is _Attempt.CONTENDED, (
+                "a child that is still starting was reported as a failure"
+            )
+        finally:
+            # It sleeps for half a minute by design, so leaving it behind would
+            # hold the daemon lock it inherited for the rest of the run.
+            for child in started:
+                child.kill()
+                child.wait(timeout=30)
+
     def test_losing_the_lock_race_waits_instead_of_giving_up(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -259,15 +300,22 @@ class TestFailingFast:
 
         monkeypatch.setattr(election_module, "_start_owner", contended)
 
+        started = time.monotonic()
         obtain_owner(
             auth_root,
             profile,
             config,
-            deadline_seconds=0.3,
+            deadline_seconds=1.0,
             connect=lambda attachment: False,
         )
+        elapsed = time.monotonic() - started
 
-        assert attempts >= 1
+        # Both halves, and the second one is what makes this a test. `attempts
+        # >= 1` was the whole assertion at first, and it passes just as well for
+        # an implementation that gives up after the first CONTENDED — which is
+        # exactly the behaviour this test is named against.
+        assert attempts > 1, "it stopped looking after the first contended attempt"
+        assert elapsed >= 0.9, f"it gave up after {elapsed:.2f}s of a 1.0s budget"
 
 
 # Deliberately unindented, and run as it stands rather than through

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1160,6 +1160,80 @@ class TestVersionSkew:
         assert _matches_token("  the-token  ", "the-token")
 
 
+class TestNotHoldingTheLockForever:
+    """An owner that cannot serve must not keep the position occupied.
+
+    Both waits below are on the owner's side, after it already holds the daemon
+    lock. Unbounded, either one turns a hung dependency into a profile nothing
+    can ever elect an owner for again: the frontend times out and moves on, and
+    the lock stays held by a process that is not serving anything.
+    """
+
+    def test_a_startup_that_never_completes_gives_up(self):
+        # `server.started` never turning true is not the same as the server
+        # dying, and only the second case was handled. An ASGI lifespan that
+        # hangs leaves the task pending and the flag false for good.
+        import asyncio
+
+        from linkedin_mcp_server import daemon_owner
+
+        class NeverStarts:
+            started = False
+            should_exit = False
+
+            async def serve(self, sockets: object = None) -> None:
+                await asyncio.sleep(3600)
+
+        async def exercise() -> None:
+            server = NeverStarts()
+            serving = asyncio.create_task(server.serve())
+            try:
+                with pytest.raises(TimeoutError):
+                    await daemon_owner._await_started(server, serving, timeout=0.5)
+            finally:
+                serving.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await serving
+
+        asyncio.run(exercise())
+
+    def test_a_shutdown_that_never_completes_stops_waiting(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Uvicorn's `timeout_graceful_shutdown` bounds the connection tasks and
+        # nothing bounds the lifespan behind them. An owner stuck there has
+        # already told a frontend it was standing down, so every later election
+        # finds the position held by a process that will never serve again.
+        import asyncio
+
+        from linkedin_mcp_server import daemon_owner
+
+        class NeverStops:
+            started = True
+            should_exit = False
+
+            async def serve(self, sockets: object = None) -> None:
+                await asyncio.sleep(3600)
+
+        monkeypatch.setattr(daemon_owner, "_STAND_DOWN_SHUTDOWN_SECONDS", 0.5)
+
+        async def exercise() -> float:
+            server = NeverStops()
+            serving = asyncio.create_task(server.serve())
+            began = time.monotonic()
+            try:
+                await daemon_owner._serve_until_stopped(server, serving, ["asked"])
+                return time.monotonic() - began
+            finally:
+                serving.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await serving
+
+        elapsed = asyncio.run(exercise())
+
+        assert elapsed < 5, f"the stand-down wait took {elapsed:.1f}s"
+
+
 class TestPublishingLast:
     """Nothing is discoverable until it has been proved to work."""
 

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -19,6 +19,7 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -370,6 +371,31 @@ class TestFailingFast:
             assert all(sleeper.poll() is not None for sleeper in sleepers), (
                 "the child that could not serve was left running"
             )
+
+            # Nothing of the abandoned attempt is left in this process either.
+            # These three are asserted together because the argument that the
+            # cleanup is safe on Windows rests on all of them: the child is
+            # confirmed dead *before* the handshake pipe is released, so the
+            # blocked reader gets an end of file rather than needing a
+            # cross-thread close, and the writer holds only the stdin stream —
+            # never a lock descriptor — so a broken pipe is enough to end it.
+            #
+            # That argument is reasoned rather than measured on Windows, which
+            # is why it is asserted here: this test runs on the Windows CI job,
+            # where the reasoning would otherwise stand unchecked.
+            #
+            # What it does not do is prove the *ordering*. Moving the release
+            # ahead of the stop leaves this green on POSIX, because `detach()`
+            # never blocks here whatever the child is doing. On Windows the same
+            # change is the difference between an end of file and a wait on a
+            # live reader, and CI is the only place that distinction is
+            # observed at all.
+            assert all(
+                sleeper.stdin is None or sleeper.stdin.closed for sleeper in sleepers
+            ), "the configuration pipe was left open"
+            assert not any(
+                "daemon-config" in thread.name for thread in threading.enumerate()
+            ), "the writer thread outlived the child it was writing to"
         finally:
             for sleeper in sleepers:
                 if sleeper.poll() is None:  # pragma: no cover - the stop worked
@@ -426,6 +452,14 @@ class TestFailingFast:
             )
             probe.release()
             assert all(child.poll() is not None for child in started)
+            # Same three post-conditions as the blocked-write path next door,
+            # for the same Windows reasoning: the child is confirmed dead before
+            # the handshake pipe is released, so nothing has to interrupt a live
+            # reader, and the writer holds no lock descriptor.
+            assert all(child.stdin is None or child.stdin.closed for child in started)
+            assert not any(
+                "daemon-config" in thread.name for thread in threading.enumerate()
+            )
 
             # And on time. The timeout bounds the *wait*, and the cleanup after
             # it used to hand that bound straight back: `child.stdout.close()`

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -299,6 +299,47 @@ class TestFailingFast:
         # And promptly: the point is recovery, not that it eventually happens.
         assert time.monotonic() - began < 10
 
+    def test_a_child_that_never_reads_its_configuration_does_not_block_the_spawn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The handshake timeout is reached only if the spawn gets that far. The
+        # configuration is written to the child's pipe first, and a pipe buffer
+        # is small — 64 KiB on Linux — while the configuration has no size limit
+        # at all: user_agent, proxy_bypass and the paths are free-form strings.
+        # A child that neither reads nor exits blocks that write indefinitely,
+        # before any budget applies, with both processes holding the lock.
+        #
+        # Reproduced with a 10 MiB user agent and a child that only sleeps: the
+        # outer process timeout fired and the wait was never entered.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        config.browser.user_agent = "x" * (10 * 1024 * 1024)
+        auth_root = profile.parent
+
+        sleepers: list[subprocess.Popen[Any]] = []
+        real = subprocess.Popen
+
+        def deaf(command: list[str], **kwargs: Any) -> subprocess.Popen[Any]:
+            child = real([command[0], "-c", "import time; time.sleep(600)"], **kwargs)
+            sleepers.append(child)
+            return child
+
+        monkeypatch.setattr(election_module.subprocess, "Popen", deaf)
+
+        began = time.monotonic()
+        attempt = election_module._start_owner(auth_root, profile, config, timeout=0.5)
+        elapsed = time.monotonic() - began
+
+        try:
+            assert elapsed < 10, f"the spawn blocked for {elapsed:.1f}s"
+            # Alive and holding the lock, so it may still come up: the same
+            # verdict a silent handshake gets.
+            assert attempt is _Attempt.CONTENDED
+        finally:
+            for sleeper in sleepers:
+                sleeper.kill()
+                sleeper.wait(timeout=30)
+
     def test_a_child_that_is_merely_slow_is_not_called_a_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -320,7 +320,21 @@ class TestFailingFast:
         real = subprocess.Popen
 
         def deaf(command: list[str], **kwargs: Any) -> subprocess.Popen[Any]:
-            child = real([command[0], "-c", "import time; time.sleep(600)"], **kwargs)
+            # Ignores SIGTERM as well as never reading stdin. Both halves
+            # matter: the second is the defect, and the first is what makes the
+            # timing assertion below meaningful. A terminate-then-kill stop
+            # would spend its whole grace period here, *after* the caller's
+            # budget was already gone.
+            child = real(
+                [
+                    command[0],
+                    "-c",
+                    "import signal, time\n"
+                    "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+                    "time.sleep(600)\n",
+                ],
+                **kwargs,
+            )
             sleepers.append(child)
             return child
 
@@ -331,7 +345,12 @@ class TestFailingFast:
         elapsed = time.monotonic() - began
 
         try:
-            assert elapsed < 10, f"the spawn blocked for {elapsed:.1f}s"
+            # Close to the budget rather than merely finite. Stopping the child
+            # happens after that budget is spent, so a grace period there is
+            # time added to a deadline the caller was promised: terminate-first
+            # turned this half-second election into five and a half against a
+            # child that ignores SIGTERM. Measured at 0.6s as it stands.
+            assert elapsed < 3, f"the spawn took {elapsed:.1f}s of a 0.5s budget"
             # Reported as a failure, not as "somebody is starting". A child that
             # never took its configuration is not coming up, and on POSIX it
             # already holds the inherited lock descriptor — so it is stopped

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -242,6 +242,63 @@ class TestFailingFast:
         # out the budget, not that it returns in any particular millisecond.
         assert elapsed < 5, elapsed
 
+    def test_a_frontend_that_lost_the_race_takes_over_when_the_winner_dies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The recovery this loop exists for, and the one a plain "wait for a
+        # descriptor" cannot provide. A wins the lock, its child adopts it and
+        # then dies without ever publishing; B lost the race and is waiting.
+        # Nothing will ever appear on disk, so only another lock attempt can
+        # discover that the position came free.
+        #
+        # A loser that waits out its budget on the descriptor alone ends the
+        # election with no owner at all, having had the lock available to it the
+        # whole time.
+        import threading
+
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+
+        # The winner, holding the lock and releasing it shortly after.
+        winner = DaemonLock(auth_root)
+        assert winner.try_acquire()
+        releasing = threading.Timer(1.0, winner.release)
+        releasing.start()
+
+        took_over: list[float] = []
+
+        def contend(
+            auth_root: Path, profile: Path, config: AppConfig, *, timeout: float
+        ) -> _Attempt:
+            contender = DaemonLock(auth_root)
+            if not contender.try_acquire():
+                return _Attempt.CONTENDED
+            took_over.append(time.monotonic())
+            _publish_stale_owner(auth_root, profile, config)
+            contender.release()
+            return _Attempt.STARTED
+
+        monkeypatch.setattr(election_module, "_start_owner", contend)
+
+        began = time.monotonic()
+        try:
+            outcome = obtain_owner(
+                auth_root,
+                profile,
+                config,
+                deadline_seconds=20,
+                connect=lambda attachment: True,
+            )
+        finally:
+            releasing.cancel()
+            winner.release()
+
+        assert took_over, "the loser never retried the lock the winner freed"
+        assert outcome.worth_connecting
+        # And promptly: the point is recovery, not that it eventually happens.
+        assert time.monotonic() - began < 10
+
     def test_a_child_that_is_merely_slow_is_not_called_a_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -1140,6 +1197,69 @@ class TestVersionSkew:
 
         assert not received, "the request was routed through the proxy"
         assert not any(b"SUPERSECRET" in seen for seen in received)
+
+    def test_the_owner_is_not_started_from_the_working_directory(self, tmp_path: Path):
+        # `python -m` puts the inherited working directory first on sys.path, so
+        # a workspace containing linkedin_mcp_server/daemon_owner.py is imported
+        # in preference to the installed package. That code would receive the
+        # inherited lock descriptor and the whole configuration on standard
+        # input, proxy_password included — merely because an MCP client happened
+        # to be started in that directory.
+        #
+        # Exercised against a real interpreter rather than by inspecting the
+        # command, because what matters is which module actually loads.
+        workspace = tmp_path / "workspace"
+        shadow = workspace / "linkedin_mcp_server"
+        shadow.mkdir(parents=True)
+        (shadow / "__init__.py").write_text("")
+        (shadow / "daemon_owner.py").write_text("print('HIJACKED')\n")
+
+        # The real command, with `-m <module>` swapped for a `-c` that reports
+        # which file that module resolved to. Everything before it — the
+        # interpreter and its flags — is exactly what production uses.
+        command = election_module._spawn_command(lock_fd=None)
+        assert command[-2:] == ["-m", "linkedin_mcp_server.daemon_owner"], command
+        result = subprocess.run(
+            [
+                *command[:-2],
+                "-c",
+                "import linkedin_mcp_server.daemon_owner as m; print(m.__file__)",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=workspace,
+            env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+            timeout=60,
+        )
+
+        assert result.returncode == 0, result.stderr[-1000:]
+        loaded = result.stdout.strip()
+        assert "HIJACKED" not in result.stdout, "the working directory won"
+        assert loaded.startswith(str(_REPO_ROOT)), loaded
+
+    def test_the_owner_does_not_inherit_the_proxy_password(self):
+        # The configuration travels on standard input specifically so that a
+        # password is not left in a readable environment. That is only half done
+        # while the child inherits the frontend's environment unchanged: the
+        # documented way to configure a proxy is PROXY_PASSWORD, so the owner
+        # would hold the raw value in /proc/<pid>/environ for its whole life,
+        # which is far longer than the frontend's.
+        import os as os_module
+
+        original = dict(os_module.environ)
+        os_module.environ["PROXY_PASSWORD"] = "hunter2"
+        os_module.environ["PROXY_USERNAME"] = "someone"
+        try:
+            handed = election_module._owner_environment()
+        finally:
+            os_module.environ.clear()
+            os_module.environ.update(original)
+
+        assert "PROXY_PASSWORD" not in handed
+        assert "PROXY_USERNAME" not in handed
+        # And the rest of the environment still crosses: the owner needs PATH,
+        # HOME and the rest to run at all.
+        assert "PATH" in handed
 
     def test_a_non_ascii_token_is_refused_rather_than_raising(self):
         # `hmac.compare_digest` raises TypeError when either *string* holds a

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -564,6 +564,52 @@ class TestRealOwner:
         finally:
             _stop(second.get("pid"))
 
+    def test_many_clients_starting_at_once_elect_exactly_one_owner(
+        self, real_state_root: Path
+    ):
+        # The property the whole feature is for, under the condition that
+        # actually produces races: several MCP clients launching together, each
+        # spawning its own stdio server, all of them arriving at an empty state
+        # directory at the same moment.
+        #
+        # Two browsers on one profile is the failure this must never have. The
+        # single-frontend tests cannot see it, because nothing contends there.
+        import json
+
+        profile = real_state_root
+        clients = 8
+
+        running = [
+            subprocess.Popen(
+                [sys.executable, "-c", _INSPECT_OWNER, str(profile)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+                cwd=_REPO_ROOT,
+            )
+            for _ in range(clients)
+        ]
+
+        results = []
+        for frontend in running:
+            out, err = frontend.communicate(timeout=300)
+            assert frontend.returncode == 0, err[-2000:]
+            results.append(json.loads(out.strip().splitlines()[-1]))
+
+        owners = {result["pid"] for result in results}
+        try:
+            assert None not in owners, "a client ended up with no owner"
+            assert len(owners) == 1, f"more than one owner was elected: {owners}"
+            # Exactly one of them did the starting; the rest attached to it.
+            assert sum(1 for r in results if r["started"]) == 1, results
+            assert all(r["state"] == OwnerState.ATTACHABLE.value for r in results)
+            # And none of them kept the lock they may have taken on the way.
+            assert not any(r["frontend_holds_lock"] for r in results)
+        finally:
+            for pid in owners:
+                _stop(pid)
+
     @_POSIX_ONLY
     def test_the_owner_outlives_the_client_that_started_it(self, real_state_root: Path):
         # The premise of the whole feature. An owner that died with its first
@@ -858,6 +904,7 @@ class TestVersionSkew:
                         url, headers={"Authorization": "Bearer nope"}
                     )
                     assert not stopped, "an unauthenticated caller stopped the daemon"
+
                     good = await client.post(
                         url, headers={"Authorization": "Bearer the-token"}
                     )
@@ -873,6 +920,24 @@ class TestVersionSkew:
         assert without_status == 401
         assert wrong_status == 401
         assert stopped == ["asked"]
+
+    def test_a_non_ascii_token_is_refused_rather_than_raising(self):
+        # `hmac.compare_digest` raises TypeError when either *string* holds a
+        # character above ASCII, and the presented one arrives in a header from
+        # anything that can reach the port. Compared as strings the route
+        # answered 500, which turns an unauthenticated request into a way to
+        # provoke an error rather than a refusal. Found by trying it.
+        #
+        # Tested against the comparison rather than over HTTP, because httpx
+        # refuses to encode such a header and so cannot send the request at all.
+        # That is a property of one client library, not of the endpoint, which
+        # is reachable by anything on the machine.
+        from linkedin_mcp_server.daemon_owner import _matches_token
+
+        assert not _matches_token("töken", "the-token")
+        assert not _matches_token("\udcff", "the-token")
+        assert _matches_token("the-token", "the-token")
+        assert _matches_token("  the-token  ", "the-token")
 
 
 class TestPublishingLast:

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -564,6 +564,88 @@ class TestRealOwner:
         finally:
             _stop(second.get("pid"))
 
+    @_POSIX_ONLY
+    def test_a_child_that_dies_after_adopting_the_lock_leaves_it_free(
+        self, real_state_root: Path, tmp_path: Path
+    ):
+        # The worst interleaving in the whole handoff. The frontend takes the
+        # lock, hands a duplicate to the child, and releases its own copy the
+        # moment the child has it — so from then on the lock exists *only* in a
+        # process that has not yet proved it can serve. If that process dies
+        # there, the lock has to come free on its own, because nothing else is
+        # holding a reference that could release it.
+        #
+        # Exercised with a child that really adopts and then exits, rather than
+        # one that fails earlier: a child that never got as far as `adopt` would
+        # pass this test while proving nothing about the case it is named for.
+        child = tmp_path / "adopting_child.py"
+        marker = tmp_path / "adopted"
+        child.write_text(
+            "import sys\n"
+            "from pathlib import Path\n"
+            "import linkedin_mcp_server.daemon_lock as daemon_lock\n"
+            "lock = daemon_lock.DaemonLock(Path(sys.argv[2]))\n"
+            "lock.adopt(int(sys.argv[1]))\n"
+            "Path(sys.argv[3]).write_text('adopted')\n"
+            "raise SystemExit(7)\n"
+        )
+
+        profile = real_state_root
+        auth_root = profile.parent
+        frontend = (
+            "import sys\n"
+            "from pathlib import Path\n"
+            "import linkedin_mcp_server.daemon_election as election\n"
+            "real = election.subprocess.Popen\n"
+            "def substitute(command, **kwargs):\n"
+            "    fd = command[command.index('--lock-fd') + 1]\n"
+            "    return real(\n"
+            "        [command[0], sys.argv[2], fd, sys.argv[3], sys.argv[4]],\n"
+            "        **kwargs,\n"
+            "    )\n"
+            "election.subprocess.Popen = substitute\n"
+            "from linkedin_mcp_server.config.schema import AppConfig\n"
+            "profile = Path(sys.argv[1])\n"
+            "config = AppConfig()\n"
+            "config.browser.user_data_dir = str(profile)\n"
+            "election.obtain_owner(\n"
+            "    profile.parent, profile, config, deadline_seconds=15\n"
+            ")\n"
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                frontend,
+                str(profile),
+                str(child),
+                str(auth_root),
+                str(marker),
+            ],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+            cwd=_REPO_ROOT,
+            timeout=200,
+        )
+        assert result.returncode == 0, result.stderr[-2000:]
+        assert marker.exists(), "the child never reached the adoption being tested"
+
+        probe = DaemonLock(auth_root)
+        assert probe.try_acquire(), (
+            "the lock survived the only process holding it, so nothing can ever "
+            "elect an owner for this profile again"
+        )
+        probe.release()
+
+        # And an ordinary election works afterwards, which is the outcome the
+        # user actually needs.
+        recovered = _run_frontend(profile)
+        try:
+            assert recovered["state"] == OwnerState.ATTACHABLE.value, recovered
+        finally:
+            _stop(recovered.get("pid"))
+
     def test_many_clients_starting_at_once_elect_exactly_one_owner(
         self, real_state_root: Path
     ):

--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -204,7 +204,7 @@ posix_handoff = pytest.mark.skipif(
 class TestHandoff:
     @posix_handoff
     def test_a_duplicate_survives_the_original_being_closed(self, tmp_path: Path):
-        # How a supervisor is launched: it inherits a copy, and the process that
+        # How an owner is launched: it inherits a copy, and the process that
         # elected it lets go. If the lock did not survive that, another client
         # would see it free and elect a second owner against a live browser.
         lock = DaemonLock(tmp_path)
@@ -222,7 +222,7 @@ class TestHandoff:
     @posix_handoff
     def test_the_copy_is_inheritable(self, tmp_path: Path):
         # The original is opened close-on-exec so a launched Chromium cannot
-        # hold the lock open. That same flag would stop a supervisor inheriting
+        # hold the lock open. That same flag would stop an owner inheriting
         # it, so the duplicate has to clear it explicitly.
         lock = DaemonLock(tmp_path)
         assert lock.try_acquire()
@@ -378,7 +378,7 @@ class TestHandoff:
     def test_adopting_a_descriptor_that_holds_no_lock_still_excludes(
         self, tmp_path: Path
     ):
-        # A supervisor launched with a descriptor that was never locked, or
+        # An owner launched with a descriptor that was never locked, or
         # whose lock was already released. Measured before the fix: it reported
         # ownership while daemon_is_running said no daemon was there and a
         # contender took the lock alongside it. Adoption now asks for the lock,
@@ -401,7 +401,7 @@ class TestHandoff:
 
     @posix_handoff
     def test_an_adopted_lock_is_held_without_reacquiring(self, tmp_path: Path):
-        # A supervisor is launched already holding a copy. Acquiring again would
+        # An owner is launched already holding a copy. Acquiring again would
         # fail on POSIX, where the process already holds it, so adoption records
         # ownership rather than taking it.
         original = DaemonLock(tmp_path)
@@ -409,13 +409,13 @@ class TestHandoff:
         inherited = original.inheritable_copy()
         original.release()
 
-        supervisor = DaemonLock(tmp_path)
-        supervisor.adopt(inherited)
+        owner = DaemonLock(tmp_path)
+        owner.adopt(inherited)
         try:
-            assert supervisor.held
+            assert owner.held
             assert daemon_is_running(tmp_path)
         finally:
-            supervisor.release()
+            owner.release()
 
         assert not daemon_is_running(tmp_path)
 
@@ -552,7 +552,7 @@ class TestReleaseSemantics:
     def test_releasing_closes_rather_than_unlocks(self, tmp_path: Path):
         # The measured trap. flock belongs to the open file description, which
         # every inherited copy shares, so unlocking would release the lock for
-        # the supervisor too. Closing drops only this descriptor.
+        # the owner too. Closing drops only this descriptor.
         lock = DaemonLock(tmp_path)
         assert lock.try_acquire()
         inherited = lock.inheritable_copy()
@@ -573,7 +573,7 @@ class TestLiveness:
 
     def test_probing_does_not_disturb_the_holder(self, tmp_path: Path):
         # Discovery calls this on every cold start, so it must not briefly
-        # exclude a supervisor that is starting up.
+        # exclude an owner that is starting up.
         lock = DaemonLock(tmp_path)
         assert lock.try_acquire()
         try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -99,6 +99,55 @@ class TestServerRoles:
         assert server_module.ServerRole is ServerRole
 
 
+class TestOwnerAuthentication:
+    """Only the shared owner authenticates, and it does so with one token.
+
+    The owner listens on a loopback port, which every process on the machine can
+    reach and which a browser reaches on behalf of any page the user visits. The
+    token is what stands between that and a logged-in LinkedIn session.
+    """
+
+    def test_an_owner_with_a_token_requires_one(self):
+        owner = create_mcp_server(role=ServerRole.OWNER, auth_token="a-token")
+
+        assert owner.auth is not None
+
+    def test_a_server_without_a_token_stays_unauthenticated(self):
+        # The stdio server has no port to protect, and adding an auth provider
+        # there would advertise metadata for a flow nothing performs.
+        assert create_mcp_server().auth is None
+        assert create_mcp_server(role=ServerRole.OWNER).auth is None
+
+    def test_a_token_on_a_role_that_cannot_use_one_is_refused(self):
+        # Passing a token to a stdio server is a caller that believes it built
+        # the owner. Ignoring it quietly would leave an endpoint that was meant
+        # to be authenticated serving anyone who finds it.
+        with pytest.raises(ValueError, match="daemon owner"):
+            create_mcp_server(role=ServerRole.DIRECT, auth_token="a-token")
+
+    async def test_the_wrong_token_is_refused_and_the_right_one_accepted(self):
+        owner = create_mcp_server(role=ServerRole.OWNER, auth_token="the-token")
+        verifier = owner.auth
+        assert verifier is not None
+
+        assert await verifier.verify_token("the-token") is not None
+        assert await verifier.verify_token("the-tokeN") is None
+        assert await verifier.verify_token("") is None
+        # A prefix must not pass. A comparison that stopped at the shorter
+        # length would accept every prefix of the real token, which turns
+        # guessing into a character-at-a-time search.
+        assert await verifier.verify_token("the-toke") is None
+
+    def test_the_token_does_not_survive_in_the_verifier(self):
+        # The owner's own repr and any process dump would otherwise carry the
+        # credential. Only its digest is kept.
+        token = "a-secret-token"
+        owner = create_mcp_server(role=ServerRole.OWNER, auth_token=token)
+
+        assert token not in repr(owner.auth)
+        assert token not in repr(vars(owner.auth))
+
+
 class TestSequentialToolExecutionMiddleware:
     async def test_create_mcp_server_registers_sequential_tool_middleware(self):
         mcp = create_mcp_server()


### PR DESCRIPTION
The second piece of #606, after #622 shipped the read-only half. This one starts a process: a detached owner that holds the daemon lock for its lifetime, drives Chromium, and serves an authenticated endpoint on a loopback port. `daemon_enabled` is still off, and the frontend still runs its own tools, so nothing changes for anyone who leaves the flag alone.

Election is two sides rather than one function, because the process that wins the lock is not the process that serves: `cli_main` runs the stdio server blocking, so the winner cannot also serve owner HTTP. On POSIX the frontend takes the lock first and hands a duplicate to the child, which closes the window in which the position would look free. Windows has no fd transfer, so the frontend takes no lock and the child competes for it. The parent then releases its own descriptor before serving anything, and that line is load-bearing: both descriptors refer to one locked open file description, so a frontend that kept its copy would keep the daemon lock alive after the owner died and lock out every recovery.

The owner binds the port itself, proves the endpoint answers a real authenticated request, and only then publishes and signals ready. Publishing earlier advertises a server that refuses tokens.

Version skew is decided here rather than left implicit. `package_version` was published and never compared, so with `@latest` mandatory a freshly updated frontend could be served by a months-old owner indefinitely. A newer frontend now asks the owner to stand down and elects a replacement; an older one attaches, because restarting a shared browser to satisfy one stale client is the worse trade.

## What running it found

Twenty-two defects, each reproduced before it was fixed. Three were ways the daemon's credentials could leave the machine or reach the wrong process:

- **the working directory could hijack the owner.** `python -m` puts the inherited cwd first on `sys.path`, so a workspace containing `linkedin_mcp_server/daemon_owner.py` was imported in preference to the installed package. That code received the inherited lock descriptor and the entire configuration on stdin, proxy password included, merely because an MCP client happened to start there. `-P` alone does not close it — `PYTHONPATH=.` puts the workspace back — so the spawn runs in isolated mode.
- **loopback requests honoured `HTTP_PROXY`**, including for `127.0.0.1`. Reproduced against a capture proxy, which received the absolute URL and the bearer token for a logged-in LinkedIn session in full.
- **the child inherited `PROXY_PASSWORD` and `PROXY_SERVER`**, the latter of which accepts embedded credentials in its documented form.

Six were ways it could hang, wedge, or double up. Four of those defeated a bound that existed to prevent exactly that:

- **the handshake cleanup undid its own timeout.** `child.stdout.close()` waits on the reader thread's I/O lock, so it blocked for as long as the child stayed silent: 29.27 s against a 30 s sleeper, unbounded against a child that never speaks.
- **the configuration write ran before any budget applied**, and a child that never read it was then left holding the inherited lock forever. Bounding the write fixed the visible hang; the lock stayed wedged until the child was stopped too.
- **the owner's own timeouts ended the wait but not the process.** `asyncio.run` then cancels the pending task and waits, unbounded, for that cancellation — and `close_browser` suppresses cancellation by design, with an unbounded cookie export in front of it.
- **a handshake timeout was read as failure**, so the frontend would have driven its own browser against the profile the still-starting child was about to open.
- **Windows was never detached.** `start_new_session` is POSIX-only; CPython names the parameter `unused_start_new_session` there.

And one that was silently wrong rather than stuck: **the owner ignored the browser mode it was handed.** That lives in a module global defaulting to headless, which `_make_browser` reads instead of the configuration. An owner started with `--no-headless` published a fingerprint saying so, the frontend compared it and attached, and the browser opened headless anyway — no window, no error.

The rest: retrying stopped after one attempt whenever a wait budget was given, which also meant a frontend that lost the race never took over when the winner died; a crashed owner's descriptor was handed back as attachable; a version turnover then spent 90 s re-reading the descriptor it had just rejected; the stand-down route compared tokens as strings and answered 500 rather than 401 on any non-ASCII character.

Ten tests that passed against broken code were rewritten until they failed. `assert attempts >= 1` held for an implementation that gave up immediately — strengthening it exposed the retry bug above. A probe count held when nothing was probed at all. One test killed the very child whose survival was the defect.

## Measured

Eight clients electing concurrently produce exactly one owner. A child that dies after adopting the lock leaves it free, and so does one stopped before it could adopt. The owner survives SIGKILL to its client's whole process group and reparents to pid 1. Five rounds of kill-and-re-elect never produced two browsers. Twenty failed spawns leak no descriptor and no lock. A wedged shutdown exits with the lock free.

Not measured, and stated in the code: Windows detachment and the Windows handshake release, both of which have only the documented mechanism behind them rather than an observed outcome; and Linux under a supervisor that kills a cgroup rather than a process group. These are gates before the flag is turned on by default; none is a regression while it is opt-in.
