### PR TITLE
feat(daemon): Keep owner out of the login flow

### DIFF
--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -30,13 +30,17 @@ from linkedin_mcp_server.exceptions import (
     AuthenticationBootstrapFailedError,
     AuthenticationInProgressError,
     AuthenticationStartedError,
+    AuthMissingOnOwnerError,
+    AuthStaleOnOwnerError,
     BrowserSetupFailedError,
     BrowserSetupInProgressError,
     DockerHostLoginRequiredError,
 )
+from linkedin_mcp_server.server_role import ServerRole, process_role
 from linkedin_mcp_server.session_state import (
     auth_root_dir,
     get_runtime_id,
+    load_source_state,
     portable_cookie_path,
     profile_exists,
     rotate_source_profile,
@@ -109,16 +113,27 @@ class BootstrapState:
 _state = BootstrapState()
 _lock = asyncio.Lock()
 
+#: Set while this process is the shared owner and has found auth it cannot fix.
+#: Deliberately not on BootstrapState: that is reset wholesale between tests, and
+#: quiescence has its own reset so the two cannot be confused for one another.
+_auth_quiescent = False
+#: The generation that was broken. ``None`` is a value (a rotated profile reads as
+#: exactly that), so it cannot double as "not set"; ``_auth_quiescent`` does that.
+_auth_quiescent_generation: str | None = None
+
 
 def reset_bootstrap_for_testing() -> None:
     """Reset bootstrap singleton state for test isolation."""
     global _state, _lock, _AUTO_IMPORT_ANNOUNCED
+    global _auth_quiescent, _auth_quiescent_generation
     for task in (_state.setup_task, _state.login_task, _state.import_task):
         if task is not None and not task.done():
             task.cancel()
     _state = BootstrapState()
     _lock = asyncio.Lock()
     _AUTO_IMPORT_ANNOUNCED = False
+    _auth_quiescent = False
+    _auth_quiescent_generation = None
     os.environ.pop("PLAYWRIGHT_BROWSERS_PATH", None)
     # Tolerate monkeypatched stand-ins that lack `cache_clear`.
     clear = getattr(_patchright_install_targets, "cache_clear", None)
@@ -556,6 +571,12 @@ async def ensure_tool_ready_or_raise(
     initialize_bootstrap()
     await _refresh_background_task_state()
 
+    # Before any branch that could reach a browser. A quiescent owner has closed
+    # Chromium and is waiting for a client to sign in; every path below would open
+    # it again on the session that just failed, because readiness is decided by
+    # whether the files exist rather than whether they work.
+    _raise_if_auth_quiescent()
+
     if get_runtime_policy() == RuntimePolicy.DOCKER:
         _raise_if_docker_auth_missing()
         return
@@ -650,6 +671,18 @@ def _auto_import_allowed() -> bool:
         return False
     if get_runtime_policy() == RuntimePolicy.DOCKER:
         # No host browser and no keychain inside a container.
+        return False
+    if process_role() is ServerRole.OWNER:
+        # The import runs headless, so the browser is not the problem: rotating
+        # the profile is. It retires the current session before validating a
+        # replacement, and the process that will actually log in needs to find
+        # that session where the owner saw it. On macOS the keychain prompt
+        # would also appear with nobody attached to approve it, so the read
+        # simply times out.
+        #
+        # The frontend does it instead, and it is the better place for both
+        # reasons: it has the desktop session, and it is the process that holds
+        # the profile while it works.
         return False
     if config.browser.proxy_server:
         # The point of configuring a proxy is that LinkedIn sees one address.
@@ -796,6 +829,19 @@ async def _try_auto_import_session(ctx: Context | None = None) -> bool:
 
 
 async def _start_login_if_needed(ctx: Context | None = None) -> None:
+    if process_role() is ServerRole.OWNER:
+        # Ahead of the lock, and ahead of every branch below, because all of them
+        # end somewhere this process cannot go: an auto-import that rotates the
+        # profile, or an interactive login window with nobody attached to answer
+        # it.
+        # Reporting from here leaves the session state exactly as the frontend
+        # will find it, which is what lets the frontend take over cleanly.
+        raise AuthMissingOnOwnerError(
+            "The shared LinkedIn browser has no usable session, and it cannot "
+            "sign in by itself. Retry this tool: the client will open a login "
+            "window."
+        )
+
     # Cheap check-and-claim under the lock; the slow work (auto-import browser
     # launch, then the bounded inline wait) runs AFTER the lock is released so
     # concurrent pollers never serialize on it.
@@ -914,6 +960,77 @@ async def start_login_if_needed(ctx: Context | None = None) -> None:
     await _start_login_if_needed(ctx)
 
 
+def current_login_generation() -> str | None:
+    """Which login generation is on disk now, or ``None`` when there is none.
+
+    ``None`` is a value here rather than an absence: it is exactly what a rotated
+    profile reads as, so the difference between "no session" and "a session I have
+    not seen" has to be carried by something else.
+    """
+    state = load_source_state(get_profile_dir())
+    return None if state is None else state.login_generation
+
+
+def go_auth_quiescent(observed_generation: str | None) -> None:
+    """Stop this owner touching the profile until a new session appears.
+
+    Closing the browser is not enough on its own. ``get_or_create_browser`` opens
+    one whenever ``_browser`` is None, and ``_auth_ready()`` tests whether the
+    files exist rather than whether they work, so the next forwarded call would
+    reopen Chromium on the same dead session, in the middle of the login the
+    frontend is running. Measured before this existed: the call after a confirmed
+    close created a second browser.
+
+    *observed_generation* is the generation this owner found broken. The caller
+    reads it before closing the browser, which is defensive rather than currently
+    necessary: the tool middleware holds a lease reference across the whole call,
+    so nothing else can write a generation in between. It costs nothing and stops
+    a later caller, or a change that frees the lease sooner, from latching onto
+    the generation written by the login it is about to ask for.
+    """
+    global _auth_quiescent_generation, _auth_quiescent
+    _auth_quiescent = True
+    _auth_quiescent_generation = observed_generation
+    logger.warning(
+        "The shared browser cannot sign in; waiting for a client to do it "
+        "(generation %s)",
+        observed_generation or "none",
+    )
+
+
+def _auth_quiescence_lifted() -> bool:
+    """Whether a usable session has replaced the one that caused quiescence.
+
+    Both halves are needed and each alone is wrong. A changed generation alone
+    lifts on an *abandoned* login: the frontend rotates the profile first, which
+    makes the generation read as ``None``, which differs from what was observed,
+    and the owner would open Chromium on a profile with no session at all.
+    ``_auth_ready()`` alone never lifts, because it tests file existence and was
+    already true of the broken session.
+
+    Together they mean what is wanted, because a generation is only written after
+    a login has validated and exported its cookies.
+    """
+    return _auth_ready() and current_login_generation() != _auth_quiescent_generation
+
+
+def _raise_if_auth_quiescent() -> None:
+    """Report instead of opening a browser, until a new session lands."""
+    global _auth_quiescent, _auth_quiescent_generation
+    if not _auth_quiescent:
+        return
+    if _auth_quiescence_lifted():
+        logger.info("A new LinkedIn session appeared; the shared browser resumes")
+        _auth_quiescent = False
+        _auth_quiescent_generation = None
+        return
+    raise AuthStaleOnOwnerError(
+        "The shared LinkedIn browser's session stopped working, and it cannot "
+        "sign in by itself. Retry this tool: the client will open a login "
+        "window."
+    )
+
+
 async def invalidate_auth_and_trigger_relogin(
     ctx: Context | None = None,
 ) -> NoReturn:
@@ -927,7 +1044,22 @@ async def invalidate_auth_and_trigger_relogin(
     Raises:
         AuthenticationStartedError: Login browser opened.
         AuthenticationInProgressError: Login already running from a prior call.
+        AuthStaleOnOwnerError: This process is the shared owner, so it reports
+            rather than rotating the profile and opening a window it has no
+            desktop session for.
     """
+    if process_role() is ServerRole.OWNER:
+        # Never reaches the rotation below. Retiring the session here would race
+        # the frontend's login for the same files, and the login window has
+        # nowhere to appear. The caller has already closed the browser and
+        # recorded the generation it found, which is what `go_auth_quiescent`
+        # needs, so all that is left is to say so.
+        raise AuthStaleOnOwnerError(
+            "The shared LinkedIn browser's session stopped working, and it "
+            "cannot sign in by itself. Retry this tool: the client will open a "
+            "login window."
+        )
+
     logger.warning("Invalidating stale auth state and triggering re-login")
     async with _lock:
         await _refresh_background_task_state()

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -7,8 +7,10 @@ from fastmcp import Context
 
 from linkedin_mcp_server.bootstrap import (
     RuntimePolicy,
+    current_login_generation,
     ensure_tool_ready_or_raise,
     get_runtime_policy,
+    go_auth_quiescent,
     invalidate_auth_and_trigger_relogin,
     invalidate_browser_setup,
 )
@@ -21,10 +23,13 @@ from linkedin_mcp_server.drivers.browser import (
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.exceptions import (
     BrowserBinaryMissingError,
+    BrowserShutdownUnconfirmedError,
     DockerHostLoginRequiredError,
     LinuxBrowserDependencyError,
 )
+from linkedin_mcp_server.profile_lease import get_profile_lease
 from linkedin_mcp_server.scraping import LinkedInExtractor
+from linkedin_mcp_server.server_role import ServerRole, process_role
 
 logger = logging.getLogger(__name__)
 
@@ -66,11 +71,41 @@ async def handle_auth_error(
             "then retry this tool."
         ) from error
 
+    # Read before the close rather than after it, deliberately, though the
+    # ordering is defensive rather than load-bearing today. On the forwarded tool
+    # path `SequentialToolExecutionMiddleware` holds a lease reference of its own
+    # from before the tool body until after this function returns
+    # (`sequential_tool_middleware.py:116-130`), and `close_browser` releases only
+    # the browser's reference, so no other process can write a generation in
+    # between. What the order costs is nothing, and what it buys is not depending
+    # on that: any future caller reaching here without the middleware, or any
+    # change that releases the lease sooner, would otherwise latch onto a
+    # generation written by the login it is about to ask for.
+    broken_generation = (
+        current_login_generation() if process_role() is ServerRole.OWNER else None
+    )
+
     logger.warning("Stale session detected; closing browser and triggering re-login")
     try:
         await close_browser()
     except Exception as close_exc:
         logger.warning("Failed to close stale browser (ignored): %s", close_exc)
+
+    if process_role() is ServerRole.OWNER:
+        if get_profile_lease().browser_open:
+            # The teardown could not be confirmed, so Chromium may still be on the
+            # profile and the lease is deliberately kept until this process exits
+            # (`drivers/browser.py:786-798`). Asking a client to sign in now would
+            # send it after a lease it can never take, and latching would then
+            # answer every later call from a state only a restart clears. Reported
+            # as what it is instead.
+            raise BrowserShutdownUnconfirmedError() from error
+
+        # The browser is down and the lease is free, so the client can take over.
+        # Recorded before raising so the next forwarded call is answered from the
+        # latch rather than by opening Chromium again.
+        go_auth_quiescent(broken_generation)
+
     await invalidate_auth_and_trigger_relogin(ctx)  # always raises
 
 

--- a/linkedin_mcp_server/error_handler.py
+++ b/linkedin_mcp_server/error_handler.py
@@ -35,6 +35,7 @@ from linkedin_mcp_server.exceptions import (
     DockerHostLoginRequiredError,
     LinuxBrowserDependencyError,
     LinkedInMCPError,
+    OwnerCannotAuthenticateError,
     SessionExpiredError,
 )
 from linkedin_mcp_server.error_diagnostics import (
@@ -146,6 +147,16 @@ def raise_tool_error(exception: Exception, context: str = "") -> NoReturn:
 
     elif isinstance(exception, AuthenticationBootstrapFailedError):
         logger.warning("Authentication bootstrap failed%s: %s", ctx, exception)
+        raise ToolError(str(exception)) from exception
+
+    # Its own branch rather than the LinkedInMCPError catch-all, which appends an
+    # issue-report template. A shared browser that cannot log in by itself is the
+    # designed behaviour, not a bug, and inviting a bug report for it would send
+    # users to the tracker for something working as intended. The two
+    # Authentication*Error branches above are diagnostics-free for the same
+    # reason.
+    elif isinstance(exception, OwnerCannotAuthenticateError):
+        logger.info("The shared browser needs this client to log in%s", ctx)
         raise ToolError(str(exception)) from exception
 
     # Contention, not a bug: no issue diagnostics, following RateLimitError.

--- a/linkedin_mcp_server/exceptions.py
+++ b/linkedin_mcp_server/exceptions.py
@@ -51,6 +51,38 @@ class AuthenticationBootstrapFailedError(LinkedInMCPError):
     """Interactive LinkedIn login could not be completed."""
 
 
+class OwnerCannotAuthenticateError(LinkedInMCPError):
+    """The shared browser owner found bad auth and cannot fix it itself.
+
+    A detached owner has nobody in front of it. It can open a browser, and does
+    when configured to run headed, but an interactive login is different in kind:
+    it waits for someone to type credentials and answer a challenge, and no client
+    is attached to this process to do that. The same goes for a keychain prompt.
+    It also must not move the shared profile aside: the process that will log in
+    needs to find the session state as the owner saw it, and rotating from here
+    would race that login for the same files.
+
+    So the owner reports instead of acting, and the frontend, which is the process
+    an MCP client actually spawned, does the work. These two carry which of the
+    two situations it is, because the frontend's response differs:
+
+    * missing means no usable session on disk, so a plain login is enough;
+    * stale means a session that exists and no longer works, which has to be
+      retired before a new one can replace it.
+
+    Subclasses rather than one class with a field: they are raised from different
+    places and the distinction has to survive being caught by type.
+    """
+
+
+class AuthMissingOnOwnerError(OwnerCannotAuthenticateError):
+    """No usable LinkedIn session exists, and the owner cannot create one."""
+
+
+class AuthStaleOnOwnerError(OwnerCannotAuthenticateError):
+    """The LinkedIn session stopped working, and the owner cannot replace it."""
+
+
 class DockerHostLoginRequiredError(LinkedInMCPError):
     """Docker runtime requires host-side login creation."""
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1921,3 +1921,207 @@ class TestProxyErrorSurvivesTheImportTask:
 
         # No login task started: the proxy has to be fixed first.
         assert get_bootstrap_state().login_task is None
+
+
+class TestAnOwnerNeverSignsInItself:
+    """A detached owner reports bad auth instead of acting on it.
+
+    It has no terminal and no desktop session, so a login window has nowhere to
+    appear. It must also leave the profile alone: the frontend that will log in
+    needs to find the session state as the owner saw it, and rotating from here
+    would race that login for the same files.
+    """
+
+    def _as_owner(self, monkeypatch):
+        from linkedin_mcp_server.server_role import ServerRole, set_process_role
+
+        set_process_role(ServerRole.OWNER)
+
+    async def test_a_missing_session_is_reported_not_repaired(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        from linkedin_mcp_server.exceptions import AuthMissingOnOwnerError
+
+        self._as_owner(monkeypatch)
+        # Both of the things the owner must not do, watched rather than assumed.
+        # Patched on `bootstrap`, not on `setup`: bootstrap imported the name
+        # directly (`bootstrap.py:49`), so patching the source module would watch
+        # a reference nothing calls and pass however the gate behaved.
+        started_login = MagicMock()
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap.interactive_login", started_login
+        )
+        imported = MagicMock()
+        monkeypatch.setattr(
+            "linkedin_mcp_server.browser_import.orchestrate.import_session_from_browser",
+            imported,
+        )
+
+        with pytest.raises(AuthMissingOnOwnerError, match="cannot sign in by itself"):
+            await _start_login_if_needed()
+
+        started_login.assert_not_called()
+        imported.assert_not_called()
+        # No login task either: one would open a window on the next poll.
+        assert get_bootstrap_state().login_task is None
+
+    async def test_a_stale_session_is_reported_without_rotating_the_profile(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        from linkedin_mcp_server.exceptions import AuthStaleOnOwnerError
+
+        self._as_owner(monkeypatch)
+        rotated = MagicMock()
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap.rotate_source_profile", rotated
+        )
+        started_login = MagicMock()
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap.interactive_login", started_login
+        )
+
+        with pytest.raises(AuthStaleOnOwnerError, match="cannot sign in by itself"):
+            await invalidate_auth_and_trigger_relogin()
+
+        # The rotation is the destructive half: it retires the session the
+        # frontend is about to replace, and it cannot be undone from there.
+        rotated.assert_not_called()
+        started_login.assert_not_called()
+
+    async def test_auto_import_is_refused(self, isolate_profile_dir, monkeypatch):
+        # As a predicate test beside the Docker and proxy ones, because gating
+        # only the call site would leave the next caller free to reopen the hole.
+        config = _auto_import_config(flag=True, is_interactive=True)
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
+
+        assert _auto_import_allowed() is True  # the same config, as a DIRECT server
+        self._as_owner(monkeypatch)
+        assert _auto_import_allowed() is False
+
+    async def test_a_direct_server_still_signs_in(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        # The gates key off the role, so the historical single-process behaviour
+        # has to be untouched. Without this, a gate written against the wrong
+        # predicate would look correct in every owner test and break every user.
+
+        config = _auto_import_config(flag=False, is_interactive=True)
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._move_invalid_auth_state_aside",
+            MagicMock(),
+        )
+        login_flow = AsyncMock()
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap._run_login_flow", login_flow)
+
+        # Reaches the login path rather than the owner refusal, and actually
+        # starts one: asserting only that an AuthenticationInProgressError came
+        # back proves a task-shaped path, not a login. Verified by mutation, that
+        # weaker form passed with _run_login_flow replaced by a bare sleep.
+        with pytest.raises(AuthenticationInProgressError):
+            await _start_login_if_needed()
+
+        login_flow.assert_called_once()
+
+
+class TestTheOwnerStaysQuiescentUntilANewSessionLands:
+    """Closing the browser is not enough to stop the next call reopening it.
+
+    ``get_or_create_browser`` opens one whenever the singleton is None, and
+    readiness tests whether the auth files exist rather than whether they work.
+    Measured before the latch existed: the call after a confirmed close created a
+    second browser, which is one opened into the middle of the frontend's login.
+    """
+
+    def _quiescent_on(self, generation):
+        import linkedin_mcp_server.bootstrap as bootstrap
+
+        bootstrap.go_auth_quiescent(generation)
+
+    def _still_latched(self) -> bool:
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.exceptions import AuthStaleOnOwnerError
+
+        try:
+            bootstrap._raise_if_auth_quiescent()
+        except AuthStaleOnOwnerError:
+            return True
+        return False
+
+    def _write_session(self, profile_dir):
+        from linkedin_mcp_server.session_state import (
+            portable_cookie_path,
+            write_source_state,
+        )
+
+        (profile_dir / "Default").mkdir(parents=True, exist_ok=True)
+        (profile_dir / "Default" / "Cookies").write_text("placeholder")
+        portable_cookie_path(profile_dir).write_text("[]")
+        write_source_state(profile_dir)
+
+    async def test_the_broken_session_alone_never_lifts_it(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        import linkedin_mcp_server.bootstrap as bootstrap
+
+        self._write_session(isolate_profile_dir)
+        self._quiescent_on(bootstrap.current_login_generation())
+
+        # `_auth_ready()` is already true of these very files, so a latch that
+        # only asked whether a session exists would lift immediately.
+        assert bootstrap._auth_ready() is True
+        assert self._still_latched() is True
+
+    async def test_an_abandoned_login_leaves_it_latched(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.session_state import rotate_source_profile
+
+        self._write_session(isolate_profile_dir)
+        self._quiescent_on(bootstrap.current_login_generation())
+
+        # What the frontend does first, and all it does if the user closes the
+        # window: the session is retired and nothing replaces it.
+        rotate_source_profile(isolate_profile_dir)
+
+        # The generation now reads as None, which *differs* from the observed
+        # one, so a latch keyed on inequality alone would lift here and open
+        # Chromium on a profile with no session at all.
+        assert bootstrap.current_login_generation() is None
+        assert self._still_latched() is True
+
+    async def test_a_real_new_session_lifts_it(self, isolate_profile_dir, monkeypatch):
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.session_state import rotate_source_profile
+
+        self._write_session(isolate_profile_dir)
+        self._quiescent_on(bootstrap.current_login_generation())
+
+        rotate_source_profile(isolate_profile_dir)
+        self._write_session(isolate_profile_dir)  # the login succeeds
+
+        assert self._still_latched() is False
+
+        # Then take the session away again. This is what proves the latch was
+        # *cleared* rather than merely reporting itself lifted because the
+        # predicate happened to be true: an implementation that answers from the
+        # predicate every time would arm again here, while a cleared latch stays
+        # silent whatever the files say. Verified by mutation, an earlier version
+        # of this test passed against exactly that.
+        rotate_source_profile(isolate_profile_dir)
+
+        assert self._still_latched() is False
+
+    async def test_the_gate_refuses_before_it_can_reach_a_browser(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.exceptions import AuthStaleOnOwnerError
+
+        self._write_session(isolate_profile_dir)
+        self._quiescent_on(bootstrap.current_login_generation())
+
+        # Through the real pre-tool gate, which is what a forwarded call hits.
+        with pytest.raises(AuthStaleOnOwnerError):
+            await ensure_tool_ready_or_raise("get_person_profile")

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -13,6 +13,7 @@ from linkedin_mcp_server.core.exceptions import (
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.exceptions import (
     AuthenticationStartedError,
+    AuthStaleOnOwnerError,
     DockerHostLoginRequiredError,
 )
 
@@ -225,3 +226,120 @@ class TestGetReadyExtractor:
             mock_handle.assert_awaited_once()
             # First arg should be the AuthenticationError
             assert isinstance(mock_handle.call_args[0][0], AuthenticationError)
+
+
+class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
+    """The owner closes the browser, records what it found, and reports."""
+
+    async def test_the_broken_generation_is_read_before_the_browser_closes(self):
+        """The ordering is the whole point, so it is asserted rather than assumed.
+
+        A confirmed close releases the profile lease, which is exactly what lets
+        another process log in. If the generation were read afterwards, a login
+        that landed in that gap would be recorded as the broken one, and the owner
+        would then hold its latch against the very session it asked for.
+        """
+        from linkedin_mcp_server.server_role import ServerRole, set_process_role
+
+        set_process_role(ServerRole.OWNER)
+        order: list[str] = []
+
+        async def closing() -> None:
+            order.append("close")
+
+        with (
+            patch(
+                "linkedin_mcp_server.dependencies.get_runtime_policy",
+                return_value="managed",
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.current_login_generation",
+                side_effect=lambda: (order.append("read"), "gen-1")[1],
+            ),
+            patch("linkedin_mcp_server.dependencies.close_browser", closing),
+            patch(
+                "linkedin_mcp_server.dependencies.go_auth_quiescent",
+                side_effect=lambda gen: order.append(f"latch:{gen}"),
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.invalidate_auth_and_trigger_relogin",
+                new_callable=AsyncMock,
+                side_effect=AuthStaleOnOwnerError("owner cannot sign in"),
+            ),
+        ):
+            with pytest.raises(AuthStaleOnOwnerError):
+                await handle_auth_error(AuthenticationError("expired"), ctx=None)
+
+        assert order == ["read", "close", "latch:gen-1"]
+
+    async def test_a_direct_server_neither_reads_nor_latches(self):
+        # The historical path has no owner state to keep, and touching it would
+        # make a single-process server refuse its own logins.
+        latched = MagicMock()
+        read = MagicMock(return_value="gen-1")
+
+        with (
+            patch(
+                "linkedin_mcp_server.dependencies.get_runtime_policy",
+                return_value="managed",
+            ),
+            patch("linkedin_mcp_server.dependencies.current_login_generation", read),
+            patch("linkedin_mcp_server.dependencies.close_browser", AsyncMock()),
+            patch("linkedin_mcp_server.dependencies.go_auth_quiescent", latched),
+            patch(
+                "linkedin_mcp_server.dependencies.invalidate_auth_and_trigger_relogin",
+                new_callable=AsyncMock,
+                side_effect=AuthenticationStartedError("login opened"),
+            ),
+        ):
+            with pytest.raises(AuthenticationStartedError):
+                await handle_auth_error(AuthenticationError("expired"), ctx=None)
+
+        # Both halves, as the name says. An earlier version asserted only the
+        # latch, so reading the generation unconditionally went unnoticed, and a
+        # DIRECT server would touch owner state it has no use for.
+        read.assert_not_called()
+        latched.assert_not_called()
+
+    async def test_an_unconfirmed_close_is_reported_instead_of_latching(self):
+        """A teardown that could not be confirmed must not invite a login.
+
+        ``close_browser`` keeps the profile lease when Chromium's shutdown times
+        out, deliberately, because it may still be running
+        (``drivers/browser.py:786-798``). Telling a client to sign in then sends it
+        after a lease it can never take, and latching would answer every later call
+        from a state only an owner restart clears.
+
+        Reproduced before this guard existed: the owner said "retry, the client
+        will open a login window" while holding the lease with ``browser_open``
+        still set.
+        """
+        from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
+        from linkedin_mcp_server.server_role import ServerRole, set_process_role
+
+        set_process_role(ServerRole.OWNER)
+        latched = MagicMock()
+        lease = MagicMock()
+        lease.browser_open = True  # what an unconfirmed close leaves behind
+
+        with (
+            patch(
+                "linkedin_mcp_server.dependencies.get_runtime_policy",
+                return_value="managed",
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.current_login_generation",
+                return_value="gen-1",
+            ),
+            patch("linkedin_mcp_server.dependencies.close_browser", AsyncMock()),
+            patch(
+                "linkedin_mcp_server.dependencies.get_profile_lease",
+                return_value=lease,
+            ),
+            patch("linkedin_mcp_server.dependencies.go_auth_quiescent", latched),
+        ):
+            with pytest.raises(BrowserShutdownUnconfirmedError, match="Restart"):
+                await handle_auth_error(AuthenticationError("expired"), ctx=None)
+
+        # Not latched: a latch here is the wedge, because nothing can clear it.
+        latched.assert_not_called()

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -13,6 +13,8 @@ from linkedin_mcp_server.core.exceptions import (
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.exceptions import (
     AuthenticationInProgressError,
+    AuthMissingOnOwnerError,
+    AuthStaleOnOwnerError,
     BrowserBinaryMissingError,
     CredentialsNotFoundError,
     LinkedInMCPError,
@@ -135,6 +137,30 @@ def test_authentication_in_progress_surfaces_poll_friendly_message_verbatim():
     # Plain str() branch, not the LinkedInMCPError catch-all that appends an
     # issue-template diagnostics block.
     assert "issue" not in surfaced.lower()
+
+
+def test_owner_auth_refusal_skips_issue_diagnostics():
+    """A shared browser that cannot sign in is designed behaviour, not a bug.
+
+    The LinkedInMCPError catch-all appends an issue-report template, which would
+    send users to the tracker for something working as intended. Its own branch
+    exists for that.
+
+    Asserted on the surfaced text rather than by patching build_issue_diagnostics:
+    a patched-out builder makes the catch-all fall back to a message with no
+    template, so the mutation of removing the branch survived. Measured, the
+    unbranched path really appends "Diagnostics:" and an issue-template path.
+    """
+    for error in (
+        AuthMissingOnOwnerError("the shared browser has no session"),
+        AuthStaleOnOwnerError("the shared browser's session stopped working"),
+    ):
+        with pytest.raises(ToolError) as caught:
+            raise_tool_error(error, "get_person_profile")
+
+        surfaced = str(caught.value)
+        assert surfaced == str(error)
+        assert "issue" not in surfaced.lower()
 
 
 def test_reraises_unknown_exception():


### PR DESCRIPTION
A detached owner has nobody in front of it. It can open a browser, and
does when configured headed, but an interactive login is different in
kind: it waits for someone to type credentials and answer a challenge,
and no client is attached to this process to do that. It also must not
move the shared profile aside, because the frontend that will log in
needs the session state as the owner saw it.

So the owner reports and the frontend acts. Three gates, keyed on the
role rather than on drives_browser, which is False for a proxy that
legitimately does open a browser for its login:

- the pre-tool gate reports a missing session instead of starting a
  login or an auto-import;
- the stale path reports instead of rotating and relaunching;
- auto-import is refused as a predicate, so gating one call site cannot
  be undone by the next caller.

Closing the browser is not enough by itself. get_or_create_browser opens
one whenever the singleton is None, and readiness asks whether the auth
files exist rather than whether they work, so the next forwarded call
reopened Chromium into the middle of the frontend's login. Measured. A
latch holds until a usable session appears.

Both halves of that condition are needed. A changed generation alone
lifts on an abandoned login, because the frontend rotates first and the
generation then reads as None. _auth_ready() alone never lifts, because
it was already true of the broken session.

An unconfirmed close is reported rather than latched. close_browser keeps
the lease when Chromium's shutdown times out, so inviting a login there
sends the client after a lease it can never take, and the latch would
then answer every later call from a state only a restart clears.
Reproduced before the guard existed.

See also: #606