### PR TITLE
fix(bootstrap): Skip the install for a custom Chrome

### DIFF
--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -65,11 +65,12 @@ _REGISTRY_NAME_TO_DIR_PREFIX = {
     "chromium-headless-shell": "chromium_headless_shell-",
 }
 
-# On-disk dir prefix of the headless shell — the only binary the default
-# headless scrape + auto-import path launches.
+# On-disk dir prefix of the headless shell. Nothing launches it any more —
+# every launch names ``channel="chromium"`` — but the prefix is still needed to
+# recognise one in an install written before that change.
 _SHELL_DIR_PREFIX = "chromium_headless_shell-"
-# On-disk dir prefix of full Chrome for Testing — needed only for the headed
-# interactive-login fallback or an operator-configured --no-headless run.
+# On-disk dir prefix of full Chrome for Testing: the browser this server runs,
+# in either mode.
 _FULL_DIR_PREFIX = "chromium-"
 
 
@@ -372,8 +373,9 @@ def _start_browser_setup_task_locked() -> None:
 async def _run_patchright_install(extra_arg: str) -> None:
     """Run one ``patchright install chromium`` stage with the given flag.
 
-    The patchright registry lock serializes concurrent installs, so the two
-    stages always run one after the other on the same browsers path.
+    The patchright registry lock serializes concurrent installs, so two
+    processes reaching this at once queue on the same browsers path rather than
+    corrupting it.
     """
     proc = await asyncio.create_subprocess_exec(
         sys.executable,
@@ -454,6 +456,14 @@ def ensure_browser_installed() -> None:
     path uses async background setup instead (non-blocking).
     """
     configure_browser_environment()
+    # An operator-supplied executable is the one that gets launched, so the
+    # managed browser would be downloaded and never run. That was survivable
+    # while two of these three modes needed only the 92 MiB shell; now they all
+    # want the full browser, so it is 170 MiB spent on nothing -- and for
+    # someone whose network cannot reach the CDN, it is the difference between
+    # signing in and not.
+    if _uses_custom_chrome():
+        return
     if browser_ready():
         return
     print("   Installing Patchright Chromium browser...")

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -742,8 +742,77 @@ class TestTwoStageInstall:
         assert calls == ["--no-shell"]
 
 
+class TestEnsureBrowserInstalledSkipsCustomChrome:
+    """A custom executable must not trigger a managed download.
+
+    The gap this closes was survivable while two of the three CLI modes needed
+    only the 92 MiB shell. Now they all want the full browser, so it is 170 MiB
+    fetched for something that is never launched -- and for an operator whose
+    network cannot reach the CDN, it is the difference between signing in and
+    not. `_uses_custom_chrome()` already existed and said so in its docstring;
+    only this caller never asked.
+    """
+
+    def test_custom_chrome_skips_the_download(self, isolate_profile_dir, monkeypatch):
+        _patch_targets_and_version(monkeypatch)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._uses_custom_chrome", lambda: True
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap.browser_ready", lambda: False
+        )
+
+        called = {"value": 0}
+
+        async def fake_install() -> None:
+            called["value"] += 1
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._ensure_browser_installed", fake_install
+        )
+
+        ensure_browser_installed()
+
+        assert called["value"] == 0
+
+    def test_managed_chrome_still_downloads(self, isolate_profile_dir, monkeypatch):
+        """The short circuit must be about the custom path, not about skipping."""
+        _patch_targets_and_version(monkeypatch)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._uses_custom_chrome", lambda: False
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap.browser_ready", lambda: False
+        )
+
+        called = {"value": 0}
+
+        async def fake_install() -> None:
+            called["value"] += 1
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._ensure_browser_installed", fake_install
+        )
+
+        ensure_browser_installed()
+
+        assert called["value"] == 1
+
+
 class TestEnsureBrowserInstalled:
     """The CLI installer: one browser, the same one for every mode."""
+
+    @pytest.fixture(autouse=True)
+    def _managed_browser(self, monkeypatch):
+        """No custom executable, stated rather than assumed.
+
+        `ensure_browser_installed` now asks whether CHROME_PATH is set, and
+        answering that reads the configuration, which pytest cannot resolve on
+        its own.
+        """
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._uses_custom_chrome", lambda: False
+        )
 
     def _stub(self, monkeypatch):
         calls = {"value": 0}


### PR DESCRIPTION
`ensure_browser_installed()` downloads the managed browser for `--login`, `--status` and `--import-from-browser` even when `CHROME_PATH` points at the executable those modes will actually launch. `_uses_custom_chrome()` already existed and its docstring already said why the download is pointless; this caller simply never asked.

It mattered less before #669, when two of the three modes needed only the 92 MiB headless shell. They all want the full browser now, so it is 170 MiB fetched for something that is never run. For an operator whose network cannot reach the CDN it is worse than waste: with a perfectly good browser on disk they can neither sign in nor check status.

Also corrects two comments that outlived the change they described. The headless shell is no longer "the only binary the default path launches", and there are no longer two install stages to serialise.

Found by review of #669 rather than by a test, which is itself the gap: the custom-Chrome path was covered for the background gate and for `_run_login_flow`, but not for this CLI wrapper. It is now, verified red against removing the short circuit.

One thing worth flagging for the next reader. Adding the check means this function reads the configuration, and `get_config()` parses `sys.argv` lazily, which pytest cannot resolve on its own. Three existing tests started failing for exactly that reason, and they now state which world they are in rather than inheriting one. The same trap is documented on `build_launch_options`.

Full suite green at 1660 passed.

See also: #606

## Synthetic prompt

> `ensure_browser_installed()` downloads the managed Chromium for the CLI modes
> even when `CHROME_PATH` is set, so an operator with their own browser and no
> CDN access cannot log in. Short-circuit it with the existing
> `_uses_custom_chrome()`, add tests for both directions, and fix the comments
> that still describe the headless shell as the default binary and the install
> as two stages.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
