### PR TITLE
fix(daemon): Ask the lease the browser actually holds

### DIFF
--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -992,7 +992,16 @@ async def release_profile_if_idle_or_requested() -> bool:
         return False
 
     config = get_config().browser
-    lease = get_profile_lease()
+    # The lease this browser holds, not one the registry resolves now. Both
+    # questions asked below are about *this* profile: `handoff_requested()`
+    # probes a file under the lease's own auth root, and `held_seconds` counts
+    # from the moment that lease was acquired. A freshly resolved object answers
+    # about whichever path the config points at now and reports a hold of zero,
+    # so a waiter would be either ignored or refused forever. `config` still
+    # comes from settings: the hold window and the idle timeout are not lease
+    # state. Bound to a local so this stays true if an `await` ever appears
+    # above it and lets a concurrent close clear the global.
+    lease = _browser_lease
     # None means no tool call has ever run, which is idle in the strongest sense.
     idle_for = time.monotonic() - _last_activity if _last_activity is not None else None
 

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -295,14 +295,11 @@ class TestIdleOwnerHandsOver:
         fake_browser = MagicMock()
         fake_browser.close = AsyncMock(return_value=True)
 
-        with (
-            patch.multiple(
-                browser_module,
-                _browser=fake_browser,
-                _browser_cookie_export_path=None,
-                _browser_lease=lease,
-            ),
-            patch.object(browser_module, "get_profile_lease", return_value=lease),
+        with patch.multiple(
+            browser_module,
+            _browser=fake_browser,
+            _browser_cookie_export_path=None,
+            _browser_lease=lease,
         ):
             watcher = asyncio.create_task(browser_module.watch_for_handoff_requests())
             waiter = subprocess.Popen(
@@ -366,14 +363,11 @@ class TestPollerDoesNotInterruptWork:
         try:
             _await_line(waiter, "ANNOUNCED")
 
-            with (
-                patch.multiple(
-                    browser_module,
-                    _browser=fake_browser,
-                    _browser_cookie_export_path=None,
-                    _browser_lease=lease,
-                ),
-                patch.object(browser_module, "get_profile_lease", return_value=lease),
+            with patch.multiple(
+                browser_module,
+                _browser=fake_browser,
+                _browser_cookie_export_path=None,
+                _browser_lease=lease,
             ):
                 browser_module.note_call_started()
                 closed = await browser_module.release_profile_if_idle_or_requested()
@@ -428,14 +422,11 @@ class TestMinimumHoldWindow:
         try:
             _await_line(waiter, "ANNOUNCED")
 
-            with (
-                patch.multiple(
-                    browser_module,
-                    _browser=fake_browser,
-                    _browser_cookie_export_path=None,
-                    _browser_lease=lease,
-                ),
-                patch.object(browser_module, "get_profile_lease", return_value=lease),
+            with patch.multiple(
+                browser_module,
+                _browser=fake_browser,
+                _browser_cookie_export_path=None,
+                _browser_lease=lease,
             ):
                 browser_module.note_activity()  # a call just finished
                 closed = await browser_module.release_profile_if_idle_or_requested()
@@ -450,6 +441,110 @@ class TestMinimumHoldWindow:
             waiter.wait(timeout=10)
             lease.mark_browser_closed()
             lease.release()
+
+
+class TestTheHandoffAsksTheLeaseTheBrowserHolds:
+    """Both handoff questions are about the profile this browser is sitting on.
+
+    Every other test in this file gives the retained lease and the registry the
+    same object, so none of them can see which one the code consulted. These two
+    hand out different objects. `handoff_requested()` probes a file under the
+    lease's own auth root, so a resolved one answers about a profile nobody is
+    waiting for; `held_seconds` counts from acquisition, so a fresh one reports
+    zero and the hold window never elapses. The second is the failure that would
+    strand a waiter outright.
+    """
+
+    @staticmethod
+    def _leases(*, retained_wants_handoff: bool, retained_held: float):
+        retained = MagicMock()
+        retained.handoff_requested.return_value = retained_wants_handoff
+        retained.held_seconds = retained_held
+
+        # What the registry would hand back for whatever path the config points
+        # at now: nobody waiting on it, and taken a moment ago.
+        resolved = MagicMock()
+        resolved.handoff_requested.return_value = False
+        resolved.held_seconds = 0.0
+        return retained, resolved
+
+    async def test_the_waiter_is_the_retained_leases_waiter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from linkedin_mcp_server.config import reset_config
+        from linkedin_mcp_server.drivers import browser as browser_module
+
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
+        monkeypatch.setenv("BROWSER_MIN_HOLD", "0")
+        reset_config()
+
+        retained, resolved = self._leases(
+            retained_wants_handoff=True, retained_held=300.0
+        )
+        fake_browser = MagicMock()
+        fake_browser.close = AsyncMock(return_value=True)
+
+        with (
+            patch.multiple(
+                browser_module,
+                _browser=fake_browser,
+                _browser_cookie_export_path=None,
+                _browser_lease=retained,
+            ),
+            patch.object(
+                browser_module, "get_profile_lease", return_value=resolved
+            ) as looked_up,
+        ):
+            browser_module.note_activity()  # a call just finished
+            closed = await browser_module.release_profile_if_idle_or_requested()
+
+        assert closed, (
+            "a process waiting on the profile this browser holds was ignored, "
+            "because the handoff probe went to a lease resolved from the path"
+        )
+        fake_browser.close.assert_awaited()
+        looked_up.assert_not_called()
+        resolved.handoff_requested.assert_not_called()
+
+    async def test_the_hold_window_runs_from_the_retained_acquisition(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from linkedin_mcp_server.config import reset_config
+        from linkedin_mcp_server.drivers import browser as browser_module
+
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
+        monkeypatch.setenv("BROWSER_MIN_HOLD", "60")
+        reset_config()
+
+        retained, resolved = self._leases(
+            retained_wants_handoff=True, retained_held=300.0
+        )
+        # Same answer on the waiter, so only the hold window can decide this one.
+        resolved.handoff_requested.return_value = True
+
+        fake_browser = MagicMock()
+        fake_browser.close = AsyncMock(return_value=True)
+
+        with (
+            patch.multiple(
+                browser_module,
+                _browser=fake_browser,
+                _browser_cookie_export_path=None,
+                _browser_lease=retained,
+            ),
+            patch.object(
+                browser_module, "get_profile_lease", return_value=resolved
+            ) as looked_up,
+        ):
+            browser_module.note_activity()
+            closed = await browser_module.release_profile_if_idle_or_requested()
+
+        assert closed, (
+            "an owner well past its hold window refused to hand over, because "
+            "the window was measured from a lease acquired just now"
+        )
+        fake_browser.close.assert_awaited()
+        looked_up.assert_not_called()
 
 
 class TestFailedLoginStillRestores:


### PR DESCRIPTION
Closes #642

`release_profile_if_idle_or_requested()` null-checks the lease the browser holds and then, twenty lines later, throws that object away and asks a freshly resolved one whether a process is waiting and how long the profile has been held. Both questions are about *this* profile: the handoff probe reads a file under the lease's own auth root, and the hold window counts from acquisition, so a resolved object reports a hold of zero and the window never elapses. That second one is what would strand a waiter outright.

#641 removed this reconstruction from the close path and from the stand-down decision. This is the one it left standing, and it is the same shape: ownership settled through a value that was looked up rather than held.

Worth saying plainly, because a reader expecting a user-visible symptom will not find one. Under the shipped CLI the two objects are the same: the registry caches one lease per resolved auth root, the configuration is loaded once, and no shipped path changes `user_data_dir` or resets the config singleton while a browser is open. This is latent.

The part worth a look in review is the tests. All three covering this function patched the resolver to return the same object they injected as `_browser_lease`, so none of them could tell which one the code consulted, and a mutation reverting the fix passed all three. Those patches are gone rather than tidied away: leaving them would let a reintroduced lookup hide behind them exactly as this one did. Two new tests hand out different objects, which is the only way anything here can see the difference.

Verified with the full suite, lint, format and type checks. Both new tests were mutation-checked: reverting `lease = _browser_lease` fails the first on the resolved lease reporting no waiter, and the second on it reporting a hold of zero, while the three existing tests stay green.

## Synthetic prompt

> `release_profile_if_idle_or_requested()` in `drivers/browser.py` still calls `get_profile_lease()` and asks that object `handoff_requested()` and `held_seconds`, even though #641 made the browser retain its own `ProfileLease`. Use the retained one. Then check whether the existing tests could ever have caught this, and fix them if not.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
