### PR TITLE
feat(post): Add delete_scheduled_post tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `search_posts` | Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter (past-24h/past-week/past-month) | working |
 | `schedule_post` | Schedule a feed post via LinkedIn's native Schedule-for-later flow (requires confirmation; publishes even when this server is offline) | working |
 | `get_scheduled_posts` | List the authenticated user's scheduled posts (scheduled moment + body preview per entry) | working |
+| `edit_scheduled_post` | Edit a scheduled post's body and/or scheduled moment in place, selected by a body-text snippet (requires confirmation) | working |
 | `close_session` | Close browser session and clean up resources | working |
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `schedule_post` | Schedule a feed post via LinkedIn's native Schedule-for-later flow (requires confirmation; publishes even when this server is offline) | working |
 | `get_scheduled_posts` | List the authenticated user's scheduled posts (scheduled moment + body preview per entry) | working |
 | `edit_scheduled_post` | Edit a scheduled post's body and/or scheduled moment in place, selected by a body-text snippet (requires confirmation) | working |
+| `delete_scheduled_post` | Delete a scheduled post, selected by a body-text snippet (requires confirmation; not recoverable) | working |
 | `close_session` | Close browser session and clean up resources | working |
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `search_posts` | Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter (past-24h/past-week/past-month) | working |
 | `schedule_post` | Schedule a feed post via LinkedIn's native Schedule-for-later flow (requires confirmation; publishes even when this server is offline) | working |
+| `get_scheduled_posts` | List the authenticated user's scheduled posts (scheduled moment + body preview per entry) | working |
 | `close_session` | Close browser session and clean up resources | working |
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `search_posts` | Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter (past-24h/past-week/past-month) | working |
+| `schedule_post` | Schedule a feed post via LinkedIn's native Schedule-for-later flow (requires confirmation; publishes even when this server is offline) | working |
 | `close_session` | Close browser session and clean up resources | working |
 
 <br/>

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5087,12 +5087,12 @@ class LinkedInExtractor:
             failure = await self._open_scheduled_posts_list()
             if failure is not None:
                 return self._scheduled_action_result(self._page.url, *failure)
-            resolved = await self._resolve_scheduled_entry(match_text, occurrence)
-            if isinstance(resolved, tuple):
+            entries: list[str] = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
+            resolved = _match_scheduled_entries(entries, match_text, occurrence)
+            if not isinstance(resolved, _ScheduledEntryMatch):
                 await self._dismiss_scheduled_posts_list()
                 return self._scheduled_action_result(self._page.url, *resolved)
-            entries: list[str] = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
-            preview = entries[resolved][:200] if resolved < len(entries) else ""
+            preview = entries[resolved.index][:200]
             await self._dismiss_scheduled_posts_list()
             return self._scheduled_action_result(
                 self._page.url,
@@ -5105,9 +5105,9 @@ class LinkedInExtractor:
         opened = await self._open_scheduled_entry_action(
             match_text, occurrence, _SCHEDULED_MENU_DELETE_SELECTOR
         )
-        if isinstance(opened, tuple):
+        if not isinstance(opened, _OpenedScheduledEntry):
             return self._scheduled_action_result(self._page.url, *opened)
-        entry_preview = opened[:200]
+        entry_preview = opened.entry_text[:200]
 
         # The confirmation is the visible dialog holding no entry overflow
         # icons — the list modal has one per entry and stays open underneath,
@@ -5139,20 +5139,26 @@ class LinkedInExtractor:
             )
         await asyncio.sleep(1.5)
 
-        # The list modal stays open; the entry's absence from it is the
-        # evidence of deletion, checked the same way resolution matched it.
+        # The list modal stays open; the evidence of deletion is the match
+        # count dropping by exactly one. Checking for *absence* would fail
+        # whenever other entries also contain the snippet (an explicit
+        # occurrence among duplicates): the survivors would read as "still
+        # listed", and a caller retrying the reported failure would delete a
+        # second, different post.
         remaining = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
         needle = " ".join(match_text.split()).casefold()
-        still_there = any(
-            needle in " ".join(entry.split()).casefold() for entry in remaining
+        remaining_matches = sum(
+            1 for entry in remaining if needle in " ".join(entry.split()).casefold()
         )
         url = self._page.url
         await self._dismiss_scheduled_posts_list()
-        if still_there:
+        if remaining_matches != opened.match_count - 1:
             return self._scheduled_action_result(
                 url,
                 "delete_unconfirmed",
-                "The entry is still listed after the delete confirmation.",
+                f"Expected {opened.match_count - 1} matching entr(ies) after "
+                f"deletion but the list shows {remaining_matches}. Re-read "
+                "the list with get_scheduled_posts before retrying anything.",
                 entry_preview=entry_preview,
             )
         return self._scheduled_action_result(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4542,7 +4542,25 @@ class LinkedInExtractor:
                 "list_unavailable",
                 "LinkedIn did not open the scheduled posts view.",
             )
-        await asyncio.sleep(1.0)  # let the list hydrate
+        # Hydration is not bounded, so a fixed delay is not either: the modal
+        # renders its heading before its entries, and a read taken in between
+        # looks exactly like an empty queue. Settled means two consecutive
+        # identical non-empty samples of the modal's own text; the deadline
+        # keeps a modal that never settles from hanging the tool.
+        previous = ""
+        for _ in range(16):
+            await asyncio.sleep(0.5)
+            try:
+                sample = await (
+                    self._page.locator(_DIALOG_SELECTOR)
+                    .filter(visible=True)
+                    .first.inner_text()
+                )
+            except Exception:
+                sample = ""
+            if sample.strip() and sample == previous:
+                break
+            previous = sample
         return None
 
     async def _dismiss_scheduled_posts_list(self) -> None:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -225,22 +225,74 @@ _SCHEDULE_VIEW_ALL_BUTTON_SELECTOR = (
     'button:has(svg[data-test-icon="arrow-right-small"]), '
     'button:has(use[href="#arrow-right-small"])'
 )
+# Each scheduled-list entry has an overflow ("...") menu.
+_SCHEDULED_ENTRY_OVERFLOW_SELECTOR = (
+    'dialog[open] button:has(svg[data-test-icon*="overflow"]), '
+    '[role="dialog"] button:has(svg[data-test-icon*="overflow"])'
+)
+# The menu's actions are div[role="button"] elements (not native buttons, which
+# keeps these selectors from ever matching composer buttons), identified by
+# icon test hooks: edit-medium = "Edit post", trash-medium = "Delete post".
+_SCHEDULED_MENU_EDIT_SELECTOR = (
+    '[role="button"]:has(svg[data-test-icon="edit-medium"]), '
+    '[role="button"]:has(use[href="#edit-medium"])'
+)
+_SCHEDULED_MENU_DELETE_SELECTOR = (
+    '[role="button"]:has(svg[data-test-icon="trash-medium"]), '
+    '[role="button"]:has(use[href="#trash-medium"])'
+)
+
+# Maps every visible overflow button in the scheduled-posts modal to its
+# entry's text, in DOM order (the same order the modal renders). This is the
+# one place the scheduled-post flows run JS: matching a button to its entry
+# means climbing to the nearest ancestor that holds one entry's text, which
+# CSS locators cannot express. The composer's shadow root is open, so the walk
+# recurses into it explicitly — `querySelectorAll` alone would see nothing.
+_SCHEDULED_ENTRY_MAP_JS = """() => {
+  const out = [];
+  const walk = (root) => {
+    for (const b of root.querySelectorAll('button')) {
+      const hasOverflow = Array.from(b.querySelectorAll('svg')).some(
+        s => (s.getAttribute('data-test-icon') || '').includes('overflow'));
+      if (!hasOverflow || !(b.offsetWidth || b.offsetHeight)) continue;
+      let node = b, entryText = '';
+      for (let i = 0; i < 8 && node; i++) {
+        node = node.parentElement;
+        if (!node) break;
+        const t = (node.innerText || '');
+        // The entry container is the largest ancestor still holding a single
+        // entry; the whole modal's text is far larger and stops the climb.
+        if (t.length > 30 && t.length < 2500) entryText = t;
+        if (t.length >= 2500) break;
+      }
+      out.push(entryText);
+    }
+    for (const el of root.querySelectorAll('*')) if (el.shadowRoot) walk(el.shadowRoot);
+  };
+  walk(document);
+  return out;
+}"""
 
 
 def _resolve_date_order(
-    current_value: str, placeholder: str, today: datetime.date
+    current_value: str, placeholder: str, today: datetime.date | None
 ) -> tuple[str, str, str] | None:
     """Determine the date input's slot order, e.g. ``("m", "d", "y")``.
 
-    Two independent measurements, tried in turn; None when neither decides.
+    Independent measurements, tried in turn; None when none decides.
 
-    1. The prefill is LinkedIn's rendering of its own "today", which can sit
+    1. A small number above 12 cannot be a month, so it names the day slot
+       outright — valid whatever date the prefill happens to render.
+    2. The prefill is LinkedIn's rendering of its own "today", which can sit
        at most one calendar day from the server's UTC today. Reading the two
        small numbers both ways yields two *different* dates whenever day and
        month differ, and two distinct readings are never both inside a
        three-consecutive-day window — so a reading that lands in the window is
-       proof of the order, not a guess.
-    2. The placeholder's short tokens. Across the Latin-script locales
+       proof of the order, not a guess. Only applies when the caller knows the
+       prefill renders today (``today`` is not None): the edit flow's prefill
+       renders the post's *current schedule*, where a window hit would be a
+       coincidence and could prove the wrong order.
+    3. The placeholder's short tokens. Across the Latin-script locales
        LinkedIn ships, the month token is the one starting with ``m`` (en
        ``mm``, de ``MM``/Monat, fr ``mm``/mois, es mes, it mese, pt mês, nl
        maand) while the day letter varies (``dd``, ``TT``, ``jj``, ``gg``) —
@@ -262,18 +314,24 @@ def _resolve_date_order(
             slots[rest[1]] = "m" if day_first else "d"
             return (slots[0], slots[1], slots[2])
 
-        window = {today + datetime.timedelta(days=k) for k in (-1, 0, 1)}
+        if a > 12 and b <= 12:
+            return order_of(day_first=True)
+        if b > 12 and a <= 12:
+            return order_of(day_first=False)
 
-        def in_window(month: int, day: int) -> bool:
-            try:
-                return datetime.date(year, month, day) in window
-            except ValueError:
-                return False
+        if today is not None:
+            window = {today + datetime.timedelta(days=k) for k in (-1, 0, 1)}
 
-        month_first = in_window(a, b)
-        day_first = in_window(b, a)
-        if month_first != day_first:
-            return order_of(day_first)
+            def in_window(month: int, day: int) -> bool:
+                try:
+                    return datetime.date(year, month, day) in window
+                except ValueError:
+                    return False
+
+            month_first = in_window(a, b)
+            day_first = in_window(b, a)
+            if month_first != day_first:
+                return order_of(day_first)
 
     tokens = re.findall(r"[^\W\d_]+", placeholder or "")
     if len(tokens) == 3:
@@ -293,6 +351,8 @@ def _format_schedule_date(
     current_value: str,
     placeholder: str = "",
     today: datetime.date | None = None,
+    *,
+    prefill_renders_today: bool = True,
 ) -> tuple[str | None, tuple[str, str, str] | None]:
     """Format a date the way the schedule dialog's own prefill formats one.
 
@@ -301,12 +361,19 @@ def _format_schedule_date(
     ``(None, None)`` is returned so the caller refuses rather than gambling
     the calendar day — a reversed date passes every later check LinkedIn
     offers, because both readings are valid dates.
+
+    ``prefill_renders_today`` must be False when the prefill renders anything
+    other than today (the edit flow: it shows the post's current schedule),
+    which withholds the today-window proof and leaves the >12 and placeholder
+    rules.
     """
-    if today is None:
+    if today is None and prefill_renders_today:
         today = datetime.datetime.now(datetime.timezone.utc).date()
     separators = re.findall(r"\D+", current_value)
     separator = separators[0] if separators else "/"
-    order = _resolve_date_order(current_value, placeholder, today)
+    order = _resolve_date_order(
+        current_value, placeholder, today if prefill_renders_today else None
+    )
     if order is None:
         if day != month:
             return None, None
@@ -4607,6 +4674,350 @@ class LinkedInExtractor:
                 "schedule.",
             }
         return self._single_section_result(url, "scheduled_posts", text)
+
+    @staticmethod
+    def _scheduled_action_result(
+        url: str,
+        status: str,
+        message: str,
+        *,
+        done: bool = False,
+        entry_preview: str | None = None,
+        composer_text: str | None = None,
+    ) -> dict[str, Any]:
+        """Build a structured response for the scheduled-entry action tools."""
+        result: dict[str, Any] = {
+            "url": url,
+            "status": status,
+            "message": message,
+            "done": done,
+        }
+        if entry_preview is not None:
+            result["entry_preview"] = entry_preview
+        if composer_text is not None:
+            result["composer_text"] = composer_text
+        return result
+
+    async def _resolve_scheduled_entry(
+        self, match_text: str, occurrence: int
+    ) -> int | tuple[str, str]:
+        """Resolve a body snippet to an overflow-button index in the open list.
+
+        Resolution happens against the live list at action time rather than
+        against a remembered index: the queue shifts whenever a scheduled post
+        publishes, so a position captured earlier can name a different post by
+        the time it is used. Returns the index, or ``(status, message)``.
+        """
+        entries: list[str] = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
+        needle = " ".join(match_text.split()).casefold()
+        matches = [
+            i
+            for i, entry in enumerate(entries)
+            if needle in " ".join(entry.split()).casefold()
+        ]
+        if not matches:
+            return (
+                "entry_not_found",
+                f"No scheduled post contains {match_text!r} "
+                f"({len(entries)} entries in the list).",
+            )
+        if len(matches) > 1 and occurrence >= len(matches):
+            return (
+                "entry_ambiguous",
+                f"{len(matches)} scheduled posts contain {match_text!r} and "
+                f"occurrence={occurrence} is out of range; pass a longer "
+                "snippet or an occurrence between 0 and "
+                f"{len(matches) - 1}.",
+            )
+        if occurrence >= len(matches):
+            return (
+                "entry_not_found",
+                f"Only {len(matches)} scheduled post(s) contain "
+                f"{match_text!r}; occurrence={occurrence} is out of range.",
+            )
+        return matches[occurrence]
+
+    async def _open_scheduled_entry_action(
+        self, match_text: str, occurrence: int, action_selector: str
+    ) -> tuple[str, str] | str:
+        """Open the list, resolve the entry, and click one of its menu actions.
+
+        Returns the matched entry's text on success, or ``(status, message)``
+        with the list dismissed on failure.
+        """
+        failure = await self._open_scheduled_posts_list()
+        if failure is not None:
+            return failure
+
+        resolved = await self._resolve_scheduled_entry(match_text, occurrence)
+        if isinstance(resolved, tuple):
+            await self._dismiss_scheduled_posts_list()
+            return resolved
+        entries: list[str] = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
+        entry_text = entries[resolved] if resolved < len(entries) else ""
+
+        try:
+            await (
+                self._page.locator(_SCHEDULED_ENTRY_OVERFLOW_SELECTOR)
+                .nth(resolved)
+                .click(timeout=5000)
+            )
+            action = self._page.locator(action_selector).filter(visible=True).first
+            await action.click(timeout=5000)
+        except Exception:
+            logger.debug("Scheduled entry menu action failed", exc_info=True)
+            await self._dismiss_scheduled_posts_list()
+            return (
+                "menu_unavailable",
+                "The scheduled post's menu did not expose the expected action.",
+            )
+        return entry_text
+
+    async def _abandon_edit_surface(self) -> None:
+        """Leave an edit composer without saving, locale-independently.
+
+        A dirty composer's dismiss button raises a discard prompt whose
+        buttons have only label text to tell apart, so instead of answering it
+        the flow navigates away: an SPA route change tears the modal down and
+        the scheduled post keeps its stored state (verified live — a dry-run
+        edit left the entry unchanged).
+        """
+        try:
+            await self._page.goto(
+                "https://www.linkedin.com/feed/", wait_until="domcontentloaded"
+            )
+        except Exception:
+            logger.debug("Abandoning the edit surface failed", exc_info=True)
+
+    async def edit_scheduled_post(
+        self,
+        match_text: str,
+        *,
+        new_text: str | None = None,
+        new_year: int | None = None,
+        new_month: int | None = None,
+        new_day: int | None = None,
+        new_hour: int | None = None,
+        new_minute: int | None = None,
+        occurrence: int = 0,
+        confirm_edit: bool,
+    ) -> dict[str, Any]:
+        """Edit a scheduled post's body and/or scheduled moment in place.
+
+        Drives the entry's "Edit post" action, which opens the full composer
+        with the schedule chip, so one flow covers body, time, or both. Date
+        and time components are each optional as a group: whichever is omitted
+        keeps the post's current value, which arrives as the schedule dialog's
+        prefill.
+        """
+        opened = await self._open_scheduled_entry_action(
+            match_text, occurrence, _SCHEDULED_MENU_EDIT_SELECTOR
+        )
+        if isinstance(opened, tuple):
+            return self._scheduled_action_result(self._page.url, *opened)
+        entry_preview = opened[:200]
+
+        editor = self._page.locator(_COMPOSER_EDITOR_SELECTOR).first
+        try:
+            await editor.wait_for(state="visible", timeout=10000)
+        except PlaywrightTimeoutError:
+            await self._abandon_edit_surface()
+            return self._scheduled_action_result(
+                self._page.url,
+                "edit_unavailable",
+                "The edit composer did not open.",
+                entry_preview=entry_preview,
+            )
+        # The right post must be under the cursor before anything is changed.
+        current_text = await editor.inner_text()
+        if (
+            " ".join(match_text.split()).casefold()
+            not in " ".join(current_text.split()).casefold()
+        ):
+            await self._abandon_edit_surface()
+            return self._scheduled_action_result(
+                self._page.url,
+                "edit_mismatch",
+                "The edit composer opened a different post than the matched entry.",
+                entry_preview=entry_preview,
+            )
+
+        wants_reschedule = any(
+            v is not None for v in (new_year, new_month, new_day, new_hour, new_minute)
+        )
+        if wants_reschedule:
+            try:
+                await self._page.locator(
+                    _COMPOSER_SCHEDULE_BUTTON_SELECTOR
+                ).first.click(timeout=8000)
+                date_input = self._page.locator(_SCHEDULE_DATE_INPUT_SELECTOR).first
+                time_input = self._page.locator(_SCHEDULE_TIME_INPUT_SELECTOR).first
+                await date_input.wait_for(state="visible", timeout=8000)
+            except Exception:
+                await self._abandon_edit_surface()
+                return self._scheduled_action_result(
+                    self._page.url,
+                    "schedule_unavailable",
+                    "The schedule dialog did not open from the edit composer.",
+                    entry_preview=entry_preview,
+                )
+
+            # The prefills are the post's *current* schedule — the format
+            # example and the fallback for whichever component stays. Because
+            # they do not render today, the today-window order proof is
+            # withheld (prefill_renders_today=False): a coincidental window
+            # hit on an arbitrary scheduled date could prove the wrong order.
+            if new_year is not None:
+                assert new_month is not None and new_day is not None
+                date_value, date_order = _format_schedule_date(
+                    new_year,
+                    new_month,
+                    new_day,
+                    await date_input.input_value(),
+                    await date_input.get_attribute("placeholder") or "",
+                    prefill_renders_today=False,
+                )
+                if date_value is None or date_order is None:
+                    await self._abandon_edit_surface()
+                    return self._scheduled_action_result(
+                        self._page.url,
+                        "schedule_rejected",
+                        "The profile's date-component order could not be "
+                        "proven, and a reversed day/month would move the post "
+                        "to the wrong calendar day, so nothing was changed.",
+                        entry_preview=entry_preview,
+                    )
+                await date_input.fill(date_value)
+                await self._page.keyboard.press("Tab")
+                await asyncio.sleep(0.5)
+                # Position-by-position against the proven order; an unordered
+                # comparison would wave a reversed day/month through.
+                expected_by_pos = [
+                    {"y": new_year, "m": new_month, "d": new_day}[slot]
+                    for slot in date_order
+                ]
+                accepted_by_pos = [
+                    int(n) for n in re.findall(r"\d+", await date_input.input_value())
+                ]
+                if accepted_by_pos != expected_by_pos:
+                    await self._abandon_edit_surface()
+                    return self._scheduled_action_result(
+                        self._page.url,
+                        "schedule_rejected",
+                        f"The date picker did not accept {date_value!r}.",
+                        entry_preview=entry_preview,
+                    )
+            if new_hour is not None:
+                assert new_minute is not None
+                time_value = _format_schedule_time(
+                    new_hour, new_minute, await time_input.input_value()
+                )
+                await time_input.fill(time_value)
+                await self._page.keyboard.press("Tab")
+                await asyncio.sleep(0.5)
+                if (await time_input.input_value()).strip() != time_value:
+                    await self._abandon_edit_surface()
+                    return self._scheduled_action_result(
+                        self._page.url,
+                        "schedule_rejected",
+                        f"The time picker did not accept {time_value!r}.",
+                        entry_preview=entry_preview,
+                    )
+
+            # Confirm the dialog via its last *enabled* visible button. In edit
+            # mode Next stays disabled until something actually changed, and
+            # then the last enabled button is Back — which also returns to the
+            # composer, with the schedule simply kept as it was. Both paths
+            # land where the flow continues.
+            schedule_dialog = self._page.locator(_DIALOG_SELECTOR).filter(
+                has=self._page.locator(_SCHEDULE_DATE_INPUT_SELECTOR)
+            )
+            try:
+                await (
+                    schedule_dialog.locator(
+                        'button:not([disabled]):not([aria-disabled="true"])'
+                    )
+                    .filter(visible=True)
+                    .last.click(timeout=5000)
+                )
+                await date_input.wait_for(state="hidden", timeout=8000)
+            except Exception:
+                await self._abandon_edit_surface()
+                return self._scheduled_action_result(
+                    self._page.url,
+                    "schedule_rejected",
+                    "LinkedIn did not accept the new scheduled moment.",
+                    entry_preview=entry_preview,
+                )
+
+        if new_text is not None:
+            await editor.click(timeout=5000)
+            await self._page.keyboard.press("ControlOrMeta+a")
+            await self._page.keyboard.press("Delete")
+            await self._page.keyboard.type(new_text, delay=10)
+            await asyncio.sleep(1.0)
+
+        composer_dialog = self._composer_dialog()
+        composer_text = ""
+        try:
+            composer_text = await composer_dialog.first.inner_text()
+        except Exception:
+            logger.debug("Could not read edit composer text", exc_info=True)
+
+        if not confirm_edit:
+            await self._abandon_edit_surface()
+            return self._scheduled_action_result(
+                self._page.url,
+                "confirmation_required",
+                "Dry run complete. Set confirm_edit=true to save these changes.",
+                entry_preview=entry_preview,
+                composer_text=composer_text,
+            )
+
+        # The save action: in edit mode LinkedIn appends a trailing Back
+        # button, so "last button" no longer names the primary. The primary is
+        # the last visible button carrying no aria-label — utility buttons
+        # (dismiss, media, Back) are labelled for a screen reader, the primary
+        # is labelled by its own visible text. Attribute *presence*, so it
+        # holds across locales.
+        primary = (
+            composer_dialog.locator("button:not([aria-label])")
+            .filter(visible=True)
+            .last
+        )
+        try:
+            if await primary.is_disabled():
+                await self._abandon_edit_surface()
+                return self._scheduled_action_result(
+                    self._page.url,
+                    "edit_unavailable",
+                    "The composer's save action stayed disabled.",
+                    entry_preview=entry_preview,
+                    composer_text=composer_text,
+                )
+            await primary.click(timeout=8000)
+            await editor.wait_for(state="hidden", timeout=10000)
+        except Exception:
+            await self._abandon_edit_surface()
+            return self._scheduled_action_result(
+                self._page.url,
+                "edit_unconfirmed",
+                "LinkedIn did not confirm that the changes were saved.",
+                entry_preview=entry_preview,
+                composer_text=composer_text,
+            )
+
+        url = self._page.url
+        # Saving lands back on the scheduled list; leave everything closed.
+        await self._dismiss_scheduled_posts_list()
+        return self._scheduled_action_result(
+            url,
+            "edited",
+            "Scheduled post updated.",
+            done=True,
+            entry_preview=entry_preview,
+            composer_text=composer_text,
+        )
 
     async def schedule_post(
         self,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -274,6 +274,76 @@ _SCHEDULED_ENTRY_MAP_JS = """() => {
 }"""
 
 
+@dataclass(frozen=True)
+class _ScheduledEntryMatch:
+    """A resolved scheduled-list entry: its index and how many entries matched."""
+
+    index: int
+    match_count: int
+
+
+@dataclass(frozen=True)
+class _OpenedScheduledEntry:
+    """A scheduled-list entry whose menu action was successfully opened."""
+
+    entry_text: str
+    match_count: int
+
+
+def _match_scheduled_entries(
+    entries: list[str], match_text: str, occurrence: int | None
+) -> _ScheduledEntryMatch | tuple[str, str]:
+    """Match a body snippet against one snapshot of the scheduled list.
+
+    Pure so a single snapshot can serve matching, preview, and later
+    verification — two separately-taken snapshots can disagree about a live
+    queue. Returns the match, or ``(status, message)``.
+
+    A blank snippet is refused outright: normalized to an empty needle it
+    would be contained in *every* entry, and with a single queued post that
+    "unique" match would act on a post the caller never named.
+
+    ``occurrence=None`` demands a *unique* match: several matching entries
+    are then an error, never a silent first pick — a defaulted zero used to
+    select the first match, and a confirmed edit could change the wrong post
+    while reporting success. Passing an integer states the caller has seen
+    the list and is choosing among known duplicates.
+    """
+    needle = " ".join(match_text.split()).casefold()
+    if not needle:
+        return (
+            "entry_not_found",
+            "match_text is empty; pass a snippet of the post's body text.",
+        )
+    matches = [
+        i
+        for i, entry in enumerate(entries)
+        if needle in " ".join(entry.split()).casefold()
+    ]
+    if not matches:
+        return (
+            "entry_not_found",
+            f"No scheduled post contains {match_text!r} "
+            f"({len(entries)} entries in the list).",
+        )
+    if occurrence is None:
+        if len(matches) > 1:
+            return (
+                "entry_ambiguous",
+                f"{len(matches)} scheduled posts contain {match_text!r}. "
+                "Pass a longer snippet, or an occurrence between 0 and "
+                f"{len(matches) - 1} to choose among them.",
+            )
+        occurrence = 0
+    if occurrence >= len(matches):
+        return (
+            "entry_not_found",
+            f"Only {len(matches)} scheduled post(s) contain "
+            f"{match_text!r}; occurrence={occurrence} is out of range.",
+        )
+    return _ScheduledEntryMatch(index=matches[occurrence], match_count=len(matches))
+
+
 def _resolve_date_order(
     current_value: str, placeholder: str, today: datetime.date | None
 ) -> tuple[str, str, str] | None:
@@ -4698,75 +4768,46 @@ class LinkedInExtractor:
             result["composer_text"] = composer_text
         return result
 
-    async def _resolve_scheduled_entry(
-        self, match_text: str, occurrence: int | None
-    ) -> int | tuple[str, str]:
-        """Resolve a body snippet to an overflow-button index in the open list.
-
-        Resolution happens against the live list at action time rather than
-        against a remembered index: the queue shifts whenever a scheduled post
-        publishes, so a position captured earlier can name a different post by
-        the time it is used. Returns the index, or ``(status, message)``.
-
-        ``occurrence=None`` demands a *unique* match: several matching entries
-        are then an error, never a silent first pick — a defaulted zero used
-        to select the first match, and a confirmed edit could change the wrong
-        post while reporting success. Passing an integer states the caller has
-        seen the list and is choosing among known duplicates.
-        """
-        entries: list[str] = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
-        needle = " ".join(match_text.split()).casefold()
-        matches = [
-            i
-            for i, entry in enumerate(entries)
-            if needle in " ".join(entry.split()).casefold()
-        ]
-        if not matches:
-            return (
-                "entry_not_found",
-                f"No scheduled post contains {match_text!r} "
-                f"({len(entries)} entries in the list).",
-            )
-        if occurrence is None:
-            if len(matches) > 1:
-                return (
-                    "entry_ambiguous",
-                    f"{len(matches)} scheduled posts contain {match_text!r}. "
-                    "Pass a longer snippet, or an occurrence between 0 and "
-                    f"{len(matches) - 1} to choose among them.",
-                )
-            occurrence = 0
-        if occurrence >= len(matches):
-            return (
-                "entry_not_found",
-                f"Only {len(matches)} scheduled post(s) contain "
-                f"{match_text!r}; occurrence={occurrence} is out of range.",
-            )
-        return matches[occurrence]
-
     async def _open_scheduled_entry_action(
         self, match_text: str, occurrence: int | None, action_selector: str
-    ) -> tuple[str, str] | str:
+    ) -> "_OpenedScheduledEntry | tuple[str, str]":
         """Open the list, resolve the entry, and click one of its menu actions.
 
-        Returns the matched entry's text on success, or ``(status, message)``
-        with the list dismissed on failure.
+        Resolution happens against the live list at action time rather than
+        against a remembered index — the queue shifts whenever a scheduled
+        post publishes — and from a *single* snapshot: matching and the entry
+        text come from one mapping. Because the click itself is positional, a
+        second snapshot immediately before it must still show the same text at
+        the same index; otherwise the action is refused as ``entry_moved``
+        rather than landing on whichever post now occupies the position.
+
+        Returns the opened entry on success, or ``(status, message)`` with the
+        list dismissed on failure.
         """
         failure = await self._open_scheduled_posts_list()
         if failure is not None:
             return failure
 
-        resolved = await self._resolve_scheduled_entry(match_text, occurrence)
-        if isinstance(resolved, tuple):
+        entries: list[str] = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
+        resolved = _match_scheduled_entries(entries, match_text, occurrence)
+        if not isinstance(resolved, _ScheduledEntryMatch):
             await self._dismiss_scheduled_posts_list()
             return resolved
-        entries: list[str] = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
-        entry_text = entries[resolved] if resolved < len(entries) else ""
+        entry_text = entries[resolved.index]
+
+        recheck: list[str] = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
+        if resolved.index >= len(recheck) or recheck[resolved.index] != entry_text:
+            await self._dismiss_scheduled_posts_list()
+            return (
+                "entry_moved",
+                "The scheduled list changed while the entry was being "
+                "resolved; nothing was touched. Retry.",
+            )
 
         try:
             await (
                 self._page.locator(_SCHEDULED_ENTRY_OVERFLOW_SELECTOR)
-                .nth(resolved)
+                .nth(resolved.index)
                 .click(timeout=5000)
             )
             action = self._page.locator(action_selector).filter(visible=True).first
@@ -4778,7 +4819,9 @@ class LinkedInExtractor:
                 "menu_unavailable",
                 "The scheduled post's menu did not expose the expected action.",
             )
-        return entry_text
+        return _OpenedScheduledEntry(
+            entry_text=entry_text, match_count=resolved.match_count
+        )
 
     async def _abandon_edit_surface(self) -> None:
         """Leave an edit composer without saving, locale-independently.
@@ -4820,9 +4863,9 @@ class LinkedInExtractor:
         opened = await self._open_scheduled_entry_action(
             match_text, occurrence, _SCHEDULED_MENU_EDIT_SELECTOR
         )
-        if isinstance(opened, tuple):
+        if not isinstance(opened, _OpenedScheduledEntry):
             return self._scheduled_action_result(self._page.url, *opened)
-        entry_preview = opened[:200]
+        entry_preview = opened.entry_text[:200]
 
         editor = self._page.locator(_COMPOSER_EDITOR_SELECTOR).first
         try:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -221,41 +221,93 @@ _SCHEDULE_TIME_INPUT_SELECTOR = "input#share-post__scheduled-time"
 _COMPOSER_DISMISS_SELECTOR = "button[data-test-modal-close-btn]"
 
 
-def _format_schedule_date(year: int, month: int, day: int, current_value: str) -> str:
-    """Format a date the way the schedule dialog's own prefill formats one.
+def _resolve_date_order(
+    current_value: str, placeholder: str, today: datetime.date
+) -> tuple[str, str, str] | None:
+    """Determine the date input's slot order, e.g. ``("m", "d", "y")``.
 
-    The date input arrives prefilled with *today* in the profile's locale
-    (measured: ``8/8/2026`` for en with placeholder ``mm/dd/yyyy``). Today's
-    components are known, so the prefill doubles as a worked example of the
-    expected order and separator — a measurement, not a translation table.
-    Only when today's day and month are equal (~1 day a month) is the order
-    unreadable from the example; then the en ``month/day/year`` order is
-    assumed. Locales whose *order* differs from en and whose prefill is
-    ambiguous that day may mis-order — a bounded, dated limitation.
+    Two independent measurements, tried in turn; None when neither decides.
+
+    1. The prefill is LinkedIn's rendering of its own "today", which can sit
+       at most one calendar day from the server's UTC today. Reading the two
+       small numbers both ways yields two *different* dates whenever day and
+       month differ, and two distinct readings are never both inside a
+       three-consecutive-day window — so a reading that lands in the window is
+       proof of the order, not a guess.
+    2. The placeholder's short tokens. Across the Latin-script locales
+       LinkedIn ships, the month token is the one starting with ``m`` (en
+       ``mm``, de ``MM``/Monat, fr ``mm``/mois, es mes, it mese, pt mês, nl
+       maand) while the day letter varies (``dd``, ``TT``, ``jj``, ``gg``) —
+       a per-locale table in the sense the scraping rules require, documented
+       here as such. Locales outside it (non-Latin scripts) fall through.
     """
     numbers = re.findall(r"\d+", current_value)
+    if len(numbers) == 3:
+        values = [int(n) for n in numbers]
+        year_pos = max(range(3), key=lambda i: (len(numbers[i]) >= 4, values[i]))
+        rest = [i for i in range(3) if i != year_pos]
+        a, b = values[rest[0]], values[rest[1]]
+        year = values[year_pos]
+
+        def order_of(day_first: bool) -> tuple[str, str, str]:
+            slots = ["", "", ""]
+            slots[year_pos] = "y"
+            slots[rest[0]] = "d" if day_first else "m"
+            slots[rest[1]] = "m" if day_first else "d"
+            return (slots[0], slots[1], slots[2])
+
+        window = {today + datetime.timedelta(days=k) for k in (-1, 0, 1)}
+
+        def in_window(month: int, day: int) -> bool:
+            try:
+                return datetime.date(year, month, day) in window
+            except ValueError:
+                return False
+
+        month_first = in_window(a, b)
+        day_first = in_window(b, a)
+        if month_first != day_first:
+            return order_of(day_first)
+
+    tokens = re.findall(r"[^\W\d_]+", placeholder or "")
+    if len(tokens) == 3:
+        parts = [
+            "y" if len(t) > 2 else ("m" if t.lower().startswith("m") else "d")
+            for t in tokens
+        ]
+        if sorted(parts) == ["d", "m", "y"]:
+            return (parts[0], parts[1], parts[2])
+    return None
+
+
+def _format_schedule_date(
+    year: int,
+    month: int,
+    day: int,
+    current_value: str,
+    placeholder: str = "",
+    today: datetime.date | None = None,
+) -> tuple[str | None, tuple[str, str, str] | None]:
+    """Format a date the way the schedule dialog's own prefill formats one.
+
+    Returns ``(value, order)``. The order comes from `_resolve_date_order`;
+    when it cannot be proven and the target's day differs from its month,
+    ``(None, None)`` is returned so the caller refuses rather than gambling
+    the calendar day — a reversed date passes every later check LinkedIn
+    offers, because both readings are valid dates.
+    """
+    if today is None:
+        today = datetime.datetime.now(datetime.timezone.utc).date()
     separators = re.findall(r"\D+", current_value)
     separator = separators[0] if separators else "/"
-    if len(numbers) != 3:
-        return f"{month}/{day}/{year}"
-    prefill = [int(n) for n in numbers]
-    year_pos = max(range(3), key=lambda i: prefill[i])
-    rest = [i for i in range(3) if i != year_pos]
-    first, second = prefill[rest[0]], prefill[rest[1]]
-    slots = {year_pos: str(year)}
-    if first > 12 or (first != second and second > 12):
-        # A number that cannot be a month names the day slot outright.
-        day_first = first > 12
-    else:
-        # Both fit a month: read the order off the machine's own today, which
-        # matches LinkedIn's prefill except across a midnight timezone skew.
-        today = datetime.date.today()
-        day_first = first != second and first == today.day and second == today.month
-    if day_first:
-        slots[rest[0]], slots[rest[1]] = str(day), str(month)
-    else:
-        slots[rest[0]], slots[rest[1]] = str(month), str(day)
-    return separator.join(slots[i] for i in range(3))
+    order = _resolve_date_order(current_value, placeholder, today)
+    if order is None:
+        if day != month:
+            return None, None
+        # Either order writes the same digits; en order names the slots.
+        order = ("m", "d", "y")
+    mapping = {"y": str(year), "m": str(month), "d": str(day)}
+    return separator.join(mapping[slot] for slot in order), order
 
 
 def _format_schedule_time(hour: int, minute: int, current_value: str) -> str:
@@ -4481,9 +4533,22 @@ class LinkedInExtractor:
 
         # The prefilled values are LinkedIn's own rendering of a date and a
         # time in this profile's locale; format ours the same way.
-        date_value = _format_schedule_date(
-            year, month, day, await date_input.input_value()
+        date_value, date_order = _format_schedule_date(
+            year,
+            month,
+            day,
+            await date_input.input_value(),
+            await date_input.get_attribute("placeholder") or "",
         )
+        if date_value is None or date_order is None:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_rejected",
+                "The profile's date-component order could not be proven from "
+                "the schedule dialog, and a reversed day/month would schedule "
+                "the wrong calendar day, so nothing was scheduled.",
+            )
         time_value = _format_schedule_time(hour, minute, await time_input.input_value())
         await date_input.fill(date_value)
         await time_input.fill(time_value)
@@ -4493,9 +4558,15 @@ class LinkedInExtractor:
 
         accepted_date = await date_input.input_value()
         accepted_time = await time_input.input_value()
-        # Compare as numbers so zero-padding differences don't fail the check.
-        accepted_numbers = {int(n) for n in re.findall(r"\d+", accepted_date)}
-        if accepted_numbers != {year, month, day}:
+        # Position-by-position against the proven order — an unordered
+        # comparison would wave a reversed day/month through, since the
+        # reversal permutes the same numbers. Ints, so zero-padding
+        # normalization cannot fail the check.
+        expected_by_pos = [
+            {"y": year, "m": month, "d": day}[slot] for slot in date_order
+        ]
+        accepted_by_pos = [int(n) for n in re.findall(r"\d+", accepted_date)]
+        if accepted_by_pos != expected_by_pos:
             await self._clear_and_dismiss_composer()
             return self._schedule_post_result(
                 self._page.url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4575,6 +4575,19 @@ class LinkedInExtractor:
             logger.debug("Could not read scheduled posts modal", exc_info=True)
         url = self._page.url
         await self._dismiss_scheduled_posts_list()
+        if not text.strip():
+            # An empty read is a failed read, never an empty schedule: the
+            # modal always carries its own heading, and a schedule with
+            # nothing queued still says so in text. Returning a section-less
+            # result here made the two indistinguishable, and a caller acting
+            # on "nothing scheduled" double-posts.
+            return {
+                "url": url,
+                "status": "list_read_failed",
+                "message": "The scheduled posts view opened but its content "
+                "could not be read. Retry rather than assuming an empty "
+                "schedule.",
+            }
         return self._single_section_result(url, "scheduled_posts", text)
 
     async def schedule_post(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 from dataclasses import dataclass
 import json
 import logging
@@ -195,6 +196,85 @@ _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Dismiss"], '
     'button[aria-label*="Close"]'
 )
+
+# --- Share composer (feed post creation) -----------------------------------
+#
+# The composer renders inside an open shadow root (`#interop-outlet`, LinkedIn's
+# SDUI interop surface). Patchright locators pierce shadow roots, so plain CSS
+# works here; `page.evaluate` + `querySelectorAll` does not — keep any JS out of
+# this flow. All selectors below are structural (role/state/test hooks), never
+# layout class names and never label text.
+#
+# Opened by URL (`/feed/?shareActive=true`) rather than by clicking the
+# "Start a post" trigger, whose only stable identity is its label text.
+_COMPOSER_EDITOR_SELECTOR = 'div[role="textbox"][contenteditable="true"]'
+# The clock icon is the schedule affordance. `data-test-icon` is LinkedIn's own
+# test hook and carries the icon's name, not a translation.
+_COMPOSER_SCHEDULE_BUTTON_SELECTOR = (
+    'button:has(svg[data-test-icon="clock-medium"]), '
+    'button:has(use[href="#clock-medium"])'
+)
+# Semantic element ids, stable across sessions (unlike `ember\d+` ids).
+_SCHEDULE_DATE_INPUT_SELECTOR = "input#share-post__scheduled-date"
+_SCHEDULE_TIME_INPUT_SELECTOR = "input#share-post__scheduled-time"
+# LinkedIn's modal close button carries this test hook in the composer.
+_COMPOSER_DISMISS_SELECTOR = "button[data-test-modal-close-btn]"
+
+
+def _format_schedule_date(year: int, month: int, day: int, current_value: str) -> str:
+    """Format a date the way the schedule dialog's own prefill formats one.
+
+    The date input arrives prefilled with *today* in the profile's locale
+    (measured: ``8/8/2026`` for en with placeholder ``mm/dd/yyyy``). Today's
+    components are known, so the prefill doubles as a worked example of the
+    expected order and separator — a measurement, not a translation table.
+    Only when today's day and month are equal (~1 day a month) is the order
+    unreadable from the example; then the en ``month/day/year`` order is
+    assumed. Locales whose *order* differs from en and whose prefill is
+    ambiguous that day may mis-order — a bounded, dated limitation.
+    """
+    numbers = re.findall(r"\d+", current_value)
+    separators = re.findall(r"\D+", current_value)
+    separator = separators[0] if separators else "/"
+    if len(numbers) != 3:
+        return f"{month}/{day}/{year}"
+    prefill = [int(n) for n in numbers]
+    year_pos = max(range(3), key=lambda i: prefill[i])
+    rest = [i for i in range(3) if i != year_pos]
+    first, second = prefill[rest[0]], prefill[rest[1]]
+    slots = {year_pos: str(year)}
+    if first > 12 or (first != second and second > 12):
+        # A number that cannot be a month names the day slot outright.
+        day_first = first > 12
+    else:
+        # Both fit a month: read the order off the machine's own today, which
+        # matches LinkedIn's prefill except across a midnight timezone skew.
+        today = datetime.date.today()
+        day_first = first != second and first == today.day and second == today.month
+    if day_first:
+        slots[rest[0]], slots[rest[1]] = str(day), str(month)
+    else:
+        slots[rest[0]], slots[rest[1]] = str(month), str(day)
+    return separator.join(slots[i] for i in range(3))
+
+
+def _format_schedule_time(hour: int, minute: int, current_value: str) -> str:
+    """Format a time the way the timepicker's own prefill formats one.
+
+    The timepicker prefills a suggested slot (measured: ``2:00 PM``). A
+    meridiem marker in the prefill means the locale renders 12-hour time; the
+    en markers are the only ones tabled here, and 24-hour ``HH:MM`` is the
+    fallback for every other locale. Documented limitation: a non-English
+    12-hour locale would get a 24-hour string, which LinkedIn's parser may
+    reject — the caller verifies the input's value after filling and reports
+    rejection rather than scheduling at a wrong time.
+    """
+    if re.search(r"\b[AP]\.?M\.?\b", current_value, re.IGNORECASE):
+        marker = "AM" if hour < 12 else "PM"
+        hour12 = hour % 12 or 12
+        return f"{hour12}:{minute:02d} {marker}"
+    return f"{hour:02d}:{minute:02d}"
+
 
 # Shared JS function that walks up from any /messaging/compose/ anchor
 # inside <main> to find the smallest ancestor that satisfies the
@@ -4288,6 +4368,226 @@ class LinkedInExtractor:
             "Message sent.",
             recipient_selected=recipient_selected,
             sent=True,
+        )
+
+    @staticmethod
+    def _schedule_post_result(
+        url: str,
+        status: str,
+        message: str,
+        *,
+        scheduled: bool = False,
+        scheduled_for: str | None = None,
+        composer_text: str | None = None,
+    ) -> dict[str, Any]:
+        """Build a structured response for the schedule_post tool."""
+        result: dict[str, Any] = {
+            "url": url,
+            "status": status,
+            "message": message,
+            "scheduled": scheduled,
+        }
+        if scheduled_for is not None:
+            result["scheduled_for"] = scheduled_for
+        if composer_text is not None:
+            result["composer_text"] = composer_text
+        return result
+
+    def _composer_dialog(self) -> Any:
+        """The dialog that holds the share composer's editor."""
+        return self._page.locator(_DIALOG_SELECTOR).filter(
+            has=self._page.locator(_COMPOSER_EDITOR_SELECTOR)
+        )
+
+    async def _clear_and_dismiss_composer(self) -> None:
+        """Empty the editor, then close the composer without a draft prompt.
+
+        Escape does not close this composer, and the discard-prompt buttons
+        have no locale-independent identity — but an *empty* composer closes
+        from its Dismiss button without any prompt (measured), so emptiness is
+        the dismissal strategy rather than prompt-button classification.
+        """
+        try:
+            editor = self._page.locator(_COMPOSER_EDITOR_SELECTOR).first
+            if await editor.is_visible():
+                await editor.click(timeout=2000)
+                await self._page.keyboard.press("ControlOrMeta+a")
+                await self._page.keyboard.press("Delete")
+            dismiss = self._page.locator(_COMPOSER_DISMISS_SELECTOR).first
+            await dismiss.click(timeout=3000)
+            await editor.wait_for(state="hidden", timeout=5000)
+        except Exception:
+            logger.debug("Composer dismissal failed", exc_info=True)
+
+    async def schedule_post(
+        self,
+        text: str,
+        *,
+        year: int,
+        month: int,
+        day: int,
+        hour: int,
+        minute: int,
+        confirm_schedule: bool,
+    ) -> dict[str, Any]:
+        """Schedule a feed post via LinkedIn's native Schedule-for-later flow.
+
+        The scheduled time is set *before* the text is typed: the composer
+        rebuilds its editor on the schedule round-trip and drops typed content
+        (measured), while text typed after the round-trip survives.
+
+        Args:
+            text: The post body.
+            year/month/day/hour/minute: Scheduled moment, interpreted by
+                LinkedIn in the profile's own timezone.
+            confirm_schedule: Must be True to actually schedule (False does a
+                dry run that fills everything and then discards).
+        """
+        await self._navigate_to_page("https://www.linkedin.com/feed/?shareActive=true")
+        await detect_rate_limit(self._page)
+
+        editor = self._page.locator(_COMPOSER_EDITOR_SELECTOR).first
+        try:
+            await editor.wait_for(state="visible", timeout=15000)
+        except PlaywrightTimeoutError:
+            return self._schedule_post_result(
+                self._page.url,
+                "composer_unavailable",
+                "LinkedIn did not open the share composer.",
+            )
+
+        schedule_button = self._page.locator(_COMPOSER_SCHEDULE_BUTTON_SELECTOR).first
+        try:
+            await schedule_button.click(timeout=8000)
+        except Exception:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_unavailable",
+                "LinkedIn did not expose a schedule (clock) action in the composer.",
+            )
+
+        date_input = self._page.locator(_SCHEDULE_DATE_INPUT_SELECTOR).first
+        time_input = self._page.locator(_SCHEDULE_TIME_INPUT_SELECTOR).first
+        try:
+            await date_input.wait_for(state="visible", timeout=8000)
+        except PlaywrightTimeoutError:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_unavailable",
+                "The schedule dialog did not open.",
+            )
+
+        # The prefilled values are LinkedIn's own rendering of a date and a
+        # time in this profile's locale; format ours the same way.
+        date_value = _format_schedule_date(
+            year, month, day, await date_input.input_value()
+        )
+        time_value = _format_schedule_time(hour, minute, await time_input.input_value())
+        await date_input.fill(date_value)
+        await time_input.fill(time_value)
+        # Blur so the pickers parse and commit what was typed.
+        await self._page.keyboard.press("Tab")
+        await asyncio.sleep(0.5)
+
+        accepted_date = await date_input.input_value()
+        accepted_time = await time_input.input_value()
+        # Compare as numbers so zero-padding differences don't fail the check.
+        accepted_numbers = {int(n) for n in re.findall(r"\d+", accepted_date)}
+        if accepted_numbers != {year, month, day}:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_rejected",
+                f"The date picker did not accept {date_value!r}; it shows {accepted_date!r}.",
+            )
+        if accepted_time.strip() != time_value:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_rejected",
+                f"The time picker did not accept {time_value!r}; it shows {accepted_time!r}.",
+            )
+
+        # Confirm the schedule: the dialog's primary action is its last button
+        # (Back/Next here — the same last-button convention the rest of this
+        # file relies on), scoped to the dialog that holds the date input so
+        # hidden video-player dialogs elsewhere on the feed cannot shift the
+        # count.
+        schedule_dialog = self._page.locator(_DIALOG_SELECTOR).filter(
+            has=self._page.locator(_SCHEDULE_DATE_INPUT_SELECTOR)
+        )
+        try:
+            await (
+                schedule_dialog.locator("button")
+                .filter(visible=True)
+                .last.click(timeout=5000)
+            )
+            await date_input.wait_for(state="hidden", timeout=8000)
+        except Exception:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_rejected",
+                "LinkedIn did not accept the scheduled date and time.",
+            )
+
+        # Now the text — clearing first, because the composer restores drafts.
+        await editor.click(timeout=5000)
+        await self._page.keyboard.press("ControlOrMeta+a")
+        await self._page.keyboard.press("Delete")
+        await self._page.keyboard.type(text, delay=10)
+        await asyncio.sleep(1.0)  # let the composer enable its primary action
+
+        composer_dialog = self._composer_dialog()
+        composer_text = ""
+        try:
+            composer_text = await composer_dialog.first.inner_text()
+        except Exception:
+            logger.debug("Could not read composer text", exc_info=True)
+
+        scheduled_for = f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute:02d}"
+        if not confirm_schedule:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "confirmation_required",
+                "Dry run complete. Set confirm_schedule=true to schedule the post.",
+                scheduled_for=scheduled_for,
+                composer_text=composer_text,
+            )
+
+        primary = composer_dialog.locator("button").filter(visible=True).last
+        try:
+            if await primary.is_disabled():
+                await self._clear_and_dismiss_composer()
+                return self._schedule_post_result(
+                    self._page.url,
+                    "schedule_unavailable",
+                    "The composer's Schedule action stayed disabled after typing.",
+                    scheduled_for=scheduled_for,
+                    composer_text=composer_text,
+                )
+            await primary.click(timeout=8000)
+            await editor.wait_for(state="hidden", timeout=10000)
+        except Exception:
+            await self._clear_and_dismiss_composer()
+            return self._schedule_post_result(
+                self._page.url,
+                "schedule_unconfirmed",
+                "LinkedIn did not confirm that the post was scheduled.",
+                scheduled_for=scheduled_for,
+                composer_text=composer_text,
+            )
+
+        return self._schedule_post_result(
+            self._page.url,
+            "scheduled",
+            "Post scheduled.",
+            scheduled=True,
+            scheduled_for=scheduled_for,
+            composer_text=composer_text,
         )
 
     async def _extract_root_content(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4699,7 +4699,7 @@ class LinkedInExtractor:
         return result
 
     async def _resolve_scheduled_entry(
-        self, match_text: str, occurrence: int
+        self, match_text: str, occurrence: int | None
     ) -> int | tuple[str, str]:
         """Resolve a body snippet to an overflow-button index in the open list.
 
@@ -4707,6 +4707,12 @@ class LinkedInExtractor:
         against a remembered index: the queue shifts whenever a scheduled post
         publishes, so a position captured earlier can name a different post by
         the time it is used. Returns the index, or ``(status, message)``.
+
+        ``occurrence=None`` demands a *unique* match: several matching entries
+        are then an error, never a silent first pick — a defaulted zero used
+        to select the first match, and a confirmed edit could change the wrong
+        post while reporting success. Passing an integer states the caller has
+        seen the list and is choosing among known duplicates.
         """
         entries: list[str] = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
         needle = " ".join(match_text.split()).casefold()
@@ -4721,14 +4727,15 @@ class LinkedInExtractor:
                 f"No scheduled post contains {match_text!r} "
                 f"({len(entries)} entries in the list).",
             )
-        if len(matches) > 1 and occurrence >= len(matches):
-            return (
-                "entry_ambiguous",
-                f"{len(matches)} scheduled posts contain {match_text!r} and "
-                f"occurrence={occurrence} is out of range; pass a longer "
-                "snippet or an occurrence between 0 and "
-                f"{len(matches) - 1}.",
-            )
+        if occurrence is None:
+            if len(matches) > 1:
+                return (
+                    "entry_ambiguous",
+                    f"{len(matches)} scheduled posts contain {match_text!r}. "
+                    "Pass a longer snippet, or an occurrence between 0 and "
+                    f"{len(matches) - 1} to choose among them.",
+                )
+            occurrence = 0
         if occurrence >= len(matches):
             return (
                 "entry_not_found",
@@ -4738,7 +4745,7 @@ class LinkedInExtractor:
         return matches[occurrence]
 
     async def _open_scheduled_entry_action(
-        self, match_text: str, occurrence: int, action_selector: str
+        self, match_text: str, occurrence: int | None, action_selector: str
     ) -> tuple[str, str] | str:
         """Open the list, resolve the entry, and click one of its menu actions.
 
@@ -4799,7 +4806,7 @@ class LinkedInExtractor:
         new_day: int | None = None,
         new_hour: int | None = None,
         new_minute: int | None = None,
-        occurrence: int = 0,
+        occurrence: int | None = None,
         confirm_edit: bool,
     ) -> dict[str, Any]:
         """Edit a scheduled post's body and/or scheduled moment in place.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5069,6 +5069,100 @@ class LinkedInExtractor:
             composer_text=composer_text,
         )
 
+    async def delete_scheduled_post(
+        self,
+        match_text: str,
+        *,
+        occurrence: int = 0,
+        confirm_delete: bool,
+    ) -> dict[str, Any]:
+        """Delete a scheduled post via its entry's Delete action.
+
+        The dry run stops after resolving the entry — LinkedIn's own dialog
+        warns "You won't be able to recover it", so the confirmation surface
+        is never even opened without confirm_delete. The confirm dialog's
+        primary is its last button (measured: Dismiss, Cancel, Delete).
+        """
+        if not confirm_delete:
+            failure = await self._open_scheduled_posts_list()
+            if failure is not None:
+                return self._scheduled_action_result(self._page.url, *failure)
+            resolved = await self._resolve_scheduled_entry(match_text, occurrence)
+            if isinstance(resolved, tuple):
+                await self._dismiss_scheduled_posts_list()
+                return self._scheduled_action_result(self._page.url, *resolved)
+            entries: list[str] = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
+            preview = entries[resolved][:200] if resolved < len(entries) else ""
+            await self._dismiss_scheduled_posts_list()
+            return self._scheduled_action_result(
+                self._page.url,
+                "confirmation_required",
+                "Dry run complete. Set confirm_delete=true to delete this "
+                "scheduled post; LinkedIn cannot recover a deleted one.",
+                entry_preview=preview,
+            )
+
+        opened = await self._open_scheduled_entry_action(
+            match_text, occurrence, _SCHEDULED_MENU_DELETE_SELECTOR
+        )
+        if isinstance(opened, tuple):
+            return self._scheduled_action_result(self._page.url, *opened)
+        entry_preview = opened[:200]
+
+        # The confirmation is the visible dialog holding no entry overflow
+        # icons — the list modal has one per entry and stays open underneath,
+        # and DOM order does not put the topmost dialog last, so "last visible
+        # dialog" resolved to the covered list modal (measured: its trailing
+        # Back button failed actionability under the confirmation overlay).
+        confirm_dialog = (
+            self._page.locator(f"{_DIALOG_SELECTOR}, [role='alertdialog']")
+            .filter(visible=True)
+            .filter(has_not=self._page.locator('svg[data-test-icon*="overflow"]'))
+            .last
+        )
+        try:
+            await confirm_dialog.wait_for(state="visible", timeout=5000)
+            await (
+                confirm_dialog.locator("button")
+                .filter(visible=True)
+                .last.click(timeout=5000)
+            )
+        except Exception:
+            logger.debug("Delete confirmation click failed", exc_info=True)
+            await self._page.keyboard.press("Escape")
+            await self._dismiss_scheduled_posts_list()
+            return self._scheduled_action_result(
+                self._page.url,
+                "delete_unconfirmed",
+                "LinkedIn's delete confirmation could not be completed.",
+                entry_preview=entry_preview,
+            )
+        await asyncio.sleep(1.5)
+
+        # The list modal stays open; the entry's absence from it is the
+        # evidence of deletion, checked the same way resolution matched it.
+        remaining = await self._page.evaluate(_SCHEDULED_ENTRY_MAP_JS)
+        needle = " ".join(match_text.split()).casefold()
+        still_there = any(
+            needle in " ".join(entry.split()).casefold() for entry in remaining
+        )
+        url = self._page.url
+        await self._dismiss_scheduled_posts_list()
+        if still_there:
+            return self._scheduled_action_result(
+                url,
+                "delete_unconfirmed",
+                "The entry is still listed after the delete confirmation.",
+                entry_preview=entry_preview,
+            )
+        return self._scheduled_action_result(
+            url,
+            "deleted",
+            "Scheduled post deleted.",
+            done=True,
+            entry_preview=entry_preview,
+        )
+
     async def schedule_post(
         self,
         text: str,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -219,6 +219,12 @@ _SCHEDULE_DATE_INPUT_SELECTOR = "input#share-post__scheduled-date"
 _SCHEDULE_TIME_INPUT_SELECTOR = "input#share-post__scheduled-time"
 # LinkedIn's modal close button carries this test hook in the composer.
 _COMPOSER_DISMISS_SELECTOR = "button[data-test-modal-close-btn]"
+# "View all scheduled posts" inside the schedule dialog: the only button there
+# carrying the forward-arrow icon (again a test-hook name, not a translation).
+_SCHEDULE_VIEW_ALL_BUTTON_SELECTOR = (
+    'button:has(svg[data-test-icon="arrow-right-small"]), '
+    'button:has(use[href="#arrow-right-small"])'
+)
 
 
 def _resolve_date_order(
@@ -4471,6 +4477,106 @@ class LinkedInExtractor:
         except Exception:
             logger.debug("Composer dismissal failed", exc_info=True)
 
+    async def _open_schedule_dialog(self) -> tuple[str, str] | None:
+        """Open the share composer and its schedule dialog.
+
+        Returns None on success, or a ``(status, message)`` pair after
+        dismissing whatever partial surface was reached. The composer is opened
+        by URL; the schedule dialog by the clock button.
+        """
+        await self._navigate_to_page("https://www.linkedin.com/feed/?shareActive=true")
+        await detect_rate_limit(self._page)
+
+        editor = self._page.locator(_COMPOSER_EDITOR_SELECTOR).first
+        try:
+            await editor.wait_for(state="visible", timeout=15000)
+        except PlaywrightTimeoutError:
+            return (
+                "composer_unavailable",
+                "LinkedIn did not open the share composer.",
+            )
+
+        schedule_button = self._page.locator(_COMPOSER_SCHEDULE_BUTTON_SELECTOR).first
+        try:
+            await schedule_button.click(timeout=8000)
+        except Exception:
+            await self._clear_and_dismiss_composer()
+            return (
+                "schedule_unavailable",
+                "LinkedIn did not expose a schedule (clock) action in the composer.",
+            )
+
+        try:
+            await self._page.locator(_SCHEDULE_DATE_INPUT_SELECTOR).first.wait_for(
+                state="visible", timeout=8000
+            )
+        except PlaywrightTimeoutError:
+            await self._clear_and_dismiss_composer()
+            return ("schedule_unavailable", "The schedule dialog did not open.")
+        return None
+
+    async def _open_scheduled_posts_list(self) -> tuple[str, str] | None:
+        """From anywhere, open the Scheduled posts modal.
+
+        LinkedIn exposes the list only behind the composer's schedule dialog
+        ("View all scheduled posts") — the modal replaces the dialog in place
+        and the address bar never changes, so there is no URL to navigate to.
+        Returns None with the modal open, or ``(status, message)``.
+        """
+        failure = await self._open_schedule_dialog()
+        if failure is not None:
+            return failure
+
+        schedule_dialog = self._page.locator(_DIALOG_SELECTOR).filter(
+            has=self._page.locator(_SCHEDULE_DATE_INPUT_SELECTOR)
+        )
+        view_all = schedule_dialog.locator(_SCHEDULE_VIEW_ALL_BUTTON_SELECTOR).first
+        try:
+            await view_all.click(timeout=5000)
+            await self._page.locator(_SCHEDULE_DATE_INPUT_SELECTOR).first.wait_for(
+                state="hidden", timeout=8000
+            )
+        except Exception:
+            await self._clear_and_dismiss_composer()
+            return (
+                "list_unavailable",
+                "LinkedIn did not open the scheduled posts view.",
+            )
+        await asyncio.sleep(1.0)  # let the list hydrate
+        return None
+
+    async def _dismiss_scheduled_posts_list(self) -> None:
+        """Close the Scheduled posts modal and any composer left behind it."""
+        try:
+            await self._page.locator(_COMPOSER_DISMISS_SELECTOR).first.click(
+                timeout=3000
+            )
+        except Exception:
+            logger.debug("Scheduled posts modal dismissal failed", exc_info=True)
+        # Defensive: tolerates the composer already being gone.
+        await self._clear_and_dismiss_composer()
+
+    async def get_scheduled_posts(self) -> dict[str, Any]:
+        """List the authenticated user's scheduled posts.
+
+        Read-only in effect: the composer is opened, never typed into, and
+        dismissed empty on every path.
+        """
+        failure = await self._open_scheduled_posts_list()
+        if failure is not None:
+            status, message = failure
+            return {"url": self._page.url, "status": status, "message": message}
+
+        list_dialog = self._page.locator(_DIALOG_SELECTOR).filter(visible=True)
+        text = ""
+        try:
+            text = await list_dialog.first.inner_text()
+        except Exception:
+            logger.debug("Could not read scheduled posts modal", exc_info=True)
+        url = self._page.url
+        await self._dismiss_scheduled_posts_list()
+        return self._single_section_result(url, "scheduled_posts", text)
+
     async def schedule_post(
         self,
         text: str,
@@ -4495,41 +4601,13 @@ class LinkedInExtractor:
             confirm_schedule: Must be True to actually schedule (False does a
                 dry run that fills everything and then discards).
         """
-        await self._navigate_to_page("https://www.linkedin.com/feed/?shareActive=true")
-        await detect_rate_limit(self._page)
+        failure = await self._open_schedule_dialog()
+        if failure is not None:
+            return self._schedule_post_result(self._page.url, *failure)
 
         editor = self._page.locator(_COMPOSER_EDITOR_SELECTOR).first
-        try:
-            await editor.wait_for(state="visible", timeout=15000)
-        except PlaywrightTimeoutError:
-            return self._schedule_post_result(
-                self._page.url,
-                "composer_unavailable",
-                "LinkedIn did not open the share composer.",
-            )
-
-        schedule_button = self._page.locator(_COMPOSER_SCHEDULE_BUTTON_SELECTOR).first
-        try:
-            await schedule_button.click(timeout=8000)
-        except Exception:
-            await self._clear_and_dismiss_composer()
-            return self._schedule_post_result(
-                self._page.url,
-                "schedule_unavailable",
-                "LinkedIn did not expose a schedule (clock) action in the composer.",
-            )
-
         date_input = self._page.locator(_SCHEDULE_DATE_INPUT_SELECTOR).first
         time_input = self._page.locator(_SCHEDULE_TIME_INPUT_SELECTOR).first
-        try:
-            await date_input.wait_for(state="visible", timeout=8000)
-        except PlaywrightTimeoutError:
-            await self._clear_and_dismiss_composer()
-            return self._schedule_post_result(
-                self._page.url,
-                "schedule_unavailable",
-                "The schedule dialog did not open.",
-            )
 
         # The prefilled values are LinkedIn's own rendering of a date and a
         # time in this profile's locale; format ours the same way.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5073,7 +5073,7 @@ class LinkedInExtractor:
         self,
         match_text: str,
         *,
-        occurrence: int = 0,
+        occurrence: int | None = None,
         confirm_delete: bool,
     ) -> dict[str, Any]:
         """Delete a scheduled post via its entry's Delete action.

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -320,6 +320,10 @@ def register_post_tools(
             own rendering of the (proposed) scheduled moment and body.
         """
         try:
+            if not match_text.strip():
+                raise ToolError(
+                    "match_text is empty; pass a snippet of the post's body text."
+                )
             if new_text is None and new_date is None and new_time is None:
                 raise ToolError(
                     "Nothing to change: pass new_text, new_date and/or new_time."

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -439,6 +439,10 @@ def register_post_tools(
             verified by the entry's absence from the list afterwards.
         """
         try:
+            if not match_text.strip():
+                raise ToolError(
+                    "match_text is empty; pass a snippet of the post's body text."
+                )
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="delete_scheduled_post"
             )
@@ -462,6 +466,8 @@ def register_post_tools(
 
             return result
 
+        except ToolError:
+            raise
         except AuthenticationError as e:
             try:
                 await handle_auth_error(e, ctx)

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -272,3 +272,125 @@ def register_post_tools(
                 raise_tool_error(relogin_exc, "get_scheduled_posts")
         except Exception as e:
             raise_tool_error(e, "get_scheduled_posts")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Edit Scheduled Post",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"post", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def edit_scheduled_post(
+        match_text: str,
+        confirm_edit: bool,
+        ctx: Context,
+        new_text: str | None = None,
+        new_date: str | None = None,
+        new_time: str | None = None,
+        occurrence: Annotated[int, Field(ge=0)] = 0,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Edit a scheduled post's body text and/or scheduled moment in place.
+
+        The post to edit is identified by match_text, a snippet of its current
+        body, resolved against the live scheduled-posts list at action time
+        (get_scheduled_posts shows the entries to pick a snippet from). The
+        snippet must match exactly one entry; when several entries share the
+        text, occurrence selects among them in list order. This is a write
+        operation when confirm_edit is True; with False it applies the changes
+        in the composer as a dry run, returns LinkedIn's rendering of the
+        result, and abandons them unsaved.
+
+        Args:
+            match_text: Snippet of the scheduled post's current body text.
+            confirm_edit: Must be True to actually save the changes.
+            ctx: FastMCP context for progress reporting
+            new_text: Replacement body text. Omit to keep the current body.
+            new_date: New date as YYYY-MM-DD. Omit to keep the current date.
+            new_time: New 24-hour time as HH:MM. Omit to keep the current time.
+            occurrence: 0-based selector among entries matching match_text.
+
+        Returns:
+            Dict with url, status, message, done (bool), entry_preview, and —
+            once the composer is reached — composer_text carrying LinkedIn's
+            own rendering of the (proposed) scheduled moment and body.
+        """
+        try:
+            if new_text is None and new_date is None and new_time is None:
+                raise ToolError(
+                    "Nothing to change: pass new_text, new_date and/or new_time."
+                )
+            parsed_date: datetime.date | None = None
+            parsed_time: datetime.time | None = None
+            try:
+                if new_date is not None:
+                    parsed_date = datetime.datetime.strptime(
+                        new_date, "%Y-%m-%d"
+                    ).date()
+                if new_time is not None:
+                    parsed_time = datetime.datetime.strptime(new_time, "%H:%M").time()
+            except ValueError as e:
+                raise ToolError(
+                    f"Invalid new_date/new_time: {e}. Use YYYY-MM-DD and 24-hour HH:MM."
+                ) from e
+            # Same bound as schedule_post: LinkedIn judges the moment in the
+            # profile's timezone, so only reject what is past in *every*
+            # timezone (more than UTC-12 behind). With only a date given the
+            # kept time is unknown, so the date is checked at its most
+            # generous end-of-day reading; with only a time given no server
+            # clock statement is possible at all and LinkedIn decides.
+            now_utc = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+            checked = (
+                datetime.datetime.combine(
+                    parsed_date, parsed_time or datetime.time(23, 59)
+                )
+                if parsed_date is not None
+                else None
+            )
+            if checked is not None and checked <= now_utc - datetime.timedelta(
+                hours=12
+            ):
+                raise ToolError(
+                    f"The new moment {checked:%Y-%m-%d %H:%M} is already past "
+                    "in every timezone. Pick a later date."
+                )
+
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="edit_scheduled_post"
+            )
+            logger.info(
+                "Editing scheduled post matching %r (confirm_edit=%s)",
+                match_text[:60],
+                confirm_edit,
+            )
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Editing scheduled post"
+            )
+
+            result = await extractor.edit_scheduled_post(
+                match_text,
+                new_text=new_text,
+                new_year=parsed_date.year if parsed_date else None,
+                new_month=parsed_date.month if parsed_date else None,
+                new_day=parsed_date.day if parsed_date else None,
+                new_hour=parsed_time.hour if parsed_time else None,
+                new_minute=parsed_time.minute if parsed_time else None,
+                occurrence=occurrence,
+                confirm_edit=confirm_edit,
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except ToolError:
+            raise
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "edit_scheduled_post")
+        except Exception as e:
+            raise_tool_error(e, "edit_scheduled_post")  # NoReturn

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -1,13 +1,19 @@
 """
-LinkedIn post/content search tool.
+LinkedIn post/content tools: global post search and post scheduling.
 
-Performs LinkedIn's global content search (the "Posts" results tab) using
-innerText extraction, so informal "we're hiring" / "Buscamos ..." posts can
-be found before a formal job listing is published. Mirrors search_people:
-build a /search/results/content/ URL, scroll to load results, and return the
-raw innerText for the LLM to parse, plus post-permalink references.
+search_posts performs LinkedIn's global content search (the "Posts" results
+tab) using innerText extraction, so informal "we're hiring" / "Buscamos ..."
+posts can be found before a formal job listing is published. Mirrors
+search_people: build a /search/results/content/ URL, scroll to load results,
+and return the raw innerText for the LLM to parse, plus post-permalink
+references.
+
+schedule_post drives LinkedIn's native Schedule-for-later flow in the share
+composer, so the scheduled post lives on LinkedIn's side and publishes
+without this server running.
 """
 
+import datetime
 import logging
 from typing import Annotated, Any
 
@@ -114,3 +120,93 @@ def register_post_tools(
                 raise_tool_error(relogin_exc, "search_posts")
         except Exception as e:
             raise_tool_error(e, "search_posts")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Schedule Post",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"post", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def schedule_post(
+        text: str,
+        schedule_date: str,
+        schedule_time: str,
+        confirm_schedule: bool,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Schedule a LinkedIn feed post via LinkedIn's native Schedule-for-later.
+
+        The post is stored by LinkedIn itself and publishes at the scheduled
+        moment whether or not this server is running. LinkedIn interprets the
+        date and time in the profile's own timezone and accepts roughly the
+        next three months. This is a write operation when confirm_schedule is
+        True; with False it performs the full flow as a dry run — filling the
+        schedule and the text — then discards the draft.
+
+        Args:
+            text: The post body text.
+            schedule_date: Date to publish, as YYYY-MM-DD (e.g. "2026-08-15").
+            schedule_time: Time to publish, as 24-hour HH:MM (e.g. "17:30").
+            confirm_schedule: Must be True to actually schedule the post.
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, status, message, scheduled (bool), and — once the
+            flow reaches the composer — scheduled_for plus composer_text, the
+            composer dialog's raw text, which carries LinkedIn's own rendering
+            of the scheduled moment for verification.
+        """
+        try:
+            try:
+                when = datetime.datetime.strptime(
+                    f"{schedule_date} {schedule_time}", "%Y-%m-%d %H:%M"
+                )
+            except ValueError as e:
+                raise ToolError(
+                    f"Invalid schedule_date/schedule_time: {e}. "
+                    "Use YYYY-MM-DD and 24-hour HH:MM."
+                ) from e
+            if when <= datetime.datetime.now():
+                raise ToolError(
+                    f"The scheduled moment {when:%Y-%m-%d %H:%M} is not in the "
+                    "future (server clock). Pick a later time."
+                )
+
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="schedule_post"
+            )
+            logger.info(
+                "Scheduling post for %s %s (confirm_schedule=%s)",
+                schedule_date,
+                schedule_time,
+                confirm_schedule,
+            )
+
+            await ctx.report_progress(progress=0, total=100, message="Scheduling post")
+
+            result = await extractor.schedule_post(
+                text,
+                year=when.year,
+                month=when.month,
+                day=when.day,
+                hour=when.hour,
+                minute=when.minute,
+                confirm_schedule=confirm_schedule,
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except ToolError:
+            raise
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "schedule_post")
+        except Exception as e:
+            raise_tool_error(e, "schedule_post")  # NoReturn

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -401,3 +401,69 @@ def register_post_tools(
                 raise_tool_error(relogin_exc, "edit_scheduled_post")
         except Exception as e:
             raise_tool_error(e, "edit_scheduled_post")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Delete Scheduled Post",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"post", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def delete_scheduled_post(
+        match_text: str,
+        confirm_delete: bool,
+        ctx: Context,
+        occurrence: Annotated[int, Field(ge=0)] = 0,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Delete a scheduled post. LinkedIn cannot recover a deleted one.
+
+        The post is identified by match_text, a snippet of its body, resolved
+        against the live scheduled-posts list at action time (same selection
+        as edit_scheduled_post; use get_scheduled_posts to pick a snippet).
+        With confirm_delete False the tool only resolves the entry and reports
+        what would be deleted — LinkedIn's confirmation dialog is not opened.
+
+        Args:
+            match_text: Snippet of the scheduled post's body text.
+            confirm_delete: Must be True to actually delete the post.
+            ctx: FastMCP context for progress reporting
+            occurrence: 0-based selector among entries matching match_text.
+
+        Returns:
+            Dict with url, status, message, done (bool), and entry_preview
+            (the matched entry's scheduled moment and body head). Deletion is
+            verified by the entry's absence from the list afterwards.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="delete_scheduled_post"
+            )
+            logger.info(
+                "Deleting scheduled post matching %r (confirm_delete=%s)",
+                match_text[:60],
+                confirm_delete,
+            )
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Deleting scheduled post"
+            )
+
+            result = await extractor.delete_scheduled_post(
+                match_text,
+                occurrence=occurrence,
+                confirm_delete=confirm_delete,
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "delete_scheduled_post")
+        except Exception as e:
+            raise_tool_error(e, "delete_scheduled_post")  # NoReturn

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -287,7 +287,7 @@ def register_post_tools(
         new_text: str | None = None,
         new_date: str | None = None,
         new_time: str | None = None,
-        occurrence: Annotated[int, Field(ge=0)] = 0,
+        occurrence: Annotated[int, Field(ge=0)] | None = None,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -295,9 +295,11 @@ def register_post_tools(
 
         The post to edit is identified by match_text, a snippet of its current
         body, resolved against the live scheduled-posts list at action time
-        (get_scheduled_posts shows the entries to pick a snippet from). The
-        snippet must match exactly one entry; when several entries share the
-        text, occurrence selects among them in list order. This is a write
+        (get_scheduled_posts shows the entries to pick a snippet from). With
+        occurrence omitted the snippet must match exactly one entry — several
+        matches are an error, never a silent first pick; pass occurrence only
+        after seeing the list, to choose among known duplicates in list
+        order. This is a write
         operation when confirm_edit is True; with False it applies the changes
         in the composer as a dry run, returns LinkedIn's rendering of the
         result, and abandons them unsaved.
@@ -310,6 +312,7 @@ def register_post_tools(
             new_date: New date as YYYY-MM-DD. Omit to keep the current date.
             new_time: New 24-hour time as HH:MM. Omit to keep the current time.
             occurrence: 0-based selector among entries matching match_text.
+                Omit to require a unique match.
 
         Returns:
             Dict with url, status, message, done (bool), entry_preview, and —

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -413,7 +413,7 @@ def register_post_tools(
         match_text: str,
         confirm_delete: bool,
         ctx: Context,
-        occurrence: Annotated[int, Field(ge=0)] = 0,
+        occurrence: Annotated[int, Field(ge=0)] | None = None,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -430,6 +430,8 @@ def register_post_tools(
             confirm_delete: Must be True to actually delete the post.
             ctx: FastMCP context for progress reporting
             occurrence: 0-based selector among entries matching match_text.
+                Omit to require a unique match; several matches then error
+                rather than silently picking the first.
 
         Returns:
             Dict with url, status, message, done (bool), and entry_preview

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -218,3 +218,57 @@ def register_post_tools(
                 raise_tool_error(relogin_exc, "schedule_post")
         except Exception as e:
             raise_tool_error(e, "schedule_post")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Get Scheduled Posts",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"post", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_scheduled_posts(
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        List the authenticated user's scheduled posts.
+
+        Reads LinkedIn's "Scheduled posts" view (the share composer's clock
+        button -> "View all scheduled posts"). Read-only in effect: the
+        composer is opened to reach the list, never typed into, and dismissed
+        empty. Entries appear in the returned text in LinkedIn's own order
+        (soonest first), each as a "Posting <day>, <date> at <time>" line
+        followed by a body preview.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url and sections (scheduled_posts -> raw text). When the
+            list cannot be reached, a dict with url, status and message
+            instead. The LLM should parse the raw text to extract each entry's
+            scheduled moment and body preview.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_scheduled_posts"
+            )
+            logger.info("Listing scheduled posts")
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Opening scheduled posts"
+            )
+
+            result = await extractor.get_scheduled_posts()
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_scheduled_posts")
+        except Exception as e:
+            raise_tool_error(e, "get_scheduled_posts")  # NoReturn

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -169,10 +169,18 @@ def register_post_tools(
                     f"Invalid schedule_date/schedule_time: {e}. "
                     "Use YYYY-MM-DD and 24-hour HH:MM."
                 ) from e
-            if when <= datetime.datetime.now():
+            # LinkedIn interprets the moment in the *profile's* timezone,
+            # which this server cannot know, so the server clock only bounds
+            # the check: a wall time is already past in every timezone once it
+            # trails UTC by more than the westernmost offset (UTC-12). Only
+            # that much is rejected here; anything nearer is LinkedIn's call,
+            # and the composer flow reports schedule_rejected when LinkedIn
+            # refuses the values.
+            now_utc = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+            if when <= now_utc - datetime.timedelta(hours=12):
                 raise ToolError(
-                    f"The scheduled moment {when:%Y-%m-%d %H:%M} is not in the "
-                    "future (server clock). Pick a later time."
+                    f"The scheduled moment {when:%Y-%m-%d %H:%M} is already "
+                    "past in every timezone. Pick a later time."
                 )
 
             extractor = extractor or await get_ready_extractor(

--- a/manifest.json
+++ b/manifest.json
@@ -132,6 +132,10 @@
       "description": "Edit a scheduled post's body text and/or scheduled moment in place, selected by a snippet of its current body, with explicit confirmation and a dry-run mode"
     },
     {
+      "name": "delete_scheduled_post",
+      "description": "Delete a scheduled post, selected by a snippet of its body, with explicit confirmation and a dry-run mode; deletion is not recoverable"
+    },
+    {
       "name": "close_session",
       "description": "Properly close browser session and clean up resources"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -128,6 +128,10 @@
       "description": "List the authenticated user's scheduled posts with each entry's scheduled moment and body preview"
     },
     {
+      "name": "edit_scheduled_post",
+      "description": "Edit a scheduled post's body text and/or scheduled moment in place, selected by a snippet of its current body, with explicit confirmation and a dry-run mode"
+    },
+    {
       "name": "close_session",
       "description": "Properly close browser session and clean up resources"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -124,6 +124,10 @@
       "description": "Schedule a LinkedIn feed post via LinkedIn's native Schedule-for-later flow, with explicit confirmation and a dry-run mode"
     },
     {
+      "name": "get_scheduled_posts",
+      "description": "List the authenticated user's scheduled posts with each entry's scheduled moment and body preview"
+    },
+    {
       "name": "close_session",
       "description": "Properly close browser session and clean up resources"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -120,6 +120,10 @@
       "description": "Search LinkedIn posts/content globally by keyword (the 'Posts' tab) with an optional recency filter (past-24h/past-week/past-month)"
     },
     {
+      "name": "schedule_post",
+      "description": "Schedule a LinkedIn feed post via LinkedIn's native Schedule-for-later flow, with explicit confirmation and a dry-run mode"
+    },
+    {
       "name": "close_session",
       "description": "Properly close browser session and clean up resources"
     }

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1485,11 +1485,38 @@ class TestRealOwner:
             names = asyncio.run(served())
 
             # The owner registers the full local set, so the proxy must show it
-            # all — including `close_session`, the one defined inline rather than
-            # in a `register_*` call.
+            # all. The expectation is derived from the same registrars the
+            # owner runs — a hand-counted number silently went stale the first
+            # time a tool was added — plus `close_session`, the one tool
+            # defined inline in `create_mcp_server` rather than in a
+            # `register_*` call. A bare FastMCP carries no role, so building
+            # it here does not collide with the PROXY claim above.
+            async def expected() -> set[str]:
+                from fastmcp import FastMCP
+
+                from linkedin_mcp_server.tools.company import register_company_tools
+                from linkedin_mcp_server.tools.feed import register_feed_tools
+                from linkedin_mcp_server.tools.job import register_job_tools
+                from linkedin_mcp_server.tools.messaging import (
+                    register_messaging_tools,
+                )
+                from linkedin_mcp_server.tools.person import register_person_tools
+                from linkedin_mcp_server.tools.post import register_post_tools
+
+                bare = FastMCP("expected-roster")
+                register_person_tools(bare)
+                register_company_tools(bare)
+                register_job_tools(bare)
+                register_messaging_tools(bare)
+                register_feed_tools(bare)
+                register_post_tools(bare)
+                async with Client(bare) as client:
+                    local = {tool.name for tool in await client.list_tools()}
+                return local | {"close_session"}
+
             assert "get_person_profile" in names
             assert "close_session" in names
-            assert len(names) == 19, sorted(names)
+            assert names == asyncio.run(expected()), sorted(names)
         finally:
             _stop(result.get("pid"))
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -6067,6 +6067,52 @@ class TestMatchScheduledEntries:
             assert result[0] == "entry_not_found"
 
 
+class TestDeleteScheduledPostVerification:
+    """Deletion evidence is the match count dropping by one, not absence."""
+
+    async def _run_confirmed_delete(self, match_count, remaining_entries):
+        from unittest.mock import patch
+
+        from linkedin_mcp_server.scraping.extractor import _OpenedScheduledEntry
+
+        page = MagicMock()
+        page.url = "https://www.linkedin.com/feed/?shareActive=true"
+        page.evaluate = AsyncMock(return_value=remaining_entries)
+        confirm = page.locator.return_value.filter.return_value.filter.return_value.last
+        confirm.wait_for = AsyncMock()
+        confirm.locator.return_value.filter.return_value.last.click = AsyncMock()
+        extractor = LinkedInExtractor(page)
+        with (
+            patch.object(
+                extractor,
+                "_open_scheduled_entry_action",
+                AsyncMock(
+                    return_value=_OpenedScheduledEntry(
+                        entry_text="Posting X\nabout x 1",
+                        match_count=match_count,
+                    )
+                ),
+            ),
+            patch.object(extractor, "_dismiss_scheduled_posts_list", AsyncMock()),
+        ):
+            return await extractor.delete_scheduled_post(
+                "about x", occurrence=0, confirm_delete=True
+            )
+
+    async def test_surviving_duplicates_still_verify_as_deleted(self):
+        # Two entries matched; one was deleted; the survivor must not read as
+        # "still listed" — that report invited a retry that would delete a
+        # second, different post.
+        result = await self._run_confirmed_delete(2, ["about x 2", "other"])
+        assert result["status"] == "deleted"
+        assert result["done"] is True
+
+    async def test_unchanged_count_reports_unconfirmed(self):
+        result = await self._run_confirmed_delete(2, ["about x 1", "about x 2"])
+        assert result["status"] == "delete_unconfirmed"
+        assert result["done"] is False
+
+
 class TestOpenScheduledEntryAction:
     async def test_entry_moved_between_resolution_and_click(self):
         """The click is positional against a live queue: when the pre-click

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -6089,6 +6089,29 @@ class TestScheduleFormatHelpers:
         )
         assert (value, order) == ("2026-8-15", ("y", "m", "d"))
 
+    def test_date_day_slot_proven_by_over_twelve(self):
+        # 31 cannot be a month, so it names the day slot whatever date the
+        # prefill renders — no today knowledge needed.
+        value, order = _format_schedule_date(
+            2026, 8, 15, "31/8/2026", prefill_renders_today=False
+        )
+        assert (value, order) == ("15/8/2026", ("d", "m", "y"))
+
+    def test_date_edit_prefill_withholds_window_proof(self):
+        # An edit prefill renders the post's schedule, not today; a window
+        # hit there would be a coincidence, so with both numbers <= 12 and no
+        # placeholder the order stays unproven and the format refuses.
+        value, order = _format_schedule_date(
+            2026, 8, 15, "7/8/2026", "", prefill_renders_today=False
+        )
+        assert (value, order) == (None, None)
+
+    def test_date_edit_prefill_still_decided_by_placeholder(self):
+        value, order = _format_schedule_date(
+            2026, 8, 15, "7/8/2026", "dd/mm/yyyy", prefill_renders_today=False
+        )
+        assert (value, order) == ("15/8/2026", ("d", "m", "y"))
+
     def test_date_empty_prefill_decided_by_placeholder(self):
         import datetime as dt
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -20,6 +20,8 @@ from linkedin_mcp_server.scraping.extractor import (
     _CONTENT_DATE_POSTED_MAP,
     _RATE_LIMITED_MSG,
     _build_feed_references,
+    _format_schedule_date,
+    _format_schedule_time,
     _truncate_linkedin_noise,
     strip_conversation_chrome,
     strip_linkedin_noise,
@@ -5990,3 +5992,38 @@ class TestNavigationFailureCrossesTheToolBoundaryClean:
         # The raw error must not survive as a cause either: the handlers
         # downstream print the whole chain.
         assert excinfo.value.__cause__ is None
+
+
+class TestScheduleFormatHelpers:
+    """The schedule dialog's prefill is the format example the helpers copy."""
+
+    def test_date_en_prefill_month_first(self):
+        assert _format_schedule_date(2026, 8, 15, "8/8/2026") == "8/15/2026"
+
+    def test_date_day_first_when_prefill_day_exceeds_twelve(self):
+        # A first number that cannot be a month names the day slot.
+        assert _format_schedule_date(2026, 8, 15, "31/8/2026") == "15/8/2026"
+
+    def test_date_month_first_when_second_number_exceeds_twelve(self):
+        assert _format_schedule_date(2026, 8, 15, "8/31/2026") == "8/15/2026"
+
+    def test_date_preserves_separator(self):
+        assert _format_schedule_date(2026, 8, 15, "31.8.2026") == "15.8.2026"
+
+    def test_date_iso_prefill_keeps_year_position(self):
+        assert _format_schedule_date(2026, 8, 15, "2026-08-31") == "2026-8-15"
+
+    def test_date_unparseable_prefill_falls_back_to_en(self):
+        assert _format_schedule_date(2026, 8, 15, "") == "8/15/2026"
+
+    def test_time_twelve_hour_from_meridiem_prefill(self):
+        assert _format_schedule_time(17, 30, "2:00 PM") == "5:30 PM"
+        assert _format_schedule_time(9, 5, "2:00 PM") == "9:05 AM"
+
+    def test_time_twelve_hour_boundaries(self):
+        assert _format_schedule_time(0, 5, "1:45 PM") == "12:05 AM"
+        assert _format_schedule_time(12, 0, "1:45 PM") == "12:00 PM"
+
+    def test_time_twenty_four_hour_without_meridiem(self):
+        assert _format_schedule_time(17, 30, "14:00") == "17:30"
+        assert _format_schedule_time(9, 5, "14:00") == "09:05"

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -22,6 +22,7 @@ from linkedin_mcp_server.scraping.extractor import (
     _build_feed_references,
     _format_schedule_date,
     _format_schedule_time,
+    _match_scheduled_entries,
     _truncate_linkedin_noise,
     strip_conversation_chrome,
     strip_linkedin_noise,
@@ -6022,41 +6023,77 @@ class TestGetScheduledPostsRead:
         assert "sections" not in result
 
 
-class TestResolveScheduledEntry:
-    """Snippet resolution: unique-match by default, explicit choice otherwise."""
+class TestMatchScheduledEntries:
+    """Snippet matching: unique-match by default, explicit choice otherwise."""
 
-    def _extractor(self, entries):
-        page = MagicMock()
-        page.evaluate = AsyncMock(return_value=entries)
-        return LinkedInExtractor(page)
+    def test_unique_match_resolves_without_occurrence(self):
+        match = _match_scheduled_entries(
+            ["about x", "about y", "about z"], "about y", None
+        )
+        assert not isinstance(match, tuple)
+        assert (match.index, match.match_count) == (1, 1)
 
-    async def test_unique_match_resolves_without_occurrence(self):
-        extractor = self._extractor(["about x", "about y", "about z"])
-        assert await extractor._resolve_scheduled_entry("about y", None) == 1
-
-    async def test_ambiguous_match_errors_without_occurrence(self):
+    def test_ambiguous_match_errors_without_occurrence(self):
         # A defaulted first-pick could edit the wrong post while reporting
         # success; several matches without an explicit choice must error.
-        extractor = self._extractor(["about x 1", "about x 2"])
-        result = await extractor._resolve_scheduled_entry("about x", None)
+        result = _match_scheduled_entries(["about x 1", "about x 2"], "about x", None)
         assert isinstance(result, tuple)
         assert result[0] == "entry_ambiguous"
 
-    async def test_explicit_occurrence_chooses_among_duplicates(self):
-        extractor = self._extractor(["about x 1", "other", "about x 2"])
-        assert await extractor._resolve_scheduled_entry("about x", 1) == 2
+    def test_explicit_occurrence_chooses_among_duplicates(self):
+        match = _match_scheduled_entries(
+            ["about x 1", "other", "about x 2"], "about x", 1
+        )
+        assert not isinstance(match, tuple)
+        assert (match.index, match.match_count) == (2, 2)
 
-    async def test_occurrence_out_of_range_errors(self):
-        extractor = self._extractor(["about x 1"])
-        result = await extractor._resolve_scheduled_entry("about x", 3)
+    def test_occurrence_out_of_range_errors(self):
+        result = _match_scheduled_entries(["about x 1"], "about x", 3)
         assert isinstance(result, tuple)
         assert result[0] == "entry_not_found"
 
-    async def test_no_match_errors(self):
-        extractor = self._extractor(["something else"])
-        result = await extractor._resolve_scheduled_entry("absent", None)
+    def test_no_match_errors(self):
+        result = _match_scheduled_entries(["something else"], "absent", None)
         assert isinstance(result, tuple)
         assert result[0] == "entry_not_found"
+
+    def test_blank_snippet_refused(self):
+        # Normalized to an empty needle, a blank snippet is contained in every
+        # entry; with one queued post it would "uniquely" match a post the
+        # caller never named — and delete flows are not recoverable.
+        for blank in ("", "   ", "\n\t"):
+            result = _match_scheduled_entries(["only post"], blank, None)
+            assert isinstance(result, tuple)
+            assert result[0] == "entry_not_found"
+
+
+class TestOpenScheduledEntryAction:
+    async def test_entry_moved_between_resolution_and_click(self):
+        """The click is positional against a live queue: when the pre-click
+        snapshot no longer shows the resolved text at the resolved index,
+        the action must refuse rather than land on whichever post now
+        occupies the position."""
+        from unittest.mock import patch
+
+        page = MagicMock()
+        page.evaluate = AsyncMock(
+            side_effect=[["post a", "post b"], ["post b", "post a"]]
+        )
+        extractor = LinkedInExtractor(page)
+        with (
+            patch.object(
+                extractor,
+                "_open_scheduled_posts_list",
+                AsyncMock(return_value=None),
+            ),
+            patch.object(extractor, "_dismiss_scheduled_posts_list", AsyncMock()),
+        ):
+            result = await extractor._open_scheduled_entry_action(
+                "post a", None, "button.irrelevant"
+            )
+
+        assert isinstance(result, tuple)
+        assert result[0] == "entry_moved"
 
 
 class TestScheduleFormatHelpers:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5994,6 +5994,34 @@ class TestNavigationFailureCrossesTheToolBoundaryClean:
         assert excinfo.value.__cause__ is None
 
 
+class TestGetScheduledPostsRead:
+    async def test_empty_read_reports_failure_not_empty_schedule(self):
+        """A failed modal read must not masquerade as an empty schedule —
+        the modal always carries its own heading text, so emptiness is
+        evidence of a broken read, and a caller told "nothing scheduled"
+        double-posts."""
+        from unittest.mock import patch
+
+        page = MagicMock()
+        page.url = "https://www.linkedin.com/feed/?shareActive=true"
+        page.locator.return_value.filter.return_value.first.inner_text = AsyncMock(
+            side_effect=Exception("element detached")
+        )
+        extractor = LinkedInExtractor(page)
+        with (
+            patch.object(
+                extractor,
+                "_open_scheduled_posts_list",
+                AsyncMock(return_value=None),
+            ),
+            patch.object(extractor, "_dismiss_scheduled_posts_list", AsyncMock()),
+        ):
+            result = await extractor.get_scheduled_posts()
+
+        assert result["status"] == "list_read_failed"
+        assert "sections" not in result
+
+
 class TestScheduleFormatHelpers:
     """The schedule dialog's prefill is the format example the helpers copy."""
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -6022,6 +6022,43 @@ class TestGetScheduledPostsRead:
         assert "sections" not in result
 
 
+class TestResolveScheduledEntry:
+    """Snippet resolution: unique-match by default, explicit choice otherwise."""
+
+    def _extractor(self, entries):
+        page = MagicMock()
+        page.evaluate = AsyncMock(return_value=entries)
+        return LinkedInExtractor(page)
+
+    async def test_unique_match_resolves_without_occurrence(self):
+        extractor = self._extractor(["about x", "about y", "about z"])
+        assert await extractor._resolve_scheduled_entry("about y", None) == 1
+
+    async def test_ambiguous_match_errors_without_occurrence(self):
+        # A defaulted first-pick could edit the wrong post while reporting
+        # success; several matches without an explicit choice must error.
+        extractor = self._extractor(["about x 1", "about x 2"])
+        result = await extractor._resolve_scheduled_entry("about x", None)
+        assert isinstance(result, tuple)
+        assert result[0] == "entry_ambiguous"
+
+    async def test_explicit_occurrence_chooses_among_duplicates(self):
+        extractor = self._extractor(["about x 1", "other", "about x 2"])
+        assert await extractor._resolve_scheduled_entry("about x", 1) == 2
+
+    async def test_occurrence_out_of_range_errors(self):
+        extractor = self._extractor(["about x 1"])
+        result = await extractor._resolve_scheduled_entry("about x", 3)
+        assert isinstance(result, tuple)
+        assert result[0] == "entry_not_found"
+
+    async def test_no_match_errors(self):
+        extractor = self._extractor(["something else"])
+        result = await extractor._resolve_scheduled_entry("absent", None)
+        assert isinstance(result, tuple)
+        assert result[0] == "entry_not_found"
+
+
 class TestScheduleFormatHelpers:
     """The schedule dialog's prefill is the format example the helpers copy."""
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5997,24 +5997,77 @@ class TestNavigationFailureCrossesTheToolBoundaryClean:
 class TestScheduleFormatHelpers:
     """The schedule dialog's prefill is the format example the helpers copy."""
 
-    def test_date_en_prefill_month_first(self):
-        assert _format_schedule_date(2026, 8, 15, "8/8/2026") == "8/15/2026"
+    def test_date_month_first_proven_by_prefill_window(self):
+        # Prefill 8/7 read month-first is Aug 7 (inside the today window);
+        # read day-first it is Jul 8 (outside). Order proven, not guessed.
+        import datetime as dt
 
-    def test_date_day_first_when_prefill_day_exceeds_twelve(self):
-        # A first number that cannot be a month names the day slot.
-        assert _format_schedule_date(2026, 8, 15, "31/8/2026") == "15/8/2026"
+        value, order = _format_schedule_date(
+            2026, 8, 15, "8/7/2026", today=dt.date(2026, 8, 7)
+        )
+        assert (value, order) == ("8/15/2026", ("m", "d", "y"))
 
-    def test_date_month_first_when_second_number_exceeds_twelve(self):
-        assert _format_schedule_date(2026, 8, 15, "8/31/2026") == "8/15/2026"
+    def test_date_day_first_proven_by_prefill_window(self):
+        import datetime as dt
 
-    def test_date_preserves_separator(self):
-        assert _format_schedule_date(2026, 8, 15, "31.8.2026") == "15.8.2026"
+        value, order = _format_schedule_date(
+            2026, 8, 15, "7/8/2026", today=dt.date(2026, 8, 7)
+        )
+        assert (value, order) == ("15/8/2026", ("d", "m", "y"))
+
+    def test_date_ambiguous_prefill_decided_by_placeholder(self):
+        # On a day==month date the prefill reads the same both ways; the
+        # placeholder's m-token breaks the tie.
+        import datetime as dt
+
+        value, order = _format_schedule_date(
+            2026, 8, 15, "8/8/2026", "dd/mm/yyyy", today=dt.date(2026, 8, 8)
+        )
+        assert (value, order) == ("15/8/2026", ("d", "m", "y"))
+
+    def test_date_german_placeholder_and_separator(self):
+        import datetime as dt
+
+        value, order = _format_schedule_date(
+            2026, 8, 15, "8.8.2026", "TT.MM.JJJJ", today=dt.date(2026, 8, 8)
+        )
+        assert (value, order) == ("15.8.2026", ("d", "m", "y"))
+
+    def test_date_undecidable_refuses_distinct_day_month(self):
+        # Neither the prefill (day == month) nor a placeholder decides the
+        # order: refusing beats gambling the calendar day, because a reversed
+        # date is a valid date and passes every later check.
+        import datetime as dt
+
+        value, order = _format_schedule_date(
+            2026, 8, 15, "8/8/2026", "", today=dt.date(2026, 8, 8)
+        )
+        assert (value, order) == (None, None)
+
+    def test_date_undecidable_allows_equal_day_month(self):
+        # Both orders write the same digits, so nothing is gambled.
+        import datetime as dt
+
+        value, order = _format_schedule_date(
+            2026, 9, 9, "8/8/2026", "", today=dt.date(2026, 8, 8)
+        )
+        assert value == "9/9/2026"
 
     def test_date_iso_prefill_keeps_year_position(self):
-        assert _format_schedule_date(2026, 8, 15, "2026-08-31") == "2026-8-15"
+        import datetime as dt
 
-    def test_date_unparseable_prefill_falls_back_to_en(self):
-        assert _format_schedule_date(2026, 8, 15, "") == "8/15/2026"
+        value, order = _format_schedule_date(
+            2026, 8, 15, "2026-08-07", today=dt.date(2026, 8, 7)
+        )
+        assert (value, order) == ("2026-8-15", ("y", "m", "d"))
+
+    def test_date_empty_prefill_decided_by_placeholder(self):
+        import datetime as dt
+
+        value, order = _format_schedule_date(
+            2026, 8, 15, "", "mm/dd/yyyy", today=dt.date(2026, 8, 8)
+        )
+        assert (value, order) == ("8/15/2026", ("m", "d", "y"))
 
     def test_time_twelve_hour_from_meridiem_prefill(self):
         assert _format_schedule_time(17, 30, "2:00 PM") == "5:30 PM"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -39,6 +39,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.search_posts = AsyncMock(return_value=scrape_result)
     mock.schedule_post = AsyncMock(return_value=scrape_result)
     mock.get_scheduled_posts = AsyncMock(return_value=scrape_result)
+    mock.edit_scheduled_post = AsyncMock(return_value=scrape_result)
     mock.get_company_employees = AsyncMock(return_value=scrape_result)
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
@@ -1360,6 +1361,128 @@ class TestPostTools:
         tool_fn = await get_tool_fn(mcp, "get_scheduled_posts")
         with pytest.raises(ToolError):
             await tool_fn(mock_context, extractor=mock_extractor)
+
+    async def test_edit_scheduled_post_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "edited",
+            "message": "Scheduled post updated.",
+            "done": True,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "edit_scheduled_post")
+        result = await tool_fn(
+            "old snippet",
+            True,
+            mock_context,
+            new_text="new body",
+            new_date="2099-08-26",
+            new_time="16:30",
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "edited"
+        mock_extractor.edit_scheduled_post.assert_awaited_once_with(
+            "old snippet",
+            new_text="new body",
+            new_year=2099,
+            new_month=8,
+            new_day=26,
+            new_hour=16,
+            new_minute=30,
+            occurrence=0,
+            confirm_edit=True,
+        )
+
+    async def test_edit_scheduled_post_time_only(self, mock_context):
+        expected = {"url": "u", "status": "edited", "message": "m", "done": True}
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "edit_scheduled_post")
+        await tool_fn(
+            "snippet",
+            False,
+            mock_context,
+            new_time="09:15",
+            occurrence=2,
+            extractor=mock_extractor,
+        )
+        mock_extractor.edit_scheduled_post.assert_awaited_once_with(
+            "snippet",
+            new_text=None,
+            new_year=None,
+            new_month=None,
+            new_day=None,
+            new_hour=9,
+            new_minute=15,
+            occurrence=2,
+            confirm_edit=False,
+        )
+
+    async def test_edit_scheduled_post_requires_a_change(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "edit_scheduled_post")
+        mock_extractor = _make_mock_extractor({})
+        with pytest.raises(ToolError, match="Nothing to change"):
+            await tool_fn("snippet", True, mock_context, extractor=mock_extractor)
+        mock_extractor.edit_scheduled_post.assert_not_awaited()
+
+    async def test_edit_scheduled_post_rejects_bad_date(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "edit_scheduled_post")
+        mock_extractor = _make_mock_extractor({})
+        with pytest.raises(ToolError, match="YYYY-MM-DD"):
+            await tool_fn(
+                "snippet",
+                True,
+                mock_context,
+                new_date="26/08/2099",
+                extractor=mock_extractor,
+            )
+        mock_extractor.edit_scheduled_post.assert_not_awaited()
+
+    async def test_edit_scheduled_post_rejects_clearly_past_date(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "edit_scheduled_post")
+        mock_extractor = _make_mock_extractor({})
+        with pytest.raises(ToolError, match="already past in every timezone"):
+            await tool_fn(
+                "snippet",
+                True,
+                mock_context,
+                new_date="2020-01-01",
+                extractor=mock_extractor,
+            )
+        mock_extractor.edit_scheduled_post.assert_not_awaited()
 
     async def test_schedule_post_rejects_bad_date_format(self, mock_context):
         from fastmcp.exceptions import ToolError

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1510,7 +1510,7 @@ class TestPostTools:
         assert result["status"] == "deleted"
         mock_extractor.delete_scheduled_post.assert_awaited_once_with(
             "old snippet",
-            occurrence=0,
+            occurrence=None,
             confirm_delete=True,
         )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1354,7 +1354,7 @@ class TestPostTools:
 
         tool_fn = await get_tool_fn(mcp, "schedule_post")
         mock_extractor = _make_mock_extractor({})
-        with pytest.raises(ToolError, match="not in the future"):
+        with pytest.raises(ToolError, match="already past in every timezone"):
             await tool_fn(
                 "Hello",
                 "2020-01-01",
@@ -1364,6 +1364,40 @@ class TestPostTools:
                 extractor=mock_extractor,
             )
         mock_extractor.schedule_post.assert_not_awaited()
+
+    async def test_schedule_post_defers_near_past_to_linkedin(self, mock_context):
+        """A moment shortly behind the server clock may still be future in the
+        profile's timezone, so the tool must pass it through and let LinkedIn
+        judge it rather than rejecting on the server's own wall clock."""
+        import datetime as _dt
+
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "schedule_rejected",
+            "message": "LinkedIn did not accept the scheduled date and time.",
+            "scheduled": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "schedule_post")
+        near_past = _dt.datetime.now(_dt.timezone.utc).replace(
+            tzinfo=None
+        ) - _dt.timedelta(hours=1)
+        result = await tool_fn(
+            "Hello",
+            near_past.strftime("%Y-%m-%d"),
+            near_past.strftime("%H:%M"),
+            True,
+            mock_context,
+            extractor=mock_extractor,
+        )
+        assert result["status"] == "schedule_rejected"
+        mock_extractor.schedule_post.assert_awaited_once()
 
 
 class TestToolTimeouts:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1543,6 +1543,36 @@ class TestPostTools:
             confirm_delete=False,
         )
 
+    async def test_delete_scheduled_post_rejects_blank_match_text(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "delete_scheduled_post")
+        mock_extractor = _make_mock_extractor({})
+        with pytest.raises(ToolError, match="match_text is empty"):
+            await tool_fn("   ", True, mock_context, extractor=mock_extractor)
+        mock_extractor.delete_scheduled_post.assert_not_awaited()
+
+    async def test_edit_scheduled_post_rejects_blank_match_text(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "edit_scheduled_post")
+        mock_extractor = _make_mock_extractor({})
+        with pytest.raises(ToolError, match="match_text is empty"):
+            await tool_fn(
+                "", True, mock_context, new_text="x", extractor=mock_extractor
+            )
+        mock_extractor.edit_scheduled_post.assert_not_awaited()
+
     async def test_delete_scheduled_post_error(self, mock_context):
         from fastmcp.exceptions import ToolError
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -37,6 +37,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.get_my_profile = AsyncMock(return_value=scrape_result)
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.search_posts = AsyncMock(return_value=scrape_result)
+    mock.schedule_post = AsyncMock(return_value=scrape_result)
     mock.get_company_employees = AsyncMock(return_value=scrape_result)
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
@@ -1249,6 +1250,120 @@ class TestPostTools:
 
         with pytest.raises(ValidationError, match="max_pages"):
             await mcp.call_tool("search_posts", {"keywords": "python", "max_pages": 0})
+
+    async def test_schedule_post_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "scheduled",
+            "message": "Post scheduled.",
+            "scheduled": True,
+            "scheduled_for": "2099-08-15 17:30",
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "schedule_post")
+        result = await tool_fn(
+            "Hello world",
+            "2099-08-15",
+            "17:30",
+            True,
+            mock_context,
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "scheduled"
+        assert result["scheduled"] is True
+        mock_extractor.schedule_post.assert_awaited_once_with(
+            "Hello world",
+            year=2099,
+            month=8,
+            day=15,
+            hour=17,
+            minute=30,
+            confirm_schedule=True,
+        )
+
+    async def test_schedule_post_dry_run_passes_confirm_false(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "confirmation_required",
+            "message": "Dry run complete.",
+            "scheduled": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "schedule_post")
+        result = await tool_fn(
+            "Hello world",
+            "2099-01-02",
+            "09:05",
+            False,
+            mock_context,
+            extractor=mock_extractor,
+        )
+
+        assert result["scheduled"] is False
+        mock_extractor.schedule_post.assert_awaited_once_with(
+            "Hello world",
+            year=2099,
+            month=1,
+            day=2,
+            hour=9,
+            minute=5,
+            confirm_schedule=False,
+        )
+
+    async def test_schedule_post_rejects_bad_date_format(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "schedule_post")
+        mock_extractor = _make_mock_extractor({})
+        with pytest.raises(ToolError, match="YYYY-MM-DD"):
+            await tool_fn(
+                "Hello",
+                "15/08/2099",
+                "17:30",
+                True,
+                mock_context,
+                extractor=mock_extractor,
+            )
+        mock_extractor.schedule_post.assert_not_awaited()
+
+    async def test_schedule_post_rejects_past_datetime(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "schedule_post")
+        mock_extractor = _make_mock_extractor({})
+        with pytest.raises(ToolError, match="not in the future"):
+            await tool_fn(
+                "Hello",
+                "2020-01-01",
+                "12:00",
+                True,
+                mock_context,
+                extractor=mock_extractor,
+            )
+        mock_extractor.schedule_post.assert_not_awaited()
 
 
 class TestToolTimeouts:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -38,6 +38,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.search_posts = AsyncMock(return_value=scrape_result)
     mock.schedule_post = AsyncMock(return_value=scrape_result)
+    mock.get_scheduled_posts = AsyncMock(return_value=scrape_result)
     mock.get_company_employees = AsyncMock(return_value=scrape_result)
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
@@ -1322,6 +1323,43 @@ class TestPostTools:
             minute=5,
             confirm_schedule=False,
         )
+
+    async def test_get_scheduled_posts_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "sections": {"scheduled_posts": "Posting Tue, Aug 11 at 10:00 AM\nHello"},
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_scheduled_posts")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+
+        assert "scheduled_posts" in result["sections"]
+        mock_extractor.get_scheduled_posts.assert_awaited_once_with()
+
+    async def test_get_scheduled_posts_error(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.exceptions import SessionExpiredError
+
+        mock_extractor = MagicMock()
+        mock_extractor.get_scheduled_posts = AsyncMock(
+            side_effect=SessionExpiredError()
+        )
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_scheduled_posts")
+        with pytest.raises(ToolError):
+            await tool_fn(mock_context, extractor=mock_extractor)
 
     async def test_schedule_post_rejects_bad_date_format(self, mock_context):
         from fastmcp.exceptions import ToolError

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1396,7 +1396,7 @@ class TestPostTools:
             new_day=26,
             new_hour=16,
             new_minute=30,
-            occurrence=0,
+            occurrence=None,
             confirm_edit=True,
         )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -40,6 +40,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.schedule_post = AsyncMock(return_value=scrape_result)
     mock.get_scheduled_posts = AsyncMock(return_value=scrape_result)
     mock.edit_scheduled_post = AsyncMock(return_value=scrape_result)
+    mock.delete_scheduled_post = AsyncMock(return_value=scrape_result)
     mock.get_company_employees = AsyncMock(return_value=scrape_result)
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
@@ -1483,6 +1484,83 @@ class TestPostTools:
                 extractor=mock_extractor,
             )
         mock_extractor.edit_scheduled_post.assert_not_awaited()
+
+    async def test_delete_scheduled_post_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "deleted",
+            "message": "Scheduled post deleted.",
+            "done": True,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "delete_scheduled_post")
+        result = await tool_fn(
+            "old snippet",
+            True,
+            mock_context,
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "deleted"
+        mock_extractor.delete_scheduled_post.assert_awaited_once_with(
+            "old snippet",
+            occurrence=0,
+            confirm_delete=True,
+        )
+
+    async def test_delete_scheduled_post_dry_run(self, mock_context):
+        expected = {
+            "url": "u",
+            "status": "confirmation_required",
+            "message": "m",
+            "done": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "delete_scheduled_post")
+        result = await tool_fn(
+            "snippet",
+            False,
+            mock_context,
+            occurrence=1,
+            extractor=mock_extractor,
+        )
+        assert result["done"] is False
+        mock_extractor.delete_scheduled_post.assert_awaited_once_with(
+            "snippet",
+            occurrence=1,
+            confirm_delete=False,
+        )
+
+    async def test_delete_scheduled_post_error(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.exceptions import SessionExpiredError
+
+        mock_extractor = MagicMock()
+        mock_extractor.delete_scheduled_post = AsyncMock(
+            side_effect=SessionExpiredError()
+        )
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "delete_scheduled_post")
+        with pytest.raises(ToolError):
+            await tool_fn("snippet", True, mock_context, extractor=mock_extractor)
 
     async def test_schedule_post_rejects_bad_date_format(self, mock_context):
         from fastmcp.exceptions import ToolError


### PR DESCRIPTION
Closes #694

> [!NOTE]
> **Stacked on #695** (`edit_scheduled_post`) → #692 → #690 — review only the last commit; the earlier ones belong to those PRs. Cross-fork PRs can only target upstream branches, so the base is `main`.

## What

Adds a `delete_scheduled_post` tool: remove a queued post via LinkedIn's own Delete action, selected by the same live-resolved body-snippet (`match_text` + optional `occurrence`) as `edit_scheduled_post`, gated by `confirm_delete`.

## How

- **Dry run stops before the confirmation surface.** LinkedIn's dialog warns "You won't be able to recover it", so with `confirm_delete=false` the tool only resolves the entry and reports what would be deleted — the menu is never opened.
- Menu action found by its `trash-medium` icon test hook (a `div[role="button"]`, so it cannot collide with native composer buttons).
- **Confirmation dialog identified structurally**: it is the visible dialog holding *no* entry-overflow icons. Measured why the naive alternative fails: DOM order does not put the topmost dialog last — "last visible dialog" resolved to the still-open list modal underneath, whose trailing Back button then failed Playwright's actionability under the confirmation overlay. Its primary is its last button (measured roster: Dismiss, Cancel, Delete).
- **Deletion is verified, not assumed**: after confirming, the entry map is re-read and the snippet must be absent; otherwise the tool reports `delete_unconfirmed`.

## Verification (live)

- Dry run: resolved and previewed the disposable entry ("Posting Wed, Aug 26 at 4:30 PM …"), list unchanged (8 entries).
- Confirmed: returned `deleted`, and the list re-read showed the entry gone (7 entries — which also cleaned up the disposable post used across this PR stack's verification).
- Full suite: 1840 passed, 22 skipped; `ruff`, `ty`, pre-commit clean.

## Synthetic prompt

> Add a `delete_scheduled_post` tool mirroring `edit_scheduled_post`'s snippet-based selection: resolve the entry against the live scheduled-posts list, open its trash-medium menu action, and confirm via LinkedIn's delete dialog — identified as the visible dialog with no entry-overflow icons (topmost is not last in DOM order), primary = last button. Keep the dry run from ever opening the confirmation, and verify deletion by the entry's absence afterwards. Tests, README/manifest entries.

Generated with Claude Fable 5 (claude-fable-5)
