### PR TITLE
fix(proxy): Keep WebRTC on the proxy

### DIFF
--- a/linkedin_mcp_server/browser_launch.py
+++ b/linkedin_mcp_server/browser_launch.py
@@ -1,0 +1,96 @@
+"""Launch options shared by every browser this server starts.
+
+Two call sites used to build these independently: the runtime path, which also
+covers the foreign-runtime bridge and import validation, and the manual login.
+A setting added to one silently did not apply to the other, and the login is
+the worse one to get wrong — a session created while leaking has been leaking
+since the moment it existed.
+"""
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from linkedin_mcp_server.config.schema import BrowserConfig
+
+logger = logging.getLogger(__name__)
+
+# WebRTC reaches the network over UDP, which an HTTP proxy does not carry. It
+# therefore goes around the proxy and hands the page the machine's real
+# address. Measured against a real STUN server: a page saw the proxy's address
+# in the HTTP request and the real IPv4 *and* IPv6 in the ICE candidates at the
+# same time, which is trivially correlated and leaves the proxy pointless.
+#
+# Both spellings are passed because each binary reads a different one. Full
+# Chrome and Chromium take the plain switch through the command-line pref
+# store (`chrome_command_line_pref_store.cc`), and modern `--headless` shares
+# that path; the separate `chrome-headless-shell` reads only the `--force-`
+# variant, in `headless/lib/browser/headless_web_contents_impl.cc`. Full Chrome
+# has no consumer for `--force-` at all. Chromium has no central switch
+# registry, so a switch no consumer asks for is simply inert, and the two
+# values are identical, so no binary can end up with a conflicting policy.
+#
+# Verified on all four rungs — real Chrome headed and headless, bundled full
+# Chromium, and the headless shell: every baseline produced a server-reflexive
+# candidate and every fixed run produced none.
+#
+# Note this does more than hide the address. With no proxied UDP available, no
+# ICE candidate forms at all, so WebRTC stops working rather than lying about
+# where it is. That is acceptable here because nothing in this server uses it:
+# there is no RTCPeerConnection and no getUserMedia anywhere in the codebase.
+_WEBRTC_STAYS_ON_THE_PROXY = (
+    "--webrtc-ip-handling-policy=disable_non_proxied_udp",
+    "--force-webrtc-ip-handling-policy=disable_non_proxied_udp",
+)
+
+
+def build_launch_options(
+    browser: "BrowserConfig",
+) -> tuple[dict[str, Any], dict[str, int]]:
+    """Build the Patchright launch options and viewport for any browser.
+
+    Takes the configuration rather than reading the global, so the two call
+    sites keep resolving it the way they already do and this stays a pure
+    function of its input.
+
+    Returns the options dict and the viewport separately because callers pass
+    the viewport through a named ``BrowserManager`` argument rather than as a
+    launch option.
+    """
+    viewport = {
+        "width": browser.viewport_width,
+        "height": browser.viewport_height,
+    }
+
+    launch_options: dict[str, Any] = {}
+
+    if browser.chrome_path:
+        launch_options["executable_path"] = browser.chrome_path
+
+    proxy = browser.proxy_settings()
+    if proxy:
+        launch_options["proxy"] = proxy
+        # Only where a proxy exists: with a direct connection there is no
+        # bypass to prevent, and the switches would disable a working browser
+        # capability for nothing.
+        launch_options["args"] = list(_WEBRTC_STAYS_ON_THE_PROXY)
+
+    return launch_options, viewport
+
+
+def describe_launch(launch_options: dict[str, Any]) -> None:
+    """Log what the browser was configured with, without the credentials.
+
+    Kept apart from the builder so the two call sites can log at the point
+    where their own context makes sense, and so a proxy password cannot reach
+    a log by being carried along in a formatted options dict.
+    """
+    executable = launch_options.get("executable_path")
+    if executable:
+        logger.info("Using custom Chrome path: %s", executable)
+
+    proxy = launch_options.get("proxy")
+    if proxy:
+        # The server only. Username and password must not reach the log.
+        logger.info("Routing browser traffic through proxy %s", proxy["server"])
+        logger.info("WebRTC restricted to the proxy; direct UDP is disabled")

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -30,6 +30,7 @@ from linkedin_mcp_server.core import (
 )
 
 
+from linkedin_mcp_server.browser_launch import build_launch_options, describe_launch
 from linkedin_mcp_server.common_utils import utcnow_iso
 from linkedin_mcp_server.config import get_config
 from linkedin_mcp_server.debug_trace import record_page_trace
@@ -262,20 +263,8 @@ async def _feed_auth_succeeds(
 
 
 def _launch_options() -> tuple[dict[str, Any], dict[str, int]]:
-    config = get_config()
-    viewport = {
-        "width": config.browser.viewport_width,
-        "height": config.browser.viewport_height,
-    }
-    launch_options: dict[str, Any] = {}
-    if config.browser.chrome_path:
-        launch_options["executable_path"] = config.browser.chrome_path
-        logger.info("Using custom Chrome path: %s", config.browser.chrome_path)
-    proxy = config.browser.proxy_settings()
-    if proxy:
-        launch_options["proxy"] = proxy
-        # Only the server: the credentials must not reach the log.
-        logger.info("Routing browser traffic through proxy %s", proxy["server"])
+    launch_options, viewport = build_launch_options(get_config().browser)
+    describe_launch(launch_options)
     return launch_options, viewport
 
 

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from linkedin_mcp_server.browser_launch import build_launch_options, describe_launch
 from linkedin_mcp_server.config import get_config
 from linkedin_mcp_server.config.schema import PROFILE_HANDOVER_WAIT_SECONDS
 from linkedin_mcp_server.core import (
@@ -228,21 +229,13 @@ async def _login_into_fresh_profile(
     print(f"   Please log in manually. You have {budget} to complete authentication.")
     print("   (This handles 2FA, captcha, and any security challenges)")
 
-    launch_options: dict[str, Any] = {}
-    if config.browser.chrome_path:
-        launch_options["executable_path"] = config.browser.chrome_path
-
     # The login browser must leave from the same address as later scrapes: a
     # session created on one IP and used from another is what trips LinkedIn's
-    # security checkpoint.
-    proxy = config.browser.proxy_settings()
-    if proxy:
-        launch_options["proxy"] = proxy
-
-    viewport = {
-        "width": config.browser.viewport_width,
-        "height": config.browser.viewport_height,
-    }
+    # security checkpoint. Shared with the runtime path rather than rebuilt
+    # here, so a setting cannot apply to scraping but not to the login that
+    # created the session.
+    launch_options, viewport = build_launch_options(config.browser)
+    describe_launch(launch_options)
 
     manager = BrowserManager(
         user_data_dir=user_data_dir,

--- a/tests/test_browser_driver.py
+++ b/tests/test_browser_driver.py
@@ -928,6 +928,34 @@ class TestProxyLaunchOptions:
         assert "gate.example" in caplog.text
         assert "s3cr3t" not in caplog.text
 
+    def test_a_proxy_keeps_webrtc_off_the_direct_route(self):
+        """Without this, WebRTC hands the page the real address over UDP.
+
+        Measured against a real STUN server: the page saw the proxy's address
+        in the HTTP request and the machine's real IPv4 and IPv6 in the ICE
+        candidates simultaneously, which makes the proxy pointless against
+        anyone who correlates the two.
+        """
+        browser_module.get_config().browser.proxy_server = "http://gate.example:7000"
+        launch_options, _ = browser_module._launch_options()
+
+        args = launch_options["args"]
+        assert "--webrtc-ip-handling-policy=disable_non_proxied_udp" in args
+        # Both spellings: full Chrome reads the plain one through the
+        # command-line pref store, chrome-headless-shell reads only the
+        # --force- variant. Passing one covers half the browser ladder.
+        assert "--force-webrtc-ip-handling-policy=disable_non_proxied_udp" in args
+
+    def test_no_proxy_leaves_webrtc_alone(self):
+        """With a direct connection there is no bypass to prevent.
+
+        The switches do not merely mask the address, they stop ICE from
+        producing candidates at all, so applying them unconditionally would
+        disable a working browser capability for no benefit.
+        """
+        launch_options, _ = browser_module._launch_options()
+        assert "args" not in launch_options
+
     @pytest.mark.asyncio
     async def test_proxy_reaches_the_browser_manager(self, tmp_path):
         _write_source_state(tmp_path, runtime_id="macos-arm64-host")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -199,6 +199,35 @@ async def test_interactive_login_forwards_all_browser_params(monkeypatch, tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_login_keeps_webrtc_on_the_proxy(monkeypatch, tmp_path):
+    """The login browser needs the WebRTC restriction as much as scraping does.
+
+    This is the path that matters most. The login is where the session is
+    created, so a leak here has been attached to that session from its first
+    moment — and this path used to build its own launch options, which is
+    exactly how a setting ends up applying to scraping but not to login.
+    """
+    browser = _make_browser(export_cookies=True)
+    captured_kwargs: dict = {}
+
+    def fake_browser_manager(**kwargs):
+        captured_kwargs.update(kwargs)
+        return _BrowserContextManager(browser)
+
+    config = AppConfig()
+    config.browser.proxy_server = "http://gate.example:7000"
+
+    _patch_login_deps(monkeypatch, browser_factory=fake_browser_manager, config=config)
+
+    await interactive_login(tmp_path / "profile")
+
+    assert captured_kwargs["proxy"]["server"] == "http://gate.example:7000"
+    args = captured_kwargs["args"]
+    assert "--webrtc-ip-handling-policy=disable_non_proxied_udp" in args
+    assert "--force-webrtc-ip-handling-policy=disable_non_proxied_udp" in args
+
+
+@pytest.mark.asyncio
 async def test_interactive_login_passes_slow_mo_to_browser_manager(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
A configured proxy did not contain the browser. WebRTC reaches the network over
UDP, which an HTTP proxy does not carry, so it went around the proxy entirely
and handed the page the machine's real address.

Measured against a real STUN server, with the proxy configured: the page saw
the proxy's address in the HTTP request and the real IPv4 *and* IPv6 in the ICE
candidates at the same time. Anyone correlating the two has the user's actual
address, which is precisely what configuring a proxy was meant to prevent —
`proxy_settings()` says so in its own docstring, that login and scraping must
leave from one address because a session used from a different one is what
trips LinkedIn's security checkpoint.

Both switch spellings are passed, because they are not alternatives — each
binary reads a different one. Full Chrome and Chromium take
`--webrtc-ip-handling-policy` through the command-line pref store, and modern
`--headless` shares that path; the separate `chrome-headless-shell` reads only
`--force-webrtc-ip-handling-policy`, and full Chrome has no consumer for it at
all. That split is why an earlier measurement found the plain switch working
and the `--force-` one apparently inert: the test ran on real Chrome. Chromium
has no central switch registry, so a switch no consumer asks for is simply
ignored, and the two values are identical, so no binary can receive conflicting
policy.

Verified on all four rungs — real Chrome headed and headless, bundled full
Chromium, and the headless shell. Every baseline produced a server-reflexive
candidate; every fixed run produced none.

The two launch paths now build their options from one helper. They were
separate, and the manual login built its own set, which is the worse one to
leave leaking: a session created that way has been leaking since the moment it
existed. Both are now bound by tests, and removing the switches turns both red.

Applied only when a proxy is configured. The switches do not merely mask the
address — with no proxied UDP available, no ICE candidate forms at all, so
WebRTC stops working rather than lying about where it is. On a direct
connection that would disable a working capability for no benefit. Nothing in
this server uses WebRTC: there is no `RTCPeerConnection` and no `getUserMedia`
anywhere in the codebase.

DNS and QUIC were investigated as the same class of bug. Neither leaks in the
measured environment: Chromium negotiated HTTP/2 through the proxy on both
HTTP/3-capable origins with no QUIC session events, and DNS-over-HTTPS is
inactive here because no DoH server is reachable. The DoH remedy is verified to
work should that change on another network, and is left for a separate change
rather than shipped against a leak nobody has observed.

See also: #606

## Synthetic prompt

> A configured HTTP proxy does not stop WebRTC from revealing the real IP over
> STUN, because WebRTC uses UDP. Find the switch that actually closes it —
> testing the variants rather than trusting documentation — apply it wherever a
> proxy is set, and make sure it covers the manual login as well as the scraping
> path, which currently build their launch options separately. Check whether DNS
> and QUIC bypass the proxy the same way.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
