### PR TITLE
feat(browser): Work in a window that never opens

### DIFF
--- a/docs/browser-fingerprint.md
+++ b/docs/browser-fingerprint.md
@@ -77,8 +77,35 @@ headless".
 | Bundled Chromium, headless, UA claiming 143 | 33% / 88% | `hasMissingChromeObject` high severity; UA and hints disagree |
 | Full Chromium headless (`channel="chromium"`) | 67% / 50% | Two high-severity fpscanner rules from the headless token |
 | Headless shell (the old default) | — | `plugins.length = 0`, no `window.chrome`, notification permission incoherent |
+| Hidden target, windowless mode | — | No headless token in UA or brands; `visible` / focused; rAF at 100% of a control window |
 | Docker, headed under Xvfb | 0% / 44% | No headless token, native hints; needs `xauth` |
 | Docker, Xvfb + Mesa llvmpipe | 0% / 44% | Restores WebGL; renderer string is a known software renderer |
+
+The windowless mode, measured end to end through `BrowserManager`:
+
+| | Value |
+|---|---|
+| User agent | `…Chrome/148.0.0.0…`, no `HeadlessChrome` |
+| `sec-ch-ua` brands | `Not/A)Brand`, `Chromium` |
+| `navigator.webdriver` | `false` |
+| `document.visibilityState` / `hasFocus()` | `visible` / `true` |
+| `requestAnimationFrame` | 122/s against a control visible window at 122/s |
+| Cookie across a full restart | survives |
+| Window on screen once settled | none |
+| Window on screen during startup | ~550 ms, median of five runs (504-593) |
+
+The rAF figure is the one that mattered: hiding the application at OS level
+throttled it to about 1 Hz against 120, which is what disqualified that
+approach. A hidden target runs at the same rate as an ordinary window.
+
+Two things this does not claim. The half second of visible window on every
+browser start cannot be shortened from here — roughly 250 ms passes before
+`launch_persistent_context()` returns and about 340 ms is macOS tearing the
+window down, leaving about 90 ms that is ours. And the windowless page reports
+`outerWidth == screen.width`, which no real window does, since a real one has
+chrome and sits inside its display. That is unchanged from the previous
+headless default rather than introduced here, and it stays on the list of
+things worth fixing.
 
 Window geometry, read from a page's own `<script>` on a loopback origin:
 

--- a/docs/browser-fingerprint.md
+++ b/docs/browser-fingerprint.md
@@ -77,7 +77,7 @@ headless".
 | Bundled Chromium, headless, UA claiming 143 | 33% / 88% | `hasMissingChromeObject` high severity; UA and hints disagree |
 | Full Chromium headless (`channel="chromium"`) | 67% / 50% | Two high-severity fpscanner rules from the headless token |
 | Headless shell (the old default) | — | `plugins.length = 0`, no `window.chrome`, notification permission incoherent |
-| Hidden target, windowless mode | — | No headless token in UA or brands; `visible` / focused; rAF at 100% of a control window |
+| Hidden target, windowless mode (macOS) | — | No headless token in UA or brands; `visible` / focused; rAF at 100% of a control window |
 | Docker, headed under Xvfb | 0% / 44% | No headless token, native hints; needs `xauth` |
 | Docker, Xvfb + Mesa llvmpipe | 0% / 44% | Restores WebGL; renderer string is a known software renderer |
 
@@ -97,6 +97,20 @@ The windowless mode, measured end to end through `BrowserManager`:
 The rAF figure is the one that mattered: hiding the application at OS level
 throttled it to about 1 Hz against 120, which is what disqualified that
 approach. A hidden target runs at the same rate as an ordinary window.
+
+**It applies to macOS only, and that is a measured limit rather than a
+scoping decision.** The mechanism needs the browser to survive losing its last
+visible window, because removing that window is the whole point. Measured in the
+published container image, under Xvfb: closing the startup page kills Chromium
+and the hidden page dies with it, while keeping that page open leaves everything
+working. Without a display a headed launch does not start at all
+(`TargetClosedError`). macOS does not quit an application when its last window
+closes, which is why it works there. Windows is untested and plausibly behaves
+like Linux, so it is not claimed.
+
+Linux is less a gap than a different answer: under a virtual display nobody is
+looking at the screen, so an ordinary window is already invisible and there is
+nothing to hide.
 
 Two things this does not claim. The half second of visible window on every
 browser start cannot be shortened from here — roughly 250 ms passes before

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -239,6 +239,17 @@ class BrowserManager:
                     type(exc).__name__,
                 )
                 self._no_window_available = True
+
+                # The driver has to be replaced, not reused. It was started
+                # with the attach flag, and that flag lives in *its* process for
+                # its whole life -- restoring the parent environment does
+                # nothing to a child that already read it. A driver that keeps
+                # promoting `other` targets would put a component extension's
+                # page into `context.pages`, and the code below takes the first
+                # one as the page to authenticate and scrape with.
+                await self._playwright.stop()
+                self._playwright = await async_playwright().start()
+
                 context_options["headless"] = True
                 context_options.pop("no_viewport", None)
                 context_options.update(self._geometry())

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -112,6 +112,9 @@ class BrowserManager:
         self._context: BrowserContext | None = None
         self._page: Page | None = None
         self._is_authenticated = False
+        #: Set when a headed launch was attempted and refused, which is the only
+        #: reliable way to learn that this machine has nowhere to put a window.
+        self._no_window_available = False
         # False until a teardown proves Chromium exited. Pessimistic by default:
         # a launch that is cancelled before close runs must not read as clean.
         self._close_confirmed = False
@@ -141,7 +144,11 @@ class BrowserManager:
         headless mode, and the browser then says so on every surface. That is a
         loss worth announcing rather than hiding, which is why it is logged.
         """
-        return self.headless and hidden_target_is_supported()
+        return (
+            self.headless
+            and hidden_target_is_supported()
+            and not self._no_window_available
+        )
 
     def _geometry(self) -> dict[str, Any]:
         """The viewport options, decided by the mode this browser actually runs in.
@@ -204,10 +211,50 @@ class BrowserManager:
             # itself on the first surface anyone checks, and it never reaches
             # service workers at all. See the browser identity rules in
             # AGENTS.md and the measurements in docs/browser-fingerprint.md.
-            self._context = await self._playwright.chromium.launch_persistent_context(
-                self.user_data_dir,
-                **context_options,
-            )
+            try:
+                self._context = (
+                    await self._playwright.chromium.launch_persistent_context(
+                        self.user_data_dir,
+                        **context_options,
+                    )
+                )
+            except Exception as exc:
+                # A headed launch needs somewhere to put a window, and whether
+                # this machine has one cannot be decided from the platform name
+                # alone: a Mac reached over SSH, a launchd daemon, or a CI
+                # runner with no GUI session all look like macOS and all refuse
+                # to open one. Rather than enumerate those, let the attempt
+                # answer it -- that is the one check that cannot be wrong about
+                # a case nobody thought of.
+                #
+                # Narrow on purpose: only when a window was asked for and only
+                # once, so a genuine launch failure still surfaces rather than
+                # being retried into a different error.
+                if not self._windowless:
+                    raise
+                logger.warning(
+                    "Could not start a browser with a window (%s), so Chromium "
+                    "runs in headless mode and will identify itself as "
+                    "HeadlessChrome on every surface.",
+                    type(exc).__name__,
+                )
+                self._no_window_available = True
+                context_options["headless"] = True
+                context_options.pop("no_viewport", None)
+                context_options.update(self._geometry())
+                try:
+                    self._context = (
+                        await self._playwright.chromium.launch_persistent_context(
+                            self.user_data_dir,
+                            **context_options,
+                        )
+                    )
+                except Exception:
+                    # The retry is a chance, not a cover-up. If the browser
+                    # will not start either way the problem was never the
+                    # window, and the first error is the one that says what it
+                    # actually was.
+                    raise exc from None
 
             logger.info(
                 "Persistent browser launched (headless=%s, user_data_dir=%s)",

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -22,6 +22,10 @@ from linkedin_mcp_server.common_utils import (
 )
 
 from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
+from linkedin_mcp_server.hidden_target import (
+    attaching_to_other_targets,
+    open_hidden_page,
+)
 
 from .exceptions import NetworkError, ProxyConnectionError
 
@@ -150,13 +154,22 @@ class BrowserManager:
         if self._context is not None:
             raise RuntimeError("Browser already started. Call close() first.")
         try:
-            self._playwright = await async_playwright().start()
+            # The flag has to be in the environment before the driver
+            # subprocess exists, and it is scoped so a launch that does not need
+            # it does not inherit it.
+            with attaching_to_other_targets():
+                self._playwright = await async_playwright().start()
 
             secure_mkdir(Path(self.user_data_dir))
             harden_linkedin_tree(Path(self.user_data_dir))
 
             context_options: dict[str, Any] = {
-                "headless": self.headless,
+                # Always headed, in both modes. ``self.headless`` keeps its
+                # public meaning -- "no visible window" -- but it is no longer
+                # how that is achieved, because Chromium's headless *mode* is
+                # what makes the browser announce itself as headless. A
+                # windowless page comes from a hidden target instead.
+                "headless": False,
                 "slow_mo": self.slow_mo,
                 **self._geometry(),
                 **self.launch_options,
@@ -179,10 +192,18 @@ class BrowserManager:
                 self.user_data_dir,
             )
 
-            if self._context.pages:
-                self._page = self._context.pages[0]
+            startup = (
+                self._context.pages[0]
+                if self._context.pages
+                else await self._context.new_page()
+            )
+            if self.headless:
+                # Fails closed. Falling back to real headless would restore the
+                # token the caller believes is gone, and falling back to the
+                # visible window would put one on their screen unannounced.
+                self._page = await open_hidden_page(self._context, startup)
             else:
-                self._page = await self._context.new_page()
+                self._page = startup
 
             logger.info("Browser context and page ready")
 

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -114,6 +114,10 @@ class BrowserManager:
         self._is_authenticated = False
         #: Set when a headed launch was attempted and refused, which is the only
         #: reliable way to learn that this machine has nowhere to put a window.
+        #: Per instance rather than per process, deliberately: a fresh manager
+        #: is built for each browser, so this saves a second doomed attempt
+        #: within one launch without cacheing a machine-wide answer that could
+        #: go stale when somebody logs into a desktop session.
         self._no_window_available = False
         # False until a teardown proves Chromium exited. Pessimistic by default:
         # a launch that is cancelled before close runs must not read as clean.
@@ -247,7 +251,21 @@ class BrowserManager:
                 # promoting `other` targets would put a component extension's
                 # page into `context.pages`, and the code below takes the first
                 # one as the page to authenticate and scrape with.
-                await self._playwright.stop()
+                # Bounded, and its failure survived, for the same reason
+                # ``close()`` bounds its own cleanup: a wedged driver can hang
+                # ``stop()`` indefinitely. Turning a recoverable launch into a
+                # permanent hang would be the worse trade, so a driver that will
+                # not stop is left behind and said so.
+                try:
+                    await asyncio.wait_for(
+                        self._playwright.stop(), timeout=_CLEANUP_TIMEOUT_SECONDS
+                    )
+                except Exception as stop_exc:
+                    logger.warning(
+                        "The refused driver did not stop (%s); continuing with a "
+                        "fresh one.",
+                        type(stop_exc).__name__,
+                    )
                 self._playwright = await async_playwright().start()
 
                 context_options["headless"] = True
@@ -260,7 +278,17 @@ class BrowserManager:
                             **context_options,
                         )
                     )
-                except Exception:
+                except Exception as retry_exc:
+                    # Logged before it is discarded. The raise below keeps the
+                    # first error because that is the one that says what went
+                    # wrong, but losing the second entirely would leave whoever
+                    # debugs this unable to see that the fallback was even
+                    # tried, let alone how it failed.
+                    logger.warning(
+                        "The headless fallback did not start either: %s: %s",
+                        type(retry_exc).__name__,
+                        retry_exc,
+                    )
                     # The retry is a chance, not a cover-up. If the browser
                     # will not start either way the problem was never the
                     # window, and the first error is the one that says what it

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -24,6 +24,7 @@ from linkedin_mcp_server.common_utils import (
 from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
 from linkedin_mcp_server.hidden_target import (
     attaching_to_other_targets,
+    hidden_target_is_supported,
     open_hidden_page,
 )
 
@@ -130,6 +131,18 @@ class BrowserManager:
         self._close_confirmed = False
         self._close_confirmed = await self.close()
 
+    @property
+    def _windowless(self) -> bool:
+        """Whether this launch hides its page in a target rather than a mode.
+
+        Both conditions, and the second is not a preference. Asking for no
+        visible window is not enough on a machine that cannot open one: a headed
+        launch there fails outright, so the only way to run at all is Chromium's
+        headless mode, and the browser then says so on every surface. That is a
+        loss worth announcing rather than hiding, which is why it is logged.
+        """
+        return self.headless and hidden_target_is_supported()
+
     def _geometry(self) -> dict[str, Any]:
         """The viewport options, decided by the mode this browser actually runs in.
 
@@ -154,22 +167,32 @@ class BrowserManager:
         if self._context is not None:
             raise RuntimeError("Browser already started. Call close() first.")
         try:
-            # The flag has to be in the environment before the driver
-            # subprocess exists, and it is scoped so a launch that does not need
-            # it does not inherit it.
-            with attaching_to_other_targets():
+            # Only where a hidden target is actually going to be created. The
+            # flag has to exist before the driver subprocess does, and it then
+            # lives in that process for its whole lifetime -- restoring it here
+            # afterwards does nothing to the child. So a visible login, or a
+            # platform that falls back to real headless, would otherwise spend
+            # its entire run promoting extension and other `other` targets into
+            # `context.pages` for no reason.
+            if self._windowless:
+                with attaching_to_other_targets():
+                    self._playwright = await async_playwright().start()
+            else:
                 self._playwright = await async_playwright().start()
 
             secure_mkdir(Path(self.user_data_dir))
             harden_linkedin_tree(Path(self.user_data_dir))
 
             context_options: dict[str, Any] = {
-                # Always headed, in both modes. ``self.headless`` keeps its
-                # public meaning -- "no visible window" -- but it is no longer
-                # how that is achieved, because Chromium's headless *mode* is
-                # what makes the browser announce itself as headless. A
+                # Headed wherever a window can exist, in both public modes.
+                # ``self.headless`` keeps its meaning -- "no visible window" --
+                # but it is no longer how that is achieved, because Chromium's
+                # headless *mode* is what makes the browser announce itself. A
                 # windowless page comes from a hidden target instead.
-                "headless": False,
+                #
+                # Where no display exists there is no choice: a headed launch
+                # dies before any of that can happen. See ``_windowless``.
+                "headless": self.headless and not self._windowless,
                 "slow_mo": self.slow_mo,
                 **self._geometry(),
                 **self.launch_options,
@@ -191,13 +214,20 @@ class BrowserManager:
                 self.headless,
                 self.user_data_dir,
             )
+            if self.headless and not self._windowless:
+                logger.info(
+                    "Chromium runs in headless mode on this platform and so "
+                    "identifies itself as HeadlessChrome on every surface. A "
+                    "windowless page needs a browser that survives losing its "
+                    "last window, which is measured only on macOS."
+                )
 
             startup = (
                 self._context.pages[0]
                 if self._context.pages
                 else await self._context.new_page()
             )
-            if self.headless:
+            if self._windowless:
                 # Fails closed. Falling back to real headless would restore the
                 # token the caller believes is gone, and falling back to the
                 # visible window would put one on their screen unannounced.

--- a/linkedin_mcp_server/hidden_target.py
+++ b/linkedin_mcp_server/hidden_target.py
@@ -29,6 +29,8 @@ import contextlib
 import logging
 import os
 import secrets
+import sys
+import threading
 import time
 from typing import TYPE_CHECKING
 
@@ -51,6 +53,35 @@ _ATTACH_TIMEOUT_SECONDS = 10.0
 _POLL_SECONDS = 0.02
 
 
+def hidden_target_is_supported() -> bool:
+    """Whether this platform can work in a window that never opens.
+
+    Two things have to be true, and only one of them is about displays.
+
+    A headed browser needs a display server. Measured in the published
+    container image: with no ``DISPLAY``, ``launch_persistent_context(
+    headless=False)`` fails with a ``TargetClosedError`` before any of this code
+    runs.
+
+    And the browser has to survive losing its last visible window, because that
+    is exactly what this does. Measured, same image, under Xvfb: closing the
+    startup page kills Chromium and the hidden page dies with it, while keeping
+    that page open leaves everything working. macOS does not quit an application
+    when its last window closes, which is why the mechanism works there.
+
+    So this is deliberately narrow. macOS is measured and supported. Windows is
+    *not* measured -- it plausibly behaves like Linux -- and claiming it without
+    looking would be the kind of guess this file exists to avoid. Everything
+    else falls back to Chromium's headless mode and says so.
+
+    Linux is not a gap so much as a different answer: under a virtual display
+    nobody is looking at the screen, so an ordinary window is already invisible
+    and there is nothing to hide. That is the container's path, and it belongs
+    with the change that gives the container a display.
+    """
+    return sys.platform == "darwin"
+
+
 class HiddenTargetError(RuntimeError):
     """The windowless page could not be created.
 
@@ -59,6 +90,22 @@ class HiddenTargetError(RuntimeError):
     window would put one on their screen unannounced. Both are worse than
     stopping.
     """
+
+
+#: Guards the flag against overlapping launches. ``os.environ`` is
+#: process-global while the block it scopes contains an ``await``, so two
+#: launches can interleave: measured, two concurrent driver starts left the flag
+#: set afterwards in two runs out of five, and the opposite ordering would let
+#: the second launch miss it entirely. Today's production paths are serialised
+#: by the bootstrap and browser-creation locks, but ``BrowserManager`` is public
+#: and nothing about it promises that.
+_flag_lock = threading.Lock()
+#: How many launches are inside the block. The first sets, the last restores.
+#: Counting rather than locking around the whole block, because that would
+#: serialise driver startup for no reason -- concurrent launches all want the
+#: flag set, so they can share it.
+_flag_depth = 0
+_flag_previous: str | None = None
 
 
 @contextlib.contextmanager
@@ -72,16 +119,26 @@ def attaching_to_other_targets():
     The value has to be in the environment before the driver subprocess starts,
     which is why this wraps ``async_playwright().start()`` rather than the
     context launch.
+
+    Safe to nest and to overlap: see ``_flag_depth``.
     """
-    previous = os.environ.get(ATTACH_TO_OTHER)
-    os.environ[ATTACH_TO_OTHER] = "1"
+    global _flag_depth, _flag_previous
+    with _flag_lock:
+        if _flag_depth == 0:
+            _flag_previous = os.environ.get(ATTACH_TO_OTHER)
+        _flag_depth += 1
+        os.environ[ATTACH_TO_OTHER] = "1"
     try:
         yield
     finally:
-        if previous is None:
-            os.environ.pop(ATTACH_TO_OTHER, None)
-        else:
-            os.environ[ATTACH_TO_OTHER] = previous
+        with _flag_lock:
+            _flag_depth -= 1
+            if _flag_depth == 0:
+                if _flag_previous is None:
+                    os.environ.pop(ATTACH_TO_OTHER, None)
+                else:
+                    os.environ[ATTACH_TO_OTHER] = _flag_previous
+                _flag_previous = None
 
 
 async def open_hidden_page(context: "BrowserContext", startup: "Page") -> "Page":

--- a/linkedin_mcp_server/hidden_target.py
+++ b/linkedin_mcp_server/hidden_target.py
@@ -1,0 +1,141 @@
+"""A page in a window that never opens.
+
+Headless mode is what makes a browser announce itself. Chromium prepends the
+bare string ``Headless`` to the product name at runtime, so both the user agent
+and the ``sec-ch-ua`` brand list read ``HeadlessChrome`` -- which is why no
+change to *which* binary runs can remove it, only a change to the mode. But this
+server must not put a window on somebody's desktop either.
+
+Chromium can create a target with no UI window at all. The page behaves like an
+ordinary one; it simply has nowhere to be drawn. Every value below was measured
+before this was written, and the notes say which measurement decided what,
+because three of these details are the difference between working and silently
+not.
+
+Not measured, and worth stating plainly: a window *is* on screen for about half
+a second on every browser start, between Chromium opening its startup window and
+this closing it. It cannot be shortened from here. Roughly 250 ms passes before
+``launch_persistent_context()`` even returns, about 340 ms is macOS tearing the
+window down after ``close()``, and the part this code controls is around 90 ms.
+The only way to zero is for the browser never to open a window, which needs
+``--no-startup-window``; that hangs Playwright for its full timeout
+(https://github.com/microsoft/playwright/issues/42093).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import secrets
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from patchright.async_api import BrowserContext, Page
+
+logger = logging.getLogger(__name__)
+
+#: Playwright only surfaces a target Chromium reports as ``type: "other"`` when
+#: this is set in the *driver process* environment. It is undocumented upstream,
+#: and byte-identical across patchright 1.60.0, 1.60.1, 1.61.1 and 1.61.2; a
+#: question about whether it is supported is open at
+#: https://github.com/Kaliiiiiiiiii-Vinyzu/patchright/discussions/232
+ATTACH_TO_OTHER = "PW_CHROMIUM_ATTACH_TO_OTHER"
+
+#: How long to wait for the created target to surface as a Page. Generous: this
+#: is a local round trip, and the failure it guards is a hang rather than a slow
+#: machine.
+_ATTACH_TIMEOUT_SECONDS = 10.0
+_POLL_SECONDS = 0.02
+
+
+class HiddenTargetError(RuntimeError):
+    """The windowless page could not be created.
+
+    Raised rather than recovered from. Falling back to real headless would
+    restore the token the user believes is gone, and falling back to a visible
+    window would put one on their screen unannounced. Both are worse than
+    stopping.
+    """
+
+
+@contextlib.contextmanager
+def attaching_to_other_targets():
+    """Set the attach flag for the duration of a driver launch, then restore it.
+
+    Scoped rather than set once at import, because the flag makes Playwright
+    promote *every* ``other`` target it sees. A headed login launched in the
+    same process has no need of that and should not inherit it.
+
+    The value has to be in the environment before the driver subprocess starts,
+    which is why this wraps ``async_playwright().start()`` rather than the
+    context launch.
+    """
+    previous = os.environ.get(ATTACH_TO_OTHER)
+    os.environ[ATTACH_TO_OTHER] = "1"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(ATTACH_TO_OTHER, None)
+        else:
+            os.environ[ATTACH_TO_OTHER] = previous
+
+
+async def open_hidden_page(context: "BrowserContext", startup: "Page") -> "Page":
+    """Return a page with no window, and close the visible startup page.
+
+    *startup* is the page Chromium opened by itself. It is closed once the
+    hidden one exists, not before: closing it first would leave the context
+    with nothing and Chromium may exit.
+    """
+    browser = context.browser
+    if browser is None:
+        raise HiddenTargetError(
+            "No browser object on the context, so no browser-level CDP session. "
+            "A hidden target created from a page's session dies with that page."
+        )
+
+    # Browser-level, and this is not a stylistic choice. Measured: a target
+    # created through `context.new_cdp_session(page)` is destroyed when that
+    # page closes -- the browser stays up, `new_page()` still works, and the
+    # hidden page is simply gone. `context.new_cdp_session` is the obvious call
+    # and it is the wrong one.
+    session = await browser.new_browser_cdp_session()
+
+    # Identified by a nonce, never by position. The attach flag promotes every
+    # `other` target, and `context.pages` was measured containing a component
+    # extension's page beside the real one, so index-based selection picks the
+    # wrong target without failing.
+    nonce = secrets.token_hex(8)
+    url = f"about:blank#{nonce}"
+
+    # `about:blank` rather than a loopback URL, and that matters with a proxy.
+    # Measured: with Playwright's `proxy` option set and no bypass, a loopback
+    # nonce origin is fetched *through* the proxy and the page lands on
+    # `chrome-error://chromewebdata/`. `about:blank` has no origin to route, so
+    # it needs no bypass entry and cannot be broken by someone's proxy.
+    await session.send(
+        "Target.createTarget", {"url": url, "hidden": True, "background": True}
+    )
+
+    deadline = time.monotonic() + _ATTACH_TIMEOUT_SECONDS
+    hidden: Page | None = None
+    while time.monotonic() < deadline:
+        hidden = next((page for page in context.pages if nonce in page.url), None)
+        if hidden is not None:
+            break
+        await asyncio.sleep(_POLL_SECONDS)
+
+    if hidden is None:
+        raise HiddenTargetError(
+            f"Chromium accepted a hidden target but it never surfaced as a page "
+            f"within {_ATTACH_TIMEOUT_SECONDS:.0f}s. This needs "
+            f"{ATTACH_TO_OTHER} set in the driver process environment."
+        )
+
+    await startup.close()
+    logger.debug("Working in a hidden target; the startup window is closed")
+    return hidden

--- a/tests/test_core_browser.py
+++ b/tests/test_core_browser.py
@@ -163,31 +163,22 @@ class TestHowNoVisibleWindowIsAchieved:
     """
 
     async def _captured_options(self, tmp_path, *, headless: bool) -> dict:
-        captured: dict = {}
+        """The options a successful launch was given.
 
-        class _Chromium:
-            async def launch_persistent_context(self, user_data_dir, **kwargs):
-                captured.update(kwargs)
-                raise RuntimeError("stop once the options are known")
-
-        class _Playwright:
-            chromium = _Chromium()
-
-            async def stop(self):
-                return None
-
+        Deliberately not "the options recorded before a crash": the launch now
+        retries once when a window is refused, so a fake that raises would be
+        describing the fallback rather than the launch under test.
+        """
+        recorder: dict = {}
+        start, _ = TestTheWindowlessLaunchEndToEnd()._fake_playwright(recorder)
         manager = BrowserManager(user_data_dir=tmp_path, headless=headless)
-
-        async def fake_start():
-            return _Playwright()
 
         with mock.patch(
             "linkedin_mcp_server.core.browser.async_playwright"
         ) as playwright:
-            playwright.return_value.start = fake_start
-            with contextlib.suppress(Exception):
-                await manager.start()
-        return captured
+            playwright.return_value.start = start
+            await manager.start()
+        return recorder["options"]
 
     async def test_launches_headed_where_the_target_is_supported(
         self, tmp_path, monkeypatch
@@ -240,7 +231,13 @@ class TestTheWindowlessLaunchEndToEnd:
     alone. This one runs the launch through and reads what came out.
     """
 
-    def _fake_playwright(self, recorder: dict):
+    def _fake_playwright(
+        self,
+        recorder: dict,
+        *,
+        refuse_headed: bool = False,
+        refuse_headless: bool = False,
+    ):
         from linkedin_mcp_server.hidden_target import ATTACH_TO_OTHER
 
         pages: list = []
@@ -279,6 +276,10 @@ class TestTheWindowlessLaunchEndToEnd:
         class _Chromium:
             async def launch_persistent_context(self, user_data_dir, **kwargs):
                 recorder["options"] = kwargs
+                if refuse_headed and not kwargs.get("headless"):
+                    raise RuntimeError("headed launch refused: no window server")
+                if refuse_headless and kwargs.get("headless"):
+                    raise RuntimeError("headless launch refused too")
                 pages.append(_Page("about:blank"))
                 return _Context()
 
@@ -322,6 +323,59 @@ class TestTheWindowlessLaunchEndToEnd:
         # The startup page went, and only once the hidden one existed.
         assert pages[0].closed is True
         assert recorder["hidden_present_at_close"] is True
+
+    async def test_a_refused_window_falls_back_to_headless(self, tmp_path):
+        """The machine decides, not the platform name.
+
+        A Mac reached over SSH, a launchd daemon and a CI runner with no GUI
+        session all look like macOS and all refuse to open a window. Rather
+        than enumerate those, the attempt answers it -- which is the one check
+        that cannot be wrong about a case nobody thought of.
+        """
+        recorder: dict = {}
+        start, _ = self._fake_playwright(recorder, refuse_headed=True)
+        manager = BrowserManager(user_data_dir=tmp_path / "p", headless=True)
+
+        with mock.patch(
+            "linkedin_mcp_server.core.browser.hidden_target_is_supported",
+            return_value=True,
+        ):
+            with mock.patch(
+                "linkedin_mcp_server.core.browser.async_playwright"
+            ) as playwright:
+                playwright.return_value.start = start
+                await manager.start()
+
+        # It ran, in headless, and the page is the ordinary startup one.
+        assert recorder["options"]["headless"] is True
+        assert manager.page.url == "about:blank"
+
+    async def test_a_launch_that_fails_either_way_reports_the_first_error(
+        self, tmp_path
+    ):
+        """The retry is a chance, not a cover-up.
+
+        If the browser will not start with or without a window then the problem
+        was never the window, and the first error is the one that says what it
+        actually was. Reporting the second would send someone looking at
+        displays over a corrupt profile.
+        """
+        recorder: dict = {}
+        start, _ = self._fake_playwright(
+            recorder, refuse_headed=True, refuse_headless=True
+        )
+        manager = BrowserManager(user_data_dir=tmp_path / "p", headless=True)
+
+        with mock.patch(
+            "linkedin_mcp_server.core.browser.hidden_target_is_supported",
+            return_value=True,
+        ):
+            with mock.patch(
+                "linkedin_mcp_server.core.browser.async_playwright"
+            ) as playwright:
+                playwright.return_value.start = start
+                with pytest.raises(Exception, match="headed launch refused"):
+                    await manager.start()
 
     async def test_a_visible_launch_keeps_the_startup_page(self, tmp_path):
         recorder: dict = {}

--- a/tests/test_core_browser.py
+++ b/tests/test_core_browser.py
@@ -289,11 +289,21 @@ class TestTheWindowlessLaunchEndToEnd:
             async def stop(self):
                 return None
 
+        stops = {"count": 0}
+
+        class _Playwright2(_Playwright):
+            async def stop(self):
+                stops["count"] += 1
+                return None
+
         async def start():
-            # The flag has to be set at the moment the driver process is
-            # created, which is what this records.
-            recorder["flag_at_driver_start"] = os.environ.get(ATTACH_TO_OTHER)
-            return _Playwright()
+            # Every driver start, not just the first: a fallback launch starts a
+            # second one, and whether *that* inherited the flag is the point.
+            recorder.setdefault("flags_at_driver_start", []).append(
+                os.environ.get(ATTACH_TO_OTHER)
+            )
+            recorder["driver_stops"] = stops
+            return _Playwright2()
 
         return start, pages
 
@@ -317,7 +327,7 @@ class TestTheWindowlessLaunchEndToEnd:
         # The page handed to callers is the windowless one, not the startup one.
         assert manager.page.url.startswith("about:blank#")
         # The driver saw the flag; setting it afterwards would be too late.
-        assert recorder["flag_at_driver_start"] == "1"
+        assert recorder["flags_at_driver_start"] == ["1"]
         # And it did not leak past the launch.
         assert ATTACH_TO_OTHER not in os.environ
         # The startup page went, and only once the hidden one existed.
@@ -349,6 +359,13 @@ class TestTheWindowlessLaunchEndToEnd:
         # It ran, in headless, and the page is the ordinary startup one.
         assert recorder["options"]["headless"] is True
         assert manager.page.url == "about:blank"
+        # The driver was replaced rather than reused. The first one read the
+        # attach flag into its own process, where restoring the parent
+        # environment cannot reach it, and a driver that keeps promoting
+        # `other` targets would put an extension page into `context.pages` --
+        # which is where the working page is taken from.
+        assert recorder["flags_at_driver_start"] == ["1", None]
+        assert recorder["driver_stops"]["count"] == 1
 
     async def test_a_launch_that_fails_either_way_reports_the_first_error(
         self, tmp_path
@@ -409,7 +426,7 @@ class TestTheWindowlessLaunchEndToEnd:
             playwright.return_value.start = start
             await manager.start()
 
-        assert recorder["flag_at_driver_start"] is None
+        assert recorder["flags_at_driver_start"] == [None]
 
     async def test_a_platform_fallback_does_not_get_the_attach_flag(self, tmp_path):
         """Same reasoning where the platform cannot support a hidden target."""
@@ -427,7 +444,7 @@ class TestTheWindowlessLaunchEndToEnd:
                 playwright.return_value.start = start
                 await manager.start()
 
-        assert recorder["flag_at_driver_start"] is None
+        assert recorder["flags_at_driver_start"] == [None]
 
 
 def _make_cookie(

--- a/tests/test_core_browser.py
+++ b/tests/test_core_browser.py
@@ -1,5 +1,6 @@
 """Tests for BrowserManager cookie import/export helpers."""
 
+import asyncio
 import contextlib
 import json
 import os
@@ -150,14 +151,15 @@ class TestGeometry:
         assert captured.get("locale") == "en-US"
 
 
-class TestTheBrowserIsAlwaysHeaded:
-    """`headless` keeps its public meaning but no longer selects the mode.
+class TestHowNoVisibleWindowIsAchieved:
+    """`headless` keeps its public meaning but no longer names the mechanism.
 
     Chromium's headless *mode* is what makes a browser announce itself: it
     prepends the bare string `Headless` to the product name at runtime, so both
-    the user agent and the `sec-ch-ua` brands read `HeadlessChrome`. No choice of
-    binary removes that. So the browser runs headed either way, and "no visible
-    window" comes from a hidden target instead.
+    the user agent and the `sec-ch-ua` brands read `HeadlessChrome`. Where the
+    platform allows it the browser runs headed and hides its page in a target
+    instead. Where it does not, headless is the only way to run at all, and the
+    token comes back.
     """
 
     async def _captured_options(self, tmp_path, *, headless: bool) -> dict:
@@ -187,17 +189,39 @@ class TestTheBrowserIsAlwaysHeaded:
                 await manager.start()
         return captured
 
-    async def test_headless_still_launches_headed(self, tmp_path):
+    async def test_launches_headed_where_the_target_is_supported(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "linkedin_mcp_server.core.browser.hidden_target_is_supported",
+            lambda: True,
+        )
+
         options = await self._captured_options(tmp_path, headless=True)
 
         assert options["headless"] is False
 
-    async def test_headed_launches_headed(self, tmp_path):
+    async def test_falls_back_to_real_headless_where_it_is_not(
+        self, tmp_path, monkeypatch
+    ):
+        """Not a preference. Measured in the container image: a headed launch
+        with no display fails outright, and under Xvfb closing the last window
+        kills Chromium and takes the hidden page with it."""
+        monkeypatch.setattr(
+            "linkedin_mcp_server.core.browser.hidden_target_is_supported",
+            lambda: False,
+        )
+
+        options = await self._captured_options(tmp_path, headless=True)
+
+        assert options["headless"] is True
+
+    async def test_a_visible_window_is_always_headed(self, tmp_path):
         options = await self._captured_options(tmp_path, headless=False)
 
         assert options["headless"] is False
 
-    async def test_the_attach_flag_is_not_left_behind(self, tmp_path):
+    async def test_the_attach_flag_is_not_left_behind(self, tmp_path):  # noqa: D401
         """It makes Playwright promote every `other` target, so it is scoped."""
         from linkedin_mcp_server.hidden_target import ATTACH_TO_OTHER
 
@@ -205,6 +229,151 @@ class TestTheBrowserIsAlwaysHeaded:
         await self._captured_options(tmp_path, headless=True)
 
         assert os.environ.get(ATTACH_TO_OTHER) == before
+
+
+class TestTheWindowlessLaunchEndToEnd:
+    """The contract `start()` owes, not the helper it delegates to.
+
+    Every other test here passes if `open_hidden_page()` is deleted from
+    `start()` outright, or if its result is never assigned to `self._page`,
+    because they stop the launch before page selection or exercise the helper
+    alone. This one runs the launch through and reads what came out.
+    """
+
+    def _fake_playwright(self, recorder: dict):
+        from linkedin_mcp_server.hidden_target import ATTACH_TO_OTHER
+
+        pages: list = []
+
+        class _Page:
+            def __init__(self, url: str):
+                self.url = url
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+                recorder["hidden_present_at_close"] = any(
+                    p.url.startswith("about:blank#") for p in pages
+                )
+
+        class _Session:
+            async def send(self, method, params):
+                if method == "Target.createTarget":
+
+                    async def surface():
+                        await asyncio.sleep(0.01)
+                        pages.append(_Page(params["url"]))
+
+                    asyncio.get_running_loop().create_task(surface())
+                return {"targetId": "T"}
+
+        class _Browser:
+            async def new_browser_cdp_session(self):
+                return _Session()
+
+        class _Context:
+            def __init__(self):
+                self.pages = pages
+                self.browser = _Browser()
+
+        class _Chromium:
+            async def launch_persistent_context(self, user_data_dir, **kwargs):
+                recorder["options"] = kwargs
+                pages.append(_Page("about:blank"))
+                return _Context()
+
+        class _Playwright:
+            chromium = _Chromium()
+
+            async def stop(self):
+                return None
+
+        async def start():
+            # The flag has to be set at the moment the driver process is
+            # created, which is what this records.
+            recorder["flag_at_driver_start"] = os.environ.get(ATTACH_TO_OTHER)
+            return _Playwright()
+
+        return start, pages
+
+    async def test_the_hidden_page_becomes_the_working_page(self, tmp_path):
+        from linkedin_mcp_server.hidden_target import ATTACH_TO_OTHER
+
+        recorder: dict = {}
+        start, pages = self._fake_playwright(recorder)
+        manager = BrowserManager(user_data_dir=tmp_path / "p", headless=True)
+
+        with mock.patch(
+            "linkedin_mcp_server.core.browser.hidden_target_is_supported",
+            return_value=True,
+        ):
+            with mock.patch(
+                "linkedin_mcp_server.core.browser.async_playwright"
+            ) as playwright:
+                playwright.return_value.start = start
+                await manager.start()
+
+        # The page handed to callers is the windowless one, not the startup one.
+        assert manager.page.url.startswith("about:blank#")
+        # The driver saw the flag; setting it afterwards would be too late.
+        assert recorder["flag_at_driver_start"] == "1"
+        # And it did not leak past the launch.
+        assert ATTACH_TO_OTHER not in os.environ
+        # The startup page went, and only once the hidden one existed.
+        assert pages[0].closed is True
+        assert recorder["hidden_present_at_close"] is True
+
+    async def test_a_visible_launch_keeps_the_startup_page(self, tmp_path):
+        recorder: dict = {}
+        start, pages = self._fake_playwright(recorder)
+        manager = BrowserManager(user_data_dir=tmp_path / "p", headless=False)
+
+        with mock.patch(
+            "linkedin_mcp_server.core.browser.async_playwright"
+        ) as playwright:
+            playwright.return_value.start = start
+            await manager.start()
+
+        assert manager.page is pages[0]
+        assert pages[0].closed is False
+
+    async def test_a_visible_launch_does_not_get_the_attach_flag(self, tmp_path):
+        """The driver keeps the flag for its whole life, so scope matters.
+
+        Restoring the parent's environment afterwards does nothing to the child
+        process. A login that never creates a hidden target would otherwise
+        spend its entire run promoting extension and other `other` targets into
+        `context.pages`.
+        """
+        recorder: dict = {}
+        start, _ = self._fake_playwright(recorder)
+        manager = BrowserManager(user_data_dir=tmp_path / "p", headless=False)
+
+        with mock.patch(
+            "linkedin_mcp_server.core.browser.async_playwright"
+        ) as playwright:
+            playwright.return_value.start = start
+            await manager.start()
+
+        assert recorder["flag_at_driver_start"] is None
+
+    async def test_a_platform_fallback_does_not_get_the_attach_flag(self, tmp_path):
+        """Same reasoning where the platform cannot support a hidden target."""
+        recorder: dict = {}
+        start, _ = self._fake_playwright(recorder)
+        manager = BrowserManager(user_data_dir=tmp_path / "p", headless=True)
+
+        with mock.patch(
+            "linkedin_mcp_server.core.browser.hidden_target_is_supported",
+            return_value=False,
+        ):
+            with mock.patch(
+                "linkedin_mcp_server.core.browser.async_playwright"
+            ) as playwright:
+                playwright.return_value.start = start
+                await manager.start()
+
+        assert recorder["flag_at_driver_start"] is None
 
 
 def _make_cookie(

--- a/tests/test_core_browser.py
+++ b/tests/test_core_browser.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import json
 import os
+import time
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
@@ -237,6 +238,7 @@ class TestTheWindowlessLaunchEndToEnd:
         *,
         refuse_headed: bool = False,
         refuse_headless: bool = False,
+        stop_hangs: bool = False,
     ):
         from linkedin_mcp_server.hidden_target import ATTACH_TO_OTHER
 
@@ -294,6 +296,8 @@ class TestTheWindowlessLaunchEndToEnd:
         class _Playwright2(_Playwright):
             async def stop(self):
                 stops["count"] += 1
+                if stop_hangs:
+                    await asyncio.sleep(30)
                 return None
 
         async def start():
@@ -366,6 +370,41 @@ class TestTheWindowlessLaunchEndToEnd:
         # which is where the working page is taken from.
         assert recorder["flags_at_driver_start"] == ["1", None]
         assert recorder["driver_stops"]["count"] == 1
+
+    async def test_a_driver_that_will_not_stop_does_not_block_the_fallback(
+        self, tmp_path
+    ):
+        """A wedged driver must not turn a recoverable launch into a hang.
+
+        `close()` bounds its own cleanup for exactly this reason. Leaving one
+        driver behind is the lesser cost against never returning.
+        """
+        recorder: dict = {}
+        start, _ = self._fake_playwright(recorder, refuse_headed=True, stop_hangs=True)
+        manager = BrowserManager(user_data_dir=tmp_path / "p", headless=True)
+
+        began = time.monotonic()
+        with mock.patch(
+            "linkedin_mcp_server.core.browser._CLEANUP_TIMEOUT_SECONDS", 0.05
+        ):
+            with mock.patch(
+                "linkedin_mcp_server.core.browser.hidden_target_is_supported",
+                return_value=True,
+            ):
+                with mock.patch(
+                    "linkedin_mcp_server.core.browser.async_playwright"
+                ) as playwright:
+                    playwright.return_value.start = start
+                    await manager.start()
+        elapsed = time.monotonic() - began
+
+        assert recorder["options"]["headless"] is True
+        assert recorder["flags_at_driver_start"] == ["1", None]
+        # The timing is the assertion, not decoration. Without the bound this
+        # still *succeeds* -- it just waits out the wedged driver first, which
+        # is precisely the behaviour being ruled out. The fake hangs for 30s;
+        # anything near that means the bound was skipped.
+        assert elapsed < 5, f"the wedged driver was waited out ({elapsed:.1f}s)"
 
     async def test_a_launch_that_fails_either_way_reports_the_first_error(
         self, tmp_path

--- a/tests/test_core_browser.py
+++ b/tests/test_core_browser.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import json
+import os
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
@@ -147,6 +148,63 @@ class TestGeometry:
         assert "viewport" not in captured
         # The locale sits after the spread on purpose and must stay pinned.
         assert captured.get("locale") == "en-US"
+
+
+class TestTheBrowserIsAlwaysHeaded:
+    """`headless` keeps its public meaning but no longer selects the mode.
+
+    Chromium's headless *mode* is what makes a browser announce itself: it
+    prepends the bare string `Headless` to the product name at runtime, so both
+    the user agent and the `sec-ch-ua` brands read `HeadlessChrome`. No choice of
+    binary removes that. So the browser runs headed either way, and "no visible
+    window" comes from a hidden target instead.
+    """
+
+    async def _captured_options(self, tmp_path, *, headless: bool) -> dict:
+        captured: dict = {}
+
+        class _Chromium:
+            async def launch_persistent_context(self, user_data_dir, **kwargs):
+                captured.update(kwargs)
+                raise RuntimeError("stop once the options are known")
+
+        class _Playwright:
+            chromium = _Chromium()
+
+            async def stop(self):
+                return None
+
+        manager = BrowserManager(user_data_dir=tmp_path, headless=headless)
+
+        async def fake_start():
+            return _Playwright()
+
+        with mock.patch(
+            "linkedin_mcp_server.core.browser.async_playwright"
+        ) as playwright:
+            playwright.return_value.start = fake_start
+            with contextlib.suppress(Exception):
+                await manager.start()
+        return captured
+
+    async def test_headless_still_launches_headed(self, tmp_path):
+        options = await self._captured_options(tmp_path, headless=True)
+
+        assert options["headless"] is False
+
+    async def test_headed_launches_headed(self, tmp_path):
+        options = await self._captured_options(tmp_path, headless=False)
+
+        assert options["headless"] is False
+
+    async def test_the_attach_flag_is_not_left_behind(self, tmp_path):
+        """It makes Playwright promote every `other` target, so it is scoped."""
+        from linkedin_mcp_server.hidden_target import ATTACH_TO_OTHER
+
+        before = os.environ.get(ATTACH_TO_OTHER)
+        await self._captured_options(tmp_path, headless=True)
+
+        assert os.environ.get(ATTACH_TO_OTHER) == before
 
 
 def _make_cookie(

--- a/tests/test_hidden_target.py
+++ b/tests/test_hidden_target.py
@@ -1,0 +1,216 @@
+"""The windowless page: how it is found, and how it refuses.
+
+Three details here are the difference between working and silently not, and each
+was measured rather than reasoned about. They get a test apiece, because a wrong
+one of them does not raise -- it hands back the wrong page, or a page that
+vanishes later.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from linkedin_mcp_server.hidden_target import (
+    ATTACH_TO_OTHER,
+    HiddenTargetError,
+    attaching_to_other_targets,
+    open_hidden_page,
+)
+
+
+class _Session:
+    """A browser-level CDP session that records what it was asked to create.
+
+    ``trailing`` is appended *after* the created target, which is what makes the
+    ordering test meaningful: the attach flag promotes every ``other`` target,
+    so the page we asked for is not reliably the last one.
+    """
+
+    def __init__(self, pages: list, *, create: bool = True, trailing=None):
+        self.sent: list[tuple[str, dict]] = []
+        self._pages = pages
+        self._create = create
+        self._trailing = trailing
+
+    async def send(self, method: str, params: dict):
+        self.sent.append((method, params))
+        if method == "Target.createTarget" and self._create:
+            self._pages.append(SimpleNamespace(url=params["url"], close=_noop))
+            if self._trailing is not None:
+                self._pages.append(self._trailing)
+        return {"targetId": "T1"}
+
+
+async def _noop():
+    return None
+
+
+class _Browser:
+    def __init__(self, session):
+        self._session = session
+
+    async def new_browser_cdp_session(self):
+        return self._session
+
+
+class _Context:
+    def __init__(self, pages, browser):
+        self.pages = pages
+        self.browser = browser
+
+
+class _Startup:
+    def __init__(self):
+        self.url = "about:blank"
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class TestTheAttachFlag:
+    """It has to be in the driver process environment, and only for that launch."""
+
+    def test_sets_and_restores_when_unset(self, monkeypatch):
+        monkeypatch.delenv(ATTACH_TO_OTHER, raising=False)
+
+        with attaching_to_other_targets():
+            assert os.environ[ATTACH_TO_OTHER] == "1"
+
+        assert ATTACH_TO_OTHER not in os.environ
+
+    def test_restores_a_previous_value(self, monkeypatch):
+        monkeypatch.setenv(ATTACH_TO_OTHER, "operator-set")
+
+        with attaching_to_other_targets():
+            assert os.environ[ATTACH_TO_OTHER] == "1"
+
+        assert os.environ[ATTACH_TO_OTHER] == "operator-set"
+
+    def test_restores_after_a_failure(self, monkeypatch):
+        """A launch that raises must not leave the flag behind.
+
+        It makes Playwright promote every `other` target it sees, so a headed
+        login later in the same process would inherit behaviour it never asked
+        for.
+        """
+        monkeypatch.delenv(ATTACH_TO_OTHER, raising=False)
+
+        with pytest.raises(RuntimeError):
+            with attaching_to_other_targets():
+                raise RuntimeError("launch failed")
+
+        assert ATTACH_TO_OTHER not in os.environ
+
+
+class TestFindingTheRightPage:
+    async def test_creates_a_hidden_about_blank_target(self):
+        pages: list = []
+        context = _Context(pages, _Browser(_Session(pages)))
+        startup = _Startup()
+        pages.append(startup)
+
+        page = await open_hidden_page(cast(Any, context), cast(Any, startup))
+
+        method, params = context.browser._session.sent[0]
+        assert method == "Target.createTarget"
+        assert params["hidden"] is True
+        assert params["background"] is True
+        # `about:blank` has no origin, so a configured proxy cannot route it.
+        # Measured: a loopback nonce URL went through the proxy and the page
+        # landed on chrome-error://chromewebdata/.
+        assert params["url"].startswith("about:blank#")
+        assert page.url == params["url"]
+
+    async def test_finds_by_nonce_and_not_by_position(self):
+        """Ordering picks the wrong page without failing.
+
+        The attach flag promotes every `other` target, and a real run was
+        measured with a component extension's page sitting in `context.pages`
+        beside the one we asked for.
+        """
+        pages: list = []
+        decoy = SimpleNamespace(url="chrome-extension://abc/offscreen.html")
+        session = _Session(pages, trailing=decoy)
+        context = _Context(pages, _Browser(session))
+        startup = _Startup()
+        pages.append(startup)
+
+        page = await open_hidden_page(cast(Any, context), cast(Any, startup))
+
+        assert pages[-1] is decoy, "the decoy must sit after the target we want"
+        assert page is not decoy
+        assert page.url.startswith("about:blank#")
+
+    async def test_closes_the_startup_page_only_after_the_hidden_one_exists(self):
+        """Closing first would leave the context empty and Chromium may exit.
+
+        Asserting that the close eventually happened proves nothing about the
+        order, so the startup page records what the session had been asked for
+        at the moment it was closed.
+        """
+        pages: list = []
+        session = _Session(pages)
+        context = _Context(pages, _Browser(session))
+
+        class _RecordingStartup(_Startup):
+            methods_at_first_close: list[str] | None = None
+
+            async def close(self):
+                # First close only. A close-before-create mutation calls this
+                # twice, and letting the second overwrite the record is exactly
+                # how this test would stop catching anything.
+                if self.methods_at_first_close is None:
+                    self.methods_at_first_close = [m for m, _ in session.sent]
+                await super().close()
+
+        startup = _RecordingStartup()
+        pages.append(startup)
+
+        await open_hidden_page(cast(Any, context), cast(Any, startup))
+
+        assert startup.closed is True
+        assert startup.methods_at_first_close == ["Target.createTarget"]
+
+
+class TestItFailsClosed:
+    async def test_refuses_without_a_browser_object(self):
+        """No browser means no browser-level session.
+
+        A target created from a page's session was measured dying with that
+        page: the browser stays up, `new_page()` still works, and the hidden
+        page is gone.
+        """
+        pages: list = []
+        context = _Context(pages, None)
+        startup = _Startup()
+
+        with pytest.raises(HiddenTargetError, match="browser-level"):
+            await open_hidden_page(cast(Any, context), cast(Any, startup))
+
+        assert startup.closed is False
+
+    async def test_raises_when_the_target_never_surfaces(self, monkeypatch):
+        """Chromium accepting the target does not mean Playwright exposed it.
+
+        Without the attach flag it detaches the session instead, and the wait
+        would otherwise hang rather than say so.
+        """
+        monkeypatch.setattr(
+            "linkedin_mcp_server.hidden_target._ATTACH_TIMEOUT_SECONDS", 0.05
+        )
+        pages: list = []
+        session = _Session(pages, create=False)
+        context = _Context(pages, _Browser(session))
+        startup = _Startup()
+        pages.append(startup)
+
+        with pytest.raises(HiddenTargetError, match=ATTACH_TO_OTHER):
+            await open_hidden_page(cast(Any, context), cast(Any, startup))
+
+        # The visible page is left alone: a caller that recovers still has one.
+        assert startup.closed is False

--- a/tests/test_hidden_target.py
+++ b/tests/test_hidden_target.py
@@ -8,6 +8,7 @@ vanishes later.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from types import SimpleNamespace
 from typing import Any, cast
@@ -18,6 +19,7 @@ from linkedin_mcp_server.hidden_target import (
     ATTACH_TO_OTHER,
     HiddenTargetError,
     attaching_to_other_targets,
+    hidden_target_is_supported,
     open_hidden_page,
 )
 
@@ -39,9 +41,17 @@ class _Session:
     async def send(self, method: str, params: dict):
         self.sent.append((method, params))
         if method == "Target.createTarget" and self._create:
-            self._pages.append(SimpleNamespace(url=params["url"], close=_noop))
-            if self._trailing is not None:
-                self._pages.append(self._trailing)
+            # Surfaced on a later tick, not synchronously. Chromium answers
+            # `createTarget` before Playwright has attached and exposed a Page,
+            # and a fake that appends immediately hides every ordering mistake:
+            # the page is already there by the time anything checks.
+            async def _surface() -> None:
+                await asyncio.sleep(0.03)
+                self._pages.append(SimpleNamespace(url=params["url"], close=_noop))
+                if self._trailing is not None:
+                    self._pages.append(self._trailing)
+
+            asyncio.get_running_loop().create_task(_surface())
         return {"targetId": "T1"}
 
 
@@ -88,6 +98,41 @@ class TestTheAttachFlag:
 
         with attaching_to_other_targets():
             assert os.environ[ATTACH_TO_OTHER] == "1"
+
+        assert os.environ[ATTACH_TO_OTHER] == "operator-set"
+
+    async def test_overlapping_launches_do_not_leave_it_set(self, monkeypatch):
+        """Two launches in flight at once must still restore exactly once.
+
+        `os.environ` is process-global and the block it scopes contains an
+        `await`, so the two interleave. Measured before the counter existed: the
+        flag was left set afterwards in two runs out of five, and the opposite
+        ordering lets the second launch miss it entirely. Today's production
+        paths are serialised by other locks, but nothing about the public
+        `BrowserManager` promises that.
+        """
+        monkeypatch.delenv(ATTACH_TO_OTHER, raising=False)
+        seen: list[str | None] = []
+
+        async def launch(delay: float) -> None:
+            with attaching_to_other_targets():
+                await asyncio.sleep(delay)
+                seen.append(os.environ.get(ATTACH_TO_OTHER))
+
+        await asyncio.gather(launch(0.02), launch(0.001))
+
+        # Both saw it set while inside, and nothing is left behind after.
+        assert seen == ["1", "1"]
+        assert ATTACH_TO_OTHER not in os.environ
+
+    async def test_an_overlapping_launch_restores_a_previous_value(self, monkeypatch):
+        monkeypatch.setenv(ATTACH_TO_OTHER, "operator-set")
+
+        async def launch(delay: float) -> None:
+            with attaching_to_other_targets():
+                await asyncio.sleep(delay)
+
+        await asyncio.gather(launch(0.02), launch(0.001))
 
         assert os.environ[ATTACH_TO_OTHER] == "operator-set"
 
@@ -149,23 +194,26 @@ class TestFindingTheRightPage:
     async def test_closes_the_startup_page_only_after_the_hidden_one_exists(self):
         """Closing first would leave the context empty and Chromium may exit.
 
-        Asserting that the close eventually happened proves nothing about the
-        order, so the startup page records what the session had been asked for
-        at the moment it was closed.
+        The contract is not "createTarget was sent before close" -- Chromium
+        answers that call before Playwright has attached anything, so it holds
+        even when the close is far too early. What has to be true is that the
+        hidden page was already *there*.
         """
         pages: list = []
         session = _Session(pages)
         context = _Context(pages, _Browser(session))
 
         class _RecordingStartup(_Startup):
-            methods_at_first_close: list[str] | None = None
+            hidden_present_at_close: bool | None = None
 
             async def close(self):
-                # First close only. A close-before-create mutation calls this
-                # twice, and letting the second overwrite the record is exactly
-                # how this test would stop catching anything.
-                if self.methods_at_first_close is None:
-                    self.methods_at_first_close = [m for m, _ in session.sent]
+                # First close only: a close-before-wait mutation calls this
+                # twice, and letting the second overwrite the record is how
+                # this test would stop catching anything.
+                if self.hidden_present_at_close is None:
+                    self.hidden_present_at_close = any(
+                        str(page.url).startswith("about:blank#") for page in pages
+                    )
                 await super().close()
 
         startup = _RecordingStartup()
@@ -174,7 +222,7 @@ class TestFindingTheRightPage:
         await open_hidden_page(cast(Any, context), cast(Any, startup))
 
         assert startup.closed is True
-        assert startup.methods_at_first_close == ["Target.createTarget"]
+        assert startup.hidden_present_at_close is True
 
 
 class TestItFailsClosed:
@@ -214,3 +262,27 @@ class TestItFailsClosed:
 
         # The visible page is left alone: a caller that recovers still has one.
         assert startup.closed is False
+
+
+class TestPlatformSupport:
+    """Where the mechanism is claimed to work, and where it is not."""
+
+    def test_macos_is_supported(self, monkeypatch):
+        monkeypatch.setattr("sys.platform", "darwin")
+
+        assert hidden_target_is_supported() is True
+
+    def test_linux_is_not(self, monkeypatch):
+        """Measured in the container image: with a display, closing the startup
+        page kills Chromium and the hidden page with it; without one, a headed
+        launch never starts."""
+        monkeypatch.setattr("sys.platform", "linux")
+
+        assert hidden_target_is_supported() is False
+
+    def test_windows_is_not_claimed(self, monkeypatch):
+        """Unmeasured, and it plausibly behaves like Linux. Claiming support
+        without looking is the guess this module exists to avoid."""
+        monkeypatch.setattr("sys.platform", "win32")
+
+        assert hidden_target_is_supported() is False


### PR DESCRIPTION
The browser announced itself as headless, and the announcement comes from the *mode* rather than the binary: Chromium prepends the bare string `Headless` to the product name at runtime, so both the user agent and the `sec-ch-ua` brands read `HeadlessChrome`. Naming a channel cannot remove that, which is why #669 deliberately did not claim to. But this server must not put a window on somebody's desktop either.

So where the platform allows it, the browser launches headed and works in a target Chromium creates with no UI window. `BrowserManager.headless` keeps its public meaning, "no visible window"; it is simply no longer how that is achieved.

Measured end to end through the production path on macOS:

```
page url  : about:blank#63dbff0c723048d6
UA        : ...Chrome/148.0.0.0...        no HeadlessChrome
brands    : Not/A)Brand, Chromium         webdriver: false
outer 1280x720  screen 1280x720  fits     visible / focused
rAF       : 122/s   control window: 122/s
cookie across a full restart: survives
```

The rAF figure is the one that mattered. Hiding the application at OS level, the obvious alternative, throttled it to about 1 Hz against 120 and un-hid itself on the next `new_page()`. A hidden target runs at the same rate as an ordinary window.

## It applies to macOS only, and that is measured rather than scoped

Two things have to be true, and only one is about displays.

A headed browser needs a display server. Measured in the published container image: with no `DISPLAY`, `launch_persistent_context(headless=False)` fails with a `TargetClosedError` before any of this code runs.

And the browser has to survive losing its last visible window, since removing that window is the whole point. Measured in the same image under Xvfb — the hidden target *is* created and found, and then:

```
close startup page : FAIL   Chromium exits, the hidden page dies with it
keep startup page  : OK
```

Linux quits a browser with its last visible window. macOS does not, which is why it works there. Windows is untested and plausibly behaves like Linux, so it is not claimed. Everything else falls back to Chromium's headless mode and logs why.

Linux is less a gap than a different answer: under a virtual display nobody is looking at the screen, so an ordinary window is already invisible and there is nothing to hide. That is the container's path and it belongs with the change that gives the container a display.

## Three details decide whether it works at all

Each was measured, and a wrong one does not raise — it hands back the wrong page, or a page that vanishes later.

**Created from a browser-level CDP session.** Through `context.new_cdp_session(page)`, the obvious call, the target dies when that page closes: the browser stays up, `new_page()` still works, and the hidden page is gone.

**Found by a nonce, never by position.** The attach flag promotes every `other` target, and a real run had a component extension's page in `context.pages` beside the one we asked for.

**`about:blank#<nonce>`, not a loopback origin.** With a proxy configured and no bypass, a loopback URL is fetched *through* the proxy and the page lands on `chrome-error://chromewebdata/`. `about:blank` has no origin to route.

No bootstrap extension is needed: Chromium's own component extension already supplies the non-visible frame target its precondition wants. That removes `--load-extension`, so `CHROME_PATH` pointing at branded Chrome keeps working — measured, since Chrome 137+ ignores that switch.

The attach flag is set only for launches that create a hidden target. It lives in the driver process for that process's whole life, so restoring the parent environment does nothing to the child; a visible login would otherwise spend its entire run promoting `other` targets. It also survives overlapping launches, which it previously did not: process-global state mutated across an `await` left it set in two runs out of five.

## What this does not fix

A window is on screen for about half a second on every browser start, median 553 ms over five runs, and it cannot be shortened from here: roughly 250 ms passes before `launch_persistent_context()` returns, about 340 ms is macOS tearing the window down, and about 90 ms is ours. Zero would need `--no-startup-window`, which hangs Playwright for its full timeout ([playwright#42093](https://github.com/microsoft/playwright/issues/42093), closed as unsupported args).

The windowless page also reports `outerWidth == screen.width`, which no real window does. Unchanged from the previous headless default rather than introduced here, and recorded in `docs/browser-fingerprint.md` as still worth fixing.

Full suite green at 1686 passed. Every new assertion was verified red against the mutation it exists to catch, including three that originally were not: the launch contract stayed green with `open_hidden_page()` deleted from `start()`, the helper's fake surfaced its page synchronously and so hid every ordering mistake, and the ordering assertion checked that `createTarget` had been *sent* before the close rather than that the page *existed*.

See also: #606

## Synthetic prompt

> Chromium's headless mode makes the browser announce itself via a `Headless`
> product prefix, so run headed and hide the page in a CDP target instead:
> `Target.createTarget({hidden: true})` on `about:blank#<nonce>` from a
> **browser-level** session, found by nonce rather than position, with
> `PW_CHROMIUM_ATTACH_TO_OTHER` scoped to launches that need it and safe against
> overlap. Measure which platforms can actually do this rather than assuming:
> a headed launch needs a display, and the browser must survive losing its last
> window. Fall back to real headless elsewhere and log why. Test the launch
> contract end to end, not just the helper.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
