### PR TITLE
refactor(daemon): Keep the profile lease with the browser

### DIFF
--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -37,7 +37,7 @@ from linkedin_mcp_server.exceptions import (
     BrowserBusyError,
     BrowserShutdownUnconfirmedError,
 )
-from linkedin_mcp_server.profile_lease import get_profile_lease
+from linkedin_mcp_server.profile_lease import ProfileLease, get_profile_lease
 from linkedin_mcp_server.server_role import a_held_profile_means_this_owner_must_go
 from linkedin_mcp_server.session_state import (
     SourceState,
@@ -67,9 +67,22 @@ _headless: bool = True
 # this path and race the first tool call, and an unguarded check-then-create
 # would launch two browsers against the same profile.
 _browser_create_lock = asyncio.Lock()
-# Set while the singleton holds a profile-lease reference, so close_browser()
-# releases exactly the reference the browser took and never someone else's.
-_browser_holds_lease: bool = False
+# The lease the singleton took, held onto rather than merely noted, so the close
+# settles the object it acquired instead of looking one up again.
+#
+# It used to be a bool, and the difference cost six review rounds. Recording only
+# *that* a lease existed left the close to reconstruct it through
+# ``get_profile_lease()``, which resolves a path and can fail — while ``_browser``
+# is already cleared and every line that keeps the profile safe sits below that
+# call. Ownership was therefore inferred from two globals that could disagree,
+# settled at the one moment one of them was already gone. Each round closed one
+# more way in; keeping the object closes the shape.
+#
+# Always the object the registry handed out (``get_profile_lease``), never one
+# constructed here: ``profile_lease`` clears inherited leases after a fork by
+# walking that registry, and an instance built outside it would silently keep a
+# parent's kernel lock alive in a child.
+_browser_lease: ProfileLease | None = None
 # Monotonic timestamp of the last completed tool call, for the idle timer.
 _last_activity: float | None = None
 # Tool calls currently driving the browser. The background handoff poll must not
@@ -562,7 +575,7 @@ async def get_or_create_browser(
 
 async def _create_browser() -> BrowserManager:
     """Create and initialize the singleton (caller holds _browser_create_lock)."""
-    global _browser, _browser_cookie_export_path, _browser_holds_lease
+    global _browser, _browser_cookie_export_path, _browser_lease
 
     lease = get_profile_lease()
 
@@ -579,7 +592,7 @@ async def _create_browser() -> BrowserManager:
     # reference already, so this is usually a cheap second reference; taking it
     # here as well keeps every launch path covered, including the CLI ones.
     took_lease = False
-    if not _browser_holds_lease:
+    if _browser_lease is None:
         if not lease.try_acquire():
             raise BrowserBusyError()
         took_lease = True
@@ -594,6 +607,10 @@ async def _create_browser() -> BrowserManager:
         # process exits.
         lease.mark_browser_open()
         lease.try_acquire()
+        # Recorded even though no browser survives, because the profile is held
+        # and something has to say by whom. There is no ``_browser`` to close, so
+        # nothing will ever settle this lease: that is the point of keeping it.
+        _browser_lease = lease
         # After the marker, not before, and that ordering is the whole reason
         # this call is here rather than only in the exception's constructor. The
         # constructor runs while `_create_browser_locked` is still raising, when
@@ -603,7 +620,7 @@ async def _create_browser() -> BrowserManager:
         # production order: `browser_open=True`, `stand_down=None`, and live, a
         # real owner that three consecutive fresh clients each attached to and
         # got the same refusal from.
-        a_held_profile_means_this_owner_must_go()
+        a_held_profile_means_this_owner_must_go(lease)
         raise
     except BaseException:
         # BaseException, not Exception: a cancelled startup would otherwise
@@ -614,7 +631,7 @@ async def _create_browser() -> BrowserManager:
         raise
 
     if took_lease:
-        _browser_holds_lease = True
+        _browser_lease = lease
     # Records that Chromium is live on the profile, which the reference count
     # cannot express: destructive helpers ask for a reference and would simply
     # get one from our own lease.
@@ -768,9 +785,61 @@ async def close_browser() -> None:
             raise asyncio.CancelledError
 
 
+def _settle_the_profile(*, confirmed: bool) -> None:
+    """Hand the profile back, or keep it and ask for a replacement.
+
+    Every way a browser stops arrives here, and there is nothing to look up: the
+    lease is the object this module took, kept for exactly this moment. That is
+    the whole of the refactor. The close used to re-derive it from a path while
+    ``_browser`` was already cleared, so a lookup that failed skipped every line
+    below it — the marker, the release, the warning and the request for a
+    successor, all at once.
+
+    *confirmed* says whether Chromium is provably gone, which is the only thing
+    that decides between the two outcomes:
+
+    * proven gone, so the profile is free: clear the marker, release the
+      reference, and forget the lease.
+    * not proven, so Chromium may still be on the profile: keep both, and say so.
+      Handing it over now is the corruption the lease exists to prevent, and the
+      kernel frees the lock when this process exits.
+
+    Never raises. Callers reach it mid-teardown, sometimes with an exception of
+    their own already on the way out.
+    """
+    global _browser_lease
+
+    lease, _browser_lease = _browser_lease, None
+    if lease is None:
+        # Nothing was ever taken, so nothing is owed. A browser created while the
+        # middleware already held a reference is the ordinary case.
+        return
+
+    if confirmed:
+        # Only now is Chromium provably gone, so only now may auth state move.
+        lease.mark_browser_closed()
+        lease.release()
+        return
+
+    # close() bounds its cleanup steps and reports failure rather than hanging,
+    # so it can return while Chromium is still running.
+    _browser_lease = lease
+    logger.warning(
+        "Browser shutdown could not be confirmed; keeping the profile "
+        "lease until this process exits."
+    )
+    # And for a shared owner that sentence is the whole problem: it outlives the
+    # client that started it, so nobody is coming to restart it and every later
+    # call meets `BrowserBusyError`. Asked from wherever the lease is *kept*
+    # rather than wherever a failure is reported, because this path reports
+    # nothing at all — a handoff, the idle timeout and `close_session` all return
+    # normally from here, and no exception is ever constructed.
+    a_held_profile_means_this_owner_must_go(lease)
+
+
 async def _close_browser_locked() -> None:
     """Tear the browser down; the caller holds the lifecycle lock."""
-    global _browser, _browser_cookie_export_path, _browser_holds_lease, _last_activity
+    global _browser, _browser_cookie_export_path, _last_activity
 
     browser = _browser
     cookie_export_path = _browser_cookie_export_path
@@ -787,59 +856,17 @@ async def _close_browser_locked() -> None:
             await browser.export_cookies(cookie_export_path)
         except Exception:
             logger.debug("Cookie export on close skipped", exc_info=True)
-    confirmed = await browser.close()
 
+    # In a `finally`, so the profile is settled however `close()` ends. It is
+    # bounded and swallows its own failures today, but the ordering here is what
+    # the whole class of wedge turned on: anything raised between clearing
+    # `_browser` and settling the lease used to leave the profile held by a
+    # process nobody had asked to give way.
+    confirmed = False
     try:
-        lease = get_profile_lease()
-    except Exception:
-        # The lookup is path-based, so it can fail on a profile directory that
-        # became unreadable while the browser was running, even though this
-        # process still holds the open descriptor. By here the singleton is
-        # already cleared, so every line that would have kept the profile safe
-        # is below this point and none of them runs. Measured in production
-        # order: browser cleared, the hold flag still set, and no stand-down.
-        #
-        # Asked before re-raising, because the helper now treats a lease it
-        # cannot read as held, which is exactly this situation. The original
-        # failure still reaches the caller.
-        #
-        # Whether Chromium closed cleanly makes no difference here, and an
-        # earlier version of this exempted the confirmed case on the reasoning
-        # that a proven-closed browser leaves the profile free. It does not: both
-        # `mark_browser_closed()` and `release()` need the object this lookup
-        # failed to produce, so a confirmed close strands the lease just as
-        # thoroughly. Measured with a real acquired lease: Chromium gone, the
-        # lease still held with its marker set, and this owner's own next launch
-        # refused with `BrowserBusyError` while nobody had asked for a
-        # replacement.
-        a_held_profile_means_this_owner_must_go()
-        raise
-    if confirmed:
-        # Only now is Chromium provably gone, so only now may auth state move.
-        lease.mark_browser_closed()
-
-    if _browser_holds_lease:
-        if confirmed:
-            _browser_holds_lease = False
-            lease.release()
-        else:
-            # Chromium may still be running: close() bounds its cleanup steps and
-            # reports failure rather than hanging. Handing the profile to another
-            # process now is exactly the corruption the lease prevents, so keep
-            # it until this process exits and the kernel frees it.
-            logger.warning(
-                "Browser shutdown could not be confirmed; keeping the profile "
-                "lease until this process exits."
-            )
-            # And for a shared owner, that sentence is the whole problem: it
-            # outlives the client that started it, so nobody is coming to restart
-            # it and every later call meets `BrowserBusyError`. Asked here rather
-            # than only where the failure is *reported*, because this path
-            # reports nothing at all: a handoff, the idle timeout and
-            # `close_session` all return normally from here, so no exception is
-            # ever constructed. Reproduced: close returned, lease kept,
-            # `stand_down_reason()` None, next launch refused.
-            a_held_profile_means_this_owner_must_go()
+        confirmed = await browser.close()
+    finally:
+        _settle_the_profile(confirmed=confirmed)
     logger.info("Browser closed")
 
 
@@ -954,7 +981,7 @@ async def release_profile_if_idle_or_requested() -> bool:
 
     Returns whether the browser was closed.
     """
-    if _browser is None or not _browser_holds_lease:
+    if _browser is None or _browser_lease is None:
         return False
 
     # A tool call is using this browser's Page right now. Closing it here would
@@ -1006,12 +1033,19 @@ async def release_profile_if_idle_or_requested() -> bool:
 
 
 def reset_browser_for_testing() -> None:
-    """Reset global browser state for test isolation."""
+    """Reset global browser state for test isolation.
+
+    The lease is dropped rather than released, deliberately. ``conftest`` resets
+    this module before ``profile_lease`` precisely so a lease the browser still
+    held is settled by its own bookkeeping first; releasing a reference here as
+    well would drop one the test never took, and the next test would find a lease
+    that reports itself free while the kernel lock is still open.
+    """
     global _browser, _browser_cookie_export_path, _headless
-    global _browser_holds_lease, _last_activity, _calls_in_flight
+    global _browser_lease, _last_activity, _calls_in_flight
     _browser = None
     _browser_cookie_export_path = None
     _headless = True
-    _browser_holds_lease = False
+    _browser_lease = None
     _last_activity = None
     _calls_in_flight = 0

--- a/linkedin_mcp_server/server_role.py
+++ b/linkedin_mcp_server/server_role.py
@@ -14,6 +14,7 @@ server to ask, and :func:`process_role` is what those ask instead.
 """
 
 import enum
+from typing import Any
 
 
 class ServerRole(enum.Enum):
@@ -149,7 +150,7 @@ def stand_down_reason() -> str | None:
     return _must_stand_down[0] if _must_stand_down else None
 
 
-def a_held_profile_means_this_owner_must_go() -> None:
+def a_held_profile_means_this_owner_must_go(lease: Any | None = None) -> None:
     """Give way if this is an owner an unconfirmed teardown has stranded.
 
     One function rather than the same three lines at each site, because the sites
@@ -166,8 +167,12 @@ def a_held_profile_means_this_owner_must_go() -> None:
     close path returns normally, so a handoff, the idle timeout and
     ``close_session`` strand an owner without raising anything at all.
 
-    Reads the lease itself. It runs from a ``finally`` a cancellation passes
-    through, and from a teardown with no caller left to have worked it out.
+    *lease* is the object the caller already holds, and passing it is what keeps
+    this function off the path-based lookup. That lookup resolves a directory and
+    consults a registry, neither of which the caller needs: it is holding the
+    very lease being asked about. Callers with nothing in hand may still omit it
+    and get the lookup, which is right for the ones reasoning about the profile
+    rather than about an object they own.
 
     A read that fails asks anyway. Not being able to tell is not the same as
     being told the profile is free, and the two outcomes are not symmetric: an
@@ -175,15 +180,22 @@ def a_held_profile_means_this_owner_must_go() -> None:
     later call until somebody kills it by hand. Measured with the read raising
     ``PermissionError``: the owner kept serving with the question unanswered.
 
+    Typed loosely on purpose. ``ProfileLease`` lives in a module this one must not
+    import — the whole point of ``server_role`` is that it depends on nothing —
+    and the only thing wanted here is ``browser_open``.
+
     Never raises. The caller is mid-teardown or mid-failure and has its own
     exception to deliver.
     """
     if process_role() is not ServerRole.OWNER:
         return
-    from linkedin_mcp_server.profile_lease import get_profile_lease
 
     try:
-        held = get_profile_lease().browser_open
+        if lease is None:
+            from linkedin_mcp_server.profile_lease import get_profile_lease
+
+            lease = get_profile_lease()
+        held = lease.browser_open
     except Exception:  # noqa: BLE001 - unreadable is not the same as free
         held = True
     if not held:

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -728,7 +728,7 @@ class TestAWedgeFromAnywhereFreesTheOwner:
 
         with (
             patch.object(drv, "_browser", fake_browser),
-            patch.object(drv, "_browser_holds_lease", True),
+            patch.object(drv, "_browser_lease", lease),
             patch.object(drv, "get_profile_lease", return_value=lease),
             patch(
                 "linkedin_mcp_server.profile_lease.get_profile_lease",
@@ -789,7 +789,7 @@ class TestAWedgeFromAnywhereFreesTheOwner:
 
         with (
             patch.object(drv, "_browser", fake_browser),
-            patch.object(drv, "_browser_holds_lease", True),
+            patch.object(drv, "_browser_lease", lease),
             patch.object(drv, "get_profile_lease", return_value=lease),
             patch(
                 "linkedin_mcp_server.profile_lease.get_profile_lease",
@@ -827,17 +827,26 @@ class TestAWedgeFromAnywhereFreesTheOwner:
 
         assert stand_down_reason() is not None
 
-    async def test_a_close_whose_own_lease_lookup_fails_still_frees_the_owner(self):
-        """The lookup sits between the teardown and every line that protects it.
+    async def test_a_close_settles_the_profile_without_any_lookup(self):
+        """The close no longer asks where its lease is, so it cannot be told wrong.
 
-        `get_profile_lease` resolves a path, so it can fail on a profile
-        directory that became unreadable while the browser was running, even
-        though this process still holds the open descriptor. By then the
-        singleton is cleared, so nothing below it runs: not the hold flag, not
-        the warning, not the request.
+        This replaces a pair of tests that injected ``get_profile_lease`` raising
+        ``PermissionError`` inside the close and asserted the workaround fired.
+        Kept as a scenario and inverted as an assertion: with the lookup raising
+        for the whole call, an unconfirmed teardown still keeps the lease and
+        still asks for a replacement. If a lookup ever returns to this path the
+        ``PermissionError`` surfaces and this fails.
 
-        Measured in production order: browser cleared, hold flag still set,
-        `stand_down_reason()` None.
+        Worth saying why the old pair had to go rather than be adjusted. Left as
+        they were they would have passed *vacuously* — green while the injected
+        failure had nothing to land on — which is the one outcome worse than a
+        red test. And the failure they injected is hard to provoke for real:
+        measured against the actual function, a removed auth root, a parent
+        directory at mode 000 and a symlink loop all return normally, because
+        ``Path.resolve()`` is non-strict and the registry is a dict. What they
+        were really pinning is structural, and that is what is asserted here:
+        whatever goes wrong between clearing ``_browser`` and settling the lease,
+        the profile must not be left held in silence.
         """
         from linkedin_mcp_server.drivers import browser as drv
         from linkedin_mcp_server.server_role import (
@@ -847,6 +856,8 @@ class TestAWedgeFromAnywhereFreesTheOwner:
         )
 
         set_process_role(ServerRole.OWNER)
+        lease = MagicMock()
+        lease.browser_open = True
         fake_browser = MagicMock()
         fake_browser.close = AsyncMock(return_value=False)  # unconfirmed
 
@@ -855,30 +866,30 @@ class TestAWedgeFromAnywhereFreesTheOwner:
 
         with (
             patch.object(drv, "_browser", fake_browser),
-            patch.object(drv, "_browser_holds_lease", True),
+            patch.object(drv, "_browser_lease", lease),
             patch.object(drv, "get_profile_lease", side_effect=unreadable),
             patch(
                 "linkedin_mcp_server.profile_lease.get_profile_lease",
                 side_effect=unreadable,
             ),
         ):
-            # The original failure still reaches the caller.
-            with pytest.raises(PermissionError):
-                await drv._close_browser_locked()
+            # No PermissionError: nothing on this path resolves a path any more.
+            await drv._close_browser_locked()
 
+        lease.release.assert_not_called()
         assert stand_down_reason() is not None, (
-            "an owner whose close could not read the lease keeps the profile"
+            "an owner stranded by an unconfirmed close keeps the profile"
         )
 
-    async def test_a_confirmed_close_with_an_unreadable_lease_also_asks(self):
-        """A proven-closed Chromium does not mean a released lease.
+    async def test_a_confirmed_close_releases_without_any_lookup_either(self):
+        """The same for the ordinary ending, which used to strand a lease too.
 
-        This asserted the opposite once, on the reasoning that a confirmed close
-        leaves the profile free. It does not: ``mark_browser_closed()`` and
-        ``release()`` both need the object the lookup failed to produce, so the
-        lease stays held with its marker set. Measured with a real acquired
-        lease: Chromium gone, and this owner's own next launch refused with
-        ``BrowserBusyError`` while nobody had asked for a replacement.
+        A proven-closed Chromium does not by itself free the profile: both
+        ``mark_browser_closed()`` and ``release()`` need the lease object, and
+        when that had to be looked up a failing lookup left it held with its
+        marker set. Measured then with a real acquired lease: Chromium gone, and
+        this owner's own next launch refused with ``BrowserBusyError`` while
+        nobody had asked for a replacement.
         """
         from linkedin_mcp_server.drivers import browser as drv
         from linkedin_mcp_server.server_role import (
@@ -888,6 +899,8 @@ class TestAWedgeFromAnywhereFreesTheOwner:
         )
 
         set_process_role(ServerRole.OWNER)
+        lease = MagicMock()
+        lease.browser_open = False  # a confirmed teardown clears it
         fake_browser = MagicMock()
         fake_browser.close = AsyncMock(return_value=True)  # confirmed
 
@@ -896,16 +909,211 @@ class TestAWedgeFromAnywhereFreesTheOwner:
 
         with (
             patch.object(drv, "_browser", fake_browser),
-            patch.object(drv, "_browser_holds_lease", True),
+            patch.object(drv, "_browser_lease", lease),
             patch.object(drv, "get_profile_lease", side_effect=unreadable),
             patch(
                 "linkedin_mcp_server.profile_lease.get_profile_lease",
                 side_effect=unreadable,
             ),
         ):
-            with pytest.raises(PermissionError):
-                await drv._close_browser_locked()
+            await drv._close_browser_locked()
 
+        lease.mark_browser_closed.assert_called_once()
+        lease.release.assert_called_once()
+        assert stand_down_reason() is None, "a healthy owner was told to exit"
+
+
+class TestTheBrowserKeepsItsOwnLease:
+    """Ownership as an object it holds, rather than a fact it remembers.
+
+    Six review rounds each found one more way for an owner to end up sitting on
+    the profile with nobody asked to replace it, and every one of them lived in
+    the same gap: the close had cleared ``_browser``, still had work to do, and
+    had to go and find its lease again before it could do any of it.
+    """
+
+    def teardown_method(self):
+        from linkedin_mcp_server.server_role import reset_process_role_for_testing
+
+        reset_process_role_for_testing()
+
+    async def test_it_keeps_the_object_the_registry_handed_out(self, tmp_path):
+        """By identity, because a fresh equivalent instance is the failure mode.
+
+        ``profile_lease`` clears inherited leases after a fork by walking its
+        registry, so a ``ProfileLease`` constructed outside it is invisible to
+        that handler: a forked child would keep its parent's kernel lock alive
+        with nothing in its own state to explain why. The two objects would
+        behave identically everywhere else, which is exactly why this asserts
+        identity rather than behaviour.
+        """
+        from linkedin_mcp_server.drivers import browser as drv
+        from linkedin_mcp_server.profile_lease import get_profile_lease
+
+        lease = get_profile_lease(tmp_path / "profile")
+
+        async def built() -> object:
+            return MagicMock()
+
+        with (
+            patch.object(drv, "_browser", None),
+            patch.object(drv, "_browser_lease", None),
+            patch.object(drv, "get_profile_lease", return_value=lease),
+            patch.object(drv, "_create_browser_locked", built),
+        ):
+            await drv._create_browser()
+            retained = drv._browser_lease
+
+        try:
+            assert retained is lease, "the browser kept a lease of its own making"
+        finally:
+            lease.release()
+
+    def test_the_test_reset_drops_the_lease_without_releasing_it(self, tmp_path):
+        """``conftest`` resets this module first, on purpose.
+
+        A lease the browser still holds is settled by its own bookkeeping before
+        ``reset_leases_for_testing`` runs. Releasing a reference here as well
+        would drop one this module never took, and the next test would meet a
+        lease reporting itself free while the kernel lock is still open.
+        """
+        from linkedin_mcp_server.drivers import browser as drv
+        from linkedin_mcp_server.profile_lease import get_profile_lease
+
+        lease = get_profile_lease(tmp_path / "profile")
+        assert lease.try_acquire()
+
+        with patch.object(drv, "_browser_lease", lease):
+            drv.reset_browser_for_testing()
+
+        try:
+            assert lease.held, "the reset released a reference it never took"
+        finally:
+            lease.release()
+
+    async def test_it_settles_the_lease_it_took_after_a_rotation(self, tmp_path):
+        """The profile can move under a live browser, and the lease does not.
+
+        ``rotate_source_profile`` takes the lease itself, and afterwards the
+        registry's entry for the new auth root is a *different* object. A close
+        that re-derived its lease from the current path would then mark and
+        release the wrong one, leaving the browser's own profile held. Holding
+        the object is what makes that unrepresentable.
+        """
+        from linkedin_mcp_server.drivers import browser as drv
+
+        took = MagicMock()
+        took.browser_open = True
+        somewhere_else = MagicMock()
+        somewhere_else.browser_open = True
+        fake_browser = MagicMock()
+        fake_browser.close = AsyncMock(return_value=True)
+
+        with (
+            patch.object(drv, "_browser", fake_browser),
+            patch.object(drv, "_browser_lease", took),
+            # What the path resolves to now, which is not what was acquired.
+            patch.object(drv, "get_profile_lease", return_value=somewhere_else),
+        ):
+            await drv._close_browser_locked()
+
+        took.release.assert_called_once()
+        somewhere_else.release.assert_not_called()
+        somewhere_else.mark_browser_closed.assert_not_called()
+
+    def test_the_stand_down_helper_uses_the_lease_it_is_given(self):
+        """And never reaches for the registry when it was handed one.
+
+        The lookup is the thing being removed from these paths, so a helper that
+        quietly consulted it anyway would leave the reconstruction alive in the
+        one decision the six rounds converged on.
+
+        Asserted against the *call*, not by making the lookup raise. That was the
+        first version of this test and it passed against a helper that ignored
+        its argument entirely: the helper catches broadly on purpose, so an
+        injected failure is swallowed and read as "cannot tell, assume held",
+        which is the same verdict the correct code reaches. The mutation was
+        invisible until the assertion moved here.
+        """
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            a_held_profile_means_this_owner_must_go,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        set_process_role(ServerRole.OWNER)
+        held = MagicMock()
+        held.browser_open = True
+
+        with patch("linkedin_mcp_server.profile_lease.get_profile_lease") as looked_up:
+            a_held_profile_means_this_owner_must_go(held)
+
+        looked_up.assert_not_called()
+        assert stand_down_reason() is not None
+
+    async def test_a_startup_that_could_not_tear_down_keeps_its_extra_reference(
+        self, tmp_path
+    ):
+        """The one path that retains a lease with no browser behind it.
+
+        ``_create_browser_locked`` can raise after Chromium is up, and then the
+        teardown may not be confirmable: something may still be on the profile
+        with nothing left to close it. So the lease is kept *and* an extra
+        reference taken, so the caller's own release cannot drop the last one and
+        let a second launch start on top of a live Chromium. The kernel frees it
+        when the process exits, which is the whole recovery.
+        """
+        from linkedin_mcp_server.drivers import browser as drv
+        from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
+        from linkedin_mcp_server.server_role import (
+            ServerRole,
+            set_process_role,
+            stand_down_reason,
+        )
+
+        class Lease:
+            """Real enough, and the marker starts false as production's does."""
+
+            def __init__(self):
+                self.browser_open = False
+                self.refs = 0
+
+            def try_acquire(self):
+                self.refs += 1
+                return True
+
+            def mark_browser_open(self):
+                self.browser_open = True
+
+            def release(self):
+                self.refs -= 1
+
+        set_process_role(ServerRole.OWNER)
+        lease = Lease()
+
+        async def teardown_that_could_not_be_confirmed():
+            raise BrowserShutdownUnconfirmedError("the startup teardown timed out")
+
+        with (
+            patch.object(drv, "_browser", None),
+            patch.object(drv, "_browser_lease", None),
+            patch.object(drv, "get_profile_lease", return_value=lease),
+            patch(
+                "linkedin_mcp_server.profile_lease.get_profile_lease",
+                return_value=lease,
+            ),
+            patch.object(
+                drv, "_create_browser_locked", teardown_that_could_not_be_confirmed
+            ),
+        ):
+            with pytest.raises(BrowserShutdownUnconfirmedError):
+                await drv._create_browser()
+            retained = drv._browser_lease
+
+        assert retained is lease, "nothing records who holds the profile"
+        assert lease.refs >= 2, "the extra reference was not taken"
+        assert lease.browser_open is True
         assert stand_down_reason() is not None, (
-            "a confirmed close that could not release the lease left it held"
+            "the owner holds the profile and nobody asked for a replacement"
         )

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -300,7 +300,7 @@ class TestIdleOwnerHandsOver:
                 browser_module,
                 _browser=fake_browser,
                 _browser_cookie_export_path=None,
-                _browser_holds_lease=True,
+                _browser_lease=lease,
             ),
             patch.object(browser_module, "get_profile_lease", return_value=lease),
         ):
@@ -371,7 +371,7 @@ class TestPollerDoesNotInterruptWork:
                     browser_module,
                     _browser=fake_browser,
                     _browser_cookie_export_path=None,
-                    _browser_holds_lease=True,
+                    _browser_lease=lease,
                 ),
                 patch.object(browser_module, "get_profile_lease", return_value=lease),
             ):
@@ -433,7 +433,7 @@ class TestMinimumHoldWindow:
                     browser_module,
                     _browser=fake_browser,
                     _browser_cookie_export_path=None,
-                    _browser_holds_lease=True,
+                    _browser_lease=lease,
                 ),
                 patch.object(browser_module, "get_profile_lease", return_value=lease),
             ):
@@ -506,7 +506,7 @@ class TestConfirmedClose:
             browser_module,
             _browser=fake_browser,
             _browser_cookie_export_path=None,
-            _browser_holds_lease=True,
+            _browser_lease=lease,
         )
         with monkey:
             with patch.object(browser_module, "get_profile_lease", return_value=lease):
@@ -528,7 +528,7 @@ class TestConfirmedClose:
             browser_module,
             _browser=fake_browser,
             _browser_cookie_export_path=None,
-            _browser_holds_lease=True,
+            _browser_lease=lease,
         ):
             with patch.object(browser_module, "get_profile_lease", return_value=lease):
                 await browser_module.close_browser()


### PR DESCRIPTION
Closes #632

Six consecutive review rounds each found one more way for a shared owner to end up holding the browser profile with nobody asked to replace it. Each fix was correct and each one revealed one more entrance. They were all the same shape: the close had already cleared the singleton, still had work to do, and had to go and find its lease again before it could do any of it.

`_browser_holds_lease: bool` recorded *that* a lease existed and discarded the object needed to settle it. So ownership was inferred from two pieces of global state that could disagree, at the one moment one of them was already gone, and every teardown ran a path-based lookup with every protective line below it.

The browser now keeps the lease it took, and one function settles it: a confirmed teardown clears the marker and releases the reference, an unconfirmed one keeps both and asks for a replacement. The stand-down helper takes the object too, so the reconstruction is gone from the decision as well as from the close.

Worth saying plainly, because it changes how urgent this looks: the sixth entrance is real but rare. Measured against the actual lookup, a removed auth root, a parent directory at mode 000 and a symlink loop all return normally, since `Path.resolve()` is non-strict and the registry is an in-memory dict. The reason to do this is the other five and the shape they share, not that one.

The tests written for those six entrances survive on their original assertions; nine needed the mechanical swap from the flag to the object. Two had to be replaced rather than adjusted, and that is the part worth a look in review: they injected a failing lookup into a path that no longer performs one, so they would have passed while asserting nothing. They are replaced by the inverted claim, that the failure cannot occur.

Verified with `uv run pytest` (1559 fast, unchanged from before the refactor, plus the process tests), lint, format and type checks. Each new test was mutation-checked; one of them initially passed against its own mutation because the helper catches broadly, and its assertion was moved until it failed.

## Synthetic prompt

> `drivers/browser.py` tracks profile ownership with a `_browser_holds_lease` bool, so the close path has to reconstruct the lease via `get_profile_lease()` after `_browser` is already cleared — the shape behind the six wedge findings in #632. Retain the concrete `ProfileLease` instead and settle browser, marker and refcount in one function, extending the stand-down helper to take the lease too. Keep the existing wedge tests on their original assertions, and check whether any of them would pass vacuously afterwards.

Generated with Claude Opus 5
