### PR TITLE
feat(daemon): Let the client sign in remotely

### DIFF
--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -839,7 +839,10 @@ async def _start_login_if_needed(ctx: Context | None = None) -> None:
         raise AuthMissingOnOwnerError(
             "The shared LinkedIn browser has no usable session, and it cannot "
             "sign in by itself. Retry this tool: the client will open a login "
-            "window."
+            "window.",
+            # The readiness gate runs before the tool body, so nothing has been
+            # scraped and the client may run the call again once it has signed in.
+            nothing_ran_yet=True,
         )
 
     # Cheap check-and-claim under the lock; the slow work (auto-import browser
@@ -1027,7 +1030,9 @@ def _raise_if_auth_quiescent() -> None:
     raise AuthStaleOnOwnerError(
         "The shared LinkedIn browser's session stopped working, and it cannot "
         "sign in by itself. Retry this tool: the client will open a login "
-        "window."
+        "window.",
+        # Raised from the readiness gate, ahead of the tool body.
+        nothing_ran_yet=True,
     )
 
 
@@ -1054,6 +1059,9 @@ async def invalidate_auth_and_trigger_relogin(
         # nowhere to appear. The caller has already closed the browser and
         # recorded the generation it found, which is what `go_auth_quiescent`
         # needs, so all that is left is to say so.
+        # Reached only if something calls this directly; `handle_auth_error`
+        # raises its own first, carrying whether any work had run. Conservative
+        # here, because a direct caller has told us nothing about that.
         raise AuthStaleOnOwnerError(
             "The shared LinkedIn browser's session stopped working, and it "
             "cannot sign in by itself. Retry this tool: the client will open a "

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -1,0 +1,244 @@
+"""Getting a login done in the process that can actually show one.
+
+The owner drives the browser, so it is the process that *notices* bad LinkedIn
+auth, and it has nobody in front of it, so it is the one that cannot fix it. Not
+because it cannot open a browser: it can, and does when configured to run headed.
+An interactive login is different in kind, because it waits for someone to type
+credentials. The frontend is the opposite: it was spawned by an MCP client, a user
+is there, and it can ask. This module carries the fact across the loopback hop between
+them, and acts on it at the other end.
+
+**Why a result and not an exception.** The owner's refusal has to survive
+``ProxyProvider`` forwarding with its meaning intact, and an exception does not.
+Measured against fastmcp 3.4.4: a middleware that re-raises delivered
+``meta=None, isError=True, content=["Error calling tool 'x'"]`` to the outer
+client, because ``mask_error_details`` is on and the type is gone by then. The
+same middleware returning ``ToolResult(..., meta=..., is_error=True)`` delivered
+the marker intact, and a client that raises on error still got its ``ToolError``
+with the original message. The proxy copies ``meta`` and ``isError`` explicitly
+(``fastmcp/server/providers/proxy.py:212-225``).
+
+**Why the exception chain and not a ContextVar.** The owner-side middleware reads
+``__cause__`` to find out what happened. A ``ContextVar`` set by the tool body
+would also work, but only by accident: fastmcp runs ``async def`` tools inline and
+offloads plain ``def`` tools to a thread, where the value set inside is invisible
+to the middleware. Every tool here is ``async def`` today, so both would pass, and
+one of them would break silently the first time that changed.
+
+That chain reaching this far depends on ``raise_tool_error`` passing an
+already-shaped ``ToolError`` through rather than re-deriving it. Before that fix
+the missing-session path arrived as ``['ToolError']`` with the cause severed, and
+this module could not have worked at all.
+
+**What the frontend does with it.** Two fields, and they answer different
+questions. ``reason`` says what to repair: a missing session needs a login, a
+stale one needs the old session retired first. ``replayable`` says whether the
+call may be run again afterwards, which depends on whether any work had happened
+when it failed. Both combinations occur, so neither field implies the other.
+
+Only the owner can decide ``replayable``, because every origin looks the same by
+the time a failure reaches a client: all 18 tool catch sites collapse them into
+one ``except`` clause.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import mcp.types as mt
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import ToolResult
+
+from linkedin_mcp_server.exceptions import (
+    AuthMissingOnOwnerError,
+    OwnerCannotAuthenticateError,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Namespaced so a future fastmcp key cannot shadow it. Measured: a custom key
+#: coexists with fastmcp's own ``{'fastmcp': {...}}`` entry as a separate
+#: top-level key, so there is no clash to work around, only a name to keep
+#: unmistakable.
+MARKER_KEY = "linkedin.dev/auth"
+
+#: Bumped when the shape below changes in a way an older reader would misread.
+#:
+#: Only forward tolerance is needed, and that asymmetry is deliberate rather than
+#: lucky. An *older* frontend attaches to a newer owner on purpose
+#: (``daemon_version.Skew.SERVICEABLE``), so it will meet markers from builds it
+#: does not know and has to ignore them. The reverse cannot arise: a newer
+#: frontend asks an older owner to stand down and elects a replacement, so it
+#: never talks to an owner that predates a version it understands.
+MARKER_VERSION = 1
+
+
+def _auth_failure_in(exc: BaseException) -> OwnerCannotAuthenticateError | None:
+    """Find the owner's auth refusal in an exception chain, if it is there.
+
+    Walked rather than type-checked directly, because nothing that leaves a tool
+    is the original exception: ``raise_tool_error`` wraps it in a ``ToolError``,
+    and the middleware only ever sees that wrapper.
+    """
+    current: BaseException | None = exc
+    while current is not None:
+        if isinstance(current, OwnerCannotAuthenticateError):
+            return current
+        current = current.__cause__
+    return None
+
+
+class OwnerAuthSignalMiddleware(Middleware):
+    """Turn the owner's auth refusal into something the hop preserves.
+
+    Installed only on an owner. On any other role it would announce a repair
+    nobody asked for, and on a frontend it would compete with the middleware that
+    is supposed to *act* on the marker.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        try:
+            return await call_next(context)
+        except Exception as exc:
+            failure = _auth_failure_in(exc)
+            if failure is None:
+                raise
+
+            marker: dict[str, Any] = {
+                "v": MARKER_VERSION,
+                "reason": "missing"
+                if isinstance(failure, AuthMissingOnOwnerError)
+                else "stale",
+                "replayable": failure.nothing_ran_yet,
+                "browser_open": _browser_still_holds_the_profile(),
+            }
+            logger.info(
+                "Asking the client to sign in (%s, replayable=%s)",
+                marker["reason"],
+                marker["replayable"],
+            )
+            # An error result rather than a raise, and `is_error` kept true so a
+            # client that never learns about markers still sees a failure with the
+            # owner's own wording rather than a success carrying no data.
+            return ToolResult(
+                content=[mt.TextContent(type="text", text=str(exc))],
+                meta={MARKER_KEY: marker},
+                is_error=True,
+            )
+
+
+def _browser_still_holds_the_profile() -> bool:
+    """Whether Chromium may still be on the profile in this process.
+
+    Reported to the frontend because a login cannot start while it is true: the
+    login takes the profile exclusively and would fail on a lease it cannot get.
+    The lease only clears this once a close is *confirmed*, so an unconfirmed
+    teardown keeps it set, which is the cautious direction.
+    """
+    from linkedin_mcp_server.profile_lease import get_profile_lease
+
+    try:
+        return get_profile_lease().browser_open
+    except Exception:  # noqa: BLE001 - a marker must not fail on a probe
+        logger.debug("Could not read the profile lease state", exc_info=True)
+        return True
+
+
+class FrontendAuthRepairMiddleware(Middleware):
+    """Sign in on the owner's behalf, then run the call again when that is safe.
+
+    Installed only on a proxy. It is the process an MCP client spawned, so it has
+    somewhere to put a login window, and it is the only process in the picture
+    that does.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        result = await call_next(context)
+        marker = _readable_marker(result)
+        if marker is None:
+            return result
+
+        if marker["browser_open"]:
+            # The owner's Chromium may still hold the profile, so a login would
+            # fail on a lease it cannot take. Passing the failure through leaves
+            # the owner's own wording, which says to retry, and by the next call
+            # the close will have been confirmed or the owner restarted.
+            logger.warning(
+                "The shared browser has not released the profile yet; not "
+                "signing in on this call"
+            )
+            return result
+
+        try:
+            await _repair_auth_locally(marker["reason"])
+        except Exception:
+            # The login path reports itself through its own exceptions, which the
+            # tool layer turns into readable messages. Whatever happened, the
+            # owner's failure is still the honest answer to this call.
+            logger.warning("Signing in for the shared browser failed", exc_info=True)
+            return result
+
+        if not marker["replayable"]:
+            # Work had already happened on the owner when it failed, and some of
+            # these tools send messages and connection requests. Running it again
+            # could repeat that, so the client is told to decide.
+            logger.info("Signed in; not repeating a call that had already started")
+            return result
+
+        logger.info("Signed in; running the call again")
+        return await call_next(context)
+
+
+def _readable_marker(result: ToolResult) -> dict[str, Any] | None:
+    """The marker on *result*, if there is one this build understands.
+
+    Every field is checked rather than assumed. This runs on whatever an owner
+    sent, and an older frontend deliberately attaches to a newer owner, so a
+    marker from a build that does not exist yet has to be ignored rather than
+    half-read.
+    """
+    marker = (result.meta or {}).get(MARKER_KEY)
+    if not isinstance(marker, dict):
+        return None
+    if marker.get("v") != MARKER_VERSION:
+        logger.info(
+            "Ignoring an auth marker from a newer shared browser (version %s)",
+            marker.get("v"),
+        )
+        return None
+    if marker.get("reason") not in ("missing", "stale"):
+        return None
+    if not isinstance(marker.get("replayable"), bool) or not isinstance(
+        marker.get("browser_open"), bool
+    ):
+        return None
+    return marker
+
+
+async def _repair_auth_locally(reason: str) -> None:
+    """Get a usable session onto disk, in this process.
+
+    Imported here rather than at module scope: this module is imported when a
+    server is assembled, and the login path pulls in the browser stack.
+    """
+    from linkedin_mcp_server.bootstrap import (
+        invalidate_auth_and_trigger_relogin,
+        start_login_if_needed,
+    )
+
+    if reason == "stale":
+        # The old session is still on disk and still does not work, so readiness
+        # would keep passing it. This is the path that retires it first, and it
+        # always raises: the login it starts is what the caller waits on.
+        await invalidate_auth_and_trigger_relogin()
+    else:
+        await start_login_if_needed()

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -22,6 +22,7 @@ from linkedin_mcp_server.drivers.browser import (
 )
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.exceptions import (
+    AuthStaleOnOwnerError,
     BrowserBinaryMissingError,
     BrowserShutdownUnconfirmedError,
     DockerHostLoginRequiredError,
@@ -58,11 +59,22 @@ def _is_browser_binary_missing_error(error: Exception) -> bool:
 async def handle_auth_error(
     error: AuthenticationError,
     ctx: Context | None,
+    *,
+    nothing_ran_yet: bool = False,
 ) -> NoReturn:
     """Close the stale browser and trigger interactive re-login.
 
     In Docker mode a GUI browser cannot be opened, so we raise
     ``DockerHostLoginRequiredError`` for a consistent user message.
+
+    *nothing_ran_yet* says whether the tool had done any work before the failure,
+    which decides whether a client may safely run the call again after signing in.
+    Only :func:`get_ready_extractor` can answer yes: it is the first statement of
+    every tool body, so a failure there means nothing has been scraped. The 18
+    catch sites in the tool bodies leave it at the default, because by then the
+    scrape may be part done, and some of these tools send messages and connection
+    requests. A 19th added later is non-replayable until someone says otherwise,
+    which is the safe direction for a default to point.
     """
     if get_runtime_policy() == RuntimePolicy.DOCKER:
         raise DockerHostLoginRequiredError(
@@ -105,6 +117,12 @@ async def handle_auth_error(
         # Recorded before raising so the next forwarded call is answered from the
         # latch rather than by opening Chromium again.
         go_auth_quiescent(broken_generation)
+        raise AuthStaleOnOwnerError(
+            "The shared LinkedIn browser's session stopped working, and it "
+            "cannot sign in by itself. Retry this tool: the client will open a "
+            "login window.",
+            nothing_ran_yet=nothing_ran_yet,
+        ) from error
 
     await invalidate_auth_and_trigger_relogin(ctx)  # always raises
 
@@ -121,7 +139,10 @@ async def get_ready_extractor(
         await ensure_authenticated()
         return LinkedInExtractor(browser.page)
     except AuthenticationError as e:
-        await handle_auth_error(e, ctx)  # always raises
+        # The first statement of every tool body, so a failure here means the
+        # scrape has not started and the client may safely run the call again once
+        # it has signed in.
+        await handle_auth_error(e, ctx, nothing_ran_yet=True)  # always raises
     except Exception as e:
         if isinstance(e, NetworkError) and _is_browser_binary_missing_error(e):
             invalidate_browser_setup()

--- a/linkedin_mcp_server/exceptions.py
+++ b/linkedin_mcp_server/exceptions.py
@@ -72,7 +72,21 @@ class OwnerCannotAuthenticateError(LinkedInMCPError):
 
     Subclasses rather than one class with a field: they are raised from different
     places and the distinction has to survive being caught by type.
+
+    ``nothing_ran_yet`` is carried separately from which subclass this is, because
+    the two are independent and conflating them costs correctness. Whether the
+    session is missing or stale says what has to be repaired; whether any work has
+    happened says whether the call may be run again afterwards. Both combinations
+    occur: a stale session is usually found by the readiness check before a tool
+    has done anything, and only the owner can tell, because by the time a failure
+    reaches a client every origin looks the same.
+
+    It defaults to False so a path that has not thought about it is not replayed.
     """
+
+    def __init__(self, message: str, *, nothing_ran_yet: bool = False) -> None:
+        super().__init__(message)
+        self.nothing_ran_yet = nothing_ran_yet
 
 
 class AuthMissingOnOwnerError(OwnerCannotAuthenticateError):

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -30,6 +30,10 @@ from linkedin_mcp_server.drivers.browser import (
     close_browser,
     watch_for_handoff_requests,
 )
+from linkedin_mcp_server.daemon_auth import (
+    FrontendAuthRepairMiddleware,
+    OwnerAuthSignalMiddleware,
+)
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
@@ -191,6 +195,17 @@ def create_mcp_server(
         mask_error_details=True,
         auth=_StaticTokenAuth(auth_token) if auth_token is not None else None,
     )
+    # Added before the serializing middleware below, which makes it the outer one.
+    # An inner position would work: `close_browser` does not consult the in-flight
+    # count, so quiescence succeeds from there, and the lease reference the inner
+    # layer holds is released in its own `finally`. Outside is preferred because
+    # the marker reports whether the profile is still held, and from inside that
+    # answer would describe the layer below rather than the process.
+    if role is ServerRole.OWNER:
+        mcp.add_middleware(OwnerAuthSignalMiddleware())
+    # The other half, and only ever on the process that has a user in front of it.
+    if role is ServerRole.PROXY:
+        mcp.add_middleware(FrontendAuthRepairMiddleware())
     # Profile ownership belongs to whoever launches Chromium. A process that
     # only forwards calls must not take the lease: it would either block itself
     # until its own timeout, or take the lease and leave the process that

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -1,0 +1,427 @@
+"""Carrying an auth failure from the owner to the process that can fix it.
+
+The owner drives the browser and notices bad LinkedIn auth; it has no terminal, so
+it cannot repair it. The frontend can. These tests cover the crossing between them
+and the decisions made at each end, because every one of them is a way to either
+lose the signal or act on it wrongly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import mcp.types as mt
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import Middleware
+from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
+from fastmcp.tools import ToolResult
+
+from linkedin_mcp_server.daemon_auth import (
+    MARKER_KEY,
+    MARKER_VERSION,
+    FrontendAuthRepairMiddleware,
+    OwnerAuthSignalMiddleware,
+)
+from linkedin_mcp_server.error_handler import raise_tool_error
+from linkedin_mcp_server.exceptions import (
+    AuthMissingOnOwnerError,
+    AuthStaleOnOwnerError,
+)
+
+
+def _owner_that_fails_with(
+    error: Exception, *, then: str = "scraped ok"
+) -> tuple[FastMCP, list[int]]:
+    """An owner whose tool fails with *error* once, then succeeds.
+
+    Through the production middleware and through ``raise_tool_error``, which is
+    how every real tool body ends. The second part matters more than it looks:
+    ``mask_error_details`` replaces the text of anything that is not already a
+    ``ToolError`` before the middleware ever sees it, so a test that raised the
+    domain exception raw would assert against ``"Error calling tool 'scrape'"``
+    and conclude the owner's wording is lost when it is not.
+    """
+    owner = FastMCP("owner", mask_error_details=True)
+    calls: list[int] = []
+
+    @owner.tool
+    async def scrape() -> str:
+        calls.append(1)
+        if len(calls) == 1:
+            raise_tool_error(error, "scrape")
+        return then
+
+    owner.add_middleware(OwnerAuthSignalMiddleware())
+    return owner, calls
+
+
+def _proxy_to(owner: FastMCP, *, repairing: bool = True) -> FastMCP:
+    """A frontend forwarding to *owner* in memory, wired as production does."""
+    front = FastMCP("front", mask_error_details=True)
+    front.add_provider(ProxyProvider(lambda: ProxyClient(owner)))
+    if repairing:
+        front.add_middleware(FrontendAuthRepairMiddleware())
+    return front
+
+
+class TestTheMarkerSurvivesTheHop:
+    """A raise loses everything that identifies the failure; a result does not."""
+
+    async def test_the_owner_marks_a_missing_session(self):
+        owner, calls = _owner_that_fails_with(
+            AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
+        )
+
+        with patch(
+            "linkedin_mcp_server.daemon_auth._browser_still_holds_the_profile",
+            return_value=False,
+        ):
+            async with Client(owner) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert result.is_error is True
+        assert result.meta is not None
+        assert result.meta[MARKER_KEY] == {
+            "v": MARKER_VERSION,
+            "reason": "missing",
+            "replayable": True,
+            "browser_open": False,
+        }
+
+    async def test_the_marker_reaches_the_outer_client_through_the_proxy(self):
+        # The property the whole design rests on. Measured before this existed: a
+        # middleware that re-raised delivered meta=None and a generic message,
+        # because mask_error_details had already discarded the type.
+        owner, calls = _owner_that_fails_with(
+            AuthStaleOnOwnerError("session stopped working", nothing_ran_yet=False)
+        )
+
+        with patch(
+            "linkedin_mcp_server.daemon_auth._browser_still_holds_the_profile",
+            return_value=False,
+        ):
+            # No repair middleware: this asserts what crosses the hop, which a
+            # working frontend consumes.
+            async with Client(_proxy_to(owner, repairing=False)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert result.meta[MARKER_KEY]["reason"] == "stale"
+        assert result.meta[MARKER_KEY]["replayable"] is False
+        # The owner's own wording survives too, so a client that knows nothing
+        # about markers still gets a usable message rather than a bare failure.
+        assert "session stopped working" in result.content[0].text
+
+    async def test_a_raising_client_still_gets_a_tool_error(self):
+        # is_error is kept true deliberately. A success carrying no data would be
+        # worse than a failure: a client would treat the empty result as an answer.
+        owner, calls = _owner_that_fails_with(AuthMissingOnOwnerError("no session"))
+
+        with patch(
+            "linkedin_mcp_server.daemon_auth._browser_still_holds_the_profile",
+            return_value=False,
+        ):
+            async with Client(owner) as client:
+                with pytest.raises(ToolError, match="no session"):
+                    await client.call_tool("scrape")
+
+    async def test_an_unrelated_failure_is_left_alone(self):
+        # The middleware must not turn every error into an invitation to log in.
+        owner, _calls = _owner_that_fails_with(RuntimeError("the page moved"))
+
+        async with Client(owner) as client:
+            result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert result.is_error is True
+        assert MARKER_KEY not in (result.meta or {})
+
+    async def test_the_marker_is_found_through_the_wrapping_tool_error(self):
+        # Nothing that leaves a tool is the original exception: raise_tool_error
+        # wraps it. Reading `type(exc)` would see only ToolError, so the chain has
+        # to be walked, and this asserts the walk rather than the ideal case.
+        owner = FastMCP("owner", mask_error_details=True)
+
+        @owner.tool
+        async def scrape() -> str:
+            try:
+                raise_tool_error(
+                    AuthMissingOnOwnerError("no session", nothing_ran_yet=True),
+                    "scrape",
+                )
+            except Exception as exc:  # what a real tool body does next
+                raise_tool_error(exc, "scrape")
+
+        owner.add_middleware(OwnerAuthSignalMiddleware())
+
+        with patch(
+            "linkedin_mcp_server.daemon_auth._browser_still_holds_the_profile",
+            return_value=False,
+        ):
+            async with Client(owner) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert result.meta[MARKER_KEY]["reason"] == "missing"
+
+
+class TestTheFrontendActsOnTheMarker:
+    """Repairing and replaying are separate decisions, and both can go wrong."""
+
+    def _repair(self):
+        """Watch the login without running one."""
+        return patch(
+            "linkedin_mcp_server.daemon_auth._repair_auth_locally",
+            new_callable=AsyncMock,
+        )
+
+    def _profile_is_free(self):
+        return patch(
+            "linkedin_mcp_server.daemon_auth._browser_still_holds_the_profile",
+            return_value=False,
+        )
+
+    async def test_a_replayable_failure_is_run_again_exactly_once(self):
+        owner, calls = _owner_that_fails_with(
+            AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
+        )
+
+        with self._profile_is_free(), self._repair() as repair:
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        repair.assert_awaited_once_with("missing")
+        # Twice on the owner: the failure, then the replay. Not three times, which
+        # is what a retry loop without a bound would give.
+        assert len(calls) == 2
+        assert result.is_error is False
+        assert result.content[0].text == "scraped ok"
+
+    async def test_a_call_that_had_already_started_is_never_run_again(self):
+        # The one that protects LinkedIn state. Some of these tools send messages
+        # and connection requests, so a replay could repeat a side effect the user
+        # never asked for twice.
+        owner, calls = _owner_that_fails_with(
+            AuthStaleOnOwnerError("session died mid-scrape", nothing_ran_yet=False)
+        )
+
+        with self._profile_is_free(), self._repair() as repair:
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        # Repaired, because the next call should succeed, but not replayed.
+        repair.assert_awaited_once_with("stale")
+        assert len(calls) == 1
+        assert result.is_error is True
+
+    async def test_no_login_starts_while_the_profile_may_still_be_held(self):
+        # A login takes the profile exclusively. Starting one while the owner's
+        # Chromium may still be on it fails on a lease it cannot get, and the user
+        # sees a login that refuses to open for no visible reason.
+        owner, calls = _owner_that_fails_with(
+            AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
+        )
+
+        with (
+            patch(
+                "linkedin_mcp_server.daemon_auth._browser_still_holds_the_profile",
+                return_value=True,
+            ),
+            self._repair() as repair,
+        ):
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        repair.assert_not_awaited()
+        assert len(calls) == 1
+        assert result.is_error is True
+
+    async def test_a_marker_from_a_newer_build_is_ignored(self):
+        # An older frontend attaches to a newer owner on purpose, so it will meet
+        # markers whose fields it cannot be sure of. Guessing at them would act on
+        # a shape that may mean something else.
+        owner = FastMCP("owner", mask_error_details=True)
+
+        @owner.tool
+        async def scrape() -> str:
+            return "unreachable"
+
+        class FromTheFuture(Middleware):
+            async def on_call_tool(self, context, call_next):
+                return ToolResult(
+                    content=[mt.TextContent(type="text", text="please sign in")],
+                    meta={
+                        MARKER_KEY: {
+                            "v": MARKER_VERSION + 1,
+                            "reason": "missing",
+                            "replayable": True,
+                            "browser_open": False,
+                        }
+                    },
+                    is_error=True,
+                )
+
+        owner.add_middleware(FromTheFuture())
+
+        with self._repair() as repair:
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        repair.assert_not_awaited()
+        assert result.is_error is True
+
+    async def test_a_malformed_marker_is_ignored(self):
+        # Every field is checked rather than assumed, because this runs on
+        # whatever arrived over the hop.
+        owner = FastMCP("owner", mask_error_details=True)
+
+        @owner.tool
+        async def scrape() -> str:
+            return "unreachable"
+
+        class Malformed(Middleware):
+            async def on_call_tool(self, context, call_next):
+                return ToolResult(
+                    content=[mt.TextContent(type="text", text="please sign in")],
+                    # replayable is a string, not a bool: acting on this would be
+                    # a truthiness bug that replays a mutating call.
+                    meta={
+                        MARKER_KEY: {
+                            "v": MARKER_VERSION,
+                            "reason": "missing",
+                            "replayable": "yes",
+                            "browser_open": False,
+                        }
+                    },
+                    is_error=True,
+                )
+
+        owner.add_middleware(Malformed())
+
+        with self._repair() as repair:
+            async with Client(_proxy_to(owner)) as client:
+                await client.call_tool("scrape", raise_on_error=False)
+
+        repair.assert_not_awaited()
+
+    async def test_a_failed_login_leaves_the_owners_answer_standing(self):
+        owner, calls = _owner_that_fails_with(
+            AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
+        )
+
+        with (
+            self._profile_is_free(),
+            patch(
+                "linkedin_mcp_server.daemon_auth._repair_auth_locally",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("the user closed the window"),
+            ),
+        ):
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        # No replay against an owner that still cannot serve the call, and the
+        # failure the owner reported is still the honest answer.
+        assert len(calls) == 1
+        assert result.is_error is True
+
+    async def test_an_ordinary_success_is_untouched(self):
+        owner = FastMCP("owner", mask_error_details=True)
+
+        @owner.tool
+        async def scrape() -> str:
+            return "scraped ok"
+
+        with self._repair() as repair:
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape")
+
+        repair.assert_not_awaited()
+        assert result.content[0].text == "scraped ok"
+        # And no control value rides along on a success, which a second proxy
+        # layer would otherwise read and act on.
+        assert MARKER_KEY not in (result.meta or {})
+
+    async def test_a_login_that_does_not_help_stops_after_one_retry(self):
+        """The bound has to hold when the repair changes nothing.
+
+        The happy path cannot show this: there the replay succeeds, so a recursive
+        or looping implementation would stop anyway and look correct. An owner that
+        keeps refusing is what separates "runs the call again" from "runs the call
+        again until something gives", and the second would hammer LinkedIn through
+        a shared browser on every forwarded call.
+        """
+        owner = FastMCP("owner", mask_error_details=True)
+        calls: list[int] = []
+
+        @owner.tool
+        async def scrape() -> str:
+            calls.append(1)
+            raise_tool_error(
+                AuthMissingOnOwnerError("still no session", nothing_ran_yet=True),
+                "scrape",
+            )
+
+        owner.add_middleware(OwnerAuthSignalMiddleware())
+
+        with self._profile_is_free(), self._repair() as repair:
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert len(calls) == 2
+        # And the login is attempted once, not once per attempt.
+        repair.assert_awaited_once()
+        assert result.is_error is True
+
+
+class TestWhichRolesGetWhichHalf:
+    """Each half belongs to exactly one role, and the wrong pairing is silent."""
+
+    def _built(self, role):
+        """A server of *role*, built as a freshly spawned process would.
+
+        Reuses the helper in ``test_server.py`` rather than growing a second one:
+        it already knows the arguments each role cannot be built without, and the
+        role is process state, so each build has to start from an unset one.
+        """
+        from test_server import _server_for  # tests/ is on the path, not a package
+
+        return _server_for(role)
+
+    def test_only_the_owner_signals(self):
+        from linkedin_mcp_server.server_role import ServerRole
+
+        for role in ServerRole:
+            has_it = any(
+                isinstance(m, OwnerAuthSignalMiddleware)
+                for m in self._built(role).middleware
+            )
+            assert has_it == (role is ServerRole.OWNER), role
+
+    def test_only_the_proxy_repairs(self):
+        from linkedin_mcp_server.server_role import ServerRole
+
+        # A DIRECT server must not get it either: it already repairs its own auth
+        # inline, and a second path would run a login on top of that one.
+        for role in ServerRole:
+            has_it = any(
+                isinstance(m, FrontendAuthRepairMiddleware)
+                for m in self._built(role).middleware
+            )
+            assert has_it == (role is ServerRole.PROXY), role
+
+    def test_the_owners_signal_sits_outside_the_serializing_middleware(self):
+        # Not a safety requirement, and an earlier version of this claimed it was:
+        # close_browser does not consult the in-flight count, so quiescence works
+        # from the inner position too. It is asserted because the marker reports
+        # whether the profile is still held, and from inside that answer describes
+        # the layer below rather than the process.
+        from linkedin_mcp_server.sequential_tool_middleware import (
+            SequentialToolExecutionMiddleware,
+        )
+        from linkedin_mcp_server.server_role import ServerRole
+
+        kinds = [type(m) for m in self._built(ServerRole.OWNER).middleware]
+
+        assert kinds.index(OwnerAuthSignalMiddleware) < kinds.index(
+            SequentialToolExecutionMiddleware
+        )


### PR DESCRIPTION
The owner notices bad LinkedIn auth and cannot repair it; the frontend
was spawned by an MCP client, so it has somewhere to put a login window.
This carries the fact across the loopback hop and acts on it there.

An error result, not an exception. Measured: a middleware that re-raises
delivers meta=None and a generic message to the outer client, because
masking has already discarded the type. The same middleware returning
ToolResult(meta=..., is_error=True) delivers the marker intact, and a
client that raises on error still gets the owner's own wording, because
raise_tool_error has already shaped it into a ToolError.

The reason is read from the exception chain rather than a ContextVar.
Both work today, but fastmcp offloads sync tools to a thread, where a
value set in the body is invisible to the middleware; every tool here is
async, so the ContextVar version would pass and break silently later.

reason and replayable answer different questions and neither implies the
other. reason says what to repair. replayable says whether any work had
happened, so whether the call may run again: a stale session found by the
readiness check has done nothing, while one found mid-scrape may have
sent a message. Only the owner can tell, because all 18 tool catch sites
collapse both origins into one except clause.

A marker whose version or field types this build does not recognise is
ignored rather than half-read. An older frontend attaches to a newer
owner on purpose, so that case is reachable; the reverse is not, because
a newer frontend stands the old owner down first.

See also: #606