### PR TITLE
fix(browser): Refuse an older Chromium

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Expand and resolve together, always.** Doing one without the other lets a
   symlink move the profile out of one directory while its sidecars come from
   another. Use `session_state.canonical()`.
+- **A browser older than the profile is refused, and only that direction.**
+  `browser_downgrade.refuse_a_downgrade()` runs in `BrowserManager.start()`
+  before anything is created or opened. Chromium does not stop a downgrade on
+  macOS or Linux: it opens the profile and lets each store decide for itself,
+  and a store that answers `INIT_TOO_NEW` is dropped in silence. Losing the
+  cookie store that way looks exactly like an expired session. Every unknown
+  here fails open (an unreadable marker, a binary that will not name itself),
+  because not knowing is not evidence. That trade is one-shot per profile: the
+  older browser then rewrites `Last Version` down to its own number, so the
+  evidence is gone for good, which is why those two branches warn.
+- **Never ask a Windows browser for its version.** Chromium compiles
+  `HandleVersionSwitches` only under `BUILDFLAG(IS_POSIX)`, so there `--version`
+  is an unrecognised switch and the binary starts a browser on whatever profile
+  it defaults to. The guard is off on Windows on purpose; a version could only
+  come from the executable's file-version resource.
+- **Two versions only compare inside one product.** `Last Version` records a
+  number and no product, so a comparison across products compares two
+  numbering schemes: Vivaldi is on 7.x and Edge's build number sits an order
+  of magnitude below Chrome's under the same major. Only the Chrome-family
+  names in `_COMPARABLE_PRODUCTS` are compared, matched **whole and never as a
+  prefix** — a prefix scan accepted a launcher script announcing itself as
+  `Chromium launcher 1.2.3` and refused the newer browser behind it. And only
+  for the *running* binary, which is all `--version` can identify. A profile
+  written by a fork is therefore still refused; that one is not repairable from
+  `Last Version`, and the error says so by naming the number to go back to
+  rather than a browser.
 
 ## Tool Return Format
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ while a container is running.
 
 - If Chrome is installed in a non-standard location, use `--chrome-path /path/to/chrome`
 - Can also set via environment variable: `CHROME_PATH=/path/to/chrome`
+- On macOS and Linux the browser must be at least as new as the one that last opened your profile, and the server refuses the launch otherwise. (Not on Windows: a browser there cannot be asked its version without starting one, so the check is off.) An older browser can silently drop stores a newer one wrote, the saved session among them, and the failure then looks exactly like an expired login. The message names both versions. Going back to the bundled Chromium after running a newer Chrome once is the usual way to meet this; either run the newer browser again, whichever one that was, or run `--login`, which moves the stored session aside and signs in fresh with the browser you have. `--logout` also clears it but discards the old session instead of keeping it recoverable, and it asks for confirmation on the terminal, so it is not usable from a server an MCP client started.
+- Only Chrome, Chromium and Chrome for Testing are compared this way. Forks number themselves differently (Vivaldi is on 7.x, Edge's build number sits far below Chrome's under the same major), so pointing `CHROME_PATH` at one turns the check off rather than producing a refusal nothing could satisfy.
 
 </details>
 
@@ -474,6 +476,9 @@ belongs behind something that provides it.
 
 - If Chrome is installed in a non-standard location, use `--chrome-path /path/to/chrome`
 - Can also set via environment variable: `CHROME_PATH=/path/to/chrome`
+- On macOS and Linux the browser must be at least as new as the one that last opened your profile, and the server refuses the launch otherwise. (Not on Windows: a browser there cannot be asked its version without starting one, so the check is off.) An older browser can silently drop stores a newer one wrote, the saved session among them, and the failure then looks exactly like an expired login. The message names both versions. Going back to the bundled Chromium after running a newer Chrome once is the usual way to meet this; either run the newer browser again, whichever one that was, or run `--login`, which moves the stored session aside and signs in fresh with the browser you have. `--logout` also clears it but discards the old session instead of keeping it recoverable, and it asks for confirmation on the terminal, so it is not usable from a server an MCP client started.
+- Only Chrome, Chromium and Chrome for Testing are compared this way. Forks number themselves differently (Vivaldi is on 7.x, Edge's build number sits far below Chrome's under the same major), so pointing `CHROME_PATH` at one turns the check off rather than producing a refusal nothing could satisfy.
+- In the documented Docker setup this check does not apply. The container never opens the profile you created with `--login`; it derives its own from your cookies, and by default rebuilds that from scratch on every start, so there is nothing for an older image to downgrade. With `EXPERIMENTAL_PERSIST_DERIVED_RUNTIME` the derived profile is kept, and an image tag that moves backwards then throws it away and re-derives it, again with nothing for you to do. The check matters on the host, where the server opens that profile directly. Not during `--login` itself, which moves the old profile aside before it starts a browser and so can never trip it.
 
 </details>
 
@@ -623,6 +628,8 @@ uv run -m linkedin_mcp_server --transport streamable-http --host 127.0.0.1 --por
 
 - If Chrome is installed in a non-standard location, use `--chrome-path /path/to/chrome`
 - Can also set via environment variable: `CHROME_PATH=/path/to/chrome`
+- On macOS and Linux the browser must be at least as new as the one that last opened your profile, and the server refuses the launch otherwise. (Not on Windows: a browser there cannot be asked its version without starting one, so the check is off.) An older browser can silently drop stores a newer one wrote, the saved session among them, and the failure then looks exactly like an expired login. The message names both versions. Going back to the bundled Chromium after running a newer Chrome once is the usual way to meet this; either run the newer browser again, whichever one that was, or run `--login`, which moves the stored session aside and signs in fresh with the browser you have. `--logout` also clears it but discards the old session instead of keeping it recoverable, and it asks for confirmation on the terminal, so it is not usable from a server an MCP client started.
+- Only Chrome, Chromium and Chrome for Testing are compared this way. Forks number themselves differently (Vivaldi is on 7.x, Edge's build number sits far below Chrome's under the same major), so pointing `CHROME_PATH` at one turns the check off rather than producing a refusal nothing could satisfy.
 
 </details>
 

--- a/linkedin_mcp_server/browser_downgrade.py
+++ b/linkedin_mcp_server/browser_downgrade.py
@@ -1,0 +1,368 @@
+"""Refuse to open a profile with a browser older than the one that wrote it.
+
+Chromium records its own version in ``<user-data-dir>/Last Version`` on every
+run and treats a later launch by an older binary as a downgrade
+(``downgrade_manager.cc``). It does not stop there on macOS or Linux -- it
+carries on and lets each store decide for itself. That is the failure mode this
+module exists to prevent: a store whose *compatible* version has been raised
+past what the older binary accepts is rejected with ``INIT_TOO_NEW`` and the
+browser simply runs without it. Cookies are such a store, so the visible symptom
+is a session that was never invalid disappearing, followed by a login nobody
+asked for.
+
+Measured, and worth keeping because it explains why the check is stricter than
+Chromium's own: bundled Chromium 148 opened a profile last written by Chrome 150
+with cookies, Local Storage, IndexedDB and Cache Storage all intact, because
+Chrome 150 marks its Web Data schema as compatible back that far. It also
+*rewrote* the version markers on the way out. So the compatibility is real, and
+it is a snapshot -- it holds until one store raises its floor, and nothing warns
+when that happens.
+
+Every answer here fails open. Being unable to read a marker, name the binary or
+parse a version is not evidence of a downgrade, and refusing to start a browser
+on the strength of a missing file would turn a guard into an outage.
+
+That choice costs more than it looks like it does, and the cost belongs here
+rather than in a reviewer's head. Failing open once is not "we will catch it
+next time": the older browser runs, and on its way out it rewrites `Last
+Version` down to its own number (measured -- a launch on a profile marked
+`1.0.0.0` left it reading `148.0.7778.96`). The evidence is gone, so every later
+launch sees no downgrade even after whatever made the version unreadable is
+fixed. It is still the right trade, because the alternative refuses working
+setups on the strength of not knowing, but the guard is one-shot per profile
+and nothing downstream can recover it.
+"""
+
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import NamedTuple
+
+from linkedin_mcp_server.exceptions import BrowserDowngradeError
+
+logger = logging.getLogger(__name__)
+
+#: Written by Chromium itself, directly inside the profile directory, with a
+#: space in the name and no extension. Not one of ours, so it is never created
+#: or removed here -- only read.
+LAST_VERSION_FILE = "Last Version"
+
+#: A binary that will not answer ``--version`` must not hold up the launch.
+#: Generous rather than tight: the measured cost is ~35 ms warm, and the only
+#: thing a low bound would buy is a false "unknown" on a loaded machine.
+_VERSION_TIMEOUT_SECONDS = 15.0
+
+#: Three components at minimum, so a two-part build suffix ("built on Debian
+#: 10.9") cannot be mistaken for a version. Real values have four:
+#: ``148.0.7778.96``.
+#:
+#: Anchored to whitespace or the start of the line, which is the part that stops
+#: the guard failing *closed*. A `CHROME_PATH` launcher script announcing itself
+#: as `Chromium launcher v1.2.3` before it execs a browser would otherwise be
+#: read as version `1.2.3` of a product called `Chromium launcher v` -- older
+#: than every profile, and named plausibly enough to be compared. The user is
+#: then told to run a newer browser, which is exactly what they were doing.
+#: A version glued to a preceding word is not a version, so it is not one here.
+_VERSION = re.compile(r"(?:^|(?<=\s))\d+(?:\.\d+){2,}")
+
+#: Product names whose version numbers track Chromium milestones, and which are
+#: therefore comparable against a `Last Version` that carries no product of its
+#: own.
+#:
+#: Matched whole, not as a prefix, and that is the second half of the wrapper
+#: defence rather than a stylistic choice. A `CHROME_PATH` launcher announcing
+#: itself as `Chromium launcher 1.2.3` parses cleanly -- the version is
+#: space-separated and the name starts with a word we know -- so a prefix scan
+#: accepted it, compared `1.2.3` against the profile, and refused a browser
+#: that was in fact newer. Measured. A name we have not seen costs the guard;
+#: a name we half-recognise cost a launch nobody could recover.
+#:
+#: Chromium forks number themselves their own way: Vivaldi is on 7.x, and Edge
+#: puts a build number an order of magnitude below Chrome's under the same
+#: major. Pointing `CHROME_PATH` at either, against a profile the bundled
+#: browser wrote, reads as a downgrade of hundreds of versions. It is not one,
+#: and the message it would produce asks for something no build of that
+#: browser will ever satisfy.
+#:
+#: This identifies the *running* binary, which is all `--version` can tell us,
+#: and that bounds the rule: a profile written by a fork and then opened by the
+#: bundled browser is still refused, because `Last Version` names no product.
+#: That case is not repairable from here. Mixing two products over one profile
+#: directory is outside what this server supports, and the error says to run
+#: whichever browser produced that number again, which is the way out.
+#:
+#: An unrecognised name costs the guard, never a false refusal, which is the
+#: right direction to be wrong in. Measured strings behind each entry:
+#: `Chromium 148.0.7778.0` (the Linux image, full browser and headless shell
+#: alike), `Google Chrome 150.0.7871.189`, `Google Chrome for Testing
+#: 148.0.7778.96` (the bundled browser *and* the headless shell on macOS).
+#: Distribution and snap builds put the build host after the number, and the
+#: beta and dev channels put the channel there, so all of those still read as
+#: `Chromium` or `Google Chrome`.
+#:
+#: One entry nobody here could measure: Chrome Canary. If it names itself
+#: `Google Chrome Canary` rather than putting the channel after the version,
+#: the guard is simply off for that install, which is the direction this errs
+#: in anyway. Recorded rather than guessed at.
+_COMPARABLE_PRODUCTS = frozenset(
+    {"chromium", "google chrome", "google chrome for testing"}
+)
+
+
+class BrowserBuild(NamedTuple):
+    """What a binary says it is: the product name and the version beside it."""
+
+    product: str
+    version: tuple[int, ...]
+
+
+def a_version_can_be_asked_for() -> bool:
+    """Whether asking a browser binary for its version is a safe thing to do.
+
+    False on Windows, and not because the answer would merely be empty.
+    Chromium handles ``--version`` in ``HandleVersionSwitches``, and both that
+    function and its call site in ``BasicStartupComplete`` sit inside
+    ``#if BUILDFLAG(IS_POSIX) && !defined(BUILDING_CHROME_RENDERER)``
+    (``chrome/app/chrome_main_delegate.cc``, verified against current main). On
+    Windows that code is not compiled, so ``--version`` is not a handled switch
+    but an *unrecognised* one, and an unrecognised switch does not stop a
+    browser from starting.
+
+    What the probe would actually do there: no ``--user-data-dir`` is passed,
+    so it opens whatever profile that binary defaults to, which with
+    ``CHROME_PATH`` set is the user's own Chrome. If a browser is already
+    running on it, the new process forwards its command line and exits, leaving
+    a window open and no output. If none is, the probe *is* the browser: it
+    never exits, blocks the launch for the full timeout, and is then killed,
+    which is what makes Chrome offer to restore pages on the user's next start.
+
+    So the guard is off on Windows, deliberately and quietly. There is no half
+    measure available: a version could only come from the executable's own
+    file-version resource, which is separate work.
+    """
+    return os.name != "nt"
+
+
+def _the_line_that_should_carry_it(text: str) -> str:
+    """The first non-empty line of *text*, which is where a browser answers.
+
+    Everything after it is out of scope on purpose. A wrapper script that says
+    something before handing over would otherwise donate both the number and
+    the product name to the parse, and the guard would compare a banner. Kept
+    to one line, a banner simply means no version is found, and not knowing
+    lets the launch proceed -- the direction this module is meant to fail in.
+    """
+    for line in text.splitlines():
+        if line.strip():
+            return line
+    return ""
+
+
+def parse_version(text: str) -> tuple[int, ...] | None:
+    """The first dotted version on *text*'s first line, as a comparable tuple.
+
+    The first rather than the last, and the difference is load-bearing on
+    Linux. Distribution builds append their own build host: `Chromium
+    90.0.4430.212 built on Debian 10.9, running on Debian 10.9` is harmless
+    because two components do not match, but a three-part release number in
+    that suffix -- an Ubuntu point release, say -- would be picked up as the
+    browser version and read as a downgrade against every profile. No real
+    product name carries a version ahead of its own, so the leading match is
+    the safe end to take.
+
+    The same parser reads the ``Last Version`` file, which holds the bare
+    number on one line, where first and last are the same thing.
+    """
+    build = parse_build(text)
+    return None if build is None else build.version
+
+
+def parse_build(text: str) -> BrowserBuild | None:
+    """A ``--version`` line split into the product name and the version."""
+    line = _the_line_that_should_carry_it(text)
+    match = _VERSION.search(line)
+    if match is None:
+        return None
+    return BrowserBuild(
+        product=line[: match.start()].strip(),
+        version=tuple(int(part) for part in match.group().split(".")),
+    )
+
+
+def is_comparable(product: str) -> bool:
+    """Whether *product* numbers itself the way ``Last Version`` is numbered.
+
+    Whole name, not a prefix. Every published Chrome-family build puts its
+    channel or build host *after* the version (`Chromium 151.0.7922.71 snap`,
+    `Google Chrome 150.0.7871.189 beta`), so the token ahead of the number is
+    always one of these three and nothing is lost by being strict.
+    """
+    return product.strip().lower() in _COMPARABLE_PRODUCTS
+
+
+def profile_was_written_by(profile_dir: Path) -> tuple[int, ...] | None:
+    """The version Chromium last recorded in *profile_dir*, if it said."""
+    marker = profile_dir / LAST_VERSION_FILE
+    try:
+        recorded = marker.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        # Absent on a profile no browser has opened yet, which is the ordinary
+        # first run and not worth a log line above debug.
+        return None
+    version = parse_version(recorded)
+    if version is None:
+        # A warning, not a debug line, and for the same reason the unnameable
+        # binary below gets one: the file exists, so a browser wrote it, and
+        # the launch that follows will rewrite it down to its own number. That
+        # is the guard gone for this profile permanently, and the default log
+        # level is WARNING, so anything quieter is invisible where it counts.
+        logger.warning(
+            "Cannot read %s in %s (%r), so no downgrade check is possible for "
+            "this profile.",
+            LAST_VERSION_FILE,
+            profile_dir,
+            recorded[:80],
+        )
+    return version
+
+
+def version_of(executable: str) -> BrowserBuild | None:
+    """What ``executable --version`` reports, or None if it will not say.
+
+    Asked of the binary rather than read from Playwright's ``browsers.json``,
+    which records what the *manifest* says should be installed. Those disagree
+    exactly when it matters: a half-finished or hand-copied install leaves the
+    manifest describing a revision the directory does not hold, and the binary
+    is the thing that is going to open the profile.
+
+    Never asked at all where asking would start a browser instead of answering:
+    see :func:`a_version_can_be_asked_for`.
+
+    The timeout below is a real bound only on POSIX, which is the same platform
+    line. CPython's ``run()`` follows its kill with a plain ``wait()`` there,
+    but with an unbounded ``communicate()`` on Windows, so a wrapper that
+    spawned a detached child holding the stdout pipe would be waited for rather
+    than us.
+    """
+    # Also checked by the caller, and the two are not the same check even
+    # though they read alike. This one guards the dangerous act at the moment
+    # it would happen, so a future caller that forgets cannot start a browser
+    # on somebody's own profile; the caller's is about staying quiet. Do not
+    # collapse them into one.
+    if not a_version_can_be_asked_for():
+        return None
+
+    try:
+        finished = subprocess.run(
+            [executable, "--version"],
+            capture_output=True,
+            text=True,
+            # `text=True` decodes strictly, and a `CHROME_PATH` wrapper is free
+            # to emit whatever bytes it likes. A `UnicodeDecodeError` is neither
+            # an `OSError` nor a `SubprocessError`, so it would escape the guard
+            # entirely and kill the launch -- the opposite of failing open.
+            errors="replace",
+            # Never the parent's stdin. Under the stdio transport that handle is
+            # the JSON-RPC channel, and a wrapper script that reads a line would
+            # eat an MCP message on its way past and then block until the
+            # timeout below.
+            stdin=subprocess.DEVNULL,
+            timeout=_VERSION_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("Could not ask %s for its version: %s", executable, exc)
+        return None
+
+    build = parse_build(finished.stdout)
+    if build is None:
+        logger.debug(
+            "No version in the output of %s --version: %r",
+            executable,
+            finished.stdout.strip()[:200],
+        )
+    return build
+
+
+def refuse_a_downgrade(profile_dir: Path, executable: str | None) -> None:
+    """Raise if *executable* is older than the browser that last wrote *profile_dir*.
+
+    A forward update is allowed and always has been: Chromium migrates a profile
+    it opens, and refusing that would make every browser upgrade a manual step.
+    Only the other direction is refused.
+
+    The whole version is compared, not the major. Chrome's own downgrade
+    detection compares the full version, and the schema floors that make a
+    downgrade lossy are raised on point releases as readily as on majors, so a
+    major-only rule would wave through the case it is meant to catch.
+
+    Only within one product line, though. ``Last Version`` records a number and
+    no product, so a comparison across two products compares two different
+    numbering schemes and means nothing. See :data:`_COMPARABLE_PRODUCTS`.
+    """
+    if executable is None:
+        return
+
+    if not a_version_can_be_asked_for():
+        # Before the marker is even read, so that Windows is silent rather than
+        # warning on every single start about a check it can never perform.
+        logger.debug(
+            "No downgrade check on this platform: a browser cannot be asked "
+            "for its version without starting it."
+        )
+        return
+
+    written_by = profile_was_written_by(profile_dir)
+    if written_by is None:
+        return
+
+    # Only once there is something to compare against. On a fresh profile this
+    # skips the subprocess entirely rather than spending it to learn nothing.
+    about_to_run = version_of(executable)
+    if about_to_run is None:
+        # A warning, unlike the two silent returns above it, and unlike the
+        # comparable-product return below. This is the branch where half the
+        # evidence exists and is about to be destroyed: the marker was read,
+        # the launch proceeds, and the older browser rewrites that marker down
+        # to its own number on the way out. The guard can never fire on this
+        # profile again, and without a line here the eventual "session
+        # expired" has nothing anywhere to connect it to. The default log
+        # level is WARNING, so anything quieter is invisible where it matters.
+        logger.warning(
+            "Could not tell which version %s is, so this profile's recorded "
+            "%s cannot be checked against it. If the session stops working "
+            "after this, an older browser may have opened a newer profile.",
+            executable,
+            _render(written_by),
+        )
+        return
+
+    if not is_comparable(about_to_run.product):
+        # Info rather than a warning, because this one follows directly from an
+        # explicit CHROME_PATH pointing at a browser outside the Chrome family.
+        # It is the configuration behaving as documented, not a surprise.
+        logger.info(
+            "Not checking %s %s against this profile's recorded %s: the number "
+            "in Last Version carries no product, and only Chrome-family "
+            "versions can be compared against it.",
+            about_to_run.product,
+            _render(about_to_run.version),
+            _render(written_by),
+        )
+        return
+
+    if about_to_run.version >= written_by:
+        return
+
+    raise BrowserDowngradeError(
+        profile_version=_render(written_by),
+        browser_version=_render(about_to_run.version),
+        browser_product=about_to_run.product,
+        profile_dir=profile_dir,
+    )
+
+
+def _render(version: tuple[int, ...]) -> str:
+    return ".".join(str(part) for part in version)

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -13,7 +13,10 @@ from linkedin_mcp_server.bootstrap import (
     ensure_browser_installed,
 )
 from linkedin_mcp_server.core import AuthenticationError
-from linkedin_mcp_server.exceptions import ProfileRootRefusedError
+from linkedin_mcp_server.exceptions import (
+    BrowserDowngradeError,
+    ProfileRootRefusedError,
+)
 from linkedin_mcp_server.authentication import clear_auth_state
 from linkedin_mcp_server.config import get_config
 from linkedin_mcp_server.config.schema import AppConfig
@@ -252,6 +255,12 @@ def profile_info_and_exit() -> None:
             return browser.is_authenticated
         except AuthenticationError:
             return False
+        except BrowserDowngradeError:
+            # Not "unexpected", and no traceback. This is the guard doing its
+            # job, the message already says which two versions and what to do,
+            # and `--status` is the first thing a puzzled user runs. The tool
+            # path treats it the same way, in `error_handler`.
+            raise
         except Exception as e:
             logger.exception(f"Unexpected error checking session: {e}")
             raise
@@ -274,6 +283,11 @@ def profile_info_and_exit() -> None:
 
     try:
         valid = asyncio.run(check_session())
+    except BrowserDowngradeError as e:
+        # Ahead of the generic handler, which would add "Check logs and browser
+        # configuration" to a message that already names the fix exactly.
+        print(f"\n❌ {e}")
+        sys.exit(1)
     except Exception as e:
         print(f"❌ Could not validate session: {e}")
         print("   Check logs and browser configuration.")

--- a/linkedin_mcp_server/core/browser.py
+++ b/linkedin_mcp_server/core/browser.py
@@ -21,7 +21,11 @@ from linkedin_mcp_server.common_utils import (
     secure_write_text,
 )
 
-from linkedin_mcp_server.exceptions import BrowserShutdownUnconfirmedError
+from linkedin_mcp_server.browser_downgrade import refuse_a_downgrade
+from linkedin_mcp_server.exceptions import (
+    BrowserDowngradeError,
+    BrowserShutdownUnconfirmedError,
+)
 from linkedin_mcp_server.hidden_target import (
     attaching_to_other_targets,
     hidden_target_is_supported,
@@ -173,6 +177,41 @@ class BrowserManager:
             return {"viewport": self.viewport or {"width": 1280, "height": 720}}
         return {"no_viewport": True}
 
+    def _executable_about_to_run(self) -> str | None:
+        """The binary this launch will use, or None if it cannot be named.
+
+        An explicit ``executable_path`` is the operator's own choice and wins,
+        exactly as it does inside Playwright (``_prepareToLaunch``). Otherwise
+        the registry answers, and with ``channel="chromium"`` set by
+        ``build_launch_options`` that is the same full Chrome for Testing in
+        both modes: ``getExecutableName()`` returns the channel unchanged
+        before it ever reaches the headless/shell split, and
+        ``executablePath()`` looks up the same registry entry. (Not via
+        ``isChromiumAlias``, which holds only ``chrome-for-testing``.)
+
+        None on anything unexpected, deliberately. Not being able to name the
+        binary says nothing about whether it is older than the profile, and the
+        launch that follows reports a missing browser far better than a guard
+        pretending to know one is there.
+        """
+        custom = self.launch_options.get("executable_path")
+        if custom:
+            return str(custom)
+        playwright = self._playwright
+        if playwright is None:
+            return None
+        try:
+            registry_path = playwright.chromium.executable_path
+        except Exception as exc:
+            logger.debug("Could not resolve the browser executable: %s", exc)
+            return None
+        # The registry answers with `... || ""` when nothing is installed, and
+        # an empty string is not a name. Passed on it would buy a doomed
+        # `subprocess.run(["", "--version"])` and then a warning naming no
+        # binary at all. The launch below is what reports a missing browser,
+        # and it says so with the path.
+        return str(registry_path) if registry_path else None
+
     async def start(self) -> None:
         """Start Patchright and launch persistent browser context."""
         if self._context is not None:
@@ -190,6 +229,19 @@ class BrowserManager:
                     self._playwright = await async_playwright().start()
             else:
                 self._playwright = await async_playwright().start()
+
+            # Before the profile directory is so much as created, and long
+            # before it is opened. The driver had to start first, because only
+            # it can say which binary the registry will hand this launch, but
+            # nothing beyond that has happened yet -- a refusal here leaves the
+            # profile exactly as it was found, which is the whole point of
+            # refusing. Off the event loop: asking a binary for its version
+            # spawns a process and waits ~35 ms for it.
+            await asyncio.to_thread(
+                refuse_a_downgrade,
+                Path(self.user_data_dir),
+                self._executable_about_to_run(),
+            )
 
             secure_mkdir(Path(self.user_data_dir))
             harden_linkedin_tree(Path(self.user_data_dir))
@@ -335,7 +387,27 @@ class BrowserManager:
             # real (a tool timeout racing server shutdown), and a second one
             # landing on the shield would discard the very result that decides
             # whether the profile may be handed on.
-            if not await _await_deferring_cancels(self.close()):
+            closed = await _await_deferring_cancels(self.close())
+            if isinstance(e, BrowserDowngradeError):
+                # Through untouched, and ahead of the shutdown check rather than
+                # after it. Both wrappings below carry a recovery that would
+                # make this worse: `NetworkError` is read downstream as a
+                # missing binary and reinstalls the same old revision, and the
+                # auth path rotates the profile away, destroying an intact
+                # session whose only fault is being newer than the browser
+                # asking for it.
+                #
+                # `BrowserShutdownUnconfirmedError` would be the third, and it
+                # is the reason for the ordering. This refusal happens before
+                # `launch_persistent_context`, so no Chromium ever existed and
+                # nothing can be holding the profile -- only the driver process
+                # is up. Yet a driver that misses its 10 s stop would replace an
+                # actionable message with a generic one *and* leave the caller
+                # marking the profile busy for the rest of this process's life,
+                # over a profile that was never opened. The close still runs;
+                # only its verdict is set aside, and only here.
+                raise
+            if not closed:
                 raise BrowserShutdownUnconfirmedError(
                     "The browser failed to start and did not shut down cleanly, "
                     "so the profile is kept. Restart the server to recover."

--- a/linkedin_mcp_server/drivers/browser.py
+++ b/linkedin_mcp_server/drivers/browser.py
@@ -37,6 +37,7 @@ from linkedin_mcp_server.debug_trace import record_page_trace
 from linkedin_mcp_server.debug_utils import stabilize_navigation
 from linkedin_mcp_server.exceptions import (
     BrowserBusyError,
+    BrowserDowngradeError,
     BrowserShutdownUnconfirmedError,
     ProfileRootRefusedError,
 )
@@ -715,10 +716,20 @@ async def _create_browser_locked() -> BrowserManager:
             _browser = browser
             _browser_cookie_export_path = None
             return _browser
-        except AuthenticationError:
+        except (AuthenticationError, BrowserDowngradeError) as exc:
+            # A downgrade belongs here and nowhere else. On the *source* profile
+            # it has to reach the user, because that directory holds the session
+            # and throwing it away to satisfy an old browser is the damage, not
+            # the repair. A derived runtime profile is the opposite: it is
+            # rebuilt from the source cookies on demand, and the re-bridge below
+            # deletes it first, so the older browser gets a directory it wrote
+            # itself. Reachable whenever a container image moves backwards with
+            # EXPERIMENTAL_PERSIST_DERIVED_RUNTIME set.
             logger.warning(
-                "Derived runtime profile auth failed for %s; re-bridging from source cookies",
+                "Derived runtime profile is unusable for %s (%s); re-bridging "
+                "from source cookies",
                 current_runtime_id,
+                type(exc).__name__,
             )
 
     if force_bridge:

--- a/linkedin_mcp_server/error_handler.py
+++ b/linkedin_mcp_server/error_handler.py
@@ -29,6 +29,7 @@ from linkedin_mcp_server.exceptions import (
     AuthenticationStartedError,
     BrowserBinaryMissingError,
     BrowserBusyError,
+    BrowserDowngradeError,
     BrowserSetupFailedError,
     BrowserSetupInProgressError,
     CredentialsNotFoundError,
@@ -183,6 +184,14 @@ def raise_tool_error(exception: Exception, context: str = "") -> NoReturn:
 
     elif isinstance(exception, BrowserBinaryMissingError):
         logger.warning("Browser binary missing%s: %s", ctx, exception)
+        raise ToolError(str(exception)) from exception
+
+    # Diagnostics-free, following BrowserBusyError. A browser refusing a profile
+    # a newer one wrote is the guard doing its job, and the message already
+    # names both versions and the two ways out. Appending an issue template
+    # would send users to the tracker for something working as intended.
+    elif isinstance(exception, BrowserDowngradeError):
+        logger.warning("Browser older than the profile%s: %s", ctx, exception)
         raise ToolError(str(exception)) from exception
 
     elif isinstance(exception, SessionExpiredError):

--- a/linkedin_mcp_server/exceptions.py
+++ b/linkedin_mcp_server/exceptions.py
@@ -138,6 +138,58 @@ class ProfileRootRefusedError(LinkedInMCPError):
     """
 
 
+class BrowserDowngradeError(LinkedInMCPError):
+    """The browser about to open a profile is older than the one that wrote it.
+
+    Its own class because neither neighbouring recovery is right, and both would
+    do damage. It is not a ``NetworkError``: that path invalidates the browser
+    metadata and reinstalls, which fetches the same old revision and changes
+    nothing. It is not an ``AuthenticationError`` either: that path rotates the
+    profile away, destroying an intact session whose only problem is having been
+    written by a newer browser than the one now asking for it.
+
+    Raised before ``launch_persistent_context``, so the profile is never opened
+    and nothing has migrated by the time anyone reads the message.
+    """
+
+    def __init__(
+        self,
+        *,
+        profile_version: str,
+        browser_version: str,
+        browser_product: str = "",
+        profile_dir: object | None = None,
+    ):
+        self.profile_version = profile_version
+        self.browser_version = browser_version
+        self.browser_product = browser_product
+        self.profile_dir = profile_dir
+        where = f"\nProfile: {profile_dir}" if profile_dir is not None else ""
+        # "a browser reporting", not "Chromium": `Last Version` holds a number
+        # and no product name, so which browser wrote it is genuinely unknown.
+        # The running one names itself, and is named.
+        running = f"{browser_product} {browser_version}".strip()
+        # "The browser profile", never "this LinkedIn profile". This message
+        # surfaces through tools like get_person_profile, where a LinkedIn
+        # profile is a member's page and the collision would read as a claim
+        # about the person being looked up.
+        super().__init__(
+            f"The browser profile this server uses was last opened by a "
+            f"browser reporting {profile_version}, and the browser about to "
+            f"open it is {running}. An older browser can leave stores a newer "
+            f"one wrote unreadable, the saved session among them, so the "
+            f"profile is kept rather than opened."
+            f"{where}\n\n"
+            f"To fix this:\n"
+            f"  Run the newer browser again -- whichever gave you "
+            f"{profile_version}, whether that is a CHROME_PATH, a newer image "
+            f"tag, or the package version that shipped it.\n"
+            f"  Or run with --login, which moves the stored session aside and "
+            f"signs in again with this browser. The old one is kept and can "
+            f"be recovered; --logout would discard it."
+        )
+
+
 class CookieDecryptionError(LinkedInMCPError):
     """A browser cookie could not be decrypted."""
 

--- a/tests/test_browser_downgrade.py
+++ b/tests/test_browser_downgrade.py
@@ -1,0 +1,1008 @@
+"""What happens when the browser is older than the profile it is handed.
+
+Chromium records its version in ``Last Version`` on every run and carries on
+regardless when an older binary opens the same profile, leaving each store to
+decide for itself whether it can still be read. A store that says no is not
+reported: the browser simply runs without it. The cookie store is one, so the
+user-visible symptom of the case these tests describe is a working session
+disappearing.
+"""
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from linkedin_mcp_server.browser_downgrade import (
+    LAST_VERSION_FILE,
+    BrowserBuild,
+    a_version_can_be_asked_for,
+    is_comparable,
+    parse_build,
+    parse_version,
+    profile_was_written_by,
+    refuse_a_downgrade,
+    version_of,
+)
+from linkedin_mcp_server.core.browser import BrowserManager
+from linkedin_mcp_server.exceptions import BrowserDowngradeError
+
+
+def _shell_wrapper(tmp_path: Path, body: str) -> Path:
+    """An executable standing in for a ``CHROME_PATH`` that is not a browser.
+
+    Not hypothetical: pointing ``CHROME_PATH`` at a launcher script is the
+    documented way to run a browser with extra arguments or under a sandbox.
+    """
+    wrapper = tmp_path / "chrome-wrapper.sh"
+    wrapper.write_text(f"#!/bin/sh\n{body}\n")
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def _profile_last_opened_by(tmp_path: Path, version: str) -> Path:
+    profile = tmp_path / "profile"
+    profile.mkdir(parents=True, exist_ok=True)
+    # No trailing newline, matching what Chromium writes.
+    (profile / LAST_VERSION_FILE).write_text(version)
+    return profile
+
+
+class TestReadingAVersion:
+    """One parser for two sources, because they disagree in shape.
+
+    ``--version`` prints a product name ahead of the number; ``Last Version``
+    holds the bare number with no newline.
+    """
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("Google Chrome for Testing 148.0.7778.96\n", (148, 0, 7778, 96)),
+            ("Chromium 148.0.7778.96\n", (148, 0, 7778, 96)),
+            ("Google Chrome 150.0.7871.187\n", (150, 0, 7871, 187)),
+            ("150.0.7871.187", (150, 0, 7871, 187)),
+        ],
+    )
+    def test_reads_the_real_shapes(self, text, expected):
+        assert parse_version(text) == expected
+
+    def test_ignores_a_build_suffix(self):
+        """Distribution builds append their build host, and a three-part
+        release number there would be read as the browser version -- a small
+        number that looks like a downgrade against every profile. The leading
+        match is the safe end to take, because no product name carries a
+        version ahead of its own."""
+        assert parse_version(
+            "Chromium 151.0.7922.71 built on Ubuntu 22.04.5, running on Ubuntu 22.04.5"
+        ) == (151, 0, 7922, 71)
+
+    def test_two_component_suffixes_are_below_the_floor(self):
+        """The real Debian shape, and why the floor is three components."""
+        assert parse_version(
+            "Chromium 90.0.4430.212 built on Debian 10.9, running on Debian 10.9"
+        ) == (90, 0, 4430, 212)
+
+    @pytest.mark.parametrize("text", ["", "no version at all", "Chrome 1.0", "148"])
+    def test_refuses_to_invent_one(self, text):
+        assert parse_version(text) is None
+
+
+class TestAWrapperThatSaysSomethingFirst:
+    """The one input shape where this used to fail *closed*.
+
+    Pointing ``CHROME_PATH`` at a launcher script is the documented way to run
+    a browser with extra arguments or under a sandbox, and a script is free to
+    announce itself. Reading the whole of stdout, and taking everything before
+    the first number as a product name, meant such a banner could donate both
+    halves of the comparison. Measured before the fix: a wrapper that printed
+    ``Chromium launcher v1.2.3`` and then exec'd Chrome 150 was refused as
+    version ``(1, 2, 3)`` of ``Chromium launcher v`` -- older than every
+    profile, plausibly enough named to be compared -- and the message told the
+    user to run a newer browser, which is what they were doing.
+    """
+
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            # The number is glued to a word, so it is not a version.
+            "Chromium launcher v1.2.3\nGoogle Chrome 150.0.7871.187\n",
+            # A path that happens to carry one.
+            "note: profile at /opt/app-1.2.3\nGoogle Chrome 150.0.7871.187\n",
+            # No number at all on the line that answers.
+            "Launching Chromium under firejail\nChromium 148.0.7778.96\n",
+        ],
+    )
+    def test_a_banner_is_never_read_as_the_browser(self, stdout):
+        assert parse_build(stdout) is None
+
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            # The shape the whitespace anchor alone does not catch: a properly
+            # separated version behind a name that merely begins with one we
+            # know. It parses; the product check is what stops it.
+            "Chromium launcher 1.2.3\nGoogle Chrome 150.0.7871.187\n",
+            "Chrome sandbox helper 2.0.1\nGoogle Chrome 150.0.7871.187\n",
+        ],
+    )
+    def test_a_banner_that_parses_is_still_not_a_product_we_compare(self, stdout):
+        build = parse_build(stdout)
+
+        assert build is not None
+        assert is_comparable(build.product) is False
+
+    @pytest.mark.parametrize(
+        "banner",
+        [
+            "Chromium launcher v1.2.3",
+            "Chromium launcher 1.2.3",
+            "Launching Chromium under firejail",
+        ],
+    )
+    def test_a_banner_therefore_only_costs_the_guard(self, tmp_path, banner):
+        """Not knowing lets the launch through, which is the whole stance.
+
+        Each of these preceded a real Chrome 150 in the measured case, so a
+        refusal here is a refusal of a browser that is *newer* than the
+        profile, and the message asks the user to do what they already did.
+        """
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+        wrapper = _shell_wrapper(
+            tmp_path,
+            f"printf '{banner}\\nGoogle Chrome 150.0.7871.187\\n'",
+        )
+
+        refuse_a_downgrade(profile, str(wrapper))
+
+    def test_a_trailing_suffix_is_still_read(self):
+        """The fix must not cost the real thing it was protecting."""
+        assert parse_build("Chromium 151.0.7922.71 snap\n") == BrowserBuild(
+            "Chromium", (151, 0, 7922, 71)
+        )
+
+    @pytest.mark.parametrize(
+        "text, product",
+        [
+            ("Google Chrome for Testing 148.0.7778.96\n", "Google Chrome for Testing"),
+            ("Google Chrome 150.0.7871.189\n", "Google Chrome"),
+            ("Brave Browser 151.1.93.129\n", "Brave Browser"),
+            ("Chromium 151.0.7922.71 built on Debian 12\n", "Chromium"),
+        ],
+    )
+    def test_the_product_is_whatever_precedes_the_version(self, text, product):
+        build = parse_build(text)
+
+        assert build is not None
+        assert build.product == product
+
+
+class TestWhichProductsCompare:
+    """``Last Version`` records a number and no product, so the comparison is
+    only meaningful inside one numbering scheme.
+
+    Chromium forks number themselves their own way. Vivaldi is on 7.x and Edge
+    puts a build number an order of magnitude below Chrome's under the same
+    major, so pointing ``CHROME_PATH`` at either against a profile the bundled
+    browser wrote reads as a downgrade of hundreds of versions. It is not one,
+    and the message it produces asks for something no build of that browser
+    will ever satisfy.
+
+    Only the *running* binary can be identified this way, which bounds what the
+    rule can do: see ``test_a_foreign_writer_cannot_be_detected``.
+    """
+
+    @pytest.mark.parametrize(
+        "product",
+        [
+            "Chromium",
+            "Google Chrome",
+            "Google Chrome for Testing",
+            "google chrome for testing",
+        ],
+    )
+    def test_the_chrome_family_compares(self, product):
+        assert is_comparable(product) is True
+
+    @pytest.mark.parametrize(
+        "product",
+        [
+            "Brave Browser",
+            "Microsoft Edge",
+            "Vivaldi",
+            "Opera",
+            "Helium",
+            "",
+            # Matched whole rather than as a prefix, because these are exactly
+            # what a launcher script's banner looks like.
+            "Chromium launcher",
+            "Chrome sandbox helper",
+            "Chromium-based Thing",
+        ],
+    )
+    def test_everything_else_does_not(self, product):
+        assert is_comparable(product) is False
+
+    @pytest.mark.parametrize(
+        "build",
+        [
+            # Same Chromium major as the profile, build number two thousand
+            # lower because Edge numbers its own builds.
+            BrowserBuild("Microsoft Edge", (148, 0, 3651, 20)),
+            # A fork that never left single digits.
+            BrowserBuild("Vivaldi", (7, 5, 3735, 54)),
+        ],
+    )
+    def test_a_foreign_running_browser_is_never_refused(self, tmp_path, build):
+        """The whole point. Neither of these is older than a Chrome for Testing
+        148 profile in any sense that matters, and the guard cannot tell that
+        from the numbers -- so it does not try."""
+        profile = _profile_last_opened_by(tmp_path, "148.0.7778.96")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of", return_value=build
+        ):
+            refuse_a_downgrade(profile, "/browser")
+
+    def test_a_foreign_writer_cannot_be_detected(self, tmp_path):
+        """The bound on the rule, pinned so nobody later reads more into it.
+
+        A profile written by a fork and then opened by the bundled browser is
+        still refused, because ``Last Version`` names no product and the
+        running binary is one we do compare. It is not a false refusal that can
+        be removed from here: mixing two products over one profile directory is
+        outside what this server supports, and the message now says to run
+        whichever browser produced that number again -- which is the repair.
+        """
+        profile = _profile_last_opened_by(tmp_path, "151.1.93.129")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of",
+            return_value=BrowserBuild("Google Chrome for Testing", (151, 0, 7922, 34)),
+        ):
+            with pytest.raises(BrowserDowngradeError):
+                refuse_a_downgrade(profile, "/browser")
+
+
+class TestWhatWroteTheProfile:
+    def test_absent_directory_says_nothing(self, tmp_path):
+        assert profile_was_written_by(tmp_path / "never-existed") is None
+
+    def test_absent_marker_says_nothing(self, tmp_path):
+        """The ordinary first run. A profile no browser has opened has no
+        marker, and that is not a reason to refuse to open it."""
+        fresh = tmp_path / "profile"
+        fresh.mkdir()
+
+        assert profile_was_written_by(fresh) is None
+
+    def test_an_unreadable_marker_is_reported(self, tmp_path, caplog):
+        """Not silent, unlike an absent one. The file exists, so a browser
+        wrote it, and the launch that follows rewrites it down to its own
+        number: the guard is gone for this profile from then on."""
+        profile = _profile_last_opened_by(tmp_path, "not a version")
+
+        with caplog.at_level(logging.WARNING):
+            assert profile_was_written_by(profile) is None
+
+        assert [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_an_absent_marker_stays_quiet(self, tmp_path, caplog):
+        """The ordinary first run is not worth interrupting anyone over."""
+        fresh = tmp_path / "fresh"
+        fresh.mkdir()
+
+        with caplog.at_level(logging.WARNING):
+            assert profile_was_written_by(fresh) is None
+
+        assert not caplog.records
+
+    def test_reads_what_chromium_recorded(self, tmp_path):
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+
+        assert profile_was_written_by(profile) == (150, 0, 7871, 187)
+
+
+class TestAskingTheBinary:
+    def test_a_binary_that_is_not_there_says_nothing(self, tmp_path):
+        """Fails open. A missing browser is the launch's error to report, and
+        it says so far better than a guard pretending to know one is there."""
+        assert version_of(str(tmp_path / "no-such-browser")) is None
+
+    def test_output_without_a_version_says_nothing(self):
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.subprocess.run",
+            return_value=mock.Mock(stdout="chrome: command not found\n"),
+        ):
+            assert version_of("/anything") is None
+
+    async def test_the_installed_browser_answers(self):
+        """The one assertion here that a Chromium update can break.
+
+        Everything else in this file feeds the parser strings written by hand
+        in 2026. If a future build changes what ``--version`` prints, only this
+        test notices, and the guard would otherwise fail open in silence for
+        every user at once.
+        """
+        from patchright.async_api import async_playwright
+
+        async with async_playwright() as p:
+            executable = p.chromium.executable_path
+        if not executable or not Path(executable).exists():
+            pytest.skip("chromium is not installed; run patchright install chromium")
+
+        build = version_of(executable)
+
+        assert build is not None, "the installed browser did not report a version"
+        assert len(build.version) == 4, f"unexpected version shape: {build}"
+        assert build.version[0] > 100, f"implausible major: {build}"
+        # And the guard must recognise the product it is about to launch,
+        # otherwise it silently stops comparing for every default install.
+        assert is_comparable(build.product), f"unrecognised product: {build.product!r}"
+
+    @pytest.mark.skipif(os.name == "nt", reason="needs a POSIX shell wrapper")
+    def test_output_it_cannot_decode_still_says_something(self, tmp_path):
+        """``text=True`` decodes strictly, and a ``CHROME_PATH`` wrapper is free
+        to emit any bytes it likes. A ``UnicodeDecodeError`` is neither an
+        ``OSError`` nor a ``SubprocessError``, so without ``errors="replace"``
+        it escapes the guard and kills the launch -- the opposite of failing
+        open."""
+        wrapper = _shell_wrapper(
+            tmp_path, "printf 'Chromium 148.0.7778.96 \\377\\376 caf\\351\\n'"
+        )
+
+        build = version_of(str(wrapper))
+
+        assert build is not None
+        assert build.version == (148, 0, 7778, 96)
+
+    @pytest.mark.skipif(os.name == "nt", reason="needs a POSIX shell wrapper")
+    def test_the_probe_never_reads_the_servers_stdin(self, tmp_path):
+        """Under the stdio transport that handle is the JSON-RPC channel. A
+        wrapper that reads a line would eat an MCP message on its way past and
+        then block until the timeout."""
+        wrapper = _shell_wrapper(
+            tmp_path, "read line\nprintf 'Chromium 148.0.7778.96\\n' \"$line\""
+        )
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, b"MCP-JSONRPC-LINE-1\nMCP-JSONRPC-LINE-2\n")
+        os.close(write_fd)
+        saved = os.dup(0)
+        try:
+            os.dup2(read_fd, 0)
+            build = version_of(str(wrapper))
+        finally:
+            os.dup2(saved, 0)
+            os.close(saved)
+            leftover = os.read(read_fd, 200)
+            os.close(read_fd)
+
+        assert build is not None
+        # Both lines are still there: the child read from /dev/null, not from us.
+        assert leftover == b"MCP-JSONRPC-LINE-1\nMCP-JSONRPC-LINE-2\n"
+
+
+class TestWhichWayTheVersionsHaveToGo:
+    def test_a_forward_update_is_allowed(self, tmp_path):
+        """Chromium migrates a profile it opens. Refusing that would make every
+        browser upgrade a manual step, which is not the failure being guarded."""
+        profile = _profile_last_opened_by(tmp_path, "148.0.7778.96")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of",
+            return_value=BrowserBuild("Chromium", (149, 0, 7827, 55)),
+        ):
+            refuse_a_downgrade(profile, "/browser")
+
+    def test_the_same_version_is_allowed(self, tmp_path):
+        profile = _profile_last_opened_by(tmp_path, "148.0.7778.96")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of",
+            return_value=BrowserBuild("Chromium", (148, 0, 7778, 96)),
+        ):
+            refuse_a_downgrade(profile, "/browser")
+
+    def test_an_older_browser_is_refused(self, tmp_path):
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of",
+            return_value=BrowserBuild("Chromium", (148, 0, 7778, 96)),
+        ):
+            with pytest.raises(BrowserDowngradeError) as raised:
+                refuse_a_downgrade(profile, "/browser")
+
+        # Both numbers, because neither alone lets anyone act: the message has
+        # to say what to point CHROME_PATH at.
+        assert raised.value.profile_version == "150.0.7871.187"
+        assert raised.value.browser_version == "148.0.7778.96"
+        assert "150.0.7871.187" in str(raised.value)
+        assert "148.0.7778.96" in str(raised.value)
+
+    def test_a_point_release_backwards_is_refused(self, tmp_path):
+        """The whole version, not the major.
+
+        Chrome's own downgrade detection compares the full version, and the
+        schema floors that make a downgrade lossy are raised on point releases
+        as readily as on majors. A major-only comparison would wave through the
+        commonest shape of this: two installs of the same series, one stale.
+        """
+        profile = _profile_last_opened_by(tmp_path, "148.0.7778.96")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of",
+            return_value=BrowserBuild("Chromium", (148, 0, 7778, 95)),
+        ):
+            with pytest.raises(BrowserDowngradeError):
+                refuse_a_downgrade(profile, "/browser")
+
+
+class TestThePlatformWhereAskingWouldStartABrowser:
+    """Windows, where ``--version`` is not answered but ignored.
+
+    Chromium compiles ``HandleVersionSwitches`` and its call site only under
+    ``BUILDFLAG(IS_POSIX)`` (``chrome/app/chrome_main_delegate.cc``, checked
+    against current main), so on Windows the switch is unrecognised and an
+    unrecognised switch does not stop a browser starting. With no
+    ``--user-data-dir`` it opens whatever profile that binary defaults to, which
+    with ``CHROME_PATH`` is the user's own Chrome: either a window appears and
+    the process forwards its command line, or the probe *is* the browser, blocks
+    for the whole timeout, and is then killed, which is what makes Chrome offer
+    to restore pages afterwards.
+
+    The Windows CI job runs four unrelated files, so nothing here would have
+    seen it. These tests force the platform answer instead of relying on it.
+    """
+
+    def test_no_binary_is_ever_run_there(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "linkedin_mcp_server.browser_downgrade.a_version_can_be_asked_for",
+            lambda: False,
+        )
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.subprocess.run"
+        ) as spawned:
+            assert version_of("/anything") is None
+
+        assert spawned.call_count == 0
+
+    def test_the_guard_gives_up_before_it_reads_anything(self, tmp_path, monkeypatch):
+        """Ahead of the marker, so the platform is silent rather than warning
+        on every start about a check it can never perform."""
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+        monkeypatch.setattr(
+            "linkedin_mcp_server.browser_downgrade.a_version_can_be_asked_for",
+            lambda: False,
+        )
+
+        with mock.patch("linkedin_mcp_server.browser_downgrade.version_of") as asked:
+            refuse_a_downgrade(profile, "/browser")
+
+        assert asked.call_count == 0
+
+    def test_it_says_nothing_at_the_default_level(self, tmp_path, monkeypatch, caplog):
+        """An *unparseable* marker, which is the only fixture that can see the
+        ordering. With a good one the marker read is silent either way, so the
+        mutation that moves it above the platform gate passes unnoticed; with
+        this one that mutation produces a warning on every Windows start about
+        a check the platform can never perform."""
+        profile = _profile_last_opened_by(tmp_path, "not a version")
+        monkeypatch.setattr(
+            "linkedin_mcp_server.browser_downgrade.a_version_can_be_asked_for",
+            lambda: False,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            refuse_a_downgrade(profile, "/browser")
+
+        assert not caplog.records, [r.getMessage() for r in caplog.records]
+
+    def test_posix_still_asks(self, monkeypatch):
+        """The other half, so the platform switch cannot be left stuck off."""
+        monkeypatch.setattr(os, "name", "posix")
+
+        assert a_version_can_be_asked_for() is True
+
+        monkeypatch.setattr(os, "name", "nt")
+
+        assert a_version_can_be_asked_for() is False
+
+
+class TestWhatTheUserIsToldWhenItGivesUp:
+    """The default log level is WARNING, so anything quieter is invisible."""
+
+    def test_an_unnameable_binary_is_reported(self, tmp_path, caplog):
+        """The one branch where half the evidence exists and is about to go.
+
+        The marker was read, the launch proceeds, and the older browser
+        rewrites that marker down to its own number on the way out. The guard
+        can never fire on this profile again, so without a line here the
+        eventual "session expired" has nothing to connect it to.
+        """
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+
+        with caplog.at_level(logging.WARNING):
+            with mock.patch(
+                "linkedin_mcp_server.browser_downgrade.version_of", return_value=None
+            ):
+                refuse_a_downgrade(profile, "/browser")
+
+        assert any(
+            record.levelno >= logging.WARNING
+            and "150.0.7871.187" in record.getMessage()
+            for record in caplog.records
+        ), f"nothing at WARNING: {[r.getMessage() for r in caplog.records]}"
+
+    def test_a_foreign_product_stays_below_a_warning(self, tmp_path, caplog):
+        """That one follows directly from an explicit CHROME_PATH outside the
+        Chrome family, so it is the configuration behaving as documented rather
+        than a surprise worth interrupting anyone over."""
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+
+        with caplog.at_level(logging.DEBUG):
+            with mock.patch(
+                "linkedin_mcp_server.browser_downgrade.version_of",
+                return_value=BrowserBuild("Vivaldi", (7, 5, 3735, 54)),
+            ):
+                refuse_a_downgrade(profile, "/browser")
+
+        assert [r for r in caplog.records if r.levelno == logging.INFO]
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestWhereItFailsOpen:
+    """Not knowing is never evidence of a downgrade.
+
+    Every unknown here has a live counterpart: Windows prints no version at
+    all, a custom ``CHROME_PATH`` can name a wrapper script, and a profile
+    directory can be on a filesystem that refuses the read.
+    """
+
+    def test_an_unnameable_binary_is_allowed(self, tmp_path):
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+
+        with mock.patch("linkedin_mcp_server.browser_downgrade.version_of") as asked:
+            refuse_a_downgrade(profile, None)
+
+        assert asked.call_count == 0
+
+    def test_a_silent_binary_is_allowed(self, tmp_path):
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of", return_value=None
+        ):
+            refuse_a_downgrade(profile, "/browser")
+
+    def test_a_fresh_profile_is_not_worth_a_subprocess(self, tmp_path):
+        """Order, not just outcome.
+
+        With nothing recorded there is nothing to compare against, so asking
+        the binary costs a process spawn to learn nothing. Reversing the two
+        still passes every other test here, which is why this one asserts that
+        the marker is read first.
+        """
+        fresh = tmp_path / "profile"
+        fresh.mkdir()
+
+        with mock.patch("linkedin_mcp_server.browser_downgrade.version_of") as asked:
+            refuse_a_downgrade(fresh, "/browser")
+
+        assert asked.call_count == 0
+
+
+def _fake_playwright(
+    recorder: dict,
+    *,
+    executable: str = "/registry/chromium",
+    stop_hangs: bool = False,
+):
+    """A driver that records the launch it was asked for and nothing else.
+
+    Deliberately smaller than the fake in ``test_core_browser``: the hidden
+    target is out of the way here, because what is under test is whether the
+    launch happens at all.
+    """
+
+    class _Page:
+        url = "about:blank"
+
+        async def close(self):
+            return None
+
+    class _Context:
+        def __init__(self):
+            self.pages = [_Page()]
+
+        async def close(self):
+            return None
+
+    class _Chromium:
+        executable_path = executable
+
+        async def launch_persistent_context(self, user_data_dir, **kwargs):
+            recorder["options"] = kwargs
+            recorder["user_data_dir"] = user_data_dir
+            return _Context()
+
+    class _Playwright:
+        chromium = _Chromium()
+
+        async def stop(self):
+            if stop_hangs:
+                await asyncio.sleep(30)
+            return None
+
+    async def start():
+        return _Playwright()
+
+    return start
+
+
+class TestWhatTheLaunchDoes:
+    """The guard where it actually sits, not the helper on its own."""
+
+    def _manager(self, profile: Path, **kwargs) -> BrowserManager:
+        return BrowserManager(user_data_dir=profile, headless=True, **kwargs)
+
+    async def _start_against(
+        self, manager: BrowserManager, recorder: dict, **fake_kwargs
+    ):
+        with mock.patch(
+            "linkedin_mcp_server.core.browser.hidden_target_is_supported",
+            return_value=False,
+        ):
+            with mock.patch(
+                "linkedin_mcp_server.core.browser.async_playwright"
+            ) as playwright:
+                playwright.return_value.start = _fake_playwright(
+                    recorder, **fake_kwargs
+                )
+                await manager.start()
+
+    async def test_the_profile_is_never_opened(self, tmp_path):
+        """A refusal that still launched would have migrated the profile before
+        anyone read the message, which is the damage being avoided."""
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+        recorder: dict = {}
+        manager = self._manager(profile, executable_path="/browser")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of",
+            return_value=BrowserBuild("Chromium", (148, 0, 7778, 96)),
+        ):
+            with pytest.raises(BrowserDowngradeError):
+                await self._start_against(manager, recorder)
+
+        assert "options" not in recorder, "the browser was launched anyway"
+
+    async def test_nothing_touches_the_profile_before_the_refusal(self, tmp_path):
+        """Ordering, and the only part of it that is observable.
+
+        A refusal cannot be reached on a directory that does not exist -- there
+        would be no marker to read -- so "the directory was not created" proves
+        nothing. What the position of the check does decide is whether the
+        profile is created and its whole tree chmodded on the way to being
+        refused, and moving the check below either of those fails here.
+        """
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+        recorder: dict = {}
+        manager = self._manager(profile, executable_path="/browser")
+
+        with (
+            mock.patch("linkedin_mcp_server.core.browser.secure_mkdir") as made,
+            mock.patch(
+                "linkedin_mcp_server.core.browser.harden_linkedin_tree"
+            ) as hardened,
+            mock.patch(
+                "linkedin_mcp_server.browser_downgrade.version_of",
+                return_value=BrowserBuild("Chromium", (148, 0, 7778, 96)),
+            ),
+        ):
+            with pytest.raises(BrowserDowngradeError):
+                await self._start_against(manager, recorder)
+
+        assert made.call_count == 0
+        assert hardened.call_count == 0
+
+    async def test_it_is_not_reported_as_a_network_failure(self, tmp_path):
+        """``start()`` wraps everything it catches into ``NetworkError``, and
+        that class is read downstream as a missing binary: the recovery
+        invalidates the browser metadata and reinstalls the same old revision,
+        which cannot help. It has to pass through as itself.
+
+        The ``pytest.raises`` is the assertion. Under the mutation that drops
+        the passthrough, what arrives is a ``NetworkError`` and this fails.
+        Asserting ``not isinstance(..., NetworkError)`` afterwards would prove
+        nothing at all, because the class cannot inherit it.
+        """
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+        recorder: dict = {}
+        manager = self._manager(profile, executable_path="/browser")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of",
+            return_value=BrowserBuild("Chromium", (148, 0, 7778, 96)),
+        ):
+            with pytest.raises(BrowserDowngradeError) as raised:
+                await self._start_against(manager, recorder)
+
+        # The message survives the trip too: the wrapping replaces it with
+        # "Failed to start browser: ...", which names neither version.
+        assert "150.0.7871.187" in str(raised.value)
+        assert "148.0.7778.96" in str(raised.value)
+
+    async def test_a_wedged_driver_does_not_hide_the_reason(self, tmp_path):
+        """No Chromium ever ran, so nothing can be holding the profile.
+
+        The refusal happens before ``launch_persistent_context``; only the
+        driver process is up. A driver that misses its stop bound would
+        otherwise replace the actionable message with the generic
+        shutdown-unconfirmed one, and the caller marks the profile busy for the
+        rest of the process's life on the strength of that -- over a profile
+        that was never opened.
+        """
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+        recorder: dict = {}
+        manager = self._manager(profile, executable_path="/browser")
+
+        with (
+            mock.patch(
+                "linkedin_mcp_server.core.browser._CLEANUP_TIMEOUT_SECONDS", 0.05
+            ),
+            mock.patch(
+                "linkedin_mcp_server.browser_downgrade.version_of",
+                return_value=BrowserBuild("Chromium", (148, 0, 7778, 96)),
+            ),
+        ):
+            with pytest.raises(BrowserDowngradeError):
+                await self._start_against(manager, recorder, stop_hangs=True)
+
+    async def test_a_matching_browser_launches_normally(self, tmp_path):
+        """The other half of the contract: the guard must not stop a launch it
+        has no reason to stop."""
+        profile = _profile_last_opened_by(tmp_path, "148.0.7778.96")
+        recorder: dict = {}
+        manager = self._manager(profile, executable_path="/browser")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of",
+            return_value=BrowserBuild("Chromium", (148, 0, 7778, 96)),
+        ):
+            await self._start_against(manager, recorder)
+
+        assert "options" in recorder
+
+    async def test_a_managed_launch_checks_the_registry_binary(self, tmp_path):
+        """No ``CHROME_PATH``, so the binary comes from Playwright's registry --
+        and that is the one nearly every user runs. Asking only when a custom
+        path was configured would leave the default install unguarded."""
+        profile = _profile_last_opened_by(tmp_path, "150.0.7871.187")
+        recorder: dict = {}
+        manager = self._manager(profile)
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of",
+            return_value=BrowserBuild("Chromium", (148, 0, 7778, 96)),
+        ) as asked:
+            with pytest.raises(BrowserDowngradeError):
+                await self._start_against(manager, recorder)
+
+        assert asked.call_args.args == ("/registry/chromium",)
+
+
+class TestWhichBinaryIsChecked:
+    def test_an_explicit_path_wins(self, tmp_path):
+        """``CHROME_PATH`` is the operator's own choice and is what Playwright
+        launches, so it is what gets asked."""
+        manager = BrowserManager(
+            user_data_dir=tmp_path, executable_path="/opt/chrome/chrome"
+        )
+
+        assert manager._executable_about_to_run() == "/opt/chrome/chrome"
+
+    def test_the_registry_answers_for_a_managed_launch(self, tmp_path):
+        manager = BrowserManager(user_data_dir=tmp_path)
+        manager._playwright = mock.Mock()
+        manager._playwright.chromium.executable_path = "/cache/chromium/chrome"
+
+        assert manager._executable_about_to_run() == "/cache/chromium/chrome"
+
+    def test_no_driver_yet_means_no_answer(self, tmp_path):
+        manager = BrowserManager(user_data_dir=tmp_path)
+
+        assert manager._executable_about_to_run() is None
+
+    def test_an_empty_registry_answer_is_not_a_name(self, tmp_path):
+        """Playwright's registry returns ``... || ""`` when nothing is
+        installed. Passed on, that buys a doomed ``subprocess.run(["", ...])``
+        and then a warning naming no binary at all; the launch that follows
+        reports the missing browser properly."""
+        manager = BrowserManager(user_data_dir=tmp_path)
+        manager._playwright = mock.Mock()
+        manager._playwright.chromium.executable_path = ""
+
+        assert manager._executable_about_to_run() is None
+
+    def test_a_registry_that_refuses_to_answer_is_not_fatal(self, tmp_path):
+        """Playwright's ``executable_path`` raises when the initializer is
+        empty, which the guard must survive: not being able to name the binary
+        says nothing about whether it is older than the profile."""
+        manager = BrowserManager(user_data_dir=tmp_path)
+        manager._playwright = mock.Mock()
+        type(manager._playwright.chromium).executable_path = mock.PropertyMock(
+            side_effect=RuntimeError("Please install the browser first")
+        )
+
+        assert manager._executable_about_to_run() is None
+
+
+class TestWhereARefusalIsRecoverableOnItsOwn:
+    """One profile is the session; the other is a cache of it.
+
+    The source profile has to reach the user, because throwing it away to
+    satisfy an old browser is the damage rather than the repair. A derived
+    runtime profile is rebuilt from the source cookies on demand, and the
+    re-bridge deletes it first, so the older browser gets a directory it wrote
+    itself. Reachable whenever a container image moves backwards with
+    ``EXPERIMENTAL_PERSIST_DERIVED_RUNTIME`` set.
+    """
+
+    def _committed_derived_runtime(self, monkeypatch, tmp_path):
+        """Enough state for ``_create_browser_locked`` to choose the stored
+        derived profile: a source session, a matching generation, and both the
+        profile and its storage snapshot on disk."""
+        from linkedin_mcp_server import session_state
+        from linkedin_mcp_server.drivers import browser as drv
+
+        source = tmp_path / "source" / "profile"
+        source.mkdir(parents=True)
+        (source / "Cookies").write_text("source")
+        session_state.portable_cookie_path(source).write_text("[]")
+        derived = session_state.runtime_profile_dir("linux-amd64-container", source)
+        derived.mkdir(parents=True)
+        (derived / "Cookies").write_text("derived")
+        snapshot = session_state.runtime_storage_state_path(
+            "linux-amd64-container", source
+        )
+        snapshot.write_text("{}")
+
+        source_state = session_state.SourceState(
+            version=1,
+            source_runtime_id="macos-arm64-host",
+            login_generation="gen-1",
+            created_at="2026-08-06T09:00:00Z",
+            profile_path=str(source),
+            cookies_path=str(session_state.portable_cookie_path(source)),
+        )
+        runtime_state = session_state.RuntimeState(
+            version=1,
+            runtime_id="linux-amd64-container",
+            source_runtime_id="macos-arm64-host",
+            source_login_generation="gen-1",
+            created_at="2026-08-06T09:00:00Z",
+            committed_at="2026-08-06T09:00:05Z",
+            profile_path=str(derived),
+            storage_state_path=str(snapshot),
+            commit_method="checkpoint_restart",
+        )
+
+        monkeypatch.setattr(drv, "_launch_options", lambda: ({}, {}))
+        monkeypatch.setattr(drv, "get_profile_dir", lambda: source)
+        monkeypatch.setattr(drv, "load_source_state", lambda _dir: source_state)
+        monkeypatch.setattr(drv, "get_runtime_id", lambda: "linux-amd64-container")
+        monkeypatch.setattr(drv, "experimental_persist_derived_runtime", lambda: True)
+        monkeypatch.setattr(drv, "_debug_bridge_every_startup", lambda: False)
+        monkeypatch.setattr(drv, "load_runtime_state", lambda *_a: runtime_state)
+        monkeypatch.setattr(drv, "_apply_browser_settings", lambda _b: None)
+        return drv, derived
+
+    async def test_a_stale_derived_profile_is_rebridged(self, monkeypatch, tmp_path):
+        drv, derived = self._committed_derived_runtime(monkeypatch, tmp_path)
+        bridged = mock.Mock(name="bridged browser")
+
+        async def refuse(profile_dir, **_kwargs):
+            raise BrowserDowngradeError(
+                profile_version="151.0.7922.34",
+                browser_version="149.0.7827.55",
+                profile_dir=profile_dir,
+            )
+
+        async def bridge(profile_dir, **_kwargs):
+            return bridged
+
+        monkeypatch.setattr(drv, "_authenticate_existing_profile", refuse)
+        monkeypatch.setattr(drv, "_bridge_runtime_profile", bridge)
+
+        assert await drv._create_browser_locked() is bridged
+
+    async def test_the_rebridge_really_clears_the_marker_first(
+        self, monkeypatch, tmp_path
+    ):
+        """The claim the re-bridge rests on, exercised rather than asserted.
+
+        Catching a downgrade only helps because ``_bridge_runtime_profile``
+        deletes the derived profile before it launches, so the older browser
+        meets a directory with no ``Last Version`` in it. The test above
+        substitutes that function, so nothing there would notice a refactor
+        that moved the clear below the launch -- the caught downgrade would
+        simply be raised again, uncaught, and every test would still pass.
+        """
+        from linkedin_mcp_server import session_state
+        from linkedin_mcp_server.drivers import browser as drv
+        from linkedin_mcp_server.profile_claim import ensure_profile_claim
+
+        source = tmp_path / "source" / "profile"
+        source.mkdir(parents=True)
+        # The delete below goes through the ownership guard, which refuses a
+        # root nobody claimed. Claiming it is part of setting the scene, not
+        # part of what is under test.
+        ensure_profile_claim(source, claim_anyway=True)
+        derived = session_state.runtime_profile_dir("linux-amd64-container", source)
+        derived.mkdir(parents=True)
+        (derived / "Last Version").write_text("151.0.7922.34")
+
+        seen: dict = {}
+
+        def _look(profile_dir, **_kwargs):
+            seen["marker_at_launch"] = (profile_dir / "Last Version").exists()
+            raise RuntimeError("far enough")
+
+        monkeypatch.setattr(drv, "get_source_profile_dir", lambda: source)
+        monkeypatch.setattr(drv, "_make_browser", _look)
+
+        with pytest.raises(RuntimeError, match="far enough"):
+            await drv._bridge_runtime_profile(
+                derived,
+                cookie_path=session_state.portable_cookie_path(source),
+                source_state=mock.Mock(login_generation="gen-1"),
+                runtime_id="linux-amd64-container",
+                launch_options={},
+                viewport={},
+                persist_runtime=True,
+            )
+
+        assert seen["marker_at_launch"] is False
+
+    async def test_the_source_profile_still_refuses(self, monkeypatch, tmp_path):
+        """Same failure, opposite answer, because the source profile is the
+        session itself. Nothing downstream may quietly rebuild it."""
+        from linkedin_mcp_server import session_state
+        from linkedin_mcp_server.drivers import browser as drv
+
+        source = tmp_path / "source" / "profile"
+        source.mkdir(parents=True)
+        (source / "Cookies").write_text("source")
+        session_state.portable_cookie_path(source).write_text("[]")
+        source_state = session_state.SourceState(
+            version=1,
+            source_runtime_id="macos-arm64-host",
+            login_generation="gen-1",
+            created_at="2026-08-06T09:00:00Z",
+            profile_path=str(source),
+            cookies_path=str(session_state.portable_cookie_path(source)),
+        )
+
+        async def refuse(profile_dir, **_kwargs):
+            raise BrowserDowngradeError(
+                profile_version="151.0.7922.34",
+                browser_version="149.0.7827.55",
+                profile_dir=profile_dir,
+            )
+
+        monkeypatch.setattr(drv, "_launch_options", lambda: ({}, {}))
+        monkeypatch.setattr(drv, "get_profile_dir", lambda: source)
+        monkeypatch.setattr(drv, "load_source_state", lambda _dir: source_state)
+        monkeypatch.setattr(drv, "get_runtime_id", lambda: "macos-arm64-host")
+        monkeypatch.setattr(drv, "_authenticate_existing_profile", refuse)
+
+        # The `raises` is the whole assertion. Checking the profile survived
+        # afterwards would prove nothing here, because the stand-in for
+        # `_authenticate_existing_profile` only raises and could not have
+        # touched it under any mutation.
+        with pytest.raises(BrowserDowngradeError):
+            await drv._create_browser_locked()

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -285,6 +285,82 @@ def test_main_non_interactive_no_auth_still_starts_server(
     assert captured.out == ""
 
 
+def test_profile_info_reports_a_downgrade_plainly(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+    tmp_path,
+) -> None:
+    """`--status` is the first thing a puzzled user runs, so a refused browser
+    must not arrive there as an unexpected internal error.
+
+    Without its own branch it goes through `logger.exception` ("Unexpected
+    error checking session") and then prints "Could not validate session ...
+    Check logs and browser configuration" over a message that already names
+    both versions and the exact fix.
+    """
+    from linkedin_mcp_server.exceptions import BrowserDowngradeError
+
+    profile_dir = tmp_path / "profile"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "Default").mkdir(parents=True)
+    (profile_dir / "Default" / "Cookies").write_text("placeholder")
+    (tmp_path / "cookies.json").write_text(json.dumps([{"name": "li_at"}]))
+    (tmp_path / "source-state.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "source_runtime_id": "macos-arm64-host",
+                "login_generation": "gen-1",
+                "created_at": "2026-03-12T17:00:00Z",
+                "profile_path": str(profile_dir),
+                "cookies_path": str(tmp_path / "cookies.json"),
+            }
+        )
+    )
+
+    async def refuse() -> bool:
+        raise BrowserDowngradeError(
+            profile_version="151.0.7922.34",
+            browser_version="148.0.7778.96",
+            browser_product="Google Chrome for Testing",
+        )
+
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.get_profile_dir", lambda: profile_dir
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.get_runtime_id", lambda: "macos-arm64-host"
+    )
+    monkeypatch.setattr("linkedin_mcp_server.cli_main.get_config", lambda: AppConfig())
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.configure_logging", lambda **_kwargs: None
+    )
+    monkeypatch.setattr("linkedin_mcp_server.cli_main.get_version", lambda: "4.0.0")
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.get_or_create_browser", lambda: refuse()
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.close_browser", AsyncMock(return_value=None)
+    )
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as exit_info:
+            cli_main.profile_info_and_exit()
+
+    assert exit_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "151.0.7922.34" in captured.out
+    assert "148.0.7778.96" in captured.out
+    assert "check logs and browser configuration" not in captured.out.lower()
+    # And no traceback logged as an unexpected failure either. The two halves
+    # of "internal error" are the printed advice and the ERROR-level trace, and
+    # each has its own branch to skip.
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR], [
+        r.getMessage() for r in caplog.records
+    ]
+
+
 def test_profile_info_reports_bridge_required_for_foreign_runtime(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -75,6 +75,38 @@ def test_profile_not_found_skips_issue_diagnostics(monkeypatch):
         raise_tool_error(ProfileNotFoundError("gone"))
 
 
+def test_browser_downgrade_skips_issue_diagnostics():
+    """A browser refused for being older than the profile is the guard working.
+
+    Without its own branch it falls into the ``LinkedInMCPError`` catch-all,
+    which appends the issue-report template and sends the user to the tracker
+    for something behaving exactly as designed. It also has to keep its own
+    message: both versions and the two ways out are in it, and a generic
+    summary would leave nobody able to act.
+
+    Asserted on the surfaced text, not by patching ``build_issue_diagnostics``:
+    that builder's failures are swallowed, so a patched-out one makes the
+    catch-all fall back to a template-free message and the mutation survives.
+    Measured, exactly as it was for the owner-auth branch above.
+    """
+    from linkedin_mcp_server.exceptions import BrowserDowngradeError
+
+    error = BrowserDowngradeError(
+        profile_version="151.0.7922.34",
+        browser_version="148.0.7778.96",
+        browser_product="Google Chrome for Testing",
+        profile_dir="/home/pwuser/.linkedin-mcp/profile",
+    )
+
+    with pytest.raises(ToolError) as caught:
+        raise_tool_error(error, "get_person_profile")
+
+    surfaced = str(caught.value)
+    assert surfaced == str(error)
+    assert "Diagnostics:" not in surfaced
+    assert "issue" not in surfaced.lower()
+
+
 def test_raises_tool_error_for_network_error():
     with pytest.raises(ToolError, match="Network error"):
         raise_tool_error(NetworkError("timeout"))


### PR DESCRIPTION
Closes #679

Chromium records its own version in `<user-data-dir>/Last Version` on every run. Nothing here read it, so an older browser would open a profile a newer one wrote, and on macOS and Linux Chromium does not stop that: it opens the profile and lets each store decide for itself whether it can still be read. A store that answers `INIT_TOO_NEW` is dropped without a word. The cookie store is one of them, so the user-visible failure is a working session disappearing and a login nobody asked for, with nothing in the logs naming the cause.

`browser_downgrade.refuse_a_downgrade()` now runs in `BrowserManager.start()` after the driver comes up and before anything is created or opened, so a refusal leaves the profile exactly as it was found. It compares the whole version rather than the major, because the schema floors that make a downgrade lossy are raised on point releases as readily as on majors. Forward updates stay allowed: Chromium migrates a profile it opens, and refusing that would make every browser upgrade a manual step.

The version comes from asking the binary itself rather than from Playwright's `browsers.json`, which describes what the manifest says should be installed. Those disagree exactly when it matters, and the binary is the thing about to open the profile.

**Only within one product, and only for a browser that can be asked.** `Last Version` records a number and no product, so a comparison across products compares two numbering schemes: measured here, Chrome for Testing reports `148.0.7778.96` while Brave reports `151.1.93.129` for the same Chromium series, and Vivaldi is on 7.x. Only the three Chrome-family names are compared, matched whole and never as a prefix, because a prefix scan accepted a launcher script calling itself `Chromium launcher 1.2.3` and refused the newer browser behind it. The parse takes the first non-empty line of stdout and requires the version to start at a whitespace boundary, so a wrapper's banner costs the guard rather than producing a refusal nobody can satisfy.

Windows is excluded outright. `HandleVersionSwitches` and its call site sit inside `#if BUILDFLAG(IS_POSIX)` in `chrome/app/chrome_main_delegate.cc`, so `--version` there is an unrecognised switch, and an unrecognised switch does not stop a browser starting: the probe would open the user's own Chrome profile, block the launch, and be killed.

Every other unknown fails open too, and the cost of that is recorded rather than glossed: failing open once is permanent, because the older browser then rewrites `Last Version` down to its own number. The two branches where evidence exists and is about to be lost warn at a level the default configuration shows.

`BrowserDowngradeError` is its own class because both neighbouring recoveries would do damage. `NetworkError` is read downstream as a missing binary and reinstalls the same old revision; `AuthenticationError` rotates the profile away, destroying an intact session whose only fault is being newer. It passes through `start()` untouched, ahead of the shutdown-unconfirmed conversion that would otherwise hold the profile for the process's life over a profile that was never opened, and it reaches tools and `--status` without an issue-report template, because the guard working is not a bug. A persisted derived runtime profile is the one place a refusal is recoverable on its own: it is disposable, the re-bridge deletes it first, and that is caught and rebuilt.

Verified live end to end against the real driver and the real bundled Chromium: a profile marked `999.0.1.2` refused with its contents untouched, a profile marked `1.0.0.0` launched and had its marker rewritten by Chromium itself, Brave on a Chrome-151 profile allowed, and a real wrapper script that prints a banner before exec'ing Chrome 150 allowed. Twenty-six mutations of the guard, the comparison, the product match, the parser, the ordering, the platform gate, the log levels and the fail-open paths each fail at least one test. Full suite 1820 passed, 10 skipped.

## Synthetic prompt

> Chromium writes `Last Version` into the profile and we never read it, so an older browser can open a profile a newer one wrote and silently lose stores, including cookies. Add a guard in `BrowserManager.start()` that reads that marker and the version of the binary about to launch, refuses only the backwards direction with a dedicated `BrowserDowngradeError` carrying both versions and a non-destructive recovery, and fails open on every unknown. Compare only within one product family, never run the probe where asking would start a browser instead of answering, and make the evidence-destroying fail-open branches visible at the default log level. Cover it with tests that die under mutation, note it in AGENTS.md and README, and verify it live.

Generated with Claude Opus 5 high
