### PR TITLE
test(ci): Run the identity gate on every platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,4 +119,38 @@ jobs:
       - name: Run platform behaviour tests
         run: uv run pytest tests/test_profile_lease.py tests/test_profile_lease_integration.py tests/test_private_state.py tests/test_daemon_lock.py tests/test_greenlet_runtime.py
 
+      # The identity gate belongs here as much as on Ubuntu, and for the same
+      # reason this job exists at all: the mechanism it guards is a different
+      # one per platform. `hidden_target_is_supported()` is macOS-only, so the
+      # hidden target -- the whole reason the default mode can run without
+      # announcing itself as headless -- is never launched by the Ubuntu job.
+      # A regression in it would be invisible everywhere CI looks.
+      #
+      # macOS only. Windows falls back to Chromium's headless mode like Linux
+      # does, so the Ubuntu job already covers that shape, and this job would
+      # pay a second browser download for a third copy of the same answer.
+      - name: Resolve the patchright version
+        if: runner.os == 'macOS'
+        id: patchright
+        run: |
+          version=$(uv run python -c 'from importlib.metadata import version; print(version("patchright"))')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the browser
+        if: runner.os == 'macOS'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/Library/Caches/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.patchright.outputs.version }}
+
+      # No `--with-deps` here: playwright installs system dependencies on
+      # Ubuntu and Windows only, and macOS needs none.
+      - name: Install the browser
+        if: runner.os == 'macOS'
+        run: uv run patchright install chromium --no-shell
+
+      - name: Run the identity gate
+        if: runner.os == 'macOS'
+        run: uv run pytest tests/test_browser_identity.py
+
       - run: uv cache prune --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        include:
+          - os: macos-latest
+            identity: true
+            browsers: ~/Library/Caches/ms-playwright
+          - os: windows-latest
+            identity: false
+          # Here for the browser rather than for the operating system.
+          # Patchright ships Chrome for Testing everywhere except Linux arm64,
+          # which gets Playwright's own Chromium build, and the release
+          # publishes an arm64 image. Without this leg an identity regression
+          # in that build reaches the container with both other jobs green.
+          - os: ubuntu-24.04-arm
+            identity: true
+            browsers: ~/.cache/ms-playwright
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
@@ -119,38 +132,54 @@ jobs:
       - name: Run platform behaviour tests
         run: uv run pytest tests/test_profile_lease.py tests/test_profile_lease_integration.py tests/test_private_state.py tests/test_daemon_lock.py tests/test_greenlet_runtime.py
 
-      # The identity gate belongs here as much as on Ubuntu, and for the same
-      # reason this job exists at all: the mechanism it guards is a different
-      # one per platform. `hidden_target_is_supported()` is macOS-only, so the
-      # hidden target -- the whole reason the default mode can run without
-      # announcing itself as headless -- is never launched by the Ubuntu job.
-      # A regression in it would be invisible everywhere CI looks.
-      #
-      # macOS only. Windows falls back to Chromium's headless mode like Linux
-      # does, so the Ubuntu job already covers that shape, and this job would
-      # pay a second browser download for a third copy of the same answer.
+      # The identity gate runs where the Ubuntu job's browser is not the one
+      # that ships. Two legs qualify and for different reasons: macOS is the
+      # only platform with a hidden target, which is the whole reason the
+      # default mode can run without announcing itself as headless, and Linux
+      # arm64 is the only platform whose bundle is Playwright's own Chromium
+      # rather than Chrome for Testing. Windows runs neither: it falls back to
+      # headless mode the way Linux x64 does, so it would pay a browser
+      # download for a third copy of an answer CI already has.
       - name: Resolve the patchright version
-        if: runner.os == 'macOS'
+        if: matrix.identity
         id: patchright
         run: |
           version=$(uv run python -c 'from importlib.metadata import version; print(version("patchright"))')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Restore the browser
-        if: runner.os == 'macOS'
+        if: matrix.identity
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/Library/Caches/ms-playwright
-          key: ms-playwright-${{ runner.os }}-${{ steps.patchright.outputs.version }}
+          path: ${{ matrix.browsers }}
+          key: ms-playwright-${{ matrix.os }}-${{ steps.patchright.outputs.version }}
 
-      # No `--with-deps` here: playwright installs system dependencies on
-      # Ubuntu and Windows only, and macOS needs none.
+      # `--with-deps` only where playwright has any to install: it acts on
+      # Ubuntu and Windows, and macOS needs none.
       - name: Install the browser
-        if: runner.os == 'macOS'
-        run: uv run patchright install chromium --no-shell
+        if: matrix.identity
+        run: uv run patchright install ${{ runner.os == 'Linux' && '--with-deps' || '' }} chromium --no-shell
+
+      # Same reason as the Ubuntu job: the headed half of the gate needs
+      # somewhere to put a window, and the default half does not.
+      - name: Start a display
+        if: matrix.identity && runner.os == 'Linux'
+        run: |
+          Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp >/tmp/xvfb.log 2>&1 &
+          for _ in $(seq 1 100); do
+            if [ -S /tmp/.X11-unix/X99 ]; then exit 0; fi
+            sleep 0.1
+          done
+          echo "Xvfb never created /tmp/.X11-unix/X99:" >&2
+          cat /tmp/xvfb.log >&2
+          exit 1
 
       - name: Run the identity gate
-        if: runner.os == 'macOS'
+        if: matrix.identity
+        env:
+          # Only where one was started. macOS ignores it, but naming a display
+          # that does not exist is the kind of thing someone later debugs.
+          DISPLAY: ${{ runner.os == 'Linux' && ':99' || '' }}
         run: uv run pytest tests/test_browser_identity.py
 
       - run: uv cache prune --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,53 @@ jobs:
 
       - run: uv sync --group dev
 
+      # The browser is keyed on the resolved patchright version, because that
+      # is what decides which Chromium revision `install` fetches. Read from
+      # the synced environment rather than from `pyproject.toml`, which names
+      # a floor and not the version in use.
+      - name: Resolve the patchright version
+        id: patchright
+        run: |
+          version=$(uv run python -c 'from importlib.metadata import version; print(version("patchright"))')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the browser
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.patchright.outputs.version }}
+
+      # `--no-shell`, the same install the server performs: the headless shell
+      # is a different product with no plugins and no `window.chrome`, and
+      # nothing here launches it. `--with-deps` runs on a cache hit too, since
+      # the cache holds the browser and not the apt packages it links against;
+      # it also brings Xvfb, which is in playwright's `tools` dependency group.
+      - name: Install the browser
+        run: uv run patchright install --with-deps chromium --no-shell
+
+      # A headed browser needs a display. The default mode does not on Linux,
+      # where the hidden target is unsupported and Chromium's own headless mode
+      # runs instead, but the identity gate launches headed as well and that is
+      # the mode where the headless token has to be absent.
+      - name: Start a display
+        run: |
+          Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp >/tmp/xvfb.log 2>&1 &
+          for _ in $(seq 1 100); do
+            if [ -S /tmp/.X11-unix/X99 ]; then exit 0; fi
+            sleep 0.1
+          done
+          echo "Xvfb never created /tmp/.X11-unix/X99:" >&2
+          cat /tmp/xvfb.log >&2
+          exit 1
+
+      # `--dist loadgroup` keeps the identity tests on one worker. They share
+      # two cached browser launches, and under plain `load` every worker that
+      # received one of them would pay for its own pair. Tests carrying no
+      # group mark are distributed exactly as before.
       - name: Run tests
-        run: uv run pytest --cov --cov-report=term-missing -n auto -v -s
+        env:
+          DISPLAY: ":99"
+        run: uv run pytest --cov --cov-report=term-missing -n auto --dist loadgroup -v -s
 
       - run: uv cache prune --ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,17 +108,15 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            identity: true
             browsers: ~/Library/Caches/ms-playwright
           - os: windows-latest
-            identity: false
+            browsers: ~\AppData\Local\ms-playwright
           # Here for the browser rather than for the operating system.
           # Patchright ships Chrome for Testing everywhere except Linux arm64,
           # which gets Playwright's own Chromium build, and the release
           # publishes an arm64 image. Without this leg an identity regression
           # in that build reaches the container with both other jobs green.
           - os: ubuntu-24.04-arm
-            identity: true
             browsers: ~/.cache/ms-playwright
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -132,45 +130,52 @@ jobs:
       - name: Run platform behaviour tests
         run: uv run pytest tests/test_profile_lease.py tests/test_profile_lease_integration.py tests/test_private_state.py tests/test_daemon_lock.py tests/test_greenlet_runtime.py
 
-      # The identity gate runs where the Ubuntu job's browser is not the one
-      # that ships. Two legs qualify and for different reasons: macOS is the
-      # only platform with a hidden target, which is the whole reason the
-      # default mode can run without announcing itself as headless, and Linux
-      # arm64 is the only platform whose bundle is Playwright's own Chromium
-      # rather than Chrome for Testing. Windows runs neither: it falls back to
-      # headless mode the way Linux x64 does, so it would pay a browser
-      # download for a third copy of an answer CI already has.
+      # The identity gate runs on every leg, because every leg's browser is a
+      # different one from the Ubuntu job's. macOS is the only platform with a
+      # hidden target, which is the whole reason the default mode can run
+      # without announcing itself as headless. Linux arm64 is the only platform
+      # whose bundle is Playwright's own Chromium rather than Chrome for
+      # Testing. Windows has its own binary, its own window manager and its own
+      # DPI handling, and the gate measures a headed window against the screen
+      # it stands on -- which is exactly where those differ. An earlier version
+      # of this file left Windows out on the grounds that it falls back to
+      # headless mode like Linux does; that is true of one of the thirty-one
+      # cases and says nothing about the other thirty.
       #
-      # These two legs report rather than block. Branch protection on `main`
+      # None of these three legs blocks a merge. Branch protection on `main`
       # requires `lint-and-check` and `test` only, which is how this job has
-      # always stood, so a red macOS or arm64 leg is visible on the pull
-      # request and does not stop a merge. The Linux x64 half of the gate is
-      # inside `test` and does block. Adding both names to the required list
-      # is a repository setting rather than anything this file can do.
+      # always stood, so a red leg here is visible on the pull request and does
+      # not stop anyone. The Linux x64 half of the gate is inside `test` and
+      # does block. Adding these names to the required list is a repository
+      # setting rather than anything this file can do.
+      #
+      # `shell: bash` because one of the legs is Windows, where the default is
+      # PowerShell and none of the syntax below means anything.
       - name: Resolve the patchright version
-        if: matrix.identity
         id: patchright
+        shell: bash
         run: |
           version=$(uv run python -c 'from importlib.metadata import version; print(version("patchright"))')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Restore the browser
-        if: matrix.identity
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ matrix.browsers }}
           key: ms-playwright-${{ matrix.os }}-${{ steps.patchright.outputs.version }}
 
-      # `--with-deps` only where playwright has any to install: it acts on
-      # Ubuntu and Windows, and macOS needs none.
+      # `--with-deps` on Linux only. It is the platform where a missing
+      # system library stops Chromium starting at all, and the runner image
+      # makes no promise about them. macOS needs none, and on Windows the
+      # switch installs a Media Pack through a script that wants privileges
+      # this job has no reason to take.
       - name: Install the browser
-        if: matrix.identity
         run: uv run patchright install ${{ runner.os == 'Linux' && '--with-deps' || '' }} chromium --no-shell
 
       # Same reason as the Ubuntu job: the headed half of the gate needs
       # somewhere to put a window, and the default half does not.
       - name: Start a display
-        if: matrix.identity && runner.os == 'Linux'
+        if: runner.os == 'Linux'
         run: |
           Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp >/tmp/xvfb.log 2>&1 &
           for _ in $(seq 1 100); do
@@ -182,7 +187,6 @@ jobs:
           exit 1
 
       - name: Run the identity gate
-        if: matrix.identity
         env:
           # Only where one was started. macOS ignores it, but naming a display
           # that does not exist is the kind of thing someone later debugs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,13 @@ jobs:
       # rather than Chrome for Testing. Windows runs neither: it falls back to
       # headless mode the way Linux x64 does, so it would pay a browser
       # download for a third copy of an answer CI already has.
+      #
+      # These two legs report rather than block. Branch protection on `main`
+      # requires `lint-and-check` and `test` only, which is how this job has
+      # always stood, so a red macOS or arm64 leg is visible on the pull
+      # request and does not stop a merge. The Linux x64 half of the gate is
+      # inside `test` and does block. Adding both names to the required list
+      # is a repository setting rather than anything this file can do.
       - name: Resolve the patchright version
         if: matrix.identity
         id: patchright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,8 @@ jobs:
       # DPI handling, and the gate measures a headed window against the screen
       # it stands on -- which is exactly where those differ. An earlier version
       # of this file left Windows out on the grounds that it falls back to
-      # headless mode like Linux does; that is true of one of the thirty-one
-      # cases and says nothing about the other thirty.
+      # headless mode like Linux does; that is true of one case in that file
+      # and says nothing about the rest of them.
       #
       # None of these three legs blocks a merge. Branch protection on `main`
       # requires `lint-and-check` and `test` only, which is how this job has

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ addopts = -v --strict-markers -ra
 markers =
     browser_dom: evaluates extractor JS against a real chromium DOM; skipped when no browser is installed
     slow: spawns real server processes; each case starts the full server graph
+    browser_identity: the identity gate; fails rather than skips in CI

--- a/tests/browser_identity_harness.py
+++ b/tests/browser_identity_harness.py
@@ -1,4 +1,4 @@
-"""A loopback origin that lets a browser describe itself, in three realms.
+"""Two loopback origins that let a browser describe itself, in four realms.
 
 Kept apart from the test so the same harness can run inside the container
 image, which has no dev dependencies. Nothing here imports pytest, and the only
@@ -103,7 +103,14 @@ _PAGE = b"""<!doctype html>
       .filter(n => /^(__pw|__playwright|\\$cdc_|__driver|__selenium|__webdriver)/.test(n)),
     webdriverDescriptor: (() => {
       const d = Object.getOwnPropertyDescriptor(Navigator.prototype, 'webdriver');
-      return d ? {get: typeof d.get, set: typeof d.set, configurable: d.configurable} : null;
+      // The getter's own source, because that is what distinguishes a native
+      // accessor from one somebody redefined. The descriptor alone does not:
+      // redefining an existing configurable property leaves every attribute
+      // the caller did not name exactly as it was.
+      return d ? {
+        get: typeof d.get, set: typeof d.set, configurable: d.configurable,
+        getSource: d.get ? String(d.get) : null,
+      } : null;
     })(),
   };
   document.getElementById('out').textContent = JSON.stringify(result);

--- a/tests/browser_identity_harness.py
+++ b/tests/browser_identity_harness.py
@@ -54,7 +54,12 @@ const describeAccessor = (name) => {
     // somebody redefined. The descriptor alone does not: redefining an
     // existing configurable property leaves every attribute the caller did
     // not name exactly as it was.
-    getSource: d.get ? String(d.get) : null,
+    //
+    // Through Function.prototype.toString and never String(), which would
+    // call the getter's *own* toString if it has one. Measured: a redefined
+    // getter carrying `toString: () => 'function get webdriver() { [native
+    // code] }'` produced exactly that text and passed for native.
+    getSource: d.get ? Function.prototype.toString.call(d.get) : null,
   };
 };
 
@@ -69,6 +74,8 @@ const describeAccessor = (name) => {
       ? await navigator.userAgentData.getHighEntropyValues(
           ['architecture', 'bitness', 'fullVersionList'])
       : null,
+    platform: navigator.userAgentData ? navigator.userAgentData.platform : null,
+    mobile: navigator.userAgentData ? navigator.userAgentData.mobile : null,
     hasWebdriver: 'webdriver' in navigator,
     webdriver: navigator.webdriver,
   });
@@ -141,6 +148,10 @@ const describeAccessor = (name) => {
     // against a remembered spelling. userAgent is the control: it is a native
     // accessor on the same prototype that nothing has any reason to touch, so
     // whatever shape V8 gives it is the shape webdriver must have too.
+    // The reader itself, because everything above trusts it. A patched
+    // Function.prototype.toString could return whatever it liked about every
+    // accessor at once, and asking it to describe itself is where that stops.
+    toStringSource: Function.prototype.toString.call(Function.prototype.toString),
     webdriverDescriptor: describeAccessor('webdriver'),
     userAgentDescriptor: describeAccessor('userAgent'),
   };

--- a/tests/browser_identity_harness.py
+++ b/tests/browser_identity_harness.py
@@ -15,6 +15,12 @@ what a website sees, so measuring through it would measure the wrong realm.
 context by definition, so service workers and ``navigator.userAgentData`` are
 available without a certificate. A self-signed certificate plus
 ``ignore_https_errors`` would perturb the very thing being measured.
+
+**There are two servers, because one of the four surfaces is another origin.**
+A port is part of an origin, so a second loopback listener is genuinely
+cross-origin to the first, with no certificate and no hosts entry. The iframe
+matters on its own: a user-agent override reaches the top document and misses
+the frame, which is the same failure as the one it misses in a service worker.
 """
 
 from __future__ import annotations
@@ -23,6 +29,7 @@ import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+from urllib.parse import quote, urlsplit
 
 #: Asked for on every response, so the *next* request from the same origin
 #: carries the high-entropy client hints. They are absent from the first
@@ -65,10 +72,24 @@ _PAGE = b"""<!doctype html>
     (registration.active || navigator.serviceWorker.controller).postMessage('describe');
   });
 
+  // Another origin, because a port is part of one. The frame reports through
+  // postMessage; nothing here can read across the boundary, which is the point.
+  const frameOrigin = new URLSearchParams(location.search).get('frame');
+  const iframe = await new Promise((resolve, reject) => {
+    addEventListener('message', e => {
+      if (e.data && e.data.realm === 'iframe') resolve(e.data);
+    });
+    setTimeout(() => reject(new Error('cross-origin iframe timed out')), 15000);
+    const el = document.createElement('iframe');
+    el.src = frameOrigin + 'frame';
+    document.body.appendChild(el);
+  });
+
   const result = {
     page: {...(await jsChannel()), headers: await echo()},
     dedicated,
     serviceWorker,
+    iframe,
     // Read here rather than in the assertions: outerWidth is a property of the
     // window the page is in, and there is no other realm that can see it.
     geometry: {
@@ -102,14 +123,29 @@ _WORKER = b"""
 _SERVICE_WORKER = b"""
 self.addEventListener('install', () => self.skipWaiting());
 self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
-self.addEventListener('message', async e => {
+// waitUntil, not a bare async listener: an EventTarget ignores what a listener
+// returns, so without it the browser is free to terminate the worker at the
+// first await. Under load that is a real answer that never arrives, and the
+// page then waits out its own timeout.
+self.addEventListener('message', e => e.waitUntil((async () => {
   const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
   e.source.postMessage({realm: 'serviceWorker', ua: navigator.userAgent, headers});
-});
+})()));
+"""
+
+_FRAME = b"""<!doctype html>
+<title>frame</title>
+<script>
+(async () => {
+  const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
+  parent.postMessage({realm: 'iframe', ua: navigator.userAgent, headers}, '*');
+})();
+</script>
 """
 
 _BODIES = {
     "/": (_PAGE, "text/html; charset=utf-8"),
+    "/frame": (_FRAME, "text/html; charset=utf-8"),
     "/worker.js": (_WORKER, "text/javascript"),
     "/sw.js": (_SERVICE_WORKER, "text/javascript"),
 }
@@ -119,11 +155,14 @@ class _Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's spelling
-        if self.path.startswith("/echo"):
+        # The query carries the other origin, so the path has to be taken apart
+        # rather than matched whole: `/?frame=http%3A%2F%2F...` is still `/`.
+        path = urlsplit(self.path).path
+        if path == "/echo":
             body = json.dumps({k.lower(): v for k, v in self.headers.items()}).encode()
             ctype = "application/json"
         else:
-            body, ctype = _BODIES.get(self.path, (b"not found", "text/plain"))
+            body, ctype = _BODIES.get(path, (b"not found", "text/plain"))
         self.send_response(200 if body != b"not found" else 404)
         self.send_header("Content-Type", ctype)
         self.send_header("Accept-CH", _ACCEPT_CH)
@@ -140,24 +179,44 @@ class _Handler(BaseHTTPRequestHandler):
 
 
 class IdentityServer:
-    """Serves the identity page on a loopback port picked by the OS."""
+    """Serves the identity page on two loopback ports picked by the OS.
+
+    Two, because the fourth surface is a cross-origin frame and a port is part
+    of an origin. Both listeners serve the same handler; which one is "the
+    other origin" is decided only by which URL the page is given.
+    """
 
     def __init__(self) -> None:
-        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._servers = [
+            ThreadingHTTPServer(("127.0.0.1", 0), _Handler) for _ in range(2)
+        ]
+        self._threads = [
+            threading.Thread(target=server.serve_forever, daemon=True)
+            for server in self._servers
+        ]
 
     def __enter__(self) -> "IdentityServer":
-        self._thread.start()
+        for thread in self._threads:
+            thread.start()
         return self
 
     def __exit__(self, *exc: object) -> None:
-        self._server.shutdown()
-        self._server.server_close()
+        for server in self._servers:
+            server.shutdown()
+            server.server_close()
+
+    def _origin(self, index: int) -> str:
+        host, port = self._servers[index].server_address[:2]
+        return f"http://{host}:{port}/"
 
     @property
     def url(self) -> str:
-        host, port = self._server.server_address[:2]
-        return f"http://{host}:{port}/"
+        """The page, told where to find the other origin.
+
+        Passed in the query string rather than hardcoded, because the port is
+        the OS's choice and the page has no other way to learn it.
+        """
+        return f"{self._origin(0)}?frame={quote(self._origin(1), safe='')}"
 
 
 async def describe_browser(page: Any, url: str, timeout_ms: int = 30_000) -> dict:

--- a/tests/browser_identity_harness.py
+++ b/tests/browser_identity_harness.py
@@ -43,6 +43,7 @@ _PAGE = b"""<!doctype html>
 <script>
 // Deliberately not page.evaluate(): that runs in an isolated world. This is
 // the realm a website actually gets.
+const REALM_BUDGET_MS = __REALM_BUDGET_MS__;
 const describeAccessor = (name) => {
   const d = Object.getOwnPropertyDescriptor(Navigator.prototype, name);
   if (!d) return null;
@@ -71,33 +72,45 @@ const describeAccessor = (name) => {
     webdriver: navigator.webdriver,
   });
 
-  const worker = new Worker('/worker.js');
-  const dedicated = await new Promise((resolve, reject) => {
-    worker.onmessage = e => resolve(e.data);
-    worker.onerror = e => reject(new Error('worker: ' + e.message));
-    setTimeout(() => reject(new Error('worker timed out')), 15000);
-  });
+  const askTheWorker = () => {
+    const worker = new Worker('/worker.js');
+    return new Promise((resolve, reject) => {
+      worker.onmessage = e => resolve(e.data);
+      worker.onerror = e => reject(new Error('worker: ' + e.message));
+      setTimeout(() => reject(new Error('worker timed out')), REALM_BUDGET_MS);
+    });
+  };
 
-  const registration = await navigator.serviceWorker.register('/sw.js');
-  await navigator.serviceWorker.ready;
-  const serviceWorker = await new Promise((resolve, reject) => {
-    navigator.serviceWorker.addEventListener('message', e => resolve(e.data));
-    setTimeout(() => reject(new Error('service worker timed out')), 15000);
-    (registration.active || navigator.serviceWorker.controller).postMessage('describe');
-  });
+  const askTheServiceWorker = async () => {
+    const registration = await navigator.serviceWorker.register('/sw.js');
+    await navigator.serviceWorker.ready;
+    return new Promise((resolve, reject) => {
+      navigator.serviceWorker.addEventListener('message', e => resolve(e.data));
+      setTimeout(() => reject(new Error('service worker timed out')), REALM_BUDGET_MS);
+      (registration.active || navigator.serviceWorker.controller).postMessage('describe');
+    });
+  };
 
   // Another origin, because a port is part of one. The frame reports through
   // postMessage; nothing here can read across the boundary, which is the point.
-  const frameOrigin = new URLSearchParams(location.search).get('frame');
-  const iframe = await new Promise((resolve, reject) => {
+  const askTheFrame = () => new Promise((resolve, reject) => {
     addEventListener('message', e => {
       if (e.data && e.data.realm === 'iframe') resolve(e.data);
     });
-    setTimeout(() => reject(new Error('cross-origin iframe timed out')), 15000);
+    setTimeout(() => reject(new Error('cross-origin iframe timed out')), REALM_BUDGET_MS);
     const el = document.createElement('iframe');
-    el.src = frameOrigin + 'frame';
+    el.src = new URLSearchParams(location.search).get('frame') + 'frame';
     document.body.appendChild(el);
   });
+
+  // Concurrently, and that is a correctness point rather than a speed one.
+  // Awaited one after another, three budgets of REALM_BUDGET_MS could add up
+  // past the host's own timeout, so a slow-but-working browser would be
+  // reported as a broken one. Started together, the whole page costs one
+  // budget and the host's bound stays comfortably above it.
+  const [dedicated, serviceWorker, iframe] = await Promise.all([
+    askTheWorker(), askTheServiceWorker(), askTheFrame(),
+  ]);
 
   const result = {
     page: {...(await jsChannel()), headers: await echo()},
@@ -114,7 +127,10 @@ const describeAccessor = (name) => {
     hasChromeObject: typeof window.chrome,
     // Automation artefacts a launcher can leave in the page's own realm.
     automationGlobals: Object.getOwnPropertyNames(window)
-      .filter(n => /^(__pw|__playwright|\\$cdc_|__driver|__selenium|__webdriver)/.test(n)),
+      // `cdc_` with no dollar as well: ChromeDriver installs
+      // `cdc_adoQpoasnfa76pfcZLmcfl_Array` and friends under the bare prefix,
+      // and only the older `$cdc_` spelling was being looked for.
+      .filter(n => /^(__pw|__playwright|\\$?cdc_|__driver|__selenium|__webdriver|__fxdriver|__nightmare|_Selenium_IDE)/.test(n)),
     // The prototype accessor can be left perfectly native while an own
     // property on the instance shadows it, which reads as false and leaves
     // every descriptor attribute untouched. Measured against the bundled
@@ -137,7 +153,8 @@ const describeAccessor = (name) => {
 _WORKER = b"""
 (async () => {
   const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
-  postMessage({realm: 'dedicated', ua: navigator.userAgent, headers});
+  postMessage({realm: 'dedicated', ua: navigator.userAgent,
+    webdriver: navigator.webdriver, headers});
 })();
 """
 
@@ -150,7 +167,8 @@ self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
 // page then waits out its own timeout.
 self.addEventListener('message', e => e.waitUntil((async () => {
   const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
-  e.source.postMessage({realm: 'serviceWorker', ua: navigator.userAgent, headers});
+  e.source.postMessage({realm: 'serviceWorker', ua: navigator.userAgent,
+    webdriver: navigator.webdriver, headers});
 })()));
 """
 
@@ -159,10 +177,22 @@ _FRAME = b"""<!doctype html>
 <script>
 (async () => {
   const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
-  parent.postMessage({realm: 'iframe', ua: navigator.userAgent, headers}, '*');
+  parent.postMessage({realm: 'iframe', ua: navigator.userAgent,
+    webdriver: navigator.webdriver, headers}, '*');
 })();
 </script>
 """
+
+#: How long any one realm may take to answer, and how much longer the host
+#: waits for the whole page. The two are declared together on purpose: they
+#: used to be written out separately, and three sequential realm budgets added
+#: up past the host's bound, so a browser that was merely slow reported as a
+#: browser that was broken. The realms run concurrently now, which is what
+#: makes one budget the cost of the page rather than three.
+REALM_BUDGET_MS = 15_000
+HOST_BUDGET_MS = REALM_BUDGET_MS * 3
+
+_PAGE = _PAGE.replace(b"__REALM_BUDGET_MS__", str(REALM_BUDGET_MS).encode())
 
 _BODIES = {
     "/": (_PAGE, "text/html; charset=utf-8"),
@@ -240,7 +270,9 @@ class IdentityServer:
         return f"{self._origin(0)}?frame={quote(self._origin(1), safe='')}"
 
 
-async def describe_browser(page: Any, url: str, timeout_ms: int = 30_000) -> dict:
+async def describe_browser(
+    page: Any, url: str, timeout_ms: int = HOST_BUDGET_MS
+) -> dict:
     """Navigate *page* at the harness and return what the browser said it is."""
     await page.goto(url, wait_until="domcontentloaded")
     await page.wait_for_function(

--- a/tests/browser_identity_harness.py
+++ b/tests/browser_identity_harness.py
@@ -1,0 +1,172 @@
+"""A loopback origin that lets a browser describe itself, in three realms.
+
+Kept apart from the test so the same harness can run inside the container
+image, which has no dev dependencies. Nothing here imports pytest, and the only
+third-party import is the browser itself.
+
+Two things about the design are not stylistic.
+
+**The page collects its own values.** Everything is gathered by a ``<script>``
+the page runs and published into the DOM; the test only reads the result.
+Patchright evaluates ``page.evaluate()`` in an isolated world, which is not
+what a website sees, so measuring through it would measure the wrong realm.
+
+**The origin is loopback, over plain HTTP.** ``http://127.0.0.1`` is a secure
+context by definition, so service workers and ``navigator.userAgentData`` are
+available without a certificate. A self-signed certificate plus
+``ignore_https_errors`` would perturb the very thing being measured.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+#: Asked for on every response, so the *next* request from the same origin
+#: carries the high-entropy client hints. They are absent from the first
+#: request by design, which is why the page fetches ``/echo`` after loading
+#: rather than reading the headers of its own document.
+_ACCEPT_CH = "Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version-List"
+
+_PAGE = b"""<!doctype html>
+<title>identity</title>
+<body><pre id="out"></pre>
+<script>
+// Deliberately not page.evaluate(): that runs in an isolated world. This is
+// the realm a website actually gets.
+(async () => {
+  const echo = async () => (await fetch('/echo', {cache: 'no-store'})).json();
+  const jsChannel = async () => ({
+    ua: navigator.userAgent,
+    brands: navigator.userAgentData
+      ? navigator.userAgentData.brands.map(b => ({brand: b.brand, version: b.version}))
+      : null,
+    highEntropy: navigator.userAgentData
+      ? await navigator.userAgentData.getHighEntropyValues(
+          ['architecture', 'bitness', 'fullVersionList'])
+      : null,
+    webdriver: navigator.webdriver,
+  });
+
+  const worker = new Worker('/worker.js');
+  const dedicated = await new Promise((resolve, reject) => {
+    worker.onmessage = e => resolve(e.data);
+    worker.onerror = e => reject(new Error('worker: ' + e.message));
+    setTimeout(() => reject(new Error('worker timed out')), 15000);
+  });
+
+  const registration = await navigator.serviceWorker.register('/sw.js');
+  await navigator.serviceWorker.ready;
+  const serviceWorker = await new Promise((resolve, reject) => {
+    navigator.serviceWorker.addEventListener('message', e => resolve(e.data));
+    setTimeout(() => reject(new Error('service worker timed out')), 15000);
+    (registration.active || navigator.serviceWorker.controller).postMessage('describe');
+  });
+
+  const result = {
+    page: {...(await jsChannel()), headers: await echo()},
+    dedicated,
+    serviceWorker,
+    // Read here rather than in the assertions: outerWidth is a property of the
+    // window the page is in, and there is no other realm that can see it.
+    geometry: {
+      outerWidth: outerWidth, outerHeight: outerHeight,
+      screenWidth: screen.width, screenHeight: screen.height,
+    },
+    plugins: navigator.plugins.length,
+    hasChromeObject: typeof window.chrome,
+    // Automation artefacts a launcher can leave in the page's own realm.
+    automationGlobals: Object.getOwnPropertyNames(window)
+      .filter(n => /^(__pw|__playwright|\\$cdc_|__driver|__selenium|__webdriver)/.test(n)),
+    webdriverDescriptor: (() => {
+      const d = Object.getOwnPropertyDescriptor(Navigator.prototype, 'webdriver');
+      return d ? {get: typeof d.get, set: typeof d.set, configurable: d.configurable} : null;
+    })(),
+  };
+  document.getElementById('out').textContent = JSON.stringify(result);
+})().catch(err => {
+  document.getElementById('out').textContent = JSON.stringify({error: String(err)});
+});
+</script>
+"""
+
+_WORKER = b"""
+(async () => {
+  const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
+  postMessage({realm: 'dedicated', ua: navigator.userAgent, headers});
+})();
+"""
+
+_SERVICE_WORKER = b"""
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
+self.addEventListener('message', async e => {
+  const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
+  e.source.postMessage({realm: 'serviceWorker', ua: navigator.userAgent, headers});
+});
+"""
+
+_BODIES = {
+    "/": (_PAGE, "text/html; charset=utf-8"),
+    "/worker.js": (_WORKER, "text/javascript"),
+    "/sw.js": (_SERVICE_WORKER, "text/javascript"),
+}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's spelling
+        if self.path.startswith("/echo"):
+            body = json.dumps({k.lower(): v for k, v in self.headers.items()}).encode()
+            ctype = "application/json"
+        else:
+            body, ctype = _BODIES.get(self.path, (b"not found", "text/plain"))
+        self.send_response(200 if body != b"not found" else 404)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Accept-CH", _ACCEPT_CH)
+        # A service worker may only claim a scope at or below its own path
+        # unless the server says otherwise.
+        self.send_header("Service-Worker-Allowed", "/")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        """Silent. The default writes every request to stderr."""
+
+
+class IdentityServer:
+    """Serves the identity page on a loopback port picked by the OS."""
+
+    def __init__(self) -> None:
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def __enter__(self) -> "IdentityServer":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+    @property
+    def url(self) -> str:
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}/"
+
+
+async def describe_browser(page: Any, url: str, timeout_ms: int = 30_000) -> dict:
+    """Navigate *page* at the harness and return what the browser said it is."""
+    await page.goto(url, wait_until="domcontentloaded")
+    await page.wait_for_function(
+        "document.getElementById('out').textContent.length > 0", timeout=timeout_ms
+    )
+    described = json.loads(await page.eval_on_selector("#out", "e => e.textContent"))
+    if "error" in described:
+        raise RuntimeError(f"the identity page failed: {described['error']}")
+    return described

--- a/tests/browser_identity_harness.py
+++ b/tests/browser_identity_harness.py
@@ -37,13 +37,11 @@ from urllib.parse import quote, urlsplit
 #: rather than reading the headers of its own document.
 _ACCEPT_CH = "Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version-List"
 
-_PAGE = b"""<!doctype html>
-<title>identity</title>
-<body><pre id="out"></pre>
-<script>
-// Deliberately not page.evaluate(): that runs in an isolated world. This is
-// the realm a website actually gets.
-const REALM_BUDGET_MS = __REALM_BUDGET_MS__;
+#: Shared by the page and by the cross-origin frame, so the two document
+#: realms are described the same way rather than one being asked less than
+#: the other. A frame is a realm of its own: a patch applied only there is
+#: invisible to everything the top document can read.
+_ACCESSORS_JS = b"""
 const describeAccessor = (name) => {
   const d = Object.getOwnPropertyDescriptor(Navigator.prototype, name);
   if (!d) return null;
@@ -63,6 +61,26 @@ const describeAccessor = (name) => {
   };
 };
 
+const describeAccessors = () => ({
+  ownWebdriver: Object.hasOwn(navigator, 'webdriver'),
+  // The reader itself, because everything else trusts it. A patched
+  // Function.prototype.toString could otherwise say whatever it liked about
+  // every accessor at once.
+  toStringSource: Function.prototype.toString.call(Function.prototype.toString),
+  webdriverDescriptor: describeAccessor('webdriver'),
+  userAgentDescriptor: describeAccessor('userAgent'),
+});
+"""
+
+_PAGE = b"""<!doctype html>
+<title>identity</title>
+<body><pre id="out"></pre>
+<script>
+// Deliberately not page.evaluate(): that runs in an isolated world. This is
+// the realm a website actually gets.
+const REALM_BUDGET_MS = __REALM_BUDGET_MS__;
+__ACCESSORS_JS__
+
 (async () => {
   const echo = async () => (await fetch('/echo', {cache: 'no-store'})).json();
   const jsChannel = async () => ({
@@ -78,6 +96,7 @@ const describeAccessor = (name) => {
     mobile: navigator.userAgentData ? navigator.userAgentData.mobile : null,
     hasWebdriver: 'webdriver' in navigator,
     webdriver: navigator.webdriver,
+    accessors: describeAccessors(),
   });
 
   const askTheWorker = () => {
@@ -139,21 +158,6 @@ const describeAccessor = (name) => {
       // `cdc_adoQpoasnfa76pfcZLmcfl_Array` and friends under the bare prefix,
       // and only the older `$cdc_` spelling was being looked for.
       .filter(n => /^(__pw|__playwright|\\$?cdc_|__driver|__selenium|__webdriver|__fxdriver|__nightmare|_Selenium_IDE|domAutomation)/.test(n)),
-    // The prototype accessor can be left perfectly native while an own
-    // property on the instance shadows it, which reads as false and leaves
-    // every descriptor attribute untouched. Measured against the bundled
-    // browser: the prototype still stringifies to [native code].
-    ownWebdriver: Object.hasOwn(navigator, 'webdriver'),
-    // Both accessors, so the test can hold one against the other instead of
-    // against a remembered spelling. userAgent is the control: it is a native
-    // accessor on the same prototype that nothing has any reason to touch, so
-    // whatever shape V8 gives it is the shape webdriver must have too.
-    // The reader itself, because everything above trusts it. A patched
-    // Function.prototype.toString could return whatever it liked about every
-    // accessor at once, and asking it to describe itself is where that stops.
-    toStringSource: Function.prototype.toString.call(Function.prototype.toString),
-    webdriverDescriptor: describeAccessor('webdriver'),
-    userAgentDescriptor: describeAccessor('userAgent'),
   };
   document.getElementById('out').textContent = JSON.stringify(result);
 })().catch(err => {
@@ -189,11 +193,13 @@ self.addEventListener('message', e => e.waitUntil((async () => {
 _FRAME = b"""<!doctype html>
 <title>frame</title>
 <script>
+__ACCESSORS_JS__
 (async () => {
   const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
   parent.postMessage({realm: 'iframe', ua: navigator.userAgent,
     hasWebdriver: 'webdriver' in navigator,
-    webdriver: navigator.webdriver, headers}, '*');
+    webdriver: navigator.webdriver,
+    accessors: describeAccessors(), headers}, '*');
 })();
 </script>
 """
@@ -208,6 +214,8 @@ REALM_BUDGET_MS = 15_000
 HOST_BUDGET_MS = REALM_BUDGET_MS * 3
 
 _PAGE = _PAGE.replace(b"__REALM_BUDGET_MS__", str(REALM_BUDGET_MS).encode())
+_PAGE = _PAGE.replace(b"__ACCESSORS_JS__", _ACCESSORS_JS)
+_FRAME = _FRAME.replace(b"__ACCESSORS_JS__", _ACCESSORS_JS)
 
 _BODIES = {
     "/": (_PAGE, "text/html; charset=utf-8"),

--- a/tests/browser_identity_harness.py
+++ b/tests/browser_identity_harness.py
@@ -101,6 +101,11 @@ _PAGE = b"""<!doctype html>
     // Automation artefacts a launcher can leave in the page's own realm.
     automationGlobals: Object.getOwnPropertyNames(window)
       .filter(n => /^(__pw|__playwright|\\$cdc_|__driver|__selenium|__webdriver)/.test(n)),
+    // The prototype accessor can be left perfectly native while an own
+    // property on the instance shadows it, which reads as false and leaves
+    // every descriptor attribute untouched. Measured against the bundled
+    // browser: the prototype still stringifies to [native code].
+    ownWebdriver: Object.hasOwn(navigator, 'webdriver'),
     webdriverDescriptor: (() => {
       const d = Object.getOwnPropertyDescriptor(Navigator.prototype, 'webdriver');
       // The getter's own source, because that is what distinguishes a native

--- a/tests/browser_identity_harness.py
+++ b/tests/browser_identity_harness.py
@@ -69,6 +69,7 @@ const describeAccessor = (name) => {
       ? await navigator.userAgentData.getHighEntropyValues(
           ['architecture', 'bitness', 'fullVersionList'])
       : null,
+    hasWebdriver: 'webdriver' in navigator,
     webdriver: navigator.webdriver,
   });
 
@@ -130,7 +131,7 @@ const describeAccessor = (name) => {
       // `cdc_` with no dollar as well: ChromeDriver installs
       // `cdc_adoQpoasnfa76pfcZLmcfl_Array` and friends under the bare prefix,
       // and only the older `$cdc_` spelling was being looked for.
-      .filter(n => /^(__pw|__playwright|\\$?cdc_|__driver|__selenium|__webdriver|__fxdriver|__nightmare|_Selenium_IDE)/.test(n)),
+      .filter(n => /^(__pw|__playwright|\\$?cdc_|__driver|__selenium|__webdriver|__fxdriver|__nightmare|_Selenium_IDE|domAutomation)/.test(n)),
     // The prototype accessor can be left perfectly native while an own
     // property on the instance shadows it, which reads as false and leaves
     // every descriptor attribute untouched. Measured against the bundled
@@ -154,6 +155,7 @@ _WORKER = b"""
 (async () => {
   const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
   postMessage({realm: 'dedicated', ua: navigator.userAgent,
+    hasWebdriver: 'webdriver' in navigator,
     webdriver: navigator.webdriver, headers});
 })();
 """
@@ -168,6 +170,7 @@ self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
 self.addEventListener('message', e => e.waitUntil((async () => {
   const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
   e.source.postMessage({realm: 'serviceWorker', ua: navigator.userAgent,
+    hasWebdriver: 'webdriver' in navigator,
     webdriver: navigator.webdriver, headers});
 })()));
 """
@@ -178,6 +181,7 @@ _FRAME = b"""<!doctype html>
 (async () => {
   const headers = await (await fetch('/echo', {cache: 'no-store'})).json();
   parent.postMessage({realm: 'iframe', ua: navigator.userAgent,
+    hasWebdriver: 'webdriver' in navigator,
     webdriver: navigator.webdriver, headers}, '*');
 })();
 </script>

--- a/tests/browser_identity_harness.py
+++ b/tests/browser_identity_harness.py
@@ -43,6 +43,20 @@ _PAGE = b"""<!doctype html>
 <script>
 // Deliberately not page.evaluate(): that runs in an isolated world. This is
 // the realm a website actually gets.
+const describeAccessor = (name) => {
+  const d = Object.getOwnPropertyDescriptor(Navigator.prototype, name);
+  if (!d) return null;
+  return {
+    get: typeof d.get, set: typeof d.set,
+    enumerable: d.enumerable, configurable: d.configurable,
+    // The source, because that is what separates a native accessor from one
+    // somebody redefined. The descriptor alone does not: redefining an
+    // existing configurable property leaves every attribute the caller did
+    // not name exactly as it was.
+    getSource: d.get ? String(d.get) : null,
+  };
+};
+
 (async () => {
   const echo = async () => (await fetch('/echo', {cache: 'no-store'})).json();
   const jsChannel = async () => ({
@@ -106,17 +120,12 @@ _PAGE = b"""<!doctype html>
     // every descriptor attribute untouched. Measured against the bundled
     // browser: the prototype still stringifies to [native code].
     ownWebdriver: Object.hasOwn(navigator, 'webdriver'),
-    webdriverDescriptor: (() => {
-      const d = Object.getOwnPropertyDescriptor(Navigator.prototype, 'webdriver');
-      // The getter's own source, because that is what distinguishes a native
-      // accessor from one somebody redefined. The descriptor alone does not:
-      // redefining an existing configurable property leaves every attribute
-      // the caller did not name exactly as it was.
-      return d ? {
-        get: typeof d.get, set: typeof d.set, configurable: d.configurable,
-        getSource: d.get ? String(d.get) : null,
-      } : null;
-    })(),
+    // Both accessors, so the test can hold one against the other instead of
+    // against a remembered spelling. userAgent is the control: it is a native
+    // accessor on the same prototype that nothing has any reason to touch, so
+    // whatever shape V8 gives it is the shape webdriver must have too.
+    webdriverDescriptor: describeAccessor('webdriver'),
+    userAgentDescriptor: describeAccessor('userAgent'),
   };
   document.getElementById('out').textContent = JSON.stringify(result);
 })().catch(err => {

--- a/tests/test_action_signals_dom.py
+++ b/tests/test_action_signals_dom.py
@@ -5,8 +5,11 @@ The unit suite mocks ``page.evaluate``, so the JS in ``_ACTION_SIGNALS_JS``
 and ``_CLICK_INCOMING_ACCEPT_JS`` never executes there. These tests run the
 real JS against synthetic HTML in headless chromium. Fixtures use German
 labels throughout: the fingerprint must classify without reading any label
-text. Skipped automatically when chromium is not installed (CI installs no
-browser; run locally after ``uv run patchright install chromium``).
+text. Skipped automatically when chromium is not installed; run locally after
+``uv run patchright install chromium --no-shell``. CI installs it, so these
+run there, but a skip is still the right answer for a missing browser here:
+this file checks extraction JS rather than the browser, and
+``test_browser_identity.py`` is the one that has to fail instead.
 
 Fixture structure mirrors the live DOM dumps of two incoming-request
 profiles (2026-06-11): three buttons sharing one parent, Accept and Ignore
@@ -160,10 +163,16 @@ async def dom_page():
     Only launch/setup is guarded by the skip — the ``yield`` is outside it
     so an assertion failure or JS error in a test body is never swallowed
     into a skip.
+
+    ``channel="chromium"`` names the browser this project installs. Without
+    it Playwright picks the *binary* from the ``headless`` flag alone and
+    asks for ``chromium-headless-shell``, which nothing here installs since
+    the setup moved to ``--no-shell``: the launch would fail and every case
+    in this file would skip itself, silently, wherever the real browser is.
     """
     async with async_playwright() as p:
         try:
-            browser = await p.chromium.launch(headless=True)
+            browser = await p.chromium.launch(channel="chromium", headless=True)
             page = await browser.new_page()
         except Exception as exc:  # browser binary missing
             pytest.skip(f"chromium unavailable: {exc}")

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -74,6 +74,15 @@ pytestmark = [
 #: character.
 _GREASE = re.compile(r"not[\W_]?a[\W_]?brand", re.IGNORECASE)
 
+#: The NativeFunction form ECMA-262 gives ``Function.prototype.toString`` for a
+#: built-in. Written as a grammar rather than as today's exact string, because
+#: the whitespace between the tokens is the engine's choice while the tokens
+#: themselves are not. What it refuses is anything carrying a function body,
+#: which is every accessor written in JavaScript.
+_NATIVE_FUNCTION = re.compile(
+    r"function\s+(get|set)\s+\S+\s*\(\s*\)\s*\{\s*\[\s*native\s+code\s*\]\s*\}"
+)
+
 
 def _running_in_ci() -> bool:
     """Whether a missing browser is a failure rather than a reason to skip."""
@@ -429,6 +438,12 @@ class TestNothingAnnouncesAutomation:
         touch. If V8 changes how it stringifies built-ins, both change together
         and this survives; pinning the spelling is what would not.
 
+        The control is checked as well, or two accessors patched together would
+        agree with each other and say nothing. Against the NativeFunction
+        grammar from ECMA-262 rather than against today's exact spelling, so it
+        holds whatever whitespace an engine chooses while still refusing
+        anything with a function body in it.
+
         And the prototype is not the only place to look. Defining ``webdriver``
         directly on ``navigator`` shadows the accessor without touching it, so
         the value reads false while every attribute here still measures native.
@@ -443,6 +458,9 @@ class TestNothingAnnouncesAutomation:
         descriptor = either_mode["webdriverDescriptor"]
         native = either_mode["userAgentDescriptor"]
         assert descriptor is not None and native is not None
+        assert _NATIVE_FUNCTION.fullmatch(native["getSource"]), (
+            f"the control accessor is not native either: {native['getSource']!r}"
+        )
 
         flags = ("get", "set", "enumerable", "configurable")
         assert {key: descriptor[key] for key in flags} == {

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -294,15 +294,19 @@ def _unescape(text: str) -> str:
     return "".join(out)
 
 
-def _brand_list(value: str | None) -> dict[str, str | None]:
-    """A ``"brand";v="version"`` list as a mapping, or empty if there is none.
+def _brand_list(value: str | None) -> list[tuple[str, str | None]]:
+    """A ``"brand";v="version"`` list as sorted pairs, empty if there is none.
 
-    Order is not preserved, deliberately: the list is shuffled on purpose and
-    reading it positionally is the mistake it exists to prevent.
+    Sorted rather than left in order, because the list is shuffled on purpose
+    and reading it positionally is the mistake it exists to prevent. Pairs
+    rather than a mapping, because a mapping silently keeps only the last
+    version of a repeated brand: a list carrying ``Chromium`` at 148 *and* at
+    149 collapses to the current one, and a browser publishing two versions of
+    itself at once is exactly the contradiction being looked for.
     """
     if not value:
-        return {}
-    listed: dict[str, str | None] = {}
+        return []
+    listed: list[tuple[str, str | None]] = []
     for item in _split_outside_quotes(value, ","):
         fields = _split_outside_quotes(item.strip(), ";")
         name = _structured_string(fields[0])
@@ -313,8 +317,13 @@ def _brand_list(value: str | None) -> dict[str, str | None]:
             key, _, raw = parameter.partition("=")
             if key.strip() == "v":
                 version = _structured_string(raw)
-        listed[name] = version
-    return listed
+        listed.append((name, version))
+    return sorted(listed)
+
+
+def _js_brand_list(entries: list[dict]) -> list[tuple[str, str | None]]:
+    """The JavaScript side of the same list, in the same shape."""
+    return sorted((entry["brand"], entry["version"]) for entry in entries)
 
 
 def _realms(described: dict) -> dict[str, dict]:
@@ -408,26 +417,44 @@ class TestNothingAnnouncesAutomation:
         leaves every attribute the caller did not name exactly as it was, so
         the shape still matches. Measured, against exactly that mutation.
 
-        The getter's source does give it away. A native accessor stringifies to
-        ``[native code]``; anything written in JavaScript stringifies to itself.
+        The getter's source does give it away, but only if the whole of it is
+        read. Looking for ``[native code]`` as a substring is not enough:
+        ``function webdriver() { /* [native code] */ return false; }`` contains
+        it and passes, measured in Chrome 151. What a native accessor produces
+        is the NativeFunction form ECMA-262 specifies, and nothing written in
+        JavaScript can be spelled that way.
+
+        Held against ``userAgent`` rather than a literal, because that is a
+        native accessor on the same prototype that nothing has a reason to
+        touch. If V8 changes how it stringifies built-ins, both change together
+        and this survives; pinning the spelling is what would not.
 
         And the prototype is not the only place to look. Defining ``webdriver``
         directly on ``navigator`` shadows the accessor without touching it, so
-        the value reads false while every attribute above still measures
-        native. Measured in the bundled browser, which is why the instance is
-        asked about separately: a real browser has no own property there.
+        the value reads false while every attribute here still measures native.
+        Measured in the bundled browser: a real browser has no own property.
         """
         assert either_mode["page"]["webdriver"] is False
         assert either_mode["ownWebdriver"] is False, (
             "navigator carries its own webdriver property, which shadows the "
             "prototype accessor and leaves it looking untouched"
         )
+
         descriptor = either_mode["webdriverDescriptor"]
-        assert descriptor is not None
-        assert descriptor["get"] == "function", descriptor
-        assert descriptor["set"] == "undefined", descriptor
-        assert descriptor["configurable"] is True, descriptor
-        assert "[native code]" in descriptor["getSource"], descriptor
+        native = either_mode["userAgentDescriptor"]
+        assert descriptor is not None and native is not None
+
+        flags = ("get", "set", "enumerable", "configurable")
+        assert {key: descriptor[key] for key in flags} == {
+            key: native[key] for key in flags
+        }, f"webdriver {descriptor} against the native userAgent {native}"
+
+        assert descriptor["getSource"] == native["getSource"].replace(
+            "userAgent", "webdriver"
+        ), (
+            f"the webdriver getter reads {descriptor['getSource']!r} where a "
+            f"native one on this prototype reads {native['getSource']!r}"
+        )
 
     async def test_no_automation_globals_in_the_pages_own_realm(self, either_mode):
         """`__pwInitScripts`, `$cdc_*` and friends. Read from the page's own
@@ -483,15 +510,15 @@ class TestTheHintsAgreeWithTheUserAgent:
         page = either_mode["page"]
         ua_major = re.search(r"Chrome/(\d+)", page["ua"])
         assert ua_major, page["ua"]
-        real = {
-            entry["brand"]: entry["version"]
-            for entry in page["highEntropy"]["fullVersionList"]
-            if not _GREASE.search(entry["brand"])
-        }
+        real = [
+            pair
+            for pair in _js_brand_list(page["highEntropy"]["fullVersionList"])
+            if not _GREASE.search(pair[0])
+        ]
 
         assert real, page["highEntropy"]["fullVersionList"]
         assert all(
-            version.split(".")[0] == ua_major.group(1) for version in real.values()
+            (version or "").split(".")[0] == ua_major.group(1) for _, version in real
         ), f"user agent says {ua_major.group(1)}, full versions say {real}"
 
     async def test_the_header_channel_carries_them_too(self, either_mode):
@@ -526,9 +553,7 @@ class TestTheHintsAgreeWithTheUserAgent:
         # comparison sees that.
         sent_brands = _brand_list(headers.get("sec-ch-ua-full-version-list"))
         assert sent_brands, headers.get("sec-ch-ua-full-version-list")
-        assert sent_brands == {
-            b["brand"]: b["version"] for b in hints["fullVersionList"]
-        }, (
+        assert sent_brands == _js_brand_list(hints["fullVersionList"]), (
             f"sec-ch-ua-full-version-list says {sent_brands} and "
             f"getHighEntropyValues says {hints['fullVersionList']}"
         )
@@ -547,35 +572,17 @@ class TestTheHintsAgreeWithTheUserAgent:
         """
         listed = _brand_list(either_mode["page"]["headers"].get("sec-ch-ua"))
 
-        assert listed == {
-            brand["brand"]: brand["version"] for brand in either_mode["page"]["brands"]
-        }, (
+        assert listed == _js_brand_list(either_mode["page"]["brands"]), (
             f"sec-ch-ua says {listed} and navigator.userAgentData says "
             f"{either_mode['page']['brands']}"
         )
 
-    async def test_the_header_brand_major_matches_too(self, either_mode):
-        """The same relation on the wire, and the same reason for ``all``.
-
-        Parsed rather than substring-matched, so a major appearing anywhere in
-        the item, including inside a brand name, cannot stand in for the
-        version.
-        """
-        headers = either_mode["page"]["headers"]
-        ua_major = re.search(r"Chrome/(\d+)", either_mode["page"]["ua"])
-        assert ua_major
-
-        listed = _brand_list(headers.get("sec-ch-ua"))
-        reals = {
-            brand: version
-            for brand, version in listed.items()
-            if not _GREASE.search(brand)
-        }
-        assert reals, headers.get("sec-ch-ua")
-        assert all(
-            (version or "").split(".")[0] == ua_major.group(1)
-            for version in reals.values()
-        ), f"user agent says {ua_major.group(1)}, sec-ch-ua says {reals}"
+    # There is no separate case checking the wire brand major against the user
+    # agent. It was here and it caught nothing once the two lists above had to
+    # be equal: the header list equals the JavaScript one, and the JavaScript
+    # one has to match the user agent, so the wire relation follows and a case
+    # asserting it can only fail alongside one of those two. This file's rule
+    # is that an assertion which catches nothing is not kept for the look of it.
 
 
 class TestTheWindowFitsTheScreenItStandsOn:

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -280,13 +280,19 @@ def _structured_string(value: str | None) -> str | None:
 
     Backslash escapes are undone rather than left in place, so a brand carrying
     a quote reads as the browser meant it and not as its wire spelling.
+
+    An unquoted value is not read leniently as the text it resembles. Every
+    field this parses is an ``sf-string``, so ``Sec-CH-UA-Arch: arm`` is not a
+    differently spelled ``"arm"`` but a header a conforming recipient rejects,
+    and treating the two alike would let a browser emitting invalid syntax pass
+    as one emitting valid syntax.
     """
     if value is None:
         return None
     token = value.strip()
-    if len(token) >= 2 and token.startswith('"') and token.endswith('"'):
-        token = _unescape(token[1:-1])
-    return token or None
+    if len(token) < 2 or not token.startswith('"') or not token.endswith('"'):
+        return None
+    return _unescape(token[1:-1]) or None
 
 
 def _unescape(text: str) -> str:
@@ -312,6 +318,13 @@ def _brand_list(value: str | None) -> list[tuple[str, str | None]]:
     version of a repeated brand: a list carrying ``Chromium`` at 148 *and* at
     149 collapses to the current one, and a browser publishing two versions of
     itself at once is exactly the contradiction being looked for.
+
+    A member that is not a quoted string raises rather than being skipped. An
+    empty member and a bare token are both parse failures under RFC 8941, and
+    dropping them would turn a browser emitting invalid syntax into one that
+    looks like it emitted the valid list the comparison expects. A repeated
+    ``v`` is not an error: later parameters overwrite earlier ones, which is
+    what the specification says to do.
     """
     if not value:
         return []
@@ -320,7 +333,7 @@ def _brand_list(value: str | None) -> list[tuple[str, str | None]]:
         fields = _split_outside_quotes(item.strip(), ";")
         name = _structured_string(fields[0])
         if name is None:
-            continue
+            raise ValueError(f"not a structured-fields list member: {item!r}")
         version = None
         for parameter in fields[1:]:
             key, _, raw = parameter.partition("=")
@@ -366,6 +379,27 @@ class TestEveryRealmTellsTheSameStory:
         override that changes the string reaches only the first."""
         for name, realm in _realms(either_mode).items():
             assert realm["headers"]["user-agent"] == realm["ua"], name
+
+    async def test_the_frame_is_told_the_same_about_the_browser(self, either_mode):
+        """The low-entropy hints reach another origin, and must not change on
+        the way.
+
+        The user agent was the only thing compared across realms, so an
+        injection that touched one origin's client hints and left its user
+        agent alone passed every case here. These three are the hints Chromium
+        sends to a third party without being asked, measured identical to the
+        page's; the high-entropy ones are not compared, because measurement
+        says they do not reach a worker at all and delegation to a frame is the
+        embedder's choice rather than a property of the browser.
+        """
+        page = either_mode["page"]["headers"]
+        frame = either_mode["iframe"]["headers"]
+
+        for hint in ("sec-ch-ua", "sec-ch-ua-mobile", "sec-ch-ua-platform"):
+            assert frame[hint] == page[hint], (
+                f"{hint} reads {frame.get(hint)!r} in the frame and "
+                f"{page.get(hint)!r} on the page"
+            )
 
 
 class TestNothingAnnouncesAutomation:
@@ -473,6 +507,33 @@ class TestNothingAnnouncesAutomation:
             f"the webdriver getter reads {descriptor['getSource']!r} where a "
             f"native one on this prototype reads {native['getSource']!r}"
         )
+
+    async def test_no_realm_admits_to_being_driven(self, either_mode):
+        """`navigator.webdriver` is readable in more than one place.
+
+        Only the top document was asked, so a frame on another origin could
+        report ``true`` while all twenty-seven cases passed. Measured, and the
+        reason the two kinds are separated rather than looped over uniformly:
+        ``WorkerNavigator`` has no ``webdriver`` attribute at all, so both
+        workers report undefined and a check written as "false everywhere"
+        would be satisfied by a browser that had simply dropped the property.
+        The absence arrives as a missing key, because ``JSON.stringify`` omits
+        a property whose value is undefined, which is a cleaner signal than a
+        null would be: the attribute is not there rather than empty.
+        """
+        realms = _realms(either_mode)
+        documents = ("page", "cross-origin iframe")
+
+        for name in documents:
+            assert realms[name]["webdriver"] is False, (
+                f"{name} reports webdriver={realms[name]['webdriver']!r}"
+            )
+        for name, realm in realms.items():
+            if name not in documents:
+                assert "webdriver" not in realm, (
+                    f"{name} grew a webdriver attribute reading "
+                    f"{realm['webdriver']!r}, which no WorkerNavigator has"
+                )
 
     async def test_no_automation_globals_in_the_pages_own_realm(self, either_mode):
         """`__pwInitScripts`, `$cdc_*` and friends. Read from the page's own

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -119,12 +119,22 @@ async def _describe(tmp_path: Path, *, headless: bool) -> dict:
             # during the launch and nothing after it changes the answer.
             described["windowless"] = manager._windowless
         finally:
-            described_close = await manager.close()
+            # Closed by name rather than through ``async with``, so the browser
+            # is torn down on the measurement's failure as well as its success.
+            #
+            # Its verdict is deliberately not asserted. ``close()`` bounds each
+            # cleanup step at ten seconds and reports ``False`` when one runs
+            # out, which is the bound working rather than a browser misbehaving:
+            # measured on a machine at load average 96, a headed teardown missed
+            # it five times in eight, while an interleaved A/B against a plain
+            # persistent context put the two within 0.3 s of each other, so
+            # there is nothing here that identity work could regress. Asserting
+            # it would report machine load as a fingerprint failure. The
+            # shutdown contract itself is covered where it can be made
+            # deterministic, in ``test_core_browser.py`` and
+            # ``test_browser_driver.py``, by shrinking that bound.
+            await manager.close()
 
-        assert described_close, (
-            "the browser did not confirm it had exited, so Chromium may still "
-            "be holding this profile while the directory is removed"
-        )
         return described
     finally:
         shutil.rmtree(profile, ignore_errors=True)

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -102,6 +102,11 @@ _NATIVE_FUNCTION = re.compile(
 #: the ones this browser can currently report, and a platform that is not here
 #: is not judged: a new one belongs in this table after somebody looks it up,
 #: rather than failing a browser that is telling the truth about itself.
+#: The ones among them that no mobile device runs. Kept beside the table
+#: rather than derived from it, because "not mobile" is a claim about the
+#: platform and not about whether its user-agent token is known.
+_DESKTOP_PLATFORMS = frozenset({"macOS", "Windows", "Linux", "Chrome OS"})
+
 _PLATFORM_TOKENS = {
     "macOS": "Macintosh",
     "Windows": "Windows",
@@ -171,6 +176,9 @@ async def _describe(tmp_path: Path, *, headless: bool) -> dict:
             # Read before the close, because ``_no_window_available`` is set
             # during the launch and nothing after it changes the answer.
             described["windowless"] = manager._windowless
+            # Whether this machine turned out to have nowhere to put a window,
+            # which is a fact about the machine rather than about the browser.
+            described["noWindowAvailable"] = manager._no_window_available
         finally:
             # Closed by name rather than through ``async with``, so the browser
             # is torn down on the measurement's failure as well as its success.
@@ -322,10 +330,7 @@ def _structured_string(value: str | None) -> str | None:
     token = value.strip()
     if len(token) < 2 or not token.startswith('"') or not token.endswith('"'):
         return None
-    inner = _unescape(token[1:-1])
-    if '"' in inner and '\\"' not in token:
-        raise ValueError(f"an unescaped quote inside a structured string: {value!r}")
-    return inner or None
+    return _unescape(token[1:-1]) or None
 
 
 def _unescape(text: str) -> str:
@@ -347,6 +352,12 @@ def _unescape(text: str) -> str:
             escaped = False
         elif character == "\\":
             escaped = True
+        elif character == '"':
+            # Every quote inside the string has to be escaped, and this is the
+            # place that can tell: looking for an escape *somewhere* in the
+            # value, as an earlier version did, accepts one escaped quote as
+            # cover for a second unescaped one.
+            raise ValueError(f"an unescaped quote in a structured string: {text!r}")
         else:
             out.append(character)
     if escaped:
@@ -382,6 +393,8 @@ def _brand_list(value: str | None) -> list[tuple[str, str | None]]:
         version = None
         for parameter in fields[1:]:
             key, _, raw = parameter.partition("=")
+            if not key.strip():
+                raise ValueError(f"an empty parameter on a list member: {item!r}")
             if key.strip() == "v":
                 version = _structured_string(raw)
         listed.append((name, version))
@@ -482,6 +495,17 @@ class TestEveryRealmTellsTheSameStory:
             f"userAgentData.mobile is {page['mobile']!r}"
         )
 
+        # Agreeing with itself is not enough for this one either. A browser
+        # reporting macOS and a mobile form factor at the same time is saying
+        # two things no device is, and it passed while only the two channels
+        # were held against each other. Judged only for platforms known to be
+        # desktop, on the same principle as the table above.
+        if page["platform"] in _DESKTOP_PLATFORMS:
+            assert page["mobile"] is False, (
+                f"the platform is {page['platform']!r} and the browser calls "
+                f"itself mobile"
+            )
+
         token = _PLATFORM_TOKENS.get(page["platform"])
         if token is not None:
             assert token in page["ua"], (
@@ -542,6 +566,15 @@ class TestNothingAnnouncesAutomation:
         """
         from linkedin_mcp_server.hidden_target import hidden_target_is_supported
 
+        if default_mode["noWindowAvailable"]:
+            # A supported configuration, not a regression: macOS reached over
+            # SSH or run from a launch daemon has no WindowServer, the headed
+            # attempt is refused, and the fallback to real headless is the
+            # right answer. Routed through the same handler as a missing
+            # browser, so it skips on the developer's machine and still fails
+            # in CI, where every runner does have somewhere to put a window.
+            _unavailable("this machine has nowhere to put a window")
+
         assert default_mode["windowless"] == hidden_target_is_supported(), (
             "the default launch fell back to Chromium's headless mode on a "
             "platform that supports a hidden target, which puts the "
@@ -592,6 +625,25 @@ class TestNothingAnnouncesAutomation:
         directly on ``navigator`` shadows the accessor without touching it, so
         the value reads false while every attribute here still measures native.
         Measured in the bundled browser: a real browser has no own property.
+
+        **Where this stops, stated rather than papered over.** Everything above
+        is read from inside the page's realm, so a patch applied to that whole
+        realm can answer every question consistently: replace the getter, patch
+        ``Function.prototype.toString`` to describe both it and itself as
+        native, delegate for everything else, and each assertion here is
+        satisfied. Measured, and one more layer of self-description does not
+        close it, because the layer is asked the same way. Two escapes were
+        tried and neither works: the isolated world ``page.evaluate`` uses
+        shares these prototypes, so it reads the patch back unchanged; and a
+        CDP read still has to evaluate ``getOwnPropertyDescriptor`` in the
+        realm, which is as patchable as the rest.
+
+        That boundary is the realm's, not this file's. The standard here is
+        that nothing the browser says is refuted by another surface of the same
+        browser, and a uniformly patched realm is coherent -- dishonest, but
+        coherent, and invisible to the websites this exists to reason about.
+        Proving the runtime unmodified is a different exercise from proving it
+        consistent, and it wants a different tool.
         """
         assert either_mode["page"]["webdriver"] is False
         assert either_mode["ownWebdriver"] is False, (

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -90,24 +90,42 @@ async def _describe(tmp_path: Path, *, headless: bool) -> dict:
     ``BrowserConfig()`` rather than ``get_config()``: the global parses
     ``sys.argv`` and aborts under pytest, and the defaults are what the gate is
     about anyway.
+
+    **Only the launch is allowed to turn into a skip.** A browser that cannot
+    start is a missing dependency; a browser that starts and then fails to
+    answer is the regression this file exists to catch, and routing both
+    through the same handler would let the second hide behind the first
+    wherever a skip is still permitted.
     """
     launch_options, viewport = build_launch_options(BrowserConfig())
     profile = tmp_path / f"identity-{'headless' if headless else 'headed'}"
+    manager = BrowserManager(
+        user_data_dir=profile,
+        headless=headless,
+        viewport=viewport,
+        **launch_options,
+    )
     try:
-        manager = BrowserManager(
-            user_data_dir=profile,
-            headless=headless,
-            viewport=viewport,
-            **launch_options,
-        )
-        async with manager as browser:
+        try:
+            await manager.start()
+        except Exception as exc:  # noqa: BLE001 - the reason is the payload
+            _unavailable(f"could not start a browser ({type(exc).__name__}: {exc})")
+            raise  # unreachable; _unavailable always raises
+
+        try:
             with IdentityServer() as server:
-                described = await describe_browser(browser.page, server.url)
-        described["windowless"] = manager._windowless
+                described = await describe_browser(manager.page, server.url)
+            # Read before the close, because ``_no_window_available`` is set
+            # during the launch and nothing after it changes the answer.
+            described["windowless"] = manager._windowless
+        finally:
+            described_close = await manager.close()
+
+        assert described_close, (
+            "the browser did not confirm it had exited, so Chromium may still "
+            "be holding this profile while the directory is removed"
+        )
         return described
-    except Exception as exc:  # noqa: BLE001 - the reason is the payload
-        _unavailable(f"could not start a browser ({type(exc).__name__}: {exc})")
-        raise  # unreachable; _unavailable always raises
     finally:
         shutil.rmtree(profile, ignore_errors=True)
 
@@ -144,17 +162,20 @@ def _realms(described: dict) -> dict[str, dict]:
         "page": described["page"],
         "dedicated worker": described["dedicated"],
         "service worker": described["serviceWorker"],
+        "cross-origin iframe": described["iframe"],
     }
 
 
 class TestEveryRealmTellsTheSameStory:
     """A contradiction between realms is the cheapest thing for a site to find.
 
-    The user agent is readable from a page, from a dedicated worker and from a
-    service worker, and each one also sends it as a request header. That is six
-    places one value has to agree with itself. An override that reaches only
-    some of them, which is what every user-agent option in this space does, is
-    visible to anyone who looks twice.
+    The user agent is readable from a page, from a dedicated worker, from a
+    service worker and from a frame on another origin, and each one also sends
+    it as a request header. That is eight places one value has to agree with
+    itself. An override that reaches only some of them, which is what every
+    user-agent option in this space does, is visible to anyone who looks twice:
+    ``user_agent=`` never reaches a service worker at all, and the frame is the
+    other surface it routinely misses.
     """
 
     async def test_all_three_realms_report_one_user_agent(self, default_mode):
@@ -182,13 +203,20 @@ class TestNothingAnnouncesAutomation:
     async def test_the_default_launch_uses_the_hidden_target_where_it_can(
         self, default_mode
     ):
-        """Not just self-consistent: actually windowless where that is possible.
+        """The hidden target was used, and not quietly given up on.
 
-        The consistency check below would pass a browser that silently gave up
-        on the hidden target and fell back to real headless, because a fallback
-        is consistent with itself. That fallback is exactly the regression worth
-        catching on the platform most people run, so it gets its own assertion
-        against what the code claims the platform can do.
+        ``_windowless`` is not merely the platform predicate restated. Its
+        third term is ``not self._no_window_available``, which the launch sets
+        when a headed browser is refused and the fallback to Chromium's real
+        headless mode runs instead. A fallback is consistent with itself, so
+        every other assertion here would pass it; this is the one that does
+        not.
+
+        What it does *not* prove is that no window is on screen. That takes a
+        window-server query, and the two ways the page could be the wrong one
+        -- a hidden target identified by position rather than by its nonce, or
+        a startup page that is never closed -- are covered directly in
+        ``tests/test_hidden_target.py``.
         """
         from linkedin_mcp_server.hidden_target import hidden_target_is_supported
 
@@ -211,10 +239,20 @@ class TestNothingAnnouncesAutomation:
         )
 
     async def test_webdriver_is_false_and_unremarkable(self, default_mode):
+        """`false` is not enough on its own: how it got there is also readable.
+
+        A native ``Navigator.prototype.webdriver`` is an accessor with a getter,
+        no setter, and configurable. Redefining it to return ``false`` is the
+        usual way to hide automation, and the cheapest tell it leaves is a
+        descriptor that is no longer configurable. The value would match; the
+        shape would not.
+        """
         assert default_mode["page"]["webdriver"] is False
         descriptor = default_mode["webdriverDescriptor"]
         assert descriptor is not None
         assert descriptor["get"] == "function", descriptor
+        assert descriptor["set"] == "undefined", descriptor
+        assert descriptor["configurable"] is True, descriptor
 
     async def test_no_automation_globals_in_the_pages_own_realm(self, default_mode):
         """`__pwInitScripts`, `$cdc_*` and friends. Read from the page's own

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -66,10 +66,12 @@ pytestmark = [
 #:
 #: The separator class has to be wide. Chromium draws it from a fixed set that
 #: includes ``;``, ``:``, ``(``, ``=`` and ``?`` alongside the obvious ones, and
-#: the entry this browser actually sends is ``Not)A;Brand`` -- which an earlier
-#: spelling of this pattern did not match, quietly promoting the GREASE entry to
-#: a real brand. ``[\W_]`` covers the whole set, since ``_`` is the one
-#: separator that is also a word character.
+#: two of those are in play right here: the bundled browser sends
+#: ``Not)A;Brand`` and Chrome 151 under ``CHROME_PATH`` sends ``Not=A?Brand``.
+#: An earlier spelling of this pattern listed five characters and matched
+#: neither, quietly promoting the GREASE entry to a real brand. ``[\W_]`` covers
+#: the whole set, since ``_`` is the one separator that is also a word
+#: character.
 _GREASE = re.compile(r"not[\W_]?a[\W_]?brand", re.IGNORECASE)
 
 
@@ -390,12 +392,13 @@ class TestTheHintsAgreeWithTheUserAgent:
         """Order is not pinned: the brand list is deliberately shuffled and
         salted with a GREASE entry to stop anyone reading it positionally.
 
-        Every real brand has to agree, not one of them. Chrome for Testing
-        advertises ``Chromium`` and branded Chrome adds ``Google Chrome``, both
-        at the running major; a list carrying one brand at the user agent's
-        major and another at a different one is a contradiction the browser is
-        publishing about itself, and ``any`` would read the agreeing half and
-        call it settled.
+        Every real brand has to agree, not one of them. Measured: Chrome for
+        Testing advertises ``Chromium`` alone, and Chrome 151 under
+        ``CHROME_PATH`` advertises ``Google Chrome`` and ``Chromium`` at the
+        same major. A list carrying one brand at the user agent's major and
+        another at a different one is a contradiction the browser is publishing
+        about itself, and ``any`` would read the agreeing half and call it
+        settled.
         """
         page = either_mode["page"]
         ua_major = re.search(r"Chrome/(\d+)", page["ua"])

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -63,7 +63,14 @@ pytestmark = [
 #: GREASE brands exist to stop anyone parsing the list positionally. They carry
 #: deliberately meaningless versions, so a real brand has to be found by
 #: excluding them rather than by index.
-_GREASE = re.compile(r"not[)/\-_. ]?a[)/\-_. ]?brand", re.IGNORECASE)
+#:
+#: The separator class has to be wide. Chromium draws it from a fixed set that
+#: includes ``;``, ``:``, ``(``, ``=`` and ``?`` alongside the obvious ones, and
+#: the entry this browser actually sends is ``Not)A;Brand`` -- which an earlier
+#: spelling of this pattern did not match, quietly promoting the GREASE entry to
+#: a real brand. ``[\W_]`` covers the whole set, since ``_`` is the one
+#: separator that is also a word character.
+_GREASE = re.compile(r"not[\W_]?a[\W_]?brand", re.IGNORECASE)
 
 
 def _running_in_ci() -> bool:
@@ -164,9 +171,15 @@ async def _for_mode(tmp_path_factory, cache: dict, headless: bool) -> dict:
     times.
 
     ``BaseException`` because the outcomes worth remembering are the ones
-    pytest raises. ``pytest.fail`` and ``pytest.skip`` both raise from
-    ``OutcomeException``, which does not descend from ``Exception``, and either
-    one re-raised for the remaining cases is exactly the right answer for them.
+    pytest raises: ``pytest.fail`` and ``pytest.skip`` both raise from
+    ``OutcomeException``, which does not descend from ``Exception``.
+
+    What is kept is a description rather than the exception object. Re-raising
+    the instance works, and it also carries its traceback, its context and the
+    frame locals of the launch that failed, so every replay appends another
+    stack to the same chain and pins the first ``BrowserManager`` alive until
+    the module ends. The first case to run reports the real failure in full;
+    the rest need only to be told that it already happened.
     """
     key = "headless" if headless else "headed"
     if key not in cache:
@@ -174,12 +187,15 @@ async def _for_mode(tmp_path_factory, cache: dict, headless: bool) -> dict:
         try:
             cache[key] = (None, await _describe(base, headless=headless))
         except BaseException as exc:
-            cache[key] = (exc, None)
+            skipped = isinstance(exc, pytest.skip.Exception)
+            cache[key] = ((skipped, f"{type(exc).__name__}: {exc}"), None)
             raise
 
     failure, described = cache[key]
     if failure is not None:
-        raise failure
+        skipped, reason = failure
+        already = f"the {key} launch already failed in this module ({reason})"
+        pytest.skip(already) if skipped else pytest.fail(already)
     return described
 
 
@@ -343,8 +359,18 @@ class TestNothingAnnouncesAutomation:
 
         The getter's source does give it away. A native accessor stringifies to
         ``[native code]``; anything written in JavaScript stringifies to itself.
+
+        And the prototype is not the only place to look. Defining ``webdriver``
+        directly on ``navigator`` shadows the accessor without touching it, so
+        the value reads false while every attribute above still measures
+        native. Measured in the bundled browser, which is why the instance is
+        asked about separately: a real browser has no own property there.
         """
         assert either_mode["page"]["webdriver"] is False
+        assert either_mode["ownWebdriver"] is False, (
+            "navigator carries its own webdriver property, which shadows the "
+            "prototype accessor and leaves it looking untouched"
+        )
         descriptor = either_mode["webdriverDescriptor"]
         assert descriptor is not None
         assert descriptor["get"] == "function", descriptor
@@ -362,14 +388,22 @@ class TestNothingAnnouncesAutomation:
 class TestTheHintsAgreeWithTheUserAgent:
     async def test_the_brand_major_matches_the_user_agent_major(self, either_mode):
         """Order is not pinned: the brand list is deliberately shuffled and
-        salted with a GREASE entry to stop anyone reading it positionally."""
+        salted with a GREASE entry to stop anyone reading it positionally.
+
+        Every real brand has to agree, not one of them. Chrome for Testing
+        advertises ``Chromium`` and branded Chrome adds ``Google Chrome``, both
+        at the running major; a list carrying one brand at the user agent's
+        major and another at a different one is a contradiction the browser is
+        publishing about itself, and ``any`` would read the agreeing half and
+        call it settled.
+        """
         page = either_mode["page"]
         ua_major = re.search(r"Chrome/(\d+)", page["ua"])
         assert ua_major, page["ua"]
         real = [b for b in page["brands"] if not _GREASE.search(b["brand"])]
 
         assert real, page["brands"]
-        assert any(b["version"].split(".")[0] == ua_major.group(1) for b in real), (
+        assert all(b["version"].split(".")[0] == ua_major.group(1) for b in real), (
             f"user agent says {ua_major.group(1)}, brands say "
             f"{[(b['brand'], b['version']) for b in real]}"
         )
@@ -423,14 +457,27 @@ class TestTheHintsAgreeWithTheUserAgent:
         )
 
     async def test_the_header_brand_major_matches_too(self, either_mode):
+        """The same relation on the wire, and the same reason for ``all``.
+
+        Parsed rather than substring-matched, so a major appearing anywhere in
+        the item, including inside a brand name, cannot stand in for the
+        version.
+        """
         headers = either_mode["page"]["headers"]
         ua_major = re.search(r"Chrome/(\d+)", either_mode["page"]["ua"])
         assert ua_major
 
-        brands = headers.get("sec-ch-ua", "")
-        reals = [part for part in brands.split(",") if not _GREASE.search(part)]
-        assert reals, brands
-        assert any(f'"{ua_major.group(1)}"' in part for part in reals), brands
+        listed = _brand_list(headers.get("sec-ch-ua"))
+        reals = {
+            brand: version
+            for brand, version in listed.items()
+            if not _GREASE.search(brand)
+        }
+        assert reals, headers.get("sec-ch-ua")
+        assert all(
+            (version or "").split(".")[0] == ua_major.group(1)
+            for version in reals.values()
+        ), f"user agent says {ua_major.group(1)}, sec-ch-ua says {reals}"
 
 
 class TestTheWindowFitsTheScreenItStandsOn:

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -231,6 +231,35 @@ async def either_mode(request, tmp_path_factory, _mode_results) -> dict:
     return await _for_mode(tmp_path_factory, _mode_results, headless=request.param)
 
 
+def _split_outside_quotes(value: str, separator: str) -> list[str]:
+    """Split on *separator* where it is not inside a quoted string.
+
+    Not a general structured-fields parser, and it does not pretend to be one:
+    it knows that a quoted string runs to its unescaped closing quote and that
+    ``\\`` escapes the next character, which is all RFC 8941 allows inside one.
+    That is enough for the two headers read here, and it is the part that
+    matters, because a plain ``split`` on the separator would cut a brand name
+    containing it in half and fail a browser that is telling the truth.
+    """
+    parts: list[str] = []
+    current: list[str] = []
+    quoted = escaped = False
+    for character in value:
+        if escaped:
+            escaped = False
+        elif quoted and character == "\\":
+            escaped = True
+        elif character == '"':
+            quoted = not quoted
+        elif character == separator and not quoted:
+            parts.append("".join(current))
+            current = []
+            continue
+        current.append(character)
+    parts.append("".join(current))
+    return parts
+
+
 def _structured_string(value: str | None) -> str | None:
     """The text inside a structured-field string, or None if there is none.
 
@@ -239,32 +268,52 @@ def _structured_string(value: str | None) -> str | None:
     Python string, and ``assert headers.get(...)`` accepts it. Blank is exactly
     the failure worth catching here, since it is what a browser emits when it
     has the value in JavaScript and cannot put it on the wire.
+
+    Backslash escapes are undone rather than left in place, so a brand carrying
+    a quote reads as the browser meant it and not as its wire spelling.
     """
     if value is None:
         return None
-    return value.strip().strip('"') or None
+    token = value.strip()
+    if len(token) >= 2 and token.startswith('"') and token.endswith('"'):
+        token = _unescape(token[1:-1])
+    return token or None
+
+
+def _unescape(text: str) -> str:
+    out: list[str] = []
+    escaped = False
+    for character in text:
+        if escaped:
+            out.append(character)
+            escaped = False
+        elif character == "\\":
+            escaped = True
+        else:
+            out.append(character)
+    return "".join(out)
 
 
 def _brand_list(value: str | None) -> dict[str, str | None]:
     """A ``"brand";v="version"`` list as a mapping, or empty if there is none.
 
-    Split on the comma at the top level and on the *last* ``;v=`` in each item.
-    Both are safe against the GREASE entry, whose separators Chromium draws
-    from a fixed set that contains ``;`` but no comma, and which cannot produce
-    the sequence ``;v=`` because what follows a separator is always ``A`` or
-    ``Brand``. Order is not preserved, deliberately: the list is shuffled on
-    purpose and reading it positionally is the mistake it exists to prevent.
+    Order is not preserved, deliberately: the list is shuffled on purpose and
+    reading it positionally is the mistake it exists to prevent.
     """
     if not value:
         return {}
     listed: dict[str, str | None] = {}
-    for part in value.split(","):
-        brand, _, version = part.strip().rpartition(";v=")
-        if not brand:  # an item with no version at all
-            brand, version = version, ""
-        name = _structured_string(brand)
-        if name is not None:
-            listed[name] = _structured_string(version)
+    for item in _split_outside_quotes(value, ","):
+        fields = _split_outside_quotes(item.strip(), ";")
+        name = _structured_string(fields[0])
+        if name is None:
+            continue
+        version = None
+        for parameter in fields[1:]:
+            key, _, raw = parameter.partition("=")
+            if key.strip() == "v":
+                version = _structured_string(raw)
+        listed[name] = version
     return listed
 
 
@@ -420,6 +469,31 @@ class TestTheHintsAgreeWithTheUserAgent:
         assert hints["bitness"], hints
         assert hints["fullVersionList"], hints
 
+    async def test_the_full_versions_name_the_running_major(self, either_mode):
+        """Non-empty is not the same as current.
+
+        The two channels are compared against each other below, so a version
+        list that has gone stale in *both* agrees with itself perfectly: user
+        agent and low-entropy brands at 149 while every full version still says
+        148 is a browser contradicting itself about its own build, and nothing
+        else here looks at it. Tying the real entries to the user agent's major
+        is what closes that, and it disposes of a GREASE-only list at the same
+        time, since after the filter there would be nothing left to check.
+        """
+        page = either_mode["page"]
+        ua_major = re.search(r"Chrome/(\d+)", page["ua"])
+        assert ua_major, page["ua"]
+        real = {
+            entry["brand"]: entry["version"]
+            for entry in page["highEntropy"]["fullVersionList"]
+            if not _GREASE.search(entry["brand"])
+        }
+
+        assert real, page["highEntropy"]["fullVersionList"]
+        assert all(
+            version.split(".")[0] == ua_major.group(1) for version in real.values()
+        ), f"user agent says {ua_major.group(1)}, full versions say {real}"
+
     async def test_the_header_channel_carries_them_too(self, either_mode):
         """A different channel from `getHighEntropyValues()`, and it only fills
         in on a request *after* the server has asked with `Accept-CH`. The page
@@ -457,6 +531,27 @@ class TestTheHintsAgreeWithTheUserAgent:
         }, (
             f"sec-ch-ua-full-version-list says {sent_brands} and "
             f"getHighEntropyValues says {hints['fullVersionList']}"
+        )
+
+    async def test_the_header_brand_list_matches_the_one_in_javascript(
+        self, either_mode
+    ):
+        """The low-entropy list is readable twice, and the two must be one list.
+
+        Both were checked against the user agent's major and never against each
+        other, which leaves the brand *names* unbound: JavaScript can say
+        ``Chromium`` while the wire says something else entirely, at the same
+        major, and every other assertion here is satisfied. That is the shape a
+        header override takes, and it is one of the two surfaces such an
+        override is known to miss.
+        """
+        listed = _brand_list(either_mode["page"]["headers"].get("sec-ch-ua"))
+
+        assert listed == {
+            brand["brand"]: brand["version"] for brand in either_mode["page"]["brands"]
+        }, (
+            f"sec-ch-ua says {listed} and navigator.userAgentData says "
+            f"{either_mode['page']['brands']}"
         )
 
     async def test_the_header_brand_major_matches_too(self, either_mode):

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -95,8 +95,21 @@ _GREASE = re.compile(r"not[\W_]?a[\W_]?brand", re.IGNORECASE)
 #: themselves are not. What it refuses is anything carrying a function body,
 #: which is every accessor written in JavaScript.
 _NATIVE_FUNCTION = re.compile(
-    r"function\s+(get|set)\s+\S+\s*\(\s*\)\s*\{\s*\[\s*native\s+code\s*\]\s*\}"
+    r"function\s+((get|set)\s+)?\S*\s*\(\s*\)\s*\{\s*\[\s*native\s+code\s*\]\s*\}"
 )
+
+#: What the user agent has to say for a platform the client hint claims. Only
+#: the ones this browser can currently report, and a platform that is not here
+#: is not judged: a new one belongs in this table after somebody looks it up,
+#: rather than failing a browser that is telling the truth about itself.
+_PLATFORM_TOKENS = {
+    "macOS": "Macintosh",
+    "Windows": "Windows",
+    "Linux": "Linux",
+    "Android": "Android",
+    "Chrome OS": "CrOS",
+    "Chromium OS": "CrOS",
+}
 
 
 def _running_in_ci() -> bool:
@@ -280,6 +293,8 @@ def _split_outside_quotes(value: str, separator: str) -> list[str]:
             current = []
             continue
         current.append(character)
+    if quoted or escaped:
+        raise ValueError(f"an unterminated structured string: {value!r}")
     parts.append("".join(current))
     return parts
 
@@ -307,7 +322,10 @@ def _structured_string(value: str | None) -> str | None:
     token = value.strip()
     if len(token) < 2 or not token.startswith('"') or not token.endswith('"'):
         return None
-    return _unescape(token[1:-1]) or None
+    inner = _unescape(token[1:-1])
+    if '"' in inner and '\\"' not in token:
+        raise ValueError(f"an unescaped quote inside a structured string: {value!r}")
+    return inner or None
 
 
 def _unescape(text: str) -> str:
@@ -436,6 +454,63 @@ class TestEveryRealmTellsTheSameStory:
                 f"{page.get(hint)!r} on the page"
             )
 
+    async def test_the_platform_and_form_factor_agree_with_javascript(
+        self, either_mode
+    ):
+        """Two hints that were compared between origins and nowhere else.
+
+        Agreeing across origins says only that whatever is being reported is
+        reported consistently, so a change that reached both said nothing: a
+        browser sending ``"Windows"`` and ``?1`` from a machine whose user
+        agent says Macintosh passed every case. The JavaScript side is the
+        other channel, and it is the one that has to match.
+
+        The user agent is brought in only where the platform is one this knows
+        a token for. An unfamiliar platform is left alone rather than guessed
+        at, because a new one is a thing to look up and not a reason to fail a
+        browser that is telling the truth.
+        """
+        page = either_mode["page"]
+        headers = page["headers"]
+
+        assert _structured_string(headers["sec-ch-ua-platform"]) == page["platform"], (
+            f"sec-ch-ua-platform says {headers['sec-ch-ua-platform']!r} and "
+            f"userAgentData says {page['platform']!r}"
+        )
+        assert headers["sec-ch-ua-mobile"] == ("?1" if page["mobile"] else "?0"), (
+            f"sec-ch-ua-mobile says {headers['sec-ch-ua-mobile']!r} and "
+            f"userAgentData.mobile is {page['mobile']!r}"
+        )
+
+        token = _PLATFORM_TOKENS.get(page["platform"])
+        if token is not None:
+            assert token in page["ua"], (
+                f"the platform is {page['platform']!r} and the user agent "
+                f"({page['ua']}) does not mention {token!r}"
+            )
+
+    async def test_the_two_brand_lists_name_the_same_browser(self, either_mode):
+        """The short list and the full one describe one browser, or should.
+
+        Each was tied to the user agent's major and to its own counterpart on
+        the wire, and never to the other. So ``brands`` could name ``Chromium``
+        while ``fullVersionList`` named something else entirely at the same
+        version, on both channels, and every case passed. The names have to be
+        the same names, and each short version has to be the major of the full
+        one it belongs to.
+        """
+        page = either_mode["page"]
+        short = _js_brand_list(page["brands"])
+        full = _js_brand_list(page["highEntropy"]["fullVersionList"])
+
+        assert [brand for brand, _ in short] == [brand for brand, _ in full], (
+            f"brands names {[b for b, _ in short]} and fullVersionList names "
+            f"{[b for b, _ in full]}"
+        )
+        assert short == [
+            (brand, (version or "").split(".")[0]) for brand, version in full
+        ], f"brands says {short} and fullVersionList says {full}"
+
 
 class TestNothingAnnouncesAutomation:
     async def test_no_headless_token_where_a_window_is_possible(self, headed_mode):
@@ -527,6 +602,10 @@ class TestNothingAnnouncesAutomation:
         descriptor = either_mode["webdriverDescriptor"]
         native = either_mode["userAgentDescriptor"]
         assert descriptor is not None and native is not None
+        assert _NATIVE_FUNCTION.fullmatch(either_mode["toStringSource"]), (
+            "Function.prototype.toString is not itself native, so nothing it "
+            f"says about any other function counts: {either_mode['toStringSource']!r}"
+        )
         assert _NATIVE_FUNCTION.fullmatch(native["getSource"]), (
             f"the control accessor is not native either: {native['getSource']!r}"
         )

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -243,9 +243,13 @@ class TestNothingAnnouncesAutomation:
 
         A native ``Navigator.prototype.webdriver`` is an accessor with a getter,
         no setter, and configurable. Redefining it to return ``false`` is the
-        usual way to hide automation, and the cheapest tell it leaves is a
-        descriptor that is no longer configurable. The value would match; the
-        shape would not.
+        usual way to hide automation, and the descriptor does not give that
+        away: ``Object.defineProperty`` on an existing configurable property
+        leaves every attribute the caller did not name exactly as it was, so
+        the shape still matches. Measured, against exactly that mutation.
+
+        The getter's source does give it away. A native accessor stringifies to
+        ``[native code]``; anything written in JavaScript stringifies to itself.
         """
         assert default_mode["page"]["webdriver"] is False
         descriptor = default_mode["webdriverDescriptor"]
@@ -253,6 +257,7 @@ class TestNothingAnnouncesAutomation:
         assert descriptor["get"] == "function", descriptor
         assert descriptor["set"] == "undefined", descriptor
         assert descriptor["configurable"] is True, descriptor
+        assert "[native code]" in descriptor["getSource"], descriptor
 
     async def test_no_automation_globals_in_the_pages_own_realm(self, default_mode):
         """`__pwInitScripts`, `$cdc_*` and friends. Read from the page's own

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -28,6 +28,13 @@ real headless mode on Linux, where it does announce itself. Asserting "no
 headless token" against the default would therefore be an assertion that
 catches nothing on the platform CI runs. The headed mode is the one the
 container image is heading for, and it is where that assertion bites.
+
+Only three cases are about a particular mode: the headless token, whether the
+hidden target was used, and whether the default mode matches its own claim.
+Everything else is true of a browser however it was started, so it runs against
+both, which costs nothing because both launches are already cached. A
+regression that appears in headed Chromium alone is otherwise invisible here,
+and headed is not the cheaper mode to leave uncovered.
 """
 
 from __future__ import annotations
@@ -167,6 +174,37 @@ async def headed_mode(tmp_path_factory, _mode_results) -> dict:
     return await _for_mode(tmp_path_factory, _mode_results, headless=False)
 
 
+@pytest.fixture(params=[True, False], ids=["default", "headed"])
+async def either_mode(request, tmp_path_factory, _mode_results) -> dict:
+    """Both launches, for every relation that does not depend on the mode.
+
+    Most of what this file asserts is true of a browser regardless of how it
+    was started, and running it against one mode only halves the gate for free:
+    a regression that shows up in headed Chromium alone would leave the two
+    headed assertions and every default-mode assertion untouched. Headed is
+    also the mode the container image is heading for, so it is not the cheaper
+    one to leave uncovered.
+
+    No extra launches. Both modes are already started and cached for the module,
+    so this only decides which of the two an existing case reads.
+    """
+    return await _for_mode(tmp_path_factory, _mode_results, headless=request.param)
+
+
+def _structured_string(value: str | None) -> str | None:
+    """The text inside a structured-field string, or None if there is none.
+
+    Client hints arrive quoted: ``Sec-CH-UA-Arch: "arm"``. So a hint the browser
+    left blank arrives as two quote characters, which is a perfectly truthy
+    Python string, and ``assert headers.get(...)`` accepts it. Blank is exactly
+    the failure worth catching here, since it is what a browser emits when it
+    has the value in JavaScript and cannot put it on the wire.
+    """
+    if value is None:
+        return None
+    return value.strip().strip('"') or None
+
+
 def _realms(described: dict) -> dict[str, dict]:
     return {
         "page": described["page"],
@@ -188,15 +226,15 @@ class TestEveryRealmTellsTheSameStory:
     other surface it routinely misses.
     """
 
-    async def test_all_three_realms_report_one_user_agent(self, default_mode):
-        agents = {name: realm["ua"] for name, realm in _realms(default_mode).items()}
+    async def test_every_realm_reports_one_user_agent(self, either_mode):
+        agents = {name: realm["ua"] for name, realm in _realms(either_mode).items()}
 
         assert len(set(agents.values())) == 1, agents
 
-    async def test_each_realm_sends_what_it_says(self, default_mode):
+    async def test_each_realm_sends_what_it_says(self, either_mode):
         """The JS value and the request header are different channels, and an
         override that changes the string reaches only the first."""
-        for name, realm in _realms(default_mode).items():
+        for name, realm in _realms(either_mode).items():
             assert realm["headers"]["user-agent"] == realm["ua"], name
 
 
@@ -248,7 +286,7 @@ class TestNothingAnnouncesAutomation:
             f"HeadlessChrome present={has_token}"
         )
 
-    async def test_webdriver_is_false_and_unremarkable(self, default_mode):
+    async def test_webdriver_is_false_and_unremarkable(self, either_mode):
         """`false` is not enough on its own: how it got there is also readable.
 
         A native ``Navigator.prototype.webdriver`` is an accessor with a getter,
@@ -261,26 +299,26 @@ class TestNothingAnnouncesAutomation:
         The getter's source does give it away. A native accessor stringifies to
         ``[native code]``; anything written in JavaScript stringifies to itself.
         """
-        assert default_mode["page"]["webdriver"] is False
-        descriptor = default_mode["webdriverDescriptor"]
+        assert either_mode["page"]["webdriver"] is False
+        descriptor = either_mode["webdriverDescriptor"]
         assert descriptor is not None
         assert descriptor["get"] == "function", descriptor
         assert descriptor["set"] == "undefined", descriptor
         assert descriptor["configurable"] is True, descriptor
         assert "[native code]" in descriptor["getSource"], descriptor
 
-    async def test_no_automation_globals_in_the_pages_own_realm(self, default_mode):
+    async def test_no_automation_globals_in_the_pages_own_realm(self, either_mode):
         """`__pwInitScripts`, `$cdc_*` and friends. Read from the page's own
         script rather than through `page.evaluate()`, which runs somewhere a
         website cannot see."""
-        assert default_mode["automationGlobals"] == []
+        assert either_mode["automationGlobals"] == []
 
 
 class TestTheHintsAgreeWithTheUserAgent:
-    async def test_the_brand_major_matches_the_user_agent_major(self, default_mode):
+    async def test_the_brand_major_matches_the_user_agent_major(self, either_mode):
         """Order is not pinned: the brand list is deliberately shuffled and
         salted with a GREASE entry to stop anyone reading it positionally."""
-        page = default_mode["page"]
+        page = either_mode["page"]
         ua_major = re.search(r"Chrome/(\d+)", page["ua"])
         assert ua_major, page["ua"]
         real = [b for b in page["brands"] if not _GREASE.search(b["brand"])]
@@ -291,16 +329,16 @@ class TestTheHintsAgreeWithTheUserAgent:
             f"{[(b['brand'], b['version']) for b in real]}"
         )
 
-    async def test_the_high_entropy_values_are_populated(self, default_mode):
+    async def test_the_high_entropy_values_are_populated(self, either_mode):
         """`platformVersion` is deliberately not checked: it is normatively
         empty on Linux, so asserting it would fail for a correct browser."""
-        hints = default_mode["page"]["highEntropy"]
+        hints = either_mode["page"]["highEntropy"]
 
         assert hints["architecture"], hints
         assert hints["bitness"], hints
         assert hints["fullVersionList"], hints
 
-    async def test_the_header_channel_carries_them_too(self, default_mode):
+    async def test_the_header_channel_carries_them_too(self, either_mode):
         """A different channel from `getHighEntropyValues()`, and it only fills
         in on a request *after* the server has asked with `Accept-CH`. The page
         fetches the echo endpoint for exactly that reason.
@@ -308,15 +346,28 @@ class TestTheHintsAgreeWithTheUserAgent:
         Asserted on the page alone: measured, the high-entropy headers do not
         appear on dedicated-worker or service-worker requests even though every
         response carries `Accept-CH`.
-        """
-        headers = default_mode["page"]["headers"]
 
-        assert headers.get("sec-ch-ua-arch"), headers.get("sec-ch-ua-arch")
+        Compared against the JavaScript channel rather than merely required to
+        be present, because "present" is the one thing a blank hint also is.
+        Two channels agreeing is the relation worth holding; it is also what a
+        browser fails when it knows the value and cannot put it on the wire.
+        """
+        headers = either_mode["page"]["headers"]
+        hints = either_mode["page"]["highEntropy"]
+
+        for header, js in (("arch", "architecture"), ("bitness", "bitness")):
+            sent = _structured_string(headers.get(f"sec-ch-ua-{header}"))
+            assert sent, f"sec-ch-ua-{header} = {headers.get(f'sec-ch-ua-{header}')!r}"
+            assert sent == hints[js], (
+                f"sec-ch-ua-{header} says {sent!r} and getHighEntropyValues "
+                f"says {hints[js]!r}"
+            )
+
         assert headers.get("sec-ch-ua-full-version-list")
 
-    async def test_the_header_brand_major_matches_too(self, default_mode):
-        headers = default_mode["page"]["headers"]
-        ua_major = re.search(r"Chrome/(\d+)", default_mode["page"]["ua"])
+    async def test_the_header_brand_major_matches_too(self, either_mode):
+        headers = either_mode["page"]["headers"]
+        ua_major = re.search(r"Chrome/(\d+)", either_mode["page"]["ua"])
         assert ua_major
 
         brands = headers.get("sec-ch-ua", "")
@@ -326,17 +377,11 @@ class TestTheHintsAgreeWithTheUserAgent:
 
 
 class TestTheWindowFitsTheScreenItStandsOn:
-    async def test_the_outer_window_does_not_exceed_the_screen(self, default_mode):
+    async def test_the_outer_window_does_not_exceed_the_screen(self, either_mode):
         """The contradiction this was measured to remove: an emulated viewport
         forced onto a headed window produced an outer height of 805 against a
         screen the same browser reported as 720 tall. Any page can read both."""
-        geometry = default_mode["geometry"]
-
-        assert geometry["outerWidth"] <= geometry["screenWidth"], geometry
-        assert geometry["outerHeight"] <= geometry["screenHeight"], geometry
-
-    async def test_headed_fits_too(self, headed_mode):
-        geometry = headed_mode["geometry"]
+        geometry = either_mode["geometry"]
 
         assert geometry["outerWidth"] <= geometry["screenWidth"], geometry
         assert geometry["outerHeight"] <= geometry["screenHeight"], geometry
@@ -350,8 +395,8 @@ class TestItIsTheFullBrowser:
     deciding to. These three are what the shell gets wrong.
     """
 
-    async def test_plugins_are_present(self, default_mode):
-        assert default_mode["plugins"] > 0
+    async def test_plugins_are_present(self, either_mode):
+        assert either_mode["plugins"] > 0
 
-    async def test_the_chrome_object_exists(self, default_mode):
-        assert default_mode["hasChromeObject"] == "object"
+    async def test_the_chrome_object_exists(self, either_mode):
+        assert either_mode["hasChromeObject"] == "object"

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -296,16 +296,28 @@ def _structured_string(value: str | None) -> str | None:
 
 
 def _unescape(text: str) -> str:
+    """Undo the two escapes RFC 8941 allows inside a string, and only those.
+
+    A backslash may precede a quote or another backslash; anything else, and a
+    backslash at the very end, is a parse failure rather than a character to
+    pass through. Accepting them would read ``"a\\rm"`` as ``arm``, so a browser
+    emitting a hint no conforming recipient would take compared equal to one
+    emitting a valid one.
+    """
     out: list[str] = []
     escaped = False
     for character in text:
         if escaped:
+            if character not in '"\\':
+                raise ValueError(f"invalid escape in a structured string: {text!r}")
             out.append(character)
             escaped = False
         elif character == "\\":
             escaped = True
         else:
             out.append(character)
+    if escaped:
+        raise ValueError(f"a structured string ends in a backslash: {text!r}")
     return "".join(out)
 
 
@@ -395,7 +407,15 @@ class TestEveryRealmTellsTheSameStory:
         page = either_mode["page"]["headers"]
         frame = either_mode["iframe"]["headers"]
 
-        for hint in ("sec-ch-ua", "sec-ch-ua-mobile", "sec-ch-ua-platform"):
+        # Parsed, not compared as text. The brand list is deliberately shuffled
+        # and the specification asks for the order to move over time, so two
+        # orderings of the same pairs are the same answer; comparing the raw
+        # strings would call that a contradiction.
+        assert _brand_list(frame["sec-ch-ua"]) == _brand_list(page["sec-ch-ua"]), (
+            f"sec-ch-ua reads {frame['sec-ch-ua']!r} in the frame and "
+            f"{page['sec-ch-ua']!r} on the page"
+        )
+        for hint in ("sec-ch-ua-mobile", "sec-ch-ua-platform"):
             assert frame[hint] == page[hint], (
                 f"{hint} reads {frame.get(hint)!r} in the frame and "
                 f"{page.get(hint)!r} on the page"
@@ -517,22 +537,25 @@ class TestNothingAnnouncesAutomation:
         ``WorkerNavigator`` has no ``webdriver`` attribute at all, so both
         workers report undefined and a check written as "false everywhere"
         would be satisfied by a browser that had simply dropped the property.
-        The absence arrives as a missing key, because ``JSON.stringify`` omits
-        a property whose value is undefined, which is a cleaner signal than a
-        null would be: the attribute is not there rather than empty.
+        Each realm answers whether the attribute is *there*, rather than the
+        test reading its absence out of a missing JSON key. Those are not the
+        same question: ``JSON.stringify`` drops a key whose value is undefined,
+        so an attribute defined as undefined looks exactly like one that was
+        never defined, while a website asking ``'webdriver' in navigator``
+        sees the difference.
         """
         realms = _realms(either_mode)
         documents = ("page", "cross-origin iframe")
 
-        for name in documents:
-            assert realms[name]["webdriver"] is False, (
-                f"{name} reports webdriver={realms[name]['webdriver']!r}"
-            )
         for name, realm in realms.items():
-            if name not in documents:
-                assert "webdriver" not in realm, (
-                    f"{name} grew a webdriver attribute reading "
-                    f"{realm['webdriver']!r}, which no WorkerNavigator has"
+            if name in documents:
+                assert realm["hasWebdriver"] is True, f"{name} has no webdriver"
+                assert realm["webdriver"] is False, (
+                    f"{name} reports webdriver={realm['webdriver']!r}"
+                )
+            else:
+                assert realm["hasWebdriver"] is False, (
+                    f"{name} grew a webdriver attribute, which no WorkerNavigator has"
                 )
 
     async def test_no_automation_globals_in_the_pages_own_realm(self, either_mode):

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -1,0 +1,274 @@
+"""The browser must not contradict itself, checked rather than remembered.
+
+Everything the identity work rests on was established by hand: a user agent
+read off one surface, client hints off another, a frame rate counted against a
+control window. None of it is repeatable, and a dependency bump can undo any of
+it without a single test going red. That has already happened twice in one
+week: the lock moved 148 to 149, and both times the only reason anyone knew the
+identity still held was that someone went and measured it again.
+
+**Relations, not values.** Every assertion here compares two things the browser
+says about itself. Nothing pins a version, a brand string or a screen size,
+because all of those move on their own and a test that pins them is a test
+somebody will delete after the third false alarm. What cannot move is that the
+page and its workers agree, that the advertised brand major matches the user
+agent, and that the window fits the screen it claims to stand on.
+
+**It fails rather than skips where it is meant to gate.** The existing
+browser-DOM tests skip when no browser is installed, which is right for them:
+they check extraction JS, and running them locally is a convenience. This one
+is a gate. A gate that skips itself when the thing it guards is missing is not
+a gate, so in CI a missing browser or display is a failure. Locally it still
+skips, with a reason that says what to install.
+
+**Two launch modes, because one of them is inert on Linux.**
+``hidden_target_is_supported()`` is macOS-only, so the product default
+(``headless=True``) is the windowless hidden target on macOS and Chromium's
+real headless mode on Linux, where it does announce itself. Asserting "no
+headless token" against the default would therefore be an assertion that
+catches nothing on the platform CI runs. The headed mode is the one the
+container image is heading for, and it is where that assertion bites.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from pathlib import Path
+
+import pytest
+
+from linkedin_mcp_server.core.browser import BrowserManager
+from browser_identity_harness import IdentityServer, describe_browser
+
+pytestmark = pytest.mark.browser_identity
+
+#: GREASE brands exist to stop anyone parsing the list positionally. They carry
+#: deliberately meaningless versions, so a real brand has to be found by
+#: excluding them rather than by index.
+_GREASE = re.compile(r"not[)/\-_. ]?a[)/\-_. ]?brand", re.IGNORECASE)
+
+
+def _running_in_ci() -> bool:
+    """Whether a missing browser is a failure rather than a reason to skip."""
+    return os.environ.get("CI", "").lower() in {"1", "true", "yes"}
+
+
+def _unavailable(reason: str) -> None:
+    """Fail in CI, skip locally. Never quietly pass."""
+    if _running_in_ci():
+        pytest.fail(
+            f"{reason}. In CI this is a failure rather than a skip: this test "
+            f"is the only thing that checks the browser still presents one "
+            f"coherent identity, and a gate that skips itself is not a gate."
+        )
+    pytest.skip(f"{reason}; run `uv run patchright install chromium --no-shell`")
+
+
+async def _describe(tmp_path: Path, *, headless: bool) -> dict:
+    profile = tmp_path / f"identity-{'headless' if headless else 'headed'}"
+    try:
+        manager = BrowserManager(user_data_dir=profile, headless=headless)
+        async with manager as browser:
+            with IdentityServer() as server:
+                described = await describe_browser(browser.page, server.url)
+        described["windowless"] = manager._windowless
+        return described
+    except Exception as exc:  # noqa: BLE001 - the reason is the payload
+        _unavailable(f"could not start a browser ({type(exc).__name__}: {exc})")
+        raise  # unreachable; _unavailable always raises
+    finally:
+        shutil.rmtree(profile, ignore_errors=True)
+
+
+@pytest.fixture(scope="module")
+def _mode_results() -> dict:
+    """One launch per mode for the whole module, because each costs seconds."""
+    return {}
+
+
+async def _for_mode(tmp_path_factory, cache: dict, headless: bool) -> dict:
+    key = "headless" if headless else "headed"
+    if key not in cache:
+        base = tmp_path_factory.mktemp(f"identity-{key}")
+        cache[key] = await _describe(base, headless=headless)
+    return cache[key]
+
+
+@pytest.fixture
+async def default_mode(tmp_path_factory, _mode_results) -> dict:
+    """The product default: what a user's browser actually is."""
+    return await _for_mode(tmp_path_factory, _mode_results, headless=True)
+
+
+@pytest.fixture
+async def headed_mode(tmp_path_factory, _mode_results) -> dict:
+    """Headed, which is where the container image is going and where the
+    headless token must be absent."""
+    return await _for_mode(tmp_path_factory, _mode_results, headless=False)
+
+
+def _realms(described: dict) -> dict[str, dict]:
+    return {
+        "page": described["page"],
+        "dedicated worker": described["dedicated"],
+        "service worker": described["serviceWorker"],
+    }
+
+
+class TestEveryRealmTellsTheSameStory:
+    """A contradiction between realms is the cheapest thing for a site to find.
+
+    The user agent is readable from a page, from a dedicated worker and from a
+    service worker, and each one also sends it as a request header. That is six
+    places one value has to agree with itself. An override that reaches only
+    some of them, which is what every user-agent option in this space does, is
+    visible to anyone who looks twice.
+    """
+
+    async def test_all_three_realms_report_one_user_agent(self, default_mode):
+        agents = {name: realm["ua"] for name, realm in _realms(default_mode).items()}
+
+        assert len(set(agents.values())) == 1, agents
+
+    async def test_each_realm_sends_what_it_says(self, default_mode):
+        """The JS value and the request header are different channels, and an
+        override that changes the string reaches only the first."""
+        for name, realm in _realms(default_mode).items():
+            assert realm["headers"]["user-agent"] == realm["ua"], name
+
+
+class TestNothingAnnouncesAutomation:
+    async def test_no_headless_token_where_a_window_is_possible(self, headed_mode):
+        """Chromium prepends the bare string `Headless` to its product name in
+        headless *mode*, so both the user agent and the brand list read
+        `HeadlessChrome`. A headed browser must not."""
+        for name, realm in _realms(headed_mode).items():
+            assert "HeadlessChrome" not in realm["ua"], f"{name}: {realm['ua']}"
+        brands = headed_mode["page"]["brands"] or []
+        assert not [b for b in brands if "Headless" in b["brand"]], brands
+
+    async def test_the_default_launch_uses_the_hidden_target_where_it_can(
+        self, default_mode
+    ):
+        """Not just self-consistent: actually windowless where that is possible.
+
+        The consistency check below would pass a browser that silently gave up
+        on the hidden target and fell back to real headless, because a fallback
+        is consistent with itself. That fallback is exactly the regression worth
+        catching on the platform most people run, so it gets its own assertion
+        against what the code claims the platform can do.
+        """
+        from linkedin_mcp_server.hidden_target import hidden_target_is_supported
+
+        assert default_mode["windowless"] == hidden_target_is_supported(), (
+            "the default launch fell back to Chromium's headless mode on a "
+            "platform that supports a hidden target, which puts the "
+            "HeadlessChrome token back on every surface"
+        )
+
+    async def test_the_default_mode_matches_its_own_claim(self, default_mode):
+        """`headless=True` means "no visible window", not "Chromium's headless
+        mode". Where a hidden target carries that, the token must be gone; where
+        the platform forces real headless the token is expected, and the code
+        says which it did."""
+        has_token = "HeadlessChrome" in default_mode["page"]["ua"]
+
+        assert has_token is not default_mode["windowless"], (
+            f"windowless={default_mode['windowless']} but "
+            f"HeadlessChrome present={has_token}"
+        )
+
+    async def test_webdriver_is_false_and_unremarkable(self, default_mode):
+        assert default_mode["page"]["webdriver"] is False
+        descriptor = default_mode["webdriverDescriptor"]
+        assert descriptor is not None
+        assert descriptor["get"] == "function", descriptor
+
+    async def test_no_automation_globals_in_the_pages_own_realm(self, default_mode):
+        """`__pwInitScripts`, `$cdc_*` and friends. Read from the page's own
+        script rather than through `page.evaluate()`, which runs somewhere a
+        website cannot see."""
+        assert default_mode["automationGlobals"] == []
+
+
+class TestTheHintsAgreeWithTheUserAgent:
+    async def test_the_brand_major_matches_the_user_agent_major(self, default_mode):
+        """Order is not pinned: the brand list is deliberately shuffled and
+        salted with a GREASE entry to stop anyone reading it positionally."""
+        page = default_mode["page"]
+        ua_major = re.search(r"Chrome/(\d+)", page["ua"])
+        assert ua_major, page["ua"]
+        real = [b for b in page["brands"] if not _GREASE.search(b["brand"])]
+
+        assert real, page["brands"]
+        assert any(b["version"].split(".")[0] == ua_major.group(1) for b in real), (
+            f"user agent says {ua_major.group(1)}, brands say "
+            f"{[(b['brand'], b['version']) for b in real]}"
+        )
+
+    async def test_the_high_entropy_values_are_populated(self, default_mode):
+        """`platformVersion` is deliberately not checked: it is normatively
+        empty on Linux, so asserting it would fail for a correct browser."""
+        hints = default_mode["page"]["highEntropy"]
+
+        assert hints["architecture"], hints
+        assert hints["bitness"], hints
+        assert hints["fullVersionList"], hints
+
+    async def test_the_header_channel_carries_them_too(self, default_mode):
+        """A different channel from `getHighEntropyValues()`, and it only fills
+        in on a request *after* the server has asked with `Accept-CH`. The page
+        fetches the echo endpoint for exactly that reason.
+
+        Asserted on the page alone: measured, the high-entropy headers do not
+        appear on dedicated-worker or service-worker requests even though every
+        response carries `Accept-CH`.
+        """
+        headers = default_mode["page"]["headers"]
+
+        assert headers.get("sec-ch-ua-arch"), headers.get("sec-ch-ua-arch")
+        assert headers.get("sec-ch-ua-full-version-list")
+
+    async def test_the_header_brand_major_matches_too(self, default_mode):
+        headers = default_mode["page"]["headers"]
+        ua_major = re.search(r"Chrome/(\d+)", default_mode["page"]["ua"])
+        assert ua_major
+
+        brands = headers.get("sec-ch-ua", "")
+        reals = [part for part in brands.split(",") if not _GREASE.search(part)]
+        assert reals, brands
+        assert any(f'"{ua_major.group(1)}"' in part for part in reals), brands
+
+
+class TestTheWindowFitsTheScreenItStandsOn:
+    async def test_the_outer_window_does_not_exceed_the_screen(self, default_mode):
+        """The contradiction this was measured to remove: an emulated viewport
+        forced onto a headed window produced an outer height of 805 against a
+        screen the same browser reported as 720 tall. Any page can read both."""
+        geometry = default_mode["geometry"]
+
+        assert geometry["outerWidth"] <= geometry["screenWidth"], geometry
+        assert geometry["outerHeight"] <= geometry["screenHeight"], geometry
+
+    async def test_headed_fits_too(self, headed_mode):
+        geometry = headed_mode["geometry"]
+
+        assert geometry["outerWidth"] <= geometry["screenWidth"], geometry
+        assert geometry["outerHeight"] <= geometry["screenHeight"], geometry
+
+
+class TestItIsTheFullBrowser:
+    """The headless shell is a different product, and it shows.
+
+    Nothing launches it since the channel became explicit, but the way that
+    could come back is a launch option changing under us rather than anyone
+    deciding to. These three are what the shell gets wrong.
+    """
+
+    async def test_plugins_are_present(self, default_mode):
+        assert default_mode["plugins"] > 0
+
+    async def test_the_chrome_object_exists(self, default_mode):
+        assert default_mode["hasChromeObject"] == "object"

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -154,11 +154,33 @@ def _mode_results() -> dict:
 
 
 async def _for_mode(tmp_path_factory, cache: dict, headless: bool) -> dict:
+    """The cached description of one launch, successful or not.
+
+    The failure is cached too, which is not symmetry for its own sake. Thirteen
+    cases read the default launch and twelve read the headed one, so a mode
+    that fails would otherwise be attempted once per case: a browser that will
+    not start costs a timeout each time, and a run whose real answer is "this
+    browser is broken" spends a quarter of an hour finding that out twelve more
+    times.
+
+    ``BaseException`` because the outcomes worth remembering are the ones
+    pytest raises. ``pytest.fail`` and ``pytest.skip`` both raise from
+    ``OutcomeException``, which does not descend from ``Exception``, and either
+    one re-raised for the remaining cases is exactly the right answer for them.
+    """
     key = "headless" if headless else "headed"
     if key not in cache:
         base = tmp_path_factory.mktemp(f"identity-{key}")
-        cache[key] = await _describe(base, headless=headless)
-    return cache[key]
+        try:
+            cache[key] = (None, await _describe(base, headless=headless))
+        except BaseException as exc:
+            cache[key] = (exc, None)
+            raise
+
+    failure, described = cache[key]
+    if failure is not None:
+        raise failure
+    return described
 
 
 @pytest.fixture

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -39,10 +39,19 @@ from pathlib import Path
 
 import pytest
 
+from linkedin_mcp_server.browser_launch import build_launch_options
+from linkedin_mcp_server.config.schema import BrowserConfig
 from linkedin_mcp_server.core.browser import BrowserManager
 from browser_identity_harness import IdentityServer, describe_browser
 
-pytestmark = pytest.mark.browser_identity
+#: The group keeps every case in this file on one xdist worker, so the two
+#: cached launches are two launches rather than two per worker. It only has an
+#: effect under ``--dist loadgroup``, which the CI job passes; without it the
+#: mark is inert and the tests still pass, only slower.
+pytestmark = [
+    pytest.mark.browser_identity,
+    pytest.mark.xdist_group("browser_identity"),
+]
 
 #: GREASE brands exist to stop anyone parsing the list positionally. They carry
 #: deliberately meaningless versions, so a real brand has to be found by
@@ -67,9 +76,30 @@ def _unavailable(reason: str) -> None:
 
 
 async def _describe(tmp_path: Path, *, headless: bool) -> dict:
+    """Launch the way the product does, and ask the browser what it is.
+
+    The options come from ``build_launch_options`` rather than being written
+    out here, because a gate that assembles its own launch measures a browser
+    nobody ships. Measured, and the reason this is not a stylistic preference:
+    constructing ``BrowserManager`` bare leaves out ``channel="chromium"``, so
+    on Linux, where the default mode is physically headless, Playwright
+    resolves the binary from that flag alone and asks for the headless shell
+    the setup no longer installs. Every default-mode case then skips itself
+    while the shipped configuration is fine.
+
+    ``BrowserConfig()`` rather than ``get_config()``: the global parses
+    ``sys.argv`` and aborts under pytest, and the defaults are what the gate is
+    about anyway.
+    """
+    launch_options, viewport = build_launch_options(BrowserConfig())
     profile = tmp_path / f"identity-{'headless' if headless else 'headed'}"
     try:
-        manager = BrowserManager(user_data_dir=profile, headless=headless)
+        manager = BrowserManager(
+            user_data_dir=profile,
+            headless=headless,
+            viewport=viewport,
+            **launch_options,
+        )
         async with manager as browser:
             with IdentityServer() as server:
                 described = await describe_browser(browser.page, server.url)

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -227,6 +227,29 @@ def _structured_string(value: str | None) -> str | None:
     return value.strip().strip('"') or None
 
 
+def _brand_list(value: str | None) -> dict[str, str | None]:
+    """A ``"brand";v="version"`` list as a mapping, or empty if there is none.
+
+    Split on the comma at the top level and on the *last* ``;v=`` in each item.
+    Both are safe against the GREASE entry, whose separators Chromium draws
+    from a fixed set that contains ``;`` but no comma, and which cannot produce
+    the sequence ``;v=`` because what follows a separator is always ``A`` or
+    ``Brand``. Order is not preserved, deliberately: the list is shuffled on
+    purpose and reading it positionally is the mistake it exists to prevent.
+    """
+    if not value:
+        return {}
+    listed: dict[str, str | None] = {}
+    for part in value.split(","):
+        brand, _, version = part.strip().rpartition(";v=")
+        if not brand:  # an item with no version at all
+            brand, version = version, ""
+        name = _structured_string(brand)
+        if name is not None:
+            listed[name] = _structured_string(version)
+    return listed
+
+
 def _realms(described: dict) -> dict[str, dict]:
     return {
         "page": described["page"],
@@ -385,7 +408,19 @@ class TestTheHintsAgreeWithTheUserAgent:
                 f"says {hints[js]!r}"
             )
 
-        assert headers.get("sec-ch-ua-full-version-list")
+        # The version list gets the same treatment rather than a presence
+        # check, which a stale or GREASE-only list would also satisfy. The
+        # contradiction worth catching is a wire header still naming the
+        # previous build while JavaScript names the current one, and only a
+        # comparison sees that.
+        sent_brands = _brand_list(headers.get("sec-ch-ua-full-version-list"))
+        assert sent_brands, headers.get("sec-ch-ua-full-version-list")
+        assert sent_brands == {
+            b["brand"]: b["version"] for b in hints["fullVersionList"]
+        }, (
+            f"sec-ch-ua-full-version-list says {sent_brands} and "
+            f"getHighEntropyValues says {hints['fullVersionList']}"
+        )
 
     async def test_the_header_brand_major_matches_too(self, either_mode):
         headers = either_mode["page"]["headers"]

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -72,6 +72,21 @@ pytestmark = [
 #: neither, quietly promoting the GREASE entry to a real brand. ``[\W_]`` covers
 #: the whole set, since ``_`` is the one separator that is also a word
 #: character.
+#:
+#: This is the one place the file names a value rather than a relation, and it
+#: is a considered trade rather than an oversight. The specification does not
+#: require the words: a future Chromium could send ``Fake?Browser`` instead,
+#: and the brand-major cases would go red on a coherent browser. What that buys
+#: is ``all`` in place of ``any``. Without a way to name the fake entry, the
+#: strongest available rule is "at least one brand agrees with the user agent",
+#: and that passes a list carrying ``Chromium`` at 149 beside ``Google Chrome``
+#: at 150 -- a browser contradicting itself in public, which is precisely what
+#: is being looked for. Identifying it structurally instead would have to
+#: assume how many fake entries there are, and the specification does not fix
+#: that either. So: a rename costs one red that names the brands it saw and is
+#: repaired by editing this line, and the alternative costs a real
+#: contradiction going unseen. If the wording ever does move, that is the
+#: failure to expect and this comment is the answer to it.
 _GREASE = re.compile(r"not[\W_]?a[\W_]?brand", re.IGNORECASE)
 
 #: The NativeFunction form ECMA-262 gives ``Function.prototype.toString`` for a

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -105,7 +105,14 @@ _NATIVE_FUNCTION = re.compile(
 #: The ones among them that no mobile device runs. Kept beside the table
 #: rather than derived from it, because "not mobile" is a claim about the
 #: platform and not about whether its user-agent token is known.
-_DESKTOP_PLATFORMS = frozenset({"macOS", "Windows", "Linux", "Chrome OS"})
+_DESKTOP_PLATFORMS = frozenset(
+    {"macOS", "Windows", "Linux", "Chrome OS", "Chromium OS"}
+)
+
+#: The realms with a ``Navigator`` rather than a ``WorkerNavigator``. Both are
+#: documents and both are asked the same questions; a frame is a realm of its
+#: own, and a patch applied only there is invisible from the top.
+_DOCUMENT_REALMS = ("page", "cross-origin iframe")
 
 _PLATFORM_TOKENS = {
     "macOS": "Macintosh",
@@ -210,12 +217,13 @@ def _mode_results() -> dict:
 async def _for_mode(tmp_path_factory, cache: dict, headless: bool) -> dict:
     """The cached description of one launch, successful or not.
 
-    The failure is cached too, which is not symmetry for its own sake. Thirteen
-    cases read the default launch and twelve read the headed one, so a mode
-    that fails would otherwise be attempted once per case: a browser that will
-    not start costs a timeout each time, and a run whose real answer is "this
-    browser is broken" spends a quarter of an hour finding that out twelve more
-    times.
+    The failure is cached too, which is not symmetry for its own sake. Most of
+    the cases in this file read one launch or the other, so a mode that fails
+    would otherwise be attempted once per case: a browser that will not start
+    costs a timeout each time, and a run whose real answer is "this browser is
+    broken" would spend a quarter of an hour finding that out again and again.
+    Measured against a launch made to fail every time: one attempt with this,
+    twelve without.
 
     ``BaseException`` because the outcomes worth remembering are the ones
     pytest raises: ``pytest.fail`` and ``pytest.skip`` both raise from
@@ -645,34 +653,42 @@ class TestNothingAnnouncesAutomation:
         Proving the runtime unmodified is a different exercise from proving it
         consistent, and it wants a different tool.
         """
-        assert either_mode["page"]["webdriver"] is False
-        assert either_mode["ownWebdriver"] is False, (
-            "navigator carries its own webdriver property, which shadows the "
-            "prototype accessor and leaves it looking untouched"
-        )
+        realms = _realms(either_mode)
+        for name in _DOCUMENT_REALMS:
+            realm = realms[name]
+            accessors = realm["accessors"]
 
-        descriptor = either_mode["webdriverDescriptor"]
-        native = either_mode["userAgentDescriptor"]
-        assert descriptor is not None and native is not None
-        assert _NATIVE_FUNCTION.fullmatch(either_mode["toStringSource"]), (
-            "Function.prototype.toString is not itself native, so nothing it "
-            f"says about any other function counts: {either_mode['toStringSource']!r}"
-        )
-        assert _NATIVE_FUNCTION.fullmatch(native["getSource"]), (
-            f"the control accessor is not native either: {native['getSource']!r}"
-        )
+            assert realm["webdriver"] is False, f"{name}: {realm['webdriver']!r}"
+            assert accessors["ownWebdriver"] is False, (
+                f"{name}: navigator carries its own webdriver property, which "
+                f"shadows the prototype accessor and leaves it looking untouched"
+            )
 
-        flags = ("get", "set", "enumerable", "configurable")
-        assert {key: descriptor[key] for key in flags} == {
-            key: native[key] for key in flags
-        }, f"webdriver {descriptor} against the native userAgent {native}"
+            descriptor = accessors["webdriverDescriptor"]
+            native = accessors["userAgentDescriptor"]
+            assert descriptor is not None and native is not None, name
+            assert _NATIVE_FUNCTION.fullmatch(accessors["toStringSource"]), (
+                f"{name}: Function.prototype.toString is not itself native, so "
+                f"nothing it says about any other function counts: "
+                f"{accessors['toStringSource']!r}"
+            )
+            assert _NATIVE_FUNCTION.fullmatch(native["getSource"]), (
+                f"{name}: the control accessor is not native either: "
+                f"{native['getSource']!r}"
+            )
 
-        assert descriptor["getSource"] == native["getSource"].replace(
-            "userAgent", "webdriver"
-        ), (
-            f"the webdriver getter reads {descriptor['getSource']!r} where a "
-            f"native one on this prototype reads {native['getSource']!r}"
-        )
+            flags = ("get", "set", "enumerable", "configurable")
+            assert {key: descriptor[key] for key in flags} == {
+                key: native[key] for key in flags
+            }, f"{name}: webdriver {descriptor} against userAgent {native}"
+
+            assert descriptor["getSource"] == native["getSource"].replace(
+                "userAgent", "webdriver"
+            ), (
+                f"{name}: the webdriver getter reads "
+                f"{descriptor['getSource']!r} where a native one on this "
+                f"prototype reads {native['getSource']!r}"
+            )
 
     async def test_no_realm_admits_to_being_driven(self, either_mode):
         """`navigator.webdriver` is readable in more than one place.
@@ -691,10 +707,9 @@ class TestNothingAnnouncesAutomation:
         sees the difference.
         """
         realms = _realms(either_mode)
-        documents = ("page", "cross-origin iframe")
 
         for name, realm in realms.items():
-            if name in documents:
+            if name in _DOCUMENT_REALMS:
                 assert realm["hasWebdriver"] is True, f"{name} has no webdriver"
                 assert realm["webdriver"] is False, (
                     f"{name} reports webdriver={realm['webdriver']!r}"


### PR DESCRIPTION
Closes #699

The regression test that ends the hand-measuring landed on this branch first. This is the half that makes it run: CI installs no browser, so the gate would have skipped itself on every pull request while reading as covered.

The `test` job now installs the same browser the server does, `patchright install --with-deps chromium --no-shell`, and starts Xvfb at 1920x1080x24 for the headed mode. The default mode needs no display on Linux, where the hidden target is unsupported and Chromium's own headless mode runs instead, but headed is the mode where the headless token has to be absent, and it is where the container image is heading. The browser is cached on the resolved patchright version, read from the synced environment rather than from `pyproject.toml`, which names a floor and not the version in use. A group mark plus `--dist loadgroup` keeps the identity cases on one xdist worker so they share the two launches they already cache. No new job, so no branch-protection change.

Three more legs run the gate, because on each of them the browser is not the one the Ubuntu job launches. `hidden_target_is_supported()` is macOS-only, so the hidden target, which is the whole reason the default mode can run without announcing itself as headless, is exercised nowhere else; it works on a GitHub runner, which had not been measured before. Linux arm64 is the only platform whose bundle is Playwright's own Chromium rather than Chrome for Testing, and the release publishes that image. Windows has its own binary, its own window manager and its own DPI handling, and one of the things measured is a headed window against the screen it stands on. None of the three blocks a merge: branch protection requires `lint-and-check` and `test` only, which is how `platform-behaviour` has always stood, and the Linux x64 half of the gate sits inside `test` and does block.

Two silent skips came out of running it rather than reasoning about it. The gate assembled its own launch options and so left out `channel="chromium"`; on Linux, where the default mode is physically headless, Playwright resolves the binary from that flag alone and asks for `chromium-headless-shell`, which the setup stopped installing in #669. Thirteen of fifteen cases skipped themselves while the shipped configuration was fine. The gate now launches through `build_launch_options`, the builder both product call sites use. `tests/test_action_signals_dom.py` had the identical gap and now names the channel too; its comment claiming CI installs no browser is no longer true either.

Twelve review rounds turned up rather more than the wiring, and nearly all of it was in the assertions. The harness was missing the cross-origin iframe `docs/browser-fingerprint.md` has always named as the fourth surface, and its service worker answered from a bare async listener the browser is free to terminate at the first await; the three realms were also awaited one after another, so their budgets could add up past the host's and report a merely slow browser as a broken one. Most cases read the default launch alone, leaving a headed-only regression two assertions to get past, and the frame was asked less than the page it was there to be compared with.

The rest were false greens in the assertions themselves. The GREASE filter matched neither spelling in play, so the fake brand counted as a real one behind an `any` that stopped at the agreeing half. The webdriver check read only the prototype, where an own property on `navigator` shadows the accessor; then, once the getter's source was read, it was read with `String()`, which calls the getter's own `toString` and let a JavaScript getter carrying a forged one measure as native. Client hints are structured-field strings, so a blank one is two quote characters and passes a presence check, and the parser smoothed unquoted tokens, unterminated strings, invalid escapes and empty parameters into valid-looking values. The version list, the two brand lists, and the platform and mobile hints were each tied to something and never to each other, so a stale pair of channels, a list naming a different product at the same version, a platform contradicting the user agent, or a desktop machine calling itself mobile all agreed with themselves and passed.

Three things are deliberate and argued where they live rather than left implicit. The GREASE filter names the fake brand instead of deriving it, which is the one value in the file: naming it is what allows every real brand to be required to match the user agent, and the alternative lets a two-brand contradiction through. A patch applied uniformly to one page realm is out of scope, and the reason is recorded with the two escapes that were measured and do not work. And the platform table is fail-open, because an unfamiliar platform is something to look up rather than a reason to fail a browser that is telling the truth.

Verified by running the CI recipe in an Ubuntu container on arm64 and by green CI on all four platforms, each reporting 35 passed with nothing skipped. Every assertion is mutation-checked, twenty-two so far: a bare `BrowserManager` skips thirteen of fifteen; removing the display turns the headed cases red instead of skipping them; dropping the channel from the DOM fixture skips all eleven; a frame reporting a different user agent, different hints or `webdriver` true fails; a webdriver getter redefined plainly, hidden behind an own property, or forged with its own `toString` each fail; the old GREASE pattern fails all four brand cases; a blank, missing, stale or duplicated client hint fails; a full version list naming another product fails; a platform changed on both origins fails; a measurement that raises produces errors rather than skips; a permanently failing launch is attempted once rather than twelve times; a getter redefined only inside the frame fails; a desktop platform claiming a mobile form factor fails; and the group mark lands every case on `gw0`.

## Synthetic prompt

> Wire the browser identity gate into CI. Install the browser the server actually installs, give the headed mode a display, cache it on the resolved patchright version, and keep the identity cases on one xdist worker. Run it on macOS, Windows and Linux arm64 too, since each of those launches a browser the Ubuntu job never does. Make sure the gate goes through the same launch builder the product uses, assert every relation against both launch modes and in every realm including the cross-origin frame the fingerprint doc already asks for, and hold each channel against the other rather than merely requiring a value to be present.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
