### PR TITLE
fix(deps): Declare the patchright version we can run on

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   written by a fork is therefore still refused; that one is not repairable from
   `Last Version`, and the error says so by naming the number to go back to
   rather than a browser.
+- **Never trim `_COMPARABLE_PRODUCTS` to one name.** At the current lock two
+  are live at once, on the same release: Playwright downloads its own Chromium
+  build for Linux arm64 and Chrome for Testing everywhere else, so the
+  published arm64 container reports `Chromium` while the amd64 one and macOS
+  report `Google Chrome for Testing`, at the same revision. Dropping either
+  entry turns the guard off for a shipped platform. That is the split *at the
+  lock* and it does not hold across the whole supported range: at the declared
+  floor every platform reports `Chromium`, and revision 1200 moved macOS and
+  Linux x64 together, leaving only Linux arm64 behind. Which is the point:
+  both managed names occur, and which one where depends on when and where, so
+  neither is redundant. The third entry, `google chrome`, is not a managed
+  browser at all but what an operator's own binary reports under `CHROME_PATH`,
+  and it earns its place only when *that* Chrome is the older one: the guard
+  reads the running binary, never the profile's writer. `browsers.json` is not
+  evidence here: its `title` key dates from patchright 1.58.0 and omits the
+  `Google` the binary prints. See `_COMPARABLE_PRODUCTS` for the measurements.
 
 ## Tool Return Format
 

--- a/docs/browser-fingerprint.md
+++ b/docs/browser-fingerprint.md
@@ -147,6 +147,46 @@ Network layer, same machine:
 The TLS handshakes differ by one extension. That is invisible to every
 JavaScript test above and cannot be influenced by any launch option.
 
+### Re-measured on Chrome for Testing 149
+
+The windowless-mode table near the top of this section is stamped at patchright
+1.60.1. When the lock moved to 1.61.2 (macOS bundles Chrome for Testing
+149.0.7827.55; the arm64 Linux image bundles Playwright's own Chromium build at
+the same revision, which is why the product names differ by platform), those
+identity properties were taken again through `BrowserManager` on macOS.
+
+Against a loopback origin rather than `about:blank`: `navigator.userAgentData`
+needs a secure context, and `about:blank` is not one, so a probe there measures
+nothing. Verified rather than assumed — `about:blank` reports
+`isSecureContext: false` and `userAgentData: undefined`, loopback reports
+`true` and an object.
+
+| | Value on 149 |
+|---|---|
+| User agent | `…Chrome/149.0.0.0…`, no `HeadlessChrome` |
+| `sec-ch-ua` brands | `Chromium/149`, `Not)A;Brand/24`, major agreeing with the UA |
+| High-entropy hints | `arm`, `64`, two `fullVersionList` entries |
+| `navigator.webdriver` | `false` |
+| `document.visibilityState` / `hasFocus()` | `visible` / `true` |
+| Outer window vs screen | 1280x720 on 1280x720, so it fits, but see below |
+| `navigator.plugins.length` / `window.chrome` | 5 / `object` |
+| `Notification.permission` | `default` |
+| `requestAnimationFrame` | 122/s, matching the 148 figure |
+
+The geometry row is not a clean result. `outerWidth == screen.width` is the
+open item recorded above: it fits, which is all the coherence bar asks, but no
+real window reports it, and 149 did not change that either way.
+
+Not re-measured on 149: the CreepJS and fpscanner scores, the JA4 and HTTP/2
+fingerprints, the startup-flash timing, and the cookie-across-restart check.
+Those rows stay 148 measurements and are labelled as such rather than assumed
+to carry over.
+
+"Window on screen once settled" is not in that list and not in the table
+either, because it is implied rather than skipped: the windowless path fails
+closed, so a run that produced these values had a hidden target and no window.
+That is an inference, not a CoreGraphics poll like the 148 row was.
+
 ## Things that look like fixes and are not
 
 - **`--user-agent` as a browser switch.** Reaches every target including

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -429,6 +429,14 @@ async def _run_browser_setup() -> None:
     against 263 MiB for anyone who previously ended up needing the full browser,
     and against 92 MiB for the default headless user who only ever fetched the
     shell. The second comparison is the one users will notice.
+
+    Those three figures are one revision's *and one platform's*, not a
+    constant. The bundled browser moves with the lockfile and is past 148 now,
+    and the sizes differ by platform as well: the arm64 container does not get
+    Chrome for Testing at all, it gets Playwright's own Chromium build. What
+    the argument needs is only that the full browser is substantially larger
+    than the shell everywhere, which holds; quoting these particular numbers
+    anywhere user-facing means re-measuring them for the platform in question.
     """
     browser_dir = configure_browser_environment()
     secure_mkdir(browser_dir)
@@ -458,10 +466,10 @@ def ensure_browser_installed() -> None:
     configure_browser_environment()
     # An operator-supplied executable is the one that gets launched, so the
     # managed browser would be downloaded and never run. That was survivable
-    # while two of these three modes needed only the 92 MiB shell; now they all
-    # want the full browser, so it is 170 MiB spent on nothing -- and for
-    # someone whose network cannot reach the CDN, it is the difference between
-    # signing in and not.
+    # while two of these three modes needed only the much smaller shell; now
+    # they all want the full browser, so it is the whole download spent on
+    # nothing -- and for someone whose network cannot reach the CDN, it is the
+    # difference between signing in and not.
     if _uses_custom_chrome():
         return
     if browser_ready():

--- a/linkedin_mcp_server/browser_downgrade.py
+++ b/linkedin_mcp_server/browser_downgrade.py
@@ -94,10 +94,98 @@ _VERSION = re.compile(r"(?:^|(?<=\s))\d+(?:\.\d+){2,}")
 #: whichever browser produced that number again, which is the way out.
 #:
 #: An unrecognised name costs the guard, never a false refusal, which is the
-#: right direction to be wrong in. Measured strings behind each entry:
-#: `Chromium 148.0.7778.0` (the Linux image, full browser and headless shell
-#: alike), `Google Chrome 150.0.7871.189`, `Google Chrome for Testing
-#: 148.0.7778.96` (the bundled browser *and* the headless shell on macOS).
+#: right direction to be wrong in.
+#:
+#: **Two of these entries are needed at the same time, on the same release, and
+#: the axis is the platform rather than the version.** Playwright downloads
+#: Chrome for Testing for most targets but its own Chromium build for Linux
+#: arm64, and the two binaries name themselves differently. From the driver's
+#: own `DOWNLOAD_PATHS` at the current lock:
+#:
+#: * every supported `ubuntu*-arm64` and `debian*-arm64` ->
+#:   `chromium-linux-arm64.zip`, which unpacks to `chrome-linux/` and reports
+#:   `Chromium`
+#: * Linux x64, every macOS, and `win64` -> `cftUrl(...)`, which unpacks to
+#:   `chrome-linux64/` or `Google Chrome for Testing.app` and reports `Google
+#:   Chrome for Testing`
+#:
+#: (`ubuntu18.04-*` is `void 0` in that table on both branches: patchright will
+#: not install there at all, so it names nothing.)
+#:
+#: Both container architectures are published, so both names are in the field
+#: on any given release. Dropping either entry as redundant would silently turn
+#: the guard off for a shipped platform, which is the mistake this paragraph
+#: exists to prevent.
+#:
+#: There is a version axis underneath as well, and it is the smaller one.
+#: Revision 1200 (patchright 1.57.0) moved macOS *and* Linux x64 to Chrome for
+#: Testing together; only Linux arm64 stayed on Playwright's own build, and
+#: that is the split that survives to the lock. Read it off `EXECUTABLE_PATHS`
+#: rather than the download table: at 1.57.0 `linux-x64` is
+#: `["chrome-linux64", "chrome"]` while `linux-arm64` is still
+#: `["chrome-linux", "chrome"]`, carrying the driver's own `// non-cft build`
+#: comment.
+#:
+#: Two separate events are easy to conflate here, and conflating them is how
+#: the first version of this paragraph got the story wrong: *what* is packaged
+#: changed at revision 1200, while *where it is fetched from* changed at
+#: patchright 1.58.0, when `cftUrl(...)` first appears. That second move is not
+#: a move to Google: `cftUrl` points at Playwright's own CDN in both eras,
+#: `cdn.playwright.dev/chrome-for-testing-public/<version>/...` at 1.58.0 and
+#: `cdn.playwright.dev/builds/cft/<version>/...` at the lock. Nothing here ever
+#: fetches from `storage.googleapis.com`.
+#:
+#: For anyone allowlisting egress, one host is not the whole answer. Every
+#: plain `builds/...` entry goes through `PLAYWRIGHT_CDN_MIRRORS`, three hosts
+#: tried in order: `cdn.playwright.dev/dbazure/download/playwright`,
+#: `playwright.download.prss.microsoft.com/dbazure/download/playwright`, then
+#: `cdn.playwright.dev`. That covers the arm64 image's browser, and ffmpeg on
+#: *every* platform, since `patchright install chromium` resolves that too and
+#: its entries are plain templates. Where `cftUrl` entries exist they are the
+#: other shape:
+#: one host, `cdn.playwright.dev`, and no fallback at all. Allowing only
+#: `cdn.playwright.dev` therefore installs everything, because two of the three
+#: mirrors are on it; what is lost is the Microsoft-hosted fallback, so the gap
+#: shows up only when the primary CDN is degraded.
+#:
+#: At the floor every target still reads from `builds/chromium/`, which says
+#: nothing about which browser is inside. Binaries run directly: revision
+#: 1194 ->
+#: `Chromium 141.0.7390.37`, revision 1200 -> `Google Chrome for Testing
+#: 143.0.7499.4`, and revisions 1217, 1223 and 1228 -> `Google Chrome for
+#: Testing`, all on macOS arm64. On Linux arm64 the container reported
+#: `Chromium 148.0.7778.0` at revision 1223 -- the same revision that reports
+#: `Google Chrome for Testing 148.0.7778.96` on macOS. One revision, two names,
+#: decided by the platform: that pair is the clearest statement of the rule.
+#:
+#: The other platforms, measured under Docker rather than reasoned about, since
+#: reasoning is what got this paragraph wrong the first time. At the floor
+#: (revision 1187) linux-x64 and linux-arm64 both report `Chromium
+#: 140.0.7339.16`, exactly as macOS does -- so at the floor there is no
+#: platform split at all. At the lock (revision 1228) linux-x64 reports `Google
+#: Chrome for Testing 149.0.7827.55` while linux-arm64 reports `Chromium
+#: 149.0.7827.0`, note the differing final component. Windows never answers:
+#: :func:`a_version_can_be_asked_for` refuses before any binary is asked.
+#:
+#: The third entry is not a managed browser at all. `Google Chrome
+#: 150.0.7871.189` is what an operator's own binary reports when `CHROME_PATH`
+#: points at real Chrome.
+#:
+#: Note carefully which direction needs it, because the obvious one does not.
+#: :func:`is_comparable` is only ever asked about the *running* binary, never
+#: about whatever wrote the profile -- `Last Version` records no product to ask
+#: about. So the familiar case, a Chrome-written profile opened by the bundled
+#: browser, is carried by the two managed names and would still be refused with
+#: this entry gone. What needs it is the reverse: `CHROME_PATH` at a real
+#: Chrome that is itself the older binary, against a profile a newer Chrome or
+#: the bundled Chrome for Testing already wrote. Drop the entry and that launch
+#: stops being checked at all, silently.
+#:
+#: Do not infer any of this from `browsers.json`. Its `title` key did not exist
+#: before patchright 1.58.0, and where it does exist it reads `Chrome for
+#: Testing` without the `Google` the binary prints. It says which family a
+#: build belongs to and nothing about the string matched here.
+#:
 #: Distribution and snap builds put the build host after the number, and the
 #: beta and dev channels put the channel there, so all of those still read as
 #: `Chromium` or `Google Chrome`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "fastmcp>=3.4.4",
     "inquirer>=3.4.0",
     "packaging>=26.2",
-    "patchright>=1.40.0",
+    "patchright>=1.55.0",
     "python-dotenv>=1.1.1",
 ]
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -746,11 +746,11 @@ class TestEnsureBrowserInstalledSkipsCustomChrome:
     """A custom executable must not trigger a managed download.
 
     The gap this closes was survivable while two of the three CLI modes needed
-    only the 92 MiB shell. Now they all want the full browser, so it is 170 MiB
-    fetched for something that is never launched -- and for an operator whose
-    network cannot reach the CDN, it is the difference between signing in and
-    not. `_uses_custom_chrome()` already existed and said so in its docstring;
-    only this caller never asked.
+    only the much smaller shell. Now they all want the full browser, so it is
+    the whole download fetched for something that is never launched -- and for
+    an operator whose network cannot reach the CDN, it is the difference
+    between signing in and not. `_uses_custom_chrome()` already existed and
+    said so in its docstring; only this caller never asked.
     """
 
     def test_custom_chrome_skips_the_download(self, isolate_profile_dir, monkeypatch):

--- a/tests/test_browser_downgrade.py
+++ b/tests/test_browser_downgrade.py
@@ -207,6 +207,33 @@ class TestWhichProductsCompare:
     def test_the_chrome_family_compares(self, product):
         assert is_comparable(product) is True
 
+    def test_an_operators_own_chrome_is_refused_when_it_is_the_older_one(
+        self, tmp_path
+    ):
+        """The only direction in which the `google chrome` entry does any work.
+
+        The obvious case for it -- a profile written by an auto-updating Chrome
+        and then opened by the bundled browser -- does not need it: the guard
+        reads the *running* binary, never the profile's writer, so the two
+        managed names carry that one. What needs it is the reverse, a
+        `CHROME_PATH` at a real Chrome that is itself behind the profile.
+
+        Without this test the entry looks removable: every other assertion here
+        passes with `google chrome` dropped from the set, and the launch it
+        protects would then be waved through with an info-level line nobody
+        sees at the default level.
+        """
+        profile = _profile_last_opened_by(tmp_path, "151.0.7922.76")
+
+        with mock.patch(
+            "linkedin_mcp_server.browser_downgrade.version_of",
+            return_value=BrowserBuild("Google Chrome", (149, 0, 7827, 55)),
+        ):
+            with pytest.raises(BrowserDowngradeError) as raised:
+                refuse_a_downgrade(profile, "/Applications/Google Chrome.app")
+
+        assert raised.value.browser_product == "Google Chrome"
+
     @pytest.mark.parametrize(
         "product",
         [

--- a/tests/test_dependency_floor.py
+++ b/tests/test_dependency_floor.py
@@ -1,0 +1,117 @@
+"""The declared patchright floor has to be a version the server can run on.
+
+A dependency floor is not usually worth a test. This one is, because it was
+wrong for a long time and nothing anywhere said so: it read ``>=1.40.0``, a
+version patchright never published, and it named five minor series below the
+one the server actually needs.
+
+Nothing catches that on its own. ``uv`` and ``pip`` resolve to the newest
+version satisfying the range, so an ordinary install never exercises the floor
+and a false one can sit in the manifest for years. It decides something only in
+the environment where another package competes for the same dependency, or
+where a resolver is asked for the lowest version on purpose, and that is
+precisely the environment nobody runs.
+
+What this file can and cannot do, stated plainly so nobody reads more into it.
+It compares a declared number against a number recorded here by hand. That is
+a review aid, not a proof: it stops the floor drifting back down, and it
+records *why* the floor is where it is, but it cannot discover that a new call
+has raised the real minimum. Only resolving to the floor and running against it
+can do that, which needs a browser and an installed environment. Treat
+:data:`_MINIMUM` as something to raise deliberately when the code starts
+calling something newer.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: The oldest patchright the server can actually open a browser with.
+#:
+#: Set by ``BrowserContext.browser`` being populated on a *persistent* context,
+#: which ``hidden_target.open_hidden_page`` requires and refuses to continue
+#: without. Through 1.52.5, ``launch_persistent_context`` returned the context
+#: alone (``from_channel(await self._channel.send("launchPersistentContext",
+#: params))``), so no ``Browser`` object existed and the attribute was ``None``.
+#: 1.55.0 switched to ``send_return_as_dict`` and calls
+#: ``browser._connect_to_browser_type(...)``, which is what populates it. There
+#: is no 1.53 or 1.54 on PyPI, so 1.52.5 is the last version that fails.
+#:
+#: This matters more than an ordinary missing parameter would, because the
+#: hidden-target path fails closed by design: falling back to real headless
+#: would restore the very token it exists to remove. On macOS, where that path
+#: is the default, an older patchright therefore means no browser at all rather
+#: than a degraded one.
+#:
+#: A lower bound that is no longer the binding one, kept because it is the
+#: other version-sensitive call: ``BrowserContext.storage_state(indexed_db=...)``,
+#: which the foreign-runtime bridge passes on every checkpoint commit, first
+#: appears in 1.51.0. It is reached only once the launch has already succeeded
+#: -- ``open_hidden_page`` runs inside ``BrowserManager.start()``, the export
+#: well after it -- so on macOS the 1.55 requirement fails first and this one
+#: is never got to. On Linux the hidden target is not used at all, so the 1.55
+#: bound is not exercised there and this is the one that would bite.
+_MINIMUM = Version("1.55.0")
+
+
+#: Operators that put a floor under the version. ``>`` is a *stricter* bound
+#: than ``>=`` and has to count, or this test would fail a change that made the
+#: dependency safer.
+_LOWER_BOUND_OPERATORS = frozenset({">=", ">", "==", "===", "~="})
+
+
+def _declared_floor() -> Version:
+    """The lower bound ``pyproject.toml`` puts on patchright.
+
+    Parsed with ``packaging`` rather than a regex, because PEP 440 treats
+    ``>=1.55`` and ``>=1.55.0`` as the same bound while string or tuple
+    comparison does not, and a test that fails on an equivalent spelling is
+    worse than no test.
+
+    Two spellings that do bound the floor are still not read: ``==1.55.*`` and
+    an arbitrary ``===`` tag. Both would have to be interpreted rather than
+    parsed, and neither is a form this project would use. They fall through to
+    "no lower bound", which is a wrong-but-loud answer naming the spec that
+    caused it, and that is the failure mode to prefer over a crash inside the
+    parser.
+    """
+    pyproject = tomllib.loads(
+        (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    for raw in pyproject["project"]["dependencies"]:
+        requirement = Requirement(raw)
+        if canonicalize_name(requirement.name) != "patchright":
+            continue
+        bounds = []
+        for specifier in requirement.specifier:
+            if specifier.operator not in _LOWER_BOUND_OPERATORS:
+                continue
+            try:
+                bounds.append(Version(specifier.version))
+            except InvalidVersion:
+                # A wildcard (`==1.55.*`) or an arbitrary `===` tag. Skipped
+                # rather than allowed to raise: an InvalidVersion escaping here
+                # would name a parse bug, and whoever reads the failure needs
+                # to be told about the floor instead.
+                continue
+        assert bounds, f"patchright has no lower bound: {raw!r}"
+        return max(bounds)
+    raise AssertionError("patchright is not a declared dependency")
+
+
+def test_the_floor_is_not_below_the_known_minimum() -> None:
+    floor = _declared_floor()
+
+    assert floor >= _MINIMUM, (
+        f"pyproject declares patchright>={floor}, below the {_MINIMUM} this "
+        f"server needs. See _MINIMUM for what breaks: an environment that "
+        f"resolves to the floor gets a persistent context with no browser "
+        f"object, and the hidden-target launch refuses rather than degrading."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1069,7 +1069,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=3.4.4" },
     { name = "inquirer", specifier = ">=3.4.0" },
     { name = "packaging", specifier = ">=26.2" },
-    { name = "patchright", specifier = ">=1.40.0" },
+    { name = "patchright", specifier = ">=1.55" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
 ]
 
@@ -1246,21 +1246,21 @@ wheels = [
 
 [[package]]
 name = "patchright"
-version = "1.60.1"
+version = "1.61.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/26/c1e858fd1acc63e410b3d33243955f36d2a0814487b97a7aa604ad2baffd/patchright-1.60.1-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:e9492100d4e2a85ff92fc3a668dd16dee03f21df6e559c7b9f7c71e86ff48c6b", size = 43458936, upload-time = "2026-06-03T12:11:50.892Z" },
-    { url = "https://files.pythonhosted.org/packages/55/dd/2dd8e4e02489ec8fd57ad93dec9ef444b6f42adcc4fe95df30237c92841d/patchright-1.60.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:20bd806df2469b451ccd2ea10f5f944ceb0e0d83c716f5752b0c956c1ee59476", size = 42245629, upload-time = "2026-06-03T12:11:56.098Z" },
-    { url = "https://files.pythonhosted.org/packages/54/cc/0fa0bedec61045fd9068682e3695557b622c483f829d341093879ec8dbd9/patchright-1.60.1-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9fd15a64c0ca80740dc2a3f41cda336a06a2ed6068d0ab893172654290b06e6b", size = 43458935, upload-time = "2026-06-03T12:12:01.077Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/c2/4b8f69de0a20d90792980c43c0e60b10b801e08cf0224ccc8a8266e1fffb/patchright-1.60.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:547e7bfb813102309789cc42933780e5fdf7c4727de59fb2791e64bd1298a7f3", size = 47451519, upload-time = "2026-06-03T12:12:06.645Z" },
-    { url = "https://files.pythonhosted.org/packages/db/fc/9fd6a70818cf0bc3b62574af483d762963cb65ca0a369826a0536faffe41/patchright-1.60.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:023945a2fd30219a284721ca36385bd44075ae7b53071dc1da38036b6dbe88ec", size = 47139153, upload-time = "2026-06-03T12:12:12.047Z" },
-    { url = "https://files.pythonhosted.org/packages/08/bc/81fb621e5ab4131e6f324c9ba6cb2a9f3b146c92f12484bec95efe8c8347/patchright-1.60.1-py3-none-win32.whl", hash = "sha256:05b98a6afdbe7e6645fe223009c47cc8e7859df55fd8ce9d8a9925b3389b0ee1", size = 37886460, upload-time = "2026-06-03T12:12:16.598Z" },
-    { url = "https://files.pythonhosted.org/packages/74/8e/fff80350ed2c2c1f62145d667070799c60ca9e9b28d54e4f751f0b4f8da6/patchright-1.60.1-py3-none-win_amd64.whl", hash = "sha256:51b306ed55cd58f1bca24641458f5c9f7e86a1f1727dcffdead669cfe4c0a485", size = 37886465, upload-time = "2026-06-03T12:12:21.448Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/b8/b6d1bfe98a420c1ccfb2f23a7bb2b4cdb40170907bae638e7ae92abd287c/patchright-1.60.1-py3-none-win_arm64.whl", hash = "sha256:f795728c1e27fc226dbe203c1aec713a537f01be963474fe0f3691f5e6457f9f", size = 34022283, upload-time = "2026-06-03T12:12:26.732Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/a76e2ea17dd4feccbf5ef6df017fb2e67f4b72a6f559f59d9aad1197f83a/patchright-1.61.2-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:43ae10cd2a3e46b222179a120ab39ba88f801f3a42aa41cab45fac9928f2103d", size = 43727572, upload-time = "2026-07-05T21:17:52.382Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e7/1ff89853c9aeaf26cd20559f401375ec71a40e4041cf7ace03d41a741f06/patchright-1.61.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a3da24d7890631255c7bef467b94ffe7f7bfa36f96fc72c10d5787d3cb396873", size = 42512921, upload-time = "2026-07-05T21:17:55.657Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/d730536a7fc43c3aaf2781518595ca71ffa1fc2f24e580c0d0cf04e00eca/patchright-1.61.2-py3-none-macosx_11_0_universal2.whl", hash = "sha256:edef852aa7d28791fa2d3f7ce135edfea2ce07a2bc5e0a74fb2dfe269af62223", size = 43727573, upload-time = "2026-07-05T21:17:59.121Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b5/c76dcda275cb0d9651321e343f3268609ae24cef196bff56751754ffba16/patchright-1.61.2-py3-none-manylinux1_x86_64.whl", hash = "sha256:545bdf2c0bb5f9ad78ab315e91c8c2990cc6a702e7f18650b71fe1071049b5c1", size = 47729338, upload-time = "2026-07-05T21:18:02.608Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ef/5de6feaedf47a6ba8efb9e8c4f8a42bad29cc59c35bbd088b1729a36b271/patchright-1.61.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1824da30cf6560749bc1bb4a7f002fec325d5b709090dd7c8c1b643899331cee", size = 47426969, upload-time = "2026-07-05T21:18:06.88Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6e/ce2c5d03a4c785ac8f3e0180bbf83ef85149cf41fdfa41c09bd8cbcfd945/patchright-1.61.2-py3-none-win32.whl", hash = "sha256:a5aaf4cec2bd38714f2447f84bcdfe7dcb592a16e9616bf6d2d872066d1c78af", size = 38155048, upload-time = "2026-07-05T21:18:09.938Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c8/fceb57b9d32ed078f53fc6a757c6e4b54cb117f59412938252a3359105e5/patchright-1.61.2-py3-none-win_amd64.whl", hash = "sha256:506bca9b72e609fd8fee35e2a3ad26e5d92e25337002f5c2cdad53d5cacb0b67", size = 38155052, upload-time = "2026-07-05T21:18:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/33/96/67a791c6b7cd76424b44d356beaf414ab97c3aef2d42fad4641e7905b41d/patchright-1.61.2-py3-none-win_arm64.whl", hash = "sha256:3dee1e2daada9f98653763831f688d39c924e0cf0eeb988e8047b703766cee73", size = 34268624, upload-time = "2026-07-05T21:18:15.966Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #684

`pyproject.toml` declared `patchright>=1.40.0`, and that line was wrong twice over.

**It named a version nobody could install.** Patchright never published a 1.40; the releases jump from `0.0.1` to `1.48.0.post0`. The floor described a baseline that could not have been tested by anyone.

**The real floor is 1.55.0, and it is set by behaviour rather than by a signature.** `hidden_target.open_hidden_page` needs `BrowserContext.browser`, and through 1.52.5 `launch_persistent_context` returned the context alone (`from_channel(await self._channel.send("launchPersistentContext", params))`), so no `Browser` object existed and the attribute was `None`. 1.55.0 switched to `send_return_as_dict` and calls `browser._connect_to_browser_type(...)`, which is what populates it. There is no 1.53 or 1.54 on PyPI, so 1.52.5 is the last version that fails.

That matters more than a missing parameter would, because the hidden-target path fails closed on purpose: falling back to real headless would restore the very token it exists to remove. On macOS, where that path is the default, an older patchright means no browser at all rather than a degraded one.

A second, lower bound that is no longer the binding one: `BrowserContext.storage_state(indexed_db=...)`, which the foreign-runtime bridge passes on every checkpoint commit, first appears in 1.51.0, and below that the Docker bridge dies with a `TypeError`. It is reached only once the launch has already succeeded, so on macOS the 1.55 requirement fails first and this one is never got to; on Linux the hidden target is not used at all, so this is the bound that would bite there.

The lockfile moves 1.60.1 to 1.61.2 in the same change, because the two halves are the same problem. The lock only governs Docker, which builds with `uv sync --frozen`; everyone installing through `uvx` or `pip` resolves the range fresh and has been getting 1.61.2 for a month. The fleet was already running a spread of Chromium versions by install path, and the one path maintained by hand was the one left behind. Docker goes from Chromium 148.0.7778.96 to 149.0.7827.55; a `uv sync` fetches the new revision once.

That bump is worth doing now rather than later because #680 just landed: a browser that moves backwards over a profile is refused with a message instead of quietly dropping the cookie store, so moving Chromium forward is no longer a one-way door.

Verified against the new browser rather than assumed. Every identity property the recent browser work rests on holds on 149, measured on a loopback origin: no `HeadlessChrome` token, `Chromium/149` brands agreeing with the user-agent major, high-entropy hints populated (`arm`, `64`, two entries), `visibilityState` visible and `hasFocus()` true so the hidden target still works, `navigator.webdriver` false, an outer window of 1280x720 on a screen of 1280x720 with no contradiction, five plugins and a `window.chrome` object proving the full browser rather than the headless shell, and 122 requestAnimationFrame callbacks per second against the 122 measured on 148. Full suite 1823 passed, 10 skipped.

Every method the package calls on the Playwright surface was matched against an older wheel's generated API with the exact keyword arguments used at each call site, and all of it exists as far back as 1.51.0. That check is what set the floor at first, and it was not enough: a signature scan sees which names exist, not what they return, and `context.browser` is a populated attribute rather than a missing one. The floor is now set by the highest requirement anyone has verified, which is a weaker claim than exhaustiveness and is stated as such in the test.

The bump also settled something the guard from #680 depended on without saying so. `_COMPARABLE_PRODUCTS` holds three names, and it turned out none of them is redundant for the reason anyone had written down. Playwright downloads its own Chromium build for Linux arm64 and Chrome for Testing everywhere else, so the two published container architectures report *different* product names at the same revision: `Chromium 149.0.7827.0` on arm64 against `Google Chrome for Testing 149.0.7827.55` on amd64. That split is a property of the lock, not of the range, because at the declared floor every platform reports `Chromium` and revision 1200 moved macOS and Linux x64 together. The third entry, `google chrome`, does no work at all in the case it was informally associated with, since the guard reads the running binary and never the profile's writer; it carries a `CHROME_PATH` at a real Chrome that is itself the older one, and now has a test that fails if the entry is removed.

Product strings were run rather than inferred, on macOS arm64 at revisions 1187, 1194, 1200, 1217, 1223 and 1228, and under Docker on linux-x64 and linux-arm64 at both ends of the supported range.

The test pins the floor against drifting back down and records why it is where it is. It cannot discover that a new call has raised the real minimum, and it says so: only resolving to the floor and running against it can, and that needs a browser CI does not install.

## Synthetic prompt

> Our patchright constraint says `>=1.40.0`. Check whether that version exists and whether the code actually runs on it, fix the floor to what the API surface really requires, and bump the lockfile to the current release. Verify the new Chromium keeps every browser-identity property the recent work depends on, and add a test that stops the floor being lowered again.

Generated with Claude Opus 5 high

