### PR TITLE
feat: reply to existing messaging threads

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2758,6 +2758,206 @@ class LinkedInExtractor:
         except PlaywrightTimeoutError:
             return False
 
+    @staticmethod
+    def _normalize_thread_id(thread_id: str) -> str:
+        """Accept a raw thread id or a LinkedIn thread URL, never another route.
+
+        A reply must be pinned to the thread the caller selected.  In particular,
+        accepting a compose URL here would silently downgrade it into a new DM.
+        """
+        raw = thread_id.strip() if isinstance(thread_id, str) else ""
+        if not raw:
+            raise LinkedInScraperException(
+                "thread_id must be a non-empty thread ID or URL."
+            )
+
+        if raw.startswith(("https://", "http://", "/")):
+            parsed = urlparse(raw)
+            if (parsed.scheme and parsed.scheme != "https") or (
+                parsed.netloc
+                and parsed.netloc.lower() not in {"www.linkedin.com", "linkedin.com"}
+            ):
+                raise LinkedInScraperException(
+                    "thread_id URL must target linkedin.com."
+                )
+            match = re.fullmatch(r"/messaging/thread/([A-Za-z0-9:_=-]+)/?", parsed.path)
+            if not match:
+                raise LinkedInScraperException(
+                    "thread_id URL must be exactly a /messaging/thread/{id}/ URL."
+                )
+            return match.group(1)
+
+        if not re.fullmatch(r"[A-Za-z0-9:_=-]+", raw):
+            raise LinkedInScraperException("thread_id contains unsupported characters.")
+        return raw
+
+    @staticmethod
+    def _thread_url(thread_id: str) -> str:
+        """Return the single canonical navigation target for a thread ID."""
+        return f"https://www.linkedin.com/messaging/thread/{thread_id}/"
+
+    async def _active_thread_matches(self, expected_thread_id: str) -> bool:
+        """Check that the browser remained on exactly the requested LinkedIn thread."""
+        current = self._page.url
+        try:
+            return self._normalize_thread_id(current) == expected_thread_id
+        except LinkedInScraperException:
+            logger.warning("Thread-targeted reply refused: final URL was %s", current)
+            return False
+
+    async def _resolve_thread_compose_box(self) -> Any | None:
+        """Find a composer only inside the active messaging page's ``main`` region."""
+        for selector in (
+            'main div[role="textbox"][contenteditable="true"][aria-label*="Write a message"]',
+            'main div[role="textbox"][contenteditable="true"]',
+            'main [contenteditable="true"][aria-label*="message"]',
+        ):
+            locator = self._page.locator(selector)
+            try:
+                if await locator.count():
+                    return locator.last
+            except Exception:
+                logger.debug("Could not resolve active-thread composer", exc_info=True)
+        return None
+
+    async def _thread_message_text_visible(self, message: str) -> bool:
+        """Read back the sent text from ``main`` after re-opening the same thread."""
+        try:
+            await self._page.wait_for_function(
+                """({ expected }) => {
+                    const normalize = value =>
+                        (value || '').replace(/\\s+/g, ' ').trim();
+                    const main = document.querySelector('main');
+                    return Boolean(main && normalize(main.innerText).includes(normalize(expected)));
+                }""",
+                arg={"expected": message},
+            )
+            return True
+        except PlaywrightTimeoutError:
+            return False
+
+    async def reply_to_thread(
+        self, thread_id: str, message: str, *, confirm_send: bool
+    ) -> dict[str, Any]:
+        """Reply only to an existing thread, with URL pinning and read-back verification.
+
+        ``confirm_send=False`` is a dry run: it may navigate and inspect the
+        intended composer but never focuses it or enters message text.
+        """
+        normalized_thread_id = self._normalize_thread_id(thread_id)
+        target_url = self._thread_url(normalized_thread_id)
+        await self._navigate_to_page(target_url)
+        await detect_rate_limit(self._page)
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("Thread page did not fully load for %s", normalized_thread_id)
+
+        if not await self._active_thread_matches(normalized_thread_id):
+            return {
+                "url": self._page.url,
+                "thread_id": normalized_thread_id,
+                "status": "thread_mismatch",
+                "message": "LinkedIn did not remain on the requested thread; no text was entered.",
+                "sent": False,
+            }
+
+        compose_box = await self._resolve_thread_compose_box()
+        if compose_box is None:
+            return {
+                "url": self._page.url,
+                "thread_id": normalized_thread_id,
+                "status": "composer_unavailable",
+                "message": "The requested thread has no usable composer in its active main area.",
+                "sent": False,
+            }
+
+        if not confirm_send:
+            return {
+                "url": self._page.url,
+                "thread_id": normalized_thread_id,
+                "status": "confirmation_required",
+                "message": "Set confirm_send=true to enter and send this reply.",
+                "sent": False,
+            }
+
+        # Re-check immediately before the first irreversible input event.
+        if not await self._active_thread_matches(normalized_thread_id):
+            return {
+                "url": self._page.url,
+                "thread_id": normalized_thread_id,
+                "status": "thread_mismatch",
+                "message": "Thread changed before input; no text was entered.",
+                "sent": False,
+            }
+
+        # DOM dependence is required to focus/type. Both the composer and send
+        # control are constrained to main, which is the active thread surface
+        # after the URL/ID pin checks above.
+        focused = await self._page.evaluate(
+            """() => {
+                const main = document.querySelector('main');
+                const box = main?.querySelector(
+                    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
+                    + 'div[role="textbox"][contenteditable="true"],'
+                    + '[contenteditable="true"][aria-label*="message"]'
+                );
+                if (!box) return false;
+                box.focus();
+                return true;
+            }"""
+        )
+        if not focused:
+            return {
+                "url": self._page.url,
+                "thread_id": normalized_thread_id,
+                "status": "compose_interact_failed",
+                "message": "Could not focus the requested thread's composer.",
+                "sent": False,
+            }
+        await self._page.keyboard.type(message, delay=15)
+        await asyncio.sleep(0.3)
+        sent_via_js = await self._page.evaluate(
+            """() => {
+                const main = document.querySelector('main');
+                const box = main?.querySelector('[contenteditable="true"]');
+                const root = box?.closest('form, section, article, [role="region"]') || main;
+                const button = Array.from(root?.querySelectorAll(
+                    'button[type="submit"], button[aria-label*="Send"], '
+                    + 'button[aria-label*="send"], button[data-control-name="send"]'
+                ) || []).find(element => !element.disabled &&
+                    (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
+                if (!button) return false;
+                button.click();
+                return true;
+            }"""
+        )
+        if not sent_via_js:
+            await self._page.keyboard.press("Enter")
+
+        # Do not report sent merely because click/Enter was attempted. Re-open
+        # the exact canonical target and inspect its main thread area.
+        await self._navigate_to_page(target_url)
+        await detect_rate_limit(self._page)
+        if await self._active_thread_matches(
+            normalized_thread_id
+        ) and await self._thread_message_text_visible(message):
+            return {
+                "url": self._page.url,
+                "thread_id": normalized_thread_id,
+                "status": "sent",
+                "message": "Reply sent and read back from the requested thread.",
+                "sent": True,
+            }
+        return {
+            "url": self._page.url,
+            "thread_id": normalized_thread_id,
+            "status": "sent_unverified",
+            "message": "A send was attempted, but the reply could not be read back from the requested thread.",
+            "sent": False,
+            "send_attempted": True,
+        }
+
     async def _dismiss_message_ui(self) -> None:
         """Best-effort dismissal for the profile messaging UI."""
         if not await self._locator_is_visible(_MESSAGING_CLOSE_SELECTOR, timeout=750):

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2808,9 +2808,8 @@ class LinkedInExtractor:
     async def _resolve_thread_compose_box(self) -> Any | None:
         """Find a composer only inside the active messaging page's ``main`` region."""
         for selector in (
-            'main div[role="textbox"][contenteditable="true"][aria-label*="Write a message"]',
             'main div[role="textbox"][contenteditable="true"]',
-            'main [contenteditable="true"][aria-label*="message"]',
+            'main [contenteditable="true"]',
         ):
             locator = self._page.locator(selector)
             try:
@@ -2820,21 +2819,46 @@ class LinkedInExtractor:
                 logger.debug("Could not resolve active-thread composer", exc_info=True)
         return None
 
-    async def _thread_message_text_visible(self, message: str) -> bool:
-        """Read back the sent text from ``main`` after re-opening the same thread."""
-        try:
-            await self._page.wait_for_function(
-                """({ expected }) => {
-                    const normalize = value =>
-                        (value || '').replace(/\\s+/g, ' ').trim();
-                    const main = document.querySelector('main');
-                    return Boolean(main && normalize(main.innerText).includes(normalize(expected)));
-                }""",
-                arg={"expected": message},
-            )
-            return True
-        except PlaywrightTimeoutError:
-            return False
+    async def _thread_message_snapshot(self, message: str) -> set[str]:
+        """Return identity signatures for visible thread messages matching ``message``.
+
+        The snapshot deliberately reads message-item structure rather than
+        ``main.innerText``: a matching string elsewhere, or one that predates
+        this operation, cannot establish that this operation sent a reply.
+        LinkedIn's rows vary between versions, so event/message attributes are
+        preferred and generic list-item structure is the fallback.
+        """
+        signatures = await self._page.evaluate(
+            """({ expected }) => {
+                const normalize = value =>
+                    (value || '').replace(/\\s+/g, ' ').trim();
+                const main = document.querySelector('main');
+                if (!main || !normalize(expected)) return [];
+                const candidates = Array.from(main.querySelectorAll(
+                    '[data-event-urn], [data-message-id], [data-urn], [role="listitem"]'
+                ));
+                return candidates.flatMap((element, index) => {
+                    const text = normalize(element.innerText || element.textContent || '');
+                    if (!text.includes(normalize(expected))) return [];
+                    const stableId = [
+                        'data-event-urn', 'data-message-id', 'data-urn', 'id'
+                    ].map(name => element.getAttribute(name)).find(Boolean);
+                    // When LinkedIn exposes no event id, the message-row path
+                    // still distinguishes a newly appended matching row.
+                    const path = [];
+                    let node = element;
+                    while (node && node !== main) {
+                        const parent = node.parentElement;
+                        if (!parent) break;
+                        path.unshift(Array.prototype.indexOf.call(parent.children, node));
+                        node = parent;
+                    }
+                    return [stableId || `${index}:${path.join('.')}:${text}`];
+                });
+            }""",
+            arg={"expected": message},
+        )
+        return {str(signature) for signature in signatures}
 
     async def reply_to_thread(
         self, thread_id: str, message: str, *, confirm_send: bool
@@ -2846,6 +2870,17 @@ class LinkedInExtractor:
         """
         normalized_thread_id = self._normalize_thread_id(thread_id)
         target_url = self._thread_url(normalized_thread_id)
+        normalized_message = (
+            " ".join(message.split()) if isinstance(message, str) else ""
+        )
+        if not normalized_message:
+            return {
+                "url": target_url,
+                "thread_id": normalized_thread_id,
+                "status": "message_empty",
+                "message": "Reply text must contain at least one non-whitespace character.",
+                "sent": False,
+            }
         await self._navigate_to_page(target_url)
         await detect_rate_limit(self._page)
         try:
@@ -2859,6 +2894,16 @@ class LinkedInExtractor:
                 "thread_id": normalized_thread_id,
                 "status": "thread_mismatch",
                 "message": "LinkedIn did not remain on the requested thread; no text was entered.",
+                "sent": False,
+            }
+
+        before_snapshot = await self._thread_message_snapshot(normalized_message)
+        if before_snapshot:
+            return {
+                "url": self._page.url,
+                "thread_id": normalized_thread_id,
+                "status": "message_already_present",
+                "message": "This reply text is already visible in the requested thread; no send was attempted.",
                 "sent": False,
             }
 
@@ -2898,9 +2943,8 @@ class LinkedInExtractor:
             """() => {
                 const main = document.querySelector('main');
                 const box = main?.querySelector(
-                    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
-                    + 'div[role="textbox"][contenteditable="true"],'
-                    + '[contenteditable="true"][aria-label*="message"]'
+                    'div[role="textbox"][contenteditable="true"],'
+                    + '[contenteditable="true"]'
                 );
                 if (!box) return false;
                 box.focus();
@@ -2915,7 +2959,7 @@ class LinkedInExtractor:
                 "message": "Could not focus the requested thread's composer.",
                 "sent": False,
             }
-        await self._page.keyboard.type(message, delay=15)
+        await self._page.keyboard.type(normalized_message, delay=15)
         await asyncio.sleep(0.3)
         sent_via_js = await self._page.evaluate(
             """() => {
@@ -2923,8 +2967,7 @@ class LinkedInExtractor:
                 const box = main?.querySelector('[contenteditable="true"]');
                 const root = box?.closest('form, section, article, [role="region"]') || main;
                 const button = Array.from(root?.querySelectorAll(
-                    'button[type="submit"], button[aria-label*="Send"], '
-                    + 'button[aria-label*="send"], button[data-control-name="send"]'
+                    'button[type="submit"]'
                 ) || []).find(element => !element.disabled &&
                     (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
                 if (!button) return false;
@@ -2936,24 +2979,25 @@ class LinkedInExtractor:
             await self._page.keyboard.press("Enter")
 
         # Do not report sent merely because click/Enter was attempted. Re-open
-        # the exact canonical target and inspect its main thread area.
+        # the exact canonical target and require a matching message row that
+        # was absent from the snapshot immediately before typing.
         await self._navigate_to_page(target_url)
         await detect_rate_limit(self._page)
-        if await self._active_thread_matches(
-            normalized_thread_id
-        ) and await self._thread_message_text_visible(message):
+        if await self._active_thread_matches(normalized_thread_id) and (
+            await self._thread_message_snapshot(normalized_message) - before_snapshot
+        ):
             return {
                 "url": self._page.url,
                 "thread_id": normalized_thread_id,
                 "status": "sent",
-                "message": "Reply sent and read back from the requested thread.",
+                "message": "Reply sent and verified as a new message in the requested thread.",
                 "sent": True,
             }
         return {
             "url": self._page.url,
             "thread_id": normalized_thread_id,
             "status": "sent_unverified",
-            "message": "A send was attempted, but the reply could not be read back from the requested thread.",
+            "message": "A send was attempted, but no new matching message was verified in the requested thread.",
             "sent": False,
             "send_attempted": True,
         }

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -276,3 +276,47 @@ def register_messaging_tools(
                 raise_tool_error(relogin_exc, "send_message")
         except Exception as e:
             raise_tool_error(e, "send_message")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Reply to Thread",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"messaging", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def reply_to_thread(
+        thread_id: str,
+        message: str,
+        confirm_send: bool,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """Reply strictly inside an existing LinkedIn messaging thread.
+
+        ``thread_id`` may be a raw ID or a LinkedIn ``/messaging/thread/{id}/``
+        URL. The extractor verifies the final URL before typing. With
+        ``confirm_send=False`` it returns ``confirmation_required`` without
+        entering text. A confirmed send is reported as ``sent`` only after a
+        read-back from the same thread; otherwise it is ``sent_unverified``.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="reply_to_thread"
+            )
+            assert extractor is not None
+            logger.info(
+                "Replying to thread %s (confirm_send=%s)", thread_id, confirm_send
+            )
+            await ctx.report_progress(progress=0, total=100, message="Opening thread")
+            result = await extractor.reply_to_thread(
+                thread_id, message, confirm_send=confirm_send
+            )
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+            return result
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "reply_to_thread")
+        except Exception as e:
+            raise_tool_error(e, "reply_to_thread")  # NoReturn

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1489,7 +1489,8 @@ class TestRealOwner:
             # in a `register_*` call.
             assert "get_person_profile" in names
             assert "close_session" in names
-            assert len(names) == 19, sorted(names)
+            assert "reply_to_thread" in names
+            assert len(names) == 20, sorted(names)
         finally:
             _stop(result.get("pid"))
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5041,6 +5041,136 @@ class TestGetConversation:
 
 
 class TestReplyToThread:
+    async def test_empty_message_returns_without_navigation_or_input(self, mock_page):
+        """Blank replies must never be treated as a successful send attempt."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.keyboard = MagicMock()
+        mock_page.keyboard.type = AsyncMock()
+
+        with patch.object(
+            extractor, "_navigate_to_page", new_callable=AsyncMock
+        ) as navigate:
+            result = await extractor.reply_to_thread(
+                "abc123", " \n\t ", confirm_send=True
+            )
+
+        assert result["status"] == "message_empty"
+        assert result["sent"] is False
+        navigate.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
+
+    async def test_existing_message_returns_without_composer_or_input(self, mock_page):
+        """An existing matching message cannot prove this call sent a new reply."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.url = "https://www.linkedin.com/messaging/thread/abc123/"
+        mock_page.keyboard = MagicMock()
+        mock_page.keyboard.type = AsyncMock()
+
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_thread_message_snapshot",
+                new_callable=AsyncMock,
+                return_value={"existing-message"},
+            ),
+            patch.object(
+                extractor,
+                "_resolve_thread_compose_box",
+                new_callable=AsyncMock,
+            ) as resolve_compose,
+        ):
+            result = await extractor.reply_to_thread(
+                "abc123", "Already in the thread", confirm_send=True
+            )
+
+        assert result["status"] == "message_already_present"
+        assert result["sent"] is False
+        resolve_compose.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
+
+    async def test_send_requires_a_new_message_snapshot(self, mock_page):
+        """Post-send text alone is insufficient: the matching message must be new."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.url = "https://www.linkedin.com/messaging/thread/abc123/"
+        mock_page.keyboard = MagicMock()
+        mock_page.keyboard.type = AsyncMock()
+        mock_page.keyboard.press = AsyncMock()
+
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_resolve_thread_compose_box",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                extractor,
+                "_thread_message_snapshot",
+                new_callable=AsyncMock,
+                side_effect=[set(), set()],
+            ),
+        ):
+            mock_page.evaluate = AsyncMock(side_effect=[True, True])
+            result = await extractor.reply_to_thread(
+                "abc123", "Only report a new message", confirm_send=True
+            )
+
+        assert result["status"] == "sent_unverified"
+        assert result["sent"] is False
+
+    async def test_send_reports_sent_only_for_a_new_message_snapshot(self, mock_page):
+        """A newly identified matching message row is the sole success condition."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.url = "https://www.linkedin.com/messaging/thread/abc123/"
+        mock_page.keyboard = MagicMock()
+        mock_page.keyboard.type = AsyncMock()
+        mock_page.keyboard.press = AsyncMock()
+
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_resolve_thread_compose_box",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                extractor,
+                "_thread_message_snapshot",
+                new_callable=AsyncMock,
+                side_effect=[set(), {"new-message-row"}],
+            ),
+        ):
+            mock_page.evaluate = AsyncMock(side_effect=[True, True])
+            result = await extractor.reply_to_thread(
+                "abc123", "Verified new reply", confirm_send=True
+            )
+
+        assert result["status"] == "sent"
+        assert result["sent"] is True
+
+    def test_thread_reply_selectors_do_not_depend_on_english_aria_labels(self):
+        """Thread composer/send detection must work regardless of UI language."""
+        import inspect
+
+        source = inspect.getsource(LinkedInExtractor.reply_to_thread)
+        source += inspect.getsource(LinkedInExtractor._resolve_thread_compose_box)
+        assert "aria-label*=" not in source
+
     async def test_dry_run_never_types_and_uses_canonical_thread_url(self, mock_page):
         """confirm_send=False may inspect but must not focus/type/send anything."""
         extractor = LinkedInExtractor(mock_page)
@@ -5061,6 +5191,12 @@ class TestReplyToThread:
                 "_resolve_thread_compose_box",
                 new_callable=AsyncMock,
                 return_value=MagicMock(),
+            ),
+            patch.object(
+                extractor,
+                "_thread_message_snapshot",
+                new_callable=AsyncMock,
+                return_value=set(),
             ),
         ):
             result = await extractor.reply_to_thread(

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4744,6 +4744,36 @@ class TestGetInbox:
 
 
 class TestGetConversation:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("abc123", "abc123"),
+            ("  2-abc_123:xyz  ", "2-abc_123:xyz"),
+            (
+                "https://www.linkedin.com/messaging/thread/abc123/?foo=bar",
+                "abc123",
+            ),
+            ("/messaging/thread/abc123/", "abc123"),
+        ],
+    )
+    def test_normalize_thread_id_accepts_raw_ids_and_thread_urls(self, raw, expected):
+        assert LinkedInExtractor._normalize_thread_id(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "abc/def",
+            "https://evil.example/messaging/thread/abc123/",
+            "//evil.example/messaging/thread/abc123/",
+            "https://www.linkedin.com/messaging/compose/?recipient=abc123",
+            "/messaging/thread/abc123/other/",
+        ],
+    )
+    def test_normalize_thread_id_rejects_non_thread_targets(self, raw):
+        with pytest.raises(LinkedInScraperException, match="thread_id"):
+            LinkedInExtractor._normalize_thread_id(raw)
+
     async def test_returns_conversation_by_thread_id(self, mock_page):
         """get_conversation with thread_id navigates directly to thread URL."""
         extractor = LinkedInExtractor(mock_page)
@@ -5008,6 +5038,73 @@ class TestGetConversation:
                 LinkedInScraperException, match="Could not find a conversation"
             ):
                 await extractor.get_conversation(linkedin_username="jacki-old")
+
+
+class TestReplyToThread:
+    async def test_dry_run_never_types_and_uses_canonical_thread_url(self, mock_page):
+        """confirm_send=False may inspect but must not focus/type/send anything."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.url = "https://www.linkedin.com/messaging/thread/abc123/"
+        mock_page.keyboard = MagicMock()
+        mock_page.keyboard.type = AsyncMock()
+        mock_page.keyboard.press = AsyncMock()
+        with (
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as navigate,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_resolve_thread_compose_box",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+        ):
+            result = await extractor.reply_to_thread(
+                "https://www.linkedin.com/messaging/thread/abc123/?source=inbox",
+                "Must remain a draft",
+                confirm_send=False,
+            )
+
+        assert result["status"] == "confirmation_required"
+        assert result["thread_id"] == "abc123"
+        navigate.assert_awaited_once_with(
+            "https://www.linkedin.com/messaging/thread/abc123/"
+        )
+        mock_page.keyboard.type.assert_not_awaited()
+        mock_page.keyboard.press.assert_not_awaited()
+        mock_page.evaluate.assert_not_awaited()
+
+    async def test_thread_mismatch_returns_before_composer_or_input(self, mock_page):
+        """A redirect or wrong final ID blocks all interaction with the page."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.url = "https://www.linkedin.com/messaging/thread/other/"
+        mock_page.keyboard = MagicMock()
+        mock_page.keyboard.type = AsyncMock()
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_resolve_thread_compose_box",
+                new_callable=AsyncMock,
+            ) as resolve_compose,
+        ):
+            result = await extractor.reply_to_thread(
+                "abc123", "Never enter this", confirm_send=True
+            )
+
+        assert result["status"] == "thread_mismatch"
+        assert result["sent"] is False
+        resolve_compose.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
+        mock_page.evaluate.assert_not_awaited()
 
 
 class TestStripSelectConversationPrefix:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -34,6 +34,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.get_conversation = AsyncMock(return_value=scrape_result)
     mock.search_conversations = AsyncMock(return_value=scrape_result)
     mock.send_message = AsyncMock(return_value=scrape_result)
+    mock.reply_to_thread = AsyncMock(return_value=scrape_result)
     mock.get_my_profile = AsyncMock(return_value=scrape_result)
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.search_posts = AsyncMock(return_value=scrape_result)
@@ -866,6 +867,38 @@ class TestMessagingTools:
                 mock_context,
                 extractor=mock_extractor,
             )
+
+    async def test_reply_to_thread_passes_confirmation_gate(self, mock_context):
+        """The tool delegates to the thread-targeted extractor method only."""
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/abc123/",
+            "thread_id": "abc123",
+            "status": "confirmation_required",
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+        tool_fn = await get_tool_fn(mcp, "reply_to_thread")
+
+        result = await tool_fn(
+            "https://www.linkedin.com/messaging/thread/abc123/?foo=bar",
+            "Draft only",
+            False,
+            mock_context,
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "confirmation_required"
+        assert result["sent"] is False
+        mock_extractor.reply_to_thread.assert_awaited_once_with(
+            "https://www.linkedin.com/messaging/thread/abc123/?foo=bar",
+            "Draft only",
+            confirm_send=False,
+        )
 
 
 class TestGetMyProfileTool:


### PR DESCRIPTION
## Summary

Adds a thread-targeted reply tool for LinkedIn messaging:

- `reply_to_thread(thread_id, message, confirm_send)` accepts a raw thread ID or canonical LinkedIn thread URL.
- Refuses redirects or final URLs that do not match the requested thread before typing.
- Scopes composer and send controls to the active messaging `main` region.
- A dry run (`confirm_send=false`) never focuses, types, or sends.
- After a confirmed send, re-reads the exact requested thread and only returns `sent` when the outgoing message is visible there; otherwise returns `sent_unverified`.

This avoids the profile-compose path used by `send_message`, which can be unavailable for Premium/Open Profile and can create a separate DM instead of replying to an existing InMail/thread.

## Validation

- `uv run pytest tests/test_tools.py tests/test_scraping.py -q` — 299 passed
- `uv run ruff check …` — passed
- `uv run ty check …` — passed
- Live controlled validation used an existing thread and verified the outgoing reply by read-back from the exact thread ID.

## Synthetic prompt

> Add a confirmation-gated `reply_to_thread` MCP tool that sends only within a validated existing LinkedIn messaging thread, rejects mismatched redirects, scopes DOM actions to the active thread, and verifies success by reading back the exact thread.

Generated with GPT-5.6 Terra.
