### PR TITLE
test(daemon): Ask the child, not the worker, who holds the lock

### DIFF
--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -512,39 +512,93 @@ class TestFork:
             os.waitpid(pid, 0)
 
 
+#: The whole adoption, in one clean interpreter: take the lock, hand a copy on,
+#: adopt it, launch an unrelated child that inherits descriptors, let go, and ask
+#: whether anyone can take the lock now.
+#:
+#: All of it in a child rather than in the test, and that is the point. `flock`
+#: is held against the inode, so *any* holder anywhere answers this question, not
+#: only the descriptor under test. Asked from a pytest worker that has run
+#: thousands of other tests, the answer is about that worker as much as about the
+#: adoption. A fresh interpreter holds only what this scenario gave it, which
+#: takes the worker out of the result — whether or not the worker is what made
+#: the earlier version of this test fail intermittently on Linux. That was never
+#: reproduced and is not claimed here.
+_ADOPT_THEN_LAUNCH_AN_UNRELATED_CHILD = """
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    import linkedin_mcp_server.daemon_descriptor as daemon_descriptor
+    from linkedin_mcp_server.daemon_lock import DaemonLock
+
+    daemon_descriptor._account_home = lambda: Path(os.environ["HOME"])
+    auth_root = Path(sys.argv[1])
+
+    original = DaemonLock(auth_root)
+    assert original.try_acquire(), "nothing else should hold this lock"
+    inherited = original.inheritable_copy()
+    original.release()
+
+    adopter = DaemonLock(auth_root)
+    adopter.adopt(inherited)
+
+    # Launched the way a browser is, inheriting whatever is still inheritable.
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.stdin.readline()"],
+        stdin=subprocess.PIPE,
+        close_fds=False,
+    )
+    try:
+        adopter.release()
+        # Through the production API rather than a raw flock, so a `try_acquire`
+        # that refused for its own reasons would be caught here too.
+        successor = DaemonLock(auth_root)
+        print("FREE" if successor.try_acquire() else "HELD")
+    finally:
+        child.kill()
+        child.wait()
+"""
+
+
 class TestAdoptedDescriptors:
+    """That an adopted descriptor is inheritable for exactly one launch.
+
+    Measured before the fix: it stayed inheritable, so an unrelated child
+    launched afterwards, a Chromium among them, inherited the lock and kept it
+    held after the owner exited, leaving every client looking at a daemon that
+    was no longer there.
+    """
+
     @posix_handoff
-    def test_an_adopted_lock_does_not_leak_to_later_children(self, tmp_path: Path):
-        # The descriptor is marked inheritable for exactly one launch. Measured
-        # before the fix: it stayed that way, so an unrelated child launched
-        # afterwards inherited the lock and kept it held after the owner exited,
-        # leaving every client looking at a daemon that was no longer there.
+    def test_adopting_takes_the_inheritable_flag_back(self, tmp_path: Path):
+        # The invariant itself, read off the descriptor rather than inferred from
+        # what a child does with it. Nothing is spawned and no lock is contended,
+        # so there is nothing here for another process to disturb.
         original = DaemonLock(tmp_path)
         assert original.try_acquire()
         inherited = original.inheritable_copy()
         original.release()
+        assert os.get_inheritable(inherited), "the copy is for exactly one launch"
 
         adopter = DaemonLock(tmp_path)
         adopter.adopt(inherited)
-
-        # Launched the way a browser would be, inheriting open descriptors.
-        child = subprocess.Popen(
-            [sys.executable, "-c", "import time; time.sleep(3)"], close_fds=False
-        )
         try:
+            assert not os.get_inheritable(inherited), (
+                "an adopted descriptor stays inheritable and leaks into any later child"
+            )
+        finally:
             adopter.release()
 
-            # Asked by electing rather than by probing. daemon_is_running takes
-            # a lock to answer, so under a loaded parallel test run it competes
-            # with whatever else is touching this file and can report a holder
-            # that is really another probe. Election is the question that
-            # matters anyway: if the child still held the lock, this would fail.
-            successor = DaemonLock(tmp_path)
-            assert successor.try_acquire(), "the child kept the lock alive"
-            successor.release()
-        finally:
-            child.kill()
-            child.wait()
+    @posix_handoff
+    def test_a_later_child_does_not_keep_the_lock_alive(self, tmp_path: Path):
+        # The consequence, end to end and away from this process entirely.
+        result = _run_child(_ADOPT_THEN_LAUNCH_AN_UNRELATED_CHILD, str(tmp_path))
+
+        assert result.stdout.strip() == "FREE", (
+            f"the child kept the lock alive\n{result.stderr}"
+        )
 
 
 class TestReleaseSemantics:


### PR DESCRIPTION
`test_an_adopted_lock_does_not_leak_to_later_children` failed intermittently in
the parallel job on Linux: three times in about eight runs across two branches,
always passing when re-run, and never failing when the file was run on its own.
It was not reproducible in seven local configurations, including Linux at the
runner's worker count under the exact CI command.

**The mechanism is not established, and this does not claim one.** The lock path
is isolated twice over — the state root lives under the test's own `tmp_path`,
and the directory under it is keyed by a hash of the auth root's device and
inode — so two tests cannot collide on it, and an ordinary open descriptor does
not block `flock` either.

What can be said is where the test asked its question. `flock` is held against
the inode, so "can anyone take this lock" is answered by every holder anywhere,
not only by the descriptor under test. Asked from a pytest worker that has run
thousands of other tests, in a session whose composition decides what that
worker has open, the answer is about the worker as much as about the adoption.

So the scenario now runs in a clean interpreter: take the lock, hand a copy on,
adopt it, launch an unrelated child that inherits descriptors, let go, and ask
whether anyone can take the lock. Nothing but this scenario exists in that
process. The suite already had a helper for exactly this, used by the ownership
tests.

Alongside it, the invariant is asserted directly: after `adopt()`, the
descriptor is no longer inheritable. That one spawns nothing and contends for
nothing, so there is nothing about it left to disturb.

Two mutations, two failures. Removing `set_inheritable(False)` from `adopt()`
fails both. A `try_acquire()` that refuses whenever the lock file already exists
fails the end-to-end one, which is why that half asks through the production API
rather than a raw `flock`: an earlier draft used `flock` and accepted that
implementation.

Verified stable across ten local runs of the pair, the full local suite, and
five Linux runs at the runner's worker count.

See also: #606

## Synthetic prompt

> A test in `tests/test_daemon_lock.py` flakes on Linux CI under xdist and
> cannot be reproduced locally. Work out why it is fragile rather than retrying
> it, and replace it with tests that cover the same property deterministically.
> Do not assert a mechanism you could not reproduce. Prove the replacement still
> catches the bug it was written for by removing the fix and watching it fail.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
