### PR TITLE
feat(daemon): Forward stdio clients to the shared owner

### DIFF
--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import sys
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import inquirer
 
@@ -34,8 +34,11 @@ from linkedin_mcp_server.session_state import (
     runtime_storage_state_path,
     source_state_path,
 )
-from linkedin_mcp_server.server import create_mcp_server
+from linkedin_mcp_server.server import ServerRole, create_mcp_server
 from linkedin_mcp_server.setup import run_profile_creation
+
+if TYPE_CHECKING:
+    from linkedin_mcp_server.daemon import Attachment
 
 logger = logging.getLogger(__name__)
 
@@ -283,36 +286,34 @@ def profile_info_and_exit() -> None:
     sys.exit(1)
 
 
-def _elect_daemon_owner_if_enabled(config: AppConfig) -> None:
-    """Make sure one shared owner is running, when the daemon is switched on.
+def _obtain_shared_owner(config: AppConfig) -> "Attachment | None":
+    """Return the shared owner to forward to, starting one if nobody has.
 
-    Off by default, and inert when off. What it establishes when on is the half
-    of the daemon that has to work before forwarding can be built: exactly one
-    owner process per profile, reachable, with the lock held by the process that
-    actually serves.
+    Off by default, and inert when off. ``None`` means this process serves its
+    own client the way it always has: the flag is off, the transport is HTTP (one
+    server for many clients already, so there is nothing to deduplicate), or no
+    owner could be established at all.
 
-    This process still runs its own tools, because the forwarding role does not
-    exist yet. So an enabled daemon costs an idle owner beside the ordinary
-    server and buys nothing, which is why the flag stays experimental and off.
+    Never fatal, and that is a decision rather than an oversight. A client that
+    refused to start because a shared browser could not be elected would fail
+    where nobody can read the reason — an MCP client reports "server failed to
+    start" and the explanation sits in a log the user has not opened. A working
+    server with a warning beats a dead one with a better excuse while the flag is
+    opt-in. It is a real trade, though: falling back means two clients can hand
+    the profile back and forth per call again, which is the cost #606 exists to
+    remove, so the warning is the only thing that says the feature was lost. The
+    balance changes when the flag becomes the default.
 
-    That also means two processes can reach the same profile while the flag is
-    on, and what keeps them off each other is the profile lease from #598, not
-    anything here: the owner takes it when it opens Chromium and hands it over
-    when another process announces itself
+    What keeps two processes off one profile on that fallback path is the profile
+    lease from #598, not anything here: the owner takes it when it opens Chromium
+    and hands it over when another process announces itself
     (``drivers/browser.py:881-901``). The daemon lock decides who *owns* the
-    browser; the lease decides who is driving it right now, and only the second
-    question is being asked while this server still runs its own tools.
-
-    Never fatal. Every failure inside is a reason to serve this client the way
-    the server always has, and a client that could not start because a shared
-    browser could not be elected would be a worse outcome than not sharing one.
-    Once forwarding lands, a failed election stops being survivable this way and
-    the decision moves with it.
+    browser; the lease decides who is driving it right now.
     """
     from linkedin_mcp_server.daemon import daemon_would_be_used
 
     if not daemon_would_be_used(config):
-        return
+        return None
 
     try:
         from linkedin_mcp_server.daemon_election import obtain_owner
@@ -322,16 +323,21 @@ def _elect_daemon_owner_if_enabled(config: AppConfig) -> None:
         outcome = obtain_owner(auth_root_dir(profile), profile, config)
     except Exception:
         logger.warning("The shared browser owner is unavailable", exc_info=True)
-        return
+        return None
 
     if outcome.worth_connecting:
-        logger.info("A shared browser owner is running")
-    else:
-        logger.warning(
-            "No shared browser owner could be started (%s); this server will "
-            "drive its own browser",
-            outcome.attachment_lookup.state.value,
-        )
+        logger.info("Forwarding to the shared browser owner")
+        # Handed on as the election verified it. Re-reading the descriptor or the
+        # token from disk would be a second, unproven read of a pair this one
+        # already matched and reached.
+        return outcome.attachment_lookup.attachment
+
+    logger.warning(
+        "No shared browser owner could be started (%s); this server will "
+        "drive its own browser",
+        outcome.attachment_lookup.state.value,
+    )
+    return None
 
 
 def get_version() -> str:
@@ -438,14 +444,25 @@ def main() -> None:
                 config.validate()
 
             # Get a shared owner running before building this process's server.
-            # Nothing downstream depends on the result yet: the frontend still
-            # runs its own tools. What this establishes is that exactly one
-            # owner exists per profile and that a client can reach it, which is
-            # what the forwarding half will attach to.
-            _elect_daemon_owner_if_enabled(config)
+            # It has to come first now: whether this process drives a browser or
+            # forwards to one that does depends on the answer.
+            #
+            # Reads the stored transport rather than the local above, which is
+            # why the interactive prompt writes its answer back into the config
+            # before this runs: `daemon_would_be_used` asks whether this is a
+            # stdio process, and an interactively chosen HTTP server must not
+            # elect a daemon.
+            attachment = _obtain_shared_owner(config)
 
             # Create and run the MCP server
-            mcp = create_mcp_server(tool_timeout=config.server.tool_timeout_seconds)
+            if attachment is None:
+                mcp = create_mcp_server(tool_timeout=config.server.tool_timeout_seconds)
+            else:
+                mcp = create_mcp_server(
+                    tool_timeout=config.server.tool_timeout_seconds,
+                    role=ServerRole.PROXY,
+                    proxy_attachment=attachment,
+                )
 
             if transport == "streamable-http":
                 # Validate Host and Origin. Without this a website the user

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -307,8 +307,19 @@ def _obtain_shared_owner(config: AppConfig) -> "Attachment | None":
     What keeps two processes off one profile on that fallback path is the profile
     lease from #598, not anything here: the owner takes it when it opens Chromium
     and hands it over when another process announces itself
-    (``drivers/browser.py:881-901``). The daemon lock decides who *owns* the
-    browser; the lease decides who is driving it right now.
+    (``drivers/browser.watch_for_handoff_requests``). The daemon lock decides who
+    *owns* the browser; the lease decides who is driving it right now.
+
+    That safety net carries more weight on Windows than elsewhere, which is worth
+    knowing before the flag becomes the default. A frontend there takes no lock
+    at all and starts a child that competes for one
+    (``daemon_election._start_contending_for_the_lock``), so a local spawn
+    failure is indistinguishable from a rival owner that holds the lock and has
+    not published yet: ``obtain_owner`` returns at once and this process falls
+    back while an owner may in fact be coming up. On POSIX the equivalent
+    outcomes are terminal, because the frontend held the lock itself. Windows
+    already carries platform gaps that gate the default flip, and this is one of
+    them.
     """
     from linkedin_mcp_server.daemon import daemon_would_be_used
 

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -6,8 +6,9 @@ moves on nearly every call, and every move reopens Chromium and revalidates the
 session against ``/feed/``. One long-lived owner removes that traffic entirely.
 
 This module is only the discovery half: it answers "is there an owner I should
-be talking to, and may I trust it with a token". Electing one, spawning it and
-forwarding to it build on this and land with the code that does them.
+be talking to, and may I trust it with a token". Electing one and spawning it
+live in :mod:`linkedin_mcp_server.daemon_election`, and forwarding to what it
+returns in :mod:`linkedin_mcp_server.daemon_proxy`.
 
 Finding an owner takes a wait rather than a single read, because the interesting
 case is neither "an owner exists" nor "none does", but the window in between. An

--- a/linkedin_mcp_server/daemon_proxy.py
+++ b/linkedin_mcp_server/daemon_proxy.py
@@ -52,9 +52,12 @@ _TIMEOUT_MARGIN_SECONDS = 30.0
 #: be a newer one than this build would have registered locally. That is the
 #: intended trade, and it still does not make the list change underneath us.
 #:
-#: Measured against ``cache_ttl=0``: 88ms versus 122ms per forwarded call, for a
-#: list that cannot go stale. The TTL only affects single lookups either way; an
-#: explicit ``tools/list`` always re-fetches.
+#: Measured against ``cache_ttl=0`` over a real loopback owner on this machine:
+#: about 23ms versus 42ms per forwarded call, for a list that cannot go stale.
+#: Both are far below the seconds a browser reopen costs, so the number to take
+#: from this is the ordering rather than the absolute figures. The TTL only
+#: affects single lookups either way; an explicit ``tools/list`` always
+#: re-fetches.
 _COMPONENT_CACHE_SECONDS = 300.0
 
 
@@ -101,8 +104,8 @@ def _client_factory(
         )
 
     # ProxyClient rather than a plain Client, and that is not a preference:
-    # a plain client installs no progress handler, so every progress update the
-    # tools report is silently dropped. Measured both ways.
+    # a plain client installs no progress handler, so the progress every
+    # browser-backed tool reports is silently dropped. Measured both ways.
     return open_client
 
 

--- a/linkedin_mcp_server/daemon_proxy.py
+++ b/linkedin_mcp_server/daemon_proxy.py
@@ -12,6 +12,25 @@ them is a way to leak a credential or to hang a call.
 Nothing here caches an owner. A client is built per upstream operation because
 that is how ``ProxyProvider`` uses its factory, and a single shared session would
 outlive the owner it was opened against.
+
+**A proxy is pinned to the owner it started with, and an upgrade is enough to
+strand it.** The address and token are resolved once, at startup, so a proxy
+whose owner goes away fails every operation afterwards rather than finding the
+replacement. Reproduced end to end: a proxy serving 19 tools was asked nothing,
+its owner was told to stand down the way a newer build does
+(``daemon_election._ask_to_stand_down``), and the next listing failed with
+``McpError: Client failed to connect``.
+
+That path is not hypothetical. ``@latest`` is the documented install, so the
+first client to launch after an upgrade stands the old owner down and every proxy
+already attached to it is dead until its own process restarts. Idle exit and a
+crashed owner end the same way.
+
+Resolving the backend per operation and re-electing on a pre-dispatch connection
+failure is what fixes this, and it belongs with the liveness work rather than
+here: a retry needs to know whether the call it is replacing may already have run
+against the browser. Until then the flag stays off by default and this is a
+documented limitation, not a solved problem.
 """
 
 from __future__ import annotations

--- a/linkedin_mcp_server/daemon_proxy.py
+++ b/linkedin_mcp_server/daemon_proxy.py
@@ -9,9 +9,10 @@ server a role gets; the loopback address, the bearer token, the proxy-environmen
 refusal and the forwarding deadline are all daemon knowledge, and every one of
 them is a way to leak a credential or to hang a call.
 
-Nothing here caches an owner. A client is built per upstream operation because
-that is how ``ProxyProvider`` uses its factory, and a single shared session would
-outlive the owner it was opened against.
+No client *session* is cached: one is built per upstream operation, because that
+is how ``ProxyProvider`` uses its factory and because a single shared session
+would outlive the owner it was opened against. The owner's *address* is another
+matter, and it is pinned for this process's life — see below.
 
 **A proxy is pinned to the owner it started with, and an upgrade is enough to
 strand it.** The address and token are resolved once, at startup, so a proxy

--- a/linkedin_mcp_server/daemon_proxy.py
+++ b/linkedin_mcp_server/daemon_proxy.py
@@ -1,0 +1,124 @@
+"""Talking to the owner, from the frontend that forwards to it.
+
+The other half of :mod:`linkedin_mcp_server.daemon_election`: that module gets an
+owner running and hands back an attachment, and this one turns the attachment into
+something a FastMCP server can serve tools from.
+
+Kept out of ``server.py`` deliberately. That module answers which parts of a
+server a role gets; the loopback address, the bearer token, the proxy-environment
+refusal and the forwarding deadline are all daemon knowledge, and every one of
+them is a way to leak a credential or to hang a call.
+
+Nothing here caches an owner. A client is built per upstream operation because
+that is how ``ProxyProvider`` uses its factory, and a single shared session would
+outlive the owner it was opened against.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Callable
+
+from linkedin_mcp_server import daemon_owner
+
+if TYPE_CHECKING:
+    from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
+
+    from linkedin_mcp_server.daemon import Attachment
+
+logger = logging.getLogger(__name__)
+
+#: Added to the owner's tool timeout to get the frontend's deadline. The owner is
+#: the one that should report a timed-out tool, so the frontend has to outlast it;
+#: an equal value races the owner's own error response and turns a diagnosable
+#: "tool timed out" into a transport failure.
+#:
+#: It does **not** bound a queued call, and no value derived from the tool timeout
+#: could. The owner serializes in middleware, and a tool's timeout only starts
+#: once the middleware lets it through — measured: a tool declared with a one
+#: second timeout, queued two seconds behind another call, succeeded after 2.02s.
+#: So under real concurrency this deadline can expire while the call is still
+#: waiting its turn, and because cancellation is not forwarded, the owner may go
+#: on scraping afterwards. That is the orphaned call #606 names, and the heartbeat
+#: is what will bound it.
+_TIMEOUT_MARGIN_SECONDS = 30.0
+
+#: How long a fetched tool list stays usable for single lookups. FastMCP's own
+#: default, set explicitly because the reasoning is not obvious: an owner's tool
+#: set never changes over its lifetime, so there is no dynamic list to miss.
+#:
+#: Not because versions always agree — they need not. An older frontend attaches
+#: to a newer owner on purpose (``daemon_version``), so the list served here can
+#: be a newer one than this build would have registered locally. That is the
+#: intended trade, and it still does not make the list change underneath us.
+#:
+#: Measured against ``cache_ttl=0``: 88ms versus 122ms per forwarded call, for a
+#: list that cannot go stale. The TTL only affects single lookups either way; an
+#: explicit ``tools/list`` always re-fetches.
+_COMPONENT_CACHE_SECONDS = 300.0
+
+
+def _client_factory(
+    attachment: Attachment, *, timeout: float
+) -> Callable[[], ProxyClient]:
+    """Build the callable ``ProxyProvider`` uses to reach the owner.
+
+    A fresh client per call rather than one shared session, because that is what
+    the provider expects: it opens and closes a client around every upstream
+    operation.
+    """
+    from fastmcp.client.transports import StreamableHttpTransport
+    from fastmcp.server.providers.proxy import ProxyClient
+
+    # Verbatim, never rebuilt from host and port: the descriptor's own URL
+    # already carries the MCP path and brackets an IPv6 literal, and FastMCP
+    # deliberately does not rewrite the path it is given.
+    url = attachment.descriptor.url
+    token = attachment.token
+
+    def open_client() -> ProxyClient:
+        return ProxyClient(
+            StreamableHttpTransport(
+                url,
+                # A plain string becomes `Authorization: Bearer <token>`, which
+                # is the form the owner's verifier compares against.
+                auth=token,
+                # The owner's own factory, reused rather than reimplemented. It
+                # forces `trust_env=False`, which is not tidiness: httpx honours
+                # HTTP_PROXY even for 127.0.0.1 unless NO_PROXY happens to say
+                # otherwise, and the owner reproduced a loopback request arriving
+                # at a capture proxy complete with this bearer token. The user's
+                # configured proxy is for LinkedIn's traffic, not for this hop.
+                httpx_client_factory=daemon_owner.direct_async_http_client,
+            ),
+            # Load-bearing rather than tuning. Measured twice against a real
+            # owner: with no timeout here, a call that outlives the underlying
+            # HTTP read timeout never returns at all — still hanging when an
+            # outer bound cut it off at 30s. With one, the same call either
+            # succeeds or fails cleanly at the deadline. Setting it here also
+            # raises the HTTP read timeout, so one value covers both layers.
+            timeout=timeout,
+        )
+
+    # ProxyClient rather than a plain Client, and that is not a preference:
+    # a plain client installs no progress handler, so every progress update the
+    # tools report is silently dropped. Measured both ways.
+    return open_client
+
+
+def create_proxy_provider(
+    attachment: Attachment, *, tool_timeout: float
+) -> ProxyProvider:
+    """Serve the owner's tools as if they were this server's own."""
+    from fastmcp.server.providers.proxy import ProxyProvider
+
+    timeout = tool_timeout + _TIMEOUT_MARGIN_SECONDS
+    logger.debug(
+        "Forwarding tool calls to the shared browser owner at %s (deadline %.0fs)",
+        attachment.descriptor.url,
+        timeout,
+    )
+    return ProxyProvider(
+        _client_factory(attachment, timeout=timeout),
+        cache_ttl=_COMPONENT_CACHE_SECONDS,
+    )

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -9,7 +9,7 @@ import asyncio
 import hashlib
 import hmac
 import logging
-from typing import Any, AsyncIterator
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from fastmcp import FastMCP
 
@@ -42,6 +42,9 @@ from linkedin_mcp_server.tools.job import register_job_tools
 from linkedin_mcp_server.tools.messaging import register_messaging_tools
 from linkedin_mcp_server.tools.person import register_person_tools
 from linkedin_mcp_server.tools.post import register_post_tools
+
+if TYPE_CHECKING:
+    from linkedin_mcp_server.daemon import Attachment
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +133,7 @@ def create_mcp_server(
     tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS,
     role: ServerRole = ServerRole.DIRECT,
     auth_token: str | None = None,
+    proxy_attachment: "Attachment | None" = None,
 ) -> FastMCP:
     """Create and configure the MCP server with all LinkedIn tools.
 
@@ -140,6 +144,11 @@ def create_mcp_server(
     *auth_token* is the bearer token a daemon owner requires. Only an owner has
     one: it listens on a loopback port that every process on the machine can
     reach, and a browser the user merely points at a page can reach it too.
+
+    *proxy_attachment* is the owner a proxy forwards to. The two credentials are
+    kept apart on purpose and must not be conflated: *auth_token* is what an
+    owner *demands* of callers, while the attachment's token is what a proxy
+    *presents* to one.
     """
     if auth_token is not None and role is not ServerRole.OWNER:
         # A token on a stdio server protects nothing — there is no port to
@@ -149,11 +158,24 @@ def create_mcp_server(
         raise ValueError(
             f"Only a daemon owner authenticates requests, not {role.value}"
         )
+    if role is ServerRole.PROXY and proxy_attachment is None:
+        # A proxy registers no tools of its own, so without an owner it would
+        # serve an empty tool list and look like a server whose tools vanished.
+        raise ValueError(
+            "A proxy has no tools of its own and needs an owner to forward to"
+        )
+    if proxy_attachment is not None and role is not ServerRole.PROXY:
+        # Only a proxy forwards. Accepting an owner here would mean a server that
+        # was handed a bearer token for a shared browser and quietly ignored it.
+        raise ValueError(f"Only a proxy forwards to an owner, not {role.value}")
 
     mcp = FastMCP(
         "mcp-server-linkedin",
         version=__version__,
-        lifespan=browser_lifespan,
+        # Selected here rather than gated inside, because for a proxy every step
+        # of it is wrong: it would install a Chromium this process never opens,
+        # and then claim to be closing a browser it never had.
+        lifespan=browser_lifespan if role.drives_browser else None,
         mask_error_details=True,
         auth=_StaticTokenAuth(auth_token) if auth_token is not None else None,
     )
@@ -170,30 +192,48 @@ def create_mcp_server(
     if role.faces_a_client:
         mcp.add_middleware(UpdateNoticeMiddleware())
 
-    # Register all tools
-    register_person_tools(mcp, tool_timeout=tool_timeout)
-    register_company_tools(mcp, tool_timeout=tool_timeout)
-    register_job_tools(mcp, tool_timeout=tool_timeout)
-    register_messaging_tools(mcp, tool_timeout=tool_timeout)
-    register_feed_tools(mcp, tool_timeout=tool_timeout)
-    register_post_tools(mcp, tool_timeout=tool_timeout)
+    if proxy_attachment is not None:
+        from linkedin_mcp_server.daemon_proxy import create_proxy_provider
 
-    # Register session management tool
-    @mcp.tool(
-        timeout=tool_timeout,
-        title="Close Session",
-        annotations={"destructiveHint": True},
-        tags={"session"},
-    )
-    async def close_session() -> dict[str, Any]:
-        """Close the current browser session and clean up resources."""
-        try:
-            await close_browser()
-            return {
-                "status": "success",
-                "message": "Successfully closed the browser session and cleaned up resources",
-            }
-        except Exception as e:
-            raise_tool_error(e, "close_session")  # NoReturn
+        mcp.add_provider(
+            create_proxy_provider(proxy_attachment, tool_timeout=tool_timeout)
+        )
+        # Not the default, which is "warn": a failing provider is logged and
+        # skipped, and for a server whose *only* provider this is, that turns a
+        # dead owner into an empty tool list with no explanation. Measured on
+        # 3.4.4 — `tools/list` returned `[]` and the call that followed failed as
+        # an unknown tool. A transport failure has to look like one.
+        mcp.provider_error_strategy = "raise"
+
+    # Every local registration below drives Chromium, so a proxy takes none of
+    # them and serves the owner's through the provider above instead.
+    if role.drives_browser:
+        register_person_tools(mcp, tool_timeout=tool_timeout)
+        register_company_tools(mcp, tool_timeout=tool_timeout)
+        register_job_tools(mcp, tool_timeout=tool_timeout)
+        register_messaging_tools(mcp, tool_timeout=tool_timeout)
+        register_feed_tools(mcp, tool_timeout=tool_timeout)
+        register_post_tools(mcp, tool_timeout=tool_timeout)
+
+        # Inside the gate with the rest, and easy to miss because it is the one
+        # tool defined here rather than in a `register_*` call. Left out of the
+        # gate it would collide with the forwarded tool of the same name and
+        # close a browser this process does not have.
+        @mcp.tool(
+            timeout=tool_timeout,
+            title="Close Session",
+            annotations={"destructiveHint": True},
+            tags={"session"},
+        )
+        async def close_session() -> dict[str, Any]:
+            """Close the current browser session and clean up resources."""
+            try:
+                await close_browser()
+                return {
+                    "status": "success",
+                    "message": "Successfully closed the browser session and cleaned up resources",
+                }
+            except Exception as e:
+                raise_tool_error(e, "close_session")  # NoReturn
 
     return mcp

--- a/linkedin_mcp_server/server_role.py
+++ b/linkedin_mcp_server/server_role.py
@@ -28,10 +28,10 @@ class ServerRole(enum.Enum):
     #: Never speaks to an end client, so nothing user-facing belongs here.
     OWNER = "owner"
 
-    # A forwarding role belongs here too, but only once something actually
-    # forwards. Adding it now would mean a server that registers the local
-    # browser-backed tools and then declines to serialize them, which is a
-    # worse starting point than not having the role at all.
+    #: Talks to its own client but drives no browser: every tool call is
+    #: forwarded to the owner over loopback HTTP. Registers none of the local
+    #: browser-backed tools, and serves the owner's instead.
+    PROXY = "proxy"
 
     @property
     def drives_browser(self) -> bool:
@@ -40,5 +40,9 @@ class ServerRole(enum.Enum):
 
     @property
     def faces_a_client(self) -> bool:
-        """Whether an end user reads this server's tool results."""
-        return self is ServerRole.DIRECT
+        """Whether an end user reads this server's tool results.
+
+        A proxy counts. It is the process the MCP client spawned, so its results
+        are the ones a user reads, however little of the work happens here.
+        """
+        return self in (ServerRole.DIRECT, ServerRole.PROXY)

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -681,15 +681,23 @@ class TestForwardingToASharedOwner:
 
         assert cli_main._obtain_shared_owner(self._config(daemon_enabled=True)) is None
 
-    def test_an_owner_makes_this_process_a_proxy(self, monkeypatch: pytest.MonkeyPatch):
+    def test_an_owner_makes_this_process_a_proxy(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ):
         from linkedin_mcp_server.server_role import ServerRole
 
         config = self._config(daemon_enabled=True)
         _patch_main_dependencies(monkeypatch, config)
         attachment = MagicMock(name="attachment")
+        # Patched at the election rather than at the helper, so the real helper
+        # runs. Stubbing `_obtain_shared_owner` would let it go on discarding the
+        # outcome — the bug this PR fixes — while this test still passed.
         monkeypatch.setattr(
-            "linkedin_mcp_server.cli_main._obtain_shared_owner",
-            lambda _config: attachment,
+            "linkedin_mcp_server.daemon_election.obtain_owner",
+            lambda *_args, **_kwargs: self._outcome(attachment),
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.get_profile_dir", lambda: tmp_path / "profile"
         )
         built = {}
         monkeypatch.setattr(
@@ -721,3 +729,41 @@ class TestForwardingToASharedOwner:
         cli_main.main()
 
         assert set(built) == {"tool_timeout"}
+
+    def test_an_interactively_chosen_http_transport_elects_no_daemon(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The ordering this depends on is easy to break by accident: the
+        # interactive answer is written back into the config, and the election
+        # reads that stored value. Moving the election above the prompt, or
+        # keeping the answer in a local, would start a detached owner for a
+        # server that is already one-for-many — and every other test here would
+        # still pass, because they all set the transport explicitly.
+        config = self._config(daemon_enabled=True, transport="stdio")
+        config.server.transport_explicitly_set = False
+        config.is_interactive = True
+        _patch_main_dependencies(monkeypatch, config)
+
+        # Recorded rather than raised from inside: the helper wraps the election
+        # in `except Exception`, so an assertion thrown there would be swallowed
+        # and this test would pass against the very bug it exists for. Found by
+        # mutating the ordering and watching it pass.
+        called = []
+
+        def record(*_args, **_kwargs):
+            called.append(True)
+            raise RuntimeError("no owner")
+
+        monkeypatch.setattr("linkedin_mcp_server.daemon_election.obtain_owner", record)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.choose_transport_interactive",
+            lambda: "streamable-http",
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.create_mcp_server",
+            lambda **_kwargs: MagicMock(),
+        )
+
+        cli_main.main()
+
+        assert called == [], "an HTTP server must not elect a daemon"

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -576,3 +576,148 @@ def test_clear_profile_and_exit_clears_all_auth_state(
     assert cleared["profile"] == profile_dir
     captured = capsys.readouterr()
     assert "authentication state cleared" in captured.out.lower()
+
+
+class TestForwardingToASharedOwner:
+    """Which server this process builds, and what it does when there is no owner.
+
+    The flag is off by default, so the ordinary case here is that nothing
+    happens. What these pin is the two ways the daemon can go wrong quietly: a
+    process that elects an owner and then ignores it, and a process that starts
+    an owner when there was never any point.
+    """
+
+    @staticmethod
+    def _outcome(attachment):
+        from linkedin_mcp_server.daemon import OwnerLookup, OwnerState
+        from linkedin_mcp_server.daemon_election import ElectionOutcome
+
+        state = OwnerState.ATTACHABLE if attachment else OwnerState.ABSENT
+        return ElectionOutcome(OwnerLookup(state=state, attachment=attachment))
+
+    def _config(self, *, daemon_enabled: bool, transport="stdio") -> AppConfig:
+        config = _make_config(
+            is_interactive=False,
+            transport=transport,
+            transport_explicitly_set=True,
+        )
+        config.server.daemon_enabled = daemon_enabled
+        return config
+
+    def test_no_owner_is_sought_when_the_daemon_is_switched_off(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The default. Electing an owner here would cost every user a detached
+        # process for a feature they did not ask for.
+        asked = MagicMock()
+        monkeypatch.setattr("linkedin_mcp_server.daemon_election.obtain_owner", asked)
+
+        assert cli_main._obtain_shared_owner(self._config(daemon_enabled=False)) is None
+        asked.assert_not_called()
+
+    def test_no_owner_is_sought_for_an_http_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # An explicit HTTP bind is already one server for many clients, so there
+        # is nothing left for a daemon to deduplicate.
+        asked = MagicMock()
+        monkeypatch.setattr("linkedin_mcp_server.daemon_election.obtain_owner", asked)
+        config = self._config(daemon_enabled=True, transport="streamable-http")
+
+        assert cli_main._obtain_shared_owner(config) is None
+        asked.assert_not_called()
+
+    def test_the_elected_owner_is_handed_back_rather_than_discarded(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ):
+        # The mutation every test that stubs this helper would miss: before this
+        # PR the election ran and its result was thrown away, which looks
+        # identical from the outside until nothing forwards.
+        attachment = MagicMock(name="attachment")
+        monkeypatch.setattr(
+            "linkedin_mcp_server.daemon_election.obtain_owner",
+            lambda *_args, **_kwargs: self._outcome(attachment),
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.get_profile_dir", lambda: tmp_path / "profile"
+        )
+
+        found = cli_main._obtain_shared_owner(self._config(daemon_enabled=True))
+
+        assert found is attachment
+
+    def test_a_failed_election_leaves_this_process_driving_its_own_browser(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path, caplog
+    ):
+        # Deliberate, and a real trade: falling back means two clients can hand
+        # the profile back and forth per call again, which is the cost #606
+        # exists to remove. A client that refused to start would fail where
+        # nobody reads the reason, so the warning is what has to carry it.
+        monkeypatch.setattr(
+            "linkedin_mcp_server.daemon_election.obtain_owner",
+            lambda *_args, **_kwargs: self._outcome(None),
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.get_profile_dir", lambda: tmp_path / "profile"
+        )
+
+        with caplog.at_level(logging.WARNING):
+            assert (
+                cli_main._obtain_shared_owner(self._config(daemon_enabled=True)) is None
+            )
+
+        assert "drive its own browser" in caplog.text
+
+    def test_an_election_that_raises_is_never_fatal(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ):
+        def explode(*_args, **_kwargs):
+            raise RuntimeError("the lock is on a filesystem without locking")
+
+        monkeypatch.setattr("linkedin_mcp_server.daemon_election.obtain_owner", explode)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.get_profile_dir", lambda: tmp_path / "profile"
+        )
+
+        assert cli_main._obtain_shared_owner(self._config(daemon_enabled=True)) is None
+
+    def test_an_owner_makes_this_process_a_proxy(self, monkeypatch: pytest.MonkeyPatch):
+        from linkedin_mcp_server.server_role import ServerRole
+
+        config = self._config(daemon_enabled=True)
+        _patch_main_dependencies(monkeypatch, config)
+        attachment = MagicMock(name="attachment")
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main._obtain_shared_owner",
+            lambda _config: attachment,
+        )
+        built = {}
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.create_mcp_server",
+            lambda **kwargs: built.update(kwargs) or MagicMock(),
+        )
+
+        cli_main.main()
+
+        assert built["role"] is ServerRole.PROXY
+        assert built["proxy_attachment"] is attachment
+        # The owner's inbound credential must not be reused for the outbound hop.
+        assert "auth_token" not in built
+
+    def test_no_owner_leaves_the_historical_server_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        config = self._config(daemon_enabled=False)
+        _patch_main_dependencies(monkeypatch, config)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main._obtain_shared_owner", lambda _config: None
+        )
+        built = {}
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.create_mcp_server",
+            lambda **kwargs: built.update(kwargs) or MagicMock(),
+        )
+
+        cli_main.main()
+
+        assert set(built) == {"tool_timeout"}

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1105,6 +1105,97 @@ class TestRealOwner:
         finally:
             _stop(second.get("pid"))
 
+    def test_a_proxy_serves_the_real_owners_tools_over_loopback(
+        self, real_state_root: Path
+    ):
+        """The whole feature, end to end, in the only test that proves it.
+
+        Everything else about the proxy runs in memory against a stand-in owner.
+        This is the one that exercises the published descriptor, the real bearer
+        token and a real socket together, which is where a wrong URL, a
+        mis-scoped credential or a refused loopback hop would actually show up.
+
+        Deliberately no tool is *executed*: the owner has no LinkedIn session and
+        driving a browser is not what this asserts. Serving the owner's list
+        through an authenticated round trip is.
+        """
+        import asyncio
+
+        from fastmcp import Client
+
+        from linkedin_mcp_server.daemon import look_up_owner
+        from linkedin_mcp_server.server import ServerRole, create_mcp_server
+
+        profile = real_state_root
+        result = _run_frontend(profile)
+        try:
+            assert result["state"] == OwnerState.ATTACHABLE.value, result
+
+            # Read the way a frontend does, rather than reusing what the child
+            # returned: the descriptor and token on disk are what a proxy is
+            # built from.
+            lookup = look_up_owner(profile.parent, profile, _config(profile))
+            assert lookup.attachment is not None, lookup.reason
+
+            proxy = create_mcp_server(
+                tool_timeout=30.0,
+                role=ServerRole.PROXY,
+                proxy_attachment=lookup.attachment,
+            )
+
+            async def served() -> set[str]:
+                async with Client(proxy) as client:
+                    return {tool.name for tool in await client.list_tools()}
+
+            names = asyncio.run(served())
+
+            # The owner registers the full local set, so the proxy must show it
+            # all — including `close_session`, the one defined inline rather than
+            # in a `register_*` call.
+            assert "get_person_profile" in names
+            assert "close_session" in names
+            assert len(names) == 19, sorted(names)
+        finally:
+            _stop(result.get("pid"))
+
+    def test_a_proxy_refuses_an_owner_it_has_the_wrong_token_for(
+        self, real_state_root: Path
+    ):
+        """The credential is load-bearing, not decoration.
+
+        The owner listens on a loopback port that every process on the machine
+        can reach, and that a website can reach through the user's own browser.
+        If a wrong token were served anyway, that port would be an open door to a
+        logged-in LinkedIn session.
+        """
+        import asyncio
+        import dataclasses
+
+        from fastmcp import Client
+
+        from linkedin_mcp_server.daemon import look_up_owner
+        from linkedin_mcp_server.server import ServerRole, create_mcp_server
+
+        profile = real_state_root
+        result = _run_frontend(profile)
+        try:
+            lookup = look_up_owner(profile.parent, profile, _config(profile))
+            assert lookup.attachment is not None, lookup.reason
+
+            wrong = dataclasses.replace(lookup.attachment, token="not-the-token")
+            proxy = create_mcp_server(
+                tool_timeout=30.0, role=ServerRole.PROXY, proxy_attachment=wrong
+            )
+
+            async def served() -> None:
+                async with Client(proxy) as client:
+                    await client.list_tools()
+
+            with pytest.raises(Exception):
+                asyncio.run(served())
+        finally:
+            _stop(result.get("pid"))
+
 
 class TestVersionSkew:
     """``@latest`` means two versions can be on one machine at the same time."""

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1191,7 +1191,12 @@ class TestRealOwner:
                 async with Client(proxy) as client:
                     await client.list_tools()
 
-            with pytest.raises(Exception):
+            # Matched on the status rather than catching anything at all. A bare
+            # `Exception` passed on any failure whatsoever, including one raised
+            # before a request ever left this process — so the test would have
+            # gone green without the owner refusing anything. Measured: the real
+            # refusal is `McpError: Client error '401 Unauthorized'`.
+            with pytest.raises(Exception, match="401 Unauthorized"):
                 asyncio.run(served())
         finally:
             _stop(result.get("pid"))

--- a/tests/test_daemon_proxy.py
+++ b/tests/test_daemon_proxy.py
@@ -257,6 +257,38 @@ class TestServingTheOwnersTools:
 
         assert connections == after_listing
 
+    async def test_a_proxy_stays_pinned_to_the_owner_it_started_with(self):
+        """Pins the limitation rather than the behaviour anyone wants.
+
+        The endpoint is resolved once, so an owner that goes away leaves this
+        process failing every operation for the rest of its life. An upgrade is
+        enough to cause it: ``@latest`` means the first client launched after one
+        asks the running owner to stand down, and every proxy already attached to
+        it is stranded.
+
+        Written as an assertion so PR 5 has something that fails when the proxy
+        learns to re-resolve, instead of a comment nobody runs.
+        """
+        owner = self._owner()
+        alive = True
+
+        def factory() -> ProxyClient:
+            if not alive:
+                # Stands in for an owner that has exited: the address the proxy
+                # holds no longer answers.
+                return ProxyClient("http://127.0.0.1:9/mcp")
+            return ProxyClient(owner)
+
+        proxy = FastMCP("proxy", providers=[ProxyProvider(factory, cache_ttl=0)])
+        proxy.provider_error_strategy = "raise"
+
+        async with Client(proxy) as client:
+            assert {t.name for t in await client.list_tools()} == {"get_person_profile"}
+
+            alive = False
+            with pytest.raises(Exception, match="connect"):
+                await client.list_tools()
+
     async def test_a_dead_owner_is_an_error_not_an_empty_tool_list(self):
         # FastMCP's default is to log a failing provider and carry on. For a
         # server whose only provider this is, that turns a dead owner into a

--- a/tests/test_daemon_proxy.py
+++ b/tests/test_daemon_proxy.py
@@ -292,6 +292,13 @@ class TestServingTheOwnersTools:
         auth_root = tmp_path / "state"
         elected = _attachment(tmp_path)
 
+        # Published state is keyed by auth root but *stored* under the account's
+        # own private directory, so a tmp_path auth root alone does not isolate
+        # anything: without this the test left a directory behind in the real
+        # ~/.mcp-server-linkedin/daemon. Caught by counting entries before and
+        # after a run.
+        monkeypatch.setattr(daemon_descriptor, "_account_home", lambda: tmp_path)
+
         # Only the socket is stood in for. A client reaches the owner when the
         # address it carries is the one currently published, and fails otherwise,
         # so what decides the outcome is the address production code chose rather

--- a/tests/test_daemon_proxy.py
+++ b/tests/test_daemon_proxy.py
@@ -22,8 +22,8 @@ from fastmcp.tools import ToolResult
 from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.daemon import Attachment
 from linkedin_mcp_server.daemon_descriptor import build, new_instance_id, new_token
+from linkedin_mcp_server import daemon_descriptor, daemon_proxy
 from linkedin_mcp_server.daemon_proxy import (
-    _COMPONENT_CACHE_SECONDS,
     _client_factory,
     create_proxy_provider,
 )
@@ -232,14 +232,19 @@ class TestServingTheOwnersTools:
 
         return owner
 
-    async def test_a_lookup_after_a_listing_costs_no_extra_round_trip(self):
+    async def test_a_lookup_after_a_listing_costs_no_extra_round_trip(
+        self, tmp_path: Path
+    ):
         # An owner's tool set never changes over its lifetime, so caching it is
-        # free correctness-wise and saves a list round trip per call — measured
-        # at 88ms against 122ms with the cache off.
+        # free correctness-wise and saves a list round trip per forwarded call —
+        # about 23ms against 42ms over a real loopback owner on this machine.
         #
-        # Asserted through the connection count rather than against the module's
-        # own constant: comparing to the constant moves with it, so setting the
-        # cache to zero passed that version of this test.
+        # Built through `create_proxy_provider` and then handed a counting
+        # factory, so the production `cache_ttl` wiring is what is under test.
+        # Two earlier versions of this were weaker: one compared against the
+        # module constant, which moves with the mutation, and one constructed its
+        # own provider, which left `create_proxy_provider(cache_ttl=0)`
+        # undetected.
         owner = self._owner()
         connections = 0
 
@@ -248,8 +253,8 @@ class TestServingTheOwnersTools:
             connections += 1
             return ProxyClient(owner)
 
-        provider = ProxyProvider(counting_factory, cache_ttl=_COMPONENT_CACHE_SECONDS)
-        assert _COMPONENT_CACHE_SECONDS > 0
+        provider = create_proxy_provider(_attachment(tmp_path), tool_timeout=1.0)
+        provider.client_factory = counting_factory
 
         await provider.list_tools()
         after_listing = connections
@@ -257,7 +262,9 @@ class TestServingTheOwnersTools:
 
         assert connections == after_listing
 
-    async def test_a_proxy_stays_pinned_to_the_owner_it_started_with(self):
+    async def test_a_proxy_stays_pinned_to_the_owner_it_started_with(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         """Pins the limitation rather than the behaviour anyone wants.
 
         The endpoint is resolved once, so an owner that goes away leaves this
@@ -266,28 +273,63 @@ class TestServingTheOwnersTools:
         asks the running owner to stand down, and every proxy already attached to
         it is stranded.
 
-        Written as an assertion so PR 5 has something that fails when the proxy
-        learns to re-resolve, instead of a comment nobody runs.
+        What this does assert, and it is narrower than it first looks: the
+        address the *production* factory puts in each client is the one it was
+        handed at construction, not a fresh reading. A replacement owner is
+        published before the second call, so the address is demonstrably stale by
+        then, and the call still goes to the old one.
+
+        What it deliberately does **not** claim is to be a tripwire that fails
+        once the liveness work lands. Three attempts at that were each defeated
+        by mutation: building a local provider missed the production wiring;
+        swapping a local URL missed a proxy reading the descriptor; and publishing
+        into an isolated root missed one reading the account's real root. A
+        re-resolution test needs the resolver to be an argument this can inject,
+        which is a design the liveness PR should introduce rather than something
+        to fake from outside. Until then this pins the pinning and nothing more.
         """
         owner = self._owner()
-        alive = True
+        auth_root = tmp_path / "state"
+        elected = _attachment(tmp_path)
 
-        def factory() -> ProxyClient:
-            if not alive:
-                # Stands in for an owner that has exited: the address the proxy
-                # holds no longer answers.
-                return ProxyClient("http://127.0.0.1:9/mcp")
+        # Only the socket is stood in for. A client reaches the owner when the
+        # address it carries is the one currently published, and fails otherwise,
+        # so what decides the outcome is the address production code chose rather
+        # than anything this test set.
+        def dial(url: str) -> ProxyClient:
+            published = daemon_descriptor.read(auth_root)
+            if published is None or url != published.url:
+                raise ConnectionError(f"nothing is listening on {url}")
             return ProxyClient(owner)
 
-        proxy = FastMCP("proxy", providers=[ProxyProvider(factory, cache_ttl=0)])
-        proxy.provider_error_strategy = "raise"
+        real_factory = daemon_proxy._client_factory
 
-        async with Client(proxy) as client:
-            assert {t.name for t in await client.list_tools()} == {"get_person_profile"}
+        def factory_over_a_socket(attachment, *, timeout):
+            build = real_factory(attachment, timeout=timeout)
 
-            alive = False
-            with pytest.raises(Exception, match="connect"):
-                await client.list_tools()
+            def open_client() -> ProxyClient:
+                built = build()
+                assert isinstance(built.transport, StreamableHttpTransport)
+                return dial(built.transport.url)
+
+            return open_client
+
+        monkeypatch.setattr(daemon_proxy, "_client_factory", factory_over_a_socket)
+
+        daemon_descriptor.publish(auth_root, elected.descriptor, elected.token)
+        provider = create_proxy_provider(elected, tool_timeout=1.0)
+        assert {t.name for t in await provider.list_tools()} == {"get_person_profile"}
+
+        # A replacement owner takes over on a new port and publishes itself, the
+        # way one does after a stand-down. A proxy that re-resolved would find it.
+        replacement = _attachment(tmp_path, port=elected.descriptor.port + 1)
+        daemon_descriptor.publish(auth_root, replacement.descriptor, replacement.token)
+        published = daemon_descriptor.read(auth_root)
+        assert published is not None
+        assert published.url == replacement.descriptor.url
+
+        with pytest.raises(ConnectionError, match="nothing is listening"):
+            await provider.list_tools()
 
     async def test_a_dead_owner_is_an_error_not_an_empty_tool_list(self):
         # FastMCP's default is to log a failing provider and carry on. For a

--- a/tests/test_daemon_proxy.py
+++ b/tests/test_daemon_proxy.py
@@ -270,9 +270,9 @@ class TestServingTheOwnersTools:
                 await client.list_tools()
 
     async def test_progress_from_the_owner_reaches_the_clients_handler(self):
-        # Every browser-backed tool reports progress, and a long scrape with no
-        # progress looks indistinguishable from a hung one. A plain Client in
-        # the factory drops these silently.
+        # Eighteen of the nineteen tools report progress (`close_session` is the
+        # exception), and a long scrape with no progress looks indistinguishable
+        # from a hung one. A plain Client in the factory drops these silently.
         owner = FastMCP("owner")
 
         @owner.tool

--- a/tests/test_daemon_proxy.py
+++ b/tests/test_daemon_proxy.py
@@ -1,0 +1,336 @@
+"""How a frontend reaches the owner it was told to forward to.
+
+Every test here pins something that is invisible in a passing round trip and
+expensive when it is wrong: a bearer token taking a detour through the user's
+proxy, a long call that hangs instead of failing, progress that silently stops
+arriving, or a dead owner that looks like a server with no tools.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+import mcp.types as mt
+import pytest
+from fastmcp import Client, Context, FastMCP
+from fastmcp.client.transports import StreamableHttpTransport
+from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
+from fastmcp.tools import ToolResult
+
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon import Attachment
+from linkedin_mcp_server.daemon_descriptor import build, new_instance_id, new_token
+from linkedin_mcp_server.daemon_proxy import (
+    _COMPONENT_CACHE_SECONDS,
+    _client_factory,
+    create_proxy_provider,
+)
+
+
+def _attachment(
+    tmp_path: Path,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 51234,
+    path: str = "/mcp",
+) -> Attachment:
+    profile = tmp_path / "profile"
+    profile.mkdir(exist_ok=True)
+    config = AppConfig()
+    config.browser.user_data_dir = str(profile)
+    token = new_token()
+    descriptor = build(
+        instance_id=new_instance_id(),
+        package_version="4.20.1",
+        runtime_id="test-runtime",
+        profile=profile,
+        host=host,
+        port=port,
+        path=path,
+        token=token,
+        config=config,
+        log_path=tmp_path / "owner.log",
+    )
+    return Attachment(descriptor=descriptor, token=token)
+
+
+class TestReachingTheOwner:
+    """The address and the credential, both used exactly as published."""
+
+    def test_the_published_url_is_used_verbatim(self, tmp_path: Path):
+        # Rebuilding it from host and port loses the MCP path, and FastMCP does
+        # not add one back: it deliberately serves whatever path it is given.
+        attachment = _attachment(tmp_path)
+        client = _client_factory(attachment, timeout=1.0)()
+
+        assert isinstance(client.transport, StreamableHttpTransport)
+        assert client.transport.url == attachment.descriptor.url
+        assert client.transport.url.endswith("/mcp")
+
+    def test_an_ipv6_owner_keeps_its_brackets(self, tmp_path: Path):
+        # Unbracketed, the colons in the address run into the one before the
+        # port and the whole URL parses as a bad port.
+        attachment = _attachment(tmp_path, host="::1")
+        client = _client_factory(attachment, timeout=1.0)()
+
+        assert isinstance(client.transport, StreamableHttpTransport)
+        assert "[::1]" in client.transport.url
+
+    def test_the_owners_token_is_sent_as_a_bearer(self, tmp_path: Path):
+        # The owner compares the token after the `Bearer ` scheme, so a raw
+        # header value would be rejected by the endpoint it was minted for.
+        attachment = _attachment(tmp_path)
+        client = _client_factory(attachment, timeout=1.0)()
+
+        request = httpx.Request("POST", attachment.descriptor.url)
+        assert client.transport.auth is not None
+        signed = next(client.transport.auth.auth_flow(request))
+
+        assert signed.headers["Authorization"] == f"Bearer {attachment.token}"
+
+    def test_a_fresh_client_is_built_for_every_operation(self, tmp_path: Path):
+        # The provider opens and closes a client around each upstream call, so a
+        # single shared session would be reused after its context had exited —
+        # and would outlive the owner it was opened against.
+        factory = _client_factory(_attachment(tmp_path), timeout=1.0)
+
+        assert factory() is not factory()
+
+    def test_it_forwards_with_a_proxy_client(self, tmp_path: Path):
+        # Not a plain Client. That one installs no progress handler, so every
+        # progress update the tools report would be dropped on the way through.
+        client = _client_factory(_attachment(tmp_path), timeout=1.0)()
+
+        assert isinstance(client, ProxyClient)
+
+
+class TestKeepingTheTokenOffTheNetwork:
+    """A loopback hop must not become a request to somebody else's proxy."""
+
+    def test_the_environment_proxy_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # httpx honours HTTP_PROXY even for 127.0.0.1 unless NO_PROXY happens to
+        # say otherwise. The owner reproduced this against a capture proxy: a
+        # loopback request arrived there complete with the bearer token. This
+        # server also has a *legitimate* proxy setting for LinkedIn's own
+        # traffic, which is exactly why the two must not be confused.
+        monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:9")
+        monkeypatch.delenv("NO_PROXY", raising=False)
+
+        client = _client_factory(_attachment(tmp_path), timeout=1.0)()
+        http_client = client.transport.httpx_client_factory(
+            headers=None, auth=None, follow_redirects=True
+        )
+
+        assert http_client.trust_env is False
+
+    def test_the_factory_survives_the_extra_arguments_fastmcp_passes(
+        self, tmp_path: Path
+    ):
+        # FastMCP's transport passes `follow_redirects` on top of the documented
+        # client-factory protocol. A factory accepting only the three declared
+        # parameters failed at connect time with an unexpected keyword.
+        client = _client_factory(_attachment(tmp_path), timeout=1.0)()
+
+        http_client = client.transport.httpx_client_factory(
+            headers={"x": "y"},
+            auth=None,
+            follow_redirects=True,
+            timeout=httpx.Timeout(5.0),
+        )
+
+        assert http_client.trust_env is False
+
+
+class TestTheForwardingDeadline:
+    """Why the timeout is an argument and not a default."""
+
+    @staticmethod
+    def _client_of(provider: ProxyProvider) -> ProxyClient:
+        """The client the provider would open, narrowed from its async-capable type."""
+        client = provider.client_factory()
+        assert isinstance(client, ProxyClient)
+        return client
+
+    @classmethod
+    def _request_deadline(cls, client: ProxyClient) -> float:
+        """The timeout the MCP session actually waits on, in seconds."""
+        read_timeout = client._session_kwargs["read_timeout_seconds"]
+        assert read_timeout is not None
+        return read_timeout.total_seconds()
+
+    def test_it_outlasts_the_owners_own_tool_timeout(self, tmp_path: Path):
+        # Equal would race the owner's error response, turning a diagnosable
+        # "tool timed out" into an unexplained transport failure. Shorter would
+        # abort calls the owner would have finished.
+        provider = create_proxy_provider(_attachment(tmp_path), tool_timeout=42.0)
+
+        assert self._request_deadline(self._client_of(provider)) > 42.0
+
+    def test_it_is_set_at_the_mcp_layer_and_not_only_on_the_http_client(
+        self, tmp_path: Path
+    ):
+        # Measured: with the deadline only on the HTTP client, a call that
+        # outlives the read timeout never returns at all. What produces an error
+        # is the MCP-level timeout, and setting that also raises the HTTP read
+        # timeout, so one value covers both layers.
+        provider = create_proxy_provider(_attachment(tmp_path), tool_timeout=42.0)
+        client = self._client_of(provider)
+
+        assert self._request_deadline(client) == 72.0
+
+        # The transport derives the HTTP read timeout from that same value.
+        http_client = client.transport.httpx_client_factory(
+            headers=None,
+            auth=None,
+            follow_redirects=True,
+            timeout=httpx.Timeout(30.0, read=self._request_deadline(client)),
+        )
+        assert http_client.timeout.read == 72.0
+
+    async def test_a_call_that_outlives_the_deadline_fails_rather_than_hangs(
+        self, tmp_path: Path
+    ):
+        # The regression this argument exists for. Without an MCP-level timeout
+        # the equivalent call hung indefinitely; `asyncio.wait_for` here is only
+        # a guard so a regression fails the suite instead of stalling it.
+        owner = FastMCP("owner")
+
+        @owner.tool
+        async def slow() -> dict[str, bool]:
+            await asyncio.sleep(30)
+            return {"ok": True}
+
+        proxy = FastMCP(
+            "proxy",
+            providers=[ProxyProvider(lambda: ProxyClient(owner, timeout=0.2))],
+        )
+        proxy.provider_error_strategy = "raise"
+
+        async with Client(proxy) as client:
+            with pytest.raises(Exception, match="[Tt]ime"):
+                await asyncio.wait_for(client.call_tool("slow", {}), timeout=10)
+
+
+class TestServingTheOwnersTools:
+    """What survives the hop, and what a dead owner looks like."""
+
+    @staticmethod
+    def _owner() -> FastMCP:
+        owner = FastMCP("owner")
+
+        @owner.tool(
+            title="Get Person Profile",
+            annotations={"readOnlyHint": True},
+            tags={"person"},
+        )
+        async def get_person_profile(linkedin_username: str) -> dict[str, str]:
+            return {"username": linkedin_username}
+
+        return owner
+
+    async def test_a_lookup_after_a_listing_costs_no_extra_round_trip(self):
+        # An owner's tool set never changes over its lifetime, so caching it is
+        # free correctness-wise and saves a list round trip per call — measured
+        # at 88ms against 122ms with the cache off.
+        #
+        # Asserted through the connection count rather than against the module's
+        # own constant: comparing to the constant moves with it, so setting the
+        # cache to zero passed that version of this test.
+        owner = self._owner()
+        connections = 0
+
+        def counting_factory() -> ProxyClient:
+            nonlocal connections
+            connections += 1
+            return ProxyClient(owner)
+
+        provider = ProxyProvider(counting_factory, cache_ttl=_COMPONENT_CACHE_SECONDS)
+        assert _COMPONENT_CACHE_SECONDS > 0
+
+        await provider.list_tools()
+        after_listing = connections
+        await provider.get_tool("get_person_profile")
+
+        assert connections == after_listing
+
+    async def test_a_dead_owner_is_an_error_not_an_empty_tool_list(self):
+        # FastMCP's default is to log a failing provider and carry on. For a
+        # server whose only provider this is, that turns a dead owner into a
+        # client that sees no tools and no reason why.
+        provider = ProxyProvider(lambda: ProxyClient("http://127.0.0.1:9/mcp"))
+        proxy = FastMCP("proxy", providers=[provider])
+        proxy.provider_error_strategy = "raise"
+
+        async with Client(proxy) as client:
+            with pytest.raises(Exception, match="connect"):
+                await client.list_tools()
+
+    async def test_progress_from_the_owner_reaches_the_clients_handler(self):
+        # Every browser-backed tool reports progress, and a long scrape with no
+        # progress looks indistinguishable from a hung one. A plain Client in
+        # the factory drops these silently.
+        owner = FastMCP("owner")
+
+        @owner.tool
+        async def scrape(ctx: Context) -> dict[str, bool]:
+            await ctx.report_progress(progress=50, total=100, message="halfway")
+            return {"ok": True}
+
+        proxy = FastMCP("proxy", providers=[ProxyProvider(lambda: ProxyClient(owner))])
+        seen: list[tuple[float, float | None, str | None]] = []
+
+        async def record(progress: float, total: float | None, message: str | None):
+            seen.append((progress, total, message))
+
+        async with Client(proxy, progress_handler=record) as client:
+            await client.call_tool("scrape", {})
+
+        assert seen == [(50.0, 100.0, "halfway")]
+
+    async def test_a_round_trip_preserves_everything_a_result_carries(self):
+        # The envelope is what a later change has to survive on: request `_meta`
+        # is how an owner will label an auth failure, and a collapsed result
+        # would lose the structured half every tool returns.
+        owner = FastMCP("owner")
+        received: dict[str, dict[str, object]] = {}
+
+        @owner.tool
+        async def report(ctx: Context) -> ToolResult:
+            request_context = ctx.request_context
+            assert request_context is not None
+            received["meta"] = dict(request_context.meta or {})
+            return ToolResult(
+                content=[mt.TextContent(type="text", text="the text half")],
+                structured_content={"the": "structured half"},
+                is_error=True,
+            )
+
+        proxy = FastMCP("proxy", providers=[ProxyProvider(lambda: ProxyClient(owner))])
+
+        async with Client(proxy) as client:
+            result = await client.call_tool(
+                "report", {}, raise_on_error=False, meta={"marker": "carried"}
+            )
+
+        assert received["meta"]["marker"] == "carried"
+        assert result.is_error is True
+        assert result.structured_content == {"the": "structured half"}
+        assert any("the text half" in getattr(c, "text", "") for c in result.content)
+
+    async def test_the_owners_tool_schema_survives_the_hop(self):
+        # A client picks tools by title and annotations, so losing them changes
+        # which tool an agent chooses even though every call still works.
+        owner = self._owner()
+        proxy = FastMCP("proxy", providers=[ProxyProvider(lambda: ProxyClient(owner))])
+
+        async with Client(proxy) as client:
+            (tool,) = await client.list_tools()
+
+        assert tool.name == "get_person_profile"
+        assert tool.title == "Get Person Profile"
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -344,8 +344,15 @@ class TestOwnerAuthentication:
         # Passing a token to a stdio server is a caller that believes it built
         # the owner. Ignoring it quietly would leave an endpoint that was meant
         # to be authenticated serving anyone who finds it.
-        with pytest.raises(ValueError, match="daemon owner"):
-            create_mcp_server(role=ServerRole.DIRECT, auth_token="a-token")
+        #
+        # A proxy is the case worth spelling out, because it is the one role that
+        # legitimately handles a token — the owner's, outbound. Accepting one
+        # here would be a caller confusing the credential it *presents* with the
+        # one an owner *demands*, and narrowing this guard to DIRECT alone would
+        # let that through.
+        for role in (ServerRole.DIRECT, ServerRole.PROXY):
+            with pytest.raises(ValueError, match="daemon owner"):
+                create_mcp_server(role=role, auth_token="a-token")
 
     async def test_the_wrong_token_is_refused_and_the_right_one_accepted(self):
         owner = create_mcp_server(role=ServerRole.OWNER, auth_token="the-token")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,8 +5,9 @@ from unittest.mock import AsyncMock, MagicMock, call
 
 import mcp.types as mt
 import pytest
-from fastmcp import FastMCP
+from fastmcp import Client, FastMCP
 from fastmcp.server.middleware import MiddlewareContext
+from fastmcp.server.providers.proxy import ProxyClient
 
 import linkedin_mcp_server.server as server_module
 from linkedin_mcp_server import __version__
@@ -19,6 +20,56 @@ from linkedin_mcp_server.update_check import UpdateNoticeMiddleware
 
 def _has_middleware(mcp: FastMCP, kind: type) -> bool:
     return any(isinstance(middleware, kind) for middleware in mcp.middleware)
+
+
+def _owner_serving(*tool_names: str) -> FastMCP:
+    """A stand-in owner that serves the named tools and nothing else."""
+    owner = FastMCP("owner")
+    for name in tool_names:
+
+        async def tool() -> dict[str, str]:
+            return {"served": "by the owner"}
+
+        tool.__name__ = name
+        owner.tool(tool)
+    return owner
+
+
+def _an_attachment() -> MagicMock:
+    """Stands in for an elected owner.
+
+    The real one carries a loopback address and a bearer token and needs a
+    published descriptor to build. These tests are about which parts of a server
+    a role gets, so the endpoint is stood in for; the real URL, token, timeout
+    and proxy-environment wiring are covered in ``tests/test_daemon_proxy.py``.
+    """
+    attachment = MagicMock(name="attachment")
+    attachment.descriptor.url = "http://127.0.0.1:1/mcp"
+    attachment.token = "a-token"
+    return attachment
+
+
+def _proxy_to(monkeypatch: pytest.MonkeyPatch, owner: FastMCP, **kwargs) -> FastMCP:
+    """Build a PROXY whose provider reaches *owner* in memory rather than over HTTP."""
+    import linkedin_mcp_server.daemon_proxy as daemon_proxy
+
+    # ProxyClient, matching production: a plain Client would drop the progress
+    # every browser-backed tool reports.
+    monkeypatch.setattr(
+        daemon_proxy,
+        "_client_factory",
+        lambda _a, *, timeout: lambda: ProxyClient(owner),
+    )
+    return create_mcp_server(
+        role=ServerRole.PROXY, proxy_attachment=_an_attachment(), **kwargs
+    )
+
+
+def _extras_for(role: ServerRole) -> dict[str, MagicMock]:
+    """The arguments a role cannot be built without."""
+    if role is ServerRole.PROXY:
+        return {"proxy_attachment": _an_attachment()}
+    return {}
 
 
 class TestServerRoles:
@@ -44,7 +95,7 @@ class TestServerRoles:
         # reach Chromium takes the lease first. A role added later that skips
         # this would corrupt the session rather than merely run slowly.
         for role in ServerRole:
-            mcp = create_mcp_server(role=role)
+            mcp = create_mcp_server(role=role, **_extras_for(role))
             serializes = _has_middleware(mcp, SequentialToolExecutionMiddleware)
 
             # Stated as the conditional it is. Asserting that every role drives
@@ -54,22 +105,36 @@ class TestServerRoles:
             assert serializes == role.drives_browser, role
 
     def test_the_update_notice_goes_only_where_a_user_reads_it(self):
-        # Appended to one tool result per process. On a server shared by many
-        # clients that means the first caller sees it and nobody afterwards
-        # does, however long that server lives.
-        owner = create_mcp_server(role=ServerRole.OWNER)
+        # Appended to one tool result per process, so it belongs wherever a user
+        # reads results and nowhere else. On the shared owner it would reach
+        # whichever client happened to call first and nobody after that, however
+        # many clients attach over its life. A proxy is the opposite case: it is
+        # the process the client spawned, so the notice has to survive there.
+        for role in ServerRole:
+            mcp = create_mcp_server(role=role, **_extras_for(role))
 
-        assert not _has_middleware(owner, UpdateNoticeMiddleware)
+            assert (
+                _has_middleware(mcp, UpdateNoticeMiddleware) == role.faces_a_client
+            ), role
 
-    def test_every_role_serves_the_same_tools(self):
+    def test_every_role_that_drives_a_browser_serves_the_same_tools(self):
         # A tool present in one role and missing from another would disappear
         # from a client's list depending on how its server happened to start.
+        #
+        # A proxy is deliberately not in here: it registers none of these and
+        # serves the owner's instead, which is a different claim and has its own
+        # test below.
         async def tool_names(role: ServerRole) -> set[str]:
             tools = await create_mcp_server(role=role).list_tools()
             return {tool.name for tool in tools}
 
-        served = {role: asyncio.run(tool_names(role)) for role in ServerRole}
+        served = {
+            role: asyncio.run(tool_names(role))
+            for role in ServerRole
+            if role.drives_browser
+        }
 
+        assert len(served) > 1
         assert len(set(map(frozenset, served.values()))) == 1
         assert "get_person_profile" in served[ServerRole.DIRECT]
 
@@ -97,6 +162,163 @@ class TestServerRoles:
         # Moving it must not break an embedder that already imports it from
         # where it used to live.
         assert server_module.ServerRole is ServerRole
+
+
+class TestProxyRole:
+    """A proxy serves the owner's tools and drives nothing itself.
+
+    The failures pinned here are all quiet ones: a browser installed in a process
+    that never opens one, a local tool shadowing the forwarded tool of the same
+    name, or a server that lost its tools and cannot say why.
+    """
+
+    async def test_a_proxy_serves_the_owners_tools(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        owner = _owner_serving("get_person_profile", "search_jobs")
+        proxy = _proxy_to(monkeypatch, owner)
+
+        async with Client(proxy) as client:
+            served = {tool.name for tool in await client.list_tools()}
+
+        assert served == {"get_person_profile", "search_jobs"}
+
+    async def test_a_proxy_registers_none_of_its_own_tools(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Only what the owner offers, exactly. An owner serving one tool proves
+        # nothing local slipped through, which a comparison against the full
+        # local list could not: that list would match by coincidence.
+        owner = _owner_serving("the_only_tool")
+        proxy = _proxy_to(monkeypatch, owner)
+
+        async with Client(proxy) as client:
+            served = {tool.name for tool in await client.list_tools()}
+
+        assert served == {"the_only_tool"}
+
+    async def test_close_session_is_not_kept_locally_by_a_proxy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The registration that is easiest to miss, because it is the one tool
+        # defined inline rather than in a `register_*` call. Left behind it would
+        # shadow the forwarded tool of the same name and close a browser this
+        # process does not have.
+        proxy = _proxy_to(monkeypatch, _owner_serving("get_person_profile"))
+
+        async with Client(proxy) as client:
+            served = {tool.name for tool in await client.list_tools()}
+
+        assert "close_session" not in served
+
+    async def test_a_proxy_never_runs_the_browser_lifespan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A proxy opens no browser, so entering this lifespan would install
+        # Chromium in a process that never uses it, poll to hand over a profile
+        # it does not hold, and then claim to close a browser it never had.
+        #
+        # Asserted through the collaborators rather than `proxy.lifespan is None`:
+        # FastMCP substitutes a default lifespan of its own when given none, so
+        # the identity check passed for a server that still had ours.
+        watcher = AsyncMock()
+        bootstrap = MagicMock()
+        browser_setup = AsyncMock()
+        close = AsyncMock()
+        monkeypatch.setattr(server_module, "initialize_bootstrap", bootstrap)
+        monkeypatch.setattr(server_module, "get_runtime_policy", MagicMock())
+        monkeypatch.setattr(
+            server_module, "start_background_browser_setup_if_needed", browser_setup
+        )
+        monkeypatch.setattr(server_module, "watch_for_handoff_requests", watcher)
+        monkeypatch.setattr(server_module, "close_browser", close)
+
+        proxy = _proxy_to(monkeypatch, _owner_serving("get_person_profile"))
+        async with Client(proxy) as client:
+            await client.list_tools()
+
+        bootstrap.assert_not_called()
+        browser_setup.assert_not_awaited()
+        watcher.assert_not_called()
+        close.assert_not_awaited()
+
+    async def test_a_browser_driving_role_does_run_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The other half of the assertion above: without this, deleting the
+        # lifespan outright would satisfy that test.
+        bootstrap = MagicMock()
+        close = AsyncMock()
+        monkeypatch.setattr(server_module, "initialize_bootstrap", bootstrap)
+        monkeypatch.setattr(server_module, "get_runtime_policy", MagicMock())
+        monkeypatch.setattr(
+            server_module, "start_background_browser_setup_if_needed", AsyncMock()
+        )
+        monkeypatch.setattr(server_module, "watch_for_handoff_requests", AsyncMock())
+        monkeypatch.setattr(server_module, "close_browser", close)
+
+        async with Client(create_mcp_server()) as client:
+            await client.list_tools()
+
+        bootstrap.assert_called_once()
+        close.assert_awaited_once()
+
+    async def test_a_dead_owner_is_an_error_rather_than_an_empty_tool_list(self):
+        # FastMCP logs a failing provider and carries on by default. For a proxy
+        # the provider *is* the server, so that default turns an unreachable
+        # owner into a client that sees no tools and no reason why. Measured on
+        # 3.4.4: `tools/list` returned `[]`.
+        proxy = create_mcp_server(
+            role=ServerRole.PROXY, proxy_attachment=_an_attachment()
+        )
+
+        async with Client(proxy) as client:
+            with pytest.raises(Exception, match="connect"):
+                await client.list_tools()
+
+    async def test_the_update_notice_still_reaches_a_forwarded_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The notice is appended by middleware around a call whose work happens in
+        # another process, so it has to survive the hop rather than be dropped
+        # with the local tool it used to ride on.
+        import linkedin_mcp_server.update_check as update_check
+
+        monkeypatch.setattr(update_check, "prime_from_cache", lambda: None)
+        monkeypatch.setattr(update_check, "refresh_latest_version", AsyncMock())
+        monkeypatch.setattr(
+            update_check, "pending_update_notice", lambda: "Update available: 9.9.9"
+        )
+
+        proxy = _proxy_to(monkeypatch, _owner_serving("get_person_profile"))
+
+        async with Client(proxy) as client:
+            result = await client.call_tool("get_person_profile", {})
+
+        texts = [getattr(block, "text", "") for block in result.content]
+        assert any("Update available: 9.9.9" in text for text in texts)
+        # And the owner's own result is still there, not replaced by the notice.
+        assert any("by the owner" in text for text in texts)
+
+    def test_a_proxy_without_an_owner_is_refused(self):
+        # It would serve an empty tool list and look like a server whose tools
+        # disappeared, which is the confusing half of the same bug.
+        with pytest.raises(ValueError, match="needs an owner"):
+            create_mcp_server(role=ServerRole.PROXY)
+
+    def test_only_a_proxy_may_be_given_an_owner(self):
+        # A role that does not forward would be handed a bearer token for a
+        # shared browser and quietly ignore it.
+        for role in (ServerRole.DIRECT, ServerRole.OWNER):
+            with pytest.raises(ValueError, match="Only a proxy forwards"):
+                create_mcp_server(role=role, proxy_attachment=_an_attachment())
+
+    def test_the_owners_inbound_token_is_not_the_proxys_outbound_one(self):
+        # Two credentials pointing opposite ways. Conflating them would either
+        # authenticate a server that has no port, or send an owner's own token
+        # back to itself.
+        with pytest.raises(ValueError, match="daemon owner"):
+            create_mcp_server(role=ServerRole.PROXY, auth_token="a-token")
 
 
 class TestOwnerAuthentication:


### PR DESCRIPTION
Every MCP client instance spawns its own stdio server process, so under sustained use ownership of Chromium moved on nearly every call. Each move closed and reopened the browser, and every reopen navigated to `/feed/` to revalidate the session, which cost one extra LinkedIn request per tool call.

The frontend now forwards rather than driving its own browser. A new `ServerRole.PROXY` registers none of the local browser-backed tools and instead serves the elected owner's tools over authenticated loopback HTTP through fastmcp's `ProxyProvider`. The lifespan is selected by role, since a proxy that entered the browser lifespan would install Chromium in a process that never opens one. `close_session` moves behind the same gate as the six `register_*` calls: it is the one tool defined inline rather than in a registration function, and left behind it would shadow the forwarded tool of the same name.

Two details in `daemon_proxy.py` are load-bearing rather than stylistic, and both were measured. The client must be a `ProxyClient`, because a plain `Client` installs no progress handler and silently drops the progress 18 of the 19 tools report. And the forwarding deadline has to be set at the MCP layer: with a short HTTP read timeout and no client timeout, a long forwarded call never returns at all, still hanging when an outer bound cut it off at 30s. Setting it on the client also raises the HTTP read timeout, so one value covers both layers. The loopback hop reuses the owner's own `direct_async_http_client`, which forces `trust_env=False` so the bearer token cannot take a detour through a configured `HTTP_PROXY`.

Verified with two stdio clients against one profile: with the daemon enabled a single Chromium process served four alternating calls, while the same run with it disabled launched a new browser for every one. An end-to-end test elects a real detached owner and serves its 19 tools through a proxy over a real socket, and asserts a wrong token is refused. The full suite passes at 1472 tests, and each new test was checked by mutating the production code it covers.

**A proxy is pinned to the owner it started with, and this release does not fix that.** The address and token are resolved once, so a proxy whose owner goes away fails every operation afterwards rather than finding the replacement. An upgrade is enough to cause it: with `@latest` the first client launched after one asks the running owner to stand down, and every proxy already attached to it is stranded until its own process restarts. Reproduced end to end and pinned by a test, so the liveness PR has a failing target rather than a note. Resolving the backend per operation belongs there, because a retry has to know whether the call it replaces may already have driven the browser.

Also still missing: a frontend timeout cannot stop a call the owner is running, since cancellation is not forwarded and the owner's queue wait falls outside the tool timeout. On Windows a frontend takes no lock of its own, so a local spawn failure is indistinguishable from a rival owner starting, and the fallback to a direct server is weaker there than on POSIX. The flag stays off by default for all of this.

See also: #606
