### PR TITLE
fix(daemon): Wait for a silent owner instead of burying it

### DIFF
--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -72,9 +72,13 @@ logger = logging.getLogger(__name__)
 #: starts: handing the configuration over, and the lock attempts before that.
 DEFAULT_ELECTION_SECONDS = 90.0
 
-#: How long a published owner has to answer before it is treated as leftovers.
+#: How long a published owner has to answer before it is treated as *silent*.
 #: This is a loopback request to a process that is either serving or gone, so
-#: the only thing a longer budget buys is a longer stall on a dead descriptor.
+#: the only thing a longer budget buys is a longer stall on a dead descriptor —
+#: and a dead one does not stall at all, it refuses. Measured against a real
+#: descriptor and token: a closed port comes back in about ten milliseconds,
+#: while a process holding a listening socket that nobody reads spends the whole
+#: budget. That is the distinction :class:`Reach` exists to carry.
 _REACHABLE_SECONDS = 5.0
 
 #: How long a superseded owner has to acknowledge a stand-down request. Short:
@@ -87,9 +91,38 @@ _STAND_DOWN_SECONDS = 5.0
 #: is an owner finishing its shutdown, and long enough not to spin.
 _RETRY_SECONDS = 0.2
 
+
+class Reach(enum.Enum):
+    """What a probe of a published endpoint established.
+
+    Three answers rather than two, because "it did not answer" covers two
+    situations that call for opposite reactions, and collapsing them is what
+    made a healthy owner unreachable for a whole election.
+
+    A process that is *gone* leaves a closed port, and the kernel refuses the
+    connection at once. A process that is *stalled* still holds its listening
+    socket, so the handshake completes into the backlog and the probe waits out
+    its whole budget. Measured against the real probe with a real descriptor and
+    token: about ten milliseconds for the first, a full five seconds for the
+    second. Three orders of magnitude apart, and the old ``bool`` threw the
+    difference away.
+    """
+
+    #: The endpoint answered an authenticated request. Attach to it.
+    ANSWERED = "answered"
+
+    #: Nothing is serving at that address, or something is and it is not this
+    #: owner. Either way the descriptor is leftovers.
+    REFUSED = "refused"
+
+    #: Something holds the port and did not answer in time. No proof it is
+    #: alive, and no proof it is dead.
+    SILENT = "silent"
+
+
 #: Proves a published endpoint is live. Injectable so the election can be tested
 #: without a real server; production passes nothing and gets a real round trip.
-Reachable = Callable[[Attachment], bool]
+Reachable = Callable[[Attachment], Reach]
 
 
 @dataclass(frozen=True)
@@ -139,9 +172,15 @@ def obtain_owner(
     deadline = time.monotonic() + max(deadline_seconds, 0.0)
     started = False
     reach = connect or _reachable
-    # Instances proved dead, so a corpse is not handed back a second time. The
-    # descriptor stays on disk until a live owner overwrites it, and without
-    # this the loop would re-read it, probe it again, and spin.
+    # Instances that answered *wrongly* — a refused connection, a rejected
+    # token, a stranger on the port — so a corpse is not handed back a second
+    # time. The descriptor stays on disk until a live owner overwrites it, and
+    # without this the loop would re-read it, probe it again, and spin.
+    #
+    # Deliberately narrower than "did not answer". An instance that merely ran
+    # out of time is never put here, because the next probe may well reach it:
+    # a paused or overloaded owner holds its port and says nothing, and burying
+    # it made a frontend refuse the healthy owner it had just started itself.
     buried: set[str] = set()
     # A turnover is asked for at most once per election, and the bound is not
     # decoration. A newer frontend replaces a stale owner and then reads the
@@ -240,6 +279,11 @@ def _live_lookup(
     it. The file is left alone and the *lock* decides what happens next, which
     is the rule the whole module is built on.
 
+    Failing the probe is itself two things, and only one of them is final. A
+    refusal says nothing usable is at that address, so the instance is buried and
+    not asked again. A silence says only that the answer did not arrive in time,
+    so nothing is recorded and the next pass asks afresh.
+
     Every path here answers on the first readable descriptor, and the waiting
     happens inside :func:`look_up_owner` alone. That split is measured rather
     than tidy: an earlier version looped, and because nothing rewrites a
@@ -297,8 +341,32 @@ def _live_lookup(
             True,
         )
 
-    if reach(attachment):
+    verdict = reach(attachment)
+    if verdict is Reach.ANSWERED:
         return lookup, False
+
+    if verdict is Reach.SILENT:
+        # Not buried, and that is the whole of the fix. Something holds the port
+        # and did not get to us inside the budget, which is what a paused or
+        # overloaded owner looks like — including one this very election started
+        # and watched report ready. Burying it made every later pass short
+        # circuit, so the owner never got a second chance inside the election it
+        # belonged to, and the frontend spent its whole budget contending for a
+        # lock the healthy owner was still holding.
+        #
+        # Left to the caller's own deadline rather than bounded by a retry
+        # count. Each probe already costs the full budget, so a fixed number of
+        # retries covers a fixed and rather short stall — measured, one retry
+        # rescues a six second freeze and still gives up on a fifteen second
+        # one. The election deadline is what bounds this, as it always was.
+        logger.info("The published daemon has not answered yet; will ask again")
+        return (
+            OwnerLookup(
+                state=OwnerState.INCOMPATIBLE,
+                reason="the published daemon has not answered yet",
+            ),
+            False,
+        )
 
     buried.add(instance)
     logger.info("The published daemon is not answering; electing a new one")
@@ -350,17 +418,23 @@ def _ask_to_stand_down(attachment: Attachment) -> None:
     logger.debug("Stand-down request answered with %s", response.status_code)
 
 
-def _reachable(attachment: Attachment) -> bool:
-    """Whether the published endpoint answers this token.
+def _reachable(attachment: Attachment) -> Reach:
+    """What the published endpoint says when asked with this token.
 
     An authenticated round trip rather than a TCP connect. A connect succeeds
     against any listener that happens to hold the port, including one the
     operating system handed to something else after the owner died, and against
     an owner whose token no longer matches the file this client just read.
+
+    The timeout is caught apart from every other failure, and that separation is
+    the whole point of this function's return type. An owner that is gone refuses
+    the connection; an owner that is merely stalled holds the port and says
+    nothing. Both used to arrive here as ``False``, so a frontend buried a live
+    owner it had just started because one ping landed in a scheduler stall.
     """
     import asyncio
 
-    async def ask() -> bool:
+    async def ask() -> Reach:
         from fastmcp import Client
         from fastmcp.client.transports import StreamableHttpTransport
 
@@ -376,17 +450,30 @@ def _reachable(attachment: Attachment) -> bool:
             ) as client:
                 await client.ping()
         except Exception:
+            # Answered, and wrongly: a refused connection, a rejected token, a
+            # stranger on the port. All of them say this descriptor is not an
+            # owner to attach to, and saying so again would not change it.
             logger.debug("The published daemon did not answer", exc_info=True)
-            return False
-        return True
+            return Reach.REFUSED
+        return Reach.ANSWERED
 
     try:
         return asyncio.run(asyncio.wait_for(ask(), _REACHABLE_SECONDS))
+    except TimeoutError:
+        # Something holds the port and did not get to us in time. Deliberately
+        # not treated as leftovers: a loaded machine, a paused process or a busy
+        # owner all look like this, and every one of them may answer a moment
+        # later.
+        logger.debug("The published daemon did not answer in time", exc_info=True)
+        return Reach.SILENT
     except Exception:
-        # Includes the timeout, and a caller that is already inside a running
-        # loop. Both mean the same thing here: no proof the owner is alive.
-        logger.debug("The daemon reachability check failed", exc_info=True)
-        return False
+        # A caller already inside a running loop, which is no observation at all.
+        # Classified with the refusals rather than the silences because asking
+        # again would fail for the same reason, so a retry would only spend the
+        # budget. Production never reaches it: the election runs synchronously
+        # from ``cli_main`` before any server exists.
+        logger.debug("The daemon reachability check could not run", exc_info=True)
+        return Reach.REFUSED
 
 
 def _log_hint(auth_root: Path) -> Path:

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import contextlib
 import os
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -35,6 +36,7 @@ from linkedin_mcp_server.daemon import Attachment, OwnerState
 from linkedin_mcp_server.daemon_election import (
     _Attempt,
     ElectionOutcome,
+    Reach,
     obtain_owner,
 )
 from linkedin_mcp_server.daemon_descriptor import (
@@ -116,6 +118,28 @@ def _publish_stale_owner(
     return descriptor.instance_id
 
 
+def _attachment_for(profile: Path, config: AppConfig, port: int) -> Attachment:
+    """An attachment pointing at *port*, for probing a socket directly.
+
+    Not published: this is for handing to the probe by itself, without an
+    election around it.
+    """
+    token = new_token()
+    descriptor = build(
+        instance_id=new_instance_id(),
+        package_version=__version__,
+        runtime_id=_RUNTIME,
+        profile=profile,
+        host="127.0.0.1",
+        port=port,
+        path="/mcp",
+        token=token,
+        config=config,
+        log_path=profile.parent / "daemon.log",
+    )
+    return Attachment(descriptor=descriptor, token=token)
+
+
 class TestLiveness:
     """A descriptor is a file. Only a request that is answered is a process."""
 
@@ -134,7 +158,7 @@ class TestLiveness:
             profile,
             config,
             deadline_seconds=0,
-            connect=lambda attachment: False,
+            connect=lambda attachment: Reach.REFUSED,
         )
 
         assert not outcome.worth_connecting
@@ -158,7 +182,7 @@ class TestLiveness:
             profile,
             config,
             deadline_seconds=0,
-            connect=lambda attachment: False,
+            connect=lambda attachment: Reach.REFUSED,
         )
 
         assert descriptor_file.exists()
@@ -176,7 +200,7 @@ class TestLiveness:
             profile,
             config,
             deadline_seconds=0,
-            connect=lambda attachment: True,
+            connect=lambda attachment: Reach.ANSWERED,
         )
 
         assert outcome.worth_connecting
@@ -194,9 +218,14 @@ class TestLiveness:
 
         probes: list[Attachment] = []
 
-        def never_answers(attachment: Attachment) -> bool:
+        def never_answers(attachment: Attachment) -> Reach:
             probes.append(attachment)
-            return False
+            # REFUSED, which is what a corpse really produces: its port is
+            # closed, so the kernel turns the connection away rather than
+            # leaving the probe to time out. A SILENT stub here would be
+            # testing a different animal, and the count below would rightly
+            # fail.
+            return Reach.REFUSED
 
         obtain_owner(
             auth_root, profile, config, deadline_seconds=1.0, connect=never_answers
@@ -208,6 +237,213 @@ class TestLiveness:
         # implementation that skipped reachability entirely would have looked
         # correct here.
         assert len(probes) == 1, [p.descriptor.instance_id for p in probes]
+
+
+class TestSilenceIsNotDeath:
+    """A probe that ran out of time proves nothing, and used to prove death.
+
+    A frontend started an owner, watched it report ready, and then refused to
+    attach to it: one ping landed in a scheduler stall, the instance was written
+    off, and every later read in that election short-circuited on the record of
+    that single observation. The owner kept running and kept the lock, so the
+    frontend spent the rest of its budget contending with the healthy process it
+    had started itself.
+    """
+
+    def test_a_dead_endpoint_and_a_frozen_one_are_told_apart(self, tmp_path: Path):
+        """The distinction the whole fix rests on, against the real probe.
+
+        Not against a stub. Everything else here keys off ``REFUSED`` versus
+        ``SILENT``, so a test that manufactured the two would pass just as
+        happily if the production probe collapsed them again.
+
+        The two sockets differ in exactly one way, and it is the way that
+        matters: a corpse's port is closed, so the kernel refuses the connection
+        outright, while a paused process still holds its listening socket and
+        the kernel completes the handshake into a backlog nobody reads. That is
+        what makes a listening-but-unaccepting socket a faithful stand-in for a
+        stopped process, without the cost of stopping one.
+        """
+        profile = _profile(tmp_path)
+        config = _config(profile)
+
+        closed = socket.socket()
+        closed.bind(("127.0.0.1", 0))
+        dead_port = closed.getsockname()[1]
+        closed.close()
+
+        began = time.monotonic()
+        refused = election_module._reachable(
+            _attachment_for(profile, config, dead_port)
+        )
+        refusal_took = time.monotonic() - began
+
+        frozen = socket.socket()
+        frozen.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        frozen.bind(("127.0.0.1", 0))
+        # Listening, and deliberately never accepted from.
+        frozen.listen(64)
+        try:
+            began = time.monotonic()
+            silent = election_module._reachable(
+                _attachment_for(profile, config, frozen.getsockname()[1])
+            )
+            silence_took = time.monotonic() - began
+        finally:
+            frozen.close()
+
+        assert refused is Reach.REFUSED, f"a closed port read as {refused}"
+        assert silent is Reach.SILENT, f"an unaccepting socket read as {silent}"
+
+        # And the refusal is genuinely cheap rather than merely different.
+        # Measured at about ten milliseconds; asserted well above that so a
+        # loaded runner cannot fail it, and well below the probe's own budget so
+        # a refusal that started timing out would.
+        assert refusal_took < election_module._REACHABLE_SECONDS / 2, (
+            f"the refusal took {refusal_took:.2f}s"
+        )
+        assert silence_took >= election_module._REACHABLE_SECONDS - 0.5, (
+            f"the silence took only {silence_took:.2f}s"
+        )
+
+    def test_an_owner_that_is_slow_twice_is_still_attached_to(self, tmp_path: Path):
+        """Two silences, not one, and the count is the point.
+
+        A single retry would satisfy a one-shot version of this test while still
+        failing every stall longer than about ten seconds, because each probe
+        costs the full budget. Measured against the real loop: one grace rescues
+        a six second freeze and gives up on a fifteen second one, which is the
+        bug as reported.
+        """
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(auth_root, profile, config)
+
+        answers = [Reach.SILENT, Reach.SILENT, Reach.ANSWERED]
+        probes: list[Attachment] = []
+
+        def slow_to_answer(attachment: Attachment) -> Reach:
+            probes.append(attachment)
+            return answers[min(len(probes) - 1, len(answers) - 1)]
+
+        # The stalled owner holds the daemon lock, which is what makes the loop
+        # keep going rather than start a replacement. That is not a convenience
+        # of the test: a process too busy to answer a ping is still a process,
+        # and it is holding the lock precisely because it is alive. Without this
+        # the frontend finds the position free, tries to start a child, and the
+        # spawn's own failure ends the election before any retry happens.
+        held = DaemonLock(auth_root)
+        assert held.try_acquire(), "could not simulate the stalled owner's lock"
+        try:
+            outcome = obtain_owner(
+                auth_root,
+                profile,
+                config,
+                deadline_seconds=20.0,
+                connect=slow_to_answer,
+            )
+        finally:
+            held.release()
+
+        assert outcome.worth_connecting, outcome.attachment_lookup.reason
+        assert len(probes) >= 3, "the owner was written off before it answered"
+
+    def test_a_silence_is_reported_as_its_own_state(self, tmp_path: Path):
+        """Which refusal it was, not merely that there was one.
+
+        The original failure was diagnosed from this string, and reusing the
+        burial's wording would have made a stalled owner indistinguishable from
+        a corpse in exactly the report a user pastes into an issue.
+        """
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(auth_root, profile, config)
+
+        silent = obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=0,
+            connect=lambda attachment: Reach.SILENT,
+        )
+        refused = obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=0,
+            connect=lambda attachment: Reach.REFUSED,
+        )
+
+        assert silent.attachment_lookup.reason != refused.attachment_lookup.reason
+        assert not silent.worth_connecting
+
+    def test_a_refusal_still_buries_on_the_first_probe(self, tmp_path: Path):
+        """The corpse path keeps its fail-fast, and the grace does not leak into it.
+
+        Written as "would have answered next time" rather than "never answers":
+        a stub that refuses forever passes even if refusals were retried, since
+        the outcome is the same either way. This one fails if the retry is
+        granted, because the second probe would succeed and the election would
+        attach.
+        """
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(auth_root, profile, config)
+
+        probes: list[Attachment] = []
+
+        def refuses_then_would_answer(attachment: Attachment) -> Reach:
+            probes.append(attachment)
+            return Reach.REFUSED if len(probes) == 1 else Reach.ANSWERED
+
+        outcome = obtain_owner(
+            auth_root,
+            profile,
+            config,
+            deadline_seconds=1.0,
+            connect=refuses_then_would_answer,
+        )
+
+        assert len(probes) == 1, "a refused instance was probed again"
+        assert not outcome.worth_connecting
+
+    def test_an_owner_that_never_answers_does_not_outlast_the_deadline(
+        self, tmp_path: Path
+    ):
+        """Nothing is buried now, so the deadline is the only thing bounding this.
+
+        The worst case for the change: an owner frozen for good that also still
+        holds the daemon lock, so no replacement can be elected either. It has to
+        end on time rather than probe forever.
+        """
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+        _publish_stale_owner(auth_root, profile, config)
+
+        held = DaemonLock(auth_root)
+        assert held.try_acquire(), "could not simulate the frozen owner's lock"
+        try:
+            began = time.monotonic()
+            outcome = obtain_owner(
+                auth_root,
+                profile,
+                config,
+                deadline_seconds=1.0,
+                connect=lambda attachment: Reach.SILENT,
+            )
+            elapsed = time.monotonic() - began
+        finally:
+            held.release()
+
+        assert not outcome.worth_connecting
+        # Generous, because the budget is spent inside probes and lock attempts
+        # that are not interrupted mid-flight. What it catches is an unbounded
+        # loop, which is the only real risk of never burying anything.
+        assert elapsed < 15, f"the election ran {elapsed:.1f}s past a 1.0s budget"
 
 
 class TestFailingFast:
@@ -234,7 +470,7 @@ class TestFailingFast:
             profile,
             config,
             deadline_seconds=30,
-            connect=lambda attachment: False,
+            connect=lambda attachment: Reach.REFUSED,
         )
         elapsed = time.monotonic() - started
 
@@ -289,7 +525,7 @@ class TestFailingFast:
                 profile,
                 config,
                 deadline_seconds=20,
-                connect=lambda attachment: True,
+                connect=lambda attachment: Reach.ANSWERED,
             )
         finally:
             releasing.cancel()
@@ -498,7 +734,7 @@ class TestFailingFast:
             profile,
             config,
             deadline_seconds=1.0,
-            connect=lambda attachment: False,
+            connect=lambda attachment: Reach.REFUSED,
         )
         elapsed = time.monotonic() - started
 
@@ -644,6 +880,19 @@ def _alive(pid: int) -> bool:
     return True
 
 
+def _resume(pid: object) -> None:
+    """Let a stopped process run again, tolerating one that is already gone.
+
+    Separate from :func:`_stop` because a paused process that is never resumed
+    cannot be killed cleanly either: ``SIGKILL`` is delivered, but the test's own
+    cleanup has no way to observe the exit while the process is not scheduled.
+    """
+    if not isinstance(pid, int):
+        return
+    with contextlib.suppress(OSError):
+        os.kill(pid, signal.SIGCONT)
+
+
 def _stop(pid: object) -> None:
     """Kill an owner, taking the pid as it comes out of the child's JSON.
 
@@ -676,6 +925,46 @@ class TestRealOwner:
             assert result["pid"] and result["pid"] != os.getpid()
         finally:
             _stop(result.get("pid"))
+
+    @_POSIX_ONLY
+    def test_a_paused_owner_is_waited_for_rather_than_written_off(
+        self, real_state_root: Path
+    ):
+        """The reported bug, against a real owner over real loopback.
+
+        The in-process tests above drive this through an injected probe, which
+        proves the loop's logic and nothing about the transport. Here the socket,
+        the token and the process are all real: the owner is genuinely stopped,
+        so its port stays open with nobody reading it, and the frontend's probe
+        genuinely times out rather than being told to.
+
+        Deterministic rather than timed. The owner is stopped *before* the second
+        frontend starts and released on a timer, so the frontend cannot miss the
+        window: every probe it makes until the resume lands in a stalled process.
+        The issue reproduced this by timing a stop against the post-start ping,
+        which is the same condition arrived at by luck.
+        """
+        profile = real_state_root
+
+        first = _run_frontend(profile)
+        owner = first["pid"]
+        assert isinstance(owner, int), first
+        assert first["state"] == OwnerState.ATTACHABLE.value, first
+
+        resume = threading.Timer(8.0, lambda: _resume(owner))
+        try:
+            os.kill(owner, signal.SIGSTOP)
+            resume.start()
+
+            second = _run_frontend(profile)
+
+            assert second["state"] == OwnerState.ATTACHABLE.value, second
+            assert second["pid"] == owner, "the paused owner was replaced"
+            assert second["started"] is False, "a second owner was started"
+        finally:
+            resume.cancel()
+            _resume(owner)
+            _stop(owner)
 
     def test_the_frontend_lets_go_of_the_lock_it_handed_over(
         self, real_state_root: Path
@@ -1321,7 +1610,7 @@ class TestVersionSkew:
             deadline_seconds=0,
             # Would attach if version were not consulted, which is what makes
             # this test about the version rather than about reachability.
-            connect=lambda attachment: True,
+            connect=lambda attachment: Reach.ANSWERED,
         )
 
         assert asked, "the stale owner was never asked to stand down"
@@ -1349,7 +1638,7 @@ class TestVersionSkew:
             profile,
             config,
             deadline_seconds=0,
-            connect=lambda attachment: True,
+            connect=lambda attachment: Reach.ANSWERED,
         )
 
         assert not asked
@@ -1378,7 +1667,7 @@ class TestVersionSkew:
             profile,
             config,
             deadline_seconds=0,
-            connect=lambda attachment: True,
+            connect=lambda attachment: Reach.ANSWERED,
         )
 
         assert not asked


### PR DESCRIPTION
Closes #631

A frontend starts a shared owner, watches it report ready, and then refuses to attach to it. The owner keeps running and keeps the daemon lock, so the frontend spends the rest of its budget contending with the healthy process it started itself, and the client ends up with no owner at all.

The cause is that the reachability probe answered with a bool. A process that is gone and a process that is merely stalled both arrived as `False`, and a single `False` marked the instance unusable for the whole election, so it never got a second ping. Under load that turns ordinary scheduler delay into a permanent verdict.

Those two are not the same thing, and they are not close. Measured against the real probe with a real descriptor and token: a closed port refuses in about ten milliseconds, because the kernel turns the connection away; a process holding a listening socket that nobody reads spends the entire five second budget, because the handshake completes into a backlog. The probe now reports which of the two it saw. A refusal buries the instance exactly as before, so a crashed owner's descriptor is still not handed back. A silence records nothing, and the next pass asks again.

Never retrying rather than retrying a fixed number of times, and that was decided by measurement. Each probe costs the full budget, so one grace covers about ten seconds of stall: driven through the real election loop, it rescues a six second freeze and still gives up on a fifteen second one, which is the bug as reported. The election deadline is what bounds the loop, as it already was.

Verified with `uv run pytest` (1559 fast, 16 process tests), lint, format and type checks. Each new test was mutation-checked: reverting the fix fails them, and the real-process test fails with the exact reason string from the issue, taking 92 seconds instead of 10.

## Synthetic prompt

> `_reachable` in `daemon_election.py` returns a bool, so a timed-out ping and a refused connection are indistinguishable, and `_live_lookup` buries the instance on either — which means a frontend that just started a healthy owner refuses to attach to it when one ping stalls. Measure how a dead port and a frozen process actually differ, then split the probe's answer accordingly so only a refusal buries and a silence is retried. Add mutation-checked tests including a real detached owner paused with SIGSTOP.

Generated with Claude Opus 5
