### PR TITLE
fix(daemon): Recover a proxy whose owner has gone away

### DIFF
--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -306,7 +306,7 @@ class FrontendAuthRepairMiddleware(Middleware):
             logger.info("Signed in; not repeating a call that had already started")
             return result
 
-        if await _the_tool_changes_something(context):
+        if await a_repeat_could_change_something(context):
             # Repaired, but not run again. The auth is fixed and the next call
             # will work; what this one gets is the owner's own message, which
             # already says to retry.
@@ -350,10 +350,15 @@ class FrontendAuthRepairMiddleware(Middleware):
             return result
 
 
-async def _the_tool_changes_something(
+async def a_repeat_could_change_something(
     context: MiddlewareContext[mt.CallToolRequestParams],
 ) -> bool:
     """Whether running this tool again could repeat an effect on LinkedIn.
+
+    Public because two middlewares need the same answer: this module replays a
+    call after signing in, and ``daemon_proxy`` replays one after electing a
+    replacement owner. One rule, in one place, so the two cannot drift apart in
+    the unsafe direction.
 
     Read from the tool's own annotations, which survive the hop
     (``ProxyProvider`` copies them), rather than from a list of names kept here:

--- a/linkedin_mcp_server/daemon_proxy.py
+++ b/linkedin_mcp_server/daemon_proxy.py
@@ -12,37 +12,41 @@ them is a way to leak a credential or to hang a call.
 No client *session* is cached: one is built per upstream operation, because that
 is how ``ProxyProvider`` uses its factory and because a single shared session
 would outlive the owner it was opened against. The address and token are read
-per operation too, from :class:`DaemonProxyBackend`, so following a replacement
-takes no further machinery — see below for what it still takes.
+per operation too, from :class:`DaemonProxyBackend`, so a proxy follows a
+replacement owner instead of keeping an address it captured at startup.
 
-**A proxy is still pinned to the owner it started with, and an upgrade is enough
-to strand it.** Not because the address is captured any more, but because
-nothing replaces the attachment the backend holds. A proxy whose owner goes away
-therefore fails every operation afterwards rather than finding the replacement.
-Reproduced end to end: a proxy serving 19 tools was asked nothing, its owner was
-told to stand down the way a newer build does
+**Which owner that is changes while this process runs**, and the rest of this
+module is about surviving it. ``@latest`` is the documented install, so the first
+client to launch after an upgrade stands the old owner down, and every proxy
+already attached to it would otherwise be dead until its own process restarts.
+Reproduced end to end before any of this existed: a proxy serving 19 tools was
+asked nothing, its owner was told to stand down the way a newer build does
 (``daemon_election._ask_to_stand_down``), and the next listing failed with
-``McpError: Client failed to connect``.
+``McpError: Client failed to connect``. Idle exit and a crashed owner end the
+same way.
 
-That path is not hypothetical. ``@latest`` is the documented install, so the
-first client to launch after an upgrade stands the old owner down and every proxy
-already attached to it is dead until its own process restarts. Idle exit and a
-crashed owner end the same way.
-
-What is left is noticing that the owner is gone and electing another. That
-belongs with the liveness work rather than here, because a retry needs to know
-whether the call it is replacing may already have run against the browser. Until
-then the flag stays off by default and this is a documented limitation, not a
-solved problem.
+Noticing the departure is one half; repeating the call is the other, and it is
+the half that can do damage. There is no dispatch acknowledgement anywhere in the
+protocol, so a failure is classified where the boundary is known
+(:class:`OwnerUnreachableError`) rather than diagnosed from a message afterwards.
+Only a request that provably never left this process may be repeated when running
+it twice would send a connection request twice.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import Awaitable
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+import mcp.types as mt
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import ToolResult
 
 from linkedin_mcp_server import daemon_owner
+from linkedin_mcp_server.daemon_auth import a_repeat_could_change_something
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -69,22 +73,280 @@ logger = logging.getLogger(__name__)
 #: is what will bound it.
 _TIMEOUT_MARGIN_SECONDS = 30.0
 
-#: How long a fetched tool list stays usable for single lookups. FastMCP's own
-#: default, set explicitly because the reasoning is not obvious: an owner's tool
-#: set never changes over its lifetime, so there is no dynamic list to miss.
+#: The provider's component cache, switched off. FastMCP's default is 300
+#: seconds and this module used to take it, on the stated grounds that an owner's
+#: tool set never changes over its lifetime. That was true and is no longer the
+#: question: a proxy now outlives several owners, and after an upgrade several
+#: versions, so what a cache holds is one owner's answer about itself being
+#: served for a different owner's calls.
 #:
-#: Not because versions always agree — they need not. An older frontend attaches
-#: to a newer owner on purpose (``daemon_version``), so the list served here can
-#: be a newer one than this build would have registered locally. That is the
-#: intended trade, and it still does not make the list change underneath us.
+#: Clearing the cache when a replacement is adopted was the first design and it
+#: is not sound. ``ProxyProvider`` writes each cache after a listing completes,
+#: outside any lock (``proxy.py``, ``_list_tools`` and its three siblings), so a
+#: listing already in flight against the departing owner can refill the cache
+#: *after* the replacement was adopted. Reproduced against the installed provider
+#: by holding a listing open across an adoption: the cleared cache came back
+#: holding the old owner's components. No clear-on-adoption design closes that,
+#: because the write is in code this module does not own.
 #:
-#: Measured against ``cache_ttl=0`` over a real loopback owner on this machine:
-#: about 23ms versus 42ms per forwarded call, for a list that cannot go stale.
-#: Both are far below the seconds a browser reopen costs, so the number to take
-#: from this is the ordering rather than the absolute figures. The TTL only
-#: affects single lookups either way; an explicit ``tools/list`` always
-#: re-fetches.
-_COMPONENT_CACHE_SECONDS = 300.0
+#: Freshness is not the sharp end. ``a_repeat_could_change_something`` reads
+#: ``readOnlyHint`` off the tool the provider hands back, so a stale annotation
+#: is what decides whether a call may be repeated against the new owner.
+#:
+#: Measured on this machine against a real loopback owner: 27.8ms versus 56.0ms
+#: median per forwarded call, so the cache was worth about 28ms. A forwarded call
+#: drives a browser through a LinkedIn page and takes seconds. Only single
+#: lookups change either way; an explicit ``tools/list`` re-fetched regardless.
+_NO_COMPONENT_CACHE = 0.0
+
+
+class OwnerUnreachableError(Exception):
+    """The owner a proxy is attached to could not be reached.
+
+    Raised where the boundary is known rather than diagnosed later, because two
+    things only the client can see decide what a caller may do about it: which
+    owner failed, and whether the request had left this process.
+
+    *instance_id* is that owner's identity. A failure carries it so a recovery
+    that has already happened is not repeated: a call that opened its client
+    before a replacement was adopted fails afterwards against the old one, and
+    without the identity that late failure would elect again.
+
+    *nothing_was_sent* is the whole of the replay question. There is no dispatch
+    acknowledgement anywhere in the protocol, so after an ambiguous transport
+    failure this process cannot tell whether the owner was still queued, already
+    held the profile lease, or had finished the effect. Only when nothing left
+    this process is repeating a mutating call safe.
+    """
+
+    def __init__(
+        self, *, instance_id: str, nothing_was_sent: bool, cause: BaseException
+    ) -> None:
+        super().__init__(f"The shared browser owner did not answer: {cause}")
+        self.instance_id = instance_id
+        self.nothing_was_sent = nothing_was_sent
+
+
+def unreachable_owner_in(exc: BaseException) -> OwnerUnreachableError | None:
+    """Find an unreachable-owner failure in an exception chain, if it is there.
+
+    Walked rather than type-checked directly, and the same reason applies here as
+    to ``daemon_auth._auth_failure_in``: what reaches a middleware is a wrapper.
+    Measured against a dead port with a warm tool cache, the chain the middleware
+    sees is ``ToolError -> RuntimeError('Client failed to connect') ->
+    httpx.ConnectError``, because ``FastMCP.call_tool`` masks whatever the tool
+    raised. A test that lists first is therefore the only one that exercises the
+    real shape; a cold lookup can deliver the failure unwrapped and let a broken
+    detector pass.
+    """
+    current: BaseException | None = exc
+    while current is not None:
+        if isinstance(current, OwnerUnreachableError):
+            return current
+        current = current.__cause__
+    return None
+
+
+def _no_connection_was_established(exc: BaseException) -> bool:
+    """Whether the cause chain proves no connection was opened.
+
+    The narrow, provable class, and it is narrow on purpose. The tempting rule is
+    to read the message: FastMCP wraps nearly everything from its connect in
+    ``RuntimeError(f"Client failed to connect: {exception}")``, so that prefix
+    looks like proof. It is not. Reproduced against a listener that accepted the
+    ``initialize`` bytes and then closed: same prefix, ``RemoteProtocolError``
+    underneath, and a request that had demonstrably left this process.
+
+    ``ConnectError`` and ``ConnectTimeout`` are the two that mean the connection
+    itself was never established, so nothing on it can have been sent.
+    """
+    import httpx
+
+    current: BaseException | None = exc
+    while current is not None:
+        if isinstance(current, (httpx.ConnectError, httpx.ConnectTimeout)):
+            return True
+        current = current.__cause__
+    return False
+
+
+#: The code the MCP client invents when a POST comes back 404 because the
+#: session is gone. Not exported by the SDK, so it is spelled out here with its
+#: source: ``mcp/client/streamable_http.py``, ``_send_session_terminated_error``.
+_SESSION_TERMINATED = 32600
+
+
+def _the_owner_answered(exc: BaseException) -> bool:
+    """Whether *exc* is the owner speaking, rather than a client that gave up.
+
+    An ``McpError`` looks like an answer and usually is one: a JSON-RPC error
+    came off the wire, so a process was there to send it. Treating those as a
+    departure would elect a replacement for a healthy owner, repeat a read-only
+    call for nothing, and swallow ``ProxyProvider``'s own ``METHOD_NOT_FOUND``
+    handling, which turns an unsupported listing into an empty list.
+
+    Three codes are not answers, and they matter more than all the real ones put
+    together, because they are what a departure *during* a request looks like.
+    The client invents each of them itself:
+
+    * ``REQUEST_TIMEOUT`` when nothing came back inside the deadline
+      (``mcp/shared/session.py``).
+    * ``CONNECTION_CLOSED`` when the read stream closes with requests still
+      pending (same file, the receive loop's ``finally``).
+    * ``32600``/"Session terminated" when a POST is answered with 404 because
+      the session is gone (``mcp/client/streamable_http.py``). Positive rather
+      than in the ``-32xxx`` range, which is what makes it unmistakably local.
+
+    Measured against a real loopback owner killed while a call was in flight:
+    ``McpError: Timed out while waiting for response to CallToolRequest``. Nobody
+    sent that. Passing it through as an answer would leave the frontend attached
+    to a process that is gone, which is the failure this module exists to end.
+
+    **Reading the code is a convention here, not a guarantee the protocol
+    makes.** Nothing stops a server from sending any of these three integers as a
+    real JSON-RPC error, and one that did would be called departed while it was
+    answering. Two things make that acceptable. The owner is this same package,
+    and it constructs no ``ErrorData`` and raises no ``McpError`` anywhere: a
+    failing tool comes back as a result with ``isError`` set, so an owner built
+    from this repository cannot send one of these as an answer. And the cost of
+    being wrong is bounded, which is the same reason a merely slow owner is fine:
+    the election probes, finds the same owner still answering, keeps the
+    attachment, and the caller repeats only what was safe to repeat anyway.
+
+    Matching the SDK's message text as well was considered and rejected. It would
+    narrow the false positives and widen the dangerous failure: a reworded
+    message in a future SDK would silently stop a real departure from being
+    recognised, and the frontend would go back to sitting on a dead owner. A
+    spurious election is a wasted probe; a missed departure is the bug this
+    module exists to fix.
+
+    A departure has three shapes, all measured with the client the provider
+    builds, and only the third reaches this question:
+
+    * already gone when the client connects: ``RuntimeError`` over
+      ``httpx.ConnectError``, out of ``__aenter__``.
+    * gone after the initialize and before the request that follows it, which is
+      a real window because one operation opens a client, initializes it and then
+      sends its request on that same session: ``anyio.BrokenResourceError`` or
+      ``ClosedResourceError``, depending on timing.
+    * gone while the request is outstanding: the invented ``McpError`` above.
+
+    The first two are not ``McpError`` and are tagged without consulting any of
+    this.
+    """
+    from mcp.shared.exceptions import McpError
+
+    if not isinstance(exc, McpError):
+        return False
+
+    import httpx
+
+    return exc.error.code not in (
+        mt.CONNECTION_CLOSED,
+        httpx.codes.REQUEST_TIMEOUT,
+        _SESSION_TERMINATED,
+    )
+
+
+def _tells_which_owner_failed() -> type:
+    """The proxy client that tags a transport failure with its owner.
+
+    Built on demand rather than at import, because ``ProxyClient`` is a lazy
+    import everywhere else here: FastMCP's server package is heavy and a direct
+    server never needs it.
+    """
+    from fastmcp.server.providers.proxy import ProxyClient
+
+    class TellsWhichOwnerFailed(ProxyClient):
+        """A ``ProxyClient`` that says which owner failed, and whether it heard.
+
+        The connect is one boundary and every discovery listing is another, and
+        the listings are the ones that are easy to miss. ``ProxyTool.run`` is
+        factory, then ``async with client``, then ``call_tool_mcp`` — but
+        ``ProxyProvider._list_tools`` runs ``client.list_tools()`` *after* a
+        successful enter, and its three siblings do the same for resources,
+        templates and prompts. An owner that dies between the initialize and the
+        list request raises out of neither the enter nor the call, so without
+        these that failure would carry no owner identity and discovery could
+        never recover.
+
+        The dispatch answer differs by boundary, and being precise beats being
+        uniformly cautious:
+
+        * ``__aenter__`` — nothing was sent, *whatever* the exception. Not
+          because the exception says so but because of where it happened:
+          ``call_tool_mcp`` is inside the ``async with`` block and cannot have
+          run. An initialize that reached the owner is still not a tool call.
+        * the listings — listing changes nothing, so a caller may always repeat
+          one and the answer is the same as an enter failure.
+        * ``call_tool_mcp`` — only a failure to establish the connection proves
+          it. A read timeout or a protocol error may mean the owner is scraping
+          right now.
+        """
+
+        def __init__(self, *args: Any, instance_id: str, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            self._instance_id = instance_id
+
+        async def _saying_which_owner(
+            self, operation: Awaitable[Any], *, nothing_was_sent: bool | None
+        ) -> Any:
+            """Await *operation*, tagging a departed owner with its identity.
+
+            *nothing_was_sent* is the boundary's own answer where the boundary
+            knows it, and ``None`` where only the cause chain can say.
+            """
+            try:
+                return await operation
+            except OwnerUnreachableError:
+                # Already ours, from a boundary further in. Tagging twice would
+                # bury the answer the inner one recorded.
+                raise
+            except Exception as exc:
+                if _the_owner_answered(exc):
+                    raise
+                raise OwnerUnreachableError(
+                    instance_id=self._instance_id,
+                    nothing_was_sent=(
+                        _no_connection_was_established(exc)
+                        if nothing_was_sent is None
+                        else nothing_was_sent
+                    ),
+                    cause=exc,
+                ) from exc
+
+        async def __aenter__(self) -> Any:
+            return await self._saying_which_owner(
+                super().__aenter__(), nothing_was_sent=True
+            )
+
+        async def list_tools_mcp(self, *args: Any, **kwargs: Any) -> Any:
+            return await self._saying_which_owner(
+                super().list_tools_mcp(*args, **kwargs), nothing_was_sent=True
+            )
+
+        async def list_resources_mcp(self, *args: Any, **kwargs: Any) -> Any:
+            return await self._saying_which_owner(
+                super().list_resources_mcp(*args, **kwargs), nothing_was_sent=True
+            )
+
+        async def list_resource_templates_mcp(self, *args: Any, **kwargs: Any) -> Any:
+            return await self._saying_which_owner(
+                super().list_resource_templates_mcp(*args, **kwargs),
+                nothing_was_sent=True,
+            )
+
+        async def list_prompts_mcp(self, *args: Any, **kwargs: Any) -> Any:
+            return await self._saying_which_owner(
+                super().list_prompts_mcp(*args, **kwargs), nothing_was_sent=True
+            )
+
+        async def call_tool_mcp(self, *args: Any, **kwargs: Any) -> Any:
+            return await self._saying_which_owner(
+                super().call_tool_mcp(*args, **kwargs), nothing_was_sent=None
+            )
+
+    return TellsWhichOwnerFailed
 
 
 class DaemonProxyBackend:
@@ -123,11 +385,87 @@ class DaemonProxyBackend:
         self.auth_root = auth_root
         self.profile = profile
         self.config = config
+        #: The one election in progress, or nothing. Only :meth:`recover` writes
+        #: it, and only :meth:`_elect` writes ``_attachment``, which is what makes
+        #: comparing instance ids a sound test of whether a failure is current.
+        self._electing: asyncio.Task[Attachment | None] | None = None
 
     @property
     def attachment(self) -> Attachment:
         """The owner to talk to right now."""
         return self._attachment
+
+    async def recover(self, failed_instance: str) -> Attachment | None:
+        """Find an owner to replace *failed_instance*, at most once at a time.
+
+        Returns the attachment to use now, or ``None`` when none could be
+        established.
+
+        **The identity check comes first, and it is what keeps a late failure
+        cheap.** Several calls can be in flight against one owner. The first to
+        fail elects a replacement; the others fail afterwards still carrying the
+        old identity, and without this they would each elect again, against an
+        owner that is already answering.
+
+        **The election runs in a thread, and that is correctness rather than
+        latency.** ``obtain_owner`` probes liveness through ``asyncio.run``, which
+        raises inside a running loop, and its own ``except`` turns that into
+        ``Reach.REFUSED``. Called in-loop it would therefore bury a *healthy*
+        owner for the whole election rather than merely blocking.
+
+        **Shielded, and this one is measured.** Cancelling the task that awaits
+        ``asyncio.to_thread`` returns to the awaiter at once while the worker runs
+        to completion regardless: driven directly, an awaiter cancelled at 0.1s
+        and a worker that still finished its 1.5s of work. So a caller that gives
+        up must not clear this guard, or the next failure starts a second election
+        while the first is still running.
+        """
+        if self._attachment.descriptor.instance_id != failed_instance:
+            # Somebody already replaced it. Nothing to do but use the answer.
+            return self._attachment
+
+        electing = self._electing
+        if electing is None:
+            # Created and stored with no await in between, so two callers cannot
+            # both get past this and start one each.
+            electing = asyncio.create_task(self._elect(failed_instance))
+            self._electing = electing
+        # Shielded so this caller's deadline cannot cancel the shared election.
+        return await asyncio.shield(electing)
+
+    async def _elect(self, failed_instance: str) -> Attachment | None:
+        """Run one election and adopt what it finds."""
+        from linkedin_mcp_server.daemon_election import obtain_owner
+
+        try:
+            outcome = await asyncio.to_thread(
+                obtain_owner, self.auth_root, self.profile, self.config
+            )
+        except Exception:
+            logger.warning(
+                "Could not elect a replacement for the shared browser owner",
+                exc_info=True,
+            )
+            return None
+        finally:
+            # Only after the worker has ended, and only if this is still the
+            # registered flight: a caller that timed out may already have left,
+            # and a later election must not be cleared by an earlier one.
+            if self._electing is asyncio.current_task():
+                self._electing = None
+
+        found = outcome.attachment_lookup.attachment
+        if not outcome.worth_connecting or found is None:
+            logger.warning(
+                "No shared browser owner could be established (%s)",
+                outcome.attachment_lookup.state.value,
+            )
+            return None
+
+        if found.descriptor.instance_id != failed_instance:
+            logger.info("Attached to a replacement shared browser owner")
+            self._attachment = found
+        return found
 
     def open_client(self, *, timeout: float) -> ProxyClient:
         """Build a client for whoever the owner is at this moment.
@@ -143,7 +481,6 @@ class DaemonProxyBackend:
         upstream operation.
         """
         from fastmcp.client.transports import StreamableHttpTransport
-        from fastmcp.server.providers.proxy import ProxyClient
 
         attachment = self._attachment
         # Verbatim, never rebuilt from host and port: the descriptor's own URL
@@ -155,7 +492,7 @@ class DaemonProxyBackend:
         # authenticate against a process it was never issued for.
         token = attachment.token
 
-        return ProxyClient(
+        return _tells_which_owner_failed()(
             StreamableHttpTransport(
                 url,
                 # A plain string becomes `Authorization: Bearer <token>`, which
@@ -176,6 +513,10 @@ class DaemonProxyBackend:
             # succeeds or fails cleanly at the deadline. Setting it here also
             # raises the HTTP read timeout, so one value covers both layers.
             timeout=timeout,
+            # So a failure says which owner it was against. Read from the same
+            # attachment as the URL and the token, so all three describe one owner
+            # even while a replacement is being adopted concurrently.
+            instance_id=attachment.descriptor.instance_id,
         )
 
 
@@ -193,7 +534,7 @@ def create_proxy_provider(
     )
     # One callable, built once and never replaced. That is a requirement rather
     # than a style: `ProxyProvider` hands this object to every `ProxyTool` it
-    # builds while listing, and keeps those tools for `_COMPONENT_CACHE_SECONDS`.
+    # builds while listing, and a tool outlives the listing that built it.
     # Reassigning the provider's factory later would not reach them, so the
     # object has to stay the same one and resolve inside.
     #
@@ -202,5 +543,107 @@ def create_proxy_provider(
     # browser-backed tool reports is silently dropped. Measured both ways.
     return ProxyProvider(
         partial(backend.open_client, timeout=timeout),
-        cache_ttl=_COMPONENT_CACHE_SECONDS,
+        cache_ttl=_NO_COMPONENT_CACHE,
     )
+
+
+class FrontendOwnerRecoveryMiddleware(Middleware):
+    """Find a replacement owner when this one is gone, and repeat what is safe.
+
+    Installed only on a proxy, and after the auth-repair middleware so that one
+    stays outermost: a call and the replay a sign-in triggers each get their own
+    liveness wrapper, rather than one wrapper around both.
+
+    Discovery is covered as well as calling, and it is the half a client hits
+    first: many list before they call. A recovery that only covered
+    ``tools/call`` would leave a client whose owner died unable to list, and
+    therefore unable to make the call that would have triggered the recovery:
+    dead in exactly the way this exists to prevent.
+
+    All four listings, not only tools, although this role serves nothing but
+    tools. A client's opening exchange asks for resources and prompts too, the
+    provider is asked in order to answer "none", and with
+    ``provider_error_strategy = "raise"`` a departed owner turns that answer into
+    an error the user sees.
+
+    Reads and renders are left out, and the reason is a fact about this
+    repository rather than about the protocol: no owner here registers a resource
+    or a prompt, so the listings in front of them find nothing and a client
+    cannot reach ``resources/read`` or ``prompts/get`` at all. The day one is
+    registered, ``read_resource_mcp`` and ``get_prompt_mcp`` need the same
+    treatment as the listings, along with ``on_read_resource`` and
+    ``on_get_prompt`` here.
+    """
+
+    def __init__(self, backend: DaemonProxyBackend) -> None:
+        self._backend = backend
+
+    async def _repeat_the_listing(
+        self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]
+    ) -> Any:
+        try:
+            return await call_next(context)
+        except Exception as exc:
+            failure = unreachable_owner_in(exc)
+            if failure is None:
+                raise
+            logger.info("Listing failed against a departed owner; looking for another")
+            if await self._backend.recover(failure.instance_id) is None:
+                raise
+            # Unconditional, because listing changes nothing on LinkedIn. There is
+            # no effect a second one could repeat.
+            return await call_next(context)
+
+    async def on_list_tools(
+        self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]
+    ) -> Any:
+        return await self._repeat_the_listing(context, call_next)
+
+    async def on_list_resources(
+        self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]
+    ) -> Any:
+        return await self._repeat_the_listing(context, call_next)
+
+    async def on_list_resource_templates(
+        self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]
+    ) -> Any:
+        return await self._repeat_the_listing(context, call_next)
+
+    async def on_list_prompts(
+        self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]
+    ) -> Any:
+        return await self._repeat_the_listing(context, call_next)
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        try:
+            return await call_next(context)
+        except Exception as exc:
+            failure = unreachable_owner_in(exc)
+            if failure is None:
+                raise
+
+            # Before deciding whether to repeat anything: a replacement is worth
+            # having for the *next* call even when this one cannot be repeated.
+            if await self._backend.recover(failure.instance_id) is None:
+                raise
+
+            if not failure.nothing_was_sent and await a_repeat_could_change_something(
+                context
+            ):
+                # The one case where the honest answer is to report the failure.
+                # Nothing in the protocol says whether the departed owner had
+                # already sent the connection request or the message, and asking
+                # costs one retry while guessing wrong sends it twice. The user
+                # knows which happened; this process does not.
+                logger.info(
+                    "Attached to a replacement owner; not repeating a call that "
+                    "could change something"
+                )
+                raise
+
+            logger.info("Attached to a replacement owner; running the call again")
+            return await call_next(context)

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -215,6 +215,15 @@ def create_mcp_server(
         # 1.2-second call, and the first read of an unloaded singleton parses
         # whatever `sys.argv` happens to hold.
         mcp.add_middleware(FrontendAuthRepairMiddleware(tool_timeout=tool_timeout))
+        # After the repair, which keeps that one outermost. The order decides how
+        # the two compose: a call and the replay a sign-in triggers each get
+        # their own liveness wrapper, rather than one wrapper around the pair.
+        # The other way round, an owner that departed between the two would leave
+        # the replay unrecoverable.
+        from linkedin_mcp_server.daemon_proxy import FrontendOwnerRecoveryMiddleware
+
+        assert proxy_backend is not None  # the role check above established it
+        mcp.add_middleware(FrontendOwnerRecoveryMiddleware(proxy_backend))
     # Profile ownership belongs to whoever launches Chromium. A process that
     # only forwards calls must not take the lease: it would either block itself
     # until its own timeout, or take the lease and leave the process that

--- a/tests/test_daemon_proxy.py
+++ b/tests/test_daemon_proxy.py
@@ -9,14 +9,23 @@ arriving, or a dead owner that looks like a server with no tools.
 from __future__ import annotations
 
 import asyncio
+import threading
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from functools import partial
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 from pathlib import Path
 
 import httpx
 import mcp.types as mt
 import pytest
 from fastmcp import Client, Context, FastMCP
-from fastmcp.client.transports import StreamableHttpTransport
+from fastmcp.client.transports import (
+    ClientTransport,
+    FastMCPTransport,
+    StreamableHttpTransport,
+)
 from fastmcp.server.providers.proxy import ProxyClient, ProxyProvider
 from fastmcp.tools import ToolResult
 
@@ -71,6 +80,127 @@ def _attachment(
         log_path=tmp_path / "owner.log",
     )
     return Attachment(descriptor=descriptor, token=token)
+
+
+def _elected(attachment: Attachment):
+    """What `obtain_owner` returns when it found *attachment*."""
+    from linkedin_mcp_server.daemon import OwnerLookup, OwnerState
+    from linkedin_mcp_server.daemon_election import ElectionOutcome
+
+    return ElectionOutcome(
+        OwnerLookup(state=OwnerState.ATTACHABLE, attachment=attachment),
+        started_owner=True,
+    )
+
+
+class _NothingIsListening(ClientTransport):
+    """An address with nothing behind it, the way a departed owner leaves one."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+    @asynccontextmanager
+    async def connect_session(self, **_kwargs: Any) -> AsyncIterator[Any]:
+        raise httpx.ConnectError(f"nothing is listening on {self.url}")
+        yield  # noqa: W0101 - unreachable, and an async generator needs one
+
+
+class _GoesAwayAfterInitialize(FastMCPTransport):
+    """An owner that answers the initialize and is gone before the next request.
+
+    The window that neither the connect nor the tool call can see, and the only
+    reason the listing boundaries are wrapped at all.
+    """
+
+    @asynccontextmanager
+    async def connect_session(self, **kwargs: Any) -> AsyncIterator[Any]:
+        async with super().connect_session(**kwargs) as session:
+            yield _AnsweredOnceAndStopped(session)
+
+
+class _AnsweredOnceAndStopped:
+    """A session that completes the handshake and then answers nothing.
+
+    Deliberately not the exception a real owner produces, and reality has three
+    shapes rather than one. Measured with the client the provider builds: an
+    owner already gone at connect time fails in `__aenter__` as `RuntimeError`
+    over `httpx.ConnectError`; one that goes away in this window, after the
+    initialize and before the request on that same session, raises
+    `anyio.BrokenResourceError` or `ClosedResourceError` depending on timing; one
+    that goes away with a request outstanding comes back as an `McpError` the
+    session invented. The first and third have their own tests.
+
+    This double stands in for the middle one, and raises something outside all
+    three on purpose, so what it pins is the boundary itself: the listing answers
+    "nothing was sent" from *where* the failure happened. A version that read the
+    cause chain instead would pass against the real shapes and fail here.
+    """
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._session, name)
+
+    async def list_tools(self, *_args: Any, **_kwargs: Any):
+        raise httpx.RemoteProtocolError("the owner closed the connection")
+
+
+class _AnswersWhenTold(FastMCPTransport):
+    """An owner whose listing is held open for as long as a test needs it."""
+
+    def __init__(self, server: FastMCP) -> None:
+        super().__init__(server)
+        self.reached = asyncio.Event()
+        self.release = asyncio.Event()
+
+    @asynccontextmanager
+    async def connect_session(self, **kwargs: Any) -> AsyncIterator[Any]:
+        async with super().connect_session(**kwargs) as session:
+            yield _WaitsBeforeListing(session, self.reached, self.release)
+
+
+class _WaitsBeforeListing:
+    """A session that reports it was asked, then waits to be let go."""
+
+    def __init__(
+        self, session: Any, reached: asyncio.Event, release: asyncio.Event
+    ) -> None:
+        self._session = session
+        self._reached = reached
+        self._release = release
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._session, name)
+
+    async def list_tools(self, *args: Any, **kwargs: Any):
+        self._reached.set()
+        await self._release.wait()
+        return await self._session.list_tools(*args, **kwargs)
+
+
+def _reach_owners_in_process(monkeypatch: pytest.MonkeyPatch, owner_at) -> None:
+    """Reach in-process owners, but only at the address production chose.
+
+    Only the socket is stood in for. The URL is still built by production code
+    from whatever attachment the backend currently holds, and the client wrapped
+    around it is the one `open_client` built, so a failure is classified by the
+    production client rather than raised in the shape a test wanted.
+
+    *owner_at* answers with a `FastMCP` to reach, a transport to use as it is, or
+    `None` for an address nobody is serving.
+    """
+    from fastmcp.client import transports
+
+    def transport_for(url: str, **_ignored: Any) -> ClientTransport:
+        reached = owner_at(url)
+        if reached is None:
+            return _NothingIsListening(url)
+        if isinstance(reached, ClientTransport):
+            return reached
+        return FastMCPTransport(reached)
+
+    monkeypatch.setattr(transports, "StreamableHttpTransport", transport_for)
 
 
 class TestReachingTheOwner:
@@ -242,121 +372,273 @@ class TestServingTheOwnersTools:
     """What survives the hop, and what a dead owner looks like."""
 
     @staticmethod
-    def _owner() -> FastMCP:
+    def _owner(*, read_only: bool = True, also: str | None = None) -> FastMCP:
         owner = FastMCP("owner")
 
         @owner.tool(
             title="Get Person Profile",
-            annotations={"readOnlyHint": True},
+            annotations={"readOnlyHint": read_only},
             tags={"person"},
         )
         async def get_person_profile(linkedin_username: str) -> dict[str, str]:
             return {"username": linkedin_username}
 
+        if also is not None:
+
+            @owner.tool(name=also)
+            async def only_this_owner_has_this() -> str:
+                return "here"
+
         return owner
 
-    async def test_a_lookup_after_a_listing_costs_no_extra_round_trip(
-        self, tmp_path: Path
-    ):
-        # An owner's tool set never changes over its lifetime, so caching it is
-        # free correctness-wise and saves a list round trip per forwarded call —
-        # about 23ms against 42ms over a real loopback owner on this machine.
-        #
-        # Built through `create_proxy_provider` and then handed a counting
-        # factory, so the production `cache_ttl` wiring is what is under test.
-        # Two earlier versions of this were weaker: one compared against the
-        # module constant, which moves with the mutation, and one constructed its
-        # own provider, which left `create_proxy_provider(cache_ttl=0)`
-        # undetected.
-        owner = self._owner()
-        connections = 0
-
-        def counting_factory() -> ProxyClient:
-            nonlocal connections
-            connections += 1
-            return ProxyClient(owner)
-
-        provider = create_proxy_provider(
-            _backend(_attachment(tmp_path), tmp_path), tool_timeout=1.0
-        )
-        provider.client_factory = counting_factory
-
-        await provider.list_tools()
-        after_listing = connections
-        await provider.get_tool("get_person_profile")
-
-        assert connections == after_listing
-
-    async def test_a_proxy_stays_pinned_to_the_owner_it_started_with(
+    async def test_a_lookup_never_serves_a_departed_owners_annotations(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        """Pins the limitation rather than the behaviour anyone wants.
+        """What decides this is the replay rule, not freshness.
 
-        Nothing replaces the attachment the backend holds, so an owner that goes
-        away leaves this process failing every operation for the rest of its
-        life. An upgrade is enough to cause it: ``@latest`` means the first
-        client launched after one asks the running owner to stand down, and every
-        proxy already attached to it is stranded.
+        `a_repeat_could_change_something` reads `readOnlyHint` off the tool the
+        provider hands back, so a component cache that outlives its owner is what
+        would authorise repeating a call the new owner declares as mutating. An
+        upgrade is exactly when a tool's annotations can change.
+        """
+        elected = _attachment(tmp_path)
+        replacement = _attachment(tmp_path, port=elected.descriptor.port + 1)
+        backend = _backend(elected, tmp_path)
+        before = self._owner(read_only=True, also="only_the_old_owner_had_this")
+        after = self._owner(read_only=False)
 
-        What this does assert, and it is narrower than it first looks: the
-        address the *production* factory puts in each client is the one the
-        backend was built with, not a fresh reading from disk. A replacement
-        owner is published before the second call, so the published address is
-        demonstrably different by then, and the call still goes to the old one.
+        _reach_owners_in_process(
+            monkeypatch,
+            lambda url: before if url == elected.descriptor.url else after,
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.daemon_election.obtain_owner",
+            lambda *_args, **_kwargs: _elected(replacement),
+        )
 
-        What it deliberately does **not** claim is to be a tripwire that fails
-        once the liveness work lands. Three attempts at that were each defeated
-        by mutation: building a local provider missed the production wiring;
-        swapping a local URL missed a proxy reading the descriptor; and publishing
-        into an isolated root missed one reading the account's real root. A
-        re-resolution test needs the resolver to be an argument this can inject,
-        which is a design the liveness PR should introduce rather than something
-        to fake from outside. Until then this pins the pinning and nothing more.
+        provider = create_proxy_provider(backend, tool_timeout=1.0)
+        # Warms whatever the provider keeps, which is the point: the lookups
+        # below are the ones a cache would answer without asking anybody.
+        await provider.list_tools()
+
+        assert await backend.recover(elected.descriptor.instance_id) is not None
+
+        served = await provider.get_tool("get_person_profile")
+        assert served is not None and served.annotations is not None
+        assert served.annotations.readOnlyHint is False, (
+            "the departed owner's annotation decided a replay against its successor"
+        )
+        assert await provider.get_tool("only_the_old_owner_had_this") is None
+
+    async def test_a_listing_still_in_flight_cannot_restore_the_old_owner(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Why adoption does not simply clear the caches.
+
+        `ProxyProvider` writes each cache after its listing completes and outside
+        any lock, so a listing already in flight against the departing owner
+        refills a cache that was cleared while it ran. Nothing available at
+        adoption time closes that window, because the write is in code this
+        repository does not own. Keeping no cache does close it.
+        """
+        elected = _attachment(tmp_path)
+        replacement = _attachment(tmp_path, port=elected.descriptor.port + 1)
+        backend = _backend(elected, tmp_path)
+        held = _AnswersWhenTold(self._owner(read_only=True))
+        after = self._owner(read_only=False)
+
+        _reach_owners_in_process(
+            monkeypatch,
+            lambda url: held if url == elected.descriptor.url else after,
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.daemon_election.obtain_owner",
+            lambda *_args, **_kwargs: _elected(replacement),
+        )
+
+        provider = create_proxy_provider(backend, tool_timeout=1.0)
+        in_flight = asyncio.create_task(provider.list_tools())
+        await asyncio.wait_for(held.reached.wait(), timeout=5)
+
+        assert await backend.recover(elected.descriptor.instance_id) is not None
+
+        # Only now does the old owner's answer arrive, and land in the provider.
+        held.release.set()
+        await asyncio.wait_for(in_flight, timeout=5)
+
+        served = await provider.get_tool("get_person_profile")
+        assert served is not None and served.annotations is not None
+        assert served.annotations.readOnlyHint is False, (
+            "a listing that outlived its owner put that owner's components back"
+        )
+
+    async def test_a_replacement_owner_is_found_and_used(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The failure this whole round exists to remove.
+
+        The test this replaces pinned the *limitation*: it published a
+        replacement and asserted the proxy still went to the old address. Its own
+        docstring said a re-resolution test would need the resolver to be
+        something a test can inject, which is what `DaemonProxyBackend` now is.
+
+        Only the socket is stood in for. A client reaches the owner when the
+        address it carries is the one currently published, and finds nothing
+        otherwise, so what decides the outcome is the address production code
+        chose rather than anything this test set.
         """
         owner = self._owner()
         auth_root = tmp_path / "state"
         elected = _attachment(tmp_path)
+        replacement = _attachment(tmp_path, port=elected.descriptor.port + 1)
 
         # Published state is keyed by auth root but *stored* under the account's
         # own private directory, so a tmp_path auth root alone does not isolate
-        # anything: without this the test left a directory behind in the real
-        # ~/.mcp-server-linkedin/daemon. Caught by counting entries before and
-        # after a run.
+        # anything. Caught by counting entries before and after a run.
         monkeypatch.setattr(daemon_descriptor, "_account_home", lambda: tmp_path)
 
-        # Only the socket is stood in for. A client reaches the owner when the
-        # address it carries is the one currently published, and fails otherwise,
-        # so what decides the outcome is the address production code chose rather
-        # than anything this test set.
-        def dial(url: str) -> ProxyClient:
+        def owner_at(url: str) -> FastMCP | None:
             published = daemon_descriptor.read(auth_root)
             if published is None or url != published.url:
-                raise ConnectionError(f"nothing is listening on {url}")
-            return ProxyClient(owner)
+                return None
+            return owner
 
-        real_open = DaemonProxyBackend.open_client
+        _reach_owners_in_process(monkeypatch, owner_at)
 
-        def open_over_a_socket(self, *, timeout: float) -> ProxyClient:
-            built = real_open(self, timeout=timeout)
-            assert isinstance(built.transport, StreamableHttpTransport)
-            return dial(built.transport.url)
+        # The election finds the replacement, the way a real one does once the
+        # departed owner's lock is free.
+        def elect(*_args, **_kwargs):
+            daemon_descriptor.publish(
+                auth_root, replacement.descriptor, replacement.token
+            )
+            return _elected(replacement)
 
-        monkeypatch.setattr(DaemonProxyBackend, "open_client", open_over_a_socket)
+        monkeypatch.setattr("linkedin_mcp_server.daemon_election.obtain_owner", elect)
 
         daemon_descriptor.publish(auth_root, elected.descriptor, elected.token)
-        provider = create_proxy_provider(_backend(elected, tmp_path), tool_timeout=1.0)
+        backend = _backend(elected, tmp_path)
+        provider = create_proxy_provider(backend, tool_timeout=1.0)
         assert {t.name for t in await provider.list_tools()} == {"get_person_profile"}
 
-        # A replacement owner takes over on a new port and publishes itself, the
-        # way one does after a stand-down. A proxy that re-resolved would find it.
-        replacement = _attachment(tmp_path, port=elected.descriptor.port + 1)
+        # The owner goes away without publishing anything, as a crash does.
         daemon_descriptor.publish(auth_root, replacement.descriptor, replacement.token)
-        published = daemon_descriptor.read(auth_root)
-        assert published is not None
-        assert published.url == replacement.descriptor.url
 
-        with pytest.raises(ConnectionError, match="nothing is listening"):
-            await provider.list_tools()
+        recovered = await backend.recover(elected.descriptor.instance_id)
+        assert recovered is not None
+        assert backend.attachment.descriptor.url == replacement.descriptor.url
+        # And the token moved with the address rather than being kept.
+        assert backend.attachment.token == replacement.token
+        assert {t.name for t in await provider.list_tools()} == {"get_person_profile"}
+
+    async def test_a_late_failure_from_the_old_owner_elects_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The test that actually pins the generation check.
+
+        Concurrent failures cannot: released together they all join the one
+        flight and produce one election with the check removed. What breaks
+        without it is a *late* failure, from a call that opened its client before
+        the replacement was adopted and fails afterwards still naming the old
+        owner. Without the check that failure elects again, against an owner that
+        is already answering.
+        """
+        elected = _attachment(tmp_path)
+        replacement = _attachment(tmp_path, port=elected.descriptor.port + 1)
+        backend = _backend(elected, tmp_path)
+
+        elections = 0
+
+        def elect(*_args, **_kwargs):
+            nonlocal elections
+            elections += 1
+            return _elected(replacement)
+
+        monkeypatch.setattr("linkedin_mcp_server.daemon_election.obtain_owner", elect)
+
+        assert await backend.recover(elected.descriptor.instance_id) is not None
+        assert elections == 1
+
+        # The same failure arrives again, from a call that was already in flight.
+        again = await backend.recover(elected.descriptor.instance_id)
+
+        assert elections == 1, "a late failure elected a second time"
+        assert again is not None
+        assert again.descriptor.url == replacement.descriptor.url
+
+    async def test_concurrent_failures_share_one_election(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        elected = _attachment(tmp_path)
+        replacement = _attachment(tmp_path, port=elected.descriptor.port + 1)
+        backend = _backend(elected, tmp_path)
+
+        elections = 0
+        holding = threading.Event()
+
+        def elect(*_args, **_kwargs):
+            nonlocal elections
+            elections += 1
+            # Held so every caller is waiting at once rather than arriving after
+            # the first has already finished, which would pass without a guard.
+            holding.wait(timeout=5)
+            return _elected(replacement)
+
+        monkeypatch.setattr("linkedin_mcp_server.daemon_election.obtain_owner", elect)
+
+        failed = elected.descriptor.instance_id
+        waiting = [asyncio.create_task(backend.recover(failed)) for _ in range(5)]
+        for _ in range(20):
+            await asyncio.sleep(0)
+        holding.set()
+        results = await asyncio.gather(*waiting)
+
+        assert elections == 1
+        assert all(
+            r is not None and r.descriptor.url == replacement.descriptor.url
+            for r in results
+        )
+
+    async def test_a_caller_that_gives_up_does_not_free_the_election(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Cancelling a caller must not let the next failure elect again.
+
+        `asyncio.to_thread` outlives the cancellation of whoever awaited it:
+        driven directly, an awaiter cancelled at 0.1s and a worker that still
+        finished its 1.5s of work. So an unshielded await that gets cancelled
+        would clear the guard while an election was still running.
+        """
+        elected = _attachment(tmp_path)
+        replacement = _attachment(tmp_path, port=elected.descriptor.port + 1)
+        backend = _backend(elected, tmp_path)
+
+        elections = 0
+        holding = threading.Event()
+
+        def elect(*_args, **_kwargs):
+            nonlocal elections
+            elections += 1
+            holding.wait(timeout=5)
+            return _elected(replacement)
+
+        monkeypatch.setattr("linkedin_mcp_server.daemon_election.obtain_owner", elect)
+
+        failed = elected.descriptor.instance_id
+        gives_up = asyncio.create_task(backend.recover(failed))
+        for _ in range(20):
+            await asyncio.sleep(0)
+        gives_up.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await gives_up
+
+        # A second failure arrives while the first election is still running.
+        second = asyncio.create_task(backend.recover(failed))
+        for _ in range(20):
+            await asyncio.sleep(0)
+        holding.set()
+        assert await second is not None
+
+        assert elections == 1, "a cancelled caller freed the guard"
 
     async def test_a_dead_owner_is_an_error_not_an_empty_tool_list(self):
         # FastMCP's default is to log a failing provider and carry on. For a
@@ -435,3 +717,473 @@ class TestServingTheOwnersTools:
         assert tool.title == "Get Person Profile"
         assert tool.annotations is not None
         assert tool.annotations.readOnlyHint is True
+
+
+class TestRepeatingOnlyWhatIsSafe:
+    """Which calls a recovery may run again, and which it must merely report.
+
+    The decision has two halves and both are load-bearing. The tool's own
+    annotation says whether a repeat could change anything on LinkedIn, and the
+    failure says whether the request had left this process. A mutating call is
+    repeated only when nothing was sent, because nothing in the protocol says
+    whether the departed owner had already done the thing.
+
+    Driven at the middleware rather than through a whole proxy stack, so that
+    what decides each outcome is the rule under test and not a transport that
+    happened to fail in a particular way.
+    """
+
+    @staticmethod
+    def _context(*, read_only: bool | None) -> MagicMock:
+        """A call context whose tool declares *read_only*, or declares nothing."""
+        tool = MagicMock()
+        tool.annotations = (
+            None if read_only is None else MagicMock(readOnlyHint=read_only)
+        )
+        context = MagicMock()
+        context.message.name = "do_the_thing"
+        context.fastmcp_context.fastmcp.get_tool = AsyncMock(return_value=tool)
+        return context
+
+    @staticmethod
+    async def _run(
+        backend: DaemonProxyBackend,
+        context: MagicMock,
+        *,
+        nothing_was_sent: bool,
+        instance_id: str,
+    ) -> tuple[bool, int]:
+        """Drive one failing call through the middleware.
+
+        Returns whether it succeeded and how many times the call was attempted.
+        """
+        from linkedin_mcp_server.daemon_proxy import (
+            FrontendOwnerRecoveryMiddleware,
+            OwnerUnreachableError,
+        )
+
+        attempts = 0
+
+        async def call_next(_context: Any) -> Any:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise OwnerUnreachableError(
+                    instance_id=instance_id,
+                    nothing_was_sent=nothing_was_sent,
+                    cause=httpx.ConnectError("gone"),
+                )
+            return "the result"
+
+        middleware = FrontendOwnerRecoveryMiddleware(backend)
+        try:
+            await middleware.on_call_tool(context, call_next)  # ty: ignore
+        except OwnerUnreachableError:
+            return False, attempts
+        return True, attempts
+
+    @pytest.fixture
+    def _recovering(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """A backend whose election always finds a replacement."""
+        elected = _attachment(tmp_path)
+        replacement = _attachment(tmp_path, port=elected.descriptor.port + 1)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.daemon_election.obtain_owner",
+            lambda *_a, **_k: _elected(replacement),
+        )
+        return _backend(elected, tmp_path), elected.descriptor.instance_id
+
+    async def test_a_mutating_call_is_not_repeated_when_it_may_have_run(
+        self, _recovering
+    ):
+        # The failure the user pays for. `daemon_auth` already recorded the
+        # measurement behind the rule: a client answered with an error at 0.66s
+        # and the effect landing 0.7s later.
+        backend, failed = _recovering
+        succeeded, attempts = await self._run(
+            backend,
+            self._context(read_only=False),
+            nothing_was_sent=False,
+            instance_id=failed,
+        )
+
+        assert not succeeded, "a call that may already have run was repeated"
+        assert attempts == 1
+        # And the replacement was still adopted, for the next call.
+        assert backend.attachment.descriptor.instance_id != failed
+
+    async def test_a_mutating_call_is_repeated_when_nothing_was_sent(self, _recovering):
+        # The only reason the dispatch question is worth asking. Without it every
+        # write tool would keep failing across an upgrade.
+        backend, failed = _recovering
+        succeeded, attempts = await self._run(
+            backend,
+            self._context(read_only=False),
+            nothing_was_sent=True,
+            instance_id=failed,
+        )
+
+        assert succeeded
+        assert attempts == 2
+
+    async def test_a_read_only_call_is_repeated_even_when_it_may_have_run(
+        self, _recovering
+    ):
+        # Repeating a read costs a page load and nothing else.
+        backend, failed = _recovering
+        succeeded, attempts = await self._run(
+            backend,
+            self._context(read_only=True),
+            nothing_was_sent=False,
+            instance_id=failed,
+        )
+
+        assert succeeded
+        assert attempts == 2
+
+    async def test_an_unannotated_call_is_treated_as_mutating(self, _recovering):
+        # A tool that declares nothing has not promised anything, and the default
+        # has to be the safe one: this is what keeps a tool added later from
+        # being replayed because nobody remembered to annotate it.
+        backend, failed = _recovering
+        succeeded, attempts = await self._run(
+            backend,
+            self._context(read_only=None),
+            nothing_was_sent=False,
+            instance_id=failed,
+        )
+
+        assert not succeeded
+        assert attempts == 1
+
+    async def test_a_failure_from_something_else_is_left_alone(self, _recovering):
+        # Only an unreachable owner is this middleware's business. Swallowing or
+        # retrying anything else would hide a real tool error behind a recovery.
+        from linkedin_mcp_server.daemon_proxy import FrontendOwnerRecoveryMiddleware
+
+        backend, _failed = _recovering
+        attempts = 0
+
+        async def call_next(_context: Any) -> Any:
+            nonlocal attempts
+            attempts += 1
+            raise ValueError("the tool itself failed")
+
+        middleware = FrontendOwnerRecoveryMiddleware(backend)
+        with pytest.raises(ValueError, match="the tool itself failed"):
+            await middleware.on_call_tool(
+                self._context(read_only=True),
+                call_next,  # ty: ignore
+            )
+
+        assert attempts == 1
+
+
+class _AnswersWithAnError(FastMCPTransport):
+    """An owner whose listing or call comes back as a JSON-RPC error.
+
+    The code is the whole point. A client cannot tell from the type whether the
+    owner said no or whether the session gave up waiting and wrote the error
+    itself, and only the second is a departure.
+    """
+
+    def __init__(
+        self, server: FastMCP, *, code: int, message: str, fails: str = "list"
+    ) -> None:
+        super().__init__(server)
+        self._code = code
+        self._message = message
+        self._fails = fails
+
+    @asynccontextmanager
+    async def connect_session(self, **kwargs: Any) -> AsyncIterator[Any]:
+        async with super().connect_session(**kwargs) as session:
+            yield _FailsOneRequest(session, self._code, self._message, self._fails)
+
+
+class _FailsOneRequest:
+    """A session that answers one kind of request with a JSON-RPC error."""
+
+    def __init__(self, session: Any, code: int, message: str, fails: str) -> None:
+        self._session = session
+        self._code = code
+        self._message = message
+        self._fails = fails
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._session, name)
+
+    def _refuse(self):
+        from mcp.shared.exceptions import McpError
+
+        return McpError(mt.ErrorData(code=self._code, message=self._message))
+
+    async def list_tools(self, *args: Any, **kwargs: Any):
+        if self._fails == "list":
+            raise self._refuse()
+        return await self._session.list_tools(*args, **kwargs)
+
+    async def call_tool(self, *args: Any, **kwargs: Any):
+        if self._fails == "call":
+            raise self._refuse()
+        return await self._session.call_tool(*args, **kwargs)
+
+
+class TestRecoveringThroughTheWholeProxy:
+    """The path a real request takes, with only the socket stood in for.
+
+    Every other test here drives one piece, and all of them stay green with the
+    pieces unconnected: a classification that is never applied, a middleware that
+    is never registered. What runs below is `create_mcp_server` in its proxy
+    role, so a failure has to travel the real exception chain, through the
+    middleware the server really installed, into an election, and back out as an
+    answer a client can use.
+    """
+
+    @staticmethod
+    def _owner(name: str = "get_person_profile") -> FastMCP:
+        owner = FastMCP("owner")
+
+        @owner.tool(name=name, annotations={"readOnlyHint": True})
+        async def a_tool() -> str:
+            return name
+
+        return owner
+
+    @staticmethod
+    def _proxy(backend: DaemonProxyBackend) -> FastMCP:
+        from linkedin_mcp_server.server import create_mcp_server
+        from linkedin_mcp_server.server_role import ServerRole
+
+        return create_mcp_server(
+            role=ServerRole.PROXY, proxy_backend=backend, tool_timeout=1.0
+        )
+
+    @pytest.fixture
+    def _upgraded(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """A backend whose owner is gone and whose election finds the new one.
+
+        Returns the backend, the id of the owner that left, and a callable
+        counting how many elections have been run.
+        """
+        elected = _attachment(tmp_path)
+        replacement = _attachment(tmp_path, port=elected.descriptor.port + 1)
+        backend = _backend(elected, tmp_path)
+        elections = 0
+
+        def elect(*_args, **_kwargs):
+            nonlocal elections
+            elections += 1
+            return _elected(replacement)
+
+        monkeypatch.setattr("linkedin_mcp_server.daemon_election.obtain_owner", elect)
+        return backend, elected, replacement, lambda: elections
+
+    async def test_a_client_lists_again_after_its_owner_went_away(
+        self, monkeypatch: pytest.MonkeyPatch, _upgraded
+    ):
+        """The reproduced failure, run backwards.
+
+        A proxy whose owner was stood down answered its next listing with
+        `McpError: Client failed to connect`. Here the same departure ends in the
+        replacement's tool list, without the proxy process restarting.
+        """
+        backend, elected, replacement, elections = _upgraded
+        after = self._owner("the_replacements_tool")
+        _reach_owners_in_process(
+            monkeypatch,
+            # Nothing is listening where the departed owner was.
+            lambda url: None if url == elected.descriptor.url else after,
+        )
+
+        async with Client(self._proxy(backend)) as client:
+            listed = {tool.name for tool in await client.list_tools()}
+
+        assert listed == {"the_replacements_tool"}
+        assert elections() == 1
+        assert backend.attachment.descriptor.url == replacement.descriptor.url
+
+    async def test_a_client_calls_a_tool_through_the_replacement(
+        self, monkeypatch: pytest.MonkeyPatch, _upgraded
+    ):
+        backend, elected, _replacement, elections = _upgraded
+        after = self._owner()
+        _reach_owners_in_process(
+            monkeypatch,
+            lambda url: None if url == elected.descriptor.url else after,
+        )
+
+        async with Client(self._proxy(backend)) as client:
+            result = await client.call_tool("get_person_profile", {})
+
+        assert result.data == "get_person_profile"
+        assert elections() == 1
+
+    async def test_an_owner_that_dies_after_the_handshake_is_still_recovered(
+        self, monkeypatch: pytest.MonkeyPatch, _upgraded
+    ):
+        """The boundary neither the connect nor the call can see.
+
+        The listing runs inside a connection that was established, so a departure
+        between the initialize and the list request raises out of neither. Every
+        other recovery test kills the owner earlier and passes with the listing
+        boundaries unwrapped.
+        """
+        backend, elected, _replacement, elections = _upgraded
+        dying = _GoesAwayAfterInitialize(self._owner())
+        after = self._owner("the_replacements_tool")
+        _reach_owners_in_process(
+            monkeypatch,
+            lambda url: dying if url == elected.descriptor.url else after,
+        )
+
+        async with Client(self._proxy(backend)) as client:
+            listed = {tool.name for tool in await client.list_tools()}
+
+        assert listed == {"the_replacements_tool"}
+        assert elections() == 1
+
+    async def test_an_owner_that_answers_with_an_error_elects_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, _upgraded
+    ):
+        """A process that returns a JSON-RPC error is reachable.
+
+        Treating one as a departure would stand a healthy owner's replacement up
+        for nothing, and hide whatever it was trying to say.
+        """
+        backend, elected, _replacement, elections = _upgraded
+        _reach_owners_in_process(
+            monkeypatch,
+            lambda _url: _AnswersWithAnError(
+                self._owner(), code=mt.INTERNAL_ERROR, message="the owner refused"
+            ),
+        )
+
+        async with Client(self._proxy(backend)) as client:
+            with pytest.raises(Exception, match="refused"):
+                await client.list_tools()
+
+        assert elections() == 0
+        assert (
+            backend.attachment.descriptor.instance_id == elected.descriptor.instance_id
+        )
+
+    @pytest.mark.parametrize(
+        "listing", ["list_resources", "list_resource_templates", "list_prompts"]
+    )
+    async def test_the_other_listings_recover_too(
+        self, monkeypatch: pytest.MonkeyPatch, _upgraded, listing: str
+    ):
+        """A client's opening exchange asks for more than tools.
+
+        This role serves none of these, so the answer is an empty list either
+        way. The provider is still asked in order to give it, and with a departed
+        owner and `provider_error_strategy = "raise"` that empty answer becomes
+        an error the user sees. One case per listing, because a hook left off
+        covers only itself.
+        """
+        backend, elected, _replacement, elections = _upgraded
+        after = self._owner()
+        _reach_owners_in_process(
+            monkeypatch,
+            lambda url: None if url == elected.descriptor.url else after,
+        )
+
+        async with Client(self._proxy(backend)) as client:
+            assert await getattr(client, listing)() == []
+
+        assert elections() == 1
+
+    @pytest.mark.parametrize(
+        ("code", "message"),
+        [
+            (
+                httpx.codes.REQUEST_TIMEOUT,
+                "Timed out while waiting for response to ListToolsRequest",
+            ),
+            (mt.CONNECTION_CLOSED, "Connection closed"),
+            (32600, "Session terminated"),
+        ],
+        ids=["timed out", "connection closed", "session terminated"],
+    )
+    async def test_a_request_that_never_came_back_is_a_departure(
+        self, monkeypatch: pytest.MonkeyPatch, _upgraded, code: int, message: str
+    ):
+        """What a departure looks like *during* a request, rather than between.
+
+        An owner killed between requests fails to connect, because streamable
+        HTTP opens a fresh connection each time. One that goes away with a
+        request outstanding does not: the client session waits, gives up, and
+        writes an `McpError` itself. So "the owner is gone" and "the owner said
+        no" arrive as the same type, and reading the type alone leaves the
+        frontend attached to a process that is not there.
+
+        Each code here is one the client invents. What this pins is the rule, not
+        its premise: nothing in the protocol reserves these integers, and the
+        reason reading them is safe is that the owner is this same package and
+        constructs no JSON-RPC error at all. That argument lives with the rule.
+        """
+        backend, elected, _replacement, elections = _upgraded
+        gone = _AnswersWithAnError(self._owner(), code=code, message=message)
+        after = self._owner("the_replacements_tool")
+        _reach_owners_in_process(
+            monkeypatch,
+            lambda url: gone if url == elected.descriptor.url else after,
+        )
+
+        async with Client(self._proxy(backend)) as client:
+            listed = {tool.name for tool in await client.list_tools()}
+
+        assert listed == {"the_replacements_tool"}
+        assert elections() == 1
+
+    async def test_a_mutating_call_that_timed_out_is_not_repeated(
+        self, monkeypatch: pytest.MonkeyPatch, _upgraded
+    ):
+        """A timeout is a departure and still no licence to run the call again.
+
+        The two halves of the decision come apart here. The owner is gone, so a
+        replacement is adopted for the next call; but a call that timed out may
+        have been queued, may have held the profile lease, may have sent the
+        connection request. Nothing in the protocol says which, so the failure is
+        reported rather than guessed at.
+        """
+        backend, elected, _replacement, elections = _upgraded
+        ran = 0
+
+        def with_a_mutating_tool() -> FastMCP:
+            owner = FastMCP("owner")
+
+            @owner.tool(name="send_connection_request")
+            async def send() -> str:
+                nonlocal ran
+                ran += 1
+                return "sent"
+
+            return owner
+
+        # The departed owner still answers the listing, so the failure comes from
+        # the call boundary rather than from the lookup in front of it.
+        gone = _AnswersWithAnError(
+            with_a_mutating_tool(),
+            code=httpx.codes.REQUEST_TIMEOUT,
+            message="Timed out while waiting for response to CallToolRequest",
+            fails="call",
+        )
+        after = with_a_mutating_tool()
+        _reach_owners_in_process(
+            monkeypatch,
+            lambda url: gone if url == elected.descriptor.url else after,
+        )
+
+        async with Client(self._proxy(backend)) as client:
+            # Reported rather than repeated. The text is the server's masked one,
+            # so what is pinned here is that the call failed, not how it read.
+            with pytest.raises(Exception, match="send_connection_request"):
+                await client.call_tool("send_connection_request", {})
+
+        assert ran == 0, "a call that may already have run was sent again"
+        assert elections() == 1
+        assert (
+            backend.attachment.descriptor.instance_id != elected.descriptor.instance_id
+        )


### PR DESCRIPTION
A proxy whose owner is replaced failed every operation afterwards. An upgrade is
enough to cause it: `@latest` is the documented install, so the first client
launched after one stands the running owner down, and every proxy already
attached to it stayed dead until its own process restarted. Reproduced end to
end before this change: a proxy serving 19 tools had its owner told to stand down
through the production path, and its next listing failed with
`McpError: Client failed to connect`. A crashed owner and an idle exit end the
same way.

A transport failure now says which owner it was against and whether the request
had left this process, and the backend elects a replacement. The connect is one
boundary and every listing is another: `ProxyProvider` runs its listings inside
a connection that was already established, so an owner dying between the
initialize and the list request raises out of neither `__aenter__` nor
`call_tool_mcp`, and a client that lists before it calls could never reach the
recovery.

A JSON-RPC error is not a departure, because a process that answers is
reachable. Three codes are the exception, and they are what a departure *during*
a request looks like: the client invents `REQUEST_TIMEOUT` when nothing came
back, `CONNECTION_CLOSED` when the read stream closes with requests still
pending, and `32600` when a POST is answered 404 for a session that is gone.
Measured against a real owner killed mid-call: `Timed out while waiting for
response to CallToolRequest`. Nobody sent that, and reading the type rather than
the code would leave the frontend sitting on a process that is not there.
Reading the code is a deployment convention rather than a protocol guarantee,
and it is written down as one: it holds because the owner is this same package,
which constructs no JSON-RPC error anywhere, and it is wrong in the direction
that self-corrects. A spurious election probes, finds the same owner answering
and keeps the attachment, while matching the SDK's message text as well would
mean a reworded message in a future release silently strands the proxy again.

Whether a failed call may be run again has two halves, and both are load-bearing.
The tool's own annotation says whether a repeat could change anything on
LinkedIn, and the failure says whether the request had left this process. There
is no dispatch acknowledgement anywhere in the protocol, so a mutating call is
repeated only when nothing was sent; otherwise the replacement is adopted for the
next call and the original failure is reported. The annotation rule is the one
`daemon_auth` already uses for its sign-in replay, promoted to a public name so
the two cannot drift apart in the unsafe direction.

The election runs in a thread for correctness rather than latency: `obtain_owner`
probes liveness through `asyncio.run`, which raises inside a running loop and is
caught as a refusal, so an in-loop call would bury a healthy owner. One election
runs at a time, keyed by the owner that failed and shielded, because a thread
outlives the cancellation of whoever awaited it.

The provider now keeps no component cache. Clearing it when a replacement is
adopted was the first design and does not hold: `ProxyProvider` writes each cache
after its listing completes and outside any lock, so a listing already in flight
against the departing owner refills a cache that was cleared while it ran, which
is reproducible by holding one open across an adoption. The cost is 27.8ms
against 56.0ms median per forwarded call, measured against a real loopback owner,
for a call that drives a browser through a LinkedIn page for seconds. What it
buys is that a five minute old `readOnlyHint` can no longer decide whether a call
is repeated.

The flag stays off. Cancellation is still not forwarded across the hop and an
owner still never exits on idle, which are the two remaining gaps in #606.

Each rule is pinned by the mutation that breaks it and nothing else: dropping the
shield fails only the cancelled-caller test, dropping the generation check only
the late-failure test, dropping the shared task the concurrent one, keeping the
cache the annotation test, and clearing it on adoption the held-listing test. A
client driven against a real proxy server covers what none of those can: with the
middleware left unregistered, only those tests fail. The full suite, ruff and ty
pass.

See also: #606

## Synthetic prompt

> A proxy is pinned to the owner it attached to at startup, so an upgrade that
> stands the old owner down strands it. Make it recover. Classify a transport
> failure where the boundary is known, tagging it with the owner that failed and
> whether the request had left the process, then elect a replacement on failure
> and repeat the call when repeating it is safe: always for a listing, for a
> mutating tool only when nothing was sent, and otherwise only when the tool
> declares `readOnlyHint`. Reuse `daemon_auth`'s annotation rule rather than
> writing a second one. Run the election in a thread, one at a time, shielded
> from a caller that gives up. Make sure a stale component cache cannot decide
> whether a call may be repeated.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
