### PR TITLE
feat(feed): Add get_notifications tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | [#526](https://github.com/stickerdaniel/linkedin-mcp-server/issues/526) |
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
+| `get_notifications` | List recent notifications (replies to comments, reactions, mentions, connection requests) from the notifications page | working |
 | `search_posts` | Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter (past-24h/past-week/past-month) | working |
 | `close_session` | Close browser session and clean up resources | working |
 

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -19,6 +19,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed
 - **Home Feed**: Get recent posts from the authenticated user's LinkedIn home feed
+- **Notifications**: List recent notifications (replies to comments, reactions, mentions, connection requests) from the notifications page
 - **Post Search**: Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter
 - **Compact References**: Return typed per-section links alongside readable text without shipping full-page markdown
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3809,6 +3809,35 @@ class LinkedInExtractor:
             result["section_errors"] = section_errors
         return result
 
+    async def get_notifications(self, limit: int = 20) -> dict[str, Any]:
+        """List recent notifications from the notifications page."""
+        url = "https://www.linkedin.com/notifications/"
+        await self._navigate_to_page(url)
+        await detect_rate_limit(self._page)
+        await self._wait_for_main_text(log_context="Notifications")
+        await handle_modal_close(self._page)
+
+        scrolls = max(1, limit // 10)
+        await self._scroll_main_scrollable_region(
+            position="bottom", attempts=scrolls, pause_time=0.5
+        )
+
+        raw_result = await self._extract_root_content(["main"])
+        raw = raw_result["text"]
+        cleaned = strip_linkedin_noise(raw) if raw else ""
+        references: list[Reference] = (
+            build_references(raw_result["references"], "notifications")
+            if cleaned
+            else []
+        )
+
+        return self._single_section_result(
+            url,
+            "notifications",
+            cleaned,
+            references=references,
+        )
+
     async def get_inbox(self, limit: int = 20) -> dict[str, Any]:
         """List recent conversations from the messaging inbox."""
         url = "https://www.linkedin.com/messaging/"

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -607,6 +607,25 @@ def strip_linkedin_noise(text: str) -> str:
     return _filter_linkedin_noise_lines(cleaned)
 
 
+def clean_main_content(raw: str) -> str:
+    """Return the cleaned innerText of a ``<main>`` extraction, or the rate-limit
+    sentinel when the page only carried LinkedIn chrome.
+
+    Mirrors the chrome-only check used by ``extract_page`` / ``extract_feed``:
+    a page whose raw text is entirely chrome (footer/sidebar) reads as a soft
+    rate limit, and callers must surface that rather than report an empty
+    section the client would read as "nothing to see". Keeps the *guess* on
+    ``_RATE_LIMITED_MSG`` visible instead of burying it in an empty section.
+    """
+    if not raw:
+        return ""
+    truncated = _truncate_linkedin_noise(raw)
+    if not truncated and raw.strip():
+        logger.warning("Section returned only LinkedIn chrome (likely rate-limited)")
+        return _RATE_LIMITED_MSG
+    return _filter_linkedin_noise_lines(truncated)
+
+
 def _filter_linkedin_noise_lines(text: str) -> str:
     """Remove known media/control noise lines from already-truncated content."""
     filtered_lines = [
@@ -3824,19 +3843,22 @@ class LinkedInExtractor:
 
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
-        cleaned = strip_linkedin_noise(raw) if raw else ""
+        cleaned = clean_main_content(raw)
         references: list[Reference] = (
             build_references(raw_result["references"], "notifications")
-            if cleaned
+            if cleaned and cleaned != _RATE_LIMITED_MSG
             else []
         )
 
-        return self._single_section_result(
+        result = self._single_section_result(
             url,
             "notifications",
-            cleaned,
+            cleaned if cleaned != _RATE_LIMITED_MSG else "",
             references=references,
         )
+        if cleaned == _RATE_LIMITED_MSG:
+            result["section_errors"] = {"notifications": rate_limited_section_error()}
+        return result
 
     async def get_inbox(self, limit: int = 20) -> dict[str, Any]:
         """List recent conversations from the messaging inbox."""
@@ -3853,9 +3875,11 @@ class LinkedInExtractor:
 
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
-        cleaned = strip_linkedin_noise(raw) if raw else ""
+        cleaned = clean_main_content(raw)
         references: list[Reference] = (
-            build_references(raw_result["references"], "inbox") if cleaned else []
+            build_references(raw_result["references"], "inbox")
+            if cleaned and cleaned != _RATE_LIMITED_MSG
+            else []
         )
 
         # LinkedIn's conversation sidebar uses JS click handlers instead of
@@ -3867,12 +3891,15 @@ class LinkedInExtractor:
         if conversation_refs:
             references = dedupe_references(conversation_refs + references)
 
-        return self._single_section_result(
+        result = self._single_section_result(
             url,
             "inbox",
-            cleaned,
+            cleaned if cleaned != _RATE_LIMITED_MSG else "",
             references=references,
         )
+        if cleaned == _RATE_LIMITED_MSG:
+            result["section_errors"] = {"inbox": rate_limited_section_error()}
+        return result
 
     async def _extract_conversation_thread_refs(
         self, limit: int | None, context: str, *, name_filter: str | None = None

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -83,6 +83,7 @@ _SECTION_CONTEXTS = {
     "job_posting": "job posting",
     "inbox": "inbox",
     "conversation": "conversation",
+    "notifications": "notification",
 }
 
 _DEFAULT_REFERENCE_CAP = 12
@@ -101,6 +102,9 @@ _REFERENCE_CAPS = {
     "contact_info": 8,
     "inbox": 30,
     "conversation": 12,
+    # Notification cards each carry an actor plus (often) a target entity;
+    # keep the cap proportional to the 50-notification tool ceiling.
+    "notifications": 50,
     # Headroom for get_feed's num_posts ceiling (Field(ge=1, le=50)).
     # Kept in sync with the literal cap=50 in extractor._build_feed_references
     # where SDUI-derived /posts/<slug> permalinks are appended.

--- a/linkedin_mcp_server/tools/__init__.py
+++ b/linkedin_mcp_server/tools/__init__.py
@@ -11,7 +11,7 @@ Available Tools:
 - Company tools: Company profile and information extraction
 - Job tools: Job posting details and search functionality
 - Messaging tools: Inbox, conversations, search, and sending messages
-- Feed tools: Home feed scraping
+- Feed tools: Home feed and notifications scraping
 - Post tools: Global post/content search
 
 Architecture:

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -34,6 +34,62 @@ def register_feed_tools(
 
     @mcp.tool(
         timeout=tool_timeout,
+        title="Get Notifications",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"feed", "notifications", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_notifications(
+        ctx: Context,
+        limit: Annotated[int, Field(ge=1, le=50)] = 20,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        List recent notifications from the LinkedIn notifications page.
+
+        Covers every notification type the page shows — replies to your
+        comments, reactions to your comments or posts, mentions, connection
+        requests and accepts, endorsements, job alerts, and company news —
+        as raw text. Pair with get_post_comments to read the full reply
+        text behind a "someone replied to your comment" notification.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+            limit: Maximum number of notifications to load (1-50, default 20).
+                   Items load as the page scrolls, so the actual count may
+                   slightly exceed the target.
+
+        Returns:
+            Dict with url, sections (notifications -> raw text), and optional
+            references["notifications"] (profile/post/company links embedded
+            in the notification cards).
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_notifications"
+            )
+            logger.info("Fetching notifications (limit=%d)", limit)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Loading notifications"
+            )
+
+            result = await extractor.get_notifications(limit=limit)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_notifications")
+        except Exception as e:
+            raise_tool_error(e, "get_notifications")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
         title="Get Feed",
         annotations={"readOnlyHint": True, "openWorldHint": True},
         tags={"feed", "scraping"},

--- a/manifest.json
+++ b/manifest.json
@@ -116,6 +116,10 @@
       "description": "Get recent posts from the authenticated user's LinkedIn home feed"
     },
     {
+      "name": "get_notifications",
+      "description": "List recent notifications (replies to comments, reactions, mentions, connection requests) from the notifications page"
+    },
+    {
       "name": "search_posts",
       "description": "Search LinkedIn posts/content globally by keyword (the 'Posts' tab) with an optional recency filter (past-24h/past-week/past-month)"
     },

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1489,7 +1489,7 @@ class TestRealOwner:
             # in a `register_*` call.
             assert "get_person_profile" in names
             assert "close_session" in names
-            assert len(names) == 19, sorted(names)
+            assert len(names) == 20, sorted(names)
         finally:
             _stop(result.get("pid"))
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4620,7 +4620,7 @@ class TestGetInbox:
                 },
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                "linkedin_mcp_server.scraping.extractor.clean_main_content",
                 return_value="Conversation A\nConversation B",
             ),
             patch(
@@ -4664,7 +4664,7 @@ class TestGetInbox:
                 return_value={"text": "", "references": []},
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                "linkedin_mcp_server.scraping.extractor.clean_main_content",
                 return_value="",
             ),
             patch.object(
@@ -4719,7 +4719,7 @@ class TestGetInbox:
                 },
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                "linkedin_mcp_server.scraping.extractor.clean_main_content",
                 return_value="Tony Chan\nPaul Jasper",
             ),
             patch(
@@ -4741,6 +4741,50 @@ class TestGetInbox:
         assert refs[0]["kind"] == "conversation"
         assert refs[0]["url"] == "/messaging/thread/2-abc123/"
         assert refs[0]["text"] == "Tony Chan"
+
+    async def test_rate_limited_inbox_surfaces_section_error(self, mock_page):
+        """A chrome-only (soft rate-limited) inbox page reports an error."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={"text": "Some chrome", "references": []},
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.clean_main_content",
+                return_value=_RATE_LIMITED_MSG,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.build_references",
+                return_value=[],
+            ),
+            patch.object(
+                extractor,
+                "_extract_conversation_thread_refs",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await extractor.get_inbox(limit=5)
+
+        assert result["sections"] == {}
+        assert "inbox" in result["section_errors"]
+        assert result["section_errors"]["inbox"]["error_type"] == "rate_limit"
 
 
 class TestGetNotifications:
@@ -4771,7 +4815,7 @@ class TestGetNotifications:
                 },
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                "linkedin_mcp_server.scraping.extractor.clean_main_content",
                 return_value="Jane Doe replied to your comment\nJohn Smith liked your post",
             ),
             patch(
@@ -4785,6 +4829,44 @@ class TestGetNotifications:
         assert "notifications" in result["sections"]
         assert "Jane Doe replied to your comment" in result["sections"]["notifications"]
         assert result["url"] == "https://www.linkedin.com/notifications/"
+
+    async def test_rate_limited_notifications_surface_section_error(self, mock_page):
+        """A chrome-only (soft rate-limited) notifications page reports an error."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={"text": "Some chrome", "references": []},
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.clean_main_content",
+                return_value=_RATE_LIMITED_MSG,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.build_references",
+                return_value=[],
+            ),
+        ):
+            result = await extractor.get_notifications(limit=5)
+
+        assert result["sections"] == {}
+        assert "notifications" in result["section_errors"]
+        assert result["section_errors"]["notifications"]["error_type"] == "rate_limit"
 
     async def test_empty_notifications(self, mock_page):
         """get_notifications returns empty sections when page has no content."""
@@ -4810,7 +4892,7 @@ class TestGetNotifications:
                 return_value={"text": "", "references": []},
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                "linkedin_mcp_server.scraping.extractor.clean_main_content",
                 return_value="",
             ),
         ):
@@ -4853,7 +4935,7 @@ class TestGetNotifications:
                 },
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                "linkedin_mcp_server.scraping.extractor.clean_main_content",
                 return_value="Jane Doe replied to your comment",
             ),
             patch(
@@ -4892,7 +4974,7 @@ class TestGetNotifications:
                 return_value={"text": "Some notification", "references": []},
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                "linkedin_mcp_server.scraping.extractor.clean_main_content",
                 return_value="Some notification",
             ),
             patch(

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4743,6 +4743,170 @@ class TestGetInbox:
         assert refs[0]["text"] == "Tony Chan"
 
 
+class TestGetNotifications:
+    async def test_returns_notifications_section(self, mock_page):
+        """get_notifications returns sections with notifications key."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={
+                    "text": "Jane Doe replied to your comment\nJohn Smith liked your post",
+                    "references": [],
+                },
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                return_value="Jane Doe replied to your comment\nJohn Smith liked your post",
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.build_references",
+                return_value=[],
+            ),
+        ):
+            result = await extractor.get_notifications(limit=10)
+
+        assert "sections" in result
+        assert "notifications" in result["sections"]
+        assert "Jane Doe replied to your comment" in result["sections"]["notifications"]
+        assert result["url"] == "https://www.linkedin.com/notifications/"
+
+    async def test_empty_notifications(self, mock_page):
+        """get_notifications returns empty sections when page has no content."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={"text": "", "references": []},
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                return_value="",
+            ),
+        ):
+            result = await extractor.get_notifications(limit=5)
+
+        assert result["sections"] == {}
+
+    async def test_includes_notification_references(self, mock_page):
+        """get_notifications passes extracted references through build_references."""
+        extractor = LinkedInExtractor(mock_page)
+        notification_refs = [
+            {
+                "kind": "person",
+                "url": "/in/janedoe/",
+                "text": "Jane Doe",
+                "context": "notification",
+            },
+        ]
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
+            ),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={
+                    "text": "Jane Doe replied to your comment",
+                    "references": [],
+                },
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                return_value="Jane Doe replied to your comment",
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.build_references",
+                return_value=notification_refs,
+            ),
+        ):
+            result = await extractor.get_notifications(limit=10)
+
+        assert "references" in result
+        refs = result["references"]["notifications"]
+        assert len(refs) == 1
+        assert refs[0]["kind"] == "person"
+        assert refs[0]["url"] == "/in/janedoe/"
+
+    async def test_scroll_attempts_scale_with_limit(self, mock_page):
+        """get_notifications computes scroll attempts from the limit."""
+        extractor = LinkedInExtractor(mock_page)
+        scroll_mock = AsyncMock()
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
+            patch.object(extractor, "_scroll_main_scrollable_region", scroll_mock),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value={"text": "Some notification", "references": []},
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise",
+                return_value="Some notification",
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.build_references",
+                return_value=[],
+            ),
+        ):
+            await extractor.get_notifications(limit=50)
+
+        scroll_mock.assert_awaited_once_with(
+            position="bottom", attempts=5, pause_time=0.5
+        )
+
+
 class TestGetConversation:
     async def test_returns_conversation_by_thread_id(self, mock_page):
         """get_conversation with thread_id navigates directly to thread URL."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -31,6 +31,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.search_people = AsyncMock(return_value=scrape_result)
     mock.get_sidebar_profiles = AsyncMock(return_value=scrape_result)
     mock.get_inbox = AsyncMock(return_value=scrape_result)
+    mock.get_notifications = AsyncMock(return_value=scrape_result)
     mock.get_conversation = AsyncMock(return_value=scrape_result)
     mock.search_conversations = AsyncMock(return_value=scrape_result)
     mock.send_message = AsyncMock(return_value=scrape_result)
@@ -1177,6 +1178,92 @@ class TestFeedTools:
 
         with pytest.raises(ValidationError, match="num_posts"):
             await mcp.call_tool("get_feed", {"num_posts": 51})
+
+    async def test_get_notifications_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/notifications/",
+            "sections": {
+                "notifications": (
+                    "Jane Doe replied to your comment\nJohn Smith liked your post"
+                )
+            },
+        }
+        mock_extractor = MagicMock()
+        mock_extractor.get_notifications = AsyncMock(return_value=expected)
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_notifications")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+
+        assert result["url"] == "https://www.linkedin.com/notifications/"
+        assert "Jane Doe replied to your comment" in result["sections"]["notifications"]
+        mock_extractor.get_notifications.assert_awaited_once_with(limit=20)
+
+    async def test_get_notifications_passes_limit(self, mock_context):
+        """Verify the limit argument is passed through to the extractor."""
+        expected = {
+            "url": "https://www.linkedin.com/notifications/",
+            "sections": {"notifications": "A notification"},
+        }
+        mock_extractor = MagicMock()
+        mock_extractor.get_notifications = AsyncMock(return_value=expected)
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_notifications")
+        await tool_fn(mock_context, limit=7, extractor=mock_extractor)
+        mock_extractor.get_notifications.assert_awaited_once_with(limit=7)
+
+    async def test_get_notifications_surfaces_references(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/notifications/",
+            "sections": {"notifications": "Jane Doe replied to your comment"},
+            "references": {
+                "notifications": [
+                    {
+                        "kind": "person",
+                        "url": "/in/janedoe/",
+                        "text": "Jane Doe",
+                        "context": "notification",
+                    }
+                ]
+            },
+        }
+        mock_extractor = MagicMock()
+        mock_extractor.get_notifications = AsyncMock(return_value=expected)
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_notifications")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+
+        refs = result["references"]["notifications"]
+        assert refs[0]["kind"] == "person"
+        assert refs[0]["url"] == "/in/janedoe/"
+
+    async def test_get_notifications_rejects_excessive_limit(self, mock_context):
+        """Verify limit=51 is rejected by Field(le=50) validation."""
+        # FastMCP wraps the pydantic error raised by Field() constraints in
+        # its own ValidationError, which does not subclass pydantic's.
+        from fastmcp.exceptions import ValidationError
+
+        from linkedin_mcp_server.tools.feed import register_feed_tools
+
+        mcp = FastMCP("test")
+        register_feed_tools(mcp)
+
+        with pytest.raises(ValidationError, match="limit"):
+            await mcp.call_tool("get_notifications", {"limit": 51})
 
 
 class TestPostTools:


### PR DESCRIPTION
Closes #211.

Adds a `get_notifications` tool that scrapes the LinkedIn notifications page (`/notifications/`) and returns the standard `{url, sections, references}` contract.

**What's in it**

- `LinkedInExtractor.get_notifications(limit)` — navigates to the notifications page, waits for main, scrolls to load up to `limit` cards, extracts `innerText` into `sections["notifications"]`, and builds `references["notifications"]` from the cards' anchors via the existing `build_references` pipeline.
- `get_notifications(limit: 1-50, default 20)` tool registered in `tools/feed.py`, `readOnlyHint`, mirroring `get_inbox`'s structure and error handling.
- Reference cap and section context entries (`"notifications"`) in `link_metadata.py`.
- Extractor-level tests (`tests/test_scraping.py`, 4 cases) and tool-level tests (`tests/test_tools.py`, 4 cases); `get_notifications` added to `_make_mock_extractor`.
- Docs: README tool table, `docs/docker-hub.md`, `manifest.json`.

**Verification**

- `uv run pytest -q -k "notification or inbox or feed"` — 38 passed.
- `uv run ruff check` and `ruff format` clean on all changed files.
- `ty check` produces only pre-existing Windows-platform diagnostics (`os.fork`/`fcntl`/POSIX signals), none in changed files.

## Synthetic prompt

> Add a `get_notifications` tool to the server that scrapes `/notifications/` and returns the standard `{url, sections, references}` contract, modeled on `get_inbox`. Add extractor and tool tests, and update README / docker-hub / manifest.

Generated with Qwen3.8-Max (Cursor)
