### PR TITLE
fix(daemon): Re-check for work before handing the browser over

### DIFF
--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -11,7 +11,8 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Any
+from collections.abc import Coroutine
+from typing import Any, TypeVar
 
 from linkedin_mcp_server.common_utils import harden_linkedin_tree, secure_mkdir
 from linkedin_mcp_server.core import (
@@ -93,6 +94,8 @@ _calls_in_flight: int = 0
 # arriving in that window would see no browser and launch a second Chromium on
 # the same profile, which is the very corruption this module prevents.
 _browser_lifecycle_lock = asyncio.Lock()
+
+T = TypeVar("T")
 
 
 def _debug_skip_checkpoint_restart() -> bool:
@@ -773,16 +776,27 @@ async def close_browser() -> None:
     exactly when a new launch must not start.
     """
     async with _browser_lifecycle_lock:
-        task = asyncio.create_task(_close_browser_locked())
-        cancelled = False
-        while True:
-            try:
-                await asyncio.shield(task)
-                break
-            except asyncio.CancelledError:
-                cancelled = True
-        if cancelled:
-            raise asyncio.CancelledError
+        await _run_deferring_cancels(_close_browser_locked())
+
+
+async def _run_deferring_cancels(coroutine: Coroutine[Any, Any, T]) -> T:
+    """Run *coroutine* to completion, holding cancellation back until it ends.
+
+    The caller holds the lifecycle lock. Splitting this out of ``close_browser``
+    lets the conditional close run its own coroutine under the same protection,
+    rather than duplicating the shield loop.
+    """
+    task = asyncio.create_task(coroutine)
+    cancelled = False
+    while True:
+        try:
+            result = await asyncio.shield(task)
+            break
+        except asyncio.CancelledError:
+            cancelled = True
+    if cancelled:
+        raise asyncio.CancelledError
+    return result
 
 
 def _settle_the_profile(*, confirmed: bool) -> None:
@@ -999,8 +1013,8 @@ async def release_profile_if_idle_or_requested() -> bool:
     # about whichever path the config points at now and reports a hold of zero,
     # so a waiter would be either ignored or refused forever. `config` still
     # comes from settings: the hold window and the idle timeout are not lease
-    # state. Bound to a local so this stays true if an `await` ever appears
-    # above it and lets a concurrent close clear the global.
+    # state. Bound to a local because the close below can clear the global, and
+    # the lines under it must keep describing the lease this decision was about.
     lease = _browser_lease
     # None means no tool call has ever run, which is idle in the strongest sense.
     idle_for = time.monotonic() - _last_activity if _last_activity is not None else None
@@ -1020,8 +1034,7 @@ async def release_profile_if_idle_or_requested() -> bool:
                 "Another process is waiting for the browser; handing over (held %.1fs)",
                 held,
             )
-            await close_browser()
-            return True
+            return await _close_unless_a_call_arrived()
         logger.debug(
             "Handoff requested but held for only %.1fs of %.1fs; keeping the "
             "browser to avoid a reopen",
@@ -1035,10 +1048,65 @@ async def release_profile_if_idle_or_requested() -> bool:
         logger.info(
             "Closing idle browser after %.0fs and releasing the profile", idle_for
         )
-        await close_browser()
-        return True
+        return await _close_unless_a_call_arrived()
 
     return False
+
+
+async def _close_unless_a_call_arrived() -> bool:
+    """Close the browser, unless a tool call started while we were deciding.
+
+    The guard in the caller ran outside the lifecycle lock, and taking that lock
+    can wait: a close in progress holds it across the cookie export and the
+    Chromium teardown. A call that starts inside that wait is invisible to a
+    check that already happened. Measured, with the lock held to open the
+    window: the decision was taken with nothing in flight, and Chromium was
+    closed and the profile released with one call running. That call's Page is
+    gone, which is exactly the closed-target error the guard exists to prevent.
+
+    Here rather than in ``close_browser``: that is the general teardown entry
+    point, and ``close_session``, shutdown, login and import all mean "close it"
+    unconditionally. A counter check there would make a deliberate close
+    silently do nothing. This is the one caller whose close is conditional.
+
+    Returns whether the browser was closed.
+    """
+    async with _browser_lifecycle_lock:
+        return await _run_deferring_cancels(_close_browser_if_still_idle())
+
+
+async def _close_browser_if_still_idle() -> bool:
+    """Tear the browser down unless a call claimed it; the lock is held.
+
+    The check has to sit *here*, in the coroutine the teardown task runs, and
+    that placement is the whole point rather than a detail. Checking in the
+    caller and then starting this as a task leaves a scheduling point between
+    the two: ``asyncio.create_task`` does not begin the coroutine, so the loop
+    gets to run whatever else is ready before the first line below executes.
+    Measured with the counter read in the caller instead: the re-check saw zero,
+    a tool call ran next and took the live browser through the fast path in
+    ``get_or_create_browser``, and the teardown then closed that same browser
+    with one call in flight.
+
+    From here there is no such gap. This body runs to its first ``await``
+    without yielding, and ``_close_browser_locked`` clears ``_browser`` before
+    *its* first await, so a call arriving afterwards finds no browser and waits
+    on the lock for a fresh one rather than losing the one it holds.
+
+    Returns whether the browser was closed.
+    """
+    if _calls_in_flight > 0:
+        logger.debug(
+            "A tool call started while the browser was being handed over; "
+            "keeping it, and the caller's post-call check hands over next"
+        )
+        return False
+    # Another close may have run while we waited, and reporting a close we did
+    # not perform would tell the middleware a handover happened.
+    if _browser is None:
+        return False
+    await _close_browser_locked()
+    return True
 
 
 def reset_browser_for_testing() -> None:

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -387,6 +387,194 @@ class TestPollerDoesNotInterruptWork:
             waiter.kill()
             waiter.wait(timeout=10)
 
+    async def test_a_call_arriving_during_the_close_still_keeps_the_browser(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The guard runs before the lifecycle lock, so it can go stale.
+
+        Taking that lock waits on any close already in progress, across the
+        cookie export and the Chromium teardown. A call that starts inside that
+        wait was not there when the counter was read, and the sibling test above
+        cannot see it: there the call is already in flight when the decision is
+        taken.
+        """
+        import asyncio
+
+        from linkedin_mcp_server.config import reset_config
+        from linkedin_mcp_server.drivers import browser as browser_module
+
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
+        monkeypatch.setenv("BROWSER_MIN_HOLD", "0")
+        reset_config()
+
+        lease = get_profile_lease(tmp_path / "profile")
+        assert lease.try_acquire()
+        lease.mark_browser_open()
+
+        fake_browser = MagicMock()
+        fake_browser.close = AsyncMock(return_value=True)
+
+        waiter = subprocess.Popen(
+            [sys.executable, str(_WORKER), "announce", str(tmp_path), "5"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            _await_line(waiter, "ANNOUNCED")
+
+            with patch.multiple(
+                browser_module,
+                _browser=fake_browser,
+                _browser_cookie_export_path=None,
+                _browser_lease=lease,
+                # `asyncio.Lock` binds to a loop the first time an acquire has
+                # to *wait*: the uncontended path returns before `_get_loop()`
+                # is ever called, which is why the rest of the suite never
+                # notices. Contending it is the whole point here, and the
+                # module-level lock outlives every test while each test gets a
+                # fresh loop, so this one brings its own.
+                _browser_lifecycle_lock=asyncio.Lock(),
+            ):
+                browser_module.note_activity()  # a call just finished
+
+                # Holding the lock is what a close in progress does, and it is
+                # the only way to open this window deterministically.
+                await browser_module._browser_lifecycle_lock.acquire()
+                handover = asyncio.create_task(
+                    browser_module.release_profile_if_idle_or_requested()
+                )
+                try:
+                    # Let the decision run until it blocks on the lock. It
+                    # cannot get past that while this test holds it.
+                    for _ in range(20):
+                        await asyncio.sleep(0)
+                    assert not handover.done(), (
+                        "the handover finished without waiting for the lock, so "
+                        "this test never opened the window it is about"
+                    )
+
+                    browser_module.note_call_started()
+                finally:
+                    browser_module._browser_lifecycle_lock.release()
+
+                closed = await handover
+
+            assert not closed, (
+                "a tool call that started while the close waited for the "
+                "lifecycle lock had its browser closed underneath it"
+            )
+            fake_browser.close.assert_not_awaited()
+            assert lease.held, "the profile was handed away from a running call"
+        finally:
+            waiter.kill()
+            waiter.wait(timeout=10)
+            browser_module.note_activity()
+            lease.mark_browser_closed()
+            lease.release()
+
+    async def test_a_call_arriving_after_the_recheck_still_keeps_the_browser(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The narrower window, one scheduling point later than the test above.
+
+        Checking the counter and then starting the teardown as a task leaves a
+        gap: `asyncio.create_task` does not begin the coroutine, so anything
+        already runnable goes first. A tool call in that gap takes the live
+        browser through the fast path in `get_or_create_browser` and then has it
+        closed underneath it. The sibling test cannot see this: it starts its
+        call before the lock is released, so the check has not run yet.
+        """
+        import asyncio
+
+        from linkedin_mcp_server.config import reset_config
+        from linkedin_mcp_server.drivers import browser as browser_module
+
+        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
+        monkeypatch.setenv("BROWSER_MIN_HOLD", "0")
+        reset_config()
+
+        lease = get_profile_lease(tmp_path / "profile")
+        assert lease.try_acquire()
+        lease.mark_browser_open()
+
+        fake_browser = MagicMock()
+        fake_browser.close = AsyncMock(return_value=True)
+
+        # What the teardown saw, rather than only what it did: an assertion on
+        # the outcome alone would pass on a close that merely lost its own race.
+        seen: dict[str, int] = {}
+        real_teardown = browser_module._close_browser_locked
+
+        async def watched_teardown() -> None:
+            seen["calls_in_flight"] = browser_module._calls_in_flight
+            await real_teardown()
+
+        waiter = subprocess.Popen(
+            [sys.executable, str(_WORKER), "announce", str(tmp_path), "5"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            _await_line(waiter, "ANNOUNCED")
+
+            with patch.multiple(
+                browser_module,
+                _browser=fake_browser,
+                _browser_cookie_export_path=None,
+                _browser_lease=lease,
+                _close_browser_locked=watched_teardown,
+                # Its own, for the loop-binding reason given in the sibling
+                # test above.
+                _browser_lifecycle_lock=asyncio.Lock(),
+            ):
+                browser_module.note_activity()  # a call just finished
+                arrive = asyncio.Event()
+
+                async def a_tool_call_starts() -> None:
+                    await arrive.wait()
+                    browser_module.note_call_started()
+
+                await browser_module._browser_lifecycle_lock.acquire()
+                handover = asyncio.create_task(
+                    browser_module.release_profile_if_idle_or_requested()
+                )
+                call = asyncio.create_task(a_tool_call_starts())
+                # Both park: the handover on the lock, the call on the event.
+                for _ in range(10):
+                    await asyncio.sleep(0)
+                assert not handover.done() and not call.done(), (
+                    "neither task parked, so this test never built the ordering "
+                    "it is about"
+                )
+
+                # Releasing the lock schedules the handover; setting the event
+                # schedules the call immediately behind it. So the handover
+                # runs, decides, and yields, and the call runs next.
+                browser_module._browser_lifecycle_lock.release()
+                arrive.set()
+
+                closed = await handover
+                await call
+
+            assert not closed, (
+                "a tool call that started one scheduling point after the "
+                "re-check had its browser closed underneath it"
+            )
+            assert "calls_in_flight" not in seen, (
+                f"the teardown ran anyway, with {seen.get('calls_in_flight')} "
+                "calls in flight"
+            )
+            fake_browser.close.assert_not_awaited()
+            assert lease.held, "the profile was handed away from a running call"
+        finally:
+            waiter.kill()
+            waiter.wait(timeout=10)
+            browser_module.note_activity()
+            lease.mark_browser_closed()
+            lease.release()
+
 
 class TestMinimumHoldWindow:
     """The hold window bounds how often ownership can move.


### PR DESCRIPTION
Closes #643

Stacked on #645, which touches the neighbouring lines. Read this diff against that one.

The in-flight guard runs, and the close it decides on then waits for the lifecycle lock, which a teardown already in progress holds across the cookie export and the Chromium shutdown. A tool call that starts inside that wait was never seen. Measured with the lock held to open the window: the decision was taken with nothing in flight, and Chromium was closed and the profile released with one call running, whose `Page` is gone. That is exactly the closed-target error the guard's comment exists to prevent.

Unlike #645 this one is reachable. The poller runs for every server and `note_call_started()` is on the ordinary tool path; it needs a call to arrive inside the lock wait, so rare rather than impossible, and any slow or concurrent teardown widens it.

The part worth review is *where* the re-check sits, because the obvious placement is wrong in a way that still passes a test written for it. Reading the counter in the caller and then starting the teardown as a task leaves a scheduling point between the two: `asyncio.create_task` does not begin the coroutine, so anything already runnable goes first. I measured that too, after a review flagged it: the re-check saw zero, a tool call ran next and took the live browser through the fast path in `get_or_create_browser`, and the teardown closed that same browser with one call in flight. So the check lives in the coroutine the task runs, where the body reaches its first `await` without yielding and `_close_browser_locked` clears `_browser` before its own first await.

Not in `close_browser()`: that is the general teardown entry point, and `close_session`, shutdown, login and import all mean "close it" unconditionally. A counter check there would make a deliberate close silently do nothing.

Two tests, because one window hides the other. The first starts its call while the close waits for the lock; the second one scheduling point later. The second fails when the check moves back into the caller while the first two stay green, which is how the narrower window went unnoticed in the first place. Both bring their own lifecycle lock, since `asyncio.Lock` binds to the first loop that awaits it and the module-level one outlives each test.

Verified with the full suite (1584 passed, 10 skipped), lint, format and type checks, plus the mutation runs described above.

## Synthetic prompt

> The `_calls_in_flight` guard in `release_profile_if_idle_or_requested()` is a check-then-act race: `close_browser()` waits on `_browser_lifecycle_lock` first, so a tool call starting during that wait gets its browser torn down. Re-establish the condition before the teardown, in this caller rather than in `close_browser`, and make sure the check and the detach of `_browser` happen in the same executed step. Cover both windows with tests.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
