### PR TITLE
fix(scraping): Surface rate-limit signals

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -55,18 +55,38 @@ _NAV_DELAY = 2.0
 # Backoff before retrying a temporarily blocked page
 _RATE_LIMIT_RETRY_DELAY = 5.0
 
-# Returned as section text when LinkedIn rate-limits the page
+# Returned as section text when a page comes back with its content gone and
+# only LinkedIn's own navigation and footer left.
+#
+# Read carefully: that condition is a *guess* that the page was throttled, not
+# an observation of one. It arrived in d8b4c62 with no cited evidence, LinkedIn
+# documents no such behaviour, and nobody here has reproduced it deliberately —
+# doing so would mean provoking a real throttle on a real account. The log line
+# hedges with "likely" for the same reason.
+#
+# The same empty shell could also be a layout change, a resource this account
+# cannot see, or a load that gave up. A session LinkedIn ended is the one
+# alternative already ruled out elsewhere: every navigation checks the URL
+# against the auth-blocker patterns first, and a redirect to /login, /authwall
+# or /checkpoint raises before extraction is reached. That check stays on URLs
+# deliberately — body text would be a per-locale guess, and this project's
+# rule is that classification never depends on text values.
 _RATE_LIMITED_MSG = "[Rate limited] LinkedIn blocked this section. Try again later or request fewer sections."
 
 
 def rate_limited_section_error() -> dict[str, str]:
-    """The ``section_errors`` entry for a section LinkedIn rate-limited.
+    """The ``section_errors`` entry for a section that came back empty.
 
     One shape for every caller, because the alternative is what this codebase
     did until now: most call sites dropped the sentinel and returned the
     section as simply absent. An agent reading an empty section with no error
     concludes there was nothing to find and calls again, which is the opposite
     of what a rate limit asks for. Being told is what lets a client back off.
+
+    Note this reports the *heuristic's* verdict, with the caveats on
+    ``_RATE_LIMITED_MSG`` above, and does not make it more accurate. What it
+    changes is that a wrong verdict is now visible and can be argued with,
+    where a silently missing section could not be.
     """
     return {
         "error_type": "rate_limit",
@@ -1802,7 +1822,16 @@ class LinkedInExtractor:
                     elif extracted.error:
                         section_errors[section_name] = extracted.error
 
-                    if section_name == "main_profile" and profile_urn is None:
+                    # Skipped once the section came back empty: there is no
+                    # content to read a URN from, and a failure here lands in
+                    # the handler below, which would overwrite the entry just
+                    # recorded with a generic diagnostic — losing the one
+                    # finding this section had.
+                    if (
+                        section_name == "main_profile"
+                        and profile_urn is None
+                        and not rate_limited
+                    ):
                         profile_urn = await self._extract_profile_urn()
                 except LinkedInScraperException:
                     raise

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -58,6 +58,22 @@ _RATE_LIMIT_RETRY_DELAY = 5.0
 # Returned as section text when LinkedIn rate-limits the page
 _RATE_LIMITED_MSG = "[Rate limited] LinkedIn blocked this section. Try again later or request fewer sections."
 
+
+def rate_limited_section_error() -> dict[str, str]:
+    """The ``section_errors`` entry for a section LinkedIn rate-limited.
+
+    One shape for every caller, because the alternative is what this codebase
+    did until now: most call sites dropped the sentinel and returned the
+    section as simply absent. An agent reading an empty section with no error
+    concludes there was nothing to find and calls again, which is the opposite
+    of what a rate limit asks for. Being told is what lets a client back off.
+    """
+    return {
+        "error_type": "rate_limit",
+        "error_message": _RATE_LIMITED_MSG,
+    }
+
+
 # LinkedIn shows 25 results per page
 _PAGE_SIZE = 25
 
@@ -1720,6 +1736,7 @@ class LinkedInExtractor:
         references: dict[str, list[Reference]] = {}
         section_errors: dict[str, dict[str, Any]] = {}
         profile_urn: str | None = None
+        rate_limited = False
 
         requested_ordered = [
             (name, suffix, is_overlay)
@@ -1775,6 +1792,13 @@ class LinkedInExtractor:
                         sections[section_name] = extracted.text
                         if extracted.references:
                             references[section_name] = extracted.references
+                    elif extracted.text == _RATE_LIMITED_MSG:
+                        section_errors[section_name] = rate_limited_section_error()
+                        # Stop rather than walk the remaining sections. Each one
+                        # is another navigation, and LinkedIn has just said it
+                        # wants fewer of them. Whatever was gathered before this
+                        # point is kept and returned.
+                        rate_limited = True
                     elif extracted.error:
                         section_errors[section_name] = extracted.error
 
@@ -1798,6 +1822,9 @@ class LinkedInExtractor:
                     await callbacks.on_progress(
                         f"Scraped {section_name} ({i + 1}/{total})", percent
                     )
+
+                if rate_limited:
+                    break
         except LinkedInScraperException as e:
             if callbacks:
                 await callbacks.on_error(e)
@@ -2852,6 +2879,7 @@ class LinkedInExtractor:
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
         section_errors: dict[str, dict[str, Any]] = {}
+        rate_limited = False
 
         requested_ordered = [
             (name, suffix, is_overlay)
@@ -2883,6 +2911,9 @@ class LinkedInExtractor:
                         sections[section_name] = extracted.text
                         if extracted.references:
                             references[section_name] = extracted.references
+                    elif extracted.text == _RATE_LIMITED_MSG:
+                        section_errors[section_name] = rate_limited_section_error()
+                        rate_limited = True
                     elif extracted.error:
                         section_errors[section_name] = extracted.error
                 except LinkedInScraperException:
@@ -2903,6 +2934,9 @@ class LinkedInExtractor:
                     await callbacks.on_progress(
                         f"Scraped {section_name} ({i + 1}/{total})", percent
                     )
+
+                if rate_limited:
+                    break
         except LinkedInScraperException as e:
             if callbacks:
                 await callbacks.on_error(e)
@@ -2944,6 +2978,8 @@ class LinkedInExtractor:
             sections["employees"] = extracted.text
             if extracted.references:
                 references["employees"] = extracted.references
+        elif extracted.text == _RATE_LIMITED_MSG:
+            section_errors["employees"] = rate_limited_section_error()
         elif extracted.error:
             section_errors["employees"] = extracted.error
 
@@ -2973,6 +3009,8 @@ class LinkedInExtractor:
             sections["job_posting"] = extracted.text
             if extracted.references:
                 references["job_posting"] = extracted.references
+        elif extracted.text == _RATE_LIMITED_MSG:
+            section_errors["job_posting"] = rate_limited_section_error()
         elif extracted.error:
             section_errors["job_posting"] = extracted.error
 
@@ -3228,9 +3266,14 @@ class LinkedInExtractor:
                 )
 
                 if not extracted.text or extracted.text == _RATE_LIMITED_MSG:
-                    if extracted.error:
+                    # Rate limit first: it is the more specific diagnosis, and a
+                    # page that was throttled may carry a generic error too.
+                    if extracted.text == _RATE_LIMITED_MSG:
+                        section_errors["search_results"] = rate_limited_section_error()
+                    elif extracted.error:
                         section_errors["search_results"] = extracted.error
-                    # Navigation failed or rate-limited; skip ID extraction
+                    # Navigation failed or rate-limited; skip ID extraction.
+                    # Pages gathered so far are kept and returned.
                     break
 
                 # Read total pages from pagination state (once only, best-effort)
@@ -3454,7 +3497,9 @@ class LinkedInExtractor:
                 )
 
                 if not extracted.text or extracted.text == _RATE_LIMITED_MSG:
-                    if extracted.error:
+                    if extracted.text == _RATE_LIMITED_MSG:
+                        section_errors["saved_jobs"] = rate_limited_section_error()
+                    elif extracted.error:
                         section_errors["saved_jobs"] = extracted.error
                     break
 
@@ -3589,6 +3634,8 @@ class LinkedInExtractor:
             sections["search_results"] = extracted.text
             if extracted.references:
                 references["search_results"] = extracted.references
+        elif extracted.text == _RATE_LIMITED_MSG:
+            section_errors["search_results"] = rate_limited_section_error()
         elif extracted.error:
             section_errors["search_results"] = extracted.error
 
@@ -3621,6 +3668,8 @@ class LinkedInExtractor:
             sections["search_results"] = extracted.text
             if extracted.references:
                 references["search_results"] = extracted.references
+        elif extracted.text == _RATE_LIMITED_MSG:
+            section_errors["search_results"] = rate_limited_section_error()
         elif extracted.error:
             section_errors["search_results"] = extracted.error
 

--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -16,7 +16,10 @@ from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.scraping import parse_company_sections
-from linkedin_mcp_server.scraping.extractor import _RATE_LIMITED_MSG
+from linkedin_mcp_server.scraping.extractor import (
+    _RATE_LIMITED_MSG,
+    rate_limited_section_error,
+)
 from linkedin_mcp_server.scraping.link_metadata import Reference
 
 logger = logging.getLogger(__name__)
@@ -138,6 +141,8 @@ def register_company_tools(
                 sections["posts"] = extracted.text
                 if extracted.references:
                     references["posts"] = extracted.references
+            elif extracted.text == _RATE_LIMITED_MSG:
+                section_errors["posts"] = rate_limited_section_error()
             elif extracted.error:
                 section_errors["posts"] = extracted.error
 

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -18,7 +18,10 @@ from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
 from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
-from linkedin_mcp_server.scraping.extractor import _RATE_LIMITED_MSG
+from linkedin_mcp_server.scraping.extractor import (
+    _RATE_LIMITED_MSG,
+    rate_limited_section_error,
+)
 from linkedin_mcp_server.scraping.link_metadata import Reference
 
 logger = logging.getLogger(__name__)
@@ -85,10 +88,7 @@ def register_feed_tools(
                 if extracted.references:
                     references["feed"] = extracted.references
             elif extracted.text == _RATE_LIMITED_MSG:
-                section_errors["feed"] = {
-                    "error_type": "rate_limit",
-                    "error_message": extracted.text,
-                }
+                section_errors["feed"] = rate_limited_section_error()
             elif extracted.error:
                 section_errors["feed"] = extracted.error
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1882,7 +1882,17 @@ class TestConnectWithPerson:
             "/tmp/issue.md"
         )
 
-    async def test_rate_limited_sections_are_omitted(self, mock_page):
+    async def test_a_rate_limited_section_is_reported_and_stops_the_rest(
+        self, mock_page
+    ):
+        """A throttled section is named as an error, and the walk stops there.
+
+        Both halves matter. Returning the section as merely absent reads as
+        "nothing to find" and invites the caller to try again, which is the
+        opposite of what LinkedIn just asked for. And continuing to the
+        remaining sections would be another navigation each, immediately after
+        being told to slow down.
+        """
         extractor = LinkedInExtractor(mock_page)
         with (
             patch.object(
@@ -1892,6 +1902,38 @@ class TestConnectWithPerson:
                 side_effect=[
                     extracted(_RATE_LIMITED_MSG),
                     extracted("Post text"),
+                ],
+            ) as mock_extract,
+            patch.object(
+                extractor,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_person("testuser", {"posts"})
+
+        assert "main_profile" not in result["sections"]
+        assert result["section_errors"]["main_profile"]["error_type"] == "rate_limit"
+        # The second section was never fetched, so its side effect is unused.
+        assert mock_extract.await_count == 1
+        assert "posts" not in result["sections"]
+
+    async def test_earlier_sections_survive_a_later_rate_limit(self, mock_page):
+        """Stopping early keeps what was already gathered."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                side_effect=[
+                    extracted("Profile text"),
+                    extracted(_RATE_LIMITED_MSG),
                 ],
             ),
             patch.object(
@@ -1907,8 +1949,8 @@ class TestConnectWithPerson:
         ):
             result = await extractor.scrape_person("testuser", {"posts"})
 
-        assert "main_profile" not in result["sections"]
-        assert result["sections"]["posts"] == "Post text"
+        assert result["sections"]["main_profile"] == "Profile text"
+        assert result["section_errors"]["posts"]["error_type"] == "rate_limit"
 
 
 class TestScrapeCompany:
@@ -1981,7 +2023,9 @@ class TestScrapeCompany:
         assert any("/jobs/" in u for u in urls)
         assert set(result["sections"]) == {"about", "posts", "jobs"}
 
-    async def test_rate_limited_company_sections_are_omitted(self, mock_page):
+    async def test_a_rate_limited_company_section_is_reported_and_stops_the_rest(
+        self, mock_page
+    ):
         extractor = LinkedInExtractor(mock_page)
         with (
             patch.object(
@@ -1992,7 +2036,7 @@ class TestScrapeCompany:
                     extracted(_RATE_LIMITED_MSG),
                     extracted("Posts text"),
                 ],
-            ),
+            ) as mock_extract,
             patch(
                 "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
                 new_callable=AsyncMock,
@@ -2001,7 +2045,9 @@ class TestScrapeCompany:
             result = await extractor.scrape_company("testcorp", {"posts"})
 
         assert "about" not in result["sections"]
-        assert result["sections"]["posts"] == "Posts text"
+        assert result["section_errors"]["about"]["error_type"] == "rate_limit"
+        assert mock_extract.await_count == 1
+        assert "posts" not in result["sections"]
 
     async def test_scrape_company_extracts_company_urn(self, mock_page):
         """End-to-end: a canned-search anchor on the company about page
@@ -2822,8 +2868,9 @@ class TestGetSavedJobs:
         """A rate-limited later page stops pagination without losing page 1.
 
         Matches the sibling behaviour of ``search_jobs``: the sentinel page
-        contributes no text, and a soft rate limit is not reported as a
-        section error (it is not a scraper bug).
+        contributes no text, and the reason pagination stopped is reported so
+        the caller can tell "LinkedIn asked us to slow down" apart from "there
+        were no more pages" — which look identical otherwise.
         """
         extractor = LinkedInExtractor(mock_page)
         pages = iter([extracted("first page"), extracted(_RATE_LIMITED_MSG)])
@@ -2856,7 +2903,7 @@ class TestGetSavedJobs:
         assert result["job_ids"] == ["100"]
         # The blocked page contributes nothing; page 1 survives intact.
         assert result["sections"]["saved_jobs"] == "first page"
-        assert "section_errors" not in result
+        assert result["section_errors"]["saved_jobs"]["error_type"] == "rate_limit"
 
     async def test_url_redirect_skips_id_extraction(self, mock_page):
         """A redirect away from the list captures the landing page, no IDs.

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1923,6 +1923,38 @@ class TestConnectWithPerson:
         assert mock_extract.await_count == 1
         assert "posts" not in result["sections"]
 
+    async def test_a_failing_urn_read_cannot_bury_the_rate_limit(self, mock_page):
+        """The URN read is skipped once throttled, so it cannot overwrite it.
+
+        It runs after the section handling but inside the same try, so a
+        failure there lands in the generic handler and replaces the entry with
+        a diagnostic — losing the one thing this section had to report. There
+        is nothing to read a URN from on a page with no content anyway.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted(_RATE_LIMITED_MSG),
+            ),
+            patch.object(
+                extractor,
+                "_extract_profile_urn",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("execution context destroyed"),
+            ) as mock_urn,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_person("testuser", set())
+
+        mock_urn.assert_not_awaited()
+        assert result["section_errors"]["main_profile"]["error_type"] == "rate_limit"
+
     async def test_earlier_sections_survive_a_later_rate_limit(self, mock_page):
         """Stopping early keeps what was already gathered."""
         extractor = LinkedInExtractor(mock_page)
@@ -2141,6 +2173,7 @@ class TestScrapeJob:
             result = await extractor.scrape_job("12345")
 
         assert result["sections"] == {}
+        assert result["section_errors"]["job_posting"]["error_type"] == "rate_limit"
 
     async def test_scrape_job_omits_orphaned_references_when_text_empty(
         self, mock_page
@@ -2645,6 +2678,7 @@ class TestSearchJobs:
 
         assert result["job_ids"] == []
         assert result["sections"] == {}
+        assert result["section_errors"]["search_results"]["error_type"] == "rate_limit"
         mock_ids.assert_not_awaited()
 
 
@@ -2943,6 +2977,36 @@ class TestGetSavedJobs:
         mock_ids.assert_not_awaited()
         assert result["job_ids"] == []
         assert result["sections"]["saved_jobs"] == "Login page content"
+
+
+class TestSingleSectionRateLimits:
+    """The single-page tools report the reason too, not just an empty result.
+
+    Without these, three of the nine repaired call sites would be unbound: the
+    branch could be deleted and the suite would stay green, because the older
+    tests only assert the sentinel does not reach ``sections``.
+    """
+
+    @pytest.mark.parametrize(
+        ("method", "args", "section"),
+        [
+            ("get_company_employees", ("testcorp",), "employees"),
+            ("search_people", ("python",), "search_results"),
+            ("search_companies", ("fintech",), "search_results"),
+        ],
+    )
+    async def test_the_reason_is_reported(self, mock_page, method, args, section):
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted(_RATE_LIMITED_MSG),
+        ):
+            result = await getattr(extractor, method)(*args)
+
+        assert result["sections"] == {}
+        assert result["section_errors"][section]["error_type"] == "rate_limit"
 
 
 class TestSearchPeople:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -559,6 +559,7 @@ class TestCompanyTools:
         tool_fn = await get_tool_fn(mcp, "get_company_posts")
         result = await tool_fn("testcorp", mock_context, extractor=mock_extractor)
         assert result["sections"] == {}
+        assert result["section_errors"]["posts"]["error_type"] == "rate_limit"
 
     async def test_get_company_posts_returns_section_errors(self, mock_context):
         mock_extractor = MagicMock()


### PR DESCRIPTION
When a page comes back with its content gone and only LinkedIn's own
navigation and footer left, the extractor retries once after five seconds and,
if it still looks that way, returns a sentinel instead of text. Nine call sites
dropped that sentinel into an empty section without recording anything, so the
tool returned a successful result with a section simply missing.

Worth stating plainly, because the code does not: that condition is a
*heuristic* for a soft rate limit, not a measurement of one. It was introduced
in d8b4c62 with no cited evidence, and the log line itself hedges with
"likely". A content-less page can also mean a layout change, a resource the
account cannot see, or a load that gave up. This change does not make the
heuristic more accurate — it makes its verdict visible, which is what allows it
to be questioned at all. A wrong diagnosis that is reported can be noticed; a
silent hole cannot.

An agent reading an empty section with no error concludes there was nothing to
find and calls again. The server therefore accelerated at exactly the moment it
had been asked to slow down, and the one signal a client needs in order to back
off never reached it.

Every consumer now reports the throttle as a `section_errors` entry, matching
the shape `get_feed` and `search_posts` already used — those two were the only
ones doing it correctly, and they are the model the rest now follow. The
multi-section walks in `scrape_person` and `scrape_company` additionally stop
rather than continuing: each remaining section is another navigation, taken
immediately after being told there had been too many. Whatever was gathered
before the limit is kept and returned, so a profile that was throttled on its
fifth section still yields the first four.

Pacing itself stays with the client, which knows the user's intent; this only
makes the information it needs visible.

The nine sites: `scrape_person`, `scrape_company`, `get_company_employees`,
`scrape_job`, `search_jobs`, `get_saved_jobs`, `search_people`,
`search_companies`, and the `get_company_posts` wrapper.

Two mutations verified red before merge: removing the `break` fails the test
asserting the walk stops, and removing the error record fails two tests
asserting it is reported. Full suite green.

See also: #606

## Synthetic prompt

> When LinkedIn soft-rate-limits a page the scraper returns a sentinel string,
> but most callers drop it into an empty section without setting
> `section_errors`, so an agent sees "no results" and retries. Find every site
> that swallows it, report it consistently the way `get_feed` already does, and
> stop the multi-section walks rather than continuing to navigate after being
> throttled. Prove each test by mutation.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
