### PR TITLE
feat(daemon): Let one client win the login race

### DIFF
--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -16,7 +16,6 @@ from typing import NoReturn
 
 from fastmcp import Context
 
-from linkedin_mcp_server.authentication import get_authentication_source
 from linkedin_mcp_server.common_utils import secure_mkdir, secure_write_text, utcnow_iso
 from linkedin_mcp_server.config import get_config
 from linkedin_mcp_server.config.schema import is_loopback_host
@@ -663,20 +662,6 @@ def _auth_ready(profile_dir: Path | None = None) -> bool:
     )
 
 
-def _has_source_state() -> bool:
-    """Whether the configured profile has a readable source state.
-
-    Kept because other callers use it. Readiness no longer goes through it: it
-    resolves the profile itself, so it could not answer for a directory handed in
-    explicitly, and it re-checks the two things the caller has already tested.
-    """
-    try:
-        get_authentication_source()
-    except Exception:
-        return False
-    return True
-
-
 def _auto_import_allowed() -> bool:
     """Return whether a silent browser-session import is safe to attempt now.
 
@@ -960,7 +945,7 @@ async def _start_login_if_needed(
                 prior_error = None
             else:
                 prior_error = _state.last_error
-                _move_invalid_auth_state_aside()
+                _move_invalid_auth_state_aside(superseded_by)
                 _state.auth_state = AuthState.STARTING
                 _state.auth_started_at = utcnow_iso()
                 _state.last_error = None
@@ -1148,44 +1133,6 @@ async def invalidate_auth_and_trigger_relogin(
                 "then retry this tool."
             )
 
-        # Checked here, after the lock and immediately before the rotation, which
-        # is the only place it means anything. Two frontends can meet the same
-        # dead session, and `_lock` is process-local: it serializes this function
-        # against itself in *this* interpreter and knows nothing about the other
-        # process.
-        #
-        # Measured. Rotation itself is safe, because it takes the profile lease
-        # (`session_state.py:727`), so nobody can rotate while a login holds it.
-        # The exposed window is afterwards: A finishes a login and writes a
-        # generation, B arrives with the *old* one still in hand, finds the lease
-        # free, and rotates. `load_source_state` then returned None, and A's fresh
-        # session was gone.
-        #
-        # Comparing generations closes it, because one is only written by a login
-        # or import that has already validated its session. A generation different
-        # from the one being complained about therefore means somebody else's
-        # repair succeeded, and the right move is to stop.
-        #
-        # This is the early half of a pair, and it is not the important one. It
-        # runs before any waiting, so it only catches a peer that finished before
-        # this client even asked. The window that actually loses data opens after
-        # this returns: the login it starts queues for the profile, and by the
-        # time it holds one its opinion may be stale. `interactive_login` checks
-        # again there, where the answer can no longer change. Removing either is
-        # visible in the tests, so neither is decoration.
-        if stale_generation is not UNGUARDED:
-            on_disk = current_login_generation()
-            if on_disk != stale_generation and _auth_ready():
-                logger.info(
-                    "Another client already signed in (generation %s); leaving "
-                    "its session alone",
-                    on_disk,
-                )
-                raise AuthenticationBootstrapFailedError(
-                    "Another LinkedIn MCP client has already signed in. Retry "
-                    "this tool to use the new session."
-                )
-
         # Force-move stale profile files (skip _auth_ready() guard).
         #
         # A failure here used to stop the login, and that reasoning has expired.
@@ -1209,7 +1156,7 @@ async def invalidate_auth_and_trigger_relogin(
         # profile. What must not happen is the login standing down there, which
         # is why the generation it was told about travels with it.
         try:
-            _force_move_auth_state_aside()
+            _force_move_auth_state_aside(stale_generation)
         except AuthenticationBootstrapFailedError as exc:
             logger.info(
                 "Could not retire the stale session yet (%s); the login will "
@@ -1245,7 +1192,9 @@ async def invalidate_auth_and_trigger_relogin(
     )
 
 
-def _move_auth_state_aside(*, force: bool = False) -> None:
+def _move_auth_state_aside(
+    *, force: bool = False, superseded_by: str | None | object = UNGUARDED
+) -> None:
     """Move auth artifacts to a timestamped backup directory.
 
     Args:
@@ -1267,7 +1216,7 @@ def _move_auth_state_aside(*, force: bool = False) -> None:
     # Quarantine creation lives in session_state so the routine rotation on a
     # new session and this stale-state path produce identically shaped backups.
     try:
-        rotate_source_profile(get_profile_dir())
+        rotate_source_profile(get_profile_dir(), superseded_by=superseded_by)
     except RuntimeError as exc:
         raise AuthenticationBootstrapFailedError(
             f"{exc} No login was started."
@@ -1278,13 +1227,17 @@ def _move_auth_state_aside(*, force: bool = False) -> None:
         ) from exc
 
 
-def _force_move_auth_state_aside() -> None:
+def _force_move_auth_state_aside(
+    superseded_by: str | None | object = UNGUARDED,
+) -> None:
     """Move auth artifacts aside unconditionally (no ``_auth_ready()`` guard)."""
-    _move_auth_state_aside(force=True)
+    _move_auth_state_aside(force=True, superseded_by=superseded_by)
 
 
-def _move_invalid_auth_state_aside() -> None:
-    _move_auth_state_aside(force=False)
+def _move_invalid_auth_state_aside(
+    superseded_by: str | None | object = UNGUARDED,
+) -> None:
+    _move_auth_state_aside(force=False, superseded_by=superseded_by)
 
 
 async def _run_login_flow() -> None:

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -46,7 +46,7 @@ from linkedin_mcp_server.session_state import (
     rotate_source_profile,
     source_state_path,
 )
-from linkedin_mcp_server.setup import interactive_login
+from linkedin_mcp_server.setup import UNGUARDED, interactive_login
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ class BootstrapState:
     #: signature: `_run_login_flow` is spawned as a bare task in several places
     #: and stubbed in as many tests, and threading an argument through all of
     #: them would change far more than the one thing that matters.
-    login_supersedes: str | None = None
+    login_supersedes: str | None | object = UNGUARDED
 
 
 _state = BootstrapState()
@@ -138,6 +138,7 @@ def reset_bootstrap_for_testing() -> None:
     _state = BootstrapState()
     _lock = asyncio.Lock()
     _AUTO_IMPORT_ANNOUNCED = False
+    _state.login_supersedes = UNGUARDED
     _auth_quiescent = False
     _auth_quiescent_generation = None
     os.environ.pop("PLAYWRIGHT_BROWSERS_PATH", None)
@@ -801,7 +802,15 @@ async def _try_auto_import_session(ctx: Context | None = None) -> bool:
         # reads are already bounded (security 10s / secret-tool 10s); this covers
         # the launch + navigation budget on top.
         result = await asyncio.wait_for(
-            import_session_from_browser(None, user_data_dir=user_data_dir),
+            import_session_from_browser(
+                None,
+                user_data_dir=user_data_dir,
+                # The import rotates the profile as soon as it holds the lease,
+                # exactly as the login does, so it needs the same guard. Without
+                # it a client whose keychain read ran long would retire a session
+                # a faster peer had already imported.
+                superseded_by=_state.login_supersedes,
+            ),
             timeout=60,
         )
         if not result:
@@ -835,7 +844,7 @@ async def _try_auto_import_session(ctx: Context | None = None) -> bool:
 
 
 async def _start_login_if_needed(
-    ctx: Context | None = None, *, superseded_by: str | None = None
+    ctx: Context | None = None, *, superseded_by: str | None | object = UNGUARDED
 ) -> None:
     if process_role() is ServerRole.OWNER:
         # Ahead of the lock, and ahead of every branch below, because all of them
@@ -880,6 +889,7 @@ async def _start_login_if_needed(
             # Claim the one-shot import under the lock so only one keychain read
             # / import browser ever runs per process episode.
             _state.import_attempted = True
+            _state.login_supersedes = superseded_by
             _state.import_task = asyncio.create_task(
                 _try_auto_import_session(ctx), name="linkedin-auto-import"
             )
@@ -968,7 +978,7 @@ async def _start_login_if_needed(
 
 
 async def start_login_if_needed(
-    ctx: Context | None = None, *, superseded_by: str | None = None
+    ctx: Context | None = None, *, superseded_by: str | None | object = UNGUARDED
 ) -> None:
     """Public wrapper for starting the shared login workflow."""
     await _start_login_if_needed(ctx, superseded_by=superseded_by)
@@ -1044,6 +1054,12 @@ def _raise_if_auth_quiescent() -> None:
         "window.",
         # Raised from the readiness gate, ahead of the tool body.
         nothing_ran_yet=True,
+        # The generation this owner latched on, not a fresh reading. Every call
+        # after the first arrives here rather than through `handle_auth_error`,
+        # so leaving it out would mean the *second* client to ask gets a marker
+        # with nothing to compare against, and repairs unguarded while the first
+        # is still signing in.
+        generation=_auth_quiescent_generation,
     )
 
 

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -990,6 +990,33 @@ async def start_login_if_needed(
     await _start_login_if_needed(ctx, superseded_by=superseded_by)
 
 
+async def wait_for_login_to_finish(timeout: float) -> bool:
+    """Wait for a login this process started, and say whether one now exists.
+
+    The two functions that start a login both report "started" by raising, and
+    they raise while the browser is still open, because the person at it has not
+    typed anything yet. That is the right answer for a tool call, which cannot
+    hold a client for half an hour. It is the wrong answer for the frontend
+    repairing auth on the owner's behalf: there the raise arrives as a *failure*
+    to sign in, and the call that could now be served is refused instead.
+
+    So this is the one place that waits it out. It reads the task rather than
+    polling readiness, because a login that fails must end the wait as surely as
+    one that succeeds; and it returns filesystem truth rather than the task's
+    result, because "a session exists" is the question the caller actually has.
+
+    Returns False when the wait runs out, which leaves the login running: it owns
+    the profile and cancelling it would strand a half-finished sign-in.
+    """
+    task = _state.login_task
+    if task is not None and not task.done():
+        # `wait`, never `wait_for`: the latter cancels on timeout, and this task
+        # is a browser window somebody may be typing into.
+        await asyncio.wait({task}, timeout=timeout)
+    await _refresh_background_task_state()
+    return _auth_ready()
+
+
 def current_login_generation() -> str | None:
     """Which login generation is on disk now, or ``None`` when there is none.
 
@@ -1095,8 +1122,9 @@ async def invalidate_auth_and_trigger_relogin(
     Raises:
         AuthenticationStartedError: Login browser opened.
         AuthenticationInProgressError: Login already running from a prior call.
-        AuthenticationBootstrapFailedError: Someone else's fresh session is now on
-            disk, so there is nothing to invalidate and no login to start.
+        PeerSessionInPlaceError: Someone else's fresh session is now on disk, so
+            there is nothing to invalidate and no login to start. The caller may
+            simply use it.
         AuthStaleOnOwnerError: This process is the shared owner, so it reports
             rather than rotating the profile and opening a login nobody could
             answer.

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -1071,7 +1071,7 @@ def _raise_if_auth_quiescent() -> None:
 async def invalidate_auth_and_trigger_relogin(
     ctx: Context | None = None,
     *,
-    stale_generation: str | None = None,
+    stale_generation: str | None | object = UNGUARDED,
 ) -> NoReturn:
     """Force-invalidate stale auth state and trigger interactive login.
 
@@ -1080,12 +1080,16 @@ async def invalidate_auth_and_trigger_relogin(
     being present on disk.  The check-task → force-move → start-login sequence
     is atomic under ``_lock`` so an in-flight login is never corrupted.
 
-    *stale_generation* is the login generation the caller found broken, when it
-    knows. Passing it is what keeps two frontends from destroying each other's
-    work: ``_lock`` is process-local, so it says nothing about the other process,
-    and the rotation below is skipped when the generation on disk has moved on
-    from the one being complained about. Without it the second frontend rotates
-    away the session the first has just created.
+    *stale_generation* is the login generation the caller found broken, which may
+    be ``None`` when it found no session at all. Passing it is what keeps two
+    clients from destroying each other's work: ``_lock`` is process-local, so it
+    says nothing about the other process, and the rotation below is skipped when
+    the generation on disk has moved on from the one being complained about.
+
+    Left at :data:`UNGUARDED` only by a caller that has observed nothing, which
+    is why the two are distinct values. Conflating them was measured to produce
+    the worst available failure: a login that reports a window has opened, opens
+    none, keeps the dead session and leaves readiness saying it is fine.
 
     Raises:
         AuthenticationStartedError: Login browser opened.
@@ -1154,7 +1158,7 @@ async def invalidate_auth_and_trigger_relogin(
         # time it holds one its opinion may be stale. `interactive_login` checks
         # again there, where the answer can no longer change. Removing either is
         # visible in the tests, so neither is decoration.
-        if stale_generation is not None:
+        if stale_generation is not UNGUARDED:
             on_disk = current_login_generation()
             if on_disk != stale_generation and _auth_ready():
                 logger.info(
@@ -1183,8 +1187,12 @@ async def invalidate_auth_and_trigger_relogin(
         # better place for it anyway: this one runs without holding anything, so
         # its result was never guaranteed to survive to the login. What is lost by
         # skipping it is only that `_auth_ready()` keeps reporting the dead
-        # session until the login retires it, and the quiescence latch on an owner
-        # already covers that window.
+        # session until the login retires it. On a shared owner the quiescence
+        # latch closes that window. On a single-process server nothing does, and
+        # it does not need to: the same call is already committed to starting a
+        # login, and the login retires the state itself once it holds the
+        # profile. What must not happen is the login standing down there, which
+        # is why the generation it was told about travels with it.
         try:
             _force_move_auth_state_aside()
         except AuthenticationBootstrapFailedError as exc:
@@ -1231,10 +1239,13 @@ def _move_auth_state_aside(*, force: bool = False) -> None:
             knows the session is stale.
 
     Raises:
-        AuthenticationBootstrapFailedError: The state could not be retired. The
-            caller must not go on to open a login browser: that login rotates
-            the same artifacts and would fail at the same point, after telling
-            the user a browser had opened.
+        AuthenticationBootstrapFailedError: The state could not be retired.
+            Whether that stops the caller depends on the caller. It used to have
+            to: the login rotated the same artifacts and would have failed at the
+            same point, after telling the user a browser had opened. The login
+            waits for the profile now, so a caller that has one to start may
+            reasonably carry on and let it retire the state under the lease it
+            waited for.
     """
     if not force and _auth_ready():
         return

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -1038,6 +1038,8 @@ def _raise_if_auth_quiescent() -> None:
 
 async def invalidate_auth_and_trigger_relogin(
     ctx: Context | None = None,
+    *,
+    stale_generation: str | None = None,
 ) -> NoReturn:
     """Force-invalidate stale auth state and trigger interactive login.
 
@@ -1046,12 +1048,21 @@ async def invalidate_auth_and_trigger_relogin(
     being present on disk.  The check-task → force-move → start-login sequence
     is atomic under ``_lock`` so an in-flight login is never corrupted.
 
+    *stale_generation* is the login generation the caller found broken, when it
+    knows. Passing it is what keeps two frontends from destroying each other's
+    work: ``_lock`` is process-local, so it says nothing about the other process,
+    and the rotation below is skipped when the generation on disk has moved on
+    from the one being complained about. Without it the second frontend rotates
+    away the session the first has just created.
+
     Raises:
         AuthenticationStartedError: Login browser opened.
         AuthenticationInProgressError: Login already running from a prior call.
+        AuthenticationBootstrapFailedError: Someone else's fresh session is now on
+            disk, so there is nothing to invalidate and no login to start.
         AuthStaleOnOwnerError: This process is the shared owner, so it reports
-            rather than rotating the profile and opening a window it has no
-            desktop session for.
+            rather than rotating the profile and opening a login nobody could
+            answer.
     """
     if process_role() is ServerRole.OWNER:
         # Never reaches the rotation below. Retiring the session here would race
@@ -1085,6 +1096,36 @@ async def invalidate_auth_and_trigger_relogin(
                 "already in progress in a browser window. Complete login there, "
                 "then retry this tool."
             )
+
+        # Checked here, after the lock and immediately before the rotation, which
+        # is the only place it means anything. Two frontends can meet the same
+        # dead session, and `_lock` is process-local: it serializes this function
+        # against itself in *this* interpreter and knows nothing about the other
+        # process.
+        #
+        # Measured. Rotation itself is safe, because it takes the profile lease
+        # (`session_state.py:727`), so nobody can rotate while a login holds it.
+        # The exposed window is afterwards: A finishes a login and writes a
+        # generation, B arrives with the *old* one still in hand, finds the lease
+        # free, and rotates. `load_source_state` then returned None, and A's fresh
+        # session was gone.
+        #
+        # Comparing generations closes it, because one is only written by a login
+        # or import that has already validated its session (`setup.py:269`). A
+        # generation different from the one being complained about therefore means
+        # somebody else's repair succeeded, and the right move is to stop.
+        if stale_generation is not None:
+            on_disk = current_login_generation()
+            if on_disk != stale_generation and _auth_ready():
+                logger.info(
+                    "Another client already signed in (generation %s); leaving "
+                    "its session alone",
+                    on_disk,
+                )
+                raise AuthenticationBootstrapFailedError(
+                    "Another LinkedIn MCP client has already signed in. Retry "
+                    "this tool to use the new session."
+                )
 
         # Force-move stale profile files (skip _auth_ready() guard).
         _force_move_auth_state_aside()

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -596,7 +596,7 @@ async def ensure_tool_ready_or_raise(
         if _auth_ready():
             _state.auth_state = AuthState.READY
             return
-        await _start_login_if_needed(ctx)
+        await _start_login_if_needed(ctx, superseded_by=current_login_generation())
         return
 
     if _browser_setup_ready():
@@ -628,7 +628,12 @@ async def ensure_tool_ready_or_raise(
         _state.auth_state = AuthState.READY
         return
 
-    await _start_login_if_needed(ctx)
+    # The generation goes with it, because this call has just looked: whatever is
+    # on disk now is what it found wanting. A login started automatically by a
+    # tool call is not somebody at a terminal insisting, so if a peer signs in
+    # while this one is still getting there, standing down is right. `--login`
+    # keeps its unguarded default, which is what makes it an override.
+    await _start_login_if_needed(ctx, superseded_by=current_login_generation())
 
 
 def _raise_if_docker_auth_missing() -> None:

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -37,6 +37,7 @@ from linkedin_mcp_server.exceptions import (
 )
 from linkedin_mcp_server.server_role import ServerRole, process_role
 from linkedin_mcp_server.session_state import (
+    PeerSessionInPlaceError,
     auth_root_dir,
     get_runtime_id,
     load_source_state,
@@ -1217,6 +1218,13 @@ def _move_auth_state_aside(
     # new session and this stale-state path produce identically shaped backups.
     try:
         rotate_source_profile(get_profile_dir(), superseded_by=superseded_by)
+    except PeerSessionInPlaceError:
+        # Ahead of RuntimeError, which it subclasses, and deliberately not turned
+        # into a bootstrap failure: nothing failed. Somebody else signed in, so
+        # the caller must stop rather than go on to promise a login window that
+        # will not open. Measured with it swallowed here: the caller was told
+        # "a login browser window has been opened" and none was.
+        raise
     except RuntimeError as exc:
         raise AuthenticationBootstrapFailedError(
             f"{exc} No login was started."

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -644,17 +644,32 @@ def _raise_if_docker_auth_missing() -> None:
     )
 
 
-def _auth_ready() -> bool:
-    profile_dir = get_profile_dir()
+def _auth_ready(profile_dir: Path | None = None) -> bool:
+    """Whether a session's files are all present under *profile_dir*.
+
+    Defaults to the configured profile, which is what every gate here means. The
+    argument exists for callers handed a directory explicitly, where asking about
+    the configured one would answer a different question than the one asked, and
+    silently: it would report the *default* profile ready while rotating another.
+    """
+    profile_dir = profile_dir or get_profile_dir()
     return (
         profile_exists(profile_dir)
         and portable_cookie_path(profile_dir).exists()
         and source_state_path(profile_dir).exists()
-        and _has_source_state()
+        # The file has to parse, not merely exist: a truncated write leaves one
+        # behind that every existence check above is happy with.
+        and load_source_state(profile_dir) is not None
     )
 
 
 def _has_source_state() -> bool:
+    """Whether the configured profile has a readable source state.
+
+    Kept because other callers use it. Readiness no longer goes through it: it
+    resolves the profile itself, so it could not answer for a directory handed in
+    explicitly, and it re-checks the two things the caller has already tested.
+    """
     try:
         get_authentication_source()
     except Exception:

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -1163,7 +1163,31 @@ async def invalidate_auth_and_trigger_relogin(
                 )
 
         # Force-move stale profile files (skip _auth_ready() guard).
-        _force_move_auth_state_aside()
+        #
+        # A failure here used to stop the login, and that reasoning has expired.
+        # It made sense when the login demanded the profile outright: if the
+        # rotation could not take it, neither could the login, and saying so beat
+        # claiming a browser had opened. Now the login *waits* for the profile,
+        # so a momentary holder is precisely the case it handles, and refusing
+        # here throws away the wait before it happens. Measured: with a lease held
+        # for 1.5 seconds, this raised "the browser profile is in use" and the
+        # 60-second wait was never reached.
+        #
+        # The rotation itself is not lost. `interactive_login` rotates under the
+        # profile it waited for (`setup.py`, `rotate_shielded`), which is the
+        # better place for it anyway: this one runs without holding anything, so
+        # its result was never guaranteed to survive to the login. What is lost by
+        # skipping it is only that `_auth_ready()` keeps reporting the dead
+        # session until the login retires it, and the quiescence latch on an owner
+        # already covers that window.
+        try:
+            _force_move_auth_state_aside()
+        except AuthenticationBootstrapFailedError as exc:
+            logger.info(
+                "Could not retire the stale session yet (%s); the login will "
+                "wait for the profile and retire it there",
+                exc,
+            )
 
         # A force-move starts a fresh no-session episode; allow auto-import to
         # be re-attempted on the next tool call (the prior latch was for the

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -108,6 +108,12 @@ class BootstrapState:
     import_task: asyncio.Task[bool] | None = None
     import_attempted: bool = False
     initialized: bool = False
+    #: The login generation the in-flight login was told is broken, so it can
+    #: stand down if a peer signs in first. On the state rather than the task's
+    #: signature: `_run_login_flow` is spawned as a bare task in several places
+    #: and stubbed in as many tests, and threading an argument through all of
+    #: them would change far more than the one thing that matters.
+    login_supersedes: str | None = None
 
 
 _state = BootstrapState()
@@ -828,7 +834,9 @@ async def _try_auto_import_session(ctx: Context | None = None) -> bool:
         set_headless(prev_headless)
 
 
-async def _start_login_if_needed(ctx: Context | None = None) -> None:
+async def _start_login_if_needed(
+    ctx: Context | None = None, *, superseded_by: str | None = None
+) -> None:
     if process_role() is ServerRole.OWNER:
         # Ahead of the lock, and ahead of every branch below, because all of them
         # end somewhere this process cannot go: an auto-import that rotates the
@@ -907,7 +915,7 @@ async def _start_login_if_needed(ctx: Context | None = None) -> None:
         # Import resolved without a session -> manual-login path. Re-enter:
         # import_attempted is now True and import_task is done, so this call
         # takes the spawn/await-login branch (no recursion loop risk).
-        return await _start_login_if_needed(ctx)
+        return await _start_login_if_needed(ctx, superseded_by=superseded_by)
 
     # No import in flight and none claimed -> the #535 manual-login + inline-wait
     # fallback. Spawn the login task if one is not already shared.
@@ -927,6 +935,7 @@ async def _start_login_if_needed(ctx: Context | None = None) -> None:
                 _state.auth_started_at = utcnow_iso()
                 _state.last_error = None
                 _state.auth_completed_at = None
+                _state.login_supersedes = superseded_by
                 _state.login_task = asyncio.create_task(
                     _run_login_flow(), name="linkedin-login"
                 )
@@ -958,9 +967,11 @@ async def _start_login_if_needed(ctx: Context | None = None) -> None:
     raise AuthenticationInProgressError(_pending_login_message(prior_error))
 
 
-async def start_login_if_needed(ctx: Context | None = None) -> None:
+async def start_login_if_needed(
+    ctx: Context | None = None, *, superseded_by: str | None = None
+) -> None:
     """Public wrapper for starting the shared login workflow."""
-    await _start_login_if_needed(ctx)
+    await _start_login_if_needed(ctx, superseded_by=superseded_by)
 
 
 def current_login_generation() -> str | None:
@@ -1111,9 +1122,17 @@ async def invalidate_auth_and_trigger_relogin(
         # session was gone.
         #
         # Comparing generations closes it, because one is only written by a login
-        # or import that has already validated its session (`setup.py:269`). A
-        # generation different from the one being complained about therefore means
-        # somebody else's repair succeeded, and the right move is to stop.
+        # or import that has already validated its session. A generation different
+        # from the one being complained about therefore means somebody else's
+        # repair succeeded, and the right move is to stop.
+        #
+        # This is the early half of a pair, and it is not the important one. It
+        # runs before any waiting, so it only catches a peer that finished before
+        # this client even asked. The window that actually loses data opens after
+        # this returns: the login it starts queues for the profile, and by the
+        # time it holds one its opinion may be stale. `interactive_login` checks
+        # again there, where the answer can no longer change. Removing either is
+        # visible in the tests, so neither is decoration.
         if stale_generation is not None:
             on_disk = current_login_generation()
             if on_disk != stale_generation and _auth_ready():
@@ -1141,6 +1160,7 @@ async def invalidate_auth_and_trigger_relogin(
         _state.auth_started_at = utcnow_iso()
         _state.last_error = None
         _state.auth_completed_at = None
+        _state.login_supersedes = stale_generation
         _state.login_task = asyncio.create_task(
             _run_login_flow(), name="linkedin-login"
         )
@@ -1197,6 +1217,13 @@ def _move_invalid_auth_state_aside() -> None:
 
 
 async def _run_login_flow() -> None:
+    """Install what a headed login needs, then run one.
+
+    The generation this login supersedes is read from the shared state rather
+    than taken as an argument, and passed on rather than checked here: this runs
+    as a background task, and the gap between this line and the profile actually
+    being held is the whole window that matters.
+    """
     _state.auth_state = AuthState.IN_PROGRESS
     # The manual-login fallback launches headed, which needs full chromium.
     # In the default headless flow only the shell is installed eagerly, so
@@ -1205,7 +1232,9 @@ async def _run_login_flow() -> None:
     # binary-missing backstop remains as a recovery path.
     if not _uses_custom_chrome():
         await _ensure_full_chromium_installed()
-    success = await interactive_login(get_profile_dir())
+    success = await interactive_login(
+        get_profile_dir(), superseded_by=_state.login_supersedes
+    )
     if not success:
         raise AuthenticationBootstrapFailedError(
             "LinkedIn login was not completed. Retry the tool call to reopen the browser and continue setup."

--- a/linkedin_mcp_server/browser_import/orchestrate.py
+++ b/linkedin_mcp_server/browser_import/orchestrate.py
@@ -47,6 +47,7 @@ from linkedin_mcp_server.exceptions import (
     NoLinkedInSessionFoundError,
 )
 from linkedin_mcp_server.profile_lease import ProfileLease, get_profile_lease
+from linkedin_mcp_server.setup import UNGUARDED, a_peer_already_signed_in
 from linkedin_mcp_server.session_state import (
     run_deferring_cancels,
     portable_cookie_path,
@@ -193,6 +194,7 @@ async def import_session_from_browser(
     browser: str | None,
     *,
     user_data_dir: Path,
+    superseded_by: str | None | object = UNGUARDED,
 ) -> bool:
     """Discover, rank, decrypt, validate and persist a browser LinkedIn session.
 
@@ -242,6 +244,17 @@ async def import_session_from_browser(
         )
     release_profile = True
     try:
+        # Checked with the profile in hand, for the same reason the login checks
+        # there: two clients meeting one bad session both decide to repair it,
+        # both queue, and the one that waited is acting on an answer formed before
+        # the winner finished. The rotation below does not ask whose session it is
+        # retiring. Measured with two real processes: the loser rotated away the
+        # session the winner had just imported.
+        if superseded_by is not UNGUARDED and a_peer_already_signed_in(
+            user_data_dir, superseded_by
+        ):
+            logger.info("Another client already signed in; keeping its session")
+            return True
         return await _import_holding_the_profile(
             live, cookie_path, user_data_dir, lease
         )

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -37,6 +37,17 @@ DEFAULT_BROWSER_MIN_HOLD_SECONDS: float = 20.0
 # notices on a one-second poll and then has to tear Chromium down (~0.7s
 # measured). Without it a waiter gives up moments before the handover lands.
 BROWSER_HANDOFF_MARGIN_SECONDS: float = 3.0
+# How long a one-shot operation waits for another process to hand the profile
+# over. Not a tool-call budget and not a human's budget: the holder notices a
+# waiter on a one-second poll (`drivers/browser.py`) and releases after at most
+# browser_min_hold_seconds plus a Chromium teardown of roughly a second, so this
+# is comfortably past the worst cooperative case. Beyond it the holder is a
+# process that will not release, where failing beats hanging.
+#
+# Deliberately not configurable. Nothing measured suggests a user would need to
+# tune it, and an unused setting is a support burden.
+PROFILE_HANDOVER_WAIT_SECONDS: float = 60.0
+
 # Close an idle browser and release the profile after this long with no calls.
 # A backstop only — the handoff signal does the real work — so it is deliberately
 # long: a reopen costs one more LinkedIn request. 0 disables it.

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -52,6 +52,20 @@ BROWSER_HANDOFF_MARGIN_SECONDS: float = 3.0
 # tune it, and an unused setting is a support burden.
 PROFILE_HANDOVER_WAIT_SECONDS: float = 60.0
 
+# How long a frontend repairing the shared browser's auth waits for the sign-in
+# it started before answering the call without it.
+#
+# Bounded by the tool timeout above it, not by how long a person takes: the
+# client is blocked on one call for the whole wait, and a wait that outlives the
+# call is spent for nothing. 150 leaves a margin under the 180-second default for
+# the replayed call to run in. Somebody still typing when it runs out loses
+# nothing but this attempt, because the login keeps running and the next call
+# finds the session it wrote.
+#
+# Deliberately not configurable, like its neighbour: it is derived from a value
+# the user can already set rather than a knob of its own.
+AUTH_REPAIR_LOGIN_WAIT_SECONDS: float = 150.0
+
 # Close an idle browser and release the profile after this long with no calls.
 # A backstop only — the handoff signal does the real work — so it is deliberately
 # long: a reopen costs one more LinkedIn request. 0 disables it.

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -38,11 +38,15 @@ DEFAULT_BROWSER_MIN_HOLD_SECONDS: float = 20.0
 # measured). Without it a waiter gives up moments before the handover lands.
 BROWSER_HANDOFF_MARGIN_SECONDS: float = 3.0
 # How long a one-shot operation waits for another process to hand the profile
-# over. Not a tool-call budget and not a human's budget: the holder notices a
-# waiter on a one-second poll (`drivers/browser.py`) and releases after at most
-# browser_min_hold_seconds plus a Chromium teardown of roughly a second, so this
-# is comfortably past the worst cooperative case. Beyond it the holder is a
-# process that will not release, where failing beats hanging.
+# over. A user-experience limit rather than a derived worst case, and the
+# distinction is worth stating because the arithmetic invites the wrong one: an
+# idle holder does release quickly, after browser_min_hold_seconds plus about a
+# second of teardown, but a holder running a tool call refuses to hand over at
+# all until that call ends (`drivers/browser.py`), and a call may take up to
+# tool_timeout_seconds. So this does not bound every cooperative case. It bounds
+# how long someone who just asked to sign in is left staring at nothing, and past
+# it they are told the browser is busy, which they can act on. Waiting three
+# minutes in silence is the worse answer.
 #
 # Deliberately not configurable. Nothing measured suggests a user would need to
 # tune it, and an unused setting is a support burden.

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -52,19 +52,21 @@ BROWSER_HANDOFF_MARGIN_SECONDS: float = 3.0
 # tune it, and an unused setting is a support burden.
 PROFILE_HANDOVER_WAIT_SECONDS: float = 60.0
 
-# How long a frontend repairing the shared browser's auth waits for the sign-in
-# it started before answering the call without it.
+# What fraction of a tool call a frontend may spend waiting for the sign-in it
+# started, before answering without it.
 #
-# Bounded by the tool timeout above it, not by how long a person takes: the
-# client is blocked on one call for the whole wait, and a wait that outlives the
-# call is spent for nothing. 150 leaves a margin under the 180-second default for
-# the replayed call to run in. Somebody still typing when it runs out loses
-# nothing but this attempt, because the login keeps running and the next call
-# finds the session it wrote.
+# A fraction rather than a number of seconds, because the bound that matters is
+# the call this wait is spent inside, and ``tool_timeout_seconds`` is something
+# the user sets. A fixed value was measured against ``TOOL_TIMEOUT=60``: the
+# client's call was cut short while the middleware was still waiting, so instead
+# of the readable "sign-in still in progress" the user got a bare timeout. The
+# login survived it and the next call succeeded, so nothing was lost but the
+# explanation -- which is the part a person acts on.
 #
-# Deliberately not configurable, like its neighbour: it is derived from a value
-# the user can already set rather than a knob of its own.
-AUTH_REPAIR_LOGIN_WAIT_SECONDS: float = 150.0
+# Five sixths leaves the remaining sixth for the replayed call, which is the
+# whole point of having waited. Somebody still typing when it runs out loses only
+# this attempt: the login keeps running and the next call finds what it wrote.
+AUTH_REPAIR_LOGIN_WAIT_FRACTION: float = 5 / 6
 
 # Close an idle browser and release the profile after this long with no calls.
 # A backstop only — the handoff signal does the real work — so it is deliberately

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -291,7 +291,17 @@ class BrowserManager:
 
         path = Path(cookie_path) if cookie_path else self._default_cookie_path()
         try:
-            all_cookies = await self._context.cookies()
+            # Bounded like the teardown steps below it, and for a stronger
+            # reason. On close this runs *before* them, with the singleton
+            # already cleared and the profile lease still held, inside a section
+            # that defers cancellation until it finishes. A protocol call that
+            # never answers therefore strands the profile before anything
+            # bounded is reached, and raises nothing for anyone to act on: no
+            # close result, no exception, no stand-down. Losing an export costs
+            # the Docker cookie file this run, which the next close rewrites.
+            all_cookies = await asyncio.wait_for(
+                self._context.cookies(), timeout=_CLEANUP_TIMEOUT_SECONDS
+            )
             cookies = [
                 self._normalize_cookie_domain(c)
                 for c in all_cookies

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -66,9 +66,10 @@ from linkedin_mcp_server.exceptions import (
 
 logger = logging.getLogger(__name__)
 
-#: The least a replay is given, however little of the call is left. Short enough
-#: that it cannot be what overruns a client's deadline, long enough that the
-#: replay is a real attempt rather than a formality.
+#: The least a replay is given, so that a call which has spent nearly all of its
+#: budget still makes a real attempt rather than failing on a zero deadline for a
+#: session that now exists. Itself capped by the budget below: as a flat floor it
+#: overran, giving a 1-second call a 5-second replay.
 _MINIMUM_REPLAY_SECONDS = 5.0
 
 
@@ -92,15 +93,21 @@ def _how_long_to_wait_for_the_sign_in(budget: float, already_spent: float) -> fl
 
 
 def _what_is_left_of_this_call(budget: float, already_spent: float) -> float:
-    """How much of the client's deadline the replay may still use.
+    """How much of the client's deadline a read-only replay may still use.
 
     The whole budget rather than the fraction above: waiting deliberately leaves
     a share for this, and by here that share is whatever has not been spent. A
     floor keeps a call that has already overrun from being handed a zero or
     negative deadline, which would fail the replay before it started for a
     session that now exists.
+
+    The floor is itself capped by the budget, because a floor that outlives its
+    own call is the very overrun this function exists to prevent: measured at
+    ``tool_timeout_seconds=1.0`` with 0.9s spent, a flat floor allowed 5 seconds.
+    Only reached for read-only tools, where an abandoned replay costs a wasted
+    page load; anything that changes something is never timed out here.
     """
-    return max(_MINIMUM_REPLAY_SECONDS, budget - already_spent)
+    return min(budget, max(_MINIMUM_REPLAY_SECONDS, budget - already_spent))
 
 
 #: Namespaced so a future fastmcp key cannot shadow it. Measured: a custom key
@@ -300,16 +307,32 @@ class FrontendAuthRepairMiddleware(Middleware):
             return result
 
         logger.info("Signed in; running the call again")
-        # Bounded by what is left of this call, not given a fresh budget. Nothing
-        # below this middleware bounds the whole path: the forwarded call has its
-        # own deadline per hop (`daemon_proxy.create_proxy_provider`), so the
-        # first call, the wait and the replay each stay inside one, while their
-        # sum is not bounded by anything. Measured shape: a sign-in finishing
-        # near the end of the wait, followed by a replay taking a full budget of
-        # its own, put the client past its deadline with the answer already in
-        # hand. Timing out here instead spends the last of the budget on the
-        # answer and, when it does not arrive, returns the owner's readable
-        # failure rather than a bare transport error.
+
+        if await _the_tool_changes_something(context):
+            # Never timed out locally, and this is the one case where waiting
+            # longer is the safer answer. Giving up here does not stop the owner:
+            # cancellation is not forwarded across the hop
+            # (`daemon_proxy._TIMEOUT_MARGIN_SECONDS` records the same), so the
+            # frontend would report the old auth failure while the owner went on
+            # to send the message. Measured over a real loopback owner: the
+            # client was answered at 0.66s with an error, and the owner appended
+            # its effect 0.7s later. The user then retries something that already
+            # happened.
+            #
+            # An overrun client call is the lesser harm: the deadline belongs to
+            # the client, which can give up on its own, and doing so leaves the
+            # same one call outstanding rather than a second one queued behind it.
+            return await call_next(context)
+
+        # Read-only, so bounded by what is left of this call rather than given a
+        # fresh budget. Nothing below this middleware bounds the whole path: the
+        # forwarded call has its own deadline per hop
+        # (`daemon_proxy.create_proxy_provider`), so the first call, the wait and
+        # the replay each stay inside one while their sum stays inside nothing.
+        # Measured shape: a sign-in finishing near the end of the wait, followed
+        # by a replay taking a full budget of its own, put the client past its
+        # deadline with the answer already in hand. An abandoned scrape costs a
+        # wasted page load and nothing else.
         remaining = _what_is_left_of_this_call(
             self._tool_timeout, time.monotonic() - began
         )
@@ -318,6 +341,32 @@ class FrontendAuthRepairMiddleware(Middleware):
         except (TimeoutError, asyncio.TimeoutError):
             logger.info("The replayed call ran out of time; reporting the failure")
             return result
+
+
+async def _the_tool_changes_something(
+    context: MiddlewareContext[mt.CallToolRequestParams],
+) -> bool:
+    """Whether running this tool again could repeat an effect on LinkedIn.
+
+    Read from the tool's own annotations, which survive the hop
+    (``ProxyProvider`` copies them), rather than from a list of names kept here:
+    a list would go stale the first time a tool is added, and it would go stale
+    silently in the unsafe direction.
+
+    Unknown counts as changing something. Only ``readOnlyHint`` says otherwise,
+    and a tool that declares nothing has not promised anything.
+    """
+    name = getattr(context.message, "name", None)
+    fastmcp_context = context.fastmcp_context
+    if name is None or fastmcp_context is None:
+        return True
+    try:
+        tool = await fastmcp_context.fastmcp.get_tool(name)
+    except Exception:  # noqa: BLE001 - an unresolvable tool is not a safe one
+        logger.debug("Could not read the annotations of %s", name, exc_info=True)
+        return True
+    annotations = getattr(tool, "annotations", None)
+    return not bool(annotations and annotations.readOnlyHint)
 
 
 def _readable_marker(result: ToolResult) -> dict[str, Any] | None:

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -52,7 +52,10 @@ import mcp.types as mt
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 
-from linkedin_mcp_server.config.schema import AUTH_REPAIR_LOGIN_WAIT_FRACTION
+from linkedin_mcp_server.config.schema import (
+    AUTH_REPAIR_LOGIN_WAIT_FRACTION,
+    DEFAULT_TOOL_TIMEOUT_SECONDS,
+)
 from linkedin_mcp_server.session_state import PeerSessionInPlaceError
 from linkedin_mcp_server.exceptions import (
     AuthenticationInProgressError,
@@ -69,27 +72,26 @@ logger = logging.getLogger(__name__)
 _MINIMUM_REPLAY_SECONDS = 5.0
 
 
-def _how_long_to_wait_for_the_sign_in(already_spent: float) -> float:
+def _how_long_to_wait_for_the_sign_in(budget: float, already_spent: float) -> float:
     """How much of this call is left to spend waiting for the login.
 
-    Read per call rather than fixed at import, because the budget it comes from
-    is a user setting: a fixed value was measured to outlive the call it was
-    spent inside once ``TOOL_TIMEOUT`` was lowered, replacing a readable answer
-    with a bare timeout.
+    A fraction of *budget* rather than a fixed number of seconds, because the
+    bound that matters is the call this is spent inside: a fixed 150 seconds was
+    measured to outlive its own call once ``TOOL_TIMEOUT`` was lowered, replacing
+    a readable answer with a bare timeout.
 
     *already_spent* is subtracted rather than ignored, and measuring caught that
     too: the fraction alone still overran, because the owner call and the inline
     login wait had gone before this is reached, and both come out of the same
     budget. Never negative, so an already-overrun call skips the wait and answers
-    rather than waiting on a deadline that has passed.
+    rather than waiting on a deadline that has passed. Zero still reaches the
+    readiness check below it, which is what notices a login that finished in
+    exactly this race.
     """
-    from linkedin_mcp_server.config import get_config
-
-    budget = get_config().server.tool_timeout_seconds * AUTH_REPAIR_LOGIN_WAIT_FRACTION
-    return max(0.0, budget - already_spent)
+    return max(0.0, budget * AUTH_REPAIR_LOGIN_WAIT_FRACTION - already_spent)
 
 
-def _what_is_left_of_this_call(already_spent: float) -> float:
+def _what_is_left_of_this_call(budget: float, already_spent: float) -> float:
     """How much of the client's deadline the replay may still use.
 
     The whole budget rather than the fraction above: waiting deliberately leaves
@@ -98,9 +100,6 @@ def _what_is_left_of_this_call(already_spent: float) -> float:
     negative deadline, which would fail the replay before it started for a
     session that now exists.
     """
-    from linkedin_mcp_server.config import get_config
-
-    budget = get_config().server.tool_timeout_seconds
     return max(_MINIMUM_REPLAY_SECONDS, budget - already_spent)
 
 
@@ -223,6 +222,19 @@ class FrontendAuthRepairMiddleware(Middleware):
     that does.
     """
 
+    def __init__(self, *, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS) -> None:
+        """*tool_timeout* is the deadline a client's call is answered within.
+
+        Taken as an argument rather than read from the configuration singleton,
+        because the two can disagree. ``create_mcp_server`` is handed the budget
+        every tool it registers gets, and a server built directly rather than by
+        ``cli_main`` may never have loaded a configuration at all: measured at
+        ``tool_timeout=1.2`` with none loaded, this budgeted itself 149.8 seconds
+        of a 1.2-second call, because the unloaded singleton falls back to
+        parsing ``sys.argv``.
+        """
+        self._tool_timeout = tool_timeout
+
     async def on_call_tool(
         self,
         context: MiddlewareContext[mt.CallToolRequestParams],
@@ -266,7 +278,9 @@ class FrontendAuthRepairMiddleware(Middleware):
             #
             # So wait the login out here. This is the process that has somewhere
             # to show it, and the client is waiting on this one call.
-            left = _how_long_to_wait_for_the_sign_in(time.monotonic() - began)
+            left = _how_long_to_wait_for_the_sign_in(
+                self._tool_timeout, time.monotonic() - began
+            )
             if not await _wait_for_the_sign_in(left):
                 logger.info("The sign-in did not finish in time; not replaying")
                 return result
@@ -296,7 +310,9 @@ class FrontendAuthRepairMiddleware(Middleware):
         # hand. Timing out here instead spends the last of the budget on the
         # answer and, when it does not arrive, returns the owner's readable
         # failure rather than a bare transport error.
-        remaining = _what_is_left_of_this_call(time.monotonic() - began)
+        remaining = _what_is_left_of_this_call(
+            self._tool_timeout, time.monotonic() - began
+        )
         try:
             return await asyncio.wait_for(call_next(context), timeout=remaining)
         except (TimeoutError, asyncio.TimeoutError):

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -43,6 +43,7 @@ one ``except`` clause.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any
@@ -61,6 +62,11 @@ from linkedin_mcp_server.exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+#: The least a replay is given, however little of the call is left. Short enough
+#: that it cannot be what overruns a client's deadline, long enough that the
+#: replay is a real attempt rather than a formality.
+_MINIMUM_REPLAY_SECONDS = 5.0
 
 
 def _how_long_to_wait_for_the_sign_in(already_spent: float) -> float:
@@ -81,6 +87,21 @@ def _how_long_to_wait_for_the_sign_in(already_spent: float) -> float:
 
     budget = get_config().server.tool_timeout_seconds * AUTH_REPAIR_LOGIN_WAIT_FRACTION
     return max(0.0, budget - already_spent)
+
+
+def _what_is_left_of_this_call(already_spent: float) -> float:
+    """How much of the client's deadline the replay may still use.
+
+    The whole budget rather than the fraction above: waiting deliberately leaves
+    a share for this, and by here that share is whatever has not been spent. A
+    floor keeps a call that has already overrun from being handed a zero or
+    negative deadline, which would fail the replay before it started for a
+    session that now exists.
+    """
+    from linkedin_mcp_server.config import get_config
+
+    budget = get_config().server.tool_timeout_seconds
+    return max(_MINIMUM_REPLAY_SECONDS, budget - already_spent)
 
 
 #: Namespaced so a future fastmcp key cannot shadow it. Measured: a custom key
@@ -244,8 +265,7 @@ class FrontendAuthRepairMiddleware(Middleware):
             # every login a person actually performs.
             #
             # So wait the login out here. This is the process that has somewhere
-            # to show it, the client is waiting on this one call, and the tool
-            # timeout above bounds how long that can last.
+            # to show it, and the client is waiting on this one call.
             left = _how_long_to_wait_for_the_sign_in(time.monotonic() - began)
             if not await _wait_for_the_sign_in(left):
                 logger.info("The sign-in did not finish in time; not replaying")
@@ -266,7 +286,22 @@ class FrontendAuthRepairMiddleware(Middleware):
             return result
 
         logger.info("Signed in; running the call again")
-        return await call_next(context)
+        # Bounded by what is left of this call, not given a fresh budget. Nothing
+        # below this middleware bounds the whole path: the forwarded call has its
+        # own deadline per hop (`daemon_proxy.create_proxy_provider`), so the
+        # first call, the wait and the replay each stay inside one, while their
+        # sum is not bounded by anything. Measured shape: a sign-in finishing
+        # near the end of the wait, followed by a replay taking a full budget of
+        # its own, put the client past its deadline with the answer already in
+        # hand. Timing out here instead spends the last of the budget on the
+        # answer and, when it does not arrive, returns the owner's readable
+        # failure rather than a bare transport error.
+        remaining = _what_is_left_of_this_call(time.monotonic() - began)
+        try:
+            return await asyncio.wait_for(call_next(context), timeout=remaining)
+        except (TimeoutError, asyncio.TimeoutError):
+            logger.info("The replayed call ran out of time; reporting the failure")
+            return result
 
 
 def _readable_marker(result: ToolResult) -> dict[str, Any] | None:

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -71,7 +71,14 @@ MARKER_KEY = "linkedin.dev/auth"
 #: does not know and has to ignore them. The reverse cannot arise: a newer
 #: frontend asks an older owner to stand down and elects a replacement, so it
 #: never talks to an owner that predates a version it understands.
-MARKER_VERSION = 1
+#:
+#: 2 adds ``generation``, and the bump is what makes it safe. A version-1 reader
+#: accepts a version-1 marker, ignores fields it does not know, and repairs
+#: without passing the generation on, which is the unguarded path that rotates a
+#: peer's fresh session away. Refusing the marker outright leaves that frontend
+#: reporting the owner's failure instead, which is the worse-informed but honest
+#: outcome, and it is the one this version number buys.
+MARKER_VERSION = 2
 
 
 def _auth_failure_in(exc: BaseException) -> OwnerCannotAuthenticateError | None:
@@ -120,8 +127,14 @@ class OwnerAuthSignalMiddleware(Middleware):
                 # "this is still the dead one" from "somebody else already fixed
                 # it". Two frontends meeting one dead session would otherwise both
                 # rotate, and the second would destroy the first's fresh login.
-                # None is a value: a rotated profile has no generation at all.
-                "generation": _broken_generation(),
+                #
+                # Taken from the failure rather than read again here. By this
+                # point the browser has closed and the profile lease is free, so a
+                # fresh read can return a generation another process has just
+                # written, and the frontend would then rotate away exactly the
+                # session it was told about. The owner's latch was armed from the
+                # same observation, so the two cannot disagree.
+                "generation": failure.generation,
             }
             logger.info(
                 "Asking the client to sign in (%s, replayable=%s)",
@@ -243,6 +256,14 @@ async def _repair_auth_locally(reason: str, generation: str | None) -> None:
         start_login_if_needed,
     )
 
+    if reason == "missing":
+        # The generation goes with it too. A missing session is diagnosed from
+        # disk, so two frontends can reach this at once, and the login itself
+        # rotates once it holds the profile: without the generation the second
+        # one retires the session the first has just created.
+        await start_login_if_needed(superseded_by=generation)
+        return
+
     if reason == "stale":
         # The old session is still on disk and still does not work, so readiness
         # would keep passing it. This is the path that retires it first, and it
@@ -251,22 +272,3 @@ async def _repair_auth_locally(reason: str, generation: str | None) -> None:
         # The generation goes with it so a frontend arriving late does not rotate
         # away a session another one has already established.
         await invalidate_auth_and_trigger_relogin(stale_generation=generation)
-    else:
-        await start_login_if_needed()
-
-
-def _broken_generation() -> str | None:
-    """Which login generation the owner is complaining about.
-
-    Read here rather than carried on the exception, because by this point the
-    browser has closed and the owner has latched onto exactly this value: reading
-    it in one place keeps the marker and the latch from ever disagreeing about
-    which session was the bad one.
-    """
-    from linkedin_mcp_server.bootstrap import current_login_generation
-
-    try:
-        return current_login_generation()
-    except Exception:  # noqa: BLE001 - a marker must not fail on a probe
-        logger.debug("Could not read the login generation", exc_info=True)
-        return None

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -116,6 +116,12 @@ class OwnerAuthSignalMiddleware(Middleware):
                 else "stale",
                 "replayable": failure.nothing_ran_yet,
                 "browser_open": _browser_still_holds_the_profile(),
+                # Which session the owner found broken, so the frontend can tell
+                # "this is still the dead one" from "somebody else already fixed
+                # it". Two frontends meeting one dead session would otherwise both
+                # rotate, and the second would destroy the first's fresh login.
+                # None is a value: a rotated profile has no generation at all.
+                "generation": _broken_generation(),
             }
             logger.info(
                 "Asking the client to sign in (%s, replayable=%s)",
@@ -179,7 +185,7 @@ class FrontendAuthRepairMiddleware(Middleware):
             return result
 
         try:
-            await _repair_auth_locally(marker["reason"])
+            await _repair_auth_locally(marker["reason"], marker["generation"])
         except Exception:
             # The login path reports itself through its own exceptions, which the
             # tool layer turns into readable messages. Whatever happened, the
@@ -221,10 +227,12 @@ def _readable_marker(result: ToolResult) -> dict[str, Any] | None:
         marker.get("browser_open"), bool
     ):
         return None
+    if not isinstance(marker.get("generation"), (str, type(None))):
+        return None
     return marker
 
 
-async def _repair_auth_locally(reason: str) -> None:
+async def _repair_auth_locally(reason: str, generation: str | None) -> None:
     """Get a usable session onto disk, in this process.
 
     Imported here rather than at module scope: this module is imported when a
@@ -239,6 +247,26 @@ async def _repair_auth_locally(reason: str) -> None:
         # The old session is still on disk and still does not work, so readiness
         # would keep passing it. This is the path that retires it first, and it
         # always raises: the login it starts is what the caller waits on.
-        await invalidate_auth_and_trigger_relogin()
+        #
+        # The generation goes with it so a frontend arriving late does not rotate
+        # away a session another one has already established.
+        await invalidate_auth_and_trigger_relogin(stale_generation=generation)
     else:
         await start_login_if_needed()
+
+
+def _broken_generation() -> str | None:
+    """Which login generation the owner is complaining about.
+
+    Read here rather than carried on the exception, because by this point the
+    browser has closed and the owner has latched onto exactly this value: reading
+    it in one place keeps the marker and the latch from ever disagreeing about
+    which session was the bad one.
+    """
+    from linkedin_mcp_server.bootstrap import current_login_generation
+
+    try:
+        return current_login_generation()
+    except Exception:  # noqa: BLE001 - a marker must not fail on a probe
+        logger.debug("Could not read the login generation", exc_info=True)
+        return None

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -50,6 +50,7 @@ import mcp.types as mt
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 
+from linkedin_mcp_server.session_state import PeerSessionInPlaceError
 from linkedin_mcp_server.exceptions import (
     AuthMissingOnOwnerError,
     OwnerCannotAuthenticateError,
@@ -199,6 +200,12 @@ class FrontendAuthRepairMiddleware(Middleware):
 
         try:
             await _repair_auth_locally(marker["reason"], marker["generation"])
+        except PeerSessionInPlaceError:
+            # Not a failure: another client signed in while this one was asking
+            # to, so the session the call needs already exists. Treating it as a
+            # failed repair would refuse the replay and send the user back for a
+            # retry that was not needed.
+            logger.info("Another client already signed in; using its session")
         except Exception:
             # The login path reports itself through its own exceptions, which the
             # tool layer turns into readable messages. Whatever happened, the

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -50,13 +50,19 @@ import mcp.types as mt
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 
+from linkedin_mcp_server.config.schema import AUTH_REPAIR_LOGIN_WAIT_SECONDS
 from linkedin_mcp_server.session_state import PeerSessionInPlaceError
 from linkedin_mcp_server.exceptions import (
+    AuthenticationInProgressError,
+    AuthenticationStartedError,
     AuthMissingOnOwnerError,
     OwnerCannotAuthenticateError,
 )
 
 logger = logging.getLogger(__name__)
+
+#: Local alias so the wait and its reasoning read together at the call site.
+_LOGIN_WAIT_SECONDS = AUTH_REPAIR_LOGIN_WAIT_SECONDS
 
 #: Namespaced so a future fastmcp key cannot shadow it. Measured: a custom key
 #: coexists with fastmcp's own ``{'fastmcp': {...}}`` entry as a separate
@@ -206,6 +212,24 @@ class FrontendAuthRepairMiddleware(Middleware):
             # failed repair would refuse the replay and send the user back for a
             # retry that was not needed.
             logger.info("Another client already signed in; using its session")
+        except (AuthenticationStartedError, AuthenticationInProgressError):
+            # Also not a failure, and the one that mattered most. Both functions
+            # behind `_repair_auth_locally` report a *started* login by raising,
+            # while the window is still open and nobody has typed anything yet.
+            # Read as a failure, every repair this middleware exists to perform
+            # was abandoned one step before it worked: measured on the stale path
+            # with a login that finished successfully, the owner was called once
+            # and the client still got the error. The missing path did the same
+            # as soon as signing in took longer than the inline budget, which is
+            # every login a person actually performs.
+            #
+            # So wait the login out here. This is the process that has somewhere
+            # to show it, the client is waiting on this one call, and the tool
+            # timeout above bounds how long that can last.
+            if not await _wait_for_the_sign_in(_LOGIN_WAIT_SECONDS):
+                logger.info("The sign-in did not finish in time; not replaying")
+                return result
+            logger.info("The sign-in finished")
         except Exception:
             # The login path reports itself through its own exceptions, which the
             # tool layer turns into readable messages. Whatever happened, the
@@ -250,6 +274,18 @@ def _readable_marker(result: ToolResult) -> dict[str, Any] | None:
     if not isinstance(marker.get("generation"), (str, type(None))):
         return None
     return marker
+
+
+async def _wait_for_the_sign_in(timeout: float) -> bool:
+    """Whether a session exists once the login this process started has run.
+
+    Imported at the call rather than at module scope, like the repair below and
+    for the same reason: the login path pulls in the browser stack, and this
+    module is imported whenever a server is assembled.
+    """
+    from linkedin_mcp_server.bootstrap import wait_for_login_to_finish
+
+    return await wait_for_login_to_finish(timeout)
 
 
 async def _repair_auth_locally(reason: str, generation: str | None) -> None:

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -44,13 +44,14 @@ one ``except`` clause.
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 import mcp.types as mt
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 
-from linkedin_mcp_server.config.schema import AUTH_REPAIR_LOGIN_WAIT_SECONDS
+from linkedin_mcp_server.config.schema import AUTH_REPAIR_LOGIN_WAIT_FRACTION
 from linkedin_mcp_server.session_state import PeerSessionInPlaceError
 from linkedin_mcp_server.exceptions import (
     AuthenticationInProgressError,
@@ -61,8 +62,26 @@ from linkedin_mcp_server.exceptions import (
 
 logger = logging.getLogger(__name__)
 
-#: Local alias so the wait and its reasoning read together at the call site.
-_LOGIN_WAIT_SECONDS = AUTH_REPAIR_LOGIN_WAIT_SECONDS
+
+def _how_long_to_wait_for_the_sign_in(already_spent: float) -> float:
+    """How much of this call is left to spend waiting for the login.
+
+    Read per call rather than fixed at import, because the budget it comes from
+    is a user setting: a fixed value was measured to outlive the call it was
+    spent inside once ``TOOL_TIMEOUT`` was lowered, replacing a readable answer
+    with a bare timeout.
+
+    *already_spent* is subtracted rather than ignored, and measuring caught that
+    too: the fraction alone still overran, because the owner call and the inline
+    login wait had gone before this is reached, and both come out of the same
+    budget. Never negative, so an already-overrun call skips the wait and answers
+    rather than waiting on a deadline that has passed.
+    """
+    from linkedin_mcp_server.config import get_config
+
+    budget = get_config().server.tool_timeout_seconds * AUTH_REPAIR_LOGIN_WAIT_FRACTION
+    return max(0.0, budget - already_spent)
+
 
 #: Namespaced so a future fastmcp key cannot shadow it. Measured: a custom key
 #: coexists with fastmcp's own ``{'fastmcp': {...}}`` entry as a separate
@@ -188,6 +207,7 @@ class FrontendAuthRepairMiddleware(Middleware):
         context: MiddlewareContext[mt.CallToolRequestParams],
         call_next: CallNext[mt.CallToolRequestParams, ToolResult],
     ) -> ToolResult:
+        began = time.monotonic()
         result = await call_next(context)
         marker = _readable_marker(result)
         if marker is None:
@@ -226,7 +246,8 @@ class FrontendAuthRepairMiddleware(Middleware):
             # So wait the login out here. This is the process that has somewhere
             # to show it, the client is waiting on this one call, and the tool
             # timeout above bounds how long that can last.
-            if not await _wait_for_the_sign_in(_LOGIN_WAIT_SECONDS):
+            left = _how_long_to_wait_for_the_sign_in(time.monotonic() - began)
+            if not await _wait_for_the_sign_in(left):
                 logger.info("The sign-in did not finish in time; not replaying")
                 return result
             logger.info("The sign-in finished")

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -306,24 +306,31 @@ class FrontendAuthRepairMiddleware(Middleware):
             logger.info("Signed in; not repeating a call that had already started")
             return result
 
-        logger.info("Signed in; running the call again")
-
         if await _the_tool_changes_something(context):
-            # Never timed out locally, and this is the one case where waiting
-            # longer is the safer answer. Giving up here does not stop the owner:
-            # cancellation is not forwarded across the hop
-            # (`daemon_proxy._TIMEOUT_MARGIN_SECONDS` records the same), so the
-            # frontend would report the old auth failure while the owner went on
-            # to send the message. Measured over a real loopback owner: the
-            # client was answered at 0.66s with an error, and the owner appended
-            # its effect 0.7s later. The user then retries something that already
-            # happened.
+            # Repaired, but not run again. The auth is fixed and the next call
+            # will work; what this one gets is the owner's own message, which
+            # already says to retry.
             #
-            # An overrun client call is the lesser harm: the deadline belongs to
-            # the client, which can give up on its own, and doing so leaves the
-            # same one call outstanding rather than a second one queued behind it.
-            return await call_next(context)
+            # An auto-replay cannot be made safe here, and two rounds of trying
+            # showed why. Bounding it locally left the owner finishing the
+            # mutation after the frontend had reported failure: cancellation is
+            # not forwarded across the hop, which
+            # `daemon_proxy._TIMEOUT_MARGIN_SECONDS` already records. Measured
+            # over a real loopback owner, the client was answered at 0.66s with
+            # an error and the effect landed 0.7s later. Removing the bound only
+            # moved the deadline: an MCP client that gives up on its own call
+            # produces exactly the same orphan, measured as effects `['sent']`
+            # after the cancel and `['sent', 'sent']` after the retry.
+            #
+            # Nothing this process can do closes that, because the deadline that
+            # matters belongs to a client it does not control. So the decision
+            # goes where the information is: the user knows whether the message
+            # was sent, and asking costs one retry, while guessing wrong sends it
+            # twice. Read-only tools keep the replay, which is where it pays.
+            logger.info("Signed in; not repeating a call that could change something")
+            return result
 
+        logger.info("Signed in; running the call again")
         # Read-only, so bounded by what is left of this call rather than given a
         # fresh budget. Nothing below this middleware bounds the whole path: the
         # forwarded call has its own deadline per hop

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -61,7 +61,11 @@ from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.daemon_lock import DaemonLock, DaemonLockError
 from linkedin_mcp_server.drivers.browser import set_headless
 from linkedin_mcp_server.logging_config import configure_logging
-from linkedin_mcp_server.server_role import ServerRole, set_process_role
+from linkedin_mcp_server.server_role import (
+    ServerRole,
+    set_process_role,
+    stand_down_reason,
+)
 from linkedin_mcp_server.session_state import auth_root_dir, get_runtime_id
 
 logger = logging.getLogger(__name__)
@@ -420,14 +424,29 @@ _FAILED_STARTUP_SHUTDOWN_SECONDS = 10.0
 async def _serve_until_stopped(
     server: Any, serving: asyncio.Task[None], turnover: list[str]
 ) -> None:
-    """Hold the endpoint open until it stops, or until a newer build asks.
+    """Hold the endpoint open until it stops, or until asked to give way.
 
-    The stand-down request is noticed here rather than acted on inside the
-    route, so the asking frontend gets its reply before this process goes away.
-    Stopping mid-request would leave it unable to tell a completed turnover from
-    a refusal, and it would then wait for a lock this process had not yet freed.
+    Two things ask, for unrelated reasons, and they are noticed in the same place
+    because the answer is the same: a newer build wants the browser, or this
+    process can no longer drive it. Both are noticed here rather than acted on
+    where they arise, so the request in flight gets its reply before this process
+    goes away. Stopping mid-request would leave the caller unable to tell a
+    completed handover from a refusal, and it would then wait for a lock this
+    process had not yet freed.
     """
     while not serving.done():
+        wedged = stand_down_reason()
+        if wedged is not None:
+            # Not recoverable in place, which is what separates this from every
+            # other error an owner reports and keeps serving after. The profile
+            # is held until this process exits, so exiting *is* the recovery: the
+            # kernel frees the daemon lock and the next call elects an owner that
+            # can open the profile. Nothing is lost, because the session lives on
+            # disk rather than in this process.
+            logger.warning("Standing down: %s", wedged)
+            server.should_exit = True
+            await _stop_within(serving, _STAND_DOWN_SHUTDOWN_SECONDS)
+            return
         if turnover:
             logger.info("A newer build asked for the browser; standing down")
             server.should_exit = True

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -30,7 +30,11 @@ from linkedin_mcp_server.exceptions import (
 )
 from linkedin_mcp_server.profile_lease import get_profile_lease
 from linkedin_mcp_server.scraping import LinkedInExtractor
-from linkedin_mcp_server.server_role import ServerRole, process_role
+from linkedin_mcp_server.server_role import (
+    ServerRole,
+    ask_this_process_to_stand_down,
+    process_role,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +121,20 @@ async def handle_auth_error(
         # the reasoning that only a marker could mislead a client. Measured
         # otherwise: the single-process server reported "a login browser window
         # has been opened", opened none, and left a state only a restart clears.
+        if process_role() is ServerRole.OWNER:
+            # For a single-process server the message below is actionable: the
+            # client restarts its server and the lock goes with it. For a
+            # detached owner it is not. This process outlives the client that
+            # started it, so restarting the client elects nothing — the next
+            # frontend attaches to this same owner and meets the same held
+            # profile, and only killing it by hand recovers.
+            #
+            # So it removes itself instead. It holds no state a restart would
+            # lose: the session is on disk, the lock is released by the exit, and
+            # the next call elects a fresh owner that opens the profile cleanly.
+            ask_this_process_to_stand_down(
+                "the browser did not shut down cleanly, so the profile is held"
+            )
         raise BrowserShutdownUnconfirmedError() from error
 
     if process_role() is ServerRole.OWNER:

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -122,6 +122,9 @@ async def handle_auth_error(
             "cannot sign in by itself. Retry this tool: the client will open a "
             "login window.",
             nothing_ran_yet=nothing_ran_yet,
+            # The same observation the latch was armed with, so the two can never
+            # name different sessions.
+            generation=broken_generation,
         ) from error
 
     await invalidate_auth_and_trigger_relogin(ctx)  # always raises

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -93,9 +93,11 @@ async def handle_auth_error(
     # on that: any future caller reaching here without the middleware, or any
     # change that releases the lease sooner, would otherwise latch onto a
     # generation written by the login it is about to ask for.
-    broken_generation = (
-        current_login_generation() if process_role() is ServerRole.OWNER else None
-    )
+    # Read for every role, not only the owner. A DIRECT server rotates through
+    # `invalidate_auth_and_trigger_relogin` exactly as a frontend does, so
+    # without this it reaches the rotation with nothing to compare against and
+    # the guard downstream reads the dead session as a peer's repair.
+    broken_generation = current_login_generation()
 
     logger.warning("Stale session detected; closing browser and triggering re-login")
     try:
@@ -127,7 +129,9 @@ async def handle_auth_error(
             generation=broken_generation,
         ) from error
 
-    await invalidate_auth_and_trigger_relogin(ctx)  # always raises
+    await invalidate_auth_and_trigger_relogin(
+        ctx, stale_generation=broken_generation
+    )  # always raises
 
 
 async def get_ready_extractor(

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -32,7 +32,7 @@ from linkedin_mcp_server.profile_lease import get_profile_lease
 from linkedin_mcp_server.scraping import LinkedInExtractor
 from linkedin_mcp_server.server_role import (
     ServerRole,
-    ask_this_process_to_stand_down,
+    a_held_profile_means_this_owner_must_go,
     process_role,
 )
 
@@ -58,36 +58,6 @@ def _is_browser_binary_missing_error(error: Exception) -> bool:
         "looks like playwright was just installed or updated",
     )
     return any(marker in message for marker in markers)
-
-
-def _ask_a_wedged_owner_to_give_way() -> None:
-    """Ask this process to exit, if it is an owner the profile is stuck on.
-
-    For a single-process server the "restart the server" message is actionable:
-    the client owns it, and restarting frees the lock. For a detached owner it is
-    not. It outlives the client that started it, so restarting the client elects
-    nothing — the next frontend attaches to this same owner and meets the same
-    held profile, and only killing it by hand recovers.
-
-    So it removes itself instead. It holds no state a restart would lose: the
-    session is on disk, the lock is released by the exit, and the next call
-    elects a fresh owner that opens the profile cleanly.
-
-    Reads the lease itself rather than taking the answer as an argument, because
-    it runs from a ``finally`` that a cancellation passes through, where there is
-    no caller left to have worked it out.
-    """
-    if process_role() is not ServerRole.OWNER:
-        return
-    try:
-        if not get_profile_lease().browser_open:
-            return
-    except Exception:  # noqa: BLE001 - a probe must not replace the real failure
-        logger.debug("Could not read the profile lease state", exc_info=True)
-        return
-    ask_this_process_to_stand_down(
-        "the browser did not shut down cleanly, so the profile is held"
-    )
 
 
 async def handle_auth_error(
@@ -153,7 +123,7 @@ async def handle_auth_error(
         # Only the request is made here. The exception below still has to be
         # raised on the normal path, and a cancelled call has nobody left to
         # raise it to, so what has to survive the cancellation is exactly this.
-        _ask_a_wedged_owner_to_give_way()
+        a_held_profile_means_this_owner_must_go()
 
     if get_profile_lease().browser_open:
         # The teardown could not be confirmed, so Chromium may still be on the

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -60,6 +60,36 @@ def _is_browser_binary_missing_error(error: Exception) -> bool:
     return any(marker in message for marker in markers)
 
 
+def _ask_a_wedged_owner_to_give_way() -> None:
+    """Ask this process to exit, if it is an owner the profile is stuck on.
+
+    For a single-process server the "restart the server" message is actionable:
+    the client owns it, and restarting frees the lock. For a detached owner it is
+    not. It outlives the client that started it, so restarting the client elects
+    nothing — the next frontend attaches to this same owner and meets the same
+    held profile, and only killing it by hand recovers.
+
+    So it removes itself instead. It holds no state a restart would lose: the
+    session is on disk, the lock is released by the exit, and the next call
+    elects a fresh owner that opens the profile cleanly.
+
+    Reads the lease itself rather than taking the answer as an argument, because
+    it runs from a ``finally`` that a cancellation passes through, where there is
+    no caller left to have worked it out.
+    """
+    if process_role() is not ServerRole.OWNER:
+        return
+    try:
+        if not get_profile_lease().browser_open:
+            return
+    except Exception:  # noqa: BLE001 - a probe must not replace the real failure
+        logger.debug("Could not read the profile lease state", exc_info=True)
+        return
+    ask_this_process_to_stand_down(
+        "the browser did not shut down cleanly, so the profile is held"
+    )
+
+
 async def handle_auth_error(
     error: AuthenticationError,
     ctx: Context | None,
@@ -108,6 +138,22 @@ async def handle_auth_error(
         await close_browser()
     except Exception as close_exc:
         logger.warning("Failed to close stale browser (ignored): %s", close_exc)
+    finally:
+        # In a `finally`, and that is the whole point of it. `close_browser`
+        # defers cancellation until teardown finishes and then re-raises
+        # `CancelledError` (`drivers/browser.py:747-757`), which is a
+        # `BaseException` and passes straight through the `except Exception`
+        # above. A tool timeout landing during the close therefore skipped
+        # everything below, and a wedged owner stayed wedged.
+        #
+        # Measured: `wait_for(handle_auth_error(...), 0.02)` against a close that
+        # defers its cancel left `stand_down_reason()` at None with the lease
+        # still held.
+        #
+        # Only the request is made here. The exception below still has to be
+        # raised on the normal path, and a cancelled call has nobody left to
+        # raise it to, so what has to survive the cancellation is exactly this.
+        _ask_a_wedged_owner_to_give_way()
 
     if get_profile_lease().browser_open:
         # The teardown could not be confirmed, so Chromium may still be on the
@@ -121,20 +167,6 @@ async def handle_auth_error(
         # the reasoning that only a marker could mislead a client. Measured
         # otherwise: the single-process server reported "a login browser window
         # has been opened", opened none, and left a state only a restart clears.
-        if process_role() is ServerRole.OWNER:
-            # For a single-process server the message below is actionable: the
-            # client restarts its server and the lock goes with it. For a
-            # detached owner it is not. This process outlives the client that
-            # started it, so restarting the client elects nothing — the next
-            # frontend attaches to this same owner and meets the same held
-            # profile, and only killing it by hand recovers.
-            #
-            # So it removes itself instead. It holds no state a restart would
-            # lose: the session is on disk, the lock is released by the exit, and
-            # the next call elects a fresh owner that opens the profile cleanly.
-            ask_this_process_to_stand_down(
-                "the browser did not shut down cleanly, so the profile is held"
-            )
         raise BrowserShutdownUnconfirmedError() from error
 
     if process_role() is ServerRole.OWNER:

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -105,16 +105,21 @@ async def handle_auth_error(
     except Exception as close_exc:
         logger.warning("Failed to close stale browser (ignored): %s", close_exc)
 
-    if process_role() is ServerRole.OWNER:
-        if get_profile_lease().browser_open:
-            # The teardown could not be confirmed, so Chromium may still be on the
-            # profile and the lease is deliberately kept until this process exits
-            # (`drivers/browser.py:786-798`). Asking a client to sign in now would
-            # send it after a lease it can never take, and latching would then
-            # answer every later call from a state only a restart clears. Reported
-            # as what it is instead.
-            raise BrowserShutdownUnconfirmedError() from error
+    if get_profile_lease().browser_open:
+        # The teardown could not be confirmed, so Chromium may still be on the
+        # profile, and the lease is deliberately kept until this process exits
+        # (`drivers/browser.py:786-798`). Nothing that follows can work: a shared
+        # owner would send a client after a lease it can never take, and a
+        # single-process server would start a login whose own rotation is refused
+        # for the same reason, after telling the user a window had opened.
+        #
+        # Checked for every role, ahead of the split. It was owner-only once, on
+        # the reasoning that only a marker could mislead a client. Measured
+        # otherwise: the single-process server reported "a login browser window
+        # has been opened", opened none, and left a state only a restart clears.
+        raise BrowserShutdownUnconfirmedError() from error
 
+    if process_role() is ServerRole.OWNER:
         # The browser is down and the lease is free, so the client can take over.
         # Recorded before raising so the next forwarded call is answered from the
         # latch rather than by opening Chromium again.

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -38,6 +38,7 @@ from linkedin_mcp_server.exceptions import (
     BrowserShutdownUnconfirmedError,
 )
 from linkedin_mcp_server.profile_lease import get_profile_lease
+from linkedin_mcp_server.server_role import a_held_profile_means_this_owner_must_go
 from linkedin_mcp_server.session_state import (
     SourceState,
     clear_runtime_profile,
@@ -796,6 +797,15 @@ async def _close_browser_locked() -> None:
                 "Browser shutdown could not be confirmed; keeping the profile "
                 "lease until this process exits."
             )
+            # And for a shared owner, that sentence is the whole problem: it
+            # outlives the client that started it, so nobody is coming to restart
+            # it and every later call meets `BrowserBusyError`. Asked here rather
+            # than only where the failure is *reported*, because this path
+            # reports nothing at all: a handoff, the idle timeout and
+            # `close_session` all return normally from here, so no exception is
+            # ever constructed. Reproduced: close returned, lease kept,
+            # `stand_down_reason()` None, next launch refused.
+            a_held_profile_means_this_owner_must_go()
     logger.info("Browser closed")
 
 

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -594,6 +594,16 @@ async def _create_browser() -> BrowserManager:
         # process exits.
         lease.mark_browser_open()
         lease.try_acquire()
+        # After the marker, not before, and that ordering is the whole reason
+        # this call is here rather than only in the exception's constructor. The
+        # constructor runs while `_create_browser_locked` is still raising, when
+        # `browser_open` is false, so the helper reads "nothing is held" and
+        # returns; the two lines above then hold the profile with nobody having
+        # asked for a replacement. Measured through `_create_browser` in
+        # production order: `browser_open=True`, `stand_down=None`, and live, a
+        # real owner that three consecutive fresh clients each attached to and
+        # got the same refusal from.
+        a_held_profile_means_this_owner_must_go()
         raise
     except BaseException:
         # BaseException, not Exception: a cancelled startup would otherwise

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -802,8 +802,17 @@ async def _close_browser_locked() -> None:
         # Asked before re-raising, because the helper now treats a lease it
         # cannot read as held, which is exactly this situation. The original
         # failure still reaches the caller.
-        if not confirmed:
-            a_held_profile_means_this_owner_must_go()
+        #
+        # Whether Chromium closed cleanly makes no difference here, and an
+        # earlier version of this exempted the confirmed case on the reasoning
+        # that a proven-closed browser leaves the profile free. It does not: both
+        # `mark_browser_closed()` and `release()` need the object this lookup
+        # failed to produce, so a confirmed close strands the lease just as
+        # thoroughly. Measured with a real acquired lease: Chromium gone, the
+        # lease still held with its marker set, and this owner's own next launch
+        # refused with `BrowserBusyError` while nobody had asked for a
+        # replacement.
+        a_held_profile_means_this_owner_must_go()
         raise
     if confirmed:
         # Only now is Chromium provably gone, so only now may auth state move.

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -789,7 +789,22 @@ async def _close_browser_locked() -> None:
             logger.debug("Cookie export on close skipped", exc_info=True)
     confirmed = await browser.close()
 
-    lease = get_profile_lease()
+    try:
+        lease = get_profile_lease()
+    except Exception:
+        # The lookup is path-based, so it can fail on a profile directory that
+        # became unreadable while the browser was running, even though this
+        # process still holds the open descriptor. By here the singleton is
+        # already cleared, so every line that would have kept the profile safe
+        # is below this point and none of them runs. Measured in production
+        # order: browser cleared, the hold flag still set, and no stand-down.
+        #
+        # Asked before re-raising, because the helper now treats a lease it
+        # cannot read as held, which is exactly this situation. The original
+        # failure still reaches the caller.
+        if not confirmed:
+            a_held_profile_means_this_owner_must_go()
+        raise
     if confirmed:
         # Only now is Chromium provably gone, so only now may auth state move.
         lease.mark_browser_closed()

--- a/linkedin_mcp_server/error_handler.py
+++ b/linkedin_mcp_server/error_handler.py
@@ -38,6 +38,7 @@ from linkedin_mcp_server.exceptions import (
     OwnerCannotAuthenticateError,
     SessionExpiredError,
 )
+from linkedin_mcp_server.session_state import PeerSessionInPlaceError
 from linkedin_mcp_server.error_diagnostics import (
     build_issue_diagnostics,
     format_tool_error_with_diagnostics,
@@ -147,6 +148,14 @@ def raise_tool_error(exception: Exception, context: str = "") -> NoReturn:
 
     elif isinstance(exception, AuthenticationBootstrapFailedError):
         logger.warning("Authentication bootstrap failed%s: %s", ctx, exception)
+        raise ToolError(str(exception)) from exception
+
+    # Not a failure at all: another client signed in while this one was asking
+    # to. Diagnostics-free for the same reason as the branches above, and worth a
+    # branch of its own so it does not reach the catch-all, where an ordinary
+    # RuntimeError is masked into something the user cannot act on.
+    elif isinstance(exception, PeerSessionInPlaceError):
+        logger.info("Another client already signed in%s", ctx)
         raise ToolError(str(exception)) from exception
 
     # Its own branch rather than the LinkedInMCPError catch-all, which appends an

--- a/linkedin_mcp_server/exceptions.py
+++ b/linkedin_mcp_server/exceptions.py
@@ -154,11 +154,15 @@ class BrowserShutdownUnconfirmedError(LinkedInMCPError):
     the same wedged owner and got the same refusal.
 
     The request lives here rather than at the raise sites because that is what
-    makes it complete, and a count of them does not belong in this sentence: the
-    first draft said seven and there were nine. It sat at one site once, in
-    ``handle_auth_error``, and the path this was measured on never goes through
-    it -- the failure came from ``_authenticate_existing_profile``, deep in the
-    driver.
+    makes it complete. It sat at one site once, in ``handle_auth_error``, and the
+    path this was measured on never goes through it: the failure came from
+    ``_authenticate_existing_profile``, deep in the driver.
+
+    Not sufficient on its own, though, and the reason is an ordering. This runs
+    while the raise is still in flight, so a site that marks the profile held
+    *after* constructing the error is invisible here and has to ask for itself;
+    ``_create_browser`` is exactly that, and was measured wedged with this in
+    place.
     """
 
     def __init__(self, message: str | None = None):

--- a/linkedin_mcp_server/exceptions.py
+++ b/linkedin_mcp_server/exceptions.py
@@ -84,9 +84,22 @@ class OwnerCannotAuthenticateError(LinkedInMCPError):
     It defaults to False so a path that has not thought about it is not replayed.
     """
 
-    def __init__(self, message: str, *, nothing_ran_yet: bool = False) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        nothing_ran_yet: bool = False,
+        generation: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.nothing_ran_yet = nothing_ran_yet
+        #: The login generation this owner found broken, as observed at the
+        #: moment it decided. Carried rather than re-read later: the profile
+        #: lease is released once the browser closes, so a second read can see a
+        #: generation somebody else has just written, and a frontend acting on
+        #: that would rotate away the very session it names. ``None`` is a value
+        #: (a rotated profile has no generation), not an absence.
+        self.generation = generation
 
 
 class AuthMissingOnOwnerError(OwnerCannotAuthenticateError):

--- a/linkedin_mcp_server/exceptions.py
+++ b/linkedin_mcp_server/exceptions.py
@@ -145,6 +145,20 @@ class BrowserShutdownUnconfirmedError(LinkedInMCPError):
     must be left exactly as it is. Resetting it, restoring over it, or trying
     the next candidate would all write underneath a Chromium that may still be
     running.
+
+    Raising it also asks a shared owner to stand down, because for that process
+    the message below is not something anyone can act on: it outlives the client
+    that started it, so restarting the client re-attaches to the same held
+    profile. Measured live against a real detached owner, over a teardown that
+    timed out after 10 seconds: three consecutive fresh clients each attached to
+    the same wedged owner and got the same refusal.
+
+    The request lives here rather than at the raise sites because that is what
+    makes it complete, and a count of them does not belong in this sentence: the
+    first draft said seven and there were nine. It sat at one site once, in
+    ``handle_auth_error``, and the path this was measured on never goes through
+    it -- the failure came from ``_authenticate_existing_profile``, deep in the
+    driver.
     """
 
     def __init__(self, message: str | None = None):
@@ -155,6 +169,13 @@ class BrowserShutdownUnconfirmedError(LinkedInMCPError):
                 "still be running. Restart the server to recover."
             )
         )
+        # Imported here rather than at module scope: this module is imported by
+        # nearly everything, and `server_role` must stay free of cycles.
+        from linkedin_mcp_server.server_role import (
+            a_held_profile_means_this_owner_must_go,
+        )
+
+        a_held_profile_means_this_owner_must_go()
 
 
 class BrowserBusyError(LinkedInMCPError):

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -205,7 +205,14 @@ def create_mcp_server(
         mcp.add_middleware(OwnerAuthSignalMiddleware())
     # The other half, and only ever on the process that has a user in front of it.
     if role is ServerRole.PROXY:
-        mcp.add_middleware(FrontendAuthRepairMiddleware())
+        # Handed the same budget every tool here is given, rather than reading it
+        # from the configuration singleton. The two agree for a server `cli_main`
+        # built, which loaded that configuration first, and need not for one
+        # constructed directly: measured at `tool_timeout=1.2` with no
+        # configuration loaded, the repair budgeted itself 149.8 seconds of a
+        # 1.2-second call, and the first read of an unloaded singleton parses
+        # whatever `sys.argv` happens to hold.
+        mcp.add_middleware(FrontendAuthRepairMiddleware(tool_timeout=tool_timeout))
     # Profile ownership belongs to whoever launches Chromium. A process that
     # only forwards calls must not take the lease: it would either block itself
     # until its own timeout, or take the lease and leave the process that

--- a/linkedin_mcp_server/server_role.py
+++ b/linkedin_mcp_server/server_role.py
@@ -119,6 +119,36 @@ def process_role() -> ServerRole:
     return ServerRole.DIRECT if _role is None else _role
 
 
+#: Set when this process can no longer serve and has to be replaced.
+#:
+#: Only an owner uses it. A single-process server telling its own client to
+#: restart is an instruction someone can follow; a detached owner saying the same
+#: is not, because it outlives the client that started it and the next frontend
+#: attaches straight back to it. So the process that cannot recover has to remove
+#: itself, and the serve loop is the only place that can do it cleanly.
+_must_stand_down: list[str] = []
+
+
+def ask_this_process_to_stand_down(why: str) -> None:
+    """Record that this process must exit so a replacement can take over.
+
+    Recorded rather than acted on. This is called from inside a tool call, and an
+    owner that stopped serving mid-call would leave the client unable to tell a
+    completed handover from a refusal. The serve loop notices, finishes what is
+    in flight, and exits; the kernel frees the daemon lock, and the next call
+    elects a fresh owner.
+
+    Safe to call more than once, and cheap enough that no caller has to check
+    first.
+    """
+    _must_stand_down.append(why)
+
+
+def stand_down_reason() -> str | None:
+    """Why this process must exit, or ``None`` while it may keep serving."""
+    return _must_stand_down[0] if _must_stand_down else None
+
+
 def reset_process_role_for_testing() -> None:
     """Return to the unclaimed state, for test isolation.
 
@@ -127,3 +157,4 @@ def reset_process_role_for_testing() -> None:
     """
     global _role
     _role = None
+    _must_stand_down.clear()

--- a/linkedin_mcp_server/server_role.py
+++ b/linkedin_mcp_server/server_role.py
@@ -168,15 +168,25 @@ def a_held_profile_means_this_owner_must_go() -> None:
 
     Reads the lease itself. It runs from a ``finally`` a cancellation passes
     through, and from a teardown with no caller left to have worked it out.
+
+    A read that fails asks anyway. Not being able to tell is not the same as
+    being told the profile is free, and the two outcomes are not symmetric: an
+    unnecessary stand-down costs one election, while a stranded owner costs every
+    later call until somebody kills it by hand. Measured with the read raising
+    ``PermissionError``: the owner kept serving with the question unanswered.
+
+    Never raises. The caller is mid-teardown or mid-failure and has its own
+    exception to deliver.
     """
     if process_role() is not ServerRole.OWNER:
         return
     from linkedin_mcp_server.profile_lease import get_profile_lease
 
     try:
-        if not get_profile_lease().browser_open:
-            return
-    except Exception:  # noqa: BLE001 - a probe must not replace the real failure
+        held = get_profile_lease().browser_open
+    except Exception:  # noqa: BLE001 - unreadable is not the same as free
+        held = True
+    if not held:
         return
     ask_this_process_to_stand_down(
         "the browser did not shut down cleanly, so the profile is held"

--- a/linkedin_mcp_server/server_role.py
+++ b/linkedin_mcp_server/server_role.py
@@ -149,6 +149,40 @@ def stand_down_reason() -> str | None:
     return _must_stand_down[0] if _must_stand_down else None
 
 
+def a_held_profile_means_this_owner_must_go() -> None:
+    """Give way if this is an owner an unconfirmed teardown has stranded.
+
+    One function rather than the same three lines at each site, because the sites
+    kept being found one at a time. A browser whose shutdown could not be
+    confirmed keeps the profile lease until its process exits, deliberately. For
+    a single-process server the resulting "restart the server" is actionable: its
+    client owns it. A detached owner outlives that client, so restarting elects
+    nothing, every later call meets ``BrowserBusyError``, and only a manual kill
+    recovers. Measured live: three consecutive fresh clients attached to the same
+    stranded owner.
+
+    Called from wherever the lease is *kept*, not from wherever the failure is
+    reported, and the difference is what the third site turned on: the routine
+    close path returns normally, so a handoff, the idle timeout and
+    ``close_session`` strand an owner without raising anything at all.
+
+    Reads the lease itself. It runs from a ``finally`` a cancellation passes
+    through, and from a teardown with no caller left to have worked it out.
+    """
+    if process_role() is not ServerRole.OWNER:
+        return
+    from linkedin_mcp_server.profile_lease import get_profile_lease
+
+    try:
+        if not get_profile_lease().browser_open:
+            return
+    except Exception:  # noqa: BLE001 - a probe must not replace the real failure
+        return
+    ask_this_process_to_stand_down(
+        "the browser did not shut down cleanly, so the profile is held"
+    )
+
+
 def reset_process_role_for_testing() -> None:
     """Return to the unclaimed state, for test isolation.
 

--- a/linkedin_mcp_server/session_state.py
+++ b/linkedin_mcp_server/session_state.py
@@ -694,7 +694,52 @@ def _exclusive_profile(profile_dir: Path, *, action: str) -> Iterator[None]:
         lease.release()
 
 
-def rotate_source_profile(source_profile_dir: Path | None = None) -> Path | None:
+#: Distinguishes "no generation was observed" from "nothing asked for a guard".
+#: ``None`` cannot do both: a profile with no session reads as ``None``, and two
+#: clients meeting that state need protecting from each other exactly as much as
+#: two meeting a stale one. Measured with the two conflated: the second client
+#: rotated away the session the first had just created.
+UNGUARDED = object()
+
+
+def a_peer_already_signed_in(
+    user_data_dir: Path, superseded_by: str | None | object
+) -> bool:
+    """Whether a usable session other than *superseded_by* is on disk now.
+
+    Asked by every path that rotates the profile to make room for a new session,
+    which is the login here and the browser import next door, and asked only once
+    that path holds the profile lease. That is the first moment the answer cannot
+    change underneath it.
+
+    Both halves are needed. A different generation alone is not enough: an
+    abandoned attempt leaves the profile rotated and no generation at all, which
+    also reads as different, and standing down there would mean nobody ever signs
+    in. A usable session alone is not enough either, because the dead one still
+    looks usable from disk: readiness asks whether the files are there, not
+    whether LinkedIn still accepts them.
+
+    Together they mean what is wanted, because a generation is written only after
+    a login or import has validated its session and exported the cookies.
+    """
+    from linkedin_mcp_server.bootstrap import _auth_ready
+    from linkedin_mcp_server.session_state import load_source_state
+
+    state = load_source_state(user_data_dir)
+    if state is None or state.login_generation == superseded_by:
+        return False
+    # The same directory the generation came from. Asking about the configured
+    # one instead would answer a different question than the one asked, and
+    # quietly: a caller handed an explicit profile would get the default
+    # profile's verdict while rotating theirs.
+    return _auth_ready(user_data_dir)
+
+
+def rotate_source_profile(
+    source_profile_dir: Path | None = None,
+    *,
+    superseded_by: str | None | object = UNGUARDED,
+) -> Path | None:
     """Retire the current source session so the next one starts clean.
 
     Chromium mints ``machine_id``, ``session_id_generator_last_value`` and
@@ -707,8 +752,19 @@ def rotate_source_profile(source_profile_dir: Path | None = None) -> Path | None
     The retired artifacts are moved, not deleted, so a session that turns out to
     have been fine is still recoverable. ``--logout`` clears the quarantines.
 
+    *superseded_by* is the generation the caller found broken. Given one, this
+    retires nothing if a *different* usable session is on disk by the time the
+    profile is held, because somebody else has replaced it in the meantime.
+
+    The comparison belongs here rather than at the call site, and that is the
+    whole point of the argument. A caller deciding first and rotating afterwards
+    leaves a gap: measured, a peer completing a login inside it had its fresh
+    session quarantined by a process acting on a view formed before it existed.
+    Under the lease below, the answer cannot change between reading it and acting
+    on it.
+
     Returns the quarantine directory, or ``None`` when there was nothing to
-    retire.
+    retire, including when a peer's session is found in place.
 
     Raises:
         RuntimeError: Another process holds the profile. Rotating underneath a
@@ -725,6 +781,14 @@ def rotate_source_profile(source_profile_dir: Path | None = None) -> Path | None
         return None
 
     with _exclusive_profile(profile_dir, action="creating a new session"):
+        if superseded_by is not UNGUARDED and a_peer_already_signed_in(
+            profile_dir, superseded_by
+        ):
+            logger.info(
+                "Another client already signed in; leaving its session in place"
+            )
+            return None
+
         # utcnow_iso() is second-resolution and rotation is now routine rather
         # than exceptional, so two rotations can land in the same second. The
         # suffix keeps them from merging into one directory.

--- a/linkedin_mcp_server/session_state.py
+++ b/linkedin_mcp_server/session_state.py
@@ -702,6 +702,17 @@ def _exclusive_profile(profile_dir: Path, *, action: str) -> Iterator[None]:
 UNGUARDED = object()
 
 
+class PeerSessionInPlaceError(RuntimeError):
+    """A peer replaced the session this rotation was asked to retire.
+
+    Raised rather than returned as ``None``, which already means "there was
+    nothing to retire". The two look identical to a caller and are not: one is a
+    no-op, the other means somebody else has done the work and this caller should
+    stop rather than carry on as though it had. Measured with them conflated: the
+    caller went on to promise a login window that never opened.
+    """
+
+
 def a_peer_already_signed_in(
     user_data_dir: Path, superseded_by: str | None | object
 ) -> bool:
@@ -787,7 +798,10 @@ def rotate_source_profile(
             logger.info(
                 "Another client already signed in; leaving its session in place"
             )
-            return None
+            raise PeerSessionInPlaceError(
+                "Another LinkedIn MCP client has already signed in. Retry this "
+                "tool to use its session."
+            )
 
         # utcnow_iso() is second-resolution and rotation is now routine rather
         # than exceptional, so two rotations can land in the same second. The

--- a/linkedin_mcp_server/session_state.py
+++ b/linkedin_mcp_server/session_state.py
@@ -775,9 +775,14 @@ def rotate_source_profile(
     on it.
 
     Returns the quarantine directory, or ``None`` when there was nothing to
-    retire, including when a peer's session is found in place.
+    retire.
 
     Raises:
+        PeerSessionInPlaceError: Another client signed in first, so its session
+            is on disk and this rotation must not touch it. Distinct from the
+            ``None`` above, and the distinction is load-bearing: both mean "did
+            not rotate", but only one of them means a usable session now exists.
+            Conflated, the caller promised a login window it never opened.
         RuntimeError: Another process holds the profile. Rotating underneath a
             live Chromium corrupts both the old and the new session.
         OSError: A move failed. Whatever had already moved is put back first, so

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -22,6 +22,8 @@ from linkedin_mcp_server.core import (
 from linkedin_mcp_server.exceptions import BrowserBusyError
 from linkedin_mcp_server.profile_lease import ProfileLease, get_profile_lease
 from linkedin_mcp_server.session_state import (
+    UNGUARDED,
+    a_peer_already_signed_in,
     run_deferring_cancels,
     portable_cookie_path,
     restore_source_profile,
@@ -30,14 +32,6 @@ from linkedin_mcp_server.session_state import (
 )
 
 from linkedin_mcp_server.drivers.browser import close_browser, get_profile_dir
-
-
-#: Distinguishes "no generation was observed" from "nothing asked for a guard".
-#: ``None`` cannot do both: a profile with no session reads as ``None``, and two
-#: clients meeting that state need protecting from each other exactly as much as
-#: two meeting a stale one. Measured with the two conflated: the second client
-#: rotated away the session the first had just created.
-UNGUARDED = object()
 
 
 async def interactive_login(
@@ -368,36 +362,3 @@ def run_interactive_setup() -> bool:
     except Exception as e:
         print(f"Login failed: {e}")
         return False
-
-
-def a_peer_already_signed_in(
-    user_data_dir: Path, superseded_by: str | None | object
-) -> bool:
-    """Whether a usable session other than *superseded_by* is on disk now.
-
-    Asked by every path that rotates the profile to make room for a new session,
-    which is the login here and the browser import next door, and asked only once
-    that path holds the profile lease. That is the first moment the answer cannot
-    change underneath it.
-
-    Both halves are needed. A different generation alone is not enough: an
-    abandoned attempt leaves the profile rotated and no generation at all, which
-    also reads as different, and standing down there would mean nobody ever signs
-    in. A usable session alone is not enough either, because the dead one still
-    looks usable from disk: readiness asks whether the files are there, not
-    whether LinkedIn still accepts them.
-
-    Together they mean what is wanted, because a generation is written only after
-    a login or import has validated its session and exported the cookies.
-    """
-    from linkedin_mcp_server.bootstrap import _auth_ready
-    from linkedin_mcp_server.session_state import load_source_state
-
-    state = load_source_state(user_data_dir)
-    if state is None or state.login_generation == superseded_by:
-        return False
-    # The same directory the generation came from. Asking about the configured
-    # one instead would answer a different question than the one asked, and
-    # quietly: a caller handed an explicit profile would get the default
-    # profile's verdict while rotating theirs.
-    return _auth_ready(user_data_dir)

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -32,10 +32,18 @@ from linkedin_mcp_server.session_state import (
 from linkedin_mcp_server.drivers.browser import close_browser, get_profile_dir
 
 
+#: Distinguishes "no generation was observed" from "nothing asked for a guard".
+#: ``None`` cannot do both: a profile with no session reads as ``None``, and two
+#: clients meeting that state need protecting from each other exactly as much as
+#: two meeting a stale one. Measured with the two conflated: the second client
+#: rotated away the session the first had just created.
+UNGUARDED = object()
+
+
 async def interactive_login(
     user_data_dir: Path | None = None,
     *,
-    superseded_by: str | None = None,
+    superseded_by: str | None | object = UNGUARDED,
 ) -> bool:
     """
     Open browser for manual LinkedIn login with persistent profile.
@@ -46,10 +54,12 @@ async def interactive_login(
 
     Args:
         user_data_dir: Path to browser profile. Defaults to config's user_data_dir.
-        superseded_by: The login generation the caller believes is broken. When
-            given, the login stands down if a *different* usable session is on
-            disk by the time it holds the profile, because somebody else has
-            already done the work.
+        superseded_by: The login generation the caller believes is broken, or
+            ``None`` when it observed no session at all. Either way the login
+            stands down if a *different* usable session is on disk by the time it
+            holds the profile, because somebody else has already done the work.
+            Left at :data:`UNGUARDED` by callers with nothing to compare against,
+            such as ``--login`` typed at a terminal.
 
     Returns:
         True if login was successful, or a peer's session is already in place
@@ -87,26 +97,29 @@ async def interactive_login(
             "Another LinkedIn MCP client is using the browser, so a login "
             "cannot start. Close it and try again."
         )
-    # Checked here and nowhere earlier, because here is the first moment it can
-    # be trusted: the profile is held, so nothing can change underneath the
-    # answer. An earlier check, before the wait, is exactly what does not work.
-    # Two clients meeting one dead session both look, both see it dead, and both
-    # queue for the profile; the one that waited then holds a stale opinion. It
-    # would rotate the session the winner has just created, which was measured:
-    # the fresh generation ended up in quarantine and `load_source_state`
-    # returned None.
-    if superseded_by is not None and _a_peer_already_signed_in(
-        user_data_dir, superseded_by
-    ):
-        print("   Another client already signed in; using its session.")
-        lease.release()
-        return True
-
     # Every exit runs through one finally: a login can fail before the browser
     # opens (rotation errors, cancellation) or after it closed cleanly but with
     # an exception, and each of those must still settle the profile correctly.
     state = _LoginState()
     try:
+        # Checked here and nowhere earlier, because here is the first moment it
+        # can be trusted: the profile is held, so nothing can change underneath
+        # the answer. An earlier check, before the wait, is exactly what does not
+        # work. Two clients meeting one dead session both look, both see it dead,
+        # and both queue for the profile; the one that waited then holds a stale
+        # opinion. It would rotate the session the winner has just created, which
+        # was measured: the fresh generation ended up in quarantine and
+        # `load_source_state` returned None.
+        #
+        # Inside the try, so a failure while asking still releases the profile.
+        # Outside it, an unreadable profile directory left the lease held until
+        # the process exited, which locks out every other client.
+        if superseded_by is not UNGUARDED and a_peer_already_signed_in(
+            user_data_dir, superseded_by
+        ):
+            print("   Another client already signed in; using its session.")
+            return True
+
         return await _login_holding_the_profile(user_data_dir, lease, state)
     finally:
         if state.close_confirmed:
@@ -357,18 +370,25 @@ def run_interactive_setup() -> bool:
         return False
 
 
-def _a_peer_already_signed_in(user_data_dir: Path, superseded_by: str) -> bool:
+def a_peer_already_signed_in(
+    user_data_dir: Path, superseded_by: str | None | object
+) -> bool:
     """Whether a usable session other than *superseded_by* is on disk now.
 
+    Asked by every path that rotates the profile to make room for a new session,
+    which is the login here and the browser import next door, and asked only once
+    that path holds the profile lease. That is the first moment the answer cannot
+    change underneath it.
+
     Both halves are needed. A different generation alone is not enough: an
-    abandoned login leaves the profile rotated and no generation at all, which
-    also reads as different, and standing down there would mean nobody ever logs
+    abandoned attempt leaves the profile rotated and no generation at all, which
+    also reads as different, and standing down there would mean nobody ever signs
     in. A usable session alone is not enough either, because the dead one still
     looks usable from disk: readiness asks whether the files are there, not
     whether LinkedIn still accepts them.
 
     Together they mean what is wanted, because a generation is written only after
-    a login has validated its session and exported the cookies.
+    a login or import has validated its session and exported the cookies.
     """
     from linkedin_mcp_server.bootstrap import _auth_ready
     from linkedin_mcp_server.session_state import load_source_state

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -32,7 +32,11 @@ from linkedin_mcp_server.session_state import (
 from linkedin_mcp_server.drivers.browser import close_browser, get_profile_dir
 
 
-async def interactive_login(user_data_dir: Path | None = None) -> bool:
+async def interactive_login(
+    user_data_dir: Path | None = None,
+    *,
+    superseded_by: str | None = None,
+) -> bool:
     """
     Open browser for manual LinkedIn login with persistent profile.
 
@@ -42,9 +46,13 @@ async def interactive_login(user_data_dir: Path | None = None) -> bool:
 
     Args:
         user_data_dir: Path to browser profile. Defaults to config's user_data_dir.
+        superseded_by: The login generation the caller believes is broken. When
+            given, the login stands down if a *different* usable session is on
+            disk by the time it holds the profile, because somebody else has
+            already done the work.
 
     Returns:
-        True if login was successful
+        True if login was successful, or a peer's session is already in place
 
     Raises:
         Exception: If login fails or times out
@@ -69,16 +77,31 @@ async def interactive_login(user_data_dir: Path | None = None) -> bool:
     # lease of its own to reuse, so a momentary holder anywhere else would leave
     # the user with a login that refuses to open and no way to make it.
     #
-    # The wait is bounded by how long a *handover* takes, not by how long a person
-    # takes at the window: the holder notices a waiter on a one-second poll and
-    # gives the profile up after at most `browser_min_hold_seconds`. Past that,
-    # the holder is a process that is not going to release, and failing is more
-    # use than hanging.
+    # Bounded by how long someone who just asked to sign in should be left
+    # waiting, rather than by any worst case: a holder part way through a tool
+    # call will not hand over until it finishes, and that can run to the tool
+    # timeout. Past this the user is told the browser is busy, which they can act
+    # on, and which beats a silent wait of several minutes.
     if not await lease.acquire(timeout=PROFILE_HANDOVER_WAIT_SECONDS):
         raise BrowserBusyError(
             "Another LinkedIn MCP client is using the browser, so a login "
             "cannot start. Close it and try again."
         )
+    # Checked here and nowhere earlier, because here is the first moment it can
+    # be trusted: the profile is held, so nothing can change underneath the
+    # answer. An earlier check, before the wait, is exactly what does not work.
+    # Two clients meeting one dead session both look, both see it dead, and both
+    # queue for the profile; the one that waited then holds a stale opinion. It
+    # would rotate the session the winner has just created, which was measured:
+    # the fresh generation ended up in quarantine and `load_source_state`
+    # returned None.
+    if superseded_by is not None and _a_peer_already_signed_in(
+        user_data_dir, superseded_by
+    ):
+        print("   Another client already signed in; using its session.")
+        lease.release()
+        return True
+
     # Every exit runs through one finally: a login can fail before the browser
     # opens (rotation errors, cancellation) or after it closed cleanly but with
     # an exception, and each of those must still settle the profile correctly.
@@ -332,3 +355,25 @@ def run_interactive_setup() -> bool:
     except Exception as e:
         print(f"Login failed: {e}")
         return False
+
+
+def _a_peer_already_signed_in(user_data_dir: Path, superseded_by: str) -> bool:
+    """Whether a usable session other than *superseded_by* is on disk now.
+
+    Both halves are needed. A different generation alone is not enough: an
+    abandoned login leaves the profile rotated and no generation at all, which
+    also reads as different, and standing down there would mean nobody ever logs
+    in. A usable session alone is not enough either, because the dead one still
+    looks usable from disk: readiness asks whether the files are there, not
+    whether LinkedIn still accepts them.
+
+    Together they mean what is wanted, because a generation is written only after
+    a login has validated its session and exported the cookies.
+    """
+    from linkedin_mcp_server.bootstrap import _auth_ready
+    from linkedin_mcp_server.session_state import load_source_state
+
+    state = load_source_state(user_data_dir)
+    if state is None or state.login_generation == superseded_by:
+        return False
+    return _auth_ready()

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -396,4 +396,8 @@ def a_peer_already_signed_in(
     state = load_source_state(user_data_dir)
     if state is None or state.login_generation == superseded_by:
         return False
-    return _auth_ready()
+    # The same directory the generation came from. Asking about the configured
+    # one instead would answer a different question than the one asked, and
+    # quietly: a caller handed an explicit profile would get the default
+    # profile's verdict while rotating theirs.
+    return _auth_ready(user_data_dir)

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from linkedin_mcp_server.config import get_config
+from linkedin_mcp_server.config.schema import PROFILE_HANDOVER_WAIT_SECONDS
 from linkedin_mcp_server.core import (
     BrowserManager,
     goto_reporting_proxy_errors,
@@ -63,7 +64,17 @@ async def interactive_login(user_data_dir: Path | None = None) -> bool:
     # moment cookies are written, and another process could launch against it
     # while this browser is still open.
     lease = get_profile_lease(user_data_dir)
-    if not lease.try_acquire():
+    # Waited for rather than demanded outright, because this is also the path a
+    # frontend takes when the shared browser asks it to sign in. A proxy holds no
+    # lease of its own to reuse, so a momentary holder anywhere else would leave
+    # the user with a login that refuses to open and no way to make it.
+    #
+    # The wait is bounded by how long a *handover* takes, not by how long a person
+    # takes at the window: the holder notices a waiter on a one-second poll and
+    # gives the profile up after at most `browser_min_hold_seconds`. Past that,
+    # the holder is a process that is not going to release, and failing is more
+    # use than hanging.
+    if not await lease.acquire(timeout=PROFILE_HANDOVER_WAIT_SECONDS):
         raise BrowserBusyError(
             "Another LinkedIn MCP client is using the browser, so a login "
             "cannot start. Close it and try again."

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -75,7 +75,11 @@ def register_messaging_tools(
     @mcp.tool(
         timeout=tool_timeout,
         title="Get Conversation",
-        annotations={"readOnlyHint": True, "openWorldHint": True},
+        # Not read-only, though it reads: resolving a username enumerates the
+        # inbox by click-visiting rows, and LinkedIn marks a visited row as read.
+        # The docstring below has always said so. An unread message the user has
+        # not seen is state, and losing it is not something a reader should do.
+        annotations={"openWorldHint": True},
         tags={"messaging", "scraping"},
         exclude_args=["extractor"],
     )
@@ -154,7 +158,10 @@ def register_messaging_tools(
     @mcp.tool(
         timeout=tool_timeout,
         title="Search Conversations",
-        annotations={"readOnlyHint": True, "openWorldHint": True},
+        # Same reason as `get_conversation`: enumerating result rows selects them
+        # in LinkedIn's UI, which can mark them read. Its own `limit` argument is
+        # documented in those terms.
+        annotations={"openWorldHint": True},
         tags={"messaging", "search"},
         exclude_args=["extractor"],
     )

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1858,7 +1858,6 @@ def test_move_auth_state_aside_reports_a_held_profile(monkeypatch):
     """Swallowing this would open a login browser whose own rotation fails at
     the same point, after telling the user the browser had opened."""
     from linkedin_mcp_server import bootstrap
-    from linkedin_mcp_server.exceptions import AuthenticationBootstrapFailedError
 
     monkeypatch.setattr(
         bootstrap,
@@ -2218,16 +2217,16 @@ class TestTwoClientsMeetingOneDeadSession:
         assert fresh != stale
 
         # B arrives with the generation it was told about, which has moved on.
-        with pytest.raises(
-            AuthenticationBootstrapFailedError, match="already signed in"
-        ):
+        # It still starts a login, and that is right rather than weaker: B was
+        # asked to repair a session, so refusing outright would leave its caller
+        # with nothing. What must not happen is B retiring the session A just
+        # created, and the rotation decides that under the profile lock.
+        with pytest.raises(AuthenticationStartedError):
             await invalidate_auth_and_trigger_relogin(stale_generation=stale)
 
-        # Intact, and no second login window opened on top of the first.
         surviving = load_source_state(isolate_profile_dir)
         assert surviving is not None
         assert surviving.login_generation == fresh
-        login.assert_not_called()
 
     async def test_the_first_client_still_retires_the_session_it_found(
         self, isolate_profile_dir, monkeypatch

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1401,7 +1401,7 @@ class TestAutoLogin:
         async def fake_run_login_flow() -> None:
             spawn_count["value"] += 1
 
-        async def fake_import(_browser, *, user_data_dir):
+        async def fake_import(_browser, *, user_data_dir, **_kwargs):
             _make_auth_ready(isolate_profile_dir)
             return True
 
@@ -1481,7 +1481,7 @@ class TestAutoLogin:
         never_done = asyncio.Event()
         spawn_count = {"value": 0}
 
-        async def fake_import(_browser, *, user_data_dir):
+        async def fake_import(_browser, *, user_data_dir, **_kwargs):
             await release_import.wait()
             return False
 
@@ -1715,7 +1715,7 @@ class TestAutoLogin:
         async def spy_close_browser() -> None:
             order.append("close")
 
-        async def fake_import(_browser, *, user_data_dir):
+        async def fake_import(_browser, *, user_data_dir, **_kwargs):
             order.append("import")
             _make_auth_ready(isolate_profile_dir)
             return True
@@ -1751,7 +1751,7 @@ class TestAutoLogin:
     ):
         """ctx.info notice fires at most once per process; a ctx.info failure never blocks the import."""
 
-        async def fake_import(_browser, *, user_data_dir):
+        async def fake_import(_browser, *, user_data_dir, **_kwargs):
             return False  # nothing to import; falls through to manual login
 
         async def fake_login_flow() -> None:
@@ -2127,6 +2127,29 @@ class TestTheOwnerStaysQuiescentUntilANewSessionLands:
         with pytest.raises(AuthStaleOnOwnerError):
             await ensure_tool_ready_or_raise("get_person_profile")
 
+    async def test_every_later_call_names_the_same_broken_session(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """The latch must put its generation on the failures it raises.
+
+        Only the first call reaches this through `handle_auth_error`, which knows
+        what it observed. Every call after that is answered by the latch, and a
+        failure raised there without the generation gives the *second* client a
+        marker with nothing to compare against. That client then repairs
+        unguarded, and rotates away the session the first one is signing in for.
+        """
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.exceptions import AuthStaleOnOwnerError
+
+        self._write_session(isolate_profile_dir)
+        broken = bootstrap.current_login_generation()
+        self._quiescent_on(broken)
+
+        with pytest.raises(AuthStaleOnOwnerError) as caught:
+            bootstrap._raise_if_auth_quiescent()
+
+        assert caught.value.generation == broken
+
 
 class TestTwoClientsMeetingOneDeadSession:
     """Only one of them may retire it, and `_lock` cannot arrange that.
@@ -2253,3 +2276,41 @@ class TestTwoClientsMeetingOneDeadSession:
             await invalidate_auth_and_trigger_relogin(stale_generation=stale)
 
         login.assert_called_once()
+
+
+class TestTheAutoImportInheritsTheGuard:
+    """`start_login_if_needed` tries an import first, and it rotates too.
+
+    The guard has to reach it, not only the login window behind it. A client whose
+    keychain read or profile discovery ran long is the realistic late arrival, and
+    the import retires the current session the moment it holds the profile.
+    """
+
+    async def test_the_generation_reaches_the_import(
+        self, isolate_profile_dir, monkeypatch, _stub_import_env
+    ):
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        # Installed rather than loaded: the import path calls get_config(), which
+        # parses sys.argv, and under pytest that is pytest's own command line.
+        config = AppConfig()
+        config.browser.auto_import_from_browser = True
+        set_config(config)
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
+
+        seen: dict[str, object] = {}
+
+        async def fake_import(_browser, *, user_data_dir, **kwargs):
+            seen.update(kwargs)
+            return False
+
+        monkeypatch.setattr(_IMPORT_TARGET, fake_import)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._run_login_flow", AsyncMock()
+        )
+
+        with pytest.raises(AuthenticationInProgressError):
+            await _start_login_if_needed(superseded_by="the-broken-one")
+
+        assert seen.get("superseded_by") == "the-broken-one"

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -860,7 +860,7 @@ class TestLazyFullChromiumTrigger:
         async def fake_full() -> None:
             order.append("full")
 
-        async def fake_login(_profile_dir) -> bool:
+        async def fake_login(_profile_dir, *, superseded_by=None) -> bool:
             order.append("login")
             return True
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -46,6 +46,7 @@ from linkedin_mcp_server.exceptions import (
     NoLinkedInSessionFoundError,
 )
 from linkedin_mcp_server.session_state import (
+    PeerSessionInPlaceError,
     portable_cookie_path,
     source_state_path,
 )
@@ -2216,14 +2217,14 @@ class TestTwoClientsMeetingOneDeadSession:
         fresh = bootstrap.current_login_generation()
         assert fresh != stale
 
-        # B arrives with the generation it was told about, which has moved on.
-        # It still starts a login, and that is right rather than weaker: B was
-        # asked to repair a session, so refusing outright would leave its caller
-        # with nothing. What must not happen is B retiring the session A just
-        # created, and the rotation decides that under the profile lock.
-        with pytest.raises(AuthenticationStartedError):
+        # B is told what actually happened, and no login is scheduled. An earlier
+        # version of this test accepted AuthenticationStartedError here, which
+        # blessed a false report: the caller was promised a login window, none
+        # opened, because the task stood down the moment it held the profile.
+        with pytest.raises(PeerSessionInPlaceError, match="already signed in"):
             await invalidate_auth_and_trigger_relogin(stale_generation=stale)
 
+        assert get_bootstrap_state().login_task is None
         surviving = load_source_state(isolate_profile_dir)
         assert surviving is not None
         assert surviving.login_generation == fresh

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -36,6 +36,7 @@ from linkedin_mcp_server.bootstrap import (
 from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.core.exceptions import NetworkError
 from linkedin_mcp_server.exceptions import (
+    AuthenticationBootstrapFailedError,
     AuthenticationInProgressError,
     AuthenticationStartedError,
     BrowserSetupInProgressError,
@@ -2125,3 +2126,130 @@ class TestTheOwnerStaysQuiescentUntilANewSessionLands:
         # Through the real pre-tool gate, which is what a forwarded call hits.
         with pytest.raises(AuthStaleOnOwnerError):
             await ensure_tool_ready_or_raise("get_person_profile")
+
+
+class TestTwoClientsMeetingOneDeadSession:
+    """Only one of them may retire it, and `_lock` cannot arrange that.
+
+    Two frontends can be told to sign in for the same dead session. The lock
+    around this function is process-local, so it serializes each process against
+    itself and knows nothing about the other one.
+    """
+
+    def _write_session(self, profile_dir):
+        from linkedin_mcp_server.session_state import (
+            portable_cookie_path,
+            write_source_state,
+        )
+
+        (profile_dir / "Default").mkdir(parents=True, exist_ok=True)
+        (profile_dir / "Default" / "Cookies").write_text("placeholder")
+        portable_cookie_path(profile_dir).write_text("[]")
+        write_source_state(profile_dir)
+
+    async def test_without_the_generation_the_second_client_destroys_the_first(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """The damage, reproduced first, so the fix below is not asserting thin air.
+
+        This is the shipped behaviour of the unguarded path: rotation is safe
+        against a *concurrent* login, because it takes the profile lease, but
+        nothing stops a client that arrives after one has finished.
+        """
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.session_state import load_source_state
+
+        self._write_session(isolate_profile_dir)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._run_login_flow", AsyncMock()
+        )
+
+        # A finishes a login: a fresh session, and a generation to go with it.
+        self._write_session(isolate_profile_dir)
+        fresh = bootstrap.current_login_generation()
+
+        # B arrives holding no generation at all, which is the old call shape.
+        with pytest.raises(AuthenticationStartedError):
+            await invalidate_auth_and_trigger_relogin()
+
+        # A's session is gone, rotated into quarantine by a client that was
+        # complaining about a session already replaced.
+        assert load_source_state(isolate_profile_dir) is None
+        assert fresh is not None
+
+    async def test_the_generation_stops_the_second_client(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.session_state import load_source_state
+
+        self._write_session(isolate_profile_dir)
+        stale = bootstrap.current_login_generation()
+
+        login = AsyncMock()
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap._run_login_flow", login)
+
+        # A finishes its login, writing a different generation.
+        self._write_session(isolate_profile_dir)
+        fresh = bootstrap.current_login_generation()
+        assert fresh != stale
+
+        # B arrives with the generation it was told about, which has moved on.
+        with pytest.raises(
+            AuthenticationBootstrapFailedError, match="already signed in"
+        ):
+            await invalidate_auth_and_trigger_relogin(stale_generation=stale)
+
+        # Intact, and no second login window opened on top of the first.
+        surviving = load_source_state(isolate_profile_dir)
+        assert surviving is not None
+        assert surviving.login_generation == fresh
+        login.assert_not_called()
+
+    async def test_the_first_client_still_retires_the_session_it_found(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        # The guard must not stop the client that is actually right about the
+        # session being dead, which is every ordinary case.
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.session_state import load_source_state
+
+        self._write_session(isolate_profile_dir)
+        stale = bootstrap.current_login_generation()
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._run_login_flow", AsyncMock()
+        )
+
+        with pytest.raises(AuthenticationStartedError):
+            await invalidate_auth_and_trigger_relogin(stale_generation=stale)
+
+        assert load_source_state(isolate_profile_dir) is None
+
+    async def test_an_abandoned_first_attempt_does_not_block_the_second_client(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """A different generation is not on its own proof that anyone succeeded.
+
+        An abandoned login leaves the profile rotated and nothing written, so the
+        generation reads as None: different from the stale one, and yet no session
+        exists. A guard that asked only whether the generation had moved would tell
+        the next client "another client already signed in" and never start the login
+        it is asking for. Measured, that is exactly what the half-guard does.
+        """
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.session_state import rotate_source_profile
+
+        self._write_session(isolate_profile_dir)
+        stale = bootstrap.current_login_generation()
+        login = AsyncMock()
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap._run_login_flow", login)
+
+        # A starts a login and the user closes the window: rotated, nothing new.
+        rotate_source_profile(isolate_profile_dir)
+        assert bootstrap.current_login_generation() is None
+
+        # B has to be allowed through, and has to open a login.
+        with pytest.raises(AuthenticationStartedError):
+            await invalidate_auth_and_trigger_relogin(stale_generation=stale)
+
+        login.assert_called_once()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -109,7 +109,7 @@ class TestBootstrap:
             await ensure_tool_ready_or_raise("search_jobs")
 
     async def test_missing_auth_starts_login(self, monkeypatch):
-        async def fake_start_login(ctx=None) -> None:
+        async def fake_start_login(ctx=None, **_kwargs) -> None:
             raise AuthenticationStartedError(
                 "No valid LinkedIn session was found. A login browser window has been opened. Sign in with your LinkedIn credentials there, then retry this tool."
             )
@@ -2314,3 +2314,72 @@ class TestTheAutoImportInheritsTheGuard:
             await _start_login_if_needed(superseded_by="the-broken-one")
 
         assert seen.get("superseded_by") == "the-broken-one"
+
+
+class TestTheAutomaticPathCarriesWhatItObserved:
+    """A login a tool call started is not somebody insisting at a terminal.
+
+    The readiness gate has just looked at the profile, so it knows which session
+    it found wanting. Passing that on lets the login stand down if a peer signs in
+    while this one is still getting there. `--login` deliberately keeps the
+    unguarded default, which is what makes it an override rather than a request.
+    """
+
+    async def test_the_gate_hands_on_the_generation_it_just_read(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.session_state import (
+            portable_cookie_path,
+            write_source_state,
+        )
+
+        # A session that exists on disk but is about to be found unusable: the
+        # gate reads this generation and must pass exactly it on.
+        (isolate_profile_dir / "Default").mkdir(parents=True, exist_ok=True)
+        (isolate_profile_dir / "Default" / "Cookies").write_text("placeholder")
+        portable_cookie_path(isolate_profile_dir).write_text("[]")
+        observed = write_source_state(isolate_profile_dir).login_generation
+
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        # Installed rather than loaded: the gate calls get_config(), which parses
+        # sys.argv, and under pytest that is pytest's own command line.
+        config = AppConfig()
+        config.browser.user_data_dir = str(isolate_profile_dir)
+        set_config(config)
+        monkeypatch.setattr(bootstrap, "get_config", lambda: config)
+
+        seen: dict[str, object] = {}
+
+        async def capture(ctx=None, **kwargs):
+            seen.update(kwargs)
+
+        monkeypatch.setattr(bootstrap, "_start_login_if_needed", capture)
+        monkeypatch.setattr(bootstrap, "_auth_ready", lambda: False)
+        monkeypatch.setattr(bootstrap, "_browser_setup_ready", lambda: True)
+
+        # Both branches of the gate, because they are separate call sites: a
+        # configured Chrome executable skips the managed-binary path entirely and
+        # reaches its own. Mutating one and not the other went unnoticed until
+        # this covered both.
+        for custom_chrome in (False, True):
+            seen.clear()
+            monkeypatch.setattr(bootstrap, "_uses_custom_chrome", lambda: custom_chrome)
+
+            await bootstrap.ensure_tool_ready_or_raise("get_person_profile")
+
+            assert seen.get("superseded_by") == observed, custom_chrome
+
+    async def test_an_explicit_login_stays_unguarded(self):
+        # `--login` reaches interactive_login directly, with no generation, so it
+        # always signs in. Asserted on the signature default rather than by
+        # driving a browser: the default is the contract.
+        import inspect
+
+        from linkedin_mcp_server.setup import UNGUARDED, interactive_login
+
+        default = inspect.signature(interactive_login).parameters["superseded_by"]
+
+        assert default.default is UNGUARDED

--- a/tests/test_browser_driver.py
+++ b/tests/test_browser_driver.py
@@ -1,5 +1,6 @@
 """Tests for linkedin_mcp_server.drivers.browser runtime-aware auth startup."""
 
+import asyncio
 import json
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1206,3 +1207,39 @@ class TestFeedFailureDoesNotLeakCredentials:
         assert not any("s3cr3t" in trace for trace in traces)
         assert "s3cr3t" not in caplog.text
         assert "acctzone9" not in caplog.text
+
+
+class TestTheCookieExportCannotStrandTheProfile:
+    """Closing runs the export first, and it used to be able to hang there.
+
+    ``export_cookies`` awaits a protocol call that has no deadline of its own,
+    and on close it runs before the bounded teardown, with the singleton already
+    cleared and the profile lease still held, inside a section that defers
+    cancellation. A call that never answered therefore stranded the profile
+    before anything bounded was reached and raised nothing for anyone to act on:
+    no close result, no exception, no stand-down.
+    """
+
+    async def test_an_export_that_never_answers_gives_up(self):
+        from unittest.mock import MagicMock, patch
+
+        from linkedin_mcp_server.core import browser as core
+
+        manager = core.BrowserManager.__new__(core.BrowserManager)
+        context = MagicMock()
+
+        async def never_answers():
+            await asyncio.sleep(3600)
+
+        context.cookies = never_answers
+        manager._context = context
+
+        with patch.object(core, "_CLEANUP_TIMEOUT_SECONDS", 0.2):
+            began = asyncio.get_running_loop().time()
+            exported = await manager.export_cookies("/tmp/never-written.json")
+            took = asyncio.get_running_loop().time() - began
+
+        # Reported as a failed export, not raised: the caller logs it and carries
+        # on to the teardown, which is the part that must not be skipped.
+        assert exported is False
+        assert took < 2, f"the export was still unbounded ({took:.1f}s)"

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -60,12 +60,24 @@ def _owner_that_fails_with(
     return owner, calls
 
 
-def _proxy_to(owner: FastMCP, *, repairing: bool = True) -> FastMCP:
-    """A frontend forwarding to *owner* in memory, wired as production does."""
+def _proxy_to(
+    owner: FastMCP, *, repairing: bool = True, tool_timeout: float | None = None
+) -> FastMCP:
+    """A frontend forwarding to *owner* in memory, wired as production does.
+
+    *tool_timeout* is handed to the middleware the way ``create_mcp_server`` does,
+    rather than left to the configuration: the repair budgets itself from what
+    its server was built with, so a test that set only the config would be
+    measuring a number the production path never reads.
+    """
     front = FastMCP("front", mask_error_details=True)
     front.add_provider(ProxyProvider(lambda: ProxyClient(owner)))
     if repairing:
-        front.add_middleware(FrontendAuthRepairMiddleware())
+        front.add_middleware(
+            FrontendAuthRepairMiddleware(
+                **({} if tool_timeout is None else {"tool_timeout": tool_timeout})
+            )
+        )
     return front
 
 
@@ -545,7 +557,7 @@ class TestTheRepairRunsForReal:
         get_config().server.tool_timeout_seconds = 0.4
 
         with self._profile_is_free(), self._a_login_that(takes=5.0):
-            async with Client(_proxy_to(owner)) as client:
+            async with Client(_proxy_to(owner, tool_timeout=0.4)) as client:
                 result = await client.call_tool("scrape", raise_on_error=False)
 
         assert len(calls) == 1
@@ -565,19 +577,25 @@ class TestTheRepairRunsForReal:
         passed alone and failed inside the full suite at 1.22s against 1.2s,
         because everything else in the call is also on that clock and a loaded
         machine stretches all of it. That measures the runner, not the code.
-        """
-        from linkedin_mcp_server.config import get_config
 
+        Both halves of the arithmetic are checked. Asserting only "less than the
+        timeout" left the subtraction untested: dropping ``- already_spent``
+        yields five sixths of the budget, which is still under it, and the test
+        stayed green while the overrun it exists for came back.
+        """
+        budget = 1.2
         owner, calls = _owner_that_fails_with(
             AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
         )
-        get_config().server.tool_timeout_seconds = 1.2
         asked_for: list[float] = []
+        spent_by_then: list[float] = []
 
         real_wait = daemon_auth._wait_for_the_sign_in
+        began = asyncio.get_running_loop().time()
 
         async def record(timeout: float) -> bool:
             asked_for.append(timeout)
+            spent_by_then.append(asyncio.get_running_loop().time() - began)
             return await real_wait(timeout)
 
         with (
@@ -585,13 +603,18 @@ class TestTheRepairRunsForReal:
             self._a_login_that(takes=30.0),
             patch.object(daemon_auth, "_wait_for_the_sign_in", record),
         ):
-            async with Client(_proxy_to(owner)) as client:
+            async with Client(_proxy_to(owner, tool_timeout=budget)) as client:
                 result = await client.call_tool("scrape", raise_on_error=False)
 
         assert asked_for, "the sign-in was never waited for"
-        assert asked_for[0] < 1.2, (
-            f"the wait asked for {asked_for[0]:.2f}s of a 1.2s call"
+        share = budget * 5 / 6
+        # What was already spent is gone from the budget, so the wait has to be
+        # measurably shorter than the share itself.
+        assert asked_for[0] < share - spent_by_then[0] + 0.05, (
+            f"the wait asked for {asked_for[0]:.2f}s having already spent "
+            f"{spent_by_then[0]:.2f}s of a {budget}s call"
         )
+        assert asked_for[0] < share, "the spent time was not subtracted"
         assert result.is_error is True
         assert len(calls) == 1
 
@@ -608,8 +631,6 @@ class TestTheRepairRunsForReal:
         exists, so the next call succeeds, and a bare transport error would say
         none of that.
         """
-        from linkedin_mcp_server.config import get_config
-
         owner = FastMCP("owner", mask_error_details=True)
         calls: list[int] = []
 
@@ -625,14 +646,12 @@ class TestTheRepairRunsForReal:
             return "scraped ok"
 
         owner.add_middleware(OwnerAuthSignalMiddleware())
-        get_config().server.tool_timeout_seconds = 1.0
-
         with (
             self._profile_is_free(),
             self._a_login_that(takes=0.05),
             patch("linkedin_mcp_server.daemon_auth._MINIMUM_REPLAY_SECONDS", 0.2),
         ):
-            async with Client(_proxy_to(owner)) as client:
+            async with Client(_proxy_to(owner, tool_timeout=1.0)) as client:
                 result = await client.call_tool("scrape", raise_on_error=False)
 
         assert len(calls) == 2, "the replay never ran"

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -8,6 +8,8 @@ lose the signal or act on it wrongly.
 
 from __future__ import annotations
 
+import asyncio
+
 from unittest.mock import AsyncMock, patch
 
 import mcp.types as mt
@@ -403,6 +405,135 @@ class TestTheFrontendActsOnTheMarker:
         assert len(calls) == 2
         assert result.is_error is False
         assert result.content[0].text == "scraped ok"
+
+
+class TestTheRepairRunsForReal:
+    """The same replay, with the production repair instead of a stand-in.
+
+    Every test above replaces ``_repair_auth_locally`` with a mock that returns
+    or raises on command. That is the right shape for asking what the middleware
+    does with an outcome, and the wrong one for asking whether the outcome ever
+    occurs: both functions behind it report a *started* login by raising, while
+    the window is still open. Mocked away, the middleware was measured to abandon
+    every repair one step before it worked, on both paths, and the tests above
+    stayed green throughout.
+
+    So these stub only the login itself -- the one thing a test cannot do -- and
+    let the real bootstrap code run in between.
+    """
+
+    def _profile_is_free(self):
+        return patch(
+            "linkedin_mcp_server.daemon_auth._browser_still_holds_the_profile",
+            return_value=False,
+        )
+
+    def _a_login_that(self, *, takes: float, succeeds: bool = True):
+        """Stub the login flow, and with it what readiness reports afterwards.
+
+        *takes* is what separates the two cases that matter: a login finishing
+        inside the inline budget returns through the normal path, while a slower
+        one leaves ``_start_login_if_needed`` raising "in progress" -- which is
+        every login a person actually performs.
+        """
+        done: list[bool] = []
+
+        async def login() -> None:
+            await asyncio.sleep(takes)
+            if succeeds:
+                done.append(True)
+
+        return patch.multiple(
+            "linkedin_mcp_server.bootstrap",
+            _run_login_flow=AsyncMock(side_effect=login),
+            _force_move_auth_state_aside=lambda *a, **k: None,
+            _move_invalid_auth_state_aside=lambda *a, **k: None,
+            _auto_import_allowed=lambda *a, **k: False,
+            # A login that succeeded has written a session; one that failed has
+            # not. This is what the wait reads to decide whether to replay.
+            _auth_ready=lambda *a, **k: bool(done),
+        )
+
+    @pytest.fixture(autouse=True)
+    def _short_budget(self, monkeypatch):
+        """Scale the inline wait down, keeping the shape of the real timings.
+
+        Built rather than read: ``get_config`` parses ``sys.argv``, which under
+        pytest is pytest's own command line.
+        """
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        config = AppConfig()
+        config.browser.login_inline_wait_seconds = 0.2
+        set_config(config)
+        monkeypatch.setattr("linkedin_mcp_server.daemon_auth._LOGIN_WAIT_SECONDS", 5.0)
+
+    async def test_a_stale_session_is_replayed_once_the_login_succeeds(self):
+        """The path that never replayed: this one raises immediately, always."""
+        owner, calls = _owner_that_fails_with(
+            AuthStaleOnOwnerError("dead", nothing_ran_yet=True, generation="g-old")
+        )
+
+        with self._profile_is_free(), self._a_login_that(takes=0.05):
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert len(calls) == 2, "the call was never run again"
+        assert result.is_error is False
+        assert result.content[0].text == "scraped ok"
+
+    async def test_a_slow_sign_in_is_still_replayed(self):
+        """A login outlasting the inline budget, which is every human one.
+
+        The missing path used to pass only because the stub finished at once.
+        Give it a login somebody has to type into and it raised "in progress",
+        which the frontend read as a failed repair.
+        """
+        owner, calls = _owner_that_fails_with(
+            AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
+        )
+
+        with self._profile_is_free(), self._a_login_that(takes=0.6):
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert len(calls) == 2, "a login slower than the budget was not waited out"
+        assert result.is_error is False
+
+    async def test_a_login_that_fails_is_not_replayed(self):
+        """Waiting is not the same as assuming success."""
+        owner, calls = _owner_that_fails_with(
+            AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
+        )
+
+        with self._profile_is_free(), self._a_login_that(takes=0.05, succeeds=False):
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert len(calls) == 1, "the call was replayed with no session to serve it"
+        assert result.is_error is True
+
+    async def test_a_sign_in_slower_than_the_wait_gives_up_without_replaying(self):
+        """The client is blocked on this call, so the wait cannot be unbounded.
+
+        Giving up costs only this attempt: the login keeps running, and the next
+        call finds the session it writes.
+        """
+        owner, calls = _owner_that_fails_with(
+            AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
+        )
+
+        with (
+            self._profile_is_free(),
+            self._a_login_that(takes=5.0),
+            patch("linkedin_mcp_server.daemon_auth._LOGIN_WAIT_SECONDS", 0.3),
+        ):
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert len(calls) == 1
+        assert result.is_error is True
 
 
 class TestWhichRolesGetWhichHalf:

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -630,11 +630,14 @@ class TestTheRepairRunsForReal:
         The owner's readable failure is the right answer then: the session now
         exists, so the next call succeeds, and a bare transport error would say
         none of that.
+
+        Read-only, which is what makes giving up safe here: an abandoned scrape
+        costs a wasted page load. The mutating case below must not do this.
         """
         owner = FastMCP("owner", mask_error_details=True)
         calls: list[int] = []
 
-        @owner.tool
+        @owner.tool(annotations={"readOnlyHint": True})
         async def scrape() -> str:
             calls.append(1)
             if len(calls) == 1:
@@ -659,6 +662,100 @@ class TestTheRepairRunsForReal:
         # and that retrying now works.
         assert result.is_error is True
         assert "no session" in result.content[0].text
+
+    async def test_a_mutating_replay_is_never_abandoned(self):
+        """Giving up on a mutating replay leaves the owner doing it anyway.
+
+        Cancellation is not forwarded across the hop, which
+        ``daemon_proxy._TIMEOUT_MARGIN_SECONDS`` already records. Timing the
+        replay out therefore does not stop it: measured over a real loopback
+        owner, the client was answered at 0.66s with the old auth failure and the
+        owner appended its effect 0.7s later. The user is told the message was
+        not sent, it was, and retrying sends it twice.
+
+        Waiting past the client's deadline is the lesser harm: the deadline
+        belongs to the client, which can give up by itself, and that leaves one
+        call outstanding rather than a second queued behind it.
+        """
+        owner = FastMCP("owner", mask_error_details=True)
+        calls: list[int] = []
+        sent: list[str] = []
+
+        @owner.tool(annotations={"destructiveHint": True})
+        async def send() -> str:
+            calls.append(1)
+            if len(calls) == 1:
+                raise_tool_error(
+                    AuthMissingOnOwnerError("no session", nothing_ran_yet=True),
+                    "send",
+                )
+            await asyncio.sleep(0.4)  # longer than what is left of the call
+            sent.append("message")
+            return "sent"
+
+        owner.add_middleware(OwnerAuthSignalMiddleware())
+        with (
+            self._profile_is_free(),
+            self._a_login_that(takes=0.05),
+            patch("linkedin_mcp_server.daemon_auth._MINIMUM_REPLAY_SECONDS", 0.05),
+        ):
+            async with Client(_proxy_to(owner, tool_timeout=0.2)) as client:
+                result = await client.call_tool("send", raise_on_error=False)
+
+        # The answer reflects what happened, which is the whole point: an effect
+        # the client was not told about is one it will repeat.
+        assert sent == ["message"], "the mutation was abandoned mid-flight"
+        assert result.is_error is False
+        assert result.content[0].text == "sent"
+
+    async def test_an_unannotated_tool_counts_as_mutating(self):
+        """A tool that promised nothing is not treated as safe.
+
+        Only ``readOnlyHint`` makes a replay abandonable. Defaulting the other
+        way would make every future tool abandonable until someone remembered to
+        annotate it, and the failure would be silent.
+        """
+        owner = FastMCP("owner", mask_error_details=True)
+        calls: list[int] = []
+        sent: list[str] = []
+
+        @owner.tool  # no annotations at all
+        async def act() -> str:
+            calls.append(1)
+            if len(calls) == 1:
+                raise_tool_error(
+                    AuthMissingOnOwnerError("no session", nothing_ran_yet=True),
+                    "act",
+                )
+            await asyncio.sleep(0.4)
+            sent.append("done")
+            return "done"
+
+        owner.add_middleware(OwnerAuthSignalMiddleware())
+        with (
+            self._profile_is_free(),
+            self._a_login_that(takes=0.05),
+            patch("linkedin_mcp_server.daemon_auth._MINIMUM_REPLAY_SECONDS", 0.05),
+        ):
+            async with Client(_proxy_to(owner, tool_timeout=0.2)) as client:
+                result = await client.call_tool("act", raise_on_error=False)
+
+        assert sent == ["done"], "an unannotated tool was abandoned mid-flight"
+        assert result.is_error is False
+
+    async def test_the_replay_floor_stays_inside_the_budget(self):
+        """The floor must not outlive the call it is a floor for.
+
+        Measured at ``tool_timeout_seconds=1.0`` with 0.9s spent: a flat floor
+        allowed a 5-second replay inside a 1-second call, which is the overrun
+        the budget arithmetic exists to prevent.
+        """
+        from linkedin_mcp_server import daemon_auth as da
+
+        assert da._what_is_left_of_this_call(1.0, 0.9) <= 1.0
+        assert da._what_is_left_of_this_call(60.0, 59.9) == da._MINIMUM_REPLAY_SECONDS
+        # The ordinary case is untouched: plenty left, so the floor never binds.
+        assert da._what_is_left_of_this_call(180.0, 30.0) == 150.0
 
 
 class TestWhichRolesGetWhichHalf:

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -171,6 +171,19 @@ class TestTheMarkerSurvivesTheHop:
 class TestTheFrontendActsOnTheMarker:
     """Repairing and replaying are separate decisions, and both can go wrong."""
 
+    @pytest.fixture(autouse=True)
+    def _a_real_config(self):
+        """The replay reads its deadline from the configuration.
+
+        Built rather than left to the default, because ``get_config`` parses
+        ``sys.argv`` when nothing has been set, which under pytest is pytest's
+        own command line.
+        """
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        set_config(AppConfig())
+
     def _repair(self):
         """Watch the login without running one."""
         return patch(
@@ -581,6 +594,52 @@ class TestTheRepairRunsForReal:
         )
         assert result.is_error is True
         assert len(calls) == 1
+
+    async def test_a_replay_that_runs_long_does_not_hang_the_client(self):
+        """Waiting bounded and replaying unbounded still overruns the deadline.
+
+        Nothing under this middleware bounds the whole path: the forwarded call
+        gets its own deadline per hop, so the first call, the wait and the replay
+        each stay inside one while their sum stays inside nothing. A sign-in
+        finishing near the end of the wait, followed by a slow replay, put the
+        client past its deadline with the answer already in hand.
+
+        The owner's readable failure is the right answer then: the session now
+        exists, so the next call succeeds, and a bare transport error would say
+        none of that.
+        """
+        from linkedin_mcp_server.config import get_config
+
+        owner = FastMCP("owner", mask_error_details=True)
+        calls: list[int] = []
+
+        @owner.tool
+        async def scrape() -> str:
+            calls.append(1)
+            if len(calls) == 1:
+                raise_tool_error(
+                    AuthMissingOnOwnerError("no session", nothing_ran_yet=True),
+                    "scrape",
+                )
+            await asyncio.sleep(30)  # a replay that outlives the call
+            return "scraped ok"
+
+        owner.add_middleware(OwnerAuthSignalMiddleware())
+        get_config().server.tool_timeout_seconds = 1.0
+
+        with (
+            self._profile_is_free(),
+            self._a_login_that(takes=0.05),
+            patch("linkedin_mcp_server.daemon_auth._MINIMUM_REPLAY_SECONDS", 0.2),
+        ):
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert len(calls) == 2, "the replay never ran"
+        # The owner's own words, not a timeout: the client is told what happened
+        # and that retrying now works.
+        assert result.is_error is True
+        assert "no session" in result.content[0].text
 
 
 class TestWhichRolesGetWhichHalf:

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -49,7 +49,11 @@ def _owner_that_fails_with(
     owner = FastMCP("owner", mask_error_details=True)
     calls: list[int] = []
 
-    @owner.tool
+    # Annotated read-only, like the scraping tools it stands for. The annotation
+    # is load-bearing rather than decoration: only a tool that declares itself
+    # read-only is ever replayed, because a replay the client never sees the
+    # result of would repeat whatever the tool did.
+    @owner.tool(annotations={"readOnlyHint": True})
     async def scrape() -> str:
         calls.append(1)
         if len(calls) == 1:
@@ -384,7 +388,7 @@ class TestTheFrontendActsOnTheMarker:
         owner = FastMCP("owner", mask_error_details=True)
         calls: list[int] = []
 
-        @owner.tool
+        @owner.tool(annotations={"readOnlyHint": True})
         async def scrape() -> str:
             calls.append(1)
             raise_tool_error(
@@ -663,19 +667,19 @@ class TestTheRepairRunsForReal:
         assert result.is_error is True
         assert "no session" in result.content[0].text
 
-    async def test_a_mutating_replay_is_never_abandoned(self):
-        """Giving up on a mutating replay leaves the owner doing it anyway.
+    async def test_a_tool_that_changes_something_is_never_replayed(self):
+        """Repaired, and left for the caller to run again.
 
-        Cancellation is not forwarded across the hop, which
-        ``daemon_proxy._TIMEOUT_MARGIN_SECONDS`` already records. Timing the
-        replay out therefore does not stop it: measured over a real loopback
-        owner, the client was answered at 0.66s with the old auth failure and the
-        owner appended its effect 0.7s later. The user is told the message was
-        not sent, it was, and retrying sends it twice.
+        No bound on the replay can make this safe, and two attempts showed why.
+        Bounding it locally left the owner finishing the mutation after the
+        frontend had reported failure, because cancellation is not forwarded
+        across the hop: measured over a real loopback owner, the client was
+        answered at 0.66s with an error and the effect landed 0.7s later.
+        Removing the bound only moved the deadline: an MCP client cancelling its
+        own call produced the same orphan, and the retry sent the message twice.
 
-        Waiting past the client's deadline is the lesser harm: the deadline
-        belongs to the client, which can give up by itself, and that leaves one
-        call outstanding rather than a second queued behind it.
+        So the decision goes to the user, who knows whether it happened. Asking
+        costs one retry; guessing wrong sends it twice.
         """
         owner = FastMCP("owner", mask_error_details=True)
         calls: list[int] = []
@@ -689,35 +693,35 @@ class TestTheRepairRunsForReal:
                     AuthMissingOnOwnerError("no session", nothing_ran_yet=True),
                     "send",
                 )
-            await asyncio.sleep(0.4)  # longer than what is left of the call
             sent.append("message")
             return "sent"
 
         owner.add_middleware(OwnerAuthSignalMiddleware())
-        with (
-            self._profile_is_free(),
-            self._a_login_that(takes=0.05),
-            patch("linkedin_mcp_server.daemon_auth._MINIMUM_REPLAY_SECONDS", 0.05),
-        ):
-            async with Client(_proxy_to(owner, tool_timeout=0.2)) as client:
+        with self._profile_is_free(), self._a_login_that(takes=0.05):
+            async with Client(_proxy_to(owner, tool_timeout=5.0)) as client:
                 result = await client.call_tool("send", raise_on_error=False)
+            # Repaired all the same, which is what makes the retry the message
+            # asks for work. Read inside the patch, where readiness reflects the
+            # stubbed login rather than the real filesystem.
+            from linkedin_mcp_server.bootstrap import _auth_ready
 
-        # The answer reflects what happened, which is the whole point: an effect
-        # the client was not told about is one it will repeat.
-        assert sent == ["message"], "the mutation was abandoned mid-flight"
-        assert result.is_error is False
-        assert result.content[0].text == "sent"
+            repaired = _auth_ready()
+
+        assert calls == [1], "a mutating call was run again on its own"
+        assert sent == [], "the message was sent without the user asking twice"
+        assert repaired, "the auth was not repaired either"
+        assert result.is_error is True
+        assert "no session" in result.content[0].text
 
     async def test_an_unannotated_tool_counts_as_mutating(self):
         """A tool that promised nothing is not treated as safe.
 
-        Only ``readOnlyHint`` makes a replay abandonable. Defaulting the other
-        way would make every future tool abandonable until someone remembered to
-        annotate it, and the failure would be silent.
+        Only ``readOnlyHint`` earns a replay. Defaulting the other way would make
+        every future tool replayable until someone remembered to annotate it, and
+        the failure would be silent and irreversible.
         """
         owner = FastMCP("owner", mask_error_details=True)
         calls: list[int] = []
-        sent: list[str] = []
 
         @owner.tool  # no annotations at all
         async def act() -> str:
@@ -727,21 +731,15 @@ class TestTheRepairRunsForReal:
                     AuthMissingOnOwnerError("no session", nothing_ran_yet=True),
                     "act",
                 )
-            await asyncio.sleep(0.4)
-            sent.append("done")
             return "done"
 
         owner.add_middleware(OwnerAuthSignalMiddleware())
-        with (
-            self._profile_is_free(),
-            self._a_login_that(takes=0.05),
-            patch("linkedin_mcp_server.daemon_auth._MINIMUM_REPLAY_SECONDS", 0.05),
-        ):
-            async with Client(_proxy_to(owner, tool_timeout=0.2)) as client:
+        with self._profile_is_free(), self._a_login_that(takes=0.05):
+            async with Client(_proxy_to(owner, tool_timeout=5.0)) as client:
                 result = await client.call_tool("act", raise_on_error=False)
 
-        assert sent == ["done"], "an unannotated tool was abandoned mid-flight"
-        assert result.is_error is False
+        assert calls == [1], "an unannotated tool was replayed"
+        assert result.is_error is True
 
     async def test_the_replay_floor_stays_inside_the_budget(self):
         """The floor must not outlive the call it is a floor for.

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -20,6 +20,7 @@ from fastmcp.server.middleware import Middleware
 from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
 from fastmcp.tools import ToolResult
 
+from linkedin_mcp_server import daemon_auth
 from linkedin_mcp_server.daemon_auth import (
     MARKER_KEY,
     MARKER_VERSION,
@@ -466,8 +467,11 @@ class TestTheRepairRunsForReal:
 
         config = AppConfig()
         config.browser.login_inline_wait_seconds = 0.2
+        # The repair wait is a fraction of this, so setting the real budget is
+        # what scales it, and the test exercises that derivation rather than
+        # patching over it.
+        config.server.tool_timeout_seconds = 6.0
         set_config(config)
-        monkeypatch.setattr("linkedin_mcp_server.daemon_auth._LOGIN_WAIT_SECONDS", 5.0)
 
     async def test_a_stale_session_is_replayed_once_the_login_succeeds(self):
         """The path that never replayed: this one raises immediately, always."""
@@ -520,20 +524,63 @@ class TestTheRepairRunsForReal:
         Giving up costs only this attempt: the login keeps running, and the next
         call finds the session it writes.
         """
+        from linkedin_mcp_server.config import get_config
+
         owner, calls = _owner_that_fails_with(
             AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
         )
+        get_config().server.tool_timeout_seconds = 0.4
 
-        with (
-            self._profile_is_free(),
-            self._a_login_that(takes=5.0),
-            patch("linkedin_mcp_server.daemon_auth._LOGIN_WAIT_SECONDS", 0.3),
-        ):
+        with self._profile_is_free(), self._a_login_that(takes=5.0):
             async with Client(_proxy_to(owner)) as client:
                 result = await client.call_tool("scrape", raise_on_error=False)
 
         assert len(calls) == 1
         assert result.is_error is True
+
+    async def test_the_wait_stays_inside_a_shortened_tool_budget(self):
+        """A user who lowers TOOL_TIMEOUT must still get the readable answer.
+
+        The wait was a fixed 150 seconds once. Measured against
+        ``TOOL_TIMEOUT=60``: the client's call was cut short while the middleware
+        was still waiting, so the user got a bare timeout instead of "sign-in
+        still in progress". Nothing was corrupted -- the login survived and the
+        next call worked -- but the explanation is the part a person acts on.
+
+        The budget asked for is asserted rather than the wall clock it produces.
+        A first version timed the whole call and compared against the timeout: it
+        passed alone and failed inside the full suite at 1.22s against 1.2s,
+        because everything else in the call is also on that clock and a loaded
+        machine stretches all of it. That measures the runner, not the code.
+        """
+        from linkedin_mcp_server.config import get_config
+
+        owner, calls = _owner_that_fails_with(
+            AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
+        )
+        get_config().server.tool_timeout_seconds = 1.2
+        asked_for: list[float] = []
+
+        real_wait = daemon_auth._wait_for_the_sign_in
+
+        async def record(timeout: float) -> bool:
+            asked_for.append(timeout)
+            return await real_wait(timeout)
+
+        with (
+            self._profile_is_free(),
+            self._a_login_that(takes=30.0),
+            patch.object(daemon_auth, "_wait_for_the_sign_in", record),
+        ):
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        assert asked_for, "the sign-in was never waited for"
+        assert asked_for[0] < 1.2, (
+            f"the wait asked for {asked_for[0]:.2f}s of a 1.2s call"
+        )
+        assert result.is_error is True
+        assert len(calls) == 1
 
 
 class TestWhichRolesGetWhichHalf:

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -592,14 +592,11 @@ class TestTheRepairRunsForReal:
             AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
         )
         asked_for: list[float] = []
-        spent_by_then: list[float] = []
 
         real_wait = daemon_auth._wait_for_the_sign_in
-        began = asyncio.get_running_loop().time()
 
         async def record(timeout: float) -> bool:
             asked_for.append(timeout)
-            spent_by_then.append(asyncio.get_running_loop().time() - began)
             return await real_wait(timeout)
 
         with (
@@ -612,15 +609,21 @@ class TestTheRepairRunsForReal:
 
         assert asked_for, "the sign-in was never waited for"
         share = budget * 5 / 6
-        # What was already spent is gone from the budget, so the wait has to be
-        # measurably shorter than the share itself.
-        assert asked_for[0] < share - spent_by_then[0] + 0.05, (
-            f"the wait asked for {asked_for[0]:.2f}s having already spent "
-            f"{spent_by_then[0]:.2f}s of a {budget}s call"
-        )
+        # Strictly under the share, because time had already gone before this was
+        # reached. Comparing against the share rather than against a second clock
+        # reading: an earlier version subtracted a duration measured from the
+        # start of the *test*, which includes client setup the middleware's own
+        # clock never saw, and it failed at 1.22s against 1.2s under full-suite
+        # load while passing alone. That measured the runner.
         assert asked_for[0] < share, "the spent time was not subtracted"
         assert result.is_error is True
         assert len(calls) == 1
+
+        # And exactly, away from the clock entirely, so the subtraction is pinned
+        # rather than merely implied by an inequality.
+        assert daemon_auth._how_long_to_wait_for_the_sign_in(1.2, 0.5) == pytest.approx(
+            0.5
+        )
 
     async def test_a_replay_that_runs_long_does_not_hang_the_client(self):
         """Waiting bounded and replaying unbounded still overruns the deadline.

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -375,6 +375,35 @@ class TestTheFrontendActsOnTheMarker:
         repair.assert_awaited_once()
         assert result.is_error is True
 
+    async def test_a_peer_win_still_replays_the_call(self):
+        """Somebody else signing in is a repair, not a failed one.
+
+        The session the call needs exists either way. Treating the peer win as a
+        failure refused the replay and sent the user back for a retry that was
+        not needed, while a usable session was already on disk.
+        """
+        from linkedin_mcp_server.session_state import PeerSessionInPlaceError
+
+        owner, calls = _owner_that_fails_with(
+            AuthMissingOnOwnerError("no session", nothing_ran_yet=True)
+        )
+
+        with (
+            self._profile_is_free(),
+            patch(
+                "linkedin_mcp_server.daemon_auth._repair_auth_locally",
+                new_callable=AsyncMock,
+                side_effect=PeerSessionInPlaceError("another client signed in"),
+            ),
+        ):
+            async with Client(_proxy_to(owner)) as client:
+                result = await client.call_tool("scrape", raise_on_error=False)
+
+        # Replayed, and the owner served it the second time.
+        assert len(calls) == 2
+        assert result.is_error is False
+        assert result.content[0].text == "scraped ok"
+
 
 class TestWhichRolesGetWhichHalf:
     """Each half belongs to exactly one role, and the wrong pairing is silent."""

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -88,6 +88,7 @@ class TestTheMarkerSurvivesTheHop:
             "reason": "missing",
             "replayable": True,
             "browser_open": False,
+            "generation": None,
         }
 
     async def test_the_marker_reaches_the_outer_client_through_the_proxy(self):
@@ -189,7 +190,7 @@ class TestTheFrontendActsOnTheMarker:
             async with Client(_proxy_to(owner)) as client:
                 result = await client.call_tool("scrape", raise_on_error=False)
 
-        repair.assert_awaited_once_with("missing")
+        repair.assert_awaited_once_with("missing", None)
         # Twice on the owner: the failure, then the replay. Not three times, which
         # is what a retry loop without a bound would give.
         assert len(calls) == 2
@@ -209,7 +210,7 @@ class TestTheFrontendActsOnTheMarker:
                 result = await client.call_tool("scrape", raise_on_error=False)
 
         # Repaired, because the next call should succeed, but not replayed.
-        repair.assert_awaited_once_with("stale")
+        repair.assert_awaited_once_with("stale", None)
         assert len(calls) == 1
         assert result.is_error is True
 
@@ -255,6 +256,7 @@ class TestTheFrontendActsOnTheMarker:
                             "reason": "missing",
                             "replayable": True,
                             "browser_open": False,
+                            "generation": None,
                         }
                     },
                     is_error=True,
@@ -290,6 +292,7 @@ class TestTheFrontendActsOnTheMarker:
                             "reason": "missing",
                             "replayable": "yes",
                             "browser_open": False,
+                            "generation": None,
                         }
                     },
                     is_error=True,

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -535,6 +535,12 @@ attachment = outcome.attachment_lookup.attachment
 # handed over.
 print(json.dumps({
     "state": outcome.attachment_lookup.state.value,
+    # Which refusal, not merely that there was one. There are five paths to
+    # INCOMPATIBLE across `daemon.py` and `daemon_election.py`, and a failure
+    # recorded without this cannot say which fired: one such failure in a full
+    # suite run left nothing to distinguish a runtime mismatch from a profile
+    # mismatch, and the state alone made it look like flake either way.
+    "reason": outcome.attachment_lookup.reason,
     "started": outcome.started_owner,
     "pid": attachment.descriptor.pid if attachment else None,
     "url": attachment.descriptor.url if attachment else None,

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1657,6 +1657,56 @@ class TestNotHoldingTheLockForever:
 
         asyncio.run(exercise())
 
+    def test_an_owner_that_cannot_release_the_profile_gives_way(self):
+        """A wedged owner has to remove itself, because nothing else can.
+
+        When Chromium's shutdown cannot be confirmed the profile lease is kept
+        until the process exits, deliberately (``drivers/browser.py``). For a
+        single-process server the resulting message is actionable: its client
+        restarts it. For a detached owner it is not -- it outlives that client,
+        and the next frontend attaches straight back to it and meets the same
+        held profile. Measured before this: recovery needed killing the process
+        by hand.
+
+        Asserted through the real serve loop, because that is the only thing that
+        can end the process cleanly; the request itself is made in
+        ``dependencies`` and covered there.
+        """
+        import asyncio
+
+        from linkedin_mcp_server import daemon_owner, server_role
+
+        class Serving:
+            started = True
+            should_exit = False
+
+            async def serve(self, sockets: object = None) -> None:
+                while not self.should_exit:
+                    await asyncio.sleep(0.02)
+
+        async def exercise() -> bool:
+            server = Serving()
+            serving = asyncio.create_task(server.serve())
+            loop = asyncio.create_task(
+                daemon_owner._serve_until_stopped(server, serving, [])
+            )
+            try:
+                await asyncio.sleep(0.3)
+                assert not loop.done(), "a healthy owner stopped serving"
+
+                server_role.ask_this_process_to_stand_down("the profile is held")
+                await asyncio.wait_for(loop, timeout=5)
+                return True
+            except TimeoutError:
+                return False
+            finally:
+                serving.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await serving
+                server_role.reset_process_role_for_testing()
+
+        assert asyncio.run(exercise()), "the wedged owner kept the lock"
+
     def test_a_shutdown_that_never_completes_stops_waiting(
         self, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1158,6 +1158,92 @@ class TestRealOwner:
         finally:
             _stop(result.get("pid"))
 
+    def test_a_real_owner_asks_the_client_to_sign_in(self, real_state_root: Path):
+        """The auth marker, over a real socket, from a real detached owner.
+
+        Everything else about the marker runs in memory. This is the one that
+        proves the owner produces it with no LinkedIn session on disk and that it
+        survives the authenticated loopback hop as a *result* rather than being
+        flattened into a generic failure, which is what an exception would be.
+
+        Observed at a plain client with no repair middleware installed, and that
+        is what makes the test possible: a fully wired frontend *consumes* the
+        marker, opens a real login window and waits out the login timeout. So this
+        asserts what the owner sends; the consume-and-replay half is covered in
+        memory with a stubbed login.
+        """
+        import asyncio
+
+        from fastmcp import Client
+
+        from linkedin_mcp_server.daemon import look_up_owner
+        from linkedin_mcp_server.daemon_auth import (
+            MARKER_KEY,
+            MARKER_VERSION,
+            FrontendAuthRepairMiddleware,
+        )
+        from linkedin_mcp_server.server import ServerRole, create_mcp_server
+
+        profile = real_state_root
+        # The browser cache is keyed to the auth root, and the fixture's is empty,
+        # so without this the owner answers "still downloading Chromium" and never
+        # reaches the auth gate at all. Symlinked rather than copied: it is about a
+        # gigabyte, and nothing here launches a browser.
+        _borrow_the_browser_cache(profile)
+
+        result = _run_frontend(profile)
+        try:
+            lookup = look_up_owner(profile.parent, profile, _config(profile))
+            assert lookup.attachment is not None, lookup.reason
+
+            proxy = create_mcp_server(
+                tool_timeout=30.0,
+                role=ServerRole.PROXY,
+                proxy_attachment=lookup.attachment,
+            )
+            # The repair middleware is removed rather than never added, because
+            # `create_mcp_server` installs it for every proxy and that is correct:
+            # a real frontend consumes this marker, opens a login window and waits
+            # out the login timeout. Removing it is what lets the marker be
+            # observed at all, and it is the reason this test asserts what the
+            # owner *sends* rather than what a client finally sees.
+            proxy.middleware[:] = [
+                m
+                for m in proxy.middleware
+                if not isinstance(m, FrontendAuthRepairMiddleware)
+            ]
+
+            async def call_it():
+                async with Client(proxy) as client:
+                    return await client.call_tool(
+                        "get_person_profile",
+                        {"linkedin_username": "williamhgates"},
+                        raise_on_error=False,
+                    )
+
+            answered = asyncio.run(call_it())
+
+            assert answered.is_error is True
+            marker = (answered.meta or {}).get(MARKER_KEY)
+            assert marker is not None, answered.meta
+            assert marker["v"] == MARKER_VERSION
+            # `missing`, because the fixture's profile has never been logged in.
+            assert marker["reason"] == "missing"
+            # Nothing ran before the readiness gate refused, so a client may run
+            # the call again once it has signed in.
+            assert marker["replayable"] is True
+            # And the owner never opened a browser to find this out, so the
+            # profile is free for the login it is asking for.
+            assert marker["browser_open"] is False
+
+            # Worth recording what this does and does not pin. Removing the
+            # owner's middleware makes it fail, and so does removing *both* role
+            # claims. Removing only the one in `main` does not, because
+            # `create_mcp_server` claims it again before any call arrives: the two
+            # are deliberately redundant, and this test cannot tell them apart.
+        finally:
+            _stop(result.get("pid"))
+
     def test_a_proxy_refuses_an_owner_it_has_the_wrong_token_for(
         self, real_state_root: Path
     ):
@@ -1842,3 +1928,21 @@ class TestOutcome:
         absent = ElectionOutcome(OwnerLookup(state=OwnerState.ABSENT))
 
         assert not absent.worth_connecting
+
+
+def _borrow_the_browser_cache(profile: Path) -> None:
+    """Point an isolated auth root at the account's real browser cache.
+
+    The cache lives under the auth root (``bootstrap.browsers_path``), so an
+    isolated root looks like a fresh install and the readiness gate reports a
+    download in progress before anything about authentication is decided. A
+    symlink is enough: these tests read the gate's verdict and never launch
+    Chromium.
+
+    Skips the test rather than downloading one, because a test that pulls a
+    gigabyte on a cold machine is a test nobody runs.
+    """
+    real = Path.home() / ".linkedin-mcp" / "patchright-browsers"
+    if not real.is_dir():
+        pytest.skip("no patchright browser cache to borrow")
+    (profile.parent / "patchright-browsers").symlink_to(real)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -870,11 +870,15 @@ class TestAWedgeFromAnywhereFreesTheOwner:
             "an owner whose close could not read the lease keeps the profile"
         )
 
-    async def test_a_confirmed_close_with_an_unreadable_lease_is_left_alone(self):
-        """Only an *unconfirmed* teardown means the profile may still be held.
+    async def test_a_confirmed_close_with_an_unreadable_lease_also_asks(self):
+        """A proven-closed Chromium does not mean a released lease.
 
-        Chromium is provably gone here, so the failed lookup is a problem for the
-        caller rather than a reason to end the owner.
+        This asserted the opposite once, on the reasoning that a confirmed close
+        leaves the profile free. It does not: ``mark_browser_closed()`` and
+        ``release()`` both need the object the lookup failed to produce, so the
+        lease stays held with its marker set. Measured with a real acquired
+        lease: Chromium gone, and this owner's own next launch refused with
+        ``BrowserBusyError`` while nobody had asked for a replacement.
         """
         from linkedin_mcp_server.drivers import browser as drv
         from linkedin_mcp_server.server_role import (
@@ -902,4 +906,6 @@ class TestAWedgeFromAnywhereFreesTheOwner:
             with pytest.raises(PermissionError):
                 await drv._close_browser_locked()
 
-        assert stand_down_reason() is None, "a proven-closed owner was told to exit"
+        assert stand_down_reason() is not None, (
+            "a confirmed close that could not release the lease left it held"
+        )

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -826,3 +826,80 @@ class TestAWedgeFromAnywhereFreesTheOwner:
             a_held_profile_means_this_owner_must_go()
 
         assert stand_down_reason() is not None
+
+    async def test_a_close_whose_own_lease_lookup_fails_still_frees_the_owner(self):
+        """The lookup sits between the teardown and every line that protects it.
+
+        `get_profile_lease` resolves a path, so it can fail on a profile
+        directory that became unreadable while the browser was running, even
+        though this process still holds the open descriptor. By then the
+        singleton is cleared, so nothing below it runs: not the hold flag, not
+        the warning, not the request.
+
+        Measured in production order: browser cleared, hold flag still set,
+        `stand_down_reason()` None.
+        """
+        from linkedin_mcp_server.drivers import browser as drv
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        set_process_role(ServerRole.OWNER)
+        fake_browser = MagicMock()
+        fake_browser.close = AsyncMock(return_value=False)  # unconfirmed
+
+        def unreadable():
+            raise PermissionError("the profile path cannot be resolved")
+
+        with (
+            patch.object(drv, "_browser", fake_browser),
+            patch.object(drv, "_browser_holds_lease", True),
+            patch.object(drv, "get_profile_lease", side_effect=unreadable),
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
+                side_effect=unreadable,
+            ),
+        ):
+            # The original failure still reaches the caller.
+            with pytest.raises(PermissionError):
+                await drv._close_browser_locked()
+
+        assert stand_down_reason() is not None, (
+            "an owner whose close could not read the lease keeps the profile"
+        )
+
+    async def test_a_confirmed_close_with_an_unreadable_lease_is_left_alone(self):
+        """Only an *unconfirmed* teardown means the profile may still be held.
+
+        Chromium is provably gone here, so the failed lookup is a problem for the
+        caller rather than a reason to end the owner.
+        """
+        from linkedin_mcp_server.drivers import browser as drv
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        set_process_role(ServerRole.OWNER)
+        fake_browser = MagicMock()
+        fake_browser.close = AsyncMock(return_value=True)  # confirmed
+
+        def unreadable():
+            raise PermissionError("the profile path cannot be resolved")
+
+        with (
+            patch.object(drv, "_browser", fake_browser),
+            patch.object(drv, "_browser_holds_lease", True),
+            patch.object(drv, "get_profile_lease", side_effect=unreadable),
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
+                side_effect=unreadable,
+            ),
+        ):
+            with pytest.raises(PermissionError):
+                await drv._close_browser_locked()
+
+        assert stand_down_reason() is None, "a proven-closed owner was told to exit"

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -357,6 +357,13 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
                 "linkedin_mcp_server.dependencies.get_profile_lease",
                 return_value=lease,
             ),
+            # Also at the source: the stand-down helper lives in `server_role`
+            # and reads the lease through `profile_lease`, not through the
+            # module under test.
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
+                return_value=lease,
+            ),
             patch("linkedin_mcp_server.dependencies.go_auth_quiescent", latched),
         ):
             with pytest.raises(BrowserShutdownUnconfirmedError, match="Restart"):
@@ -393,6 +400,13 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
             patch("linkedin_mcp_server.dependencies.close_browser", AsyncMock()),
             patch(
                 "linkedin_mcp_server.dependencies.get_profile_lease",
+                return_value=lease,
+            ),
+            # Also at the source: the stand-down helper lives in `server_role`
+            # and reads the lease through `profile_lease`, not through the
+            # module under test.
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
                 return_value=lease,
             ),
             patch(
@@ -442,6 +456,13 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
             patch("linkedin_mcp_server.dependencies.close_browser", AsyncMock()),
             patch(
                 "linkedin_mcp_server.dependencies.get_profile_lease",
+                return_value=lease,
+            ),
+            # Also at the source: the stand-down helper lives in `server_role`
+            # and reads the lease through `profile_lease`, not through the
+            # module under test.
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
                 return_value=lease,
             ),
         ):
@@ -499,6 +520,13 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
                 "linkedin_mcp_server.dependencies.get_profile_lease",
                 return_value=lease,
             ),
+            # Also at the source: the stand-down helper lives in `server_role`
+            # and reads the lease through `profile_lease`, not through the
+            # module under test.
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
+                return_value=lease,
+            ),
         ):
             with pytest.raises((TimeoutError, asyncio.CancelledError)):
                 await asyncio.wait_for(
@@ -536,6 +564,13 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
                 "linkedin_mcp_server.dependencies.get_profile_lease",
                 return_value=lease,
             ),
+            # Also at the source: the stand-down helper lives in `server_role`
+            # and reads the lease through `profile_lease`, not through the
+            # module under test.
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
+                return_value=lease,
+            ),
             patch(
                 "linkedin_mcp_server.dependencies.invalidate_auth_and_trigger_relogin",
                 AsyncMock(),
@@ -545,3 +580,100 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
                 await handle_auth_error(AuthenticationError("expired"), ctx=None)
 
         assert stand_down_reason() is None
+
+
+class TestAWedgeFromAnywhereFreesTheOwner:
+    """The request belongs to the error, not to one of its raise sites.
+
+    Found live rather than by review. A real detached owner failed to close
+    Chromium inside 10 seconds during `_authenticate_existing_profile`, deep in
+    the driver, which never reaches `handle_auth_error`. The owner kept the
+    profile and three consecutive fresh clients each attached to it and got the
+    same refusal, recoverable only by killing it.
+    """
+
+    def teardown_method(self):
+        from linkedin_mcp_server.server_role import reset_process_role_for_testing
+
+        reset_process_role_for_testing()
+
+    def test_raising_it_asks_an_owner_to_give_way(self):
+        from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        set_process_role(ServerRole.OWNER)
+        # Production marks the browser open before the startup that fails, so by
+        # the time this is raised the lease says the profile is held. Without
+        # that the request is correctly skipped, and asserting on the bare
+        # construction would test a state the code never reaches.
+        lease = MagicMock()
+        lease.browser_open = True
+        with patch(
+            "linkedin_mcp_server.profile_lease.get_profile_lease", return_value=lease
+        ):
+            BrowserShutdownUnconfirmedError("the startup teardown timed out")
+
+        assert stand_down_reason() is not None, (
+            "an owner wedged outside handle_auth_error keeps the profile forever"
+        )
+
+    def test_a_single_server_is_left_alone(self):
+        """Its client owns it, so "restart the server" is something to act on."""
+        from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
+        from linkedin_mcp_server.server_role import stand_down_reason
+
+        lease = MagicMock()
+        lease.browser_open = True
+        with patch(
+            "linkedin_mcp_server.profile_lease.get_profile_lease", return_value=lease
+        ):
+            BrowserShutdownUnconfirmedError("the startup teardown timed out")
+
+        assert stand_down_reason() is None
+
+    async def test_a_quiet_close_that_keeps_the_profile_also_frees_the_owner(self):
+        """The path that reports nothing at all, which is why it was missed twice.
+
+        A handoff, the idle timeout and ``close_session`` all reach
+        ``_close_browser_locked``, which returns *normally* when the teardown
+        cannot be confirmed: it logs, keeps the lease, and raises nothing. So
+        neither the exception constructor nor ``handle_auth_error`` runs, and the
+        owner sits on the profile while every later launch is refused with
+        ``BrowserBusyError``.
+
+        Reproduced before this: close returned, the lease was kept, and
+        ``stand_down_reason()`` was still None.
+        """
+        from linkedin_mcp_server.drivers import browser as drv
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        set_process_role(ServerRole.OWNER)
+        lease = MagicMock()
+        lease.browser_open = True
+        fake_browser = MagicMock()
+        fake_browser.close = AsyncMock(return_value=False)  # unconfirmed teardown
+
+        with (
+            patch.object(drv, "_browser", fake_browser),
+            patch.object(drv, "_browser_holds_lease", True),
+            patch.object(drv, "get_profile_lease", return_value=lease),
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
+                return_value=lease,
+            ),
+        ):
+            await drv._close_browser_locked()
+
+        # The lease is kept deliberately; what must not also happen is silence.
+        lease.release.assert_not_called()
+        assert stand_down_reason() is not None, (
+            "an owner stranded by a routine close keeps the profile forever"
+        )

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import asyncio
+
 import pytest
 from fastmcp.exceptions import ToolError
 
@@ -447,6 +449,66 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
                 await handle_auth_error(AuthenticationError("expired"), ctx=None)
 
         assert stand_down_reason() is not None, "the wedged owner keeps serving"
+
+    async def test_a_timeout_during_the_close_still_frees_the_owner(self):
+        """The wedge must be noticed even when the call it runs in is cut short.
+
+        ``close_browser`` defers cancellation until teardown finishes and then
+        re-raises ``CancelledError`` (``drivers/browser.py``), which is a
+        ``BaseException`` and passes through ``except Exception`` untouched. A
+        tool timeout landing during the close therefore skipped the whole
+        stand-down decision, and the owner stayed wedged exactly as before the
+        fix -- recoverable only by killing it.
+
+        Measured with the decision outside the ``finally``: the call ended in
+        ``TimeoutError`` with ``stand_down_reason()`` still None and the lease
+        still held.
+        """
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        set_process_role(ServerRole.OWNER)
+        lease = MagicMock()
+        lease.browser_open = True
+
+        async def close_that_defers_its_cancel():
+            """What the production close does, in miniature."""
+            try:
+                await asyncio.sleep(0.05)
+            except asyncio.CancelledError:
+                pass  # teardown runs to the end regardless
+            raise asyncio.CancelledError
+
+        with (
+            patch(
+                "linkedin_mcp_server.dependencies.get_runtime_policy",
+                return_value="managed",
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.current_login_generation",
+                return_value="gen-1",
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.close_browser",
+                close_that_defers_its_cancel,
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.get_profile_lease",
+                return_value=lease,
+            ),
+        ):
+            with pytest.raises((TimeoutError, asyncio.CancelledError)):
+                await asyncio.wait_for(
+                    handle_auth_error(AuthenticationError("expired"), ctx=None),
+                    timeout=0.02,
+                )
+
+        assert stand_down_reason() is not None, (
+            "a timeout during the close left the owner wedged"
+        )
 
     async def test_a_single_server_is_not_asked_to_stand_down(self):
         """The same condition, and deliberately not the same answer.

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -606,10 +606,11 @@ class TestAWedgeFromAnywhereFreesTheOwner:
         )
 
         set_process_role(ServerRole.OWNER)
-        # Production marks the browser open before the startup that fails, so by
-        # the time this is raised the lease says the profile is held. Without
-        # that the request is correctly skipped, and asserting on the bare
-        # construction would test a state the code never reaches.
+        # Constructed with the profile already held, which is the state the
+        # request is about. This asserts the constructor's own contribution; the
+        # startup path that produces that state in the real order is asserted
+        # through `_create_browser` below, because a mocked flag there hid a live
+        # wedge for a whole review round.
         lease = MagicMock()
         lease.browser_open = True
         with patch(
@@ -619,6 +620,70 @@ class TestAWedgeFromAnywhereFreesTheOwner:
 
         assert stand_down_reason() is not None, (
             "an owner wedged outside handle_auth_error keeps the profile forever"
+        )
+
+    async def test_the_startup_path_frees_the_owner_in_the_real_order(self):
+        """The live wedge, driven through the function that produces it.
+
+        `_create_browser_locked` raises while `browser_open` is still false, so
+        the helper inside the exception's constructor reads "nothing is held" and
+        returns. Only the catch afterwards marks the browser open and takes the
+        extra reference -- holding the profile with nobody having asked for a
+        replacement.
+
+        Measured in production order: `browser_open=True`, `stand_down=None`.
+        The previous test for this handed the constructor a lease that already
+        said True, which is exactly the state production has not reached yet, and
+        that mock is what hid it.
+        """
+        from linkedin_mcp_server.drivers import browser as drv
+        from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        class Lease:
+            """Real enough: the marker starts false, as production's does."""
+
+            def __init__(self):
+                self.browser_open = False
+                self.refs = 1
+
+            def try_acquire(self):
+                self.refs += 1
+                return True
+
+            def mark_browser_open(self):
+                self.browser_open = True
+
+            def release(self):
+                self.refs -= 1
+
+        set_process_role(ServerRole.OWNER)
+        lease = Lease()
+
+        async def teardown_that_could_not_be_confirmed():
+            raise BrowserShutdownUnconfirmedError("the startup teardown timed out")
+
+        with (
+            patch.object(drv, "_browser", None),
+            patch.object(drv, "get_profile_lease", return_value=lease),
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
+                return_value=lease,
+            ),
+            patch.object(
+                drv, "_create_browser_locked", teardown_that_could_not_be_confirmed
+            ),
+        ):
+            with pytest.raises(BrowserShutdownUnconfirmedError):
+                await drv._create_browser()
+
+        assert lease.browser_open is True, "the profile was not actually held"
+        assert stand_down_reason() is not None, (
+            "the owner holds the profile and nobody asked for a replacement"
         )
 
     def test_a_single_server_is_left_alone(self):

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -742,3 +742,87 @@ class TestAWedgeFromAnywhereFreesTheOwner:
         assert stand_down_reason() is not None, (
             "an owner stranded by a routine close keeps the profile forever"
         )
+
+    def test_a_free_profile_leaves_the_owner_serving(self):
+        """The guard is what keeps this from firing on every ordinary close.
+
+        Asserted against the helper directly rather than through a confirmed
+        close: that branch never reaches the helper at all, so a test driving it
+        stays green with the guard deleted. Measured -- the first version of this
+        did exactly that.
+
+        Without the guard every call here would end the owner, healthy or not,
+        and the daemon would churn a process per stale session.
+        """
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            a_held_profile_means_this_owner_must_go,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        set_process_role(ServerRole.OWNER)
+        lease = MagicMock()
+        lease.browser_open = False  # a confirmed teardown clears it
+
+        with patch(
+            "linkedin_mcp_server.profile_lease.get_profile_lease", return_value=lease
+        ):
+            a_held_profile_means_this_owner_must_go()
+
+        assert stand_down_reason() is None, "a healthy owner was told to exit"
+
+    async def test_a_confirmed_close_does_not_reach_the_request(self):
+        """And the ordinary close path stays silent end to end."""
+        from linkedin_mcp_server.drivers import browser as drv
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        set_process_role(ServerRole.OWNER)
+        lease = MagicMock()
+        lease.browser_open = False  # a confirmed teardown clears it
+        fake_browser = MagicMock()
+        fake_browser.close = AsyncMock(return_value=True)
+
+        with (
+            patch.object(drv, "_browser", fake_browser),
+            patch.object(drv, "_browser_holds_lease", True),
+            patch.object(drv, "get_profile_lease", return_value=lease),
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
+                return_value=lease,
+            ),
+        ):
+            await drv._close_browser_locked()
+
+        assert stand_down_reason() is None, "a healthy owner was told to exit"
+
+    def test_a_lease_it_cannot_read_counts_as_held(self):
+        """Not being able to tell is not the same as being told it is free.
+
+        The two outcomes are not symmetric: an unnecessary stand-down costs one
+        election, a stranded owner costs every later call. Measured with the read
+        raising ``PermissionError``: the owner kept serving.
+        """
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            a_held_profile_means_this_owner_must_go,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        set_process_role(ServerRole.OWNER)
+
+        def unreadable():
+            raise PermissionError("the profile path cannot be resolved")
+
+        with patch(
+            "linkedin_mcp_server.profile_lease.get_profile_lease",
+            side_effect=unreadable,
+        ):
+            a_held_profile_means_this_owner_must_go()
+
+        assert stand_down_reason() is not None

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -31,6 +31,10 @@ class TestHandleAuthError:
                 new_callable=AsyncMock,
             ) as mock_close,
             patch(
+                "linkedin_mcp_server.dependencies.current_login_generation",
+                return_value="the-dead-one",
+            ),
+            patch(
                 "linkedin_mcp_server.dependencies.invalidate_auth_and_trigger_relogin",
                 new_callable=AsyncMock,
                 side_effect=AuthenticationStartedError("login opened"),
@@ -46,7 +50,10 @@ class TestHandleAuthError:
             # downstream can tell the dead session from a peer's repair.
             mock_relogin.assert_awaited_once()
             assert mock_relogin.await_args.args == (None,)
-            assert "stale_generation" in mock_relogin.await_args.kwargs
+            # The value, not merely the keyword. Asserting only that the argument
+            # exists left a mutation passing a hardcoded None green, which is the
+            # regression this whole path was fixed for.
+            assert mock_relogin.await_args.kwargs["stale_generation"] == "the-dead-one"
 
     async def test_docker_raises_host_error(self):
         """On Docker runtime, raise DockerHostLoginRequiredError."""
@@ -355,3 +362,44 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
 
         # Not latched: a latch here is the wedge, because nothing can clear it.
         latched.assert_not_called()
+
+    async def test_an_unconfirmed_close_stops_a_single_server_too(self):
+        """Not only the shared owner: nothing that follows can work for either.
+
+        An unconfirmed teardown keeps the profile lease until the process exits,
+        so a single-process server that carried on would start a login whose own
+        rotation is refused for exactly that reason, after having told the user a
+        window had opened. Measured with the check owner-only: the server reported
+        "a login browser window has been opened", opened none, kept the dead
+        session, and left a state only a restart clears.
+        """
+        from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
+
+        relogin = AsyncMock()
+        lease = MagicMock()
+        lease.browser_open = True
+
+        with (
+            patch(
+                "linkedin_mcp_server.dependencies.get_runtime_policy",
+                return_value="managed",
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.current_login_generation",
+                return_value="gen-1",
+            ),
+            patch("linkedin_mcp_server.dependencies.close_browser", AsyncMock()),
+            patch(
+                "linkedin_mcp_server.dependencies.get_profile_lease",
+                return_value=lease,
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.invalidate_auth_and_trigger_relogin",
+                relogin,
+            ),
+        ):
+            # A DIRECT server: the role is never set, so it is the default.
+            with pytest.raises(BrowserShutdownUnconfirmedError, match="Restart"):
+                await handle_auth_error(AuthenticationError("expired"), ctx=None)
+
+        relogin.assert_not_awaited()

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -403,3 +403,83 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
                 await handle_auth_error(AuthenticationError("expired"), ctx=None)
 
         relogin.assert_not_awaited()
+
+    async def test_a_wedged_owner_asks_to_be_replaced(self):
+        """Reporting the wedge is not enough for an owner: it has to go.
+
+        The two roles need different answers to the same condition. "Restart the
+        server" is actionable for a single-process server, whose client owns it.
+        A detached owner outlives the client that started it, so restarting the
+        client elects nothing: the next frontend attaches to this same owner and
+        meets the same held profile. Only exiting frees the lock.
+
+        Asserted against the request rather than against a real exit, because the
+        exit itself belongs to the serve loop; ``test_daemon_owner`` covers that
+        the loop acts on this.
+        """
+        from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        set_process_role(ServerRole.OWNER)
+        lease = MagicMock()
+        lease.browser_open = True
+
+        with (
+            patch(
+                "linkedin_mcp_server.dependencies.get_runtime_policy",
+                return_value="managed",
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.current_login_generation",
+                return_value="gen-1",
+            ),
+            patch("linkedin_mcp_server.dependencies.close_browser", AsyncMock()),
+            patch(
+                "linkedin_mcp_server.dependencies.get_profile_lease",
+                return_value=lease,
+            ),
+        ):
+            with pytest.raises(BrowserShutdownUnconfirmedError):
+                await handle_auth_error(AuthenticationError("expired"), ctx=None)
+
+        assert stand_down_reason() is not None, "the wedged owner keeps serving"
+
+    async def test_a_single_server_is_not_asked_to_stand_down(self):
+        """The same condition, and deliberately not the same answer.
+
+        A DIRECT server has no successor to elect. Asking it to stand down would
+        end the only server the client has, over something a restart fixes.
+        """
+        from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
+        from linkedin_mcp_server.server_role import stand_down_reason
+
+        lease = MagicMock()
+        lease.browser_open = True
+
+        with (
+            patch(
+                "linkedin_mcp_server.dependencies.get_runtime_policy",
+                return_value="managed",
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.current_login_generation",
+                return_value="gen-1",
+            ),
+            patch("linkedin_mcp_server.dependencies.close_browser", AsyncMock()),
+            patch(
+                "linkedin_mcp_server.dependencies.get_profile_lease",
+                return_value=lease,
+            ),
+            patch(
+                "linkedin_mcp_server.dependencies.invalidate_auth_and_trigger_relogin",
+                AsyncMock(),
+            ),
+        ):
+            with pytest.raises(BrowserShutdownUnconfirmedError):
+                await handle_auth_error(AuthenticationError("expired"), ctx=None)
+
+        assert stand_down_reason() is None

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -42,7 +42,11 @@ class TestHandleAuthError:
                 )
 
             mock_close.assert_awaited_once()
-            mock_relogin.assert_awaited_once_with(None)
+            # The generation it observed travels with it, so the rotation
+            # downstream can tell the dead session from a peer's repair.
+            mock_relogin.assert_awaited_once()
+            assert mock_relogin.await_args.args == (None,)
+            assert "stale_generation" in mock_relogin.await_args.kwargs
 
     async def test_docker_raises_host_error(self):
         """On Docker runtime, raise DockerHostLoginRequiredError."""
@@ -272,9 +276,20 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
 
         assert order == ["read", "close", "latch:gen-1"]
 
-    async def test_a_direct_server_neither_reads_nor_latches(self):
-        # The historical path has no owner state to keep, and touching it would
-        # make a single-process server refuse its own logins.
+    async def test_a_direct_server_reads_the_generation_but_does_not_latch(self):
+        """DIRECT reads it too, and that is a correction rather than a widening.
+
+        An earlier version asserted that DIRECT read nothing, on the reasoning
+        that the generation was owner state. It is not: a DIRECT server rotates
+        through the same function a frontend does, so without the generation it
+        reaches the rotation with nothing to compare against. Measured with the
+        old behaviour and a momentary profile holder: the login reported that a
+        window had opened, opened none, kept the dead session, and left readiness
+        saying the session was fine.
+
+        The latch stays owner-only. That is process state a single-process server
+        has no use for, and setting it would make it refuse its own logins.
+        """
         latched = MagicMock()
         read = MagicMock(return_value="gen-1")
 
@@ -295,10 +310,7 @@ class TestAnOwnerGoesQuiescentInsteadOfLoggingIn:
             with pytest.raises(AuthenticationStartedError):
                 await handle_auth_error(AuthenticationError("expired"), ctx=None)
 
-        # Both halves, as the name says. An earlier version asserted only the
-        # latch, so reading the generation unconditionally went unnoticed, and a
-        # DIRECT server would touch owner state it has no use for.
-        read.assert_not_called()
+        read.assert_called_once()
         latched.assert_not_called()
 
     async def test_an_unconfirmed_close_is_reported_instead_of_latching(self):

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -760,3 +760,155 @@ class TestALateLoginDoesNotUndoAnEarlierOne:
         assert await interactive_login(isolate_profile_dir, superseded_by=stale) is True
 
         assert opened == [True]
+
+    async def test_an_observed_empty_profile_is_guarded_too(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """Two clients meeting an empty profile need the same protection.
+
+        A profile with no session reads as no generation at all, so the observed
+        value and "nothing asked for a guard" would be the same thing if both were
+        spelled None. Measured with them conflated: the second client rotated away
+        the session the first had just created, on a profile that started empty.
+        """
+        from linkedin_mcp_server.session_state import load_source_state
+        from linkedin_mcp_server.setup import interactive_login
+
+        opened = self._login_without_a_browser(monkeypatch)
+        assert load_source_state(isolate_profile_dir) is None
+
+        # The winner signs in where there was nothing.
+        fresh = self._write_session(isolate_profile_dir)
+
+        # The loser decided when the profile was empty, so it observed None.
+        assert await interactive_login(isolate_profile_dir, superseded_by=None) is True
+
+        surviving = load_source_state(isolate_profile_dir)
+        assert surviving is not None
+        assert surviving.login_generation == fresh
+        assert opened == []
+
+    async def test_a_login_with_nothing_to_compare_is_left_alone(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        # `--login` typed at a terminal has no peer to defer to and must always
+        # sign in, however new the session on disk looks.
+        from linkedin_mcp_server.setup import interactive_login
+
+        self._write_session(isolate_profile_dir)
+        opened = self._login_without_a_browser(monkeypatch)
+        self._write_session(isolate_profile_dir)
+
+        assert await interactive_login(isolate_profile_dir) is True
+
+        assert opened == [True]
+
+    async def test_the_guard_releases_the_profile_when_it_fails(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        # The check runs with the profile held, so a failure inside it has to
+        # release. Left outside the try, an unreadable profile directory kept the
+        # lease until the process exited, locking out every other client.
+        import linkedin_mcp_server.setup as setup
+        from linkedin_mcp_server.profile_lease import get_profile_lease
+        from linkedin_mcp_server.setup import interactive_login
+
+        self._login_without_a_browser(monkeypatch)
+        monkeypatch.setattr(
+            setup,
+            "a_peer_already_signed_in",
+            MagicMock(side_effect=PermissionError("cannot read the profile")),
+        )
+
+        with pytest.raises(PermissionError):
+            await interactive_login(isolate_profile_dir, superseded_by="g0")
+
+        assert get_profile_lease(isolate_profile_dir).held is False
+
+
+class TestALateImportDoesNotUndoALogin:
+    """The import rotates the profile too, so it needs the same guard.
+
+    `start_login_if_needed` tries an auto-import before it opens a login window,
+    and the import retires the current session as soon as it holds the profile.
+    A client whose keychain read or profile discovery ran long is exactly the late
+    arrival this protects against.
+    """
+
+    def _write_session(self, profile_dir) -> str:
+        from linkedin_mcp_server.session_state import (
+            portable_cookie_path,
+            write_source_state,
+        )
+
+        (profile_dir / "Default").mkdir(parents=True, exist_ok=True)
+        (profile_dir / "Default" / "Cookies").write_text("placeholder")
+        portable_cookie_path(profile_dir).write_text("[]")
+        return write_source_state(profile_dir).login_generation
+
+    def _import_without_a_browser(self, monkeypatch) -> list[bool]:
+        """Stub discovery and validation; the real rotation still runs."""
+        import linkedin_mcp_server.browser_import.orchestrate as orchestrate
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        set_config(AppConfig())
+        committed: list[bool] = []
+
+        async def imported(live, cookie_path, user_data_dir):
+            committed.append(True)
+            return True
+
+        monkeypatch.setattr(orchestrate, "_import_first_accepted", imported)
+        # Imported inside the function, so patched at the source module.
+        monkeypatch.setattr(
+            "linkedin_mcp_server.drivers.browser.close_browser", AsyncMock()
+        )
+        monkeypatch.setattr(
+            orchestrate,
+            "_discover_and_rank",
+            MagicMock(return_value=([(MagicMock(), MagicMock())], [])),
+        )
+        return committed
+
+    async def test_a_late_import_stands_down(self, isolate_profile_dir, monkeypatch):
+        from linkedin_mcp_server.browser_import.orchestrate import (
+            import_session_from_browser,
+        )
+        from linkedin_mcp_server.session_state import load_source_state
+
+        stale = self._write_session(isolate_profile_dir)
+        committed = self._import_without_a_browser(monkeypatch)
+
+        # A peer signs in while this import is still reading the keychain.
+        fresh = self._write_session(isolate_profile_dir)
+
+        assert (
+            await import_session_from_browser(
+                None, user_data_dir=isolate_profile_dir, superseded_by=stale
+            )
+            is True
+        )
+
+        surviving = load_source_state(isolate_profile_dir)
+        assert surviving is not None
+        assert surviving.login_generation == fresh
+        assert committed == []
+
+    async def test_an_import_with_nothing_to_compare_still_runs(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        # `--import-from-browser` typed at a terminal has no peer to defer to.
+        from linkedin_mcp_server.browser_import.orchestrate import (
+            import_session_from_browser,
+        )
+
+        self._write_session(isolate_profile_dir)
+        committed = self._import_without_a_browser(monkeypatch)
+
+        assert (
+            await import_session_from_browser(None, user_data_dir=isolate_profile_dir)
+            is True
+        )
+
+        assert committed == [True]

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -1073,3 +1073,41 @@ class TestAMomentaryHolderDoesNotCancelTheRepair:
         surviving = load_source_state(isolate_profile_dir)
         assert surviving is not None
         assert surviving.login_generation == peer
+
+    async def test_the_guard_asks_about_the_profile_it_was_given(
+        self, isolate_profile_dir, monkeypatch, tmp_path
+    ):
+        """Readiness has to be asked of the same directory the generation came from.
+
+        `interactive_login` and the browser import both accept an explicit profile
+        alongside the generation, and the check read the generation from that one
+        while asking the *configured* profile whether a session was usable.
+        Measured with the two apart: a peer's fresh session in the explicit
+        profile was rotated away, because the configured one happened to be empty.
+        """
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+        from linkedin_mcp_server.session_state import (
+            load_source_state,
+            portable_cookie_path,
+            write_source_state,
+        )
+        from linkedin_mcp_server.setup import a_peer_already_signed_in
+
+        # The configured profile is empty, so its readiness is False.
+        config = AppConfig()
+        config.browser.user_data_dir = str(isolate_profile_dir)
+        set_config(config)
+
+        # A different profile, handed in explicitly, holds a complete session.
+        other = tmp_path / "other" / "profile"
+        (other / "Default").mkdir(parents=True)
+        (other / "Default" / "Cookies").write_text("placeholder")
+        portable_cookie_path(other).write_text("[]")
+        fresh = write_source_state(other).login_generation
+        assert load_source_state(isolate_profile_dir) is None
+
+        # Asked about `other`, the answer is yes: somebody has signed in there.
+        assert a_peer_already_signed_in(other, "a-different-generation") is True
+        # And the same call still says no when the generation is the one in hand.
+        assert a_peer_already_signed_in(other, fresh) is False

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -1043,8 +1043,8 @@ class TestAMomentaryHolderDoesNotCancelTheRepair:
         import linkedin_mcp_server.bootstrap as bootstrap
         from linkedin_mcp_server.config import set_config
         from linkedin_mcp_server.config.schema import AppConfig
-        from linkedin_mcp_server.exceptions import AuthenticationStartedError
         from linkedin_mcp_server.session_state import (
+            PeerSessionInPlaceError,
             load_source_state,
             portable_cookie_path,
             write_source_state,
@@ -1063,7 +1063,9 @@ class TestAMomentaryHolderDoesNotCancelTheRepair:
         portable_cookie_path(isolate_profile_dir).write_text("[]")
         peer = write_source_state(isolate_profile_dir).login_generation
 
-        with pytest.raises(AuthenticationStartedError):
+        # Reported as the peer win it is, and no login is scheduled: the rotation
+        # decides that under the lock and says so.
+        with pytest.raises(PeerSessionInPlaceError):
             await bootstrap.invalidate_auth_and_trigger_relogin(stale_generation=None)
 
         surviving = load_source_state(isolate_profile_dir)
@@ -1140,6 +1142,7 @@ class TestTheComparisonHappensUnderTheLock:
     ):
         import linkedin_mcp_server.session_state as session_state
         from linkedin_mcp_server.session_state import (
+            PeerSessionInPlaceError,
             load_source_state,
             rotate_source_profile,
         )
@@ -1160,9 +1163,12 @@ class TestTheComparisonHappensUnderTheLock:
             session_state, "_exclusive_profile", peer_signs_in_then_we_lock
         )
 
-        retired = rotate_source_profile(isolate_profile_dir, superseded_by=stale)
+        # Raised rather than returning None, so a caller can tell "a peer won"
+        # from "there was nothing to retire" and stop instead of promising a
+        # login window it will not open.
+        with pytest.raises(PeerSessionInPlaceError):
+            rotate_source_profile(isolate_profile_dir, superseded_by=stale)
 
-        assert retired is None, "it rotated a session it should have left alone"
         surviving = load_source_state(isolate_profile_dir)
         assert surviving is not None
         assert surviving.login_generation == landed[0]
@@ -1249,3 +1255,57 @@ class TestTheComparisonHappensUnderTheLock:
         with pytest.raises(AuthenticationInProgressError):
             await bootstrap._start_login_if_needed(superseded_by="the-missing-one")
         assert seen == ["the-missing-one"], seen
+
+    async def test_a_peer_win_is_reported_as_one(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """Preserving a peer's session is not the same as retiring one.
+
+        The rotation returns None for "there was nothing to retire", so signalling
+        a peer win the same way made the two indistinguishable. The caller then
+        carried on and promised a login window, and the task stood down the moment
+        it held the profile, so none opened. The data was safe and the report was
+        a lie, which is the same user-visible failure as an earlier round's
+        blocker without the wedge.
+        """
+        from unittest.mock import AsyncMock
+
+        import linkedin_mcp_server.bootstrap as bootstrap
+        import linkedin_mcp_server.setup as setup
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+        from linkedin_mcp_server.session_state import (
+            PeerSessionInPlaceError,
+            load_source_state,
+        )
+
+        config = AppConfig()
+        config.browser.user_data_dir = str(isolate_profile_dir)
+        config.browser.auto_import_from_browser = False
+        set_config(config)
+        monkeypatch.setattr(bootstrap, "get_config", lambda: config)
+
+        opened: list[bool] = []
+
+        async def browser_body(user_data_dir, *, config, state):
+            opened.append(True)
+            state.browser_opened = True
+            state.close_confirmed = True
+            return True
+
+        monkeypatch.setattr(setup, "_login_into_fresh_profile", browser_body)
+        monkeypatch.setattr(setup, "close_browser", AsyncMock())
+        monkeypatch.setattr(bootstrap, "close_browser", AsyncMock())
+
+        stale = self._write_session(isolate_profile_dir)
+        peer = self._write_session(isolate_profile_dir)
+
+        with pytest.raises(PeerSessionInPlaceError, match="already signed in"):
+            await bootstrap.invalidate_auth_and_trigger_relogin(stale_generation=stale)
+
+        # No task, so nothing to await and nothing that could have opened.
+        assert bootstrap.get_bootstrap_state().login_task is None
+        assert opened == []
+        surviving = load_source_state(isolate_profile_dir)
+        assert surviving is not None
+        assert surviving.login_generation == peer

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -534,3 +534,71 @@ class TestConfirmedClose:
                 await browser_module.close_browser()
 
         assert not lease.held
+
+
+class TestALoginWaitsForTheProfile:
+    """A login asks for the profile and waits, rather than demanding it at once.
+
+    This is also the path a frontend takes when the shared browser asks it to sign
+    in, and a proxy holds no lease of its own to reuse. Left non-blocking, any
+    momentary holder anywhere on the machine leaves the user with a login that
+    refuses to open and nothing they can do about it.
+    """
+
+    async def test_it_waits_for_a_real_holder_to_let_go(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        from linkedin_mcp_server.setup import interactive_login
+
+        auth_root = isolate_profile_dir.parent
+        # A real second process, because the lease is a kernel lock: an in-process
+        # stand-in would be reference-counted and simply succeed.
+        holder = _hold_profile(auth_root, seconds=1.5)
+
+        opened: list[bool] = []
+
+        async def login_once_we_have_the_profile(user_data_dir, lease, state):
+            opened.append(True)
+            return True
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.setup._login_holding_the_profile",
+            login_once_we_have_the_profile,
+        )
+        monkeypatch.setattr("linkedin_mcp_server.setup.close_browser", AsyncMock())
+
+        try:
+            assert await interactive_login(isolate_profile_dir) is True
+        finally:
+            holder.wait(timeout=10)
+
+        assert opened == [True]
+
+    async def test_it_still_gives_up_on_a_holder_that_never_releases(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        # Bounded, not indefinite. Past the handover window the holder is a process
+        # that is not going to release, and hanging would be worse than saying so.
+        from linkedin_mcp_server.exceptions import BrowserBusyError
+        from linkedin_mcp_server.setup import interactive_login
+
+        auth_root = isolate_profile_dir.parent
+        holder = _hold_profile(auth_root, seconds=30)
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.setup.PROFILE_HANDOVER_WAIT_SECONDS", 0.3
+        )
+        monkeypatch.setattr("linkedin_mcp_server.setup.close_browser", AsyncMock())
+        never = MagicMock()
+        monkeypatch.setattr(
+            "linkedin_mcp_server.setup._login_holding_the_profile", never
+        )
+
+        try:
+            with pytest.raises(BrowserBusyError):
+                await interactive_login(isolate_profile_dir)
+        finally:
+            holder.kill()
+            holder.wait(timeout=10)
+
+        never.assert_not_called()

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -602,3 +602,161 @@ class TestALoginWaitsForTheProfile:
             holder.wait(timeout=10)
 
         never.assert_not_called()
+
+
+class TestALateLoginDoesNotUndoAnEarlierOne:
+    """The window the generation check in `interactive_login` exists for.
+
+    Two clients told to sign in for one dead session both look, both see it dead,
+    and both queue for the profile. The one that waited then holds an opinion
+    formed before the winner finished. Its login rotates the profile as soon as it
+    has the lease, and rotation does not ask whose session it is retiring.
+
+    So the check cannot live where the decision to log in is made. It has to be
+    where the profile is actually held, which is the first moment the answer
+    cannot change underneath it.
+    """
+
+    def _write_session(self, profile_dir) -> str:
+        """Put a usable session on disk and return its generation."""
+        from linkedin_mcp_server.session_state import (
+            portable_cookie_path,
+            write_source_state,
+        )
+
+        (profile_dir / "Default").mkdir(parents=True, exist_ok=True)
+        (profile_dir / "Default" / "Cookies").write_text("placeholder")
+        portable_cookie_path(profile_dir).write_text("[]")
+        return write_source_state(profile_dir).login_generation
+
+    def _login_without_a_browser(self, monkeypatch) -> list[bool]:
+        """Stub only the browser half, so the real rotation still runs.
+
+        Returns a list that gains an entry each time a login would have opened,
+        which is how the tests below tell "stood down" from "signed in".
+        """
+        import linkedin_mcp_server.setup as setup
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        # Installed rather than loaded: `_login_holding_the_profile` calls
+        # get_config(), which parses sys.argv, and under pytest that is pytest's
+        # own command line.
+        set_config(AppConfig())
+
+        opened: list[bool] = []
+
+        async def signed_in(user_data_dir, config, state):
+            opened.append(True)
+            state.browser_opened = True
+            state.close_confirmed = True
+            return True
+
+        monkeypatch.setattr(setup, "_login_into_fresh_profile", signed_in)
+        monkeypatch.setattr(setup, "close_browser", AsyncMock())
+        return opened
+
+    async def test_without_the_generation_the_later_login_destroys_the_earlier(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        # The damage, reproduced, so the guarded case below is not asserting thin
+        # air. This is what the old call shape did.
+        from linkedin_mcp_server.session_state import load_source_state
+        from linkedin_mcp_server.setup import interactive_login
+
+        self._write_session(isolate_profile_dir)
+        self._login_without_a_browser(monkeypatch)
+
+        # The winner finishes and writes a fresh generation.
+        fresh = self._write_session(isolate_profile_dir)
+
+        # The loser's login proceeds anyway, knowing nothing.
+        assert await interactive_login(isolate_profile_dir) is True
+
+        surviving = load_source_state(isolate_profile_dir)
+        assert surviving is None or surviving.login_generation != fresh
+
+    async def test_the_generation_makes_the_later_login_stand_down(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        from linkedin_mcp_server.session_state import load_source_state
+        from linkedin_mcp_server.setup import interactive_login
+
+        stale = self._write_session(isolate_profile_dir)
+        self._login_without_a_browser(monkeypatch)
+
+        fresh = self._write_session(isolate_profile_dir)
+        assert fresh != stale
+
+        # Reports success, because from the caller's point of view there is now a
+        # usable session, which is what it asked for.
+        assert await interactive_login(isolate_profile_dir, superseded_by=stale) is True
+
+        surviving = load_source_state(isolate_profile_dir)
+        assert surviving is not None
+        assert surviving.login_generation == fresh
+
+    async def test_it_still_logs_in_when_the_session_really_is_the_dead_one(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        # The guard must not stop the client that is right, which is every
+        # ordinary case: same generation, so nobody has repaired anything.
+        from linkedin_mcp_server.setup import interactive_login
+
+        stale = self._write_session(isolate_profile_dir)
+
+        opened = self._login_without_a_browser(monkeypatch)
+
+        assert await interactive_login(isolate_profile_dir, superseded_by=stale) is True
+
+        assert opened == [True]
+
+    async def test_an_abandoned_peer_attempt_does_not_stop_the_next_login(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        # A rotated profile has no generation, which also differs from the stale
+        # one. Standing down there would mean nobody ever signs in.
+        from linkedin_mcp_server.session_state import (
+            load_source_state,
+            rotate_source_profile,
+        )
+        from linkedin_mcp_server.setup import interactive_login
+
+        stale = self._write_session(isolate_profile_dir)
+
+        opened = self._login_without_a_browser(monkeypatch)
+
+        rotate_source_profile(isolate_profile_dir)
+        assert load_source_state(isolate_profile_dir) is None
+
+        assert await interactive_login(isolate_profile_dir, superseded_by=stale) is True
+
+        assert opened == [True]
+
+    async def test_a_new_generation_without_a_usable_session_does_not_stop_it(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """A different generation is not on its own proof that anyone succeeded.
+
+        The abandoned case above never reaches this: rotation removes the state
+        file entirely, so the check stops at "there is no generation". This is the
+        other shape, where a generation *is* written and the session still is not
+        usable, and it is what the readiness half of the condition is for.
+        Measured: without it, the login stands down while nothing on disk works,
+        and the user is left with no session and no way to get one.
+        """
+        from linkedin_mcp_server.session_state import (
+            portable_cookie_path,
+        )
+        from linkedin_mcp_server.setup import interactive_login
+
+        stale = self._write_session(isolate_profile_dir)
+        opened = self._login_without_a_browser(monkeypatch)
+
+        # A newer generation, but the cookies that make it usable are gone.
+        assert self._write_session(isolate_profile_dir) != stale
+        portable_cookie_path(isolate_profile_dir).unlink()
+
+        assert await interactive_login(isolate_profile_dir, superseded_by=stale) is True
+
+        assert opened == [True]

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -912,3 +912,54 @@ class TestALateImportDoesNotUndoALogin:
         )
 
         assert committed == [True]
+
+
+class TestAMomentaryHolderDoesNotCancelTheRepair:
+    """A profile held for a moment must not defeat the wait built to survive it.
+
+    `invalidate_auth_and_trigger_relogin` retires the dead session before it
+    starts a login. That rotation takes the profile, and it does not wait for it,
+    so a holder anywhere else made it fail. Refusing the login there was right
+    when the login also demanded the profile outright; now that it waits, refusing
+    throws away the wait before it happens.
+    """
+
+    async def test_the_login_still_starts_while_another_process_holds_it(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        from unittest.mock import AsyncMock
+
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+        from linkedin_mcp_server.exceptions import AuthenticationStartedError
+        from linkedin_mcp_server.profile_lease import get_profile_lease
+        from linkedin_mcp_server.session_state import (
+            portable_cookie_path,
+            write_source_state,
+        )
+
+        config = AppConfig()
+        config.browser.user_data_dir = str(isolate_profile_dir)
+        set_config(config)
+        monkeypatch.setattr(bootstrap, "get_config", lambda: config)
+
+        # A complete session, so the rotation has something to move and really
+        # reaches for the profile.
+        (isolate_profile_dir / "Default").mkdir(parents=True, exist_ok=True)
+        (isolate_profile_dir / "Default" / "Cookies").write_text("placeholder")
+        portable_cookie_path(isolate_profile_dir).write_text("[]")
+        write_source_state(isolate_profile_dir)
+
+        holder = _hold_profile(get_profile_lease(isolate_profile_dir).auth_root, 1.5)
+        monkeypatch.setattr(bootstrap, "_run_login_flow", AsyncMock())
+
+        try:
+            # Started, not refused. Before this, the rotation raised "the browser
+            # profile is in use" and no login was ever attempted.
+            with pytest.raises(AuthenticationStartedError):
+                await bootstrap.invalidate_auth_and_trigger_relogin()
+        finally:
+            holder.wait(timeout=10)
+
+        assert bootstrap.get_bootstrap_state().login_task is not None

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -963,3 +963,113 @@ class TestAMomentaryHolderDoesNotCancelTheRepair:
             holder.wait(timeout=10)
 
         assert bootstrap.get_bootstrap_state().login_task is not None
+
+    async def test_a_direct_server_still_opens_a_window_after_the_delay(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """The end of the path, not just its start, and it caught a real defect.
+
+        The test above stubs the login task away, so it proves the repair is
+        *attempted* and nothing more. This one lets the real login run, and with
+        the earlier code it exposed the worst available failure: the server
+        reported that a login window had opened, opened none, kept the dead
+        session, and left readiness saying the session was fine.
+
+        The cause was a single-process server reaching the rotation with no
+        generation to compare against, so the guard read the dead session as
+        somebody else's repair and stood down.
+        """
+        import linkedin_mcp_server.bootstrap as bootstrap
+        import linkedin_mcp_server.setup as setup
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+        from linkedin_mcp_server.exceptions import AuthenticationStartedError
+        from linkedin_mcp_server.profile_lease import get_profile_lease
+        from linkedin_mcp_server.session_state import (
+            load_source_state,
+            portable_cookie_path,
+            write_source_state,
+        )
+
+        config = AppConfig()
+        config.browser.user_data_dir = str(isolate_profile_dir)
+        set_config(config)
+        monkeypatch.setattr(bootstrap, "get_config", lambda: config)
+
+        (isolate_profile_dir / "Default").mkdir(parents=True, exist_ok=True)
+        (isolate_profile_dir / "Default" / "Cookies").write_text("placeholder")
+        portable_cookie_path(isolate_profile_dir).write_text("[]")
+        dead = write_source_state(isolate_profile_dir).login_generation
+
+        opened: list[bool] = []
+
+        async def signed_in(user_data_dir, *, config, state):
+            opened.append(True)
+            state.browser_opened = True
+            state.close_confirmed = True
+            return True
+
+        monkeypatch.setattr(setup, "_login_into_fresh_profile", signed_in)
+        monkeypatch.setattr(setup, "close_browser", AsyncMock())
+        monkeypatch.setattr(bootstrap, "close_browser", AsyncMock())
+
+        holder = _hold_profile(get_profile_lease(isolate_profile_dir).auth_root, 1.5)
+        try:
+            with pytest.raises(AuthenticationStartedError):
+                await bootstrap.invalidate_auth_and_trigger_relogin(
+                    stale_generation=dead
+                )
+            task = bootstrap.get_bootstrap_state().login_task
+            assert task is not None
+            await task
+        finally:
+            holder.wait(timeout=10)
+
+        # A window really opened, and the dead session is gone.
+        assert opened == [True]
+        surviving = load_source_state(isolate_profile_dir)
+        assert surviving is None or surviving.login_generation != dead
+
+    async def test_an_observed_empty_profile_still_guards_the_rotation(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """Observing no session is an observation, not the absence of one.
+
+        A stale failure can arrive with the profile already empty, and then the
+        generation reads as None. If that were also how "nobody asked for a
+        guard" were spelled, this rotation would run unguarded and retire a
+        session a peer had established in the meantime.
+        """
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+        from linkedin_mcp_server.exceptions import (
+            AuthenticationBootstrapFailedError,
+        )
+        from linkedin_mcp_server.session_state import (
+            load_source_state,
+            portable_cookie_path,
+            write_source_state,
+        )
+
+        config = AppConfig()
+        config.browser.user_data_dir = str(isolate_profile_dir)
+        set_config(config)
+        monkeypatch.setattr(bootstrap, "get_config", lambda: config)
+        monkeypatch.setattr(bootstrap, "_run_login_flow", AsyncMock())
+
+        # Observed empty, then a peer signs in.
+        assert load_source_state(isolate_profile_dir) is None
+        (isolate_profile_dir / "Default").mkdir(parents=True, exist_ok=True)
+        (isolate_profile_dir / "Default" / "Cookies").write_text("placeholder")
+        portable_cookie_path(isolate_profile_dir).write_text("[]")
+        peer = write_source_state(isolate_profile_dir).login_generation
+
+        with pytest.raises(
+            AuthenticationBootstrapFailedError, match="already signed in"
+        ):
+            await bootstrap.invalidate_auth_and_trigger_relogin(stale_generation=None)
+
+        surviving = load_source_state(isolate_profile_dir)
+        assert surviving is not None
+        assert surviving.login_generation == peer

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -1043,9 +1043,7 @@ class TestAMomentaryHolderDoesNotCancelTheRepair:
         import linkedin_mcp_server.bootstrap as bootstrap
         from linkedin_mcp_server.config import set_config
         from linkedin_mcp_server.config.schema import AppConfig
-        from linkedin_mcp_server.exceptions import (
-            AuthenticationBootstrapFailedError,
-        )
+        from linkedin_mcp_server.exceptions import AuthenticationStartedError
         from linkedin_mcp_server.session_state import (
             load_source_state,
             portable_cookie_path,
@@ -1065,9 +1063,7 @@ class TestAMomentaryHolderDoesNotCancelTheRepair:
         portable_cookie_path(isolate_profile_dir).write_text("[]")
         peer = write_source_state(isolate_profile_dir).login_generation
 
-        with pytest.raises(
-            AuthenticationBootstrapFailedError, match="already signed in"
-        ):
+        with pytest.raises(AuthenticationStartedError):
             await bootstrap.invalidate_auth_and_trigger_relogin(stale_generation=None)
 
         surviving = load_source_state(isolate_profile_dir)
@@ -1111,3 +1107,145 @@ class TestAMomentaryHolderDoesNotCancelTheRepair:
         assert a_peer_already_signed_in(other, "a-different-generation") is True
         # And the same call still says no when the generation is the one in hand.
         assert a_peer_already_signed_in(other, fresh) is False
+
+
+class TestTheComparisonHappensUnderTheLock:
+    """Deciding first and rotating afterwards leaves a gap wide enough to lose a
+    session in.
+
+    Every automatic path used to compare generations at the call site and then
+    call a rotation that takes the profile itself. A peer completing a login
+    between those two points had its fresh session quarantined by a process
+    acting on a view formed before that session existed. Five review rounds
+    missed it, because reproducing it needs the peer to land at the rotation
+    boundary rather than anywhere earlier.
+
+    Moving the comparison inside the lock is what closes it: there, the answer
+    cannot change between reading it and acting on it.
+    """
+
+    def _write_session(self, profile_dir) -> str:
+        from linkedin_mcp_server.session_state import (
+            portable_cookie_path,
+            write_source_state,
+        )
+
+        (profile_dir / "Default").mkdir(parents=True, exist_ok=True)
+        (profile_dir / "Default" / "Cookies").write_text("placeholder")
+        portable_cookie_path(profile_dir).write_text("[]")
+        return write_source_state(profile_dir).login_generation
+
+    def test_a_peer_landing_at_the_rotation_keeps_its_session(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        import linkedin_mcp_server.session_state as session_state
+        from linkedin_mcp_server.session_state import (
+            load_source_state,
+            rotate_source_profile,
+        )
+
+        stale = self._write_session(isolate_profile_dir)
+
+        real_lock = session_state._exclusive_profile
+        landed: list[str] = []
+
+        def peer_signs_in_then_we_lock(profile_dir, *, action):
+            # The peer finishes exactly at the boundary: after any caller-side
+            # decision, before this rotation holds anything.
+            if not landed:
+                landed.append(self._write_session(isolate_profile_dir))
+            return real_lock(profile_dir, action=action)
+
+        monkeypatch.setattr(
+            session_state, "_exclusive_profile", peer_signs_in_then_we_lock
+        )
+
+        retired = rotate_source_profile(isolate_profile_dir, superseded_by=stale)
+
+        assert retired is None, "it rotated a session it should have left alone"
+        surviving = load_source_state(isolate_profile_dir)
+        assert surviving is not None
+        assert surviving.login_generation == landed[0]
+
+    def test_it_still_retires_the_session_it_was_told_about(self, isolate_profile_dir):
+        # The guard must not stop the ordinary case, which is every rotation
+        # where nobody else has done anything.
+        from linkedin_mcp_server.session_state import (
+            load_source_state,
+            rotate_source_profile,
+        )
+
+        stale = self._write_session(isolate_profile_dir)
+
+        retired = rotate_source_profile(isolate_profile_dir, superseded_by=stale)
+
+        assert retired is not None
+        assert load_source_state(isolate_profile_dir) is None
+
+    def test_an_unguarded_rotation_is_unchanged(self, isolate_profile_dir):
+        # `--login` and `--logout` rotate without a generation, and must keep
+        # retiring whatever is there.
+        from linkedin_mcp_server.session_state import (
+            load_source_state,
+            rotate_source_profile,
+        )
+
+        self._write_session(isolate_profile_dir)
+
+        assert rotate_source_profile(isolate_profile_dir) is not None
+        assert load_source_state(isolate_profile_dir) is None
+
+    async def test_both_automatic_paths_hand_their_generation_to_the_rotation(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """The comparison is only under the lock if the generation gets there.
+
+        Moving it inside `rotate_source_profile` is half the fix; the other half
+        is every automatic caller passing what it observed. A call site that
+        stopped forwarding would leave the rotation unguarded again, and nothing
+        else would notice.
+        """
+        from unittest.mock import AsyncMock
+
+        import linkedin_mcp_server.bootstrap as bootstrap
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+        from linkedin_mcp_server.exceptions import (
+            AuthenticationInProgressError,
+            AuthenticationStartedError,
+        )
+
+        config = AppConfig()
+        config.browser.user_data_dir = str(isolate_profile_dir)
+        config.browser.auto_import_from_browser = False
+        set_config(config)
+        monkeypatch.setattr(bootstrap, "get_config", lambda: config)
+        monkeypatch.setattr(bootstrap, "_run_login_flow", AsyncMock())
+
+        seen: list[object] = []
+
+        def capture(profile_dir=None, *, superseded_by=None):
+            seen.append(superseded_by)
+            return None
+
+        monkeypatch.setattr(bootstrap, "rotate_source_profile", capture)
+
+        # The stale path.
+        self._write_session(isolate_profile_dir)
+        with pytest.raises(AuthenticationStartedError):
+            await bootstrap.invalidate_auth_and_trigger_relogin(
+                stale_generation="the-stale-one"
+            )
+        assert seen == ["the-stale-one"], seen
+
+        # The missing path, which rotates through the other helper.
+        seen.clear()
+        bootstrap.reset_bootstrap_for_testing()
+        monkeypatch.setattr(bootstrap, "get_config", lambda: config)
+        monkeypatch.setattr(bootstrap, "_run_login_flow", AsyncMock())
+        monkeypatch.setattr(bootstrap, "rotate_source_profile", capture)
+        monkeypatch.setattr(bootstrap, "_auth_ready", lambda *_a, **_k: False)
+
+        with pytest.raises(AuthenticationInProgressError):
+            await bootstrap._start_login_if_needed(superseded_by="the-missing-one")
+        assert seen == ["the-missing-one"], seen

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -763,3 +763,39 @@ class TestServerVersion:
         mcp = create_mcp_server()
 
         assert mcp.version == __version__
+
+
+class TestWhatTheToolsPromise:
+    """``readOnlyHint`` is a claim the daemon acts on, not documentation.
+
+    A tool that declares it is replayed automatically after the frontend repairs
+    auth, with no second confirmation from anyone. So the annotation has to mean
+    what it says: anything that can change LinkedIn's state, however slightly,
+    must not carry it.
+    """
+
+    async def test_no_tool_claims_read_only_while_changing_state(self):
+        """The two messaging tools that read by clicking are the reason for this.
+
+        Resolving a conversation by username enumerates the inbox by visiting
+        rows, and LinkedIn marks a visited row as read. Both tools' own
+        docstrings say so, and both carried ``readOnlyHint`` anyway. An unread
+        message the user has not seen is state, and a replay that silently clears
+        it is not something a reader should do.
+        """
+        mcp = create_mcp_server()
+        marks_things_read = {"get_conversation", "search_conversations"}
+        claiming = set()
+        for name in marks_things_read:
+            tool = await mcp.get_tool(name)
+            # A missing tool means this test is guarding a name that no longer
+            # exists, which is worse than a wrong annotation: it would pass
+            # forever while covering nothing.
+            assert tool is not None, f"{name} is not registered any more"
+            if tool.annotations and tool.annotations.readOnlyHint:
+                claiming.add(name)
+
+        assert not (marks_things_read & claiming), (
+            "these tools mark conversations as read, so they cannot be replayed "
+            f"unattended: {sorted(marks_things_read & claiming)}"
+        )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -526,3 +526,63 @@ async def test_interactive_login_without_proxy_omits_the_key(monkeypatch, tmp_pa
     await interactive_login(tmp_path / "profile")
 
     assert "proxy" not in captured_kwargs
+
+
+class TestTheExplicitCommandsStayUnguarded:
+    """`--login` and `--import-from-browser` are insistence, not a request.
+
+    Somebody typing them wants a new session whatever is on disk, so they must
+    not stand down for a peer. Asserted at the call sites rather than on the
+    helper's signature default: an earlier version checked only the default, and
+    a mutation passing `superseded_by=None` at the call site left it green while
+    the real command would have skipped the login it was asked for.
+    """
+
+    def test_login_passes_no_generation(self, monkeypatch):
+        import linkedin_mcp_server.setup as setup
+
+        seen: dict[str, object] = {}
+
+        async def capture(profile_dir=None, **kwargs):
+            seen.update(kwargs)
+            return True
+
+        monkeypatch.setattr(setup, "interactive_login", capture)
+
+        assert setup.run_profile_creation("/tmp/whatever") is True
+
+        assert "superseded_by" not in seen, seen
+
+    def test_import_passes_no_generation(self, monkeypatch):
+        import linkedin_mcp_server.browser_import.orchestrate as orchestrate
+
+        seen: dict[str, object] = {}
+
+        async def capture(_browser, *, user_data_dir, **kwargs):
+            seen.update(kwargs)
+            return True
+
+        from linkedin_mcp_server.config import set_config
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        # Installed rather than loaded: the handler calls get_config(), which
+        # parses sys.argv, and under pytest that is pytest's own command line.
+        config = AppConfig()
+        config.server.import_from_browser = "auto"
+        set_config(config)
+
+        monkeypatch.setattr(orchestrate, "import_session_from_browser", capture)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.configure_browser_environment", lambda: None
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.set_headless", lambda _v: None
+        )
+
+        from linkedin_mcp_server.cli_main import import_from_browser_and_exit
+
+        with pytest.raises(SystemExit) as caught:
+            import_from_browser_and_exit()
+
+        assert caught.value.code == 0
+        assert "superseded_by" not in seen, seen


### PR DESCRIPTION
feat(daemon): Let one client win the login race

Two frontends can be told to sign in for the same dead session, and the
lock around the invalidation is process-local: it serializes each process
against itself and knows nothing about the other one.

Rotation itself is safe, because it takes the profile lease, so nobody
can rotate while a login holds it. The exposed window is afterwards: A
finishes a login and writes a generation, B arrives with the old one
still in hand, finds the lease free, and rotates. Measured,
load_source_state then returned None and A's fresh session was gone. The
test reproduces that destruction before asserting the fix.

So the generation the owner found broken travels in the marker, and the
invalidation skips its rotation when the one on disk has moved on. A
generation is only written after a login has validated its session, so a
different one means somebody else's repair succeeded.

Both halves of that check are needed. Without the readiness half, an
abandoned login leaves the profile rotated and the generation reading as
None, which differs from the stale one, so the next client would be told
another client had signed in when the profile is empty and no login would
ever start.

The login also waits for the profile now instead of demanding it. That
path is what a frontend takes when the shared browser asks it to sign in,
and a proxy holds no lease of its own to reuse, so any momentary holder
would leave the user with a login that refuses to open. Bounded by how
long a handover takes rather than how long a person takes, because past
that the holder is a process that will not release.

See also: #606

test(daemon): Prove the marker over a real socket

Everything else about the auth marker runs in memory against a stand-in
owner. This is the one that starts a real detached owner with no LinkedIn
session and asserts the marker arrives over the authenticated loopback
hop as a result rather than being flattened into a generic failure, which
is what an exception would be.

Observed at a plain client with the repair middleware removed, and that
removal is what makes the test possible: create_mcp_server installs it
for every proxy, correctly, so a real frontend consumes the marker, opens
a login window and waits out the login timeout. The test therefore
asserts what the owner sends; the consume-and-replay half stays in memory
with a stubbed login.

The browser cache is symlinked from the account's own. It lives under the
auth root, so an isolated root looks like a fresh install and the
readiness gate reports a download in progress before authentication is
decided at all. Nothing here launches Chromium.

Mutation-checked, including one that survives: removing the role claim in
daemon_owner.main alone changes nothing, because create_mcp_server claims
it again before any call arrives. Removing both fails. The redundancy is
deliberate and this test cannot tell the two apart, which is recorded
next to the assertions.

See also: #606

fix(daemon): Check the generation under the lease

The generation check was in the wrong place. It ran before the login was
even started, and the login then queues for the profile: by the time it
holds one, its opinion can be minutes old. Measured on the real rotation
path, with only the browser stubbed: the winner wrote a fresh generation,
the waiting loser took the lease, rotated, and load_source_state returned
None. The fresh session was gone.

So interactive_login checks again once it holds the profile, which is the
first moment the answer cannot change underneath it. The earlier check
stays: it catches a peer that finished before this client asked at all,
costs nothing, and both are visible in the tests. The missing path is
guarded too, which it was not: a missing session is diagnosed from disk,
so two frontends reach it at once and the login rotates regardless.

The generation now rides on the owner's exception rather than being read
again when the marker is built. The browser has closed by then and the
lease is free, so a second read can return a generation another process
has just written, and the frontend would rotate away the very session it
was told about.

Marker version 2, because the reader from the previous commit accepts a
version-1 marker, ignores the field it does not know, and repairs without
passing the generation on. That is the unguarded path, and an older
frontend attaching to a newer owner is supported on purpose. Refusing the
marker leaves it reporting the owner's failure instead, which is less
informed and honest.

The 60-second wait is a user-experience limit, not a derived worst case:
a holder part way through a tool call does not hand over until it
finishes, and that runs to the tool timeout. The comments said otherwise.

See also: #606

fix(daemon): Guard every path that rotates

The previous guard covered one caller and one shape of the question, and
three ways past it remained.

None meant both "the owner observed no session" and "nothing asked for a
guard", so two clients meeting a genuinely empty profile were unprotected
from each other. Reproduced: the second rotated away the session the
first had just created. A sentinel separates the two, and `--login` typed
at a terminal keeps signing in unconditionally, which is what it is for.

The quiescent gate raised its failures without a generation. Only the
first call reaches the frontend through handle_auth_error; every one
after it is answered by the latch, so the second client to ask got a
marker with nothing to compare against and repaired unguarded.

The auto-import rotates as soon as it holds the profile, exactly as the
login does, and ran ahead of it without the guard. A client whose
keychain read took longer would retire a session a faster peer had
already imported.

The check itself sat outside the lease's try, so a failure while asking
kept the profile until the process exited. An unreadable profile
directory was enough.

The predicate moved to session_state, which owns the generation and is
already imported by both callers.

See also: #606

fix(auth): Let a held profile delay a login

invalidate_auth_and_trigger_relogin retires the dead session before it
starts a login, and that rotation takes the profile without waiting for
it. A holder anywhere else made it raise, and the caller then reported
"the browser profile is in use" without attempting anything.

Refusing there was right when the login also demanded the profile
outright: if the rotation could not take it, neither could the login.
The login waits now, so a momentary holder is exactly the case it was
built for, and failing first throws the wait away before it happens.
Measured with a lease held for 1.5 seconds: the 60-second wait was never
reached.

The rotation is not lost. interactive_login rotates under the profile it
waited for, which is the better place for it anyway, because this one
holds nothing and its result was never guaranteed to survive to the
login. What the failure costs is only that readiness keeps reporting the
dead session until the login retires it, and on a shared owner the
quiescence latch already covers that window.

See also: #606

fix(auth): Pass on the session found wanting

The readiness gate has just looked at the profile when it starts a login,
so it knows which session it found unusable, but it threw that away and
started an unguarded one. Two stdio servers meeting the same bad session
could therefore both sign in, and this is the path every user runs today,
since the shared-browser mode is off by default.

Measured, the damage is bounded: the only case where the earlier session
disappears is one where a second person actually signed in, and then the
later session winning is the expected outcome rather than lost work. What
the guard saves is the pointless second login window.

--login keeps the unguarded default. Somebody typing it is insisting, not
asking, and that is the difference between an override and a request.

Both branches of the gate carry it. A configured Chrome executable skips
the managed-binary path and reaches its own call site; mutating one and
not the other went unnoticed until the test covered both.

See also: #606

fix(auth): Stop a server skipping its own login

A regression from the sentinel work. invalidate_auth_and_trigger_relogin
still used None to mean "no guard requested", and a single-process server
reached it with exactly that, because only the shared owner read the
generation before closing the browser.

The result was the worst available failure. With another process holding
the profile for a moment, the pre-rotation failed and was swallowed, the
login then found the dead session still in place, read it as a peer's
repair, and stood down. The server reported that a login window had
opened. None had. The dead session stayed, and readiness went back to
saying it was fine.

So every role reads the generation now, and the sentinel reaches this
function too, which keeps "observed no session" apart from "nothing asked
for a guard" here as well.

Two tests asserted the old behaviour and were wrong rather than broken:
one required that a single-process server read nothing, which is what
caused this. The new end-to-end test lets the real login run instead of
stubbing the task away, which is what the earlier one missed.

The explicit commands are pinned at their call sites now. Asserting the
helper's default left a mutation passing a generation from --login green
while the real command would have skipped the login it was asked for.

See also: #606

fix(auth): Refuse a login the profile forbids

Two holes the previous round left, both found by review.

An unconfirmed browser teardown keeps the profile lease until the process
exits, and the check for it was owner-only. A single-process server
carried on into a login whose own rotation is refused for exactly that
reason, after having reported that a window had opened. Measured: no
window, the dead session still there, and a state only a restart clears.
The check now runs for every role, ahead of the split, because nothing
that follows can work for either of them.

The generation guard read the generation from the profile it was given
and then asked the *configured* profile whether a session was usable.
Both callers accept an explicit directory, so the two can differ, and
then a peer's fresh session was rotated away because a different profile
happened to be empty. Readiness takes the directory now.

That also removed a redundant hop: readiness went through a helper that
resolves the profile itself and re-checks two things the caller has
already tested. It now reads the state file directly, which is what makes
it answerable for a directory handed in.

The DIRECT test asserted only that the keyword was present, so a mutation
passing a hardcoded None stayed green. It asserts the value now.

See also: #606

fix(auth): Compare generations under the lock

Every automatic path decided whether to retire a session and then called a
rotation that takes the profile itself. A peer completing a login between
those two points had its fresh session quarantined by a process acting on
a view formed before that session existed.

Five rounds of review missed this, including one of my own attempts:
reproducing it needs the peer to land at the rotation boundary rather
than anywhere earlier, and the earlier guards were close enough to the
decision to look like they covered it.

So the comparison moves into rotate_source_profile, inside the lock it
already takes. There the answer cannot change between reading it and
acting on it, which is the property the call sites could not offer at any
distance. Both automatic callers hand their observed generation through,
and a test pins each, because the comparison is only under the lock if
the generation reaches it.

The early guard in invalidate_auth_and_trigger_relogin is gone. It is
redundant now, and its outcome was worse: it refused the whole repair
where the rotation simply retires nothing and lets the login proceed. A
client asking to repair a session should not be left with nothing because
somebody else got there first.

The sentinel and the predicate move to session_state with it. That module
owns the generation, and the rotation cannot import them from setup.

_has_source_state is deleted. The last commit removed its only caller and
left a docstring claiming otherwise.

See also: #606

fix(auth): Report a peer win as what it is

The rotation signalled "I preserved a peer's session" the same way it
signals "there was nothing to retire": by returning None. The caller
could not tell them apart, so it carried on, scheduled a login and told
the user a browser window had opened. The task then took the profile, saw
the peer's session, and stood down without opening anything.

The data was safe. The report was not, and it is the same user-visible
lie as an earlier round's blocker, without the wedge behind it. The test
I had changed to accept AuthenticationStartedError there blessed exactly
that outcome, and did not await the task, so nothing noticed.

A distinct exception now carries the outcome, with its own diagnostics-
free branch in the error handler: nothing failed, somebody else simply
got there first, and the honest answer is to retry and use their session.

See also: #606

fix(daemon): Replay after a peer signs in

The frontend caught the peer-win outcome with its general failure handler,
so a repair that had in fact succeeded, by somebody else, refused the
replay. The user was sent back for a retry while the session the call
needed was already on disk.

The two side effects reported alongside it are already gone with the
previous commit: no login task is scheduled, so nothing reaches
_ensure_full_chromium_installed, and no headed browser is downloaded for
a window that was never going to open. Verified on both the stale and the
missing path.

See also: #606

fix(daemon): Wait out the sign-in before replaying

A started login reports itself by raising, while the window is still open
and nobody has typed anything yet. The frontend read that as a failed
repair and refused the replay, so every repair this middleware exists to
perform was abandoned one step before it worked.

Measured on the stale path with a login that finished successfully: the
owner was called once and the client still got the error. The missing
path did the same as soon as signing in took longer than the inline
budget, which is every login a person actually performs.

The tests missed it because they replaced the repair with a mock that
returned on command, which is exactly the step that raises.

See also: #606

fix(daemon): Let a wedged owner give way

An unconfirmed browser shutdown keeps the profile lease until the process
exits. For a single-process server the resulting advice is actionable:
its client restarts it. A detached owner outlives that client, so the
next frontend attaches straight back to it and meets the same held
profile, and only killing it by hand recovered.

It now asks to stand down. The serve loop finishes what is in flight and
exits, the kernel frees the daemon lock, and the next call elects a fresh
owner. Nothing is lost, because the session lives on disk.

The frontend login has the same unconfirmed-shutdown hole and is left
alone deliberately: there a client restart does recover.

See also: #606

fix(daemon): Keep the sign-in wait inside its call

The wait was a fixed 150 seconds, chosen against the 180-second default
tool timeout. TOOL_TIMEOUT is a user setting: measured at 60, the
client's call was cut short while the middleware was still waiting, so
instead of the readable 'sign-in still in progress' the user got a bare
timeout. The login survived and the next call worked, so nothing was
lost but the explanation, which is the part a person acts on.

It is now a fraction of the configured budget, minus what the call has
already spent. Subtracting matters: the fraction alone still overran,
because the owner call and the inline login wait come out of the same
budget before this is reached.

See also: #606

fix(daemon): Decide the stand-down in a finally

close_browser defers cancellation until teardown finishes and then
re-raises CancelledError, which is a BaseException and passes straight
through the except Exception around it. A tool timeout landing during
the close therefore skipped the whole stand-down decision, and a wedged
owner stayed wedged: recoverable only by killing it.

Measured: wait_for(handle_auth_error(...), 0.02) against a close that
defers its cancel left stand_down_reason() at None with the lease held.

The decision now runs in a finally, so it survives the cancellation.
Raising the error stays on the normal path, because a cancelled call has
nobody left to raise it to.

See also: #606

fix(daemon): Bound the replay by what is left

Nothing under this middleware bounds the whole path. The forwarded call
carries its own deadline per hop, so the first call, the wait and the
replay each stay inside one while their sum stays inside nothing. A
sign-in finishing near the end of the wait, followed by a slow replay,
put the client past its deadline with the answer already in hand.

The replay now gets what the call has not spent, with a floor so an
already-overrun call still makes a real attempt. When it runs out, the
owner's readable failure is the answer: the session exists by then, so
the next call succeeds, and a bare transport error would say none of
that.

See also: #606

fix(daemon): Budget the repair from its own server

The repair read tool_timeout_seconds from the configuration singleton
while create_mcp_server is handed the budget every tool it registers
gets. The two agree for a server cli_main built, which loaded that
configuration first, and need not for one constructed directly:
measured at tool_timeout=1.2 with no configuration loaded, the repair
budgeted itself 149.8 seconds of a 1.2-second call, because the unloaded
singleton falls back to parsing sys.argv.

The middleware now takes the budget it was built with.

The budget test also asserted only 'less than the timeout', which left
the subtraction untested: dropping it yields five sixths of the budget,
still under, and the overrun the test exists for came back green.

See also: #606

fix(daemon): Never abandon a mutating replay

Timing the replay out does not stop it. Cancellation is not forwarded
across the hop, which daemon_proxy already records, so the frontend
reported the old auth failure while the owner went on to send the
message. Measured over a real loopback owner: the client was answered at
0.66s with an error and the owner appended its effect 0.7s later. The
user is told the message was not sent, it was, and retrying sends it
twice.

The bound now applies only to tools that declare readOnlyHint, where an
abandoned replay costs a wasted page load. Anything else, including a
tool that declares nothing, runs to completion: an overrun call is the
client's own deadline to give up on, and that leaves one call
outstanding rather than a second queued behind it.

The in-memory test could not see this. ProxyClient delivers cancellation
into the owner's coroutine, so it proved a property the HTTP path does
not have.

Also caps the replay floor by the budget: at tool_timeout_seconds=1.0
with 0.9s spent it allowed 5 seconds.

See also: #606

fix(daemon): Leave a changing call for the caller to retry

No bound on an automatic replay can make it safe. Bounding it locally
left the owner finishing the mutation after the frontend had reported
failure, because cancellation is not forwarded across the hop. Removing
the bound only moved the deadline: an MCP client cancelling its own call
produced the same orphan, and the retry sent the message twice.

Nothing this process can do closes that, because the deadline that
matters belongs to a client it does not control. So the auth is repaired
and the owner's own message, which already says to retry, is returned.
The user knows whether it happened; asking costs one retry, guessing
wrong sends it twice. Read-only tools keep the replay.

get_conversation and search_conversations lose readOnlyHint. Both
enumerate by visiting rows, which marks conversations as read, and both
docstrings always said so. An unread message is state.

See also: #606

test(daemon): Pin the budget arithmetic off the clock

The budget test subtracted a duration measured from the start of the
test, which includes client setup the middleware's own clock never saw.
It passed alone and failed inside the full suite at 1.22s against 1.2s.
That measured the runner.

It now asserts the timeout asked for against the share, plus the
subtraction directly, so the property is pinned rather than inferred
from wall clock.

See also: #606

fix(daemon): Free an owner stranded by any close

Three ways into one dead end, found one at a time, so the decision now
lives in one place that every one of them reaches.

The routine close is the path that hid longest: a handoff, the idle
timeout and close_session all return normally when the teardown cannot
be confirmed. They log, keep the lease, and raise nothing, so neither
the exception nor handle_auth_error ever runs. Reproduced: close
returned, lease kept, stand_down_reason None, next launch refused.

The cookie export could strand the profile even earlier. It awaits a
protocol call with no deadline, before the bounded teardown, with the
singleton already cleared and cancellation deferred. It is now bounded
like the teardown steps below it; a lost export costs the Docker cookie
file this run, which the next close rewrites.

See also: #606

fix(daemon): Ask after the profile is marked held

The startup path was the one measured live, and it was still open. The
exception's constructor runs while _create_browser_locked is raising,
when browser_open is false, so the helper reads that nothing is held and
returns. Only the catch afterwards marks the browser open and takes the
extra reference, holding the profile with nobody having asked for a
replacement.

Reproduced in production order: browser_open=True, stand_down=None.

The test for this handed the constructor a lease that already said True,
which is the state production has not reached yet. That mock is what hid
it, and the comment above it asserted the opposite of what the code
does. It now drives _create_browser and lets the marker start false.

See also: #606

fix(daemon): Treat an unreadable lease as held

Not being able to tell whether the profile is held is not the same as
being told it is free, and the two outcomes are not symmetric: an
unnecessary stand-down costs one election, a stranded owner costs every
later call until somebody kills it by hand. Measured with the read
raising PermissionError: the owner kept serving with the question
unanswered.

The guard test that was supposed to keep this from firing on healthy
owners drove a confirmed close, which never reaches the helper at all,
so it stayed green with the guard deleted. It now asserts the helper
directly and fails on that mutation.

Also drops the raise-site count from the docstring. It said seven, then
nine; there are eight, and the ninth match was the class itself.

See also: #606

fix(daemon): Ask when the close cannot read the lease

The lookup sits between the teardown and every line that protects the
profile. It resolves a path, so it can fail on a profile directory that
became unreadable while the browser was running, even though this
process still holds the open descriptor. By then the singleton is
cleared, so nothing below it runs: not the hold flag, not the warning,
not the request.

Measured in production order with an unconfirmed close and the lookup
raising: browser cleared, hold flag still set, no stand-down.

Asked before re-raising, and only for an unconfirmed teardown. A proven
close means the profile is free, so a failed lookup there is the
caller's problem rather than a reason to end the owner. The original
error reaches the caller either way.

See also: #606

fix(daemon): Ask on any failed lease lookup at close

The confirmed case was exempted on the reasoning that a proven-closed
Chromium leaves the profile free. It does not: mark_browser_closed() and
release() both need the object the lookup failed to produce, so a
confirmed close strands the lease just as thoroughly.

Measured with a real acquired lease: Chromium gone, the lease still held
with its marker set, and this owner's own next launch refused with
BrowserBusyError while nobody had asked for a replacement.

The test for that branch asserted the exemption, so it pinned the wrong
recovery. It now asserts the request, and fails when the exemption is
restored.

See also: #606