### PR TITLE
feat(post): Add schedule_post tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `search_posts` | Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter (past-24h/past-week/past-month) | working |
+| `schedule_post` | Schedule a feed post via LinkedIn's native Schedule-for-later flow (requires confirmation; publishes even when this server is offline) | working |
 | `close_session` | Close browser session and clean up resources | working |
 
 <br/>

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -221,41 +221,93 @@ _SCHEDULE_TIME_INPUT_SELECTOR = "input#share-post__scheduled-time"
 _COMPOSER_DISMISS_SELECTOR = "button[data-test-modal-close-btn]"
 
 
-def _format_schedule_date(year: int, month: int, day: int, current_value: str) -> str:
-    """Format a date the way the schedule dialog's own prefill formats one.
+def _resolve_date_order(
+    current_value: str, placeholder: str, today: datetime.date
+) -> tuple[str, str, str] | None:
+    """Determine the date input's slot order, e.g. ``("m", "d", "y")``.
 
-    The date input arrives prefilled with *today* in the profile's locale
-    (measured: ``8/8/2026`` for en with placeholder ``mm/dd/yyyy``). Today's
-    components are known, so the prefill doubles as a worked example of the
-    expected order and separator — a measurement, not a translation table.
-    Only when today's day and month are equal (~1 day a month) is the order
-    unreadable from the example; then the en ``month/day/year`` order is
-    assumed. Locales whose *order* differs from en and whose prefill is
-    ambiguous that day may mis-order — a bounded, dated limitation.
+    Two independent measurements, tried in turn; None when neither decides.
+
+    1. The prefill is LinkedIn's rendering of its own "today", which can sit
+       at most one calendar day from the server's UTC today. Reading the two
+       small numbers both ways yields two *different* dates whenever day and
+       month differ, and two distinct readings are never both inside a
+       three-consecutive-day window — so a reading that lands in the window is
+       proof of the order, not a guess.
+    2. The placeholder's short tokens. Across the Latin-script locales
+       LinkedIn ships, the month token is the one starting with ``m`` (en
+       ``mm``, de ``MM``/Monat, fr ``mm``/mois, es mes, it mese, pt mês, nl
+       maand) while the day letter varies (``dd``, ``TT``, ``jj``, ``gg``) —
+       a per-locale table in the sense the scraping rules require, documented
+       here as such. Locales outside it (non-Latin scripts) fall through.
     """
     numbers = re.findall(r"\d+", current_value)
+    if len(numbers) == 3:
+        values = [int(n) for n in numbers]
+        year_pos = max(range(3), key=lambda i: (len(numbers[i]) >= 4, values[i]))
+        rest = [i for i in range(3) if i != year_pos]
+        a, b = values[rest[0]], values[rest[1]]
+        year = values[year_pos]
+
+        def order_of(day_first: bool) -> tuple[str, str, str]:
+            slots = ["", "", ""]
+            slots[year_pos] = "y"
+            slots[rest[0]] = "d" if day_first else "m"
+            slots[rest[1]] = "m" if day_first else "d"
+            return (slots[0], slots[1], slots[2])
+
+        window = {today + datetime.timedelta(days=k) for k in (-1, 0, 1)}
+
+        def in_window(month: int, day: int) -> bool:
+            try:
+                return datetime.date(year, month, day) in window
+            except ValueError:
+                return False
+
+        month_first = in_window(a, b)
+        day_first = in_window(b, a)
+        if month_first != day_first:
+            return order_of(day_first)
+
+    tokens = re.findall(r"[^\W\d_]+", placeholder or "")
+    if len(tokens) == 3:
+        parts = [
+            "y" if len(t) > 2 else ("m" if t.lower().startswith("m") else "d")
+            for t in tokens
+        ]
+        if sorted(parts) == ["d", "m", "y"]:
+            return (parts[0], parts[1], parts[2])
+    return None
+
+
+def _format_schedule_date(
+    year: int,
+    month: int,
+    day: int,
+    current_value: str,
+    placeholder: str = "",
+    today: datetime.date | None = None,
+) -> tuple[str | None, tuple[str, str, str] | None]:
+    """Format a date the way the schedule dialog's own prefill formats one.
+
+    Returns ``(value, order)``. The order comes from `_resolve_date_order`;
+    when it cannot be proven and the target's day differs from its month,
+    ``(None, None)`` is returned so the caller refuses rather than gambling
+    the calendar day — a reversed date passes every later check LinkedIn
+    offers, because both readings are valid dates.
+    """
+    if today is None:
+        today = datetime.datetime.now(datetime.timezone.utc).date()
     separators = re.findall(r"\D+", current_value)
     separator = separators[0] if separators else "/"
-    if len(numbers) != 3:
-        return f"{month}/{day}/{year}"
-    prefill = [int(n) for n in numbers]
-    year_pos = max(range(3), key=lambda i: prefill[i])
-    rest = [i for i in range(3) if i != year_pos]
-    first, second = prefill[rest[0]], prefill[rest[1]]
-    slots = {year_pos: str(year)}
-    if first > 12 or (first != second and second > 12):
-        # A number that cannot be a month names the day slot outright.
-        day_first = first > 12
-    else:
-        # Both fit a month: read the order off the machine's own today, which
-        # matches LinkedIn's prefill except across a midnight timezone skew.
-        today = datetime.date.today()
-        day_first = first != second and first == today.day and second == today.month
-    if day_first:
-        slots[rest[0]], slots[rest[1]] = str(day), str(month)
-    else:
-        slots[rest[0]], slots[rest[1]] = str(month), str(day)
-    return separator.join(slots[i] for i in range(3))
+    order = _resolve_date_order(current_value, placeholder, today)
+    if order is None:
+        if day != month:
+            return None, None
+        # Either order writes the same digits; en order names the slots.
+        order = ("m", "d", "y")
+    mapping = {"y": str(year), "m": str(month), "d": str(day)}
+    return separator.join(mapping[slot] for slot in order), order
 
 
 def _format_schedule_time(hour: int, minute: int, current_value: str) -> str:
@@ -4481,9 +4533,22 @@ class LinkedInExtractor:
 
         # The prefilled values are LinkedIn's own rendering of a date and a
         # time in this profile's locale; format ours the same way.
-        date_value = _format_schedule_date(
-            year, month, day, await date_input.input_value()
+        date_value, date_order = _format_schedule_date(
+            year,
+            month,
+            day,
+            await date_input.input_value(),
+            await date_input.get_attribute("placeholder") or "",
         )
+        if date_value is None or date_order is None:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_rejected",
+                "The profile's date-component order could not be proven from "
+                "the schedule dialog, and a reversed day/month would schedule "
+                "the wrong calendar day, so nothing was scheduled.",
+            )
         time_value = _format_schedule_time(hour, minute, await time_input.input_value())
         await date_input.fill(date_value)
         await time_input.fill(time_value)
@@ -4493,9 +4558,15 @@ class LinkedInExtractor:
 
         accepted_date = await date_input.input_value()
         accepted_time = await time_input.input_value()
-        # Compare as numbers so zero-padding differences don't fail the check.
-        accepted_numbers = {int(n) for n in re.findall(r"\d+", accepted_date)}
-        if accepted_numbers != {year, month, day}:
+        # Position-by-position against the proven order — an unordered
+        # comparison would wave a reversed day/month through, since the
+        # reversal permutes the same numbers. Ints, so zero-padding
+        # normalization cannot fail the check.
+        expected_by_pos = [
+            {"y": year, "m": month, "d": day}[slot] for slot in date_order
+        ]
+        accepted_by_pos = [int(n) for n in re.findall(r"\d+", accepted_date)]
+        if accepted_by_pos != expected_by_pos:
             await self._clear_and_dismiss_composer()
             return self._schedule_post_result(
                 self._page.url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 from dataclasses import dataclass
 import json
 import logging
@@ -195,6 +196,85 @@ _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Dismiss"], '
     'button[aria-label*="Close"]'
 )
+
+# --- Share composer (feed post creation) -----------------------------------
+#
+# The composer renders inside an open shadow root (`#interop-outlet`, LinkedIn's
+# SDUI interop surface). Patchright locators pierce shadow roots, so plain CSS
+# works here; `page.evaluate` + `querySelectorAll` does not — keep any JS out of
+# this flow. All selectors below are structural (role/state/test hooks), never
+# layout class names and never label text.
+#
+# Opened by URL (`/feed/?shareActive=true`) rather than by clicking the
+# "Start a post" trigger, whose only stable identity is its label text.
+_COMPOSER_EDITOR_SELECTOR = 'div[role="textbox"][contenteditable="true"]'
+# The clock icon is the schedule affordance. `data-test-icon` is LinkedIn's own
+# test hook and carries the icon's name, not a translation.
+_COMPOSER_SCHEDULE_BUTTON_SELECTOR = (
+    'button:has(svg[data-test-icon="clock-medium"]), '
+    'button:has(use[href="#clock-medium"])'
+)
+# Semantic element ids, stable across sessions (unlike `ember\d+` ids).
+_SCHEDULE_DATE_INPUT_SELECTOR = "input#share-post__scheduled-date"
+_SCHEDULE_TIME_INPUT_SELECTOR = "input#share-post__scheduled-time"
+# LinkedIn's modal close button carries this test hook in the composer.
+_COMPOSER_DISMISS_SELECTOR = "button[data-test-modal-close-btn]"
+
+
+def _format_schedule_date(year: int, month: int, day: int, current_value: str) -> str:
+    """Format a date the way the schedule dialog's own prefill formats one.
+
+    The date input arrives prefilled with *today* in the profile's locale
+    (measured: ``8/8/2026`` for en with placeholder ``mm/dd/yyyy``). Today's
+    components are known, so the prefill doubles as a worked example of the
+    expected order and separator — a measurement, not a translation table.
+    Only when today's day and month are equal (~1 day a month) is the order
+    unreadable from the example; then the en ``month/day/year`` order is
+    assumed. Locales whose *order* differs from en and whose prefill is
+    ambiguous that day may mis-order — a bounded, dated limitation.
+    """
+    numbers = re.findall(r"\d+", current_value)
+    separators = re.findall(r"\D+", current_value)
+    separator = separators[0] if separators else "/"
+    if len(numbers) != 3:
+        return f"{month}/{day}/{year}"
+    prefill = [int(n) for n in numbers]
+    year_pos = max(range(3), key=lambda i: prefill[i])
+    rest = [i for i in range(3) if i != year_pos]
+    first, second = prefill[rest[0]], prefill[rest[1]]
+    slots = {year_pos: str(year)}
+    if first > 12 or (first != second and second > 12):
+        # A number that cannot be a month names the day slot outright.
+        day_first = first > 12
+    else:
+        # Both fit a month: read the order off the machine's own today, which
+        # matches LinkedIn's prefill except across a midnight timezone skew.
+        today = datetime.date.today()
+        day_first = first != second and first == today.day and second == today.month
+    if day_first:
+        slots[rest[0]], slots[rest[1]] = str(day), str(month)
+    else:
+        slots[rest[0]], slots[rest[1]] = str(month), str(day)
+    return separator.join(slots[i] for i in range(3))
+
+
+def _format_schedule_time(hour: int, minute: int, current_value: str) -> str:
+    """Format a time the way the timepicker's own prefill formats one.
+
+    The timepicker prefills a suggested slot (measured: ``2:00 PM``). A
+    meridiem marker in the prefill means the locale renders 12-hour time; the
+    en markers are the only ones tabled here, and 24-hour ``HH:MM`` is the
+    fallback for every other locale. Documented limitation: a non-English
+    12-hour locale would get a 24-hour string, which LinkedIn's parser may
+    reject — the caller verifies the input's value after filling and reports
+    rejection rather than scheduling at a wrong time.
+    """
+    if re.search(r"\b[AP]\.?M\.?\b", current_value, re.IGNORECASE):
+        marker = "AM" if hour < 12 else "PM"
+        hour12 = hour % 12 or 12
+        return f"{hour12}:{minute:02d} {marker}"
+    return f"{hour:02d}:{minute:02d}"
+
 
 # Shared JS function that walks up from any /messaging/compose/ anchor
 # inside <main> to find the smallest ancestor that satisfies the
@@ -4288,6 +4368,226 @@ class LinkedInExtractor:
             "Message sent.",
             recipient_selected=recipient_selected,
             sent=True,
+        )
+
+    @staticmethod
+    def _schedule_post_result(
+        url: str,
+        status: str,
+        message: str,
+        *,
+        scheduled: bool = False,
+        scheduled_for: str | None = None,
+        composer_text: str | None = None,
+    ) -> dict[str, Any]:
+        """Build a structured response for the schedule_post tool."""
+        result: dict[str, Any] = {
+            "url": url,
+            "status": status,
+            "message": message,
+            "scheduled": scheduled,
+        }
+        if scheduled_for is not None:
+            result["scheduled_for"] = scheduled_for
+        if composer_text is not None:
+            result["composer_text"] = composer_text
+        return result
+
+    def _composer_dialog(self) -> Any:
+        """The dialog that holds the share composer's editor."""
+        return self._page.locator(_DIALOG_SELECTOR).filter(
+            has=self._page.locator(_COMPOSER_EDITOR_SELECTOR)
+        )
+
+    async def _clear_and_dismiss_composer(self) -> None:
+        """Empty the editor, then close the composer without a draft prompt.
+
+        Escape does not close this composer, and the discard-prompt buttons
+        have no locale-independent identity — but an *empty* composer closes
+        from its Dismiss button without any prompt (measured), so emptiness is
+        the dismissal strategy rather than prompt-button classification.
+        """
+        try:
+            editor = self._page.locator(_COMPOSER_EDITOR_SELECTOR).first
+            if await editor.is_visible():
+                await editor.click(timeout=2000)
+                await self._page.keyboard.press("ControlOrMeta+a")
+                await self._page.keyboard.press("Delete")
+            dismiss = self._page.locator(_COMPOSER_DISMISS_SELECTOR).first
+            await dismiss.click(timeout=3000)
+            await editor.wait_for(state="hidden", timeout=5000)
+        except Exception:
+            logger.debug("Composer dismissal failed", exc_info=True)
+
+    async def schedule_post(
+        self,
+        text: str,
+        *,
+        year: int,
+        month: int,
+        day: int,
+        hour: int,
+        minute: int,
+        confirm_schedule: bool,
+    ) -> dict[str, Any]:
+        """Schedule a feed post via LinkedIn's native Schedule-for-later flow.
+
+        The scheduled time is set *before* the text is typed: the composer
+        rebuilds its editor on the schedule round-trip and drops typed content
+        (measured), while text typed after the round-trip survives.
+
+        Args:
+            text: The post body.
+            year/month/day/hour/minute: Scheduled moment, interpreted by
+                LinkedIn in the profile's own timezone.
+            confirm_schedule: Must be True to actually schedule (False does a
+                dry run that fills everything and then discards).
+        """
+        await self._navigate_to_page("https://www.linkedin.com/feed/?shareActive=true")
+        await detect_rate_limit(self._page)
+
+        editor = self._page.locator(_COMPOSER_EDITOR_SELECTOR).first
+        try:
+            await editor.wait_for(state="visible", timeout=15000)
+        except PlaywrightTimeoutError:
+            return self._schedule_post_result(
+                self._page.url,
+                "composer_unavailable",
+                "LinkedIn did not open the share composer.",
+            )
+
+        schedule_button = self._page.locator(_COMPOSER_SCHEDULE_BUTTON_SELECTOR).first
+        try:
+            await schedule_button.click(timeout=8000)
+        except Exception:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_unavailable",
+                "LinkedIn did not expose a schedule (clock) action in the composer.",
+            )
+
+        date_input = self._page.locator(_SCHEDULE_DATE_INPUT_SELECTOR).first
+        time_input = self._page.locator(_SCHEDULE_TIME_INPUT_SELECTOR).first
+        try:
+            await date_input.wait_for(state="visible", timeout=8000)
+        except PlaywrightTimeoutError:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_unavailable",
+                "The schedule dialog did not open.",
+            )
+
+        # The prefilled values are LinkedIn's own rendering of a date and a
+        # time in this profile's locale; format ours the same way.
+        date_value = _format_schedule_date(
+            year, month, day, await date_input.input_value()
+        )
+        time_value = _format_schedule_time(hour, minute, await time_input.input_value())
+        await date_input.fill(date_value)
+        await time_input.fill(time_value)
+        # Blur so the pickers parse and commit what was typed.
+        await self._page.keyboard.press("Tab")
+        await asyncio.sleep(0.5)
+
+        accepted_date = await date_input.input_value()
+        accepted_time = await time_input.input_value()
+        # Compare as numbers so zero-padding differences don't fail the check.
+        accepted_numbers = {int(n) for n in re.findall(r"\d+", accepted_date)}
+        if accepted_numbers != {year, month, day}:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_rejected",
+                f"The date picker did not accept {date_value!r}; it shows {accepted_date!r}.",
+            )
+        if accepted_time.strip() != time_value:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_rejected",
+                f"The time picker did not accept {time_value!r}; it shows {accepted_time!r}.",
+            )
+
+        # Confirm the schedule: the dialog's primary action is its last button
+        # (Back/Next here — the same last-button convention the rest of this
+        # file relies on), scoped to the dialog that holds the date input so
+        # hidden video-player dialogs elsewhere on the feed cannot shift the
+        # count.
+        schedule_dialog = self._page.locator(_DIALOG_SELECTOR).filter(
+            has=self._page.locator(_SCHEDULE_DATE_INPUT_SELECTOR)
+        )
+        try:
+            await (
+                schedule_dialog.locator("button")
+                .filter(visible=True)
+                .last.click(timeout=5000)
+            )
+            await date_input.wait_for(state="hidden", timeout=8000)
+        except Exception:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_rejected",
+                "LinkedIn did not accept the scheduled date and time.",
+            )
+
+        # Now the text — clearing first, because the composer restores drafts.
+        await editor.click(timeout=5000)
+        await self._page.keyboard.press("ControlOrMeta+a")
+        await self._page.keyboard.press("Delete")
+        await self._page.keyboard.type(text, delay=10)
+        await asyncio.sleep(1.0)  # let the composer enable its primary action
+
+        composer_dialog = self._composer_dialog()
+        composer_text = ""
+        try:
+            composer_text = await composer_dialog.first.inner_text()
+        except Exception:
+            logger.debug("Could not read composer text", exc_info=True)
+
+        scheduled_for = f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute:02d}"
+        if not confirm_schedule:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "confirmation_required",
+                "Dry run complete. Set confirm_schedule=true to schedule the post.",
+                scheduled_for=scheduled_for,
+                composer_text=composer_text,
+            )
+
+        primary = composer_dialog.locator("button").filter(visible=True).last
+        try:
+            if await primary.is_disabled():
+                await self._clear_and_dismiss_composer()
+                return self._schedule_post_result(
+                    self._page.url,
+                    "schedule_unavailable",
+                    "The composer's Schedule action stayed disabled after typing.",
+                    scheduled_for=scheduled_for,
+                    composer_text=composer_text,
+                )
+            await primary.click(timeout=8000)
+            await editor.wait_for(state="hidden", timeout=10000)
+        except Exception:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_unconfirmed",
+                "LinkedIn did not confirm that the post was scheduled.",
+                scheduled_for=scheduled_for,
+                composer_text=composer_text,
+            )
+
+        return self._schedule_post_result(
+            self._page.url,
+            "scheduled",
+            "Post scheduled.",
+            scheduled=True,
+            scheduled_for=scheduled_for,
+            composer_text=composer_text,
         )
 
     async def _extract_root_content(

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -1,13 +1,19 @@
 """
-LinkedIn post/content search tool.
+LinkedIn post/content tools: global post search and post scheduling.
 
-Performs LinkedIn's global content search (the "Posts" results tab) using
-innerText extraction, so informal "we're hiring" / "Buscamos ..." posts can
-be found before a formal job listing is published. Mirrors search_people:
-build a /search/results/content/ URL, scroll to load results, and return the
-raw innerText for the LLM to parse, plus post-permalink references.
+search_posts performs LinkedIn's global content search (the "Posts" results
+tab) using innerText extraction, so informal "we're hiring" / "Buscamos ..."
+posts can be found before a formal job listing is published. Mirrors
+search_people: build a /search/results/content/ URL, scroll to load results,
+and return the raw innerText for the LLM to parse, plus post-permalink
+references.
+
+schedule_post drives LinkedIn's native Schedule-for-later flow in the share
+composer, so the scheduled post lives on LinkedIn's side and publishes
+without this server running.
 """
 
+import datetime
 import logging
 from typing import Annotated, Any
 
@@ -114,3 +120,93 @@ def register_post_tools(
                 raise_tool_error(relogin_exc, "search_posts")
         except Exception as e:
             raise_tool_error(e, "search_posts")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Schedule Post",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"post", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def schedule_post(
+        text: str,
+        schedule_date: str,
+        schedule_time: str,
+        confirm_schedule: bool,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Schedule a LinkedIn feed post via LinkedIn's native Schedule-for-later.
+
+        The post is stored by LinkedIn itself and publishes at the scheduled
+        moment whether or not this server is running. LinkedIn interprets the
+        date and time in the profile's own timezone and accepts roughly the
+        next three months. This is a write operation when confirm_schedule is
+        True; with False it performs the full flow as a dry run — filling the
+        schedule and the text — then discards the draft.
+
+        Args:
+            text: The post body text.
+            schedule_date: Date to publish, as YYYY-MM-DD (e.g. "2026-08-15").
+            schedule_time: Time to publish, as 24-hour HH:MM (e.g. "17:30").
+            confirm_schedule: Must be True to actually schedule the post.
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, status, message, scheduled (bool), and — once the
+            flow reaches the composer — scheduled_for plus composer_text, the
+            composer dialog's raw text, which carries LinkedIn's own rendering
+            of the scheduled moment for verification.
+        """
+        try:
+            try:
+                when = datetime.datetime.strptime(
+                    f"{schedule_date} {schedule_time}", "%Y-%m-%d %H:%M"
+                )
+            except ValueError as e:
+                raise ToolError(
+                    f"Invalid schedule_date/schedule_time: {e}. "
+                    "Use YYYY-MM-DD and 24-hour HH:MM."
+                ) from e
+            if when <= datetime.datetime.now():
+                raise ToolError(
+                    f"The scheduled moment {when:%Y-%m-%d %H:%M} is not in the "
+                    "future (server clock). Pick a later time."
+                )
+
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="schedule_post"
+            )
+            logger.info(
+                "Scheduling post for %s %s (confirm_schedule=%s)",
+                schedule_date,
+                schedule_time,
+                confirm_schedule,
+            )
+
+            await ctx.report_progress(progress=0, total=100, message="Scheduling post")
+
+            result = await extractor.schedule_post(
+                text,
+                year=when.year,
+                month=when.month,
+                day=when.day,
+                hour=when.hour,
+                minute=when.minute,
+                confirm_schedule=confirm_schedule,
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except ToolError:
+            raise
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "schedule_post")
+        except Exception as e:
+            raise_tool_error(e, "schedule_post")  # NoReturn

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -169,10 +169,18 @@ def register_post_tools(
                     f"Invalid schedule_date/schedule_time: {e}. "
                     "Use YYYY-MM-DD and 24-hour HH:MM."
                 ) from e
-            if when <= datetime.datetime.now():
+            # LinkedIn interprets the moment in the *profile's* timezone,
+            # which this server cannot know, so the server clock only bounds
+            # the check: a wall time is already past in every timezone once it
+            # trails UTC by more than the westernmost offset (UTC-12). Only
+            # that much is rejected here; anything nearer is LinkedIn's call,
+            # and the composer flow reports schedule_rejected when LinkedIn
+            # refuses the values.
+            now_utc = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+            if when <= now_utc - datetime.timedelta(hours=12):
                 raise ToolError(
-                    f"The scheduled moment {when:%Y-%m-%d %H:%M} is not in the "
-                    "future (server clock). Pick a later time."
+                    f"The scheduled moment {when:%Y-%m-%d %H:%M} is already "
+                    "past in every timezone. Pick a later time."
                 )
 
             extractor = extractor or await get_ready_extractor(

--- a/manifest.json
+++ b/manifest.json
@@ -120,6 +120,10 @@
       "description": "Search LinkedIn posts/content globally by keyword (the 'Posts' tab) with an optional recency filter (past-24h/past-week/past-month)"
     },
     {
+      "name": "schedule_post",
+      "description": "Schedule a LinkedIn feed post via LinkedIn's native Schedule-for-later flow, with explicit confirmation and a dry-run mode"
+    },
+    {
       "name": "close_session",
       "description": "Properly close browser session and clean up resources"
     }

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1485,11 +1485,38 @@ class TestRealOwner:
             names = asyncio.run(served())
 
             # The owner registers the full local set, so the proxy must show it
-            # all — including `close_session`, the one defined inline rather than
-            # in a `register_*` call.
+            # all. The expectation is derived from the same registrars the
+            # owner runs — a hand-counted number silently went stale the first
+            # time a tool was added — plus `close_session`, the one tool
+            # defined inline in `create_mcp_server` rather than in a
+            # `register_*` call. A bare FastMCP carries no role, so building
+            # it here does not collide with the PROXY claim above.
+            async def expected() -> set[str]:
+                from fastmcp import FastMCP
+
+                from linkedin_mcp_server.tools.company import register_company_tools
+                from linkedin_mcp_server.tools.feed import register_feed_tools
+                from linkedin_mcp_server.tools.job import register_job_tools
+                from linkedin_mcp_server.tools.messaging import (
+                    register_messaging_tools,
+                )
+                from linkedin_mcp_server.tools.person import register_person_tools
+                from linkedin_mcp_server.tools.post import register_post_tools
+
+                bare = FastMCP("expected-roster")
+                register_person_tools(bare)
+                register_company_tools(bare)
+                register_job_tools(bare)
+                register_messaging_tools(bare)
+                register_feed_tools(bare)
+                register_post_tools(bare)
+                async with Client(bare) as client:
+                    local = {tool.name for tool in await client.list_tools()}
+                return local | {"close_session"}
+
             assert "get_person_profile" in names
             assert "close_session" in names
-            assert len(names) == 19, sorted(names)
+            assert names == asyncio.run(expected()), sorted(names)
         finally:
             _stop(result.get("pid"))
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -20,6 +20,8 @@ from linkedin_mcp_server.scraping.extractor import (
     _CONTENT_DATE_POSTED_MAP,
     _RATE_LIMITED_MSG,
     _build_feed_references,
+    _format_schedule_date,
+    _format_schedule_time,
     _truncate_linkedin_noise,
     strip_conversation_chrome,
     strip_linkedin_noise,
@@ -5990,3 +5992,38 @@ class TestNavigationFailureCrossesTheToolBoundaryClean:
         # The raw error must not survive as a cause either: the handlers
         # downstream print the whole chain.
         assert excinfo.value.__cause__ is None
+
+
+class TestScheduleFormatHelpers:
+    """The schedule dialog's prefill is the format example the helpers copy."""
+
+    def test_date_en_prefill_month_first(self):
+        assert _format_schedule_date(2026, 8, 15, "8/8/2026") == "8/15/2026"
+
+    def test_date_day_first_when_prefill_day_exceeds_twelve(self):
+        # A first number that cannot be a month names the day slot.
+        assert _format_schedule_date(2026, 8, 15, "31/8/2026") == "15/8/2026"
+
+    def test_date_month_first_when_second_number_exceeds_twelve(self):
+        assert _format_schedule_date(2026, 8, 15, "8/31/2026") == "8/15/2026"
+
+    def test_date_preserves_separator(self):
+        assert _format_schedule_date(2026, 8, 15, "31.8.2026") == "15.8.2026"
+
+    def test_date_iso_prefill_keeps_year_position(self):
+        assert _format_schedule_date(2026, 8, 15, "2026-08-31") == "2026-8-15"
+
+    def test_date_unparseable_prefill_falls_back_to_en(self):
+        assert _format_schedule_date(2026, 8, 15, "") == "8/15/2026"
+
+    def test_time_twelve_hour_from_meridiem_prefill(self):
+        assert _format_schedule_time(17, 30, "2:00 PM") == "5:30 PM"
+        assert _format_schedule_time(9, 5, "2:00 PM") == "9:05 AM"
+
+    def test_time_twelve_hour_boundaries(self):
+        assert _format_schedule_time(0, 5, "1:45 PM") == "12:05 AM"
+        assert _format_schedule_time(12, 0, "1:45 PM") == "12:00 PM"
+
+    def test_time_twenty_four_hour_without_meridiem(self):
+        assert _format_schedule_time(17, 30, "14:00") == "17:30"
+        assert _format_schedule_time(9, 5, "14:00") == "09:05"

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5997,24 +5997,77 @@ class TestNavigationFailureCrossesTheToolBoundaryClean:
 class TestScheduleFormatHelpers:
     """The schedule dialog's prefill is the format example the helpers copy."""
 
-    def test_date_en_prefill_month_first(self):
-        assert _format_schedule_date(2026, 8, 15, "8/8/2026") == "8/15/2026"
+    def test_date_month_first_proven_by_prefill_window(self):
+        # Prefill 8/7 read month-first is Aug 7 (inside the today window);
+        # read day-first it is Jul 8 (outside). Order proven, not guessed.
+        import datetime as dt
 
-    def test_date_day_first_when_prefill_day_exceeds_twelve(self):
-        # A first number that cannot be a month names the day slot.
-        assert _format_schedule_date(2026, 8, 15, "31/8/2026") == "15/8/2026"
+        value, order = _format_schedule_date(
+            2026, 8, 15, "8/7/2026", today=dt.date(2026, 8, 7)
+        )
+        assert (value, order) == ("8/15/2026", ("m", "d", "y"))
 
-    def test_date_month_first_when_second_number_exceeds_twelve(self):
-        assert _format_schedule_date(2026, 8, 15, "8/31/2026") == "8/15/2026"
+    def test_date_day_first_proven_by_prefill_window(self):
+        import datetime as dt
 
-    def test_date_preserves_separator(self):
-        assert _format_schedule_date(2026, 8, 15, "31.8.2026") == "15.8.2026"
+        value, order = _format_schedule_date(
+            2026, 8, 15, "7/8/2026", today=dt.date(2026, 8, 7)
+        )
+        assert (value, order) == ("15/8/2026", ("d", "m", "y"))
+
+    def test_date_ambiguous_prefill_decided_by_placeholder(self):
+        # On a day==month date the prefill reads the same both ways; the
+        # placeholder's m-token breaks the tie.
+        import datetime as dt
+
+        value, order = _format_schedule_date(
+            2026, 8, 15, "8/8/2026", "dd/mm/yyyy", today=dt.date(2026, 8, 8)
+        )
+        assert (value, order) == ("15/8/2026", ("d", "m", "y"))
+
+    def test_date_german_placeholder_and_separator(self):
+        import datetime as dt
+
+        value, order = _format_schedule_date(
+            2026, 8, 15, "8.8.2026", "TT.MM.JJJJ", today=dt.date(2026, 8, 8)
+        )
+        assert (value, order) == ("15.8.2026", ("d", "m", "y"))
+
+    def test_date_undecidable_refuses_distinct_day_month(self):
+        # Neither the prefill (day == month) nor a placeholder decides the
+        # order: refusing beats gambling the calendar day, because a reversed
+        # date is a valid date and passes every later check.
+        import datetime as dt
+
+        value, order = _format_schedule_date(
+            2026, 8, 15, "8/8/2026", "", today=dt.date(2026, 8, 8)
+        )
+        assert (value, order) == (None, None)
+
+    def test_date_undecidable_allows_equal_day_month(self):
+        # Both orders write the same digits, so nothing is gambled.
+        import datetime as dt
+
+        value, order = _format_schedule_date(
+            2026, 9, 9, "8/8/2026", "", today=dt.date(2026, 8, 8)
+        )
+        assert value == "9/9/2026"
 
     def test_date_iso_prefill_keeps_year_position(self):
-        assert _format_schedule_date(2026, 8, 15, "2026-08-31") == "2026-8-15"
+        import datetime as dt
 
-    def test_date_unparseable_prefill_falls_back_to_en(self):
-        assert _format_schedule_date(2026, 8, 15, "") == "8/15/2026"
+        value, order = _format_schedule_date(
+            2026, 8, 15, "2026-08-07", today=dt.date(2026, 8, 7)
+        )
+        assert (value, order) == ("2026-8-15", ("y", "m", "d"))
+
+    def test_date_empty_prefill_decided_by_placeholder(self):
+        import datetime as dt
+
+        value, order = _format_schedule_date(
+            2026, 8, 15, "", "mm/dd/yyyy", today=dt.date(2026, 8, 8)
+        )
+        assert (value, order) == ("8/15/2026", ("m", "d", "y"))
 
     def test_time_twelve_hour_from_meridiem_prefill(self):
         assert _format_schedule_time(17, 30, "2:00 PM") == "5:30 PM"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1354,7 +1354,7 @@ class TestPostTools:
 
         tool_fn = await get_tool_fn(mcp, "schedule_post")
         mock_extractor = _make_mock_extractor({})
-        with pytest.raises(ToolError, match="not in the future"):
+        with pytest.raises(ToolError, match="already past in every timezone"):
             await tool_fn(
                 "Hello",
                 "2020-01-01",
@@ -1364,6 +1364,40 @@ class TestPostTools:
                 extractor=mock_extractor,
             )
         mock_extractor.schedule_post.assert_not_awaited()
+
+    async def test_schedule_post_defers_near_past_to_linkedin(self, mock_context):
+        """A moment shortly behind the server clock may still be future in the
+        profile's timezone, so the tool must pass it through and let LinkedIn
+        judge it rather than rejecting on the server's own wall clock."""
+        import datetime as _dt
+
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "schedule_rejected",
+            "message": "LinkedIn did not accept the scheduled date and time.",
+            "scheduled": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "schedule_post")
+        near_past = _dt.datetime.now(_dt.timezone.utc).replace(
+            tzinfo=None
+        ) - _dt.timedelta(hours=1)
+        result = await tool_fn(
+            "Hello",
+            near_past.strftime("%Y-%m-%d"),
+            near_past.strftime("%H:%M"),
+            True,
+            mock_context,
+            extractor=mock_extractor,
+        )
+        assert result["status"] == "schedule_rejected"
+        mock_extractor.schedule_post.assert_awaited_once()
 
 
 class TestToolTimeouts:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -37,6 +37,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.get_my_profile = AsyncMock(return_value=scrape_result)
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.search_posts = AsyncMock(return_value=scrape_result)
+    mock.schedule_post = AsyncMock(return_value=scrape_result)
     mock.get_company_employees = AsyncMock(return_value=scrape_result)
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
@@ -1249,6 +1250,120 @@ class TestPostTools:
 
         with pytest.raises(ValidationError, match="max_pages"):
             await mcp.call_tool("search_posts", {"keywords": "python", "max_pages": 0})
+
+    async def test_schedule_post_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "scheduled",
+            "message": "Post scheduled.",
+            "scheduled": True,
+            "scheduled_for": "2099-08-15 17:30",
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "schedule_post")
+        result = await tool_fn(
+            "Hello world",
+            "2099-08-15",
+            "17:30",
+            True,
+            mock_context,
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "scheduled"
+        assert result["scheduled"] is True
+        mock_extractor.schedule_post.assert_awaited_once_with(
+            "Hello world",
+            year=2099,
+            month=8,
+            day=15,
+            hour=17,
+            minute=30,
+            confirm_schedule=True,
+        )
+
+    async def test_schedule_post_dry_run_passes_confirm_false(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "confirmation_required",
+            "message": "Dry run complete.",
+            "scheduled": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "schedule_post")
+        result = await tool_fn(
+            "Hello world",
+            "2099-01-02",
+            "09:05",
+            False,
+            mock_context,
+            extractor=mock_extractor,
+        )
+
+        assert result["scheduled"] is False
+        mock_extractor.schedule_post.assert_awaited_once_with(
+            "Hello world",
+            year=2099,
+            month=1,
+            day=2,
+            hour=9,
+            minute=5,
+            confirm_schedule=False,
+        )
+
+    async def test_schedule_post_rejects_bad_date_format(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "schedule_post")
+        mock_extractor = _make_mock_extractor({})
+        with pytest.raises(ToolError, match="YYYY-MM-DD"):
+            await tool_fn(
+                "Hello",
+                "15/08/2099",
+                "17:30",
+                True,
+                mock_context,
+                extractor=mock_extractor,
+            )
+        mock_extractor.schedule_post.assert_not_awaited()
+
+    async def test_schedule_post_rejects_past_datetime(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "schedule_post")
+        mock_extractor = _make_mock_extractor({})
+        with pytest.raises(ToolError, match="not in the future"):
+            await tool_fn(
+                "Hello",
+                "2020-01-01",
+                "12:00",
+                True,
+                mock_context,
+                extractor=mock_extractor,
+            )
+        mock_extractor.schedule_post.assert_not_awaited()
 
 
 class TestToolTimeouts:


### PR DESCRIPTION
Closes #689

## What

Adds a `schedule_post` tool that schedules a feed post through LinkedIn's **native Schedule-for-later** flow, so the scheduled post lives on LinkedIn's side and publishes at the chosen moment whether or not this server is running.

- `schedule_post(text, schedule_date "YYYY-MM-DD", schedule_time "HH:MM" 24h, confirm_schedule)`
- Same explicit gating as `send_message` (`destructiveHint: True`): `confirm_schedule=false` runs the **entire** flow as a dry run — LinkedIn parses the date/time and its rendering is returned in `composer_text` — then discards the draft.
- Rejects malformed dates/times and past datetimes before touching the browser.

## How (what live probing established)

- **The composer lives in an open shadow root** (`#interop-outlet`, LinkedIn's SDUI interop surface). Patchright locators pierce shadow roots ([documented](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-python#closed-shadow-roots)); `page.evaluate` + `querySelectorAll` does not. The flow therefore uses plain CSS locators only, and a comment in `extractor.py` warns future edits away from JS in this flow.
- **Opened by URL**, `/feed/?shareActive=true`, not by clicking the "Start a post" trigger whose only stable identity is label text.
- **Schedule before typing.** The schedule dialog round-trip rebuilds the editor and silently drops typed text (measured); text typed after the round-trip survives.
- **Locale independence** per the scraping rules:
  - Clock button via LinkedIn's own test hook `svg[data-test-icon="clock-medium"]` (icon name, not a translation).
  - Date/time inputs via stable semantic ids `#share-post__scheduled-date` / `#share-post__scheduled-time` (not `ember\d+`).
  - Date and time strings are formatted **by copying the dialog's own prefill** — it arrives prefilled with "today"/a suggested slot in the profile's locale, which doubles as a worked example of order, separator, and 12h/24h convention. Residual ambiguity (prefill day == month, non-English 12h locales) is documented in the helpers' docstrings; the flow verifies the pickers' accepted values and reports `schedule_rejected` rather than scheduling at a wrong time.
  - Dialog primary action via the repo's existing last-button convention, scoped to the dialog holding the date input (hidden video-player dialogs on the feed would otherwise shift the count).
- **Dry-run cleanup without the discard prompt.** Escape does not close this composer, and the discard-prompt buttons have no locale-independent identity — but an *empty* composer dismisses cleanly, so cleanup empties the editor first and closes via `button[data-test-modal-close-btn]`.

## Verification (live, end-to-end)

- Dry run via direct extractor call and via `tools/call` on a running streamable-http server: LinkedIn echoed `Posting Fri, Aug 14 at 11:45 AM` for `2026-08-14 11:45`, draft discarded, no dialogs left behind.
- Real run (`confirm_schedule=true`): returned `scheduled: true`, and the post was independently confirmed in LinkedIn's own **Scheduled posts** list (screenshot taken during verification showed the entry "Posting Tue, Aug 11 at 10:00 AM").
- `ruff check`, `ruff format`, `ty check`, pre-commit all pass; 13 new tests (9 for the two locale-format helpers, 4 for the tool wrapper) and the affected test files pass (338 tests).

## Synthetic prompt

> Add a `schedule_post` tool that schedules a feed post via LinkedIn's native Schedule-for-later composer flow. Probe the live composer first (it renders in the `#interop-outlet` shadow root — use piercing locators, not page.evaluate; open it via `/feed/?shareActive=true`; set the schedule before typing because the round-trip drops typed text). Identify controls locale-independently (`data-test-icon="clock-medium"`, the `#share-post__scheduled-*` input ids, last-button-primary convention) and format date/time by copying the dialog's own prefill. Gate with `confirm_schedule` like `send_message`, with a full dry-run mode that discards by emptying the editor before dismissing. Add tool + extractor method, unit tests, README/manifest entries.

Generated with Claude Fable 5 (claude-fable-5)
