### PR TITLE
feat(daemon): Stop a call once nobody is waiting for it

### DIFF
--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -69,12 +69,24 @@ from linkedin_mcp_server.private_state import harden_directory, harden_file
 #: recognise the value refuses rather than guessing at fields it cannot read.
 SCHEMA_VERSION = 2
 
-#: Bumped when the daemon's own protocol changes: the control routes, the call
-#: metadata, or the ping contract. Compatibility keys on this rather than on the
-#: package version, because the documented install is ``@latest`` and this
-#: project releases often. Matching exact versions would mean a manual shutdown
-#: after almost every release, which is precisely the friction the daemon exists
-#: to remove.
+#: Bumped when the daemon's own protocol changes incompatibly: the control
+#: routes, the call metadata, or the ping contract. Compatibility keys on this
+#: rather than on the package version, because the documented install is
+#: ``@latest`` and this project releases often. Matching exact versions would
+#: mean a manual shutdown after almost every release, which is precisely the
+#: friction the daemon exists to remove.
+#:
+#: **Incompatibly is doing the work in that sentence, and it was added rather
+#: than assumed.** The heartbeat route and the call marker
+#: (:mod:`linkedin_mcp_server.daemon_liveness`) are a control route and call
+#: metadata both, and they did not bump this. A bump makes an old owner
+#: unreadable — :func:`read` refuses the file before an attachment exists — and
+#: an owner nobody can read is an owner nobody can ask to stand down, so the
+#: turnover that an upgrade depends on would break for every owner already
+#: installed. An addition that both sides can do without is therefore not a
+#: reason to bump; one that either side would misread is. The test for it is
+#: whether the two mixed pairings still work, and for the heartbeat they are
+#: tested rather than asserted.
 PROTOCOL_VERSION = 1
 
 _DESCRIPTOR_FILE = "daemon.json"

--- a/linkedin_mcp_server/daemon_liveness.py
+++ b/linkedin_mcp_server/daemon_liveness.py
@@ -1,0 +1,281 @@
+"""Whether anybody is still waiting for a call the owner is running.
+
+A frontend that gives up does not take its call with it. Cancellation is not
+forwarded across the loopback hop: measured in this repository, the client was
+answered at 0.66s with an error and the effect landed 0.7s later, against a
+LinkedIn account nobody was watching any more. The owner has no way to notice,
+because a call it is already running looks exactly like one somebody wants.
+
+So the frontend says so, repeatedly, for as long as it is still waiting, and the
+owner cancels what nobody is waiting for. Kept in its own module rather than in
+``daemon_owner`` or ``server`` because both ends need the same names and those
+two must not import each other.
+
+**No ``PROTOCOL_VERSION`` bump, which is a departure from the rule and is meant
+to be read as one.** The descriptor says the field is bumped when the control
+routes or the call metadata change, and this is both. A bump would also make
+every currently installed owner unreadable to a new frontend, and an unreadable
+owner cannot be asked to stand down: the upgrade path would break in exactly the
+way the recovery work just repaired. The additions are optional in both
+directions instead, which is what makes that safe. A new frontend against an old
+owner gets 404 on the heartbeat route and proceeds without one. An old frontend
+against a new owner sends no call marker, and a call with no marker counts as
+active for as long as it runs and is never cancelled. Both directions are
+tested, because compatibility that is only asserted is the thing the invariant
+was written to prevent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+import time
+from dataclasses import dataclass, field
+
+import mcp.types as mt
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools import ToolResult
+
+logger = logging.getLogger(__name__)
+
+#: The route a frontend beats on for as long as it is still waiting. Part of the
+#: daemon's own protocol; see the module docstring for why the version is not
+#: bumped for it.
+HEARTBEAT_PATH = "/control/heartbeat"
+
+#: The header naming which call a request belongs to. A header rather than MCP
+#: call metadata, because the identifier has to reach the owner on both the tool
+#: call *and* the heartbeat, and only one of those is an MCP message at all.
+CALL_HEADER = "x-linkedin-mcp-call"
+
+#: Version prefix on the header value. Versioned so an owner meeting a shape it
+#: does not know can ignore it rather than half-read it, which is the same rule
+#: `daemon_auth` applies to markers travelling the other way.
+_MARKER_PREFIX = "v1."
+
+#: A call id is this many hex characters after the prefix. Bounded and checked,
+#: because this arrives in an HTTP header from anything that can reach the port,
+#: and it is used as a dictionary key on a long-lived process.
+_ID_HEX = 32
+
+#: How often a waiting frontend says it is still there. Measured on this machine
+#: against a server built the way the owner builds one: a heartbeat round trip
+#: costs 0.9ms median while the owner is idle and 1.8ms while it is driving
+#: Chromium, so this cadence occupies an owner about a thousandth of its time
+#: per waiting call.
+HEARTBEAT_SECONDS = 2.0
+
+#: How long a call may go unheard before the owner stops it. Five cadences, and
+#: the margin is the point rather than the number. Measured worst cases: 9.5ms
+#: for a heartbeat served while a page is being driven, 3.6ms of timer lateness
+#: in a detached process over 25 beats, and 130ms for the longest the owner's
+#: synchronous text extraction holds its event loop, on a 2MiB page far larger
+#: than a real one. A live call therefore needs a stall roughly seventy times
+#: worse than anything measured, or three consecutive beats lost, before it is
+#: wrongly cancelled. The relationship is what matters and what the tests pin;
+#: the two numbers are only a comfortable point on it.
+EXPIRY_SECONDS = 10.0
+
+#: A gap between two of the owner's own expiry scans that means the owner was
+#: not running rather than that a frontend went quiet. The serving loop polls
+#: ten times a second, so anything approaching this is the process itself having
+#: missed its turn: a laptop that slept, a machine under heavy load, or a long
+#: synchronous stretch on the event loop. Expiring on the tick after one of
+#: those would cancel calls whose frontends were beating the whole time and
+#: never got heard, which is the opposite of what any of this is for.
+_STALL_SECONDS = 1.0
+
+
+def new_call_id() -> str:
+    """A marker for one call, in the form the header carries."""
+    return f"{_MARKER_PREFIX}{secrets.token_hex(_ID_HEX // 2)}"
+
+
+def call_id_in(header_value: str | None) -> str | None:
+    """The call id in *header_value*, or ``None`` if there is not one this build reads.
+
+    Strict rather than forgiving, and every part of it is checked: an older
+    frontend sends nothing, a newer one may send a shape that does not exist yet,
+    and anything on the machine can reach the port and send whatever it likes.
+    A value that is not understood makes the call unmarked, which is the safe
+    answer, because an unmarked call is never cancelled.
+    """
+    if header_value is None:
+        return None
+    if not header_value.startswith(_MARKER_PREFIX):
+        return None
+    body = header_value[len(_MARKER_PREFIX) :]
+    if len(body) != _ID_HEX:
+        return None
+    try:
+        int(body, 16)
+    except ValueError:
+        return None
+    return header_value
+
+
+@dataclass
+class _Waiting:
+    """One call the owner is running, and when it was last asked for."""
+
+    task: asyncio.Task[object]
+    last_heard: float
+
+
+@dataclass
+class CallLiveness:
+    """Which calls somebody is still waiting for.
+
+    One instance per owner process. Times are monotonic, so a clock the user
+    changes mid-call cannot expire one.
+    """
+
+    _waiting: dict[str, _Waiting] = field(default_factory=dict)
+
+    #: When the owner last got round to asking who was still waiting. Compared
+    #: against the next scan so a stall in this process is not charged to the
+    #: frontends.
+    _last_scan: float | None = None
+
+    def watch(self, call_id: str, task: asyncio.Task[object]) -> None:
+        """Start counting for *call_id*, running as *task*.
+
+        The first heartbeat arrives before the call is dispatched, so a call is
+        registered already knowing it was heard, rather than starting from a
+        deadline it has to catch up with.
+        """
+        self._waiting[call_id] = _Waiting(task=task, last_heard=time.monotonic())
+
+    def heard(self, call_id: str) -> bool:
+        """Note that somebody is still waiting. False if this call is unknown.
+
+        Unknown covers both an id for a call that already finished and one that
+        was never registered, and neither is worth distinguishing: the answer to
+        the frontend is the same and it does not get to learn which.
+        """
+        entry = self._waiting.get(call_id)
+        if entry is None:
+            return False
+        entry.last_heard = time.monotonic()
+        return True
+
+    def release(self, call_id: str) -> None:
+        """Stop counting for *call_id*, however its call ended."""
+        self._waiting.pop(call_id, None)
+
+    def cancel_the_abandoned(self) -> list[str]:
+        """Cancel every call nobody has asked for lately, and say which.
+
+        Called from the owner's own polling loop rather than from a timer of its
+        own, so this costs one dictionary scan per tick on a process that is
+        already ticking.
+        """
+        now = time.monotonic()
+        since_last = now - self._last_scan if self._last_scan is not None else 0.0
+        self._last_scan = now
+        if since_last > _STALL_SECONDS:
+            # The owner itself was not running, so nobody had a chance to be
+            # heard. Charging that silence to the frontends would cancel calls
+            # that were being asked for the whole time. Everyone's clock starts
+            # again instead, rather than moving by the length of the stall,
+            # which for a stall longer than the expiry would push deadlines into
+            # the future. A call that really was abandoned gets one more cycle,
+            # which is the cheaper of the two mistakes.
+            logger.info(
+                "The owner was not scheduled for %.1fs; nobody is written off for that",
+                since_last,
+            )
+            for entry in self._waiting.values():
+                entry.last_heard = now
+            return []
+
+        deadline = now - EXPIRY_SECONDS
+        abandoned = [
+            call_id
+            for call_id, entry in self._waiting.items()
+            if entry.last_heard < deadline
+        ]
+        for call_id in abandoned:
+            entry = self._waiting.pop(call_id)
+            logger.info(
+                "Nobody has waited for call %s in %.0fs; stopping it",
+                call_id,
+                EXPIRY_SECONDS,
+            )
+            entry.task.cancel()
+        return abandoned
+
+
+#: The tracker for this process. Module state rather than something threaded
+#: through, for the same reason the browser is: the middleware that registers a
+#: call and the serving loop that expires it have no object in common.
+_liveness = CallLiveness()
+
+
+def get_liveness() -> CallLiveness:
+    """The tracker for this process."""
+    return _liveness
+
+
+def reset_liveness_for_testing() -> None:
+    """Forget every watched call, so one test cannot leak into the next."""
+    _liveness._waiting.clear()
+    _liveness._last_scan = None
+
+
+class OwnerCallLivenessMiddleware(Middleware):
+    """Stop running a call once nobody is waiting for it.
+
+    Registered outside the serializing middleware, which is deliberate: a call
+    can spend most of its life queued behind another one, and a frontend that
+    gives up while its call is still in the queue is the commonest way to end up
+    with work nobody wants. Inside, the call would only become cancellable once
+    it had already taken the browser.
+
+    A call with no marker this build understands runs to completion. That covers
+    an older frontend, which sends nothing, and a newer one whose marker this
+    build cannot read, and in both cases refusing to cancel is the only safe
+    answer: the alternative is stopping a call somebody is waiting for because
+    its heartbeats were addressed to a shape we did not parse.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        from fastmcp.server.dependencies import get_http_headers
+
+        call_id = call_id_in(get_http_headers().get(CALL_HEADER))
+        if call_id is None:
+            return await call_next(context)
+
+        # A task rather than a plain await, because cancelling is the whole
+        # point and there is nothing to cancel until the work has a handle.
+        # `create_task` copies the current context, so everything the call reads
+        # from it downstream is the same as it would have been.
+        running: asyncio.Task[ToolResult] = asyncio.ensure_future(call_next(context))
+        _liveness.watch(call_id, running)
+        try:
+            return await running
+        except asyncio.CancelledError:
+            outer = asyncio.current_task()
+            if outer is not None and outer.cancelling():
+                # Somebody cancelled *this* middleware, which is shutdown rather
+                # than an abandoned call. Reporting it as one would tell whoever
+                # asked us to stop that the call merely lost its client. The
+                # same counter tells the two apart in `browser_lifespan`, for
+                # the same reason.
+                raise
+            if running.cancelled() and call_id not in _liveness._waiting:
+                # Ours: this call was expired above. Reported as an error rather
+                # than re-raised, so the cancellation stops here instead of
+                # travelling on into a server nobody asked to shut down.
+                raise ToolError(
+                    "Stopped because the client that asked for it stopped waiting"
+                ) from None
+            raise
+        finally:
+            _liveness.release(call_id)

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -59,6 +59,12 @@ from linkedin_mcp_server import __version__, daemon_config, daemon_descriptor
 from linkedin_mcp_server.config import set_config
 from linkedin_mcp_server.config.schema import AppConfig
 from linkedin_mcp_server.daemon_lock import DaemonLock, DaemonLockError
+from linkedin_mcp_server.daemon_liveness import (
+    CALL_HEADER,
+    HEARTBEAT_PATH,
+    call_id_in,
+    get_liveness,
+)
 from linkedin_mcp_server.drivers.browser import set_headless
 from linkedin_mcp_server.logging_config import configure_logging
 from linkedin_mcp_server.server_role import (
@@ -227,7 +233,13 @@ async def _probe(url: str, token: str) -> None:
 
 
 #: The route a newer frontend uses to ask a stale owner to stand down. Part of
-#: the daemon's own protocol, so a change here is a ``PROTOCOL_VERSION`` bump.
+#: the daemon's own protocol, so a change to *this* route is a
+#: ``PROTOCOL_VERSION`` bump: every turnover depends on it, and a frontend that
+#: guessed wrong about it would wait out its whole budget against a held lock.
+#:
+#: Adding a route beside it is a different question, answered where the version
+#: is defined. The heartbeat route was added without a bump because both sides
+#: work without it; this one they do not.
 STAND_DOWN_PATH = "/control/stand-down"
 
 
@@ -302,6 +314,29 @@ def create_owner_server(
                 return JSONResponse({"error": "unauthorized"}, status_code=401)
             stand_down()
             return JSONResponse({"standing_down": True})
+
+    @mcp.custom_route(HEARTBEAT_PATH, methods=["POST"])
+    async def heartbeat_route(request: Request) -> JSONResponse:
+        """Note that somebody is still waiting for a call this owner is running.
+
+        The same explicit token check as the route above, for the same measured
+        reason: a custom route is mounted outside the authentication middleware,
+        so without this any process on the machine could keep a call alive that
+        its own frontend had already abandoned.
+
+        A call this owner does not know gets ``watched: false`` rather than an
+        error. It is the ordinary race, not a fault: a beat sent while the call
+        was returning arrives after it was released, and the frontend has
+        nothing useful to do about that.
+        """
+        header = request.headers.get("authorization", "")
+        scheme, _, presented = header.partition(" ")
+        if scheme.lower() != "bearer" or not _matches_token(presented, token):
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+        call_id = call_id_in(request.headers.get(CALL_HEADER))
+        if call_id is None:
+            return JSONResponse({"error": "no call named"}, status_code=400)
+        return JSONResponse({"watched": get_liveness().heard(call_id)})
 
     app = mcp.http_app(
         path=MCP_PATH,
@@ -464,6 +499,10 @@ async def _serve_until_stopped(
             # freed by the exit either way.
             await _stop_within(serving, _STAND_DOWN_SHUTDOWN_SECONDS)
             return
+        # Cheap enough to do on the same tick as the two questions above: one
+        # dictionary scan over the calls in flight, on a process that is already
+        # polling. A timer of its own would be a second thing to shut down.
+        get_liveness().cancel_the_abandoned()
         await asyncio.sleep(_STAND_DOWN_POLL_SECONDS)
     await serving
 

--- a/linkedin_mcp_server/daemon_proxy.py
+++ b/linkedin_mcp_server/daemon_proxy.py
@@ -36,17 +36,26 @@ it twice would send a connection request twice.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 from collections.abc import Awaitable
+from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
+import httpx
 import mcp.types as mt
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 
 from linkedin_mcp_server import daemon_owner
 from linkedin_mcp_server.daemon_auth import a_repeat_could_change_something
+from linkedin_mcp_server.daemon_liveness import (
+    CALL_HEADER,
+    HEARTBEAT_PATH,
+    HEARTBEAT_SECONDS,
+    new_call_id,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -57,6 +66,32 @@ if TYPE_CHECKING:
     from linkedin_mcp_server.daemon import Attachment
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _CallBinding:
+    """One call, and the owner it belongs to for as long as it runs.
+
+    The two travel together and must not be read separately. The heartbeats and
+    the request itself both name an owner, and if they name *different* ones the
+    mechanism inverts: the owner running the call never hears a beat and cancels
+    it after the expiry, while a call that is very much alive is reported to the
+    user as abandoned. That is reachable, because with no component cache every
+    call re-lists first, and a replacement adopted between the two would move
+    the backend underneath this call.
+    """
+
+    call_id: str
+    attachment: Attachment
+
+
+#: The call the current task is making, for the factory to address and stamp.
+#: A context variable rather than an argument because `ProxyProvider` builds the
+#: client itself: the middleware that knows the call never sees the code that
+#: builds the transport.
+_call_being_made: contextvars.ContextVar[_CallBinding | None] = contextvars.ContextVar(
+    "linkedin_mcp_call", default=None
+)
 
 #: Added to the owner's tool timeout to get the frontend's deadline. The owner is
 #: the one that should report a timed-out tool, so the frontend has to outlast it;
@@ -482,7 +517,12 @@ class DaemonProxyBackend:
         """
         from fastmcp.client.transports import StreamableHttpTransport
 
-        attachment = self._attachment
+        # Which call this request belongs to, if it belongs to one, and the owner
+        # that call was bound to. Read together and never separately: a call that
+        # dialled a replacement while its heartbeats stayed with the departing
+        # owner would be cancelled by the owner actually running it.
+        bound = _call_being_made.get()
+        attachment = bound.attachment if bound is not None else self._attachment
         # Verbatim, never rebuilt from host and port: the descriptor's own URL
         # already carries the MCP path and brackets an IPv6 literal, and FastMCP
         # deliberately does not rewrite the path it is given.
@@ -495,6 +535,7 @@ class DaemonProxyBackend:
         return _tells_which_owner_failed()(
             StreamableHttpTransport(
                 url,
+                headers={CALL_HEADER: bound.call_id} if bound is not None else None,
                 # A plain string becomes `Authorization: Bearer <token>`, which
                 # is the form the owner's verifier compares against.
                 auth=token,
@@ -647,3 +688,121 @@ class FrontendOwnerRecoveryMiddleware(Middleware):
 
             logger.info("Attached to a replacement owner; running the call again")
             return await call_next(context)
+
+
+class FrontendCallHeartbeatMiddleware(Middleware):
+    """Say, for as long as this frontend is waiting, that it still is.
+
+    The other half of `daemon_liveness`. Cancellation does not cross the hop, so
+    an owner cannot tell a call somebody wants from one whose client has gone;
+    this is the frontend answering that question over and over until it stops
+    caring, at which point the answer stops arriving and the owner draws the
+    obvious conclusion.
+
+    Innermost of the three a proxy installs, and that is what makes a replay
+    behave: the recovery middleware sits outside, so a call it runs again enters
+    here a second time and gets its own identifier and its own heartbeats
+    against whichever owner it is now talking to.
+    """
+
+    def __init__(self, backend: DaemonProxyBackend) -> None:
+        self._backend = backend
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        call_id = new_call_id()
+        # Captured once, and every beat for this call goes here even if another
+        # call adopts a replacement owner meanwhile. Beating at the new owner
+        # would name a call it has never heard of, while the owner actually
+        # running this one stopped being told about it.
+        attachment = self._backend.attachment
+
+        if not await self._route_exists(attachment, call_id):
+            return await call_next(context)
+
+        beating = asyncio.create_task(self._keep_saying(attachment, call_id))
+        marked = _call_being_made.set(_CallBinding(call_id, attachment))
+        try:
+            return await call_next(context)
+        finally:
+            _call_being_made.reset(marked)
+            # In a finally, and unconditionally: a task left running would go on
+            # keeping a finished call alive in the owner's tracker, which is the
+            # exact state this exists to prevent.
+            beating.cancel()
+
+    async def _route_exists(self, attachment: Attachment, call_id: str) -> bool:
+        """Beat once, to learn whether this owner understands heartbeats at all.
+
+        A 404 is an owner from before this existed. It is served rather than
+        refused: the additions are optional in both directions, so the call goes
+        ahead unheard, exactly as every call did before this change.
+
+        Anything else that goes wrong here is reported and then ignored, and
+        that is deliberate. A 401 or a dead socket will stop the call itself a
+        moment later, with a classification this middleware has no business
+        second-guessing. Beating on regardless would only add a failing request
+        every two seconds to a call that is already failing.
+        """
+        try:
+            answered = await self._beat(attachment, call_id)
+        except Exception:
+            logger.debug(
+                "Could not reach the shared browser owner to say we are waiting",
+                exc_info=True,
+            )
+            return False
+        if answered == 404:
+            logger.debug("This shared browser owner predates heartbeats")
+            return False
+        if answered != 200:
+            logger.warning(
+                "The shared browser owner refused a heartbeat (HTTP %s)", answered
+            )
+            return False
+        return True
+
+    async def _keep_saying(self, attachment: Attachment, call_id: str) -> None:
+        """Beat until cancelled, and never let a failed beat end the run.
+
+        A beat that fails is not evidence the call is over: the owner may be
+        momentarily busy, and giving up here would expire a call that is running
+        perfectly well. The frontend stops saying it is waiting only when it
+        stops waiting, which is what the cancellation in the caller's `finally`
+        expresses.
+        """
+        while True:
+            await asyncio.sleep(HEARTBEAT_SECONDS)
+            try:
+                await self._beat(attachment, call_id)
+            except Exception:
+                logger.debug("A heartbeat did not arrive", exc_info=True)
+
+    @staticmethod
+    async def _beat(attachment: Attachment, call_id: str) -> int:
+        """One heartbeat, returning the owner's status code.
+
+        The address is the published one with its path replaced, rather than
+        rebuilt from host and port: the descriptor's URL already brackets an
+        IPv6 literal, and rebuilding is how that bracket gets lost.
+
+        The owner's own client factory, for the reason it exists: httpx honours
+        ``HTTP_PROXY`` even for loopback unless ``NO_PROXY`` happens to say
+        otherwise, and this request carries the bearer token.
+        """
+        from urllib.parse import urlsplit, urlunsplit
+
+        parts = urlsplit(attachment.descriptor.url)
+        url = urlunsplit((parts.scheme, parts.netloc, HEARTBEAT_PATH, "", ""))
+        async with daemon_owner.direct_async_http_client(
+            headers={
+                "Authorization": f"Bearer {attachment.token}",
+                CALL_HEADER: call_id,
+            },
+            timeout=httpx.Timeout(HEARTBEAT_SECONDS),
+        ) as client:
+            response = await client.post(url)
+            return response.status_code

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -205,6 +205,15 @@ def create_mcp_server(
     # answer would describe the layer below rather than the process.
     if role is ServerRole.OWNER:
         mcp.add_middleware(OwnerAuthSignalMiddleware())
+        # Before the serializing middleware below, which puts it outside. That
+        # is the whole point rather than a detail: a call spends most of its
+        # life queued, and a frontend that gives up while its call is still
+        # waiting its turn is the commonest way to end up with work nobody
+        # wants. Inside, a call would only become cancellable once it already
+        # had the browser.
+        from linkedin_mcp_server.daemon_liveness import OwnerCallLivenessMiddleware
+
+        mcp.add_middleware(OwnerCallLivenessMiddleware())
     # The other half, and only ever on the process that has a user in front of it.
     if role is ServerRole.PROXY:
         # Handed the same budget every tool here is given, rather than reading it
@@ -220,10 +229,18 @@ def create_mcp_server(
         # their own liveness wrapper, rather than one wrapper around the pair.
         # The other way round, an owner that departed between the two would leave
         # the replay unrecoverable.
-        from linkedin_mcp_server.daemon_proxy import FrontendOwnerRecoveryMiddleware
+        from linkedin_mcp_server.daemon_proxy import (
+            FrontendCallHeartbeatMiddleware,
+            FrontendOwnerRecoveryMiddleware,
+        )
 
         assert proxy_backend is not None  # the role check above established it
         mcp.add_middleware(FrontendOwnerRecoveryMiddleware(proxy_backend))
+        # Innermost of the three, which is what makes a replay behave: a call the
+        # recovery middleware runs again enters here a second time and gets its
+        # own identifier and its own heartbeats, against whichever owner it is
+        # talking to now.
+        mcp.add_middleware(FrontendCallHeartbeatMiddleware(proxy_backend))
     # Profile ownership belongs to whoever launches Chromium. A process that
     # only forwards calls must not take the lease: it would either block itself
     # until its own timeout, or take the lease and leave the process that

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,17 @@ def reset_singletons():
     """Reset global state for test isolation."""
     from linkedin_mcp_server.bootstrap import reset_bootstrap_for_testing
     from linkedin_mcp_server.config import reset_config
+    from linkedin_mcp_server.daemon_liveness import reset_liveness_for_testing
     from linkedin_mcp_server.drivers.browser import reset_browser_for_testing
     from linkedin_mcp_server.profile_lease import reset_leases_for_testing
     from linkedin_mcp_server.server_role import reset_process_role_for_testing
 
     reset_bootstrap_for_testing()
+    # The owner's call tracker is process state like the rest. Left standing,
+    # the moment of one test's last expiry scan is the baseline for the next,
+    # and a gap of seconds between them reads as an owner that was not
+    # running, so nothing expires.
+    reset_liveness_for_testing()
     reset_browser_for_testing()
     reset_leases_for_testing()
     reset_config()
@@ -26,6 +32,7 @@ def reset_singletons():
     reset_leases_for_testing()
     reset_config()
     reset_process_role_for_testing()
+    reset_liveness_for_testing()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_daemon_liveness.py
+++ b/tests/test_daemon_liveness.py
@@ -1,0 +1,800 @@
+"""Bounding work whose client has gone away.
+
+Every test here pins something that is invisible when everything works: a call
+nobody is waiting for that keeps driving the browser, a heartbeat that keeps a
+finished call alive, or an owner that stops a call somebody *is* waiting for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from linkedin_mcp_server.daemon_liveness import (
+    CALL_HEADER,
+    EXPIRY_SECONDS,
+    HEARTBEAT_SECONDS,
+    CallLiveness,
+    OwnerCallLivenessMiddleware,
+    call_id_in,
+    new_call_id,
+)
+
+
+def _last_heard(liveness: CallLiveness, call_id: str, seconds_ago: float) -> None:
+    """Pretend the last beat for *call_id* arrived *seconds_ago*."""
+    liveness._waiting[call_id].last_heard -= seconds_ago
+
+
+class TestReadingTheMarker:
+    """What counts as a call this build can be asked about."""
+
+    def test_a_minted_marker_reads_back(self):
+        marker = new_call_id()
+        assert call_id_in(marker) == marker
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "",
+            "deadbeef",  # no version
+            "v2." + "a" * 32,  # a shape from a build that does not exist yet
+            "v1." + "a" * 31,  # too short
+            "v1." + "a" * 33,  # too long
+            "v1." + "z" * 32,  # not hex
+        ],
+        ids=[
+            "absent",
+            "empty",
+            "unversioned",
+            "newer version",
+            "short",
+            "long",
+            "not hex",
+        ],
+    )
+    def test_anything_else_is_no_marker(self, value: str | None):
+        # Unreadable has to mean unmarked rather than "close enough": an
+        # unmarked call is never cancelled, and that is the safe direction. This
+        # arrives in a header from anything that can reach the port.
+        assert call_id_in(value) is None
+
+    def test_two_calls_do_not_share_an_identifier(self):
+        # One process-wide id would mean expiring one call cancels another.
+        assert len({new_call_id() for _ in range(50)}) == 50
+
+
+class TestCountingWhoIsWaiting:
+    """The owner's side of the question, without any transport in the way."""
+
+    @staticmethod
+    def _task() -> Any:
+        task = MagicMock()
+        task.cancel = MagicMock()
+        return task
+
+    def test_a_call_nobody_asks_for_is_cancelled(self):
+        liveness = CallLiveness()
+        task = self._task()
+        liveness.watch("v1.a", task)
+
+        # The entry is aged rather than the clock moved. `time.monotonic` is the
+        # one the whole interpreter reads, and patching it moves time for
+        # everything in the test session, including asyncio's own timers.
+        _last_heard(liveness, "v1.a", EXPIRY_SECONDS + 0.1)
+
+        assert liveness.cancel_the_abandoned() == ["v1.a"]
+        task.cancel.assert_called_once()
+
+    def test_a_call_somebody_is_waiting_for_is_left_alone(self):
+        liveness = CallLiveness()
+        heard, unheard = self._task(), self._task()
+        liveness.watch("v1.heard", heard)
+        liveness.watch("v1.unheard", unheard)
+
+        # Both have been running well past the expiry; only one frontend is
+        # still saying so.
+        _last_heard(liveness, "v1.heard", EXPIRY_SECONDS + 5)
+        _last_heard(liveness, "v1.unheard", EXPIRY_SECONDS + 5)
+        assert liveness.heard("v1.heard")
+
+        assert liveness.cancel_the_abandoned() == ["v1.unheard"]
+        heard.cancel.assert_not_called()
+        unheard.cancel.assert_called_once()
+
+    def test_a_beat_for_an_unknown_call_changes_nothing(self):
+        # A beat that arrives just after its call returned. Ordinary, not a
+        # fault, and it must not resurrect an entry.
+        liveness = CallLiveness()
+        assert liveness.heard("v1.never-registered") is False
+
+    def test_a_released_call_is_no_longer_watched(self):
+        liveness = CallLiveness()
+        task = self._task()
+        liveness.watch("v1.a", task)
+        liveness.release("v1.a")
+
+        assert liveness.cancel_the_abandoned() == []
+        task.cancel.assert_not_called()
+
+    def test_a_stall_is_longer_than_the_owner_looking(self):
+        # The threshold has to sit above the interval the owner polls at, or
+        # every ordinary scan looks like a stall and nothing is ever expired.
+        # Below the poll it is not a smaller margin, it is the feature switched
+        # off, and nothing else here would notice.
+        from linkedin_mcp_server.daemon_liveness import _STALL_SECONDS
+        from linkedin_mcp_server.daemon_owner import _STAND_DOWN_POLL_SECONDS
+
+        assert _STALL_SECONDS > _STAND_DOWN_POLL_SECONDS * 5
+
+    def test_the_expiry_is_several_cadences(self):
+        # The relationship rather than the numbers. Both were measured, but what
+        # keeps a live call safe is that a single late beat cannot expire it.
+        assert EXPIRY_SECONDS >= 3 * HEARTBEAT_SECONDS
+
+
+class TestTheOwnerSideMiddleware:
+    """What the owner does with a call, marked or not."""
+
+    @staticmethod
+    def _context() -> Any:
+        context = MagicMock()
+        context.message.name = "get_person_profile"
+        return context
+
+    @staticmethod
+    def _headers(monkeypatch, headers: dict[str, str]) -> None:
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_http_headers", lambda **_kw: headers
+        )
+
+    async def test_an_unmarked_call_runs_and_is_never_watched(self, monkeypatch):
+        # The old-frontend direction of the compatibility claim. A frontend from
+        # before this existed sends no marker, and its calls must run exactly as
+        # they always did rather than becoming cancellable by anybody.
+        from linkedin_mcp_server import daemon_liveness
+
+        self._headers(monkeypatch, {})
+        liveness = daemon_liveness.get_liveness()
+
+        async def call_next(_context: Any) -> str:
+            assert liveness._waiting == {}, "an unmarked call was watched"
+            return "the result"
+
+        result = await OwnerCallLivenessMiddleware().on_call_tool(
+            self._context(),
+            call_next,  # ty: ignore
+        )
+        assert result == "the result"
+
+    async def test_a_marked_call_is_watched_while_it_runs(self, monkeypatch):
+        from linkedin_mcp_server import daemon_liveness
+
+        marker = new_call_id()
+        self._headers(monkeypatch, {CALL_HEADER: marker})
+        liveness = daemon_liveness.get_liveness()
+
+        async def call_next(_context: Any) -> str:
+            assert marker in liveness._waiting
+            return "the result"
+
+        assert (
+            await OwnerCallLivenessMiddleware().on_call_tool(
+                self._context(),
+                call_next,  # ty: ignore
+            )
+            == "the result"
+        )
+        # And released afterwards, or the tracker would grow for the life of the
+        # process and expire identifiers nothing is running.
+        assert marker not in liveness._waiting
+
+    async def test_a_marked_call_is_released_when_it_fails(self, monkeypatch):
+        from linkedin_mcp_server import daemon_liveness
+
+        marker = new_call_id()
+        self._headers(monkeypatch, {CALL_HEADER: marker})
+
+        async def call_next(_context: Any) -> str:
+            raise ValueError("the tool itself failed")
+
+        with pytest.raises(ValueError):
+            await OwnerCallLivenessMiddleware().on_call_tool(
+                self._context(),
+                call_next,  # ty: ignore
+            )
+        assert marker not in daemon_liveness.get_liveness()._waiting
+
+    async def test_an_abandoned_call_is_stopped_and_says_so(self, monkeypatch):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server import daemon_liveness
+
+        marker = new_call_id()
+        self._headers(monkeypatch, {CALL_HEADER: marker})
+        liveness = daemon_liveness.get_liveness()
+        started = asyncio.Event()
+
+        async def call_next(_context: Any) -> str:
+            started.set()
+            await asyncio.sleep(3600)  # the scrape nobody is waiting for
+            return "never reached"  # pragma: no cover
+
+        running = asyncio.create_task(
+            OwnerCallLivenessMiddleware().on_call_tool(
+                self._context(),
+                call_next,  # ty: ignore
+            )
+        )
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        # The owner's own loop notices, without waiting out the real expiry.
+        _last_heard(liveness, marker, EXPIRY_SECONDS + 1)
+        assert liveness.cancel_the_abandoned() == [marker]
+
+        with pytest.raises(ToolError, match="stopped waiting"):
+            await asyncio.wait_for(running, timeout=5)
+        assert marker not in liveness._waiting
+
+    async def test_a_cancellation_from_elsewhere_is_not_swallowed(self, monkeypatch):
+        # Shutdown cancels every task. That is not an abandoned call, and
+        # reporting it as one would tell whoever asked us to stop that the call
+        # merely lost its client.
+        marker = new_call_id()
+        self._headers(monkeypatch, {CALL_HEADER: marker})
+
+        async def call_next(_context: Any) -> str:
+            await asyncio.sleep(3600)
+            return "never reached"  # pragma: no cover
+
+        running = asyncio.create_task(
+            OwnerCallLivenessMiddleware().on_call_tool(
+                self._context(),
+                call_next,  # ty: ignore
+            )
+        )
+        await asyncio.sleep(0.05)
+        running.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await running
+
+
+class TestTheFrontendSide:
+    """Saying we are still waiting, and stopping the moment we are not."""
+
+    @staticmethod
+    def _backend(tmp_path: Path) -> Any:
+        from test_daemon_proxy import _attachment, _backend
+
+        return _backend(_attachment(tmp_path), tmp_path)
+
+    @staticmethod
+    def _middleware(backend: Any, beats: list[tuple[str, str]], status: int = 200):
+        """The middleware with its one network call stood in for.
+
+        Records which owner each beat was addressed to, which is the only way to
+        see a beat that followed a replacement owner rather than staying with
+        the one running the call.
+        """
+        from linkedin_mcp_server.daemon_proxy import FrontendCallHeartbeatMiddleware
+
+        middleware = FrontendCallHeartbeatMiddleware(backend)
+
+        async def beat(attachment: Any, call_id: str) -> int:
+            beats.append((attachment.descriptor.instance_id, call_id))
+            return status
+
+        middleware._beat = beat  # ty: ignore[invalid-assignment]
+        return middleware
+
+    @staticmethod
+    def _context() -> Any:
+        context = MagicMock()
+        context.message.name = "get_person_profile"
+        return context
+
+    async def test_the_first_beat_precedes_the_dispatch(self, tmp_path: Path):
+        # Otherwise the owner registers a call it has never been told about, and
+        # the window before the first beat is one where an expiry would fire
+        # against a call that is perfectly alive.
+        backend = self._backend(tmp_path)
+        beats: list[tuple[str, str]] = []
+        order: list[str] = []
+
+        async def call_next(_context: Any) -> str:
+            order.append(f"dispatch after {len(beats)} beats")
+            return "the result"
+
+        middleware = self._middleware(backend, beats)
+        assert (
+            await middleware.on_call_tool(
+                self._context(),
+                call_next,
+            )
+            == "the result"
+        )
+        assert order == ["dispatch after 1 beats"]
+
+    async def test_an_owner_without_the_route_is_served_anyway(
+        self, tmp_path: Path, quick_cadence: float
+    ):
+        # The new-frontend direction of the compatibility claim. A 404 is an
+        # owner from before heartbeats existed, and its calls must go ahead
+        # unheard rather than fail.
+        backend = self._backend(tmp_path)
+        beats: list[tuple[str, str]] = []
+        middleware = self._middleware(backend, beats, status=404)
+
+        during: list[int] = []
+
+        async def call_next(_context: Any) -> str:
+            # Counted while the call is still running. Afterwards proves
+            # nothing: the beater is cancelled when the call returns either
+            # way, so a beater that should never have started looks identical
+            # from outside.
+            await asyncio.sleep(quick_cadence * 6)
+            during.append(len(beats))
+            return "the result"
+
+        assert (
+            await middleware.on_call_tool(
+                self._context(),
+                call_next,
+            )
+            == "the result"
+        )
+        assert during == [1], "kept beating at an owner with no such route"
+
+    async def test_the_marker_reaches_the_client_the_provider_builds(
+        self, tmp_path: Path
+    ):
+        # The identifier has to arrive on the tool call as well as on the beats,
+        # or the owner cannot connect the two.
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        backend = self._backend(tmp_path)
+        beats: list[tuple[str, str]] = []
+        middleware = self._middleware(backend, beats)
+        seen: list[str | None] = []
+
+        async def call_next(_context: Any) -> str:
+            client = backend.open_client(timeout=1.0)
+            assert isinstance(client.transport, StreamableHttpTransport)
+            seen.append(client.transport.headers.get(CALL_HEADER))
+            return "the result"
+
+        await middleware.on_call_tool(
+            self._context(),
+            call_next,
+        )
+        assert seen == [beats[0][1]], "the call and its beats named different calls"
+
+    async def test_no_marker_is_left_behind_afterwards(self, tmp_path: Path):
+        # A leaked context variable would stamp the next unrelated operation,
+        # including a listing, with a call identifier that is over.
+        from linkedin_mcp_server.daemon_proxy import _call_being_made
+
+        backend = self._backend(tmp_path)
+        middleware = self._middleware(backend, [])
+
+        async def call_next(_context: Any) -> str:
+            return "the result"
+
+        await middleware.on_call_tool(
+            self._context(),
+            call_next,
+        )
+        assert _call_being_made.get() is None
+
+    @pytest.fixture
+    def quick_cadence(self, monkeypatch):
+        """Beat every 50ms instead of every two seconds.
+
+        Patched in `daemon_proxy`'s own namespace, which is where
+        `_keep_saying` reads it. Without this a test would have to outlast a
+        real period to see anything at all, and one that waits less than a
+        period proves nothing: it stays green with the cancellation removed.
+        """
+        monkeypatch.setattr("linkedin_mcp_server.daemon_proxy.HEARTBEAT_SECONDS", 0.05)
+        return 0.05
+
+    @pytest.mark.parametrize("outcome", ["succeeds", "fails", "is cancelled"])
+    async def test_the_beating_stops_however_the_call_ends(
+        self, tmp_path: Path, outcome: str, quick_cadence: float
+    ):
+        # A leaked beater keeps a finished call alive in the owner's tracker,
+        # which is the exact state this mechanism exists to prevent.
+        backend = self._backend(tmp_path)
+        beats: list[tuple[str, str]] = []
+        middleware = self._middleware(backend, beats)
+        entered = asyncio.Event()
+
+        async def call_next(_context: Any) -> str:
+            entered.set()
+            if outcome == "fails":
+                raise ValueError("the tool itself failed")
+            if outcome == "is cancelled":
+                await asyncio.sleep(3600)
+            return "the result"
+
+        running = asyncio.create_task(
+            middleware.on_call_tool(
+                self._context(),
+                call_next,
+            )
+        )
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        if outcome == "is cancelled":
+            running.cancel()
+        with (
+            pytest.raises((ValueError, asyncio.CancelledError))
+            if outcome != ("succeeds")
+            else _nothing_raised()
+        ):
+            await running
+
+        before = len(beats)
+        # Several cadences. A beater still running would add to the list.
+        await asyncio.sleep(quick_cadence * 6)
+        assert len(beats) == before, "a heartbeat outlived the call it belonged to"
+
+    async def test_beats_stay_with_the_owner_running_the_call(
+        self, tmp_path: Path, quick_cadence: float
+    ):
+        # A call belongs to the owner it was dispatched to. Following the
+        # backend to a replacement would beat at an owner that has never heard
+        # of this call, while the one actually running it stops being told.
+        from test_daemon_proxy import _attachment
+
+        backend = self._backend(tmp_path)
+        original = backend.attachment.descriptor.instance_id
+        beats: list[tuple[str, str]] = []
+        middleware = self._middleware(backend, beats)
+
+        dialled: list[str] = []
+
+        async def call_next(_context: Any) -> str:
+            # Another call elects a replacement while this one is running. With
+            # no component cache every call re-lists first, so this really is
+            # reachable between a call's own two upstream operations.
+            backend._attachment = _attachment(tmp_path, port=51999)
+            await asyncio.sleep(quick_cadence * 4)
+            # What the provider would open for this call, after the move.
+            # Twice, because one call opens more than one client: with no
+            # component cache FastMCP resolves the tool through its own listing
+            # first and then runs it, each with a client of its own. A binding
+            # that only held for the first would send the listing to one owner
+            # and the call itself to another, and one client per test cannot
+            # see that.
+            dialled.append(backend.open_client(timeout=1.0)._instance_id)
+            backend._attachment = _attachment(tmp_path, port=52000)
+            dialled.append(backend.open_client(timeout=1.0)._instance_id)
+            return "the result"
+
+        await middleware.on_call_tool(
+            self._context(),
+            call_next,
+        )
+        assert len(beats) >= 2, "no beat followed the first one"
+        assert {owner for owner, _ in beats} == {original}
+        # The half that matters most, and the half a beats-only assertion misses
+        # entirely: the request goes where the beats go. Split between two owners,
+        # the one running the call never hears a beat and cancels it after the
+        # expiry, so a live call is reported to the user as abandoned.
+        assert dialled == [original, original], (
+            "the call and its heartbeats named different owners"
+        )
+
+
+class _nothing_raised:
+    """A ``pytest.raises`` stand-in for the case that must not raise."""
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+
+class TestTheRouteOnARealOwner:
+    """The heartbeat as an actual HTTP request against the owner's own app.
+
+    Built the way `daemon_owner._build_server` builds it, because the thing
+    under test is a custom route and those are mounted *outside* the
+    authentication middleware. Measured on 3.4.4 and recorded next to the
+    stand-down route: an unauthenticated POST to a custom path is served. Every
+    check on this route is therefore its own, and a test that never sends a
+    request would not see it.
+    """
+
+    HOST = "127.0.0.1"
+    TOKEN = "the-owners-token"
+
+    @staticmethod
+    def _owner_app(token: str, host: str, port: int):
+        from linkedin_mcp_server.daemon_owner import create_owner_server
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        return create_owner_server(
+            config=AppConfig(), token=token, host=host, port=port, stand_down=None
+        )
+
+    @pytest.fixture
+    def serving(self):
+        """The owner's real ASGI app, driven without a socket.
+
+        No uvicorn and no port: the owner's server object carries the app that
+        would be served, and the question here is where the route sits relative
+        to the authentication middleware, which is a property of that app. The
+        real process also runs a lifespan that opens Chromium, and a route test
+        has no business starting a browser.
+        """
+        from linkedin_mcp_server import daemon_liveness
+
+        port = 51234
+        server = self._owner_app(self.TOKEN, self.HOST, port)
+        return (
+            server.config.app,
+            f"http://{self.HOST}:{port}",
+            daemon_liveness.get_liveness(),
+        )
+
+    @staticmethod
+    async def _post(
+        app: Any, base: str, *, token: str | None, marker: str | None
+    ) -> int:
+        import httpx
+
+        from linkedin_mcp_server.daemon_liveness import HEARTBEAT_PATH
+
+        headers = {}
+        if token is not None:
+            headers["Authorization"] = f"Bearer {token}"
+        if marker is not None:
+            headers[CALL_HEADER] = marker
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=base, trust_env=False
+        ) as client:
+            response = await client.post(HEARTBEAT_PATH, headers=headers)
+            return response.status_code
+
+    async def test_a_beat_without_the_token_is_refused_and_does_not_count(
+        self, serving
+    ):
+        # The failure this route could quietly have: anything on the machine, and
+        # any page the user's browser visits, keeping a call alive that its own
+        # frontend abandoned.
+        app, base, liveness = serving
+        marker = new_call_id()
+        task = MagicMock()
+        liveness.watch(marker, task)
+        _last_heard(liveness, marker, EXPIRY_SECONDS + 1)
+
+        assert await self._post(app, base, token=None, marker=marker) == 401
+        assert (
+            await self._post(app, base, token="the-wrong-token", marker=marker) == 401
+        )
+
+        assert liveness.cancel_the_abandoned() == [marker]
+
+    async def test_a_beat_with_the_token_keeps_the_call(self, serving):
+        app, base, liveness = serving
+        marker = new_call_id()
+        liveness.watch(marker, MagicMock())
+        _last_heard(liveness, marker, EXPIRY_SECONDS + 1)
+
+        assert await self._post(app, base, token=self.TOKEN, marker=marker) == 200
+
+        assert liveness.cancel_the_abandoned() == []
+
+    async def test_a_beat_naming_no_call_is_a_bad_request(self, serving):
+        app, base, _liveness = serving
+        assert await self._post(app, base, token=self.TOKEN, marker=None) == 400
+        assert await self._post(app, base, token=self.TOKEN, marker="nonsense") == 400
+
+
+class TestTheOwnersOwnLoop:
+    """That anything expires at all, which no rule above establishes.
+
+    Every test further up drives `cancel_the_abandoned` itself. If the owner
+    never called it, all of them would still pass and no call would ever be
+    stopped in production. This is the wiring, and it is the part that is easy
+    to leave out.
+    """
+
+    async def test_the_serving_loop_expires_abandoned_calls(self):
+        from linkedin_mcp_server import daemon_liveness
+        from linkedin_mcp_server.daemon_owner import _serve_until_stopped
+
+        liveness = daemon_liveness.get_liveness()
+        marker = new_call_id()
+        abandoned = asyncio.create_task(asyncio.sleep(3600))
+        liveness.watch(marker, abandoned)
+        _last_heard(liveness, marker, EXPIRY_SECONDS + 1)
+
+        # A server that stops on its own once the loop has had a tick or two.
+        async def serves() -> None:
+            await asyncio.sleep(0.35)
+
+        serving = asyncio.create_task(serves())
+        await _serve_until_stopped(MagicMock(), serving, [])
+
+        assert abandoned.cancelled(), "the owner never expired an abandoned call"
+        assert marker not in liveness._waiting
+
+
+class TestTheMarkerSurvivesTheRealClient:
+    """That the header the middleware sets is still there when it goes out.
+
+    Every other test stops at the transport object. The client factory in
+    between is the owner's own, it is shared with the heartbeat requests, and it
+    is free to rebuild the headers it is given: a version of it that dropped
+    this one would leave the owner seeing every real tool call unmarked, with
+    all the rules above still green.
+    """
+
+    def test_the_owners_client_factory_keeps_the_call_header(self):
+        from linkedin_mcp_server.daemon_owner import direct_async_http_client
+
+        marker = new_call_id()
+        client = direct_async_http_client(headers={CALL_HEADER: marker})
+
+        assert client.headers.get(CALL_HEADER) == marker
+
+    async def test_the_header_reaches_the_wire(self):
+        import httpx
+
+        from linkedin_mcp_server.daemon_owner import direct_async_http_client
+
+        marker = new_call_id()
+        seen: dict[str, str] = {}
+
+        def record(request: httpx.Request) -> httpx.Response:
+            seen.update(request.headers)
+            return httpx.Response(200)
+
+        client = direct_async_http_client(headers={CALL_HEADER: marker})
+        client._transport = httpx.MockTransport(record)
+        async with client:
+            await client.post("http://127.0.0.1:1/mcp")
+
+        assert seen.get(CALL_HEADER) == marker
+
+
+class TestAnOwnerThatWasNotRunning:
+    """A stall in the owner is not a frontend that stopped waiting.
+
+    The expiry reads elapsed time, and elapsed time cannot tell "nobody asked
+    for this call" from "this process was not scheduled to hear them". A laptop
+    that slept, a machine under load, or a long synchronous stretch all look
+    like abandonment on the tick that follows, and cancelling then stops calls
+    whose frontends were beating throughout.
+    """
+
+    def test_a_late_scan_expires_nothing(self):
+        liveness = CallLiveness()
+        task = MagicMock()
+        liveness.watch("v1.a", task)
+        _last_heard(liveness, "v1.a", EXPIRY_SECONDS + 5)
+
+        # A first scan establishes when the owner last looked, and a second one
+        # arrives far too late for the gap to be anything but the owner itself.
+        liveness._last_scan = liveness._last_scan or 0.0
+        import time as clock
+
+        liveness._last_scan = clock.monotonic() - 30
+
+        assert liveness.cancel_the_abandoned() == []
+        task.cancel.assert_not_called()
+
+    def test_the_next_scan_after_a_stall_judges_normally(self):
+        # The stall buys one cycle, not immunity: a call that is still unheard
+        # by the following scan is expired as usual.
+        import time as clock
+
+        liveness = CallLiveness()
+        task = MagicMock()
+        liveness.watch("v1.a", task)
+        _last_heard(liveness, "v1.a", EXPIRY_SECONDS + 5)
+        liveness._last_scan = clock.monotonic() - 30
+        assert liveness.cancel_the_abandoned() == []
+
+        _last_heard(liveness, "v1.a", EXPIRY_SECONDS + 1)
+        assert liveness.cancel_the_abandoned() == ["v1.a"]
+        task.cancel.assert_called_once()
+
+
+class TestTellingShutdownFromAbandonment:
+    """Which cancellation this was, when both arrive at once."""
+
+    async def test_a_shutdown_that_races_the_expiry_is_still_a_shutdown(
+        self, monkeypatch
+    ):
+        # The ordering that makes this hard: the outer task is cancelled first,
+        # and before that reaches the child the expiry scan removes the entry and
+        # cancels the same child. Reading only "the child was cancelled and its
+        # entry is gone" then reports a shutdown as an abandoned call.
+        from linkedin_mcp_server import daemon_liveness
+
+        marker = new_call_id()
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_http_headers",
+            lambda **_kw: {CALL_HEADER: marker},
+        )
+        liveness = daemon_liveness.get_liveness()
+        started = asyncio.Event()
+
+        async def call_next(_context: Any) -> str:
+            started.set()
+            await asyncio.sleep(3600)
+            return "never reached"  # pragma: no cover
+
+        context = MagicMock()
+        context.message.name = "get_person_profile"
+        running = asyncio.create_task(
+            OwnerCallLivenessMiddleware().on_call_tool(
+                context,
+                call_next,  # ty: ignore
+            )
+        )
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        running.cancel()
+        _last_heard(liveness, marker, EXPIRY_SECONDS + 1)
+        liveness.cancel_the_abandoned()
+
+        with pytest.raises(asyncio.CancelledError):
+            await running
+
+
+class TestAnAbandonedCallStillExpiresUnderTheLoop:
+    """That the stall rule protects the owner without disabling the expiry.
+
+    The rule reads the gap between the owner's own scans, so a threshold set
+    below the poll interval would classify every ordinary tick as a stall and
+    nothing would ever be cancelled. Every other test here calls
+    `cancel_the_abandoned` itself and never sees a second scan, so all of them
+    stay green against exactly that.
+    """
+
+    async def test_a_call_that_goes_quiet_is_cancelled_by_the_running_loop(self):
+        from linkedin_mcp_server import daemon_liveness
+        from linkedin_mcp_server.daemon_owner import _serve_until_stopped
+
+        liveness = daemon_liveness.get_liveness()
+        marker = new_call_id()
+        abandoned = asyncio.create_task(asyncio.sleep(3600))
+        liveness.watch(marker, abandoned)
+
+        # Driven by events rather than by sleeping for a plausible-looking time.
+        # An earlier version aged the call after a fixed pause and raced the
+        # loop's own lifetime under load.
+        stop = asyncio.Event()
+
+        async def serves() -> None:
+            await stop.wait()
+
+        serving = asyncio.create_task(serves())
+        loop = asyncio.create_task(_serve_until_stopped(MagicMock(), serving, []))
+        try:
+            # The first scan has to be behind us, so the decision is taken on a
+            # later tick with a real and short gap in front of it.
+            while liveness._last_scan is None:
+                await asyncio.sleep(0.01)
+            _last_heard(liveness, marker, EXPIRY_SECONDS + 1)
+
+            for _ in range(500):
+                if abandoned.cancelled():
+                    break
+                await asyncio.sleep(0.01)
+        finally:
+            stop.set()
+            await loop
+
+        assert abandoned.cancelled(), "an abandoned call outlived the owner's loop"


### PR DESCRIPTION
Cancellation does not cross the daemon's loopback hop, so a frontend that gives
up leaves the owner driving the browser for nobody. Measured in this repository:
the client was answered at 0.66s with an error and the effect landed 0.7s later,
against a LinkedIn account nobody was watching. The owner cannot tell the
difference, because a call somebody abandoned looks exactly like one somebody
wants.

The frontend now says it is still waiting, every two seconds, on an
authenticated control route, and the owner cancels a call it has not heard about
in ten. The identifier travels in a header rather than in MCP call metadata,
because it has to reach the owner on the heartbeat as well as on the call and
only one of those is an MCP message. A call and its heartbeats are bound to one
owner together: with no component cache every call re-lists first, so a
replacement adopted in between would otherwise send the request to one owner and
the beats to another, and the owner running the call would cancel it for silence
it never had a chance to hear.

The middleware sits outside the serializing one. A call spends most of its life
queued, and a frontend that gives up while its call is still waiting its turn is
the commonest way to end up with work nobody wants; inside, a call would only
become cancellable once it already had the browser.

A stall in the owner is not abandonment. A gap between the owner's own expiry
scans of ten times its poll interval means the process itself was not
scheduled — a slept laptop, heavy load, a long synchronous stretch — and every
clock restarts rather than expiring calls whose frontends were beating
throughout. A shutdown that races the expiry is reported as a shutdown, told
apart by the same `cancelling()` counter `browser_lifespan` already uses.

There is no `PROTOCOL_VERSION` bump, and both invariant comments now say why
instead of being quietly contradicted. A bump makes an old owner unreadable, and
an owner nobody can read is one nobody can ask to stand down, so the turnover an
upgrade depends on would break for every owner already installed. The additions
are optional in both directions instead: a new frontend meeting an old owner
gets 404 and proceeds unheard, and an old frontend sends no marker, which counts
as active and is never cancelled. Both directions are tested rather than
asserted.

The cadence and the expiry were measured rather than chosen. A heartbeat round
trip costs 0.9ms against an idle owner and 1.8ms while it drives Chromium; a
detached process was at most 3.6ms late over 25 beats; and the longest the
owner's synchronous extraction holds its event loop is 130ms, on a page far
larger than a real one. Ten seconds is five cadences and about seventy times the
worst delay measured, and the test pins the relationship rather than the numbers.

Each rule is caught by one mutation and nothing else: dropping the route's token
check, dispatching before the first beat, leaking the beater task, one
process-wide identifier, watching an unmarked call, following the backend to a
replacement mid-call, treating 404 as support, stripping the header in the
client factory, and omitting the expiry from the owner's serving loop. Two of
those tests were vacuous when first written, and only the mutations said so. The
full suite, ruff and ty pass.

See also: #606

## Synthetic prompt

> A frontend that gives up leaves the daemon owner scraping, because
> cancellation is not forwarded across the hop. Add heartbeats: an authenticated
> `POST /control/heartbeat` on the owner, a call identifier in a header that
> reaches the owner on both the beat and the call, a frontend middleware that
> beats while it waits and stops the moment it does not, and an owner middleware
> outside the serializing one that cancels a call nobody has asked about.
> Measure the cadence and the expiry instead of choosing them. Decide the
> `PROTOCOL_VERSION` question explicitly and make the invariant comments say
> what you decided.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
