### PR TITLE
refactor(daemon): Give the proxy a backend it can re-resolve

### DIFF
--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -38,7 +38,7 @@ from linkedin_mcp_server.server import ServerRole, create_mcp_server
 from linkedin_mcp_server.setup import run_profile_creation
 
 if TYPE_CHECKING:
-    from linkedin_mcp_server.daemon import Attachment
+    from linkedin_mcp_server.daemon_proxy import DaemonProxyBackend
 
 logger = logging.getLogger(__name__)
 
@@ -286,7 +286,7 @@ def profile_info_and_exit() -> None:
     sys.exit(1)
 
 
-def _obtain_shared_owner(config: AppConfig) -> "Attachment | None":
+def _obtain_shared_owner(config: AppConfig) -> "DaemonProxyBackend | None":
     """Return the shared owner to forward to, starting one if nobody has.
 
     Off by default, and inert when off. ``None`` means this process serves its
@@ -328,20 +328,33 @@ def _obtain_shared_owner(config: AppConfig) -> "Attachment | None":
 
     try:
         from linkedin_mcp_server.daemon_election import obtain_owner
+        from linkedin_mcp_server.daemon_proxy import DaemonProxyBackend
         from linkedin_mcp_server.session_state import auth_root_dir
 
         profile = get_profile_dir()
-        outcome = obtain_owner(auth_root_dir(profile), profile, config)
+        auth_root = auth_root_dir(profile)
+        outcome = obtain_owner(auth_root, profile, config)
     except Exception:
         logger.warning("The shared browser owner is unavailable", exc_info=True)
         return None
 
-    if outcome.worth_connecting:
+    attachment = outcome.attachment_lookup.attachment
+    if outcome.worth_connecting and attachment is not None:
         logger.info("Forwarding to the shared browser owner")
         # Handed on as the election verified it. Re-reading the descriptor or the
         # token from disk would be a second, unproven read of a pair this one
         # already matched and reached.
-        return outcome.attachment_lookup.attachment
+        #
+        # The election's own inputs travel with it, because they are what finding
+        # a *replacement* would take and nothing downstream has them: the proxy
+        # layer receives no configuration, and reading the singleton there would
+        # parse whatever `sys.argv` holds.
+        return DaemonProxyBackend(
+            attachment=attachment,
+            auth_root=auth_root,
+            profile=profile,
+            config=config,
+        )
 
     logger.warning(
         "No shared browser owner could be started (%s); this server will "
@@ -463,16 +476,16 @@ def main() -> None:
             # before this runs: `daemon_would_be_used` asks whether this is a
             # stdio process, and an interactively chosen HTTP server must not
             # elect a daemon.
-            attachment = _obtain_shared_owner(config)
+            proxy_backend = _obtain_shared_owner(config)
 
             # Create and run the MCP server
-            if attachment is None:
+            if proxy_backend is None:
                 mcp = create_mcp_server(tool_timeout=config.server.tool_timeout_seconds)
             else:
                 mcp = create_mcp_server(
                     tool_timeout=config.server.tool_timeout_seconds,
                     role=ServerRole.PROXY,
-                    proxy_attachment=attachment,
+                    proxy_backend=proxy_backend,
                 )
 
             if transport == "streamable-http":

--- a/linkedin_mcp_server/daemon_proxy.py
+++ b/linkedin_mcp_server/daemon_proxy.py
@@ -11,14 +11,16 @@ them is a way to leak a credential or to hang a call.
 
 No client *session* is cached: one is built per upstream operation, because that
 is how ``ProxyProvider`` uses its factory and because a single shared session
-would outlive the owner it was opened against. The owner's *address* is another
-matter, and it is pinned for this process's life — see below.
+would outlive the owner it was opened against. The address and token are read
+per operation too, from :class:`DaemonProxyBackend`, so following a replacement
+takes no further machinery — see below for what it still takes.
 
-**A proxy is pinned to the owner it started with, and an upgrade is enough to
-strand it.** The address and token are resolved once, at startup, so a proxy
-whose owner goes away fails every operation afterwards rather than finding the
-replacement. Reproduced end to end: a proxy serving 19 tools was asked nothing,
-its owner was told to stand down the way a newer build does
+**A proxy is still pinned to the owner it started with, and an upgrade is enough
+to strand it.** Not because the address is captured any more, but because
+nothing replaces the attachment the backend holds. A proxy whose owner goes away
+therefore fails every operation afterwards rather than finding the replacement.
+Reproduced end to end: a proxy serving 19 tools was asked nothing, its owner was
+told to stand down the way a newer build does
 (``daemon_election._ask_to_stand_down``), and the next listing failed with
 ``McpError: Client failed to connect``.
 
@@ -27,23 +29,27 @@ first client to launch after an upgrade stands the old owner down and every prox
 already attached to it is dead until its own process restarts. Idle exit and a
 crashed owner end the same way.
 
-Resolving the backend per operation and re-electing on a pre-dispatch connection
-failure is what fixes this, and it belongs with the liveness work rather than
-here: a retry needs to know whether the call it is replacing may already have run
-against the browser. Until then the flag stays off by default and this is a
-documented limitation, not a solved problem.
+What is left is noticing that the owner is gone and electing another. That
+belongs with the liveness work rather than here, because a retry needs to know
+whether the call it is replacing may already have run against the browser. Until
+then the flag stays off by default and this is a documented limitation, not a
+solved problem.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Callable
+from functools import partial
+from typing import TYPE_CHECKING
 
 from linkedin_mcp_server import daemon_owner
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
 
+    from linkedin_mcp_server.config.schema import AppConfig
     from linkedin_mcp_server.daemon import Attachment
 
 logger = logging.getLogger(__name__)
@@ -81,25 +87,74 @@ _TIMEOUT_MARGIN_SECONDS = 30.0
 _COMPONENT_CACHE_SECONDS = 300.0
 
 
-def _client_factory(
-    attachment: Attachment, *, timeout: float
-) -> Callable[[], ProxyClient]:
-    """Build the callable ``ProxyProvider`` uses to reach the owner.
+class DaemonProxyBackend:
+    """The owner this proxy forwards to, and what it would take to find another.
 
-    A fresh client per call rather than one shared session, because that is what
-    the provider expects: it opens and closes a client around every upstream
-    operation.
+    One object rather than two loose values, and the reason is the second half:
+    an owner is replaced by every upgrade, so the address a proxy uses has to be
+    a thing that can change rather than a value captured at startup. Nothing
+    changes it yet — that is the next change — but the shape has to exist before
+    anything can.
+
+    It carries the election's inputs alongside the answer because nothing
+    downstream has them otherwise. ``create_proxy_provider`` used to receive an
+    ``Attachment`` and a timeout, and ``create_mcp_server`` has no configuration
+    parameter at all, so the proxy layer could not have elected a replacement
+    even if it had wanted to. Reaching for ``get_config()`` there instead would
+    walk into the argv sensitivity ``daemon_auth`` already documents: an unloaded
+    singleton parses whatever ``sys.argv`` happens to hold, which for a directly
+    constructed server is pytest's command line.
+
+    Not frozen, unlike the ``Attachment`` it holds. The attachment is a proved
+    fact about one owner and must not be edited; which attachment is current is
+    exactly the thing that moves.
     """
-    from fastmcp.client.transports import StreamableHttpTransport
-    from fastmcp.server.providers.proxy import ProxyClient
 
-    # Verbatim, never rebuilt from host and port: the descriptor's own URL
-    # already carries the MCP path and brackets an IPv6 literal, and FastMCP
-    # deliberately does not rewrite the path it is given.
-    url = attachment.descriptor.url
-    token = attachment.token
+    def __init__(
+        self,
+        *,
+        attachment: Attachment,
+        auth_root: Path,
+        profile: Path,
+        config: AppConfig,
+    ) -> None:
+        self._attachment = attachment
+        #: What an election needs, kept rather than looked up again.
+        self.auth_root = auth_root
+        self.profile = profile
+        self.config = config
 
-    def open_client() -> ProxyClient:
+    @property
+    def attachment(self) -> Attachment:
+        """The owner to talk to right now."""
+        return self._attachment
+
+    def open_client(self, *, timeout: float) -> ProxyClient:
+        """Build a client for whoever the owner is at this moment.
+
+        Read here rather than closed over, and that is the whole point of this
+        object. ``ProxyProvider`` calls its factory for every upstream operation
+        and never caches the client, so a factory that reads current state
+        follows a replacement without any further machinery. A factory that
+        captured the address instead keeps using it for the process's life.
+
+        A fresh client per call rather than one shared session, because that is
+        what the provider expects: it opens and closes a client around every
+        upstream operation.
+        """
+        from fastmcp.client.transports import StreamableHttpTransport
+        from fastmcp.server.providers.proxy import ProxyClient
+
+        attachment = self._attachment
+        # Verbatim, never rebuilt from host and port: the descriptor's own URL
+        # already carries the MCP path and brackets an IPv6 literal, and FastMCP
+        # deliberately does not rewrite the path it is given.
+        url = attachment.descriptor.url
+        # Read together with the URL, never separately. They are one credential
+        # pair for one owner, and a token kept across an address change would
+        # authenticate against a process it was never issued for.
+        token = attachment.token
+
         return ProxyClient(
             StreamableHttpTransport(
                 url,
@@ -123,14 +178,9 @@ def _client_factory(
             timeout=timeout,
         )
 
-    # ProxyClient rather than a plain Client, and that is not a preference:
-    # a plain client installs no progress handler, so the progress every
-    # browser-backed tool reports is silently dropped. Measured both ways.
-    return open_client
-
 
 def create_proxy_provider(
-    attachment: Attachment, *, tool_timeout: float
+    backend: DaemonProxyBackend, *, tool_timeout: float
 ) -> ProxyProvider:
     """Serve the owner's tools as if they were this server's own."""
     from fastmcp.server.providers.proxy import ProxyProvider
@@ -138,10 +188,19 @@ def create_proxy_provider(
     timeout = tool_timeout + _TIMEOUT_MARGIN_SECONDS
     logger.debug(
         "Forwarding tool calls to the shared browser owner at %s (deadline %.0fs)",
-        attachment.descriptor.url,
+        backend.attachment.descriptor.url,
         timeout,
     )
+    # One callable, built once and never replaced. That is a requirement rather
+    # than a style: `ProxyProvider` hands this object to every `ProxyTool` it
+    # builds while listing, and keeps those tools for `_COMPONENT_CACHE_SECONDS`.
+    # Reassigning the provider's factory later would not reach them, so the
+    # object has to stay the same one and resolve inside.
+    #
+    # ProxyClient rather than a plain Client, and that is not a preference
+    # either: a plain client installs no progress handler, so the progress every
+    # browser-backed tool reports is silently dropped. Measured both ways.
     return ProxyProvider(
-        _client_factory(attachment, timeout=timeout),
+        partial(backend.open_client, timeout=timeout),
         cache_ttl=_COMPONENT_CACHE_SECONDS,
     )

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -48,7 +48,7 @@ from linkedin_mcp_server.tools.person import register_person_tools
 from linkedin_mcp_server.tools.post import register_post_tools
 
 if TYPE_CHECKING:
-    from linkedin_mcp_server.daemon import Attachment
+    from linkedin_mcp_server.daemon_proxy import DaemonProxyBackend
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ def create_mcp_server(
     tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS,
     role: ServerRole = ServerRole.DIRECT,
     auth_token: str | None = None,
-    proxy_attachment: "Attachment | None" = None,
+    proxy_backend: "DaemonProxyBackend | None" = None,
 ) -> FastMCP:
     """Create and configure the MCP server with all LinkedIn tools.
 
@@ -149,10 +149,12 @@ def create_mcp_server(
     one: it listens on a loopback port that every process on the machine can
     reach, and a browser the user merely points at a page can reach it too.
 
-    *proxy_attachment* is the owner a proxy forwards to. The two credentials are
-    kept apart on purpose and must not be conflated: *auth_token* is what an
-    owner *demands* of callers, while the attachment's token is what a proxy
-    *presents* to one.
+    *proxy_backend* is the owner a proxy forwards to, held as an object rather
+    than as a bare attachment because which owner that is can change: an upgrade
+    replaces one, and a proxy that captured the address at startup would keep
+    using it. The two credentials are kept apart on purpose and must not be
+    conflated: *auth_token* is what an owner *demands* of callers, while the
+    backend's token is what a proxy *presents* to one.
     """
     if auth_token is not None and role is not ServerRole.OWNER:
         # A token on a stdio server protects nothing — there is no port to
@@ -162,13 +164,13 @@ def create_mcp_server(
         raise ValueError(
             f"Only a daemon owner authenticates requests, not {role.value}"
         )
-    if role is ServerRole.PROXY and proxy_attachment is None:
+    if role is ServerRole.PROXY and proxy_backend is None:
         # A proxy registers no tools of its own, so without an owner it would
         # serve an empty tool list and look like a server whose tools vanished.
         raise ValueError(
             "A proxy has no tools of its own and needs an owner to forward to"
         )
-    if proxy_attachment is not None and role is not ServerRole.PROXY:
+    if proxy_backend is not None and role is not ServerRole.PROXY:
         # Only a proxy forwards. Accepting an owner here would mean a server that
         # was handed a bearer token for a shared browser and quietly ignored it.
         raise ValueError(f"Only a proxy forwards to an owner, not {role.value}")
@@ -226,11 +228,11 @@ def create_mcp_server(
     if role.faces_a_client:
         mcp.add_middleware(UpdateNoticeMiddleware())
 
-    if proxy_attachment is not None:
+    if proxy_backend is not None:
         from linkedin_mcp_server.daemon_proxy import create_proxy_provider
 
         mcp.add_provider(
-            create_proxy_provider(proxy_attachment, tool_timeout=tool_timeout)
+            create_proxy_provider(proxy_backend, tool_timeout=tool_timeout)
         )
         # Not the default, which is "warn": a failing provider is logged and
         # skipped, and for a server whose *only* provider this is, that turns a

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -644,7 +644,10 @@ class TestForwardingToASharedOwner:
 
         found = cli_main._obtain_shared_owner(self._config(daemon_enabled=True))
 
-        assert found is attachment
+        # Through the backend the proxy layer is built from, which is what now
+        # carries it. The claim is unchanged: the election's answer survives.
+        assert found is not None
+        assert found.attachment is attachment
 
     def test_a_failed_election_leaves_this_process_driving_its_own_browser(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path, caplog
@@ -708,7 +711,7 @@ class TestForwardingToASharedOwner:
         cli_main.main()
 
         assert built["role"] is ServerRole.PROXY
-        assert built["proxy_attachment"] is attachment
+        assert built["proxy_backend"].attachment is attachment
         # The owner's inbound credential must not be reused for the outbound hop.
         assert "auth_token" not in built
 

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -118,6 +118,24 @@ def _publish_stale_owner(
     return descriptor.instance_id
 
 
+def _proxy_backend_for(attachment: Attachment):
+    """The state object a proxy is built from, around a proved attachment.
+
+    The election's inputs travel with the answer so that a later change can find
+    a replacement. These tests only need the answer, and the profile they pass is
+    the one the attachment already describes.
+    """
+    from linkedin_mcp_server.daemon_proxy import DaemonProxyBackend
+
+    profile = Path(attachment.descriptor.profile_path)
+    return DaemonProxyBackend(
+        attachment=attachment,
+        auth_root=profile.parent,
+        profile=profile,
+        config=_config(profile),
+    )
+
+
 def _attachment_for(profile: Path, config: AppConfig, port: int) -> Attachment:
     """An attachment pointing at *port*, for probing a socket directly.
 
@@ -1457,7 +1475,7 @@ class TestRealOwner:
             proxy = create_mcp_server(
                 tool_timeout=30.0,
                 role=ServerRole.PROXY,
-                proxy_attachment=lookup.attachment,
+                proxy_backend=_proxy_backend_for(lookup.attachment),
             )
 
             async def served() -> set[str]:
@@ -1516,7 +1534,7 @@ class TestRealOwner:
             proxy = create_mcp_server(
                 tool_timeout=30.0,
                 role=ServerRole.PROXY,
-                proxy_attachment=lookup.attachment,
+                proxy_backend=_proxy_backend_for(lookup.attachment),
             )
             # The repair middleware is removed rather than never added, because
             # `create_mcp_server` installs it for every proxy and that is correct:
@@ -1587,7 +1605,9 @@ class TestRealOwner:
 
             wrong = dataclasses.replace(lookup.attachment, token="not-the-token")
             proxy = create_mcp_server(
-                tool_timeout=30.0, role=ServerRole.PROXY, proxy_attachment=wrong
+                tool_timeout=30.0,
+                role=ServerRole.PROXY,
+                proxy_backend=_proxy_backend_for(wrong),
             )
 
             async def served() -> None:

--- a/tests/test_daemon_proxy.py
+++ b/tests/test_daemon_proxy.py
@@ -9,6 +9,7 @@ arriving, or a dead owner that looks like a server with no tools.
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 from pathlib import Path
 
 import httpx
@@ -22,11 +23,27 @@ from fastmcp.tools import ToolResult
 from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.daemon import Attachment
 from linkedin_mcp_server.daemon_descriptor import build, new_instance_id, new_token
-from linkedin_mcp_server import daemon_descriptor, daemon_proxy
+from linkedin_mcp_server import daemon_descriptor
 from linkedin_mcp_server.daemon_proxy import (
-    _client_factory,
+    DaemonProxyBackend,
     create_proxy_provider,
 )
+
+
+def _backend(attachment: Attachment, tmp_path: Path) -> DaemonProxyBackend:
+    """The state object the proxy layer is built from.
+
+    The election's inputs travel with the answer, so a later change can find a
+    replacement without reading a configuration singleton whose first read parses
+    `sys.argv`.
+    """
+    profile = tmp_path / "profile"
+    return DaemonProxyBackend(
+        attachment=attachment,
+        auth_root=profile.parent,
+        profile=profile,
+        config=AppConfig(),
+    )
 
 
 def _attachment(
@@ -63,7 +80,7 @@ class TestReachingTheOwner:
         # Rebuilding it from host and port loses the MCP path, and FastMCP does
         # not add one back: it deliberately serves whatever path it is given.
         attachment = _attachment(tmp_path)
-        client = _client_factory(attachment, timeout=1.0)()
+        client = _backend(attachment, tmp_path).open_client(timeout=1.0)
 
         assert isinstance(client.transport, StreamableHttpTransport)
         assert client.transport.url == attachment.descriptor.url
@@ -73,7 +90,7 @@ class TestReachingTheOwner:
         # Unbracketed, the colons in the address run into the one before the
         # port and the whole URL parses as a bad port.
         attachment = _attachment(tmp_path, host="::1")
-        client = _client_factory(attachment, timeout=1.0)()
+        client = _backend(attachment, tmp_path).open_client(timeout=1.0)
 
         assert isinstance(client.transport, StreamableHttpTransport)
         assert "[::1]" in client.transport.url
@@ -82,7 +99,7 @@ class TestReachingTheOwner:
         # The owner compares the token after the `Bearer ` scheme, so a raw
         # header value would be rejected by the endpoint it was minted for.
         attachment = _attachment(tmp_path)
-        client = _client_factory(attachment, timeout=1.0)()
+        client = _backend(attachment, tmp_path).open_client(timeout=1.0)
 
         request = httpx.Request("POST", attachment.descriptor.url)
         assert client.transport.auth is not None
@@ -94,14 +111,16 @@ class TestReachingTheOwner:
         # The provider opens and closes a client around each upstream call, so a
         # single shared session would be reused after its context had exited —
         # and would outlive the owner it was opened against.
-        factory = _client_factory(_attachment(tmp_path), timeout=1.0)
+        factory = partial(
+            _backend(_attachment(tmp_path), tmp_path).open_client, timeout=1.0
+        )
 
         assert factory() is not factory()
 
     def test_it_forwards_with_a_proxy_client(self, tmp_path: Path):
         # Not a plain Client. That one installs no progress handler, so every
         # progress update the tools report would be dropped on the way through.
-        client = _client_factory(_attachment(tmp_path), timeout=1.0)()
+        client = _backend(_attachment(tmp_path), tmp_path).open_client(timeout=1.0)
 
         assert isinstance(client, ProxyClient)
 
@@ -120,7 +139,7 @@ class TestKeepingTheTokenOffTheNetwork:
         monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:9")
         monkeypatch.delenv("NO_PROXY", raising=False)
 
-        client = _client_factory(_attachment(tmp_path), timeout=1.0)()
+        client = _backend(_attachment(tmp_path), tmp_path).open_client(timeout=1.0)
         http_client = client.transport.httpx_client_factory(
             headers=None, auth=None, follow_redirects=True
         )
@@ -133,7 +152,7 @@ class TestKeepingTheTokenOffTheNetwork:
         # FastMCP's transport passes `follow_redirects` on top of the documented
         # client-factory protocol. A factory accepting only the three declared
         # parameters failed at connect time with an unexpected keyword.
-        client = _client_factory(_attachment(tmp_path), timeout=1.0)()
+        client = _backend(_attachment(tmp_path), tmp_path).open_client(timeout=1.0)
 
         http_client = client.transport.httpx_client_factory(
             headers={"x": "y"},
@@ -166,7 +185,9 @@ class TestTheForwardingDeadline:
         # Equal would race the owner's error response, turning a diagnosable
         # "tool timed out" into an unexplained transport failure. Shorter would
         # abort calls the owner would have finished.
-        provider = create_proxy_provider(_attachment(tmp_path), tool_timeout=42.0)
+        provider = create_proxy_provider(
+            _backend(_attachment(tmp_path), tmp_path), tool_timeout=42.0
+        )
 
         assert self._request_deadline(self._client_of(provider)) > 42.0
 
@@ -177,7 +198,9 @@ class TestTheForwardingDeadline:
         # outlives the read timeout never returns at all. What produces an error
         # is the MCP-level timeout, and setting that also raises the HTTP read
         # timeout, so one value covers both layers.
-        provider = create_proxy_provider(_attachment(tmp_path), tool_timeout=42.0)
+        provider = create_proxy_provider(
+            _backend(_attachment(tmp_path), tmp_path), tool_timeout=42.0
+        )
         client = self._client_of(provider)
 
         assert self._request_deadline(client) == 72.0
@@ -253,7 +276,9 @@ class TestServingTheOwnersTools:
             connections += 1
             return ProxyClient(owner)
 
-        provider = create_proxy_provider(_attachment(tmp_path), tool_timeout=1.0)
+        provider = create_proxy_provider(
+            _backend(_attachment(tmp_path), tmp_path), tool_timeout=1.0
+        )
         provider.client_factory = counting_factory
 
         await provider.list_tools()
@@ -267,17 +292,17 @@ class TestServingTheOwnersTools:
     ):
         """Pins the limitation rather than the behaviour anyone wants.
 
-        The endpoint is resolved once, so an owner that goes away leaves this
-        process failing every operation for the rest of its life. An upgrade is
-        enough to cause it: ``@latest`` means the first client launched after one
-        asks the running owner to stand down, and every proxy already attached to
-        it is stranded.
+        Nothing replaces the attachment the backend holds, so an owner that goes
+        away leaves this process failing every operation for the rest of its
+        life. An upgrade is enough to cause it: ``@latest`` means the first
+        client launched after one asks the running owner to stand down, and every
+        proxy already attached to it is stranded.
 
         What this does assert, and it is narrower than it first looks: the
-        address the *production* factory puts in each client is the one it was
-        handed at construction, not a fresh reading. A replacement owner is
-        published before the second call, so the address is demonstrably stale by
-        then, and the call still goes to the old one.
+        address the *production* factory puts in each client is the one the
+        backend was built with, not a fresh reading from disk. A replacement
+        owner is published before the second call, so the published address is
+        demonstrably different by then, and the call still goes to the old one.
 
         What it deliberately does **not** claim is to be a tripwire that fails
         once the liveness work lands. Three attempts at that were each defeated
@@ -309,22 +334,17 @@ class TestServingTheOwnersTools:
                 raise ConnectionError(f"nothing is listening on {url}")
             return ProxyClient(owner)
 
-        real_factory = daemon_proxy._client_factory
+        real_open = DaemonProxyBackend.open_client
 
-        def factory_over_a_socket(attachment, *, timeout):
-            build = real_factory(attachment, timeout=timeout)
+        def open_over_a_socket(self, *, timeout: float) -> ProxyClient:
+            built = real_open(self, timeout=timeout)
+            assert isinstance(built.transport, StreamableHttpTransport)
+            return dial(built.transport.url)
 
-            def open_client() -> ProxyClient:
-                built = build()
-                assert isinstance(built.transport, StreamableHttpTransport)
-                return dial(built.transport.url)
-
-            return open_client
-
-        monkeypatch.setattr(daemon_proxy, "_client_factory", factory_over_a_socket)
+        monkeypatch.setattr(DaemonProxyBackend, "open_client", open_over_a_socket)
 
         daemon_descriptor.publish(auth_root, elected.descriptor, elected.token)
-        provider = create_proxy_provider(elected, tool_timeout=1.0)
+        provider = create_proxy_provider(_backend(elected, tmp_path), tool_timeout=1.0)
         assert {t.name for t in await provider.list_tools()} == {"get_person_profile"}
 
         # A replacement owner takes over on a new port and publishes itself, the

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,8 @@
 import asyncio
 import subprocess
 import sys
+from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call
 
 import mcp.types as mt
@@ -14,6 +16,8 @@ from linkedin_mcp_server import __version__
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon_proxy import DaemonProxyBackend
 from linkedin_mcp_server.server import ServerRole, create_mcp_server
 from linkedin_mcp_server.server_role import (
     RoleAlreadyClaimedError,
@@ -39,40 +43,61 @@ def _owner_serving(*tool_names: str) -> FastMCP:
     return owner
 
 
-def _an_attachment() -> MagicMock:
-    """Stands in for an elected owner.
+def _a_backend() -> DaemonProxyBackend:
+    """A real backend around a stood-in owner.
 
-    The real one carries a loopback address and a bearer token and needs a
-    published descriptor to build. These tests are about which parts of a server
-    a role gets, so the endpoint is stood in for; the real URL, token, timeout
-    and proxy-environment wiring are covered in ``tests/test_daemon_proxy.py``.
+    The backend itself is production's, so the client it builds is production's
+    too: pointed at a port nothing listens on, it fails to connect exactly as a
+    proxy whose owner is gone does. Only the *attachment* is stood in, because a
+    real one needs a published descriptor; the real URL, token, timeout and
+    proxy-environment wiring are covered in ``tests/test_daemon_proxy.py``.
     """
     attachment = MagicMock(name="attachment")
     attachment.descriptor.url = "http://127.0.0.1:1/mcp"
     attachment.token = "a-token"
-    return attachment
+    return DaemonProxyBackend(
+        attachment=attachment,
+        auth_root=Path("/nonexistent"),
+        profile=Path("/nonexistent/profile"),
+        config=AppConfig(),
+    )
+
+
+class _BackendReaching(DaemonProxyBackend):
+    """A backend whose client reaches an in-process owner instead of a socket.
+
+    A subclass rather than a patched attribute, because the provider is handed
+    *this object's* bound method: production reads the override exactly where it
+    would read the real one, and none of the wiring around it is stood in.
+    """
+
+    def __init__(self, owner: FastMCP) -> None:
+        base = _a_backend()
+        super().__init__(
+            attachment=base.attachment,
+            auth_root=base.auth_root,
+            profile=base.profile,
+            config=base.config,
+        )
+        self._owner = owner
+
+    def open_client(self, *, timeout: float) -> ProxyClient:
+        # ProxyClient, matching production: a plain Client would drop the
+        # progress every browser-backed tool reports.
+        return ProxyClient(self._owner)
 
 
 def _proxy_to(monkeypatch: pytest.MonkeyPatch, owner: FastMCP, **kwargs) -> FastMCP:
     """Build a PROXY whose provider reaches *owner* in memory rather than over HTTP."""
-    import linkedin_mcp_server.daemon_proxy as daemon_proxy
-
-    # ProxyClient, matching production: a plain Client would drop the progress
-    # every browser-backed tool reports.
-    monkeypatch.setattr(
-        daemon_proxy,
-        "_client_factory",
-        lambda _a, *, timeout: lambda: ProxyClient(owner),
-    )
     return create_mcp_server(
-        role=ServerRole.PROXY, proxy_attachment=_an_attachment(), **kwargs
+        role=ServerRole.PROXY, proxy_backend=_BackendReaching(owner), **kwargs
     )
 
 
-def _extras_for(role: ServerRole) -> dict[str, MagicMock]:
+def _extras_for(role: ServerRole) -> dict[str, Any]:
     """The arguments a role cannot be built without."""
     if role is ServerRole.PROXY:
-        return {"proxy_attachment": _an_attachment()}
+        return {"proxy_backend": _a_backend()}
     return {}
 
 
@@ -238,7 +263,7 @@ class TestTheRoleAsProcessState:
         # Not a resolvable disagreement: the two would have to disagree about
         # whether this process may open a login window.
         with pytest.raises(RoleAlreadyClaimedError, match="already serves as owner"):
-            create_mcp_server(role=ServerRole.PROXY, proxy_attachment=_an_attachment())
+            create_mcp_server(role=ServerRole.PROXY, proxy_backend=_a_backend())
 
     def test_restating_the_same_role_is_allowed(self):
         # A process that builds two servers of one kind is doing nothing
@@ -409,9 +434,7 @@ class TestProxyRole:
         # the provider *is* the server, so that default turns an unreachable
         # owner into a client that sees no tools and no reason why. Measured on
         # 3.4.4: `tools/list` returned `[]`.
-        proxy = create_mcp_server(
-            role=ServerRole.PROXY, proxy_attachment=_an_attachment()
-        )
+        proxy = create_mcp_server(role=ServerRole.PROXY, proxy_backend=_a_backend())
 
         async with Client(proxy) as client:
             with pytest.raises(Exception, match="connect"):
@@ -452,7 +475,7 @@ class TestProxyRole:
         # shared browser and quietly ignore it.
         for role in (ServerRole.DIRECT, ServerRole.OWNER):
             with pytest.raises(ValueError, match="Only a proxy forwards"):
-                create_mcp_server(role=role, proxy_attachment=_an_attachment())
+                create_mcp_server(role=role, proxy_backend=_a_backend())
 
     def test_the_owners_inbound_token_is_not_the_proxys_outbound_one(self):
         # Two credentials pointing opposite ways. Conflating them would either


### PR DESCRIPTION
A proxy resolves its owner's address and token once, at startup, and nothing
downstream can change them. `create_proxy_provider` receives an `Attachment` and
a timeout, and `create_mcp_server` has no configuration parameter at all, so the
proxy layer could not elect a replacement owner even if it wanted to.

This replaces the bare attachment with a `DaemonProxyBackend` that holds the
current attachment alongside the inputs an election needs, and turns the client
factory into a bound method that reads it per operation. `ProxyProvider` calls
its factory for every upstream operation, so following a replacement needs no
further machinery once the address is read rather than captured. Reaching for
`get_config()` in the proxy layer instead would walk into the argv sensitivity
`daemon_auth` already documents: the first read of an unloaded singleton parses
whatever `sys.argv` holds, which for a directly constructed server is pytest's
command line.

Behaviour is unchanged, and no test's assertion changes. The call sites move with
the signature, two assertions reach the attachment through the backend, and one
helper stopped being a `MagicMock` because the dead-owner test needs production's
own client builder to fail against a dead port.

Nothing replaces the attachment yet. That is the next change in the stack.

The full suite, ruff and ty pass.

See also: #606

## Synthetic prompt

> Give the daemon proxy a state object it can re-resolve. Replace the
> `Attachment` that `create_proxy_provider` and `create_mcp_server` take with a
> `DaemonProxyBackend` holding the attachment plus the auth root, profile and
> config an election would need, make the client factory a bound method that
> reads the current attachment per upstream operation, and carry the inputs
> through `cli_main`. Pure refactor, no behaviour change.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
