### PR TITLE
docs: Record the browser identity bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,30 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Minimize DOM dependence.** Prefer innerText and URL navigation over DOM selectors. When DOM access is unavoidable, use minimal generic selectors (`a[href*="/jobs/view/"]`) — never class names tied to LinkedIn's layout.
 - **Detection must be locale-independent.** Classification logic — connection state, action availability, button identity — must rely on URL patterns (`/preload/custom-invite/?vanityName=USER`, `/in/USER/edit/intro/`, `/messaging/compose/`), attribute *presence* (`aria-label` exists, `aria-expanded` exists, `aria-disabled` exists), or structural counts — never on text values like "Connect", "Follow", "Message", "1st", "Pending". The verb in an `aria-label` is locale-dependent; whether the attribute exists is not. Where text is genuinely the only signal, guard it behind an explicit per-locale table and document the limitation in code.
 
+## Browser Identity Rules
+
+- **The browser must not contradict itself.** Anything it says about itself has
+  to survive being checked against another surface of the same browser: the
+  user-agent against `sec-ch-ua`, the page against its workers and iframes, the
+  reported screen against the window sitting on it. The goal is coherence, not
+  invisibility — invisibility cannot be proven, while a contradiction is a fact
+  and can be found by anyone who looks twice.
+- **Never inject a fingerprint.** No `user_agent`, no custom headers, no
+  spoofed client hints. Patchright's own guidance says the same, and every
+  override measured here made things worse: a `user_agent=` argument changes
+  the string but not the client hints, and never reaches service workers at
+  all ([playwright#5237](https://github.com/microsoft/playwright/issues/5237),
+  closed as an upstream Chromium bug). A browser telling the truth beats one
+  caught lying.
+- **A proxy must contain every egress path, not just HTTP.** WebRTC uses UDP
+  and went around a configured proxy until the switches in
+  `browser_launch.py`. DNS and QUIC belong to the same family; check them
+  before assuming a new setting is contained.
+- **Verify identity changes by measurement.** `docs/browser-fingerprint.md`
+  lists the four detectors, what each one alone would miss, and the values
+  measured so far. A launch-configuration change without a measurement against
+  them is a guess.
+
 ## Tool Return Format
 
 All scraping tools return: `{url, sections: {name: raw_text}}`.

--- a/docs/browser-fingerprint.md
+++ b/docs/browser-fingerprint.md
@@ -1,0 +1,110 @@
+# Browser fingerprint verification
+
+How to check that the browser this server drives still presents one coherent
+identity, and what has been measured so far.
+
+The rules live in `AGENTS.md`. This file is the reference behind them: which
+tools to run, what each one alone would miss, and the numbers to compare
+against.
+
+## The bar
+
+**Coherence, not invisibility.**
+
+Invisibility cannot be demonstrated — no measurement proves a detector did not
+notice. A contradiction can be demonstrated, by anyone, at any time. So the
+standard is that nothing the browser says about itself is refuted by another
+surface of the same browser.
+
+Concretely, all of the following must hold:
+
+- page, dedicated worker, service worker and cross-origin iframe report the
+  same user-agent, and their request headers match what their JavaScript says
+- the UA major version equals the `sec-ch-ua` brand major version
+- `architecture`, `bitness` and `fullVersionList` are non-empty
+  (`platformVersion` is normatively empty on Linux)
+- no `HeadlessChrome` on any surface
+- `navigator.webdriver` is `false` and its property descriptor is unremarkable
+- no `__pwInitScripts`, `__playwright__`, `$cdc_*` or similar globals
+- the outer window is not larger than the reported screen
+- with a proxy configured, no server-reflexive ICE candidate appears
+
+## The tools
+
+Four, because each sees a layer the others cannot. Any one alone gives false
+confidence.
+
+| Tool | Covers | What it alone would miss |
+|---|---|---|
+| [CreepJS](https://github.com/abrahamjuliot/creepjs) | Broadest JS surface; flags self-contradictions as "lies" | Network layer, and current automation-library artefacts |
+| [fpscanner](https://github.com/antoinevastel/fpscanner) | Automation and CDP signals, worker/iframe coherence | Network layer; renewed in 2026, so it knows current Playwright tells |
+| [rebrowser-bot-detector](https://github.com/rebrowser/rebrowser-bot-detector) | `Runtime.enable`, `__pwInitScripts`, default viewport, Chrome-for-Testing UA | Everything CreepJS covers |
+| [TrackMe](https://github.com/pagpeter/TrackMe) / [Fingerproxy](https://github.com/wi1dcard/fingerproxy) | JA3, JA4, HTTP/2 Akamai fingerprint, header order | Anything visible to JavaScript |
+
+Hosted equivalents exist (`tls.peet.ws/api/all` returns the network layer as
+JSON) but send the fingerprint to a third party. Clone locally under `.debug/`
+where that matters.
+
+Loopback is a secure context, so a local `http://127.0.0.1` server is enough
+for service workers and the other secure-context APIs. No self-signed
+certificate, no `ignore_https_errors` — both would perturb what is being
+measured.
+
+Read the values from a `<script>` in the page itself, not through
+`page.evaluate()`. Patchright evaluates in an isolated world, which is not what
+a website sees.
+
+## Not covered by any of them
+
+**Behaviour.** Mouse paths, typing rhythm, scroll cadence, the spacing between
+navigations across a session. No static page can measure it, and for a platform
+like LinkedIn it is plausibly weighted higher than anything above. Out of scope
+here; noted so nobody mistakes a clean sweep for a clean bill of health.
+
+Of roughly 112 observable categories catalogued, about twenty have been
+measured. The largest untested groups are realm consistency beyond the UA,
+codec and DRM support, and Chrome-versus-Chromium feature detection.
+
+## Measured
+
+macOS 26.6 arm64, patchright 1.60.1, Google Chrome 150.0.7871.187, bundled
+Chrome for Testing 148.0.7778.96. CreepJS scores are "headless" / "like
+headless".
+
+| Configuration | CreepJS | Notes |
+|---|---|---|
+| Real Chrome, headed, no override | 0% / 44% | Genuine `"Google Chrome"` brand, `sec-ch-ua-arch: arm`, DPR 2 |
+| Bundled Chromium, headless, UA claiming 143 | 33% / 88% | `hasMissingChromeObject` high severity; UA and hints disagree |
+| Full Chromium headless (`channel="chromium"`) | 67% / 50% | Two high-severity fpscanner rules from the headless token |
+| Headless shell (the old default) | — | `plugins.length = 0`, no `window.chrome`, notification permission incoherent |
+| Docker, headed under Xvfb | 0% / 44% | No headless token, native hints; needs `xauth` |
+| Docker, Xvfb + Mesa llvmpipe | 0% / 44% | Restores WebGL; renderer string is a known software renderer |
+
+Network layer, same machine:
+
+| | Real Chrome 150 | Bundled Chromium 148 |
+|---|---|---|
+| JA4 | `t13d1517h2_8daaf6152771_…` | `t13d15**16**h2_8daaf6152771_…` |
+| HTTP/2 Akamai | `1:65536;2:0;4:6291456;6:262144\|15663105\|0\|m,a,s,p` | identical |
+
+The TLS handshakes differ by one extension. That is invisible to every
+JavaScript test above and cannot be influenced by any launch option.
+
+## Things that look like fixes and are not
+
+- **`--user-agent` as a browser switch.** Reaches every target including
+  service workers, but empties `architecture`, `bitness`, `platformVersion` and
+  `fullVersionList` everywhere. A browser answering `Accept-CH` with blanks is
+  rarer than one admitting it is headless.
+- **A context-level `user_agent`.** Changes the string, leaves the hints, never
+  reaches service workers. On Apple Silicon it also flips `sec-ch-ua-arch` to
+  `x86` while WebGL still reports an Apple GPU.
+- **`--force-webrtc-ip-handling-policy` on its own.** Read only by
+  `chrome-headless-shell`; full Chrome has no consumer for it. The plain
+  spelling is the one full Chrome reads. Both are passed for that reason.
+- **`--host-resolver-rules=MAP * ~NOTFOUND` without an exclusion.** Fails every
+  navigation with `ERR_PROXY_CONNECTION_FAILED`, including when the proxy is a
+  bare IP. The proxy host always needs excluding.
+- **A patched Chromium fork.** Would genuinely fix the service-worker case, at
+  the cost of a per-platform build, signing, notarisation and a rebase every
+  two weeks. Xvfb reaches the same place without a fork.


### PR DESCRIPTION
A night of fingerprint measurement produced findings that existed only in pull
request bodies and would have been lost. This writes them down.

`AGENTS.md` gets the rules, next to the scraping rules they belong with: the
browser must not contradict itself, never inject a fingerprint, a proxy has to
contain every egress path rather than just HTTP, and identity changes are
verified by measurement. Those are decisions a contributor needs at the moment
of writing code — the same reason "Detection must be locale-independent" sits
there, a rule this work managed to break once precisely because it was not in
view.

`docs/browser-fingerprint.md` gets the reference material: the four detectors
and what each one alone would miss, why loopback is enough (it is a secure
context, so no self-signed certificate perturbs the measurement), why values
must be read from a page `<script>` rather than `page.evaluate()` (patchright
evaluates in an isolated world, which is not what a site sees), the measured
numbers, and a list of things that look like fixes and are not.

The bar is stated as **coherence, not invisibility**. Invisibility cannot be
demonstrated — no measurement proves a detector failed to notice. A
contradiction can be demonstrated by anyone who looks twice, which makes it the
only thing worth holding a standard against.

Behaviour is named as out of scope rather than quietly omitted: mouse paths and
navigation rhythm are plausibly weighted higher than anything measurable here,
and no static page can see them. Roughly twenty of about 112 catalogued
categories have been measured. A clean sweep of these tools is not a clean bill
of health, and the document says so.

See also: #606

## Synthetic prompt

> Fingerprint findings from a measurement session live only in PR descriptions.
> Write the behavioural rules into AGENTS.md alongside the existing scraping
> rules, and put the tooling, the measured values and the dead ends into a
> reference doc. State the standard being aimed for, and be explicit about what
> is not covered.