### PR TITLE
feat(jobs): add native support for distance radius and exact time range filters

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3196,6 +3196,8 @@ class LinkedInExtractor:
         work_type: str | None = None,
         easy_apply: bool = False,
         sort_by: str | None = None,
+        distance_km: float | None = None,
+        days_ago: int | None = None,
     ) -> str:
         """Build a LinkedIn job search URL with optional filters.
 
@@ -3203,13 +3205,23 @@ class LinkedInExtractor:
         Comma-separated values are normalized individually.
         Unknown values pass through unchanged.
         """
-        params = f"keywords={quote_plus(keywords)}"
+        # Aggiungiamo origin di default
+        params = f"keywords={quote_plus(keywords)}&origin=JOBS_HOME_KEYWORD_HISTORY"
+        
         if location:
             params += f"&location={quote_plus(location)}"
+            
+        if distance_km is not None:
+            distance_miles = distance_km / 1.609344
+            params += f"&distance={distance_miles}"
 
-        if date_posted:
+        if days_ago is not None:
+            secondi = int(days_ago * 86400)
+            params += f"&f_TPR=r{secondi}"
+        elif date_posted:
             mapped = _JOB_DATE_POSTED_MAP.get(date_posted.strip(), date_posted)
             params += f"&f_TPR={quote_plus(mapped)}"
+            
         if job_type:
             params += f"&f_JT={_normalize_csv(job_type, _JOB_TYPE_MAP)}"
         if experience_level:
@@ -3222,7 +3234,8 @@ class LinkedInExtractor:
             mapped = _SORT_BY_MAP.get(sort_by.strip(), sort_by)
             params += f"&sortBy={quote_plus(mapped)}"
 
-        return f"https://www.linkedin.com/jobs/search/?{params}"
+        # Sostituito search/ con search-results/ come richiesto
+        return f"https://www.linkedin.com/jobs/search-results/?{params}"
 
     async def search_jobs(
         self,
@@ -3235,6 +3248,8 @@ class LinkedInExtractor:
         work_type: str | None = None,
         easy_apply: bool = False,
         sort_by: str | None = None,
+        distance_km: float | None = None,
+        days_ago: int | None = None,
     ) -> dict[str, Any]:
         """Search for jobs with pagination and job ID extraction.
 
@@ -3252,6 +3267,8 @@ class LinkedInExtractor:
             work_type: Filter by work type (on_site, remote, hybrid)
             easy_apply: Only show Easy Apply jobs
             sort_by: Sort results (date, relevance)
+            distance_km: Distance in km
+            days_ago: Days ago to search
 
         Returns:
             {url, sections: {search_results: text}, job_ids: [str]}
@@ -3265,6 +3282,8 @@ class LinkedInExtractor:
             work_type=work_type,
             easy_apply=easy_apply,
             sort_by=sort_by,
+            distance_km=distance_km,
+            days_ago=days_ago,
         )
         all_job_ids: list[str] = []
         seen_ids: set[str] = set()

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -89,6 +89,8 @@ def register_job_tools(
         easy_apply: bool = False,
         sort_by: str | None = None,
         extractor: Any | None = None,
+        distance_km: float | None = None,
+        days_ago: int | None = None,
     ) -> dict[str, Any]:
         """
         Search for jobs on LinkedIn.
@@ -106,6 +108,8 @@ def register_job_tools(
             work_type: Filter by work type, comma-separated (on_site, remote, hybrid)
             easy_apply: Only show Easy Apply jobs (default false)
             sort_by: Sort results (date, relevance)
+            distance_km: Distance in km
+            days_ago: Days ago to search
 
         Returns:
             Dict with url, sections (name -> raw text), job_ids (list of
@@ -116,10 +120,11 @@ def register_job_tools(
                 ctx, tool_name="search_jobs"
             )
             logger.info(
-                "Searching jobs: keywords='%s', location='%s', max_pages=%d",
+                "Searching jobs: keywords='%s', location='%s', max_pages=%d, distance_km=%s",
                 keywords,
                 location,
                 max_pages,
+                distance_km,
             )
 
             await ctx.report_progress(
@@ -136,6 +141,8 @@ def register_job_tools(
                 work_type=work_type,
                 easy_apply=easy_apply,
                 sort_by=sort_by,
+                distance_km=distance_km,
+                days_ago=days_ago,
             )
 
             await ctx.report_progress(progress=100, total=100, message="Complete")


### PR DESCRIPTION
## Summary
This PR introduces native support for **geographic search radius (`distance_km`)** and **exact time-range filtering (`days_ago`)** in the `search_jobs` tool, while standardizing the search URL format to align with LinkedIn's current web interface (`/jobs/search-results/`).

These additions significantly improve search accuracy for AI agents and users targeting specific local job markets or strictly recent postings.

---

## 🚀 Key Improvements

### 1. Geographic Distance Radius (`distance_km`)
- **Problem:** Previously, location filtering relied solely on text strings without specifying a search radius, missing relevant opportunities in nearby towns/cities.
- **Solution:** Added `distance_km: float | None = None`. The server automatically converts kilometers to exact miles (`distance_km / 1.609344`) and appends `&distance=...` to the query, mirroring native browser filtering.

### 2. Precise Time Windowing (`days_ago`)
- **Problem:** Standard relative date filters (`past_week`, `past_month`) are often too coarse for fast-paced job searches.
- **Solution:** Added `days_ago: int | None = None`. It converts days into exact second thresholds (`f_TPR=r{seconds}`) used by LinkedIn, allowing agents to fetch jobs posted within an exact custom timeframe (e.g. last 3 days, last 14 days).

### 3. URL Standardization & Search Compatibility
- Updated base search URL from `/jobs/search/` to `/jobs/search-results/`.
- Included default `&origin=JOBS_HOME_KEYWORD_HISTORY` parameter to reflect standard user navigation paths and improve search response consistency.

---

## 🛠️ Changes Breakdown

- **`linkedin_mcp_server/tools/job.py`**: Exposed `distance_km` and `days_ago` in the `search_jobs` FastMCP tool signature.
- **`linkedin_mcp_server/scraping/extractor.py`**: Updated `_build_job_search_url()` and `search_jobs()` to handle unit conversion, custom `f_TPR` calculation, and updated endpoint formatting.

---

## ✅ Backwards Compatibility

All new parameters are **completely optional** (`None` by default). Existing queries using `keywords`, `location`, or standard `date_posted` filters will continue to work without any breaking changes.