### PR TITLE
fix(test): Wait for the child before asking

### DIFF
--- a/tests/test_daemon_lock.py
+++ b/tests/test_daemon_lock.py
@@ -546,11 +546,24 @@ _ADOPT_THEN_LAUNCH_AN_UNRELATED_CHILD = """
 
     # Launched the way a browser is, inheriting whatever is still inheritable.
     child = subprocess.Popen(
-        [sys.executable, "-c", "import sys; sys.stdin.readline()"],
+        [
+            sys.executable,
+            "-c",
+            "import sys; print('up', flush=True); sys.stdin.readline()",
+        ],
         stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
         close_fds=False,
     )
     try:
+        # Wait for the child to reach its own code before asking anything about
+        # the lock. Between fork and exec it is a copy of this process and holds
+        # a copy of every descriptor, inheritable or not -- CLOEXEC only takes
+        # effect at exec. Asking inside that window reports the lock as held no
+        # matter what adopt() did, which is a race in the test rather than a
+        # finding about the code.
+        assert child.stdout.readline().strip() == b"up", "the child never started"
+
         adopter.release()
         # Through the production API rather than a raw flock, so a `try_acquire`
         # that refused for its own reasons would be caught here too.


### PR DESCRIPTION
`main` has been red since #656. The replacement test added there fails on Linux
CI, and the failure is a race in the test rather than anything about the lock.

Between `fork` and `exec`, the launched child is a copy of the launching
process and holds a copy of every descriptor — inheritable or not, because
CLOEXEC only takes effect at `exec`. The test asked whether the lock was free
inside that window, so a slow enough runner answered "held" no matter what
`adopt()` had done. It now waits for the child to print from its own code
first.

Removing `set_inheritable(False)` still fails it, so the property it exists for
is still bound.

Stated plainly: this was not reproduced locally. Twelve runs under eight busy
loops stayed green, exactly as the original did before it went red on CI. What
is different from #656 is that the mechanism is named — it follows from fork
semantics — rather than guessed at. #656 replaced a flake whose cause was never
established, and shipped a test with a race of its own. Only CI can confirm
this one, since that is the only place it has ever failed.

See also: #606

## Synthetic prompt

> `main` is red: a daemon lock test fails on Linux CI and passes locally. Work
> out why rather than retrying it, fix the cause, and confirm the test still
> catches the bug it was written for.