### PR TITLE
fix(browser): Use native headed geometry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,7 +93,10 @@ HTTP_PATH=/mcp
 # Debugging options
 # Slow down browser actions by this many milliseconds (default: 0)
 SLOW_MO=0
-# Browser viewport size as WIDTHxHEIGHT (default: 1280x720)
+# Browser viewport size as WIDTHxHEIGHT (default: 1280x720). Applies to the
+# normal windowless mode only: a headed launch (--no-headless, --login) uses
+# the real window size instead, so that the window and the screen it reports
+# standing on agree.
 VIEWPORT=1280x720
 # Custom Chrome/Chromium executable path (optional)
 # Use this if Chrome is installed in a non-standard location

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ The local server uses the same managed-runtime flow as MCPB and `uvx`: it prepar
 - `--status` - Check if current session is valid and exit
 - `--user-data-dir PATH` - Path to persistent browser profile directory (default: ~/.linkedin-mcp/profile)
 - `--slow-mo MS` - Delay between browser actions in milliseconds (default: 0, useful for debugging)
-- `--viewport WxH` - Browser viewport size (default: 1280x720)
+- `--viewport WxH` - Browser viewport size (default: 1280x720). Applies to the normal windowless mode only; a headed launch (`--no-headless`, `--login`) uses the real window size
 - `--chrome-path PATH` - Path to Chrome/Chromium executable (for custom browser installations)
 - `--proxy-server URL` - Route the browser through a proxy, as `scheme://host:port`. Set the password via `PROXY_PASSWORD` (no flag, so it stays out of the process list)
 - `--help` - Show help

--- a/docs/browser-fingerprint.md
+++ b/docs/browser-fingerprint.md
@@ -80,6 +80,22 @@ headless".
 | Docker, headed under Xvfb | 0% / 44% | No headless token, native hints; needs `xauth` |
 | Docker, Xvfb + Mesa llvmpipe | 0% / 44% | Restores WebGL; renderer string is a known software renderer |
 
+Window geometry, read from a page's own `<script>` on a loopback origin:
+
+| Configuration | Outer | Screen | DPR | Window fits its screen |
+|---|---|---|---|---|
+| Headless, explicit viewport | 1280x720 | 1280x720 | 1 | yes |
+| Headed, `no_viewport=True` | 1200x958 | 1728x1117 | 2 | yes |
+| Headed with an emulated viewport (before) | 1280x805 | 1280x720 | 1 | **no** |
+
+The last row is the contradiction this was measured to remove: an outer window
+taller than the screen the same browser reported standing on. Any page can read
+both and compare them. Note the headed row now shows the real display and a
+Retina DPR of 2, which is an ordinary Mac rather than a shape nothing sells.
+
+Headless keeps an explicit viewport deliberately: headless plus `no_viewport`
+collapses the screen to 800x600.
+
 Network layer, same machine:
 
 | | Real Chrome 150 | Bundled Chromium 148 |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -94,7 +94,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 | `PORT` | `8000` | HTTP server port (for streamable-http transport) |
 | `HTTP_PATH` | `/mcp` | HTTP server path (for streamable-http transport) |
 | `SLOW_MO` | `0` | Delay between browser actions in ms (debugging) |
-| `VIEWPORT` | `1280x720` | Browser viewport size as WIDTHxHEIGHT |
+| `VIEWPORT` | `1280x720` | Browser viewport size as WIDTHxHEIGHT. Applies to the normal windowless mode only; a headed launch uses the real window size. |
 | `CHROME_PATH` | - | Path to Chrome/Chromium executable (rarely needed in Docker) |
 | `PROXY_SERVER` | - | Optional, and most setups are better off without one: LinkedIn advises against proxies and scores the addresses a session signs in from, so a stable known address beats a commercial exit node. Worth it when the container runs somewhere its address is obviously a data centre, and even then a WireGuard or Tailscale exit node on your own network is preferable. Route the browser through a proxy, as `scheme://host:port` (`http`, `https`, `socks4`, `socks5`). May also carry credentials directly (`http://user:pass@host:port`), which is how most providers hand them out. Inside a container `127.0.0.1` is the container itself: for a relay running on the host use `host.docker.internal` (on native Linux Docker, add `--add-host=host.docker.internal:host-gateway`). Only browser traffic is routed, not the MCP transport. |
 | `PROXY_USERNAME` | - | Username for the proxy |

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -431,7 +431,10 @@ def load_from_args(config: AppConfig) -> AppConfig:
         type=str,
         default=None,
         metavar="WxH",
-        help="Browser viewport size (default: 1280x720)",
+        help=(
+            "Browser viewport size (default: 1280x720). Applies to the normal "
+            "windowless mode only; a headed launch uses the real window size."
+        ),
     )
 
     parser.add_argument(

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -79,6 +79,19 @@ class BrowserManager:
                 "not the client hints, and never reaches service workers."
             )
 
+        # Same funnel, same hazard. ``_geometry()`` is spread *before*
+        # ``launch_options``, so a stray ``no_viewport`` would win: passing
+        # ``no_viewport=False`` on a headed launch puts the emulated screen back
+        # and restores the window-larger-than-screen contradiction, and passing
+        # ``no_viewport=True`` on a headless one sends both keys at once.
+        # Nothing produces this today; it is refused so it cannot start.
+        if "no_viewport" in launch_options:
+            raise TypeError(
+                "BrowserManager decides no_viewport from the launch mode. Pass "
+                "headless= instead: a headed window must report its real size, "
+                "and a headless one needs an explicit viewport."
+            )
+
         self.user_data_dir = str(Path(user_data_dir).expanduser())
         self.headless = headless
         self.slow_mo = slow_mo

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -82,7 +82,12 @@ class BrowserManager:
         self.user_data_dir = str(Path(user_data_dir).expanduser())
         self.headless = headless
         self.slow_mo = slow_mo
-        self.viewport = viewport or {"width": 1280, "height": 720}
+        # Kept as passed, including ``None``. The old ``viewport or {...}``
+        # meant "no viewport" could not be expressed at all, which is what
+        # forced an emulated screen onto a headed window and produced the
+        # measured contradiction: an outer window of 805 pixels standing on a
+        # screen the same browser reported as 720 tall.
+        self.viewport = viewport
         self.launch_options = launch_options
 
         self._playwright: Playwright | None = None
@@ -108,6 +113,25 @@ class BrowserManager:
         self._close_confirmed = False
         self._close_confirmed = await self.close()
 
+    def _geometry(self) -> dict[str, Any]:
+        """The viewport options, decided by the mode this browser actually runs in.
+
+        This lives here rather than in ``build_launch_options`` because only
+        this object knows the answer. The builder is a pure function of the
+        configuration, and the configuration says ``headless=True`` by default
+        even when the manual login is about to launch headed -- the login passes
+        ``headless=False`` directly. A builder reading the configuration would
+        get it wrong for exactly the launch that puts a window on screen.
+
+        Headed gets no viewport at all, so the window reports the size it really
+        is. Headless keeps an explicit one, because a headless browser with
+        ``no_viewport`` collapses its screen to 800x600, which is its own
+        oddity.
+        """
+        if self.headless:
+            return {"viewport": self.viewport or {"width": 1280, "height": 720}}
+        return {"no_viewport": True}
+
     async def start(self) -> None:
         """Start Patchright and launch persistent browser context."""
         if self._context is not None:
@@ -121,7 +145,7 @@ class BrowserManager:
             context_options: dict[str, Any] = {
                 "headless": self.headless,
                 "slow_mo": self.slow_mo,
-                "viewport": self.viewport,
+                **self._geometry(),
                 **self.launch_options,
                 "locale": "en-US",
             }

--- a/tests/test_core_browser.py
+++ b/tests/test_core_browser.py
@@ -22,6 +22,71 @@ def test_a_user_agent_is_refused_rather_than_applied(tmp_path):
         )
 
 
+class TestGeometry:
+    """Which window geometry a launch gets, and why it depends on the mode.
+
+    The contradiction this fixes was measured: a headed window reported an
+    outer height of 805 while the same browser reported a screen 720 tall,
+    because an emulated viewport was forced onto a real window.
+    """
+
+    def test_headless_keeps_an_explicit_viewport(self, tmp_path):
+        """Headless plus `no_viewport` collapses the screen to 800x600, so the
+        explicit size stays for the mode that has no real window."""
+        manager = BrowserManager(user_data_dir=tmp_path, headless=True)
+
+        assert manager._geometry() == {"viewport": {"width": 1280, "height": 720}}
+
+    def test_headless_honours_a_configured_viewport(self, tmp_path):
+        manager = BrowserManager(
+            user_data_dir=tmp_path,
+            headless=True,
+            viewport={"width": 1920, "height": 1080},
+        )
+
+        assert manager._geometry() == {"viewport": {"width": 1920, "height": 1080}}
+
+    def test_headed_sends_no_viewport_at_all(self, tmp_path):
+        """A real window reports the size it really is.
+
+        `no_viewport` has to be the only geometry key: sending a viewport
+        alongside it is what emulated a screen the window did not fit on.
+        """
+        manager = BrowserManager(user_data_dir=tmp_path, headless=False)
+
+        assert manager._geometry() == {"no_viewport": True}
+
+    def test_headed_ignores_a_configured_viewport(self, tmp_path):
+        """VIEWPORT stops applying to headed launches, deliberately.
+
+        Documented behaviour change: the setting now describes the windowless
+        default mode only.
+        """
+        manager = BrowserManager(
+            user_data_dir=tmp_path,
+            headless=False,
+            viewport={"width": 1920, "height": 1080},
+        )
+
+        assert manager._geometry() == {"no_viewport": True}
+
+    def test_the_mode_comes_from_the_launch_not_the_configuration(self, tmp_path):
+        """Only this object knows the answer.
+
+        The manual login always constructs with `headless=False` while the
+        configuration default stays `True`, so a decision made from the
+        configuration would be wrong for exactly the launch that opens a window.
+        """
+        assert (
+            "no_viewport"
+            in BrowserManager(user_data_dir=tmp_path, headless=False)._geometry()
+        )
+        assert (
+            "viewport"
+            in BrowserManager(user_data_dir=tmp_path, headless=True)._geometry()
+        )
+
+
 def _make_cookie(
     name: str,
     value: str = "value",

--- a/tests/test_core_browser.py
+++ b/tests/test_core_browser.py
@@ -1,11 +1,27 @@
 """Tests for BrowserManager cookie import/export helpers."""
 
+import contextlib
 import json
+from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from linkedin_mcp_server.core.browser import BrowserManager
+
+
+def test_a_no_viewport_override_is_refused(tmp_path):
+    """The geometry decision must not be overridable through launch options.
+
+    `_geometry()` is spread *before* `**launch_options`, so a caller-supplied
+    `no_viewport` would win. `no_viewport=False` on a headed launch puts the
+    emulated screen back and restores the window-larger-than-screen
+    contradiction this change exists to remove; `no_viewport=True` on a
+    headless one sends both geometry keys at once. Nothing produces either
+    today, which is why it is refused now rather than after something does.
+    """
+    with pytest.raises(TypeError, match="no_viewport"):
+        BrowserManager(user_data_dir=tmp_path / "profile", no_viewport=False)
 
 
 def test_a_user_agent_is_refused_rather_than_applied(tmp_path):
@@ -70,21 +86,67 @@ class TestGeometry:
 
         assert manager._geometry() == {"no_viewport": True}
 
-    def test_the_mode_comes_from_the_launch_not_the_configuration(self, tmp_path):
-        """Only this object knows the answer.
+    def test_the_mode_comes_from_the_launch_not_the_configuration(
+        self, tmp_path, monkeypatch
+    ):
+        """The constructor argument wins over the configuration, which differs.
 
-        The manual login always constructs with `headless=False` while the
-        configuration default stays `True`, so a decision made from the
-        configuration would be wrong for exactly the launch that opens a window.
+        This is the confusion worth pinning. The manual login constructs with
+        `headless=False` while `BrowserConfig.headless` stays `True`, so a
+        decision read from configuration would be wrong for exactly the launch
+        that opens a window. Asserted by making the two disagree.
         """
-        assert (
-            "no_viewport"
-            in BrowserManager(user_data_dir=tmp_path, headless=False)._geometry()
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        config = AppConfig()
+        config.browser.headless = True
+        monkeypatch.setattr(
+            "linkedin_mcp_server.config.get_config", lambda: config, raising=False
         )
-        assert (
-            "viewport"
-            in BrowserManager(user_data_dir=tmp_path, headless=True)._geometry()
-        )
+
+        headed = BrowserManager(user_data_dir=tmp_path, headless=False)
+
+        assert headed._geometry() == {"no_viewport": True}
+
+    async def test_the_launch_actually_receives_the_geometry(self, tmp_path):
+        """The helper is not the behaviour.
+
+        Every other test here would stay green if `start()` stopped calling
+        `_geometry()` and went back to sending a viewport unconditionally. This
+        one reads the kwargs Patchright is actually handed.
+        """
+        captured: dict = {}
+
+        class _FakeChromium:
+            async def launch_persistent_context(self, user_data_dir, **kwargs):
+                captured.update(kwargs)
+                raise _StopLaunch()
+
+        class _FakePlaywright:
+            chromium = _FakeChromium()
+
+            async def stop(self):
+                return None
+
+        class _StopLaunch(Exception):
+            """Ends the launch once the options have been observed."""
+
+        manager = BrowserManager(user_data_dir=tmp_path, headless=False)
+
+        async def fake_start():
+            return _FakePlaywright()
+
+        with mock.patch(
+            "linkedin_mcp_server.core.browser.async_playwright"
+        ) as playwright:
+            playwright.return_value.start = fake_start
+            with contextlib.suppress(Exception):
+                await manager.start()
+
+        assert captured.get("no_viewport") is True
+        assert "viewport" not in captured
+        # The locale sits after the spread on purpose and must stay pinned.
+        assert captured.get("locale") == "en-US"
 
 
 def _make_cookie(


### PR DESCRIPTION
`BrowserManager` collapsed a `None` viewport into a default with `viewport or {...}`, so "no viewport" could not be expressed at all. Every launch therefore got an emulated screen, including headed ones, which is what produced the contradiction measured during this work: an outer window of 805 pixels standing on a screen the same browser reported as 720 tall. A page can read both and compare them.

Headed launches now send `no_viewport=True` and no viewport, so the window reports the size it really is. Headless keeps an explicit one, because headless plus `no_viewport` collapses the screen to 800x600, which is its own oddity.

The decision belongs to `BrowserManager` rather than to `build_launch_options`, and the reason is the interesting part. The builder is a pure function of the configuration, and the configuration says `headless=True` by default *even while the manual login is launching headed*, because the login passes `headless=False` directly to the constructor. A builder reading `config.browser.headless` would therefore be wrong for exactly the launch that puts a window on someone's screen. Only the object being constructed knows which mode it is in. There is a test for that specific confusion.

`VIEWPORT` consequently stops applying to `--no-headless` and `--login`. It is publicly documented, so README, `.env.example`, `docs/docker-hub.md` and the CLI help are narrowed to say it describes the windowless default mode.

Full suite green at 1663 passed. The new geometry tests were verified red against both mutations: always sending a viewport, and deciding from the configuration instead of the actual launch.

See also: #606

## Synthetic prompt

> `BrowserManager` forces an emulated viewport onto every launch because
> `viewport or {...}` makes `None` inexpressible, so a headed window reports an
> outer size larger than the screen it claims to sit on. Give headed launches
> `no_viewport=True` and no viewport, keep an explicit viewport for headless
> (where `no_viewport` collapses the screen to 800x600), and put the decision in
> `BrowserManager` rather than the launch-options builder, because only the
> manager knows the actual mode: the login passes `headless=False` while the
> config default stays `True`. Narrow the documented meaning of `VIEWPORT`.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
