### PR TITLE
test(daemon): Wait for the owner to reach the auth gate

### DIFF
--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1556,7 +1556,24 @@ class TestRealOwner:
                         raise_on_error=False,
                     )
 
+            # Retried until the owner has something to say about *auth*.
+            #
+            # A real owner answers whichever gate it reaches first, and browser
+            # setup runs in the background: arrive before it finishes and the
+            # answer is "still installing", which carries no auth marker and is
+            # a correct answer to a different question. Measured at roughly one
+            # run in eight, which is frequent enough to cost CI runs and rare
+            # enough to look like something else.
+            #
+            # A client does exactly this, so the retry is not a workaround so
+            # much as the shape of the thing being tested.
+            deadline = time.monotonic() + 60
             answered = asyncio.run(call_it())
+            while (answered.meta or {}).get(
+                MARKER_KEY
+            ) is None and time.monotonic() < deadline:
+                time.sleep(0.5)
+                answered = asyncio.run(call_it())
 
             assert answered.is_error is True
             marker = (answered.meta or {}).get(MARKER_KEY)


### PR DESCRIPTION
The test asked a real owner for a profile and asserted the auth marker in its answer. But a real owner answers whichever gate it reaches first, and browser setup runs in the background: arrive before that finishes and the answer is "still installing", which carries no auth marker and is a perfectly correct answer to a different question.

Measured at roughly one run in eight in isolation. That is frequent enough to cost CI runs and rare enough to look like something else — it cost exactly that here, where it was briefly mistaken for a regression in an unrelated change on the strength of one run with the change and one without.

It now retries until the owner has something to say about auth, or a minute passes. A client does the same thing, so the retry is less a workaround than the shape of the thing being tested.

Ten runs, ten passes, against seven of eight before.

See also: #606

## Synthetic prompt

> `test_a_real_owner_asks_the_client_to_sign_in` flakes about one run in eight
> because it calls the tool once and asserts the auth marker, while a real owner
> may still be answering the browser-setup gate. Retry the call until the answer
> carries the marker or a deadline passes, and say in a comment why that is the
> behaviour under test rather than a workaround.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
