### PR TITLE
feat(daemon): Read the server role process-wide

### DIFF
--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -61,7 +61,7 @@ from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.daemon_lock import DaemonLock, DaemonLockError
 from linkedin_mcp_server.drivers.browser import set_headless
 from linkedin_mcp_server.logging_config import configure_logging
-from linkedin_mcp_server.server_role import ServerRole
+from linkedin_mcp_server.server_role import ServerRole, set_process_role
 from linkedin_mcp_server.session_state import auth_root_dir, get_runtime_id
 
 logger = logging.getLogger(__name__)
@@ -691,6 +691,12 @@ def main(argv: list[str] | None = None) -> int:
     # and then opens headless anyway. A user who asked to watch the browser
     # would get no window and no error.
     set_headless(config.browser.headless)
+    # Before anything can reach an auth gate. `create_owner_server` records it
+    # too, but that runs several steps later, inside `_serve`: a failure between
+    # here and there would be handled by a process that still believed it had a
+    # terminal. This process has neither one nor a desktop session for its whole
+    # life, so it says so as early as it says anything.
+    set_process_role(ServerRole.OWNER)
     configure_logging(log_level=config.server.log_level, json_format=True)
 
     profile = Path(config.browser.user_data_dir).expanduser().resolve()

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -34,7 +34,7 @@ from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
-from linkedin_mcp_server.server_role import ServerRole
+from linkedin_mcp_server.server_role import ServerRole, set_process_role
 from linkedin_mcp_server.update_check import UpdateNoticeMiddleware
 from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.feed import register_feed_tools
@@ -168,6 +168,18 @@ def create_mcp_server(
         # Only a proxy forwards. Accepting an owner here would mean a server that
         # was handed a bearer token for a shared browser and quietly ignored it.
         raise ValueError(f"Only a proxy forwards to an owner, not {role.value}")
+
+    # The role is also process state, because the auth gates live in `bootstrap`
+    # and are reached from a tool body with no server to ask (`server_role`).
+    # Claimed here rather than left to the entry points: anything may call this
+    # function directly, and a caller that built an OWNER while the process was
+    # still unclaimed would get an owner with every auth gate switched off, which
+    # is a detached process opening a login window nobody can see.
+    #
+    # The claim refuses a second, different role rather than applying it. That
+    # check lives in `set_process_role` so every entry point is covered by one
+    # rule, including the owner's, which claims OWNER before it ever gets here.
+    set_process_role(role)
 
     mcp = FastMCP(
         "mcp-server-linkedin",

--- a/linkedin_mcp_server/server_role.py
+++ b/linkedin_mcp_server/server_role.py
@@ -6,6 +6,11 @@ open a login window, a proxy must not take the profile lease — so the modules
 that answer those questions need to read it. ``dependencies`` is one of them,
 and it cannot import from ``server``: ``server`` imports the tool modules, and
 those import ``dependencies``, so the edge would close the cycle.
+
+Which is why the role also lives here as process state, not only as an argument.
+``create_mcp_server`` is handed a role and that settles everything it decides,
+but the auth gates sit in ``bootstrap``, reached from a tool body that has no
+server to ask, and :func:`process_role` is what those ask instead.
 """
 
 import enum
@@ -46,3 +51,79 @@ class ServerRole(enum.Enum):
         are the ones a user reads, however little of the work happens here.
         """
         return self in (ServerRole.DIRECT, ServerRole.PROXY)
+
+
+#: What this process is, for the code that cannot be handed the role.
+#:
+#: Assembling a server takes the role as an argument, which is enough for
+#: everything ``server`` decides. Authentication is not like that: whether a
+#: login window may be opened is decided far down the stack, in ``bootstrap``,
+#: which is reached from a tool body with no server in sight. A detached owner
+#: has no terminal and no desktop session, so it must answer that question
+#: differently, and the only thing it can consult is the process it is.
+#:
+#: Deliberately not in ``AppConfig``. That is settings a user chose, and it
+#: travels to the owner over a pipe (``daemon_config``) carrying exactly the
+#: fields both ends must agree on. The role is not one of them: an owner knows
+#: what it is, and being told by the frontend would be the wrong direction.
+#:
+#: ``None`` means nothing has claimed this process yet, which is distinct from
+#: ``DIRECT``. Using ``DIRECT`` for both would make the claim below unable to
+#: tell "nobody said" from "somebody said single-process", and a real ``DIRECT``
+#: server followed by an ``OWNER`` would then be accepted: the ``DIRECT``
+#: server's own tool calls would afterwards read ``OWNER`` and refuse the logins
+#: it is supposed to perform.
+_role: ServerRole | None = None
+
+
+class RoleAlreadyClaimedError(RuntimeError):
+    """Two different roles were claimed in one process.
+
+    Not resolvable by picking one. The role decides whether this process may open
+    a login window, and a proxy and an owner cannot both be right about that, so
+    the second claim is refused rather than applied or ignored.
+    """
+
+
+def set_process_role(role: ServerRole) -> None:
+    """Claim this process for *role*, or refuse if another already has it.
+
+    The check lives here rather than at the call sites so every entry point is
+    covered by one rule. Re-stating the same role is allowed: the owner records
+    it at its entry point and again when it assembles its server, and a test
+    building several servers of one kind is doing nothing contradictory.
+
+    Not locked. Every production caller builds exactly one server synchronously
+    before anything else runs, so there is no window to protect. A threaded
+    embedder claiming two roles at once would need one, and would also need to
+    explain which of them was supposed to win.
+    """
+    global _role
+    if _role is not None and _role is not role:
+        raise RoleAlreadyClaimedError(
+            f"This process already serves as {_role.value}, so it cannot also "
+            f"serve as {role.value}"
+        )
+    _role = role
+
+
+def process_role() -> ServerRole:
+    """What this process is, defaulting to the historical single-process server.
+
+    ``DIRECT`` when nothing has claimed it, so an embedder that never calls
+    :func:`set_process_role`, and every test that does not care, get exactly the
+    behaviour they had. The unclaimed state is deliberately not visible here:
+    callers ask what this process *is*, and "not yet decided" is not an answer
+    any of them could act on.
+    """
+    return ServerRole.DIRECT if _role is None else _role
+
+
+def reset_process_role_for_testing() -> None:
+    """Return to the unclaimed state, for test isolation.
+
+    Without this an ``OWNER`` claimed by one test would refuse logins in every
+    test after it, in a suite where most never mention a role at all.
+    """
+    global _role
+    _role = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,16 @@ def reset_singletons():
     from linkedin_mcp_server.config import reset_config
     from linkedin_mcp_server.drivers.browser import reset_browser_for_testing
     from linkedin_mcp_server.profile_lease import reset_leases_for_testing
+    from linkedin_mcp_server.server_role import reset_process_role_for_testing
 
     reset_bootstrap_for_testing()
     reset_browser_for_testing()
     reset_leases_for_testing()
     reset_config()
+    # Every test that builds a server records a role, and the auth gates read it
+    # from process state. Left standing, one OWNER would refuse logins in every
+    # test after it, in a suite where most never mention a role.
+    reset_process_role_for_testing()
     yield
     reset_bootstrap_for_testing()
     reset_browser_for_testing()
@@ -20,6 +25,7 @@ def reset_singletons():
     # own bookkeeping first rather than yanked out from under it.
     reset_leases_for_testing()
     reset_config()
+    reset_process_role_for_testing()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,6 +15,10 @@ from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
 from linkedin_mcp_server.server import ServerRole, create_mcp_server
+from linkedin_mcp_server.server_role import (
+    RoleAlreadyClaimedError,
+    process_role,
+)
 from linkedin_mcp_server.update_check import UpdateNoticeMiddleware
 
 
@@ -72,6 +76,22 @@ def _extras_for(role: ServerRole) -> dict[str, MagicMock]:
     return {}
 
 
+def _server_for(role: ServerRole) -> FastMCP:
+    """Build a server of *role*, as a fresh process would.
+
+    The role is process state as well as an argument, and ``create_mcp_server``
+    refuses a second, different one: in production that is a process trying to be
+    both a proxy and an owner, which cannot be right about whether it may open a
+    login window. A test comparing every role in one interpreter is the one
+    legitimate exception, so it starts each build from an unset role the way a
+    newly spawned process does.
+    """
+    from linkedin_mcp_server.server_role import reset_process_role_for_testing
+
+    reset_process_role_for_testing()
+    return create_mcp_server(role=role, **_extras_for(role))
+
+
 class TestServerRoles:
     """Which middleware each role gets, and why the split has to exist.
 
@@ -95,7 +115,7 @@ class TestServerRoles:
         # reach Chromium takes the lease first. A role added later that skips
         # this would corrupt the session rather than merely run slowly.
         for role in ServerRole:
-            mcp = create_mcp_server(role=role, **_extras_for(role))
+            mcp = _server_for(role)
             serializes = _has_middleware(mcp, SequentialToolExecutionMiddleware)
 
             # Stated as the conditional it is. Asserting that every role drives
@@ -111,7 +131,7 @@ class TestServerRoles:
         # many clients attach over its life. A proxy is the opposite case: it is
         # the process the client spawned, so the notice has to survive there.
         for role in ServerRole:
-            mcp = create_mcp_server(role=role, **_extras_for(role))
+            mcp = _server_for(role)
 
             assert (
                 _has_middleware(mcp, UpdateNoticeMiddleware) == role.faces_a_client
@@ -125,7 +145,7 @@ class TestServerRoles:
         # serves the owner's instead, which is a different claim and has its own
         # test below.
         async def tool_names(role: ServerRole) -> set[str]:
-            tools = await create_mcp_server(role=role).list_tools()
+            tools = await _server_for(role).list_tools()
             return {tool.name for tool in tools}
 
         served = {
@@ -162,6 +182,127 @@ class TestServerRoles:
         # Moving it must not break an embedder that already imports it from
         # where it used to live.
         assert server_module.ServerRole is ServerRole
+
+
+class TestTheRoleAsProcessState:
+    """The role has to be readable where no server can be passed in.
+
+    ``create_mcp_server`` is handed a role, and that settles everything it
+    assembles. The auth gates are elsewhere: whether a login window may open is
+    decided in ``bootstrap``, reached from a tool body with nothing to ask. A
+    detached owner has no terminal, so it has to be able to find out what it is.
+    """
+
+    def test_a_fresh_process_is_direct(self):
+        # The default carries every embedder and every test that never mentions a
+        # role, so it has to be the historical behaviour.
+        #
+        # Asserted in a subprocess rather than here. This suite resets the role per
+        # test, so an in-process assertion passes even against a module default
+        # mutated to OWNER: it would be testing the fixture, not the module.
+        probe = (
+            "from linkedin_mcp_server.server_role import process_role, ServerRole;"
+            "print(process_role() is ServerRole.DIRECT)"
+        )
+        answered = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        assert answered == "True"
+
+    def test_a_direct_server_followed_by_an_owner_is_refused(self):
+        # The gap a separate unclaimed state exists to close. With DIRECT doubling
+        # as "nothing said yet", this sequence was accepted, and the DIRECT
+        # server's own later tool calls would read OWNER and refuse the logins it
+        # is supposed to perform.
+        create_mcp_server()
+
+        with pytest.raises(RoleAlreadyClaimedError, match="already serves as direct"):
+            create_mcp_server(role=ServerRole.OWNER, auth_token="a-token")
+
+    def test_building_a_server_records_what_this_process_is(self):
+        # Recorded by the assembly rather than only by the entry points, because
+        # anything may call it directly. A caller that built an OWNER while the
+        # process still said DIRECT would get an owner with every auth gate off,
+        # which is a detached process opening a window nobody can see.
+        create_mcp_server(role=ServerRole.OWNER, auth_token="a-token")
+
+        assert process_role() is ServerRole.OWNER
+
+    def test_a_second_role_in_one_process_is_refused(self):
+        create_mcp_server(role=ServerRole.OWNER, auth_token="a-token")
+
+        # Not a resolvable disagreement: the two would have to disagree about
+        # whether this process may open a login window.
+        with pytest.raises(RoleAlreadyClaimedError, match="already serves as owner"):
+            create_mcp_server(role=ServerRole.PROXY, proxy_attachment=_an_attachment())
+
+    def test_restating_the_same_role_is_allowed(self):
+        # A process that builds two servers of one kind is doing nothing
+        # contradictory, and refusing it would break the owner, which records the
+        # role at its entry point and again when it assembles.
+        create_mcp_server(role=ServerRole.OWNER, auth_token="a-token")
+        create_mcp_server(role=ServerRole.OWNER, auth_token="another-token")
+
+        assert process_role() is ServerRole.OWNER
+
+    def test_the_owner_entry_point_says_so_before_it_can_fail(self, monkeypatch):
+        """`main` claims OWNER before anything downstream could need to know.
+
+        `create_owner_server` claims it too, but that runs several steps into
+        `_serve`. A failure between the two would be handled by a process that
+        still believed it had a terminal.
+
+        Driven rather than read: an earlier version of this asserted on the source
+        text of `main`, which stayed green when the call was made unreachable.
+        `configure_logging` is the first thing after the claim, so it serves as a
+        checkpoint to observe the role at and abort from.
+        """
+        from linkedin_mcp_server import daemon_owner
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        class Checkpoint(Exception):
+            pass
+
+        seen: list[ServerRole] = []
+
+        def at_checkpoint(**_kwargs):
+            seen.append(process_role())
+            raise Checkpoint
+
+        monkeypatch.setattr(daemon_owner, "_read_config", lambda: AppConfig())
+        monkeypatch.setattr(daemon_owner, "set_headless", lambda _headless: None)
+        monkeypatch.setattr(daemon_owner, "configure_logging", at_checkpoint)
+        monkeypatch.setattr(
+            daemon_owner, "_claim_handshake_stream", lambda: MagicMock()
+        )
+
+        with pytest.raises(Checkpoint):
+            daemon_owner.main([])
+
+        assert seen == [ServerRole.OWNER]
+
+    def test_the_state_is_readable_without_importing_the_server(self):
+        # Same reason the enum lives here: `bootstrap` reads this, and `server`
+        # reaches `bootstrap` through the tool modules, so importing back would
+        # close the cycle.
+        probe = (
+            "from linkedin_mcp_server.server_role import process_role, ServerRole;"
+            "import sys;"
+            "print(process_role() is ServerRole.DIRECT"
+            " and 'linkedin_mcp_server.server' not in sys.modules)"
+        )
+        answered = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        assert answered == "True"
 
 
 class TestProxyRole:
@@ -337,8 +478,11 @@ class TestOwnerAuthentication:
     def test_a_server_without_a_token_stays_unauthenticated(self):
         # The stdio server has no port to protect, and adding an auth provider
         # there would advertise metadata for a flow nothing performs.
-        assert create_mcp_server().auth is None
-        assert create_mcp_server(role=ServerRole.OWNER).auth is None
+        #
+        # Two roles in one test, so each starts from an unclaimed process the way
+        # a freshly spawned one does.
+        assert _server_for(ServerRole.DIRECT).auth is None
+        assert _server_for(ServerRole.OWNER).auth is None
 
     def test_a_token_on_a_role_that_cannot_use_one_is_refused(self):
         # Passing a token to a stdio server is a caller that believes it built


### PR DESCRIPTION
Assembling a server takes the role as an argument, and that settles
everything the assembly decides. The auth gates are not like that:
whether a login window may open is decided in bootstrap, reached from a
tool body with no server to ask. A detached owner has no terminal and no
desktop session, so it has to be able to find out what it is.

So the role is also process state, in server_role, which is already
import-free for exactly this class of reader.

Unclaimed is its own state rather than DIRECT. With DIRECT doubling as
"nothing said yet", a real DIRECT server followed by an OWNER was
accepted, and that DIRECT server's own tool calls would afterwards read
OWNER and refuse the logins it is supposed to perform.

The claim refuses a second, different role, and that check lives in the
setter so every entry point is covered by one rule. Two servers in one
interpreter cannot both be right about whether this process may open a
login window, so it is an error to ask for rather than a state to
half-configure. Re-stating the same role is allowed, which is what the
owner does: it claims OWNER at its entry point, ahead of anything that
could fail, and again when it assembles.

No gate reads it yet.

See also: #606