### PR TITLE
test(daemon): Wait for the writer instead of racing it

### DIFF
--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -771,7 +771,16 @@ def _hand_over_config(
     Written on a thread for the same reason the verdict is read on one: it is
     the one mechanism that bounds a blocking pipe operation on every platform.
     The thread is a daemon, so a write that never completes cannot keep the
-    frontend from exiting, and the descriptor it holds is closed by the caller.
+    frontend from exiting.
+
+    Nothing outside closes the descriptor it holds. The thread's own ``with``
+    below does, as it unwinds, and on a timeout that is a moment after this
+    function has already returned: the writer stays blocked inside ``write``
+    until the child dies and breaks the pipe. ``_release_handshake`` closes
+    ``stdout`` and only ``stdout``.
+
+    So a caller that wants the write side gone ends the child, rather than
+    closing the stream under a thread that is writing to it.
     """
     stream = child.stdin
     assert stream is not None

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -626,6 +626,28 @@ class TestFailingFast:
             # change is the difference between an end of file and a wait on a
             # live reader, and CI is the only place that distinction is
             # observed at all.
+            #
+            # Joined first, because nothing in production closes that
+            # descriptor: the writer's own `with stream:` does, as it unwinds
+            # from the broken pipe, so asserting the instant `_start_owner`
+            # returns races that unwinding by construction. It has lost that
+            # race twice on CI, both times on these two assertions and both
+            # times green on a rerun. The rate is a property of the machine
+            # rather than of the code: on a saturated laptop it failed 4 runs in
+            # 10, and elsewhere it would not reproduce at all.
+            #
+            # So the property meant here is that the writer ends *promptly* once
+            # the child is gone, which is what the join states and the instant
+            # read only approximated. The bound stays well under the 3s margin
+            # above, which is the assertion that carries this test's weight on
+            # POSIX and must not be masked.
+            #
+            # It buys nothing beyond that. A writer blocked on a full pipe
+            # survives the handshake release and ends only when the child dies,
+            # in either order, so the ordering above stays a Windows claim.
+            for thread in threading.enumerate():
+                if "daemon-config" in thread.name:
+                    thread.join(timeout=1)
             assert all(
                 sleeper.stdin is None or sleeper.stdin.closed for sleeper in sleepers
             ), "the configuration pipe was left open"


### PR DESCRIPTION
Closes #644

`test_a_child_that_never_reads_its_configuration_does_not_block_the_spawn` asserts that the child's configuration pipe is closed and that no `daemon-config` writer thread survives, the instant `_start_owner` returns. Nothing in production closes that descriptor: `_stop_child` kills and reaps the child, `_release_handshake` handles `stdout` alone, and the writer's own `with stream:` closes it as it unwinds from the broken pipe. So both assertions race that unwinding by construction. They have lost twice on `main`, both times on exactly these two lines, both times green on a rerun.

Both assertions keep their exact wording. They carry the Windows half of the cleanup argument, and the CI job is the only place that argument is observed at all, so deleting either would remove the check the surrounding comment exists to keep. Only their timing becomes deterministic, via a bounded join on the surviving writer. The property meant here is that the writer ends promptly once the child is gone, which is what a join states and what an instant read only approximated.

Worth stating because the obvious justification is wrong: the join buys nothing beyond that. It does not make this a detector for the stop-then-release ordering. A writer blocked on a full pipe survives the handshake release and ends only when the child dies, in either order, so on POSIX that mutation passes with or without it. The test's own comment already said as much.

Nor can the join mask the assertion that carries this test's weight: `elapsed` is captured before the join and asserted well above it, and the bound is a second against a three-second margin.

Two things I could not settle with a green run, and did not pretend to. The rate is a property of the machine: 4 runs in 10 on a saturated laptop, and 10/10 green elsewhere, including on this tree afterwards, where the writer had already finished in every run. What justifies the change is the mechanism. And the join is genuinely exercised only when the writer is still unwinding, which I confirmed separately by keeping a child alive: the loop finds the thread, and it ends as soon as the child dies.

Also corrected, without behaviour change: `_hand_over_config`'s docstring claimed the descriptor it holds is closed by the caller. No caller does.

Verified with the full suite, lint, format and type checks, and the election file green under CPU saturation.

## Synthetic prompt

> `test_a_child_that_never_reads_its_configuration_does_not_block_the_spawn` flakes on CI on its stdin-closed and writer-thread-gone assertions. Work out whether there is a production leak underneath, then make the assertions deterministic without weakening what they claim or masking the timing assertion above them.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
