### PR TITLE
feat(daemon): Let an owner exit once nothing needs it

### DIFF
--- a/linkedin_mcp_server/daemon_liveness.py
+++ b/linkedin_mcp_server/daemon_liveness.py
@@ -134,6 +134,18 @@ class CallLiveness:
 
     _waiting: dict[str, _Waiting] = field(default_factory=dict)
 
+    #: How many calls are running, marked or not. Separate from ``_waiting`` on
+    #: purpose: an unmarked call cannot be cancelled, but it is emphatically not
+    #: idleness, and an owner that exited during one would cut off the very
+    #: frontends this build promises to keep serving.
+    _in_flight: int = 0
+
+    #: When this owner last did anything for anybody, or ``None`` while it is
+    #: still starting. Idleness is only meaningful once the endpoint is
+    #: published: before that nobody could have called, and an owner that
+    #: counted its own startup as idle time would exit during it.
+    _quiet_since: float | None = None
+
     #: When the owner last got round to asking who was still waiting. Compared
     #: against the next scan so a stall in this process is not charged to the
     #: frontends.
@@ -147,6 +159,45 @@ class CallLiveness:
         deadline it has to catch up with.
         """
         self._waiting[call_id] = _Waiting(task=task, last_heard=time.monotonic())
+
+    def call_started(self) -> None:
+        """Note a call arriving, whether or not this build can identify it."""
+        self._in_flight += 1
+        self._quiet_since = None
+
+    def call_finished(self) -> None:
+        """Note a call ending, however it ended."""
+        self._in_flight = max(0, self._in_flight - 1)
+        if self._in_flight == 0:
+            self._quiet_since = time.monotonic()
+
+    def the_endpoint_is_live(self) -> None:
+        """Start the idle clock, once there is something to be idle *at*.
+
+        Called where the descriptor is published rather than at startup. An
+        owner spends its first seconds importing and launching Chromium, and
+        counting that as quiet would let a short timeout expire before the
+        frontend that asked for this owner had any way to reach it.
+        """
+        if self._quiet_since is None and self._in_flight == 0:
+            self._quiet_since = time.monotonic()
+
+    def quiet_for(self) -> float | None:
+        """Seconds since this owner last had anything to do, if it is free now.
+
+        ``None`` while a call is running, and while the endpoint has not been
+        published, which are the two states where the question does not apply.
+
+        The ``_in_flight`` half of that test is redundant today and is kept
+        anyway, which is worth saying rather than leaving to be discovered: what
+        actually protects a running call is :meth:`call_started` clearing the
+        clock, and removing this check breaks no test. It is here so the answer
+        stays right if the two ever drift, and it should not be counted as a
+        rule anything verifies.
+        """
+        if self._in_flight > 0 or self._quiet_since is None:
+            return None
+        return time.monotonic() - self._quiet_since
 
     def heard(self, call_id: str) -> bool:
         """Note that somebody is still waiting. False if this call is unknown.
@@ -222,6 +273,8 @@ def get_liveness() -> CallLiveness:
 def reset_liveness_for_testing() -> None:
     """Forget every watched call, so one test cannot leak into the next."""
     _liveness._waiting.clear()
+    _liveness._in_flight = 0
+    _liveness._quiet_since = None
     _liveness._last_scan = None
 
 
@@ -249,33 +302,46 @@ class OwnerCallLivenessMiddleware(Middleware):
         from fastmcp.server.dependencies import get_http_headers
 
         call_id = call_id_in(get_http_headers().get(CALL_HEADER))
-        if call_id is None:
-            return await call_next(context)
 
-        # A task rather than a plain await, because cancelling is the whole
-        # point and there is nothing to cancel until the work has a handle.
-        # `create_task` copies the current context, so everything the call reads
-        # from it downstream is the same as it would have been.
-        running: asyncio.Task[ToolResult] = asyncio.ensure_future(call_next(context))
-        _liveness.watch(call_id, running)
+        # Counted before anything else, and counted even when the marker is
+        # missing. Cancelling an unidentified call is not safe, but calling it
+        # idleness is worse: the owner would exit in the middle of one, and the
+        # frontends that send no marker are exactly the older ones this build
+        # promises to keep serving.
+        _liveness.call_started()
         try:
-            return await running
-        except asyncio.CancelledError:
-            outer = asyncio.current_task()
-            if outer is not None and outer.cancelling():
-                # Somebody cancelled *this* middleware, which is shutdown rather
-                # than an abandoned call. Reporting it as one would tell whoever
-                # asked us to stop that the call merely lost its client. The
-                # same counter tells the two apart in `browser_lifespan`, for
-                # the same reason.
+            if call_id is None:
+                return await call_next(context)
+
+            # A task rather than a plain await, because cancelling is the whole
+            # point and there is nothing to cancel until the work has a handle.
+            # `create_task` copies the current context, so everything the call
+            # reads from it downstream is the same as it would have been.
+            running: asyncio.Task[ToolResult] = asyncio.ensure_future(
+                call_next(context)
+            )
+            _liveness.watch(call_id, running)
+            try:
+                return await running
+            except asyncio.CancelledError:
+                outer = asyncio.current_task()
+                if outer is not None and outer.cancelling():
+                    # Somebody cancelled *this* middleware, which is shutdown
+                    # rather than an abandoned call. Reporting it as one would
+                    # tell whoever asked us to stop that the call merely lost
+                    # its client. The same counter tells the two apart in
+                    # `browser_lifespan`, for the same reason.
+                    raise
+                if running.cancelled() and call_id not in _liveness._waiting:
+                    # Ours: this call was expired above. Reported as an error
+                    # rather than re-raised, so the cancellation stops here
+                    # instead of travelling on into a server nobody asked to
+                    # shut down.
+                    raise ToolError(
+                        "Stopped because the client that asked for it stopped waiting"
+                    ) from None
                 raise
-            if running.cancelled() and call_id not in _liveness._waiting:
-                # Ours: this call was expired above. Reported as an error rather
-                # than re-raised, so the cancellation stops here instead of
-                # travelling on into a server nobody asked to shut down.
-                raise ToolError(
-                    "Stopped because the client that asked for it stopped waiting"
-                ) from None
-            raise
+            finally:
+                _liveness.release(call_id)
         finally:
-            _liveness.release(call_id)
+            _liveness.call_finished()

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -417,6 +417,11 @@ async def _serve(
         )
 
         daemon_descriptor.publish(auth_root, descriptor, token)
+        # The idle clock starts here rather than at startup: before the
+        # descriptor is published nobody can reach this owner, and counting the
+        # import and the browser launch as quiet time would let a short timeout
+        # expire before the frontend that asked for it could call.
+        get_liveness().the_endpoint_is_live()
         # Only now, and only while the lock is held: a token file that is not
         # this generation's belongs to an owner that is gone, because a live one
         # would be holding the lock this process has.
@@ -435,7 +440,9 @@ async def _serve(
         raise
 
     del lock  # held for the process lifetime; named to say so
-    await _serve_until_stopped(server, serving, turnover)
+    await _serve_until_stopped(
+        server, serving, turnover, config.browser.browser_idle_timeout_seconds
+    )
     return 0
 
 
@@ -457,7 +464,10 @@ _FAILED_STARTUP_SHUTDOWN_SECONDS = 10.0
 
 
 async def _serve_until_stopped(
-    server: Any, serving: asyncio.Task[None], turnover: list[str]
+    server: Any,
+    serving: asyncio.Task[None],
+    turnover: list[str],
+    idle_timeout: float = 0.0,
 ) -> None:
     """Hold the endpoint open until it stops, or until asked to give way.
 
@@ -502,7 +512,24 @@ async def _serve_until_stopped(
         # Cheap enough to do on the same tick as the two questions above: one
         # dictionary scan over the calls in flight, on a process that is already
         # polling. A timer of its own would be a second thing to shut down.
-        get_liveness().cancel_the_abandoned()
+        liveness = get_liveness()
+        liveness.cancel_the_abandoned()
+        # And the third reason to go, after wedge and turnover. An owner holds
+        # the daemon lock for the machine's uptime otherwise, having closed the
+        # browser hours ago: the process is what the next election has to wait
+        # for, not the Chromium it is no longer running.
+        #
+        # `quiet_for` answers None while any call is in flight, marked or not,
+        # so this cannot cut one off. The stale descriptor is left behind
+        # deliberately: the next election probes it, is refused, and elects a
+        # replacement, whereas deleting it here would race whoever publishes
+        # next.
+        quiet = liveness.quiet_for()
+        if idle_timeout > 0 and quiet is not None and quiet >= idle_timeout:
+            logger.info("Nothing has needed the browser in %.0fs; exiting", quiet)
+            server.should_exit = True
+            await _stop_within(serving, _STAND_DOWN_SHUTDOWN_SECONDS)
+            return
         await asyncio.sleep(_STAND_DOWN_POLL_SECONDS)
     await serving
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,11 @@ def reset_singletons():
     from linkedin_mcp_server.server_role import reset_process_role_for_testing
 
     reset_bootstrap_for_testing()
-    # The owner's call tracker is process state like the rest. Left standing,
-    # the moment of one test's last expiry scan is the baseline for the next,
-    # and a gap of seconds between them reads as an owner that was not
-    # running, so nothing expires.
+    # The owner's call tracker is process state like the rest. Left standing, a
+    # call one test watched is still in flight for the next, which reads as an
+    # owner that is never idle, and the moment of one test's last expiry scan
+    # becomes the baseline for the next, where a gap of seconds reads as an
+    # owner that was not running.
     reset_liveness_for_testing()
     reset_browser_for_testing()
     reset_leases_for_testing()

--- a/tests/test_daemon_liveness.py
+++ b/tests/test_daemon_liveness.py
@@ -629,6 +629,203 @@ class TestTheOwnersOwnLoop:
         assert marker not in liveness._waiting
 
 
+class TestGoingAwayWhenNobodyNeedsIt:
+    """The owner's third reason to exit, after wedge and turnover.
+
+    Without it the process holds the daemon lock for the machine's uptime,
+    having closed the browser hours earlier. What the next election waits for is
+    the process, not the Chromium it stopped running.
+    """
+
+    @staticmethod
+    async def _run_loop(idle_timeout: float, *, ticks: float = 0.4) -> bool:
+        """Run the owner's loop briefly. True if it decided to exit."""
+        from linkedin_mcp_server.daemon_owner import _serve_until_stopped
+
+        server = MagicMock()
+        server.should_exit = False
+
+        async def serves() -> None:
+            await asyncio.sleep(ticks)
+
+        serving = asyncio.create_task(serves())
+        await _serve_until_stopped(server, serving, [], idle_timeout)
+        return bool(server.should_exit)
+
+    async def test_an_owner_nobody_ever_called_still_exits(self):
+        # Idleness counted from the first *call* rather than from the endpoint
+        # going live would leave an owner that was started and then never used
+        # running forever, which is the commonest way to reach this state: an
+        # election starts one, and the frontend that asked dies before calling.
+        from linkedin_mcp_server import daemon_liveness
+
+        liveness = daemon_liveness.get_liveness()
+        liveness.the_endpoint_is_live()
+        liveness._quiet_since = liveness._quiet_since - 60  # ty: ignore
+
+        assert await self._run_loop(idle_timeout=5.0) is True
+
+    async def test_it_does_not_exit_before_the_endpoint_is_published(self):
+        # The clock has not started. An owner spends its first seconds importing
+        # and launching Chromium, and a short timeout would otherwise fire
+        # during startup, before the frontend that asked for it could call.
+        from linkedin_mcp_server import daemon_liveness
+
+        assert daemon_liveness.get_liveness().quiet_for() is None
+        assert await self._run_loop(idle_timeout=0.05) is False
+
+    @pytest.mark.parametrize("marked", [True, False], ids=["marked", "unmarked"])
+    async def test_a_call_in_flight_holds_the_door(
+        self, marked: bool, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Both cases matter and only one is obvious. An unmarked call cannot be
+        # cancelled, and calling it idleness would exit in the middle of one,
+        # cutting off exactly the older frontends this build promises to serve.
+        #
+        # Driven through the middleware rather than by calling the tracker here.
+        # An earlier version of this test registered the call itself and stayed
+        # green when the middleware stopped counting unmarked calls at all,
+        # which is the whole thing it exists to catch.
+        from linkedin_mcp_server import daemon_liveness
+
+        headers = {CALL_HEADER: new_call_id()} if marked else {}
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_http_headers", lambda **_kw: headers
+        )
+        liveness = daemon_liveness.get_liveness()
+        liveness.the_endpoint_is_live()
+        liveness._quiet_since = liveness._quiet_since - 3600  # ty: ignore
+
+        running = asyncio.Event()
+
+        async def call_next(_context: Any) -> str:
+            running.set()
+            await asyncio.sleep(3600)
+            return "never reached"  # pragma: no cover
+
+        context = MagicMock()
+        context.message.name = "get_person_profile"
+        call = asyncio.create_task(
+            OwnerCallLivenessMiddleware().on_call_tool(
+                context,
+                call_next,  # ty: ignore
+            )
+        )
+        await asyncio.wait_for(running.wait(), timeout=5)
+
+        try:
+            assert liveness.quiet_for() is None, "a running call read as idleness"
+            assert await self._run_loop(idle_timeout=0.05) is False
+        finally:
+            call.cancel()
+
+    async def test_the_clock_restarts_when_a_call_ends(self):
+        from linkedin_mcp_server import daemon_liveness
+
+        liveness = daemon_liveness.get_liveness()
+        liveness.the_endpoint_is_live()
+        liveness._quiet_since = liveness._quiet_since - 60  # ty: ignore
+
+        liveness.call_started()
+        liveness.call_finished()
+
+        # Quiet again, but only just: the wait starts from the call rather than
+        # from whenever the endpoint went live.
+        quiet = liveness.quiet_for()
+        assert quiet is not None and quiet < 1
+        assert await self._run_loop(idle_timeout=5.0) is False
+
+    async def test_a_zero_timeout_keeps_the_owner_forever(self):
+        # The documented way to switch it off, and the same value that already
+        # disables the browser's own idle close.
+        from linkedin_mcp_server import daemon_liveness
+
+        liveness = daemon_liveness.get_liveness()
+        liveness.the_endpoint_is_live()
+        liveness._quiet_since = liveness._quiet_since - 86400  # ty: ignore
+
+        assert await self._run_loop(idle_timeout=0.0) is False
+
+
+#: A frontend that elects an owner with a short idle timeout and then leaves.
+#: Its own script rather than the election suite's, because that one builds an
+#: `AppConfig()` directly and ignores the environment: an idle timeout set as a
+#: variable never reached the owner, and the first version of the test below
+#: watched an owner running on the 600 second default and called the feature
+#: broken.
+_ELECT_WITH_IDLE_TIMEOUT = """
+import json
+import sys
+from pathlib import Path
+
+from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.daemon_election import obtain_owner
+
+profile = Path(sys.argv[1])
+config = AppConfig()
+config.browser.user_data_dir = str(profile)
+config.browser.browser_idle_timeout_seconds = float(sys.argv[2])
+
+outcome = obtain_owner(profile.parent, profile, config, deadline_seconds=90)
+attachment = outcome.attachment_lookup.attachment
+print(json.dumps({
+    "started": outcome.started_owner,
+    "pid": attachment.descriptor.pid if attachment else None,
+}))
+"""
+
+
+@pytest.mark.slow
+class TestARealOwnerGoingAway:
+    """The idle exit with a real detached process on the other end.
+
+    Nothing in one interpreter can see this. The rules above are all driven by
+    calling the tracker or the loop directly, so every one of them stays green
+    with the clock never started at the publish site, and the owner would then
+    hold the daemon lock for the machine's uptime having closed the browser
+    hours before. That line is the whole feature, and this is the only test that
+    touches it.
+    """
+
+    def test_an_idle_owner_exits(self, tmp_path):
+        import json
+        import os
+        import subprocess
+        import sys
+        import time as clock
+
+        from test_daemon_election import _REPO_ROOT, _alive, _stop
+
+        profile = tmp_path / "state"
+        profile.mkdir()
+
+        # Short enough to watch, and comfortably longer than the startup it must
+        # not count as quiet.
+        idle = 4.0
+        started = subprocess.run(
+            [sys.executable, "-c", _ELECT_WITH_IDLE_TIMEOUT, str(profile), str(idle)],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+            cwd=_REPO_ROOT,
+            timeout=180,
+        )
+        assert started.returncode == 0, started.stderr
+        result = json.loads(started.stdout.strip().splitlines()[-1])
+        owner = result["pid"]
+        assert isinstance(owner, int) and _alive(owner), result
+
+        try:
+            deadline = clock.monotonic() + idle * 8
+            while clock.monotonic() < deadline and _alive(owner):
+                clock.sleep(0.25)
+            assert not _alive(owner), (
+                "an owner nobody called kept running past its idle timeout"
+            )
+        finally:
+            _stop(owner)
+
+
 class TestTheMarkerSurvivesTheRealClient:
     """That the header the middleware sets is still there when it goes out.
 


### PR DESCRIPTION
An owner closes the browser when it goes idle and then keeps the daemon lock for
the machine's uptime. What the next election waits for is the process, not the
Chromium it stopped running hours ago.

It now exits on a third condition, after wedge and turnover, reusing
`browser_idle_timeout_seconds` rather than adding a second dial: that setting
already says how long the owner keeps the browser, and a separate one would let
the browser close while the process stayed, which is the same gap with an extra
knob on it. Zero still disables it.

The idle clock starts where the descriptor is published, not at startup. Before
that nobody can reach this owner, and counting the import and the browser launch
as quiet time would let a short timeout fire before the frontend that asked for
the owner could call it.

Every call holds the door open, marked or not. An unmarked call cannot be
cancelled, but calling it idleness would exit in the middle of one and cut off
exactly the older frontends the heartbeat change promises to keep serving. That
accounting is new here; the previous change tracked only the calls it could
identify.

The stale descriptor is left behind deliberately. The next election probes it,
is refused, and elects a replacement, whereas deleting it here would race
whoever publishes next.

The real-process test is the one that matters, and it earned its place twice.
Every in-process rule stayed green with the clock never started at the publish
site, because each of them drives the tracker directly. And the first version of
that test watched an owner running on the 600 second default, because the
election suite's harness builds an `AppConfig()` and ignores the environment:
the feature worked and the test was lying. It elects through its own script now
and fails if either the publish-site call or the exit branch is removed.

One redundancy is documented rather than removed: the in-flight check inside
`quiet_for()` is belt-and-braces, since `call_started()` already clears the
clock, and removing it breaks no test. It should not be read as a rule anything
verifies.

The full suite, the slow test, ruff and ty pass.

See also: #606

## Synthetic prompt

> The daemon owner never exits on idle: it closes the browser and keeps the lock
> for the machine's uptime. Add a third exit condition to its serving loop after
> wedge and turnover, reusing `browser_idle_timeout_seconds` with zero as the
> off switch. Start the idle clock where the descriptor is published rather than
> at startup, and count every call as activity including the ones with no
> heartbeat marker, since those cannot be cancelled but are not idleness either.
> Leave the stale descriptor for the next election to probe. Cover it with a
> real detached process, because nothing in one interpreter can see the wiring.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
