### PR TITLE
fix(mcpb): Start with the proxy fields left blank

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   and the loader reads an empty variable as unset. `required: true` is the only
   other safe shape, because a host skips the whole MCP config while a required
   field is empty. `tests/test_manifest.py` holds this line; `mcpb validate`
-  does not, and cannot — the schema knows nothing about substitution.
+  does not, and cannot: the schema knows nothing about substitution.
 - **A placeholder that does reach the process is not a value.** `_env()` in
   `config/loaders.py` drops it. Both directions matter and only one is loud:
   `PROXY_SERVER` fails validation and stops the server, while

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   evidence here: its `title` key dates from patchright 1.58.0 and omits the
   `Google` the binary prints. See `_COMPARABLE_PRODUCTS` for the measurements.
 
+## Extension Bundle Rules
+
+- **An optional `user_config` field needs a `default`.** A host substitutes
+  `${user_config.NAME}` from the manifest's defaults plus the answers the user
+  gave; a field in neither is not in that map, so the placeholder is handed to
+  the server verbatim as if it were a setting. Measured in Claude Desktop's own
+  substitution routine. `"default": ""` is enough: it substitutes to nothing,
+  and the loader reads an empty variable as unset. `required: true` is the only
+  other safe shape, because a host skips the whole MCP config while a required
+  field is empty. `tests/test_manifest.py` holds this line; `mcpb validate`
+  does not, and cannot — the schema knows nothing about substitution.
+- **A placeholder that does reach the process is not a value.** `_env()` in
+  `config/loaders.py` drops it. Both directions matter and only one is loud:
+  `PROXY_SERVER` fails validation and stops the server, while
+  `PROXY_USERNAME` is offered to the proxy as a credential and comes back as a
+  timeout that reads like an expired session.
+
 ## Tool Return Format
 
 All scraping tools return: `{url, sections: {name: raw_text}}`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,11 +116,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   `${user_config.NAME}` from the manifest's defaults plus the answers the user
   gave; a field in neither is not in that map, so the placeholder is handed to
   the server verbatim as if it were a setting. Measured in Claude Desktop's own
-  substitution routine. `"default": ""` is enough: it substitutes to nothing,
-  and the loader reads an empty variable as unset. `required: true` is the only
-  other safe shape, because a host skips the whole MCP config while a required
-  field is empty. `tests/test_manifest.py` holds this line; `mcpb validate`
-  does not, and cannot: the schema knows nothing about substitution.
+  substitution routine. `required: true` is the other safe shape, because a
+  host skips the whole MCP config while a required field is empty.
+  `tests/test_manifest.py` holds this line; `mcpb validate` does not, and
+  cannot: the schema knows nothing about substitution.
+- **What counts as a sufficient default depends on where the placeholder
+  sits.** In a string, which is where the four `env` mappings sit, `""` is
+  enough: it substitutes to nothing and the loader reads an empty variable as
+  unset. As an entire element of `args` it is not, because that substitution
+  is guarded by a truthiness test on the replacement and `""` is falsy, so the
+  element keeps its literal. An array-valued default reached from a string is
+  refused outright and also keeps the literal. Measured; the test knows all
+  three.
 - **A placeholder that does reach the process is not a value.** `_env()` in
   `config/loaders.py` drops it. Both directions matter and only one is loud:
   `PROXY_SERVER` fails validation and stops the server, while

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -424,9 +424,9 @@ def main() -> None:
         # user sees behind "Server disconnected", with the setting at fault on
         # its last line and everything above it looking like a crash.
         #
-        # Printed rather than logged, because logging is configured from the
-        # configuration that just failed to load. stderr for the same reason it
-        # carries every other diagnostic here: stdout belongs to the protocol.
+        # Printed, because logging is configured from the configuration that
+        # just failed to load. To stderr for the same reason it carries every
+        # other diagnostic here: stdout belongs to the protocol.
         print(f"❌ Configuration error: {e}", file=sys.stderr)
         sys.exit(1)
 

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -428,12 +428,11 @@ def main() -> None:
     try:
         config = get_config()
     except ConfigurationError as e:
-        # Every other failure in this file reaches a handler that says what
-        # happened. A bad setting did not: it left the loader as an exception
-        # nothing caught, so Python printed the whole stack down through the
-        # loader and the process died. Under a stdio host that stack is all the
-        # user sees behind "Server disconnected", with the setting at fault on
-        # its last line and everything above it looking like a crash.
+        # A bad setting used to leave the loader as an exception nothing
+        # caught, so Python printed the whole stack down through the loader and
+        # the process died. Under a stdio host that stack is all the user sees
+        # behind "Server disconnected", with the setting at fault on its last
+        # line and everything above it looking like a crash.
         _exit_on_a_bad_setting(e)
 
     # Configure logging

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -19,7 +19,7 @@ from linkedin_mcp_server.exceptions import (
 )
 from linkedin_mcp_server.authentication import clear_auth_state
 from linkedin_mcp_server.config import get_config
-from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.config.schema import AppConfig, ConfigurationError
 from linkedin_mcp_server.drivers.browser import (
     experimental_persist_derived_runtime,
     close_browser,
@@ -414,7 +414,21 @@ def get_version() -> str:
 
 def main() -> None:
     """Main application entry point."""
-    config = get_config()
+    try:
+        config = get_config()
+    except ConfigurationError as e:
+        # Every other failure in this file reaches a handler that says what
+        # happened. A bad setting did not: it left the loader as an exception
+        # nothing caught, so Python printed the whole stack down through the
+        # loader and the process died. Under a stdio host that stack is all the
+        # user sees behind "Server disconnected", with the setting at fault on
+        # its last line and everything above it looking like a crash.
+        #
+        # Printed rather than logged, because logging is configured from the
+        # configuration that just failed to load. stderr for the same reason it
+        # carries every other diagnostic here: stdout belongs to the protocol.
+        print(f"❌ Configuration error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     # Configure logging
     configure_logging(

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -434,7 +434,6 @@ def main() -> None:
         # loader and the process died. Under a stdio host that stack is all the
         # user sees behind "Server disconnected", with the setting at fault on
         # its last line and everything above it looking like a crash.
-        #
         _exit_on_a_bad_setting(e)
 
     # Configure logging

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, NoReturn
 
 import inquirer
 
@@ -412,6 +412,17 @@ def get_version() -> str:
         return "unknown"
 
 
+def _exit_on_a_bad_setting(error: ConfigurationError) -> NoReturn:
+    """Report a configuration error the way a user can act on it.
+
+    Printed, because logging is configured from the configuration that may be
+    what failed. To stderr for the same reason it carries every other
+    diagnostic here: stdout belongs to the protocol.
+    """
+    print(f"❌ Configuration error: {error}", file=sys.stderr)
+    sys.exit(1)
+
+
 def main() -> None:
     """Main application entry point."""
     try:
@@ -424,11 +435,7 @@ def main() -> None:
         # user sees behind "Server disconnected", with the setting at fault on
         # its last line and everything above it looking like a crash.
         #
-        # Printed, because logging is configured from the configuration that
-        # just failed to load. To stderr for the same reason it carries every
-        # other diagnostic here: stdout belongs to the protocol.
-        print(f"❌ Configuration error: {e}", file=sys.stderr)
-        sys.exit(1)
+        _exit_on_a_bad_setting(e)
 
     # Configure logging
     configure_logging(
@@ -513,7 +520,14 @@ def main() -> None:
                 # server was a private one. Re-validating applies the HTTP
                 # rules that were skipped when the value said stdio.
                 config.server.transport = transport
-                config.validate()
+                try:
+                    config.validate()
+                except ConfigurationError as e:
+                    # Inside the runtime `try` below, whose handler calls
+                    # logger.exception. A setting that only applies to HTTP
+                    # fails here and nowhere else, and it deserves the same
+                    # answer as one caught at startup.
+                    _exit_on_a_bad_setting(e)
 
             # Get a shared owner running before building this process's server.
             # It has to come first now: whether this process drives a browser or

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -8,7 +8,6 @@ import argparse
 import logging
 import math
 import os
-import re
 import sys
 from typing import Literal, cast
 from urllib.parse import unquote, urlsplit
@@ -30,47 +29,6 @@ FALSY_VALUES = ("0", "false", "no", "off")
 def _normalize_env(value: str) -> str:
     """Normalize environment variable values for tolerant parsing."""
     return value.strip().lower()
-
-
-# An MCPB host substitutes ``${user_config.NAME}`` in the extension's
-# ``mcp_config`` from the values the user entered, plus whatever ``default`` the
-# manifest declares. A field with neither is not in that table at all, so the
-# placeholder is handed to the process verbatim. Measured against Claude
-# Desktop's own substitution routine, which builds its replacement map from
-# ``default`` first and the user's answers second, then leaves every unknown
-# ``${...}`` untouched.
-_MCPB_PLACEHOLDER = re.compile(r"^\$\{user_config\.[^}]*\}$")
-
-
-def _env(key: str) -> str | None:
-    """Read an environment variable, treating an MCPB placeholder as unset.
-
-    The ``default`` entries in ``manifest.json`` are what keep the placeholders
-    out of the environment in the first place, and a manifest test holds that
-    line. This is the second half, for hosts that resolve ``user_config``
-    differently and for the bundles already installed with the broken manifest.
-
-    Both failure modes are worth refusing. A literal in ``PROXY_SERVER`` aborts
-    startup, which is loud. A literal in ``PROXY_USERNAME`` is not: the browser
-    offers ``${user_config.proxy_username}`` to the proxy as a credential, and
-    an authentication that fails that way surfaces as a timeout or an expired
-    session, never as a configuration problem.
-
-    Deliberately no ``strip()``: a proxy password may legitimately begin or end
-    with a space, and silently trimming it would be a wrong password nobody can
-    see.
-    """
-    value = os.environ.get(key)
-    if not value or _MCPB_PLACEHOLDER.fullmatch(value):
-        return None
-    return value
-
-
-def _mcpb_placeholder_keys(*keys: str) -> list[str]:
-    """The names among *keys* that hold an unsubstituted MCPB placeholder."""
-    return [
-        key for key in keys if _MCPB_PLACEHOLDER.fullmatch(os.environ.get(key) or "")
-    ]
 
 
 def positive_int(value: str) -> int:
@@ -187,6 +145,53 @@ class EnvironmentKeys:
     AUTO_IMPORT_FROM_BROWSER = "AUTO_IMPORT_FROM_BROWSER"
     EAGER_FULL_CHROMIUM = "EAGER_FULL_CHROMIUM"
     DAEMON_ENABLED = "DAEMON_ENABLED"
+
+
+# What ``manifest.json`` fills from ``user_config``, and the exact string each
+# mapping leaves behind when the host does not substitute it.
+#
+# An MCPB host builds its replacement map from the manifest's ``default`` values
+# overlaid with the answers the user gave, then rewrites only the ``${...}``
+# occurrences it has a key for. A field with neither a default nor an answer is
+# absent from that map, so its placeholder is handed to the process verbatim.
+# Measured against Claude Desktop's own substitution routine.
+#
+# One exact string per variable, not a pattern for the shape. A pattern would
+# also swallow a password that happens to read ``${user_config.token}``, which
+# is a legal password and would leave the browser authenticating with nothing.
+# Spelling the mapping out costs a line each and cannot do that.
+# ``tests/test_manifest.py`` checks this table against the manifest itself, so
+# the two cannot drift.
+_MCPB_PLACEHOLDERS = {
+    EnvironmentKeys.PROXY_SERVER: "${user_config.proxy_server}",
+    EnvironmentKeys.PROXY_USERNAME: "${user_config.proxy_username}",
+    EnvironmentKeys.PROXY_PASSWORD: "${user_config.proxy_password}",
+    EnvironmentKeys.PROXY_BYPASS: "${user_config.proxy_bypass}",
+}
+
+
+def _env(key: str) -> str | None:
+    """Read an environment variable, treating an MCPB placeholder as unset.
+
+    The ``default`` entries in ``manifest.json`` are what keep the placeholders
+    out of the environment in the first place, and a manifest test holds that
+    line. This is the second half, for hosts that resolve ``user_config``
+    differently and for the bundles already installed with the broken manifest.
+
+    Both failure modes are worth refusing. A literal in ``PROXY_SERVER`` aborts
+    startup, which is loud. A literal in ``PROXY_USERNAME`` is not: the browser
+    offers ``${user_config.proxy_username}`` to the proxy as a credential, and
+    an authentication that fails that way surfaces as a timeout or an expired
+    session, never as a configuration problem.
+
+    Deliberately no ``strip()``: a proxy password may legitimately begin or end
+    with a space, and silently trimming it would be a wrong password nobody can
+    see.
+    """
+    value = os.environ.get(key)
+    if not value or value == _MCPB_PLACEHOLDERS.get(key):
+        return None
+    return value
 
 
 def is_interactive_environment() -> bool:
@@ -360,20 +365,15 @@ def load_from_env(config: AppConfig) -> AppConfig:
     # the environment is not world-readable the way a process argument list is.
     #
     # Read through _env(), which drops an MCPB placeholder an older bundle left
-    # behind. Said once and by name rather than in silence: if a host ever fails
-    # to substitute a field the user *did* fill in, the proxy is skipped and the
-    # browser goes out on the real address, and that is the direction worth a
-    # line in the log. The values are placeholders, so naming them leaks nothing.
-    #
-    # These four and no others, because these are the only variables
-    # `manifest.json` fills from `user_config`. `tests/test_manifest.py` keeps
-    # that true, and a fifth would have to be added here as well as there.
-    if unsubstituted := _mcpb_placeholder_keys(
-        EnvironmentKeys.PROXY_SERVER,
-        EnvironmentKeys.PROXY_USERNAME,
-        EnvironmentKeys.PROXY_PASSWORD,
-        EnvironmentKeys.PROXY_BYPASS,
-    ):
+    # behind. That is a fail-open path and it says so: a host that fails to
+    # substitute a field the user *did* fill in skips the proxy, and the browser
+    # then goes out on the real address. So the variables are named in the log
+    # once. They hold placeholders, so naming them leaks nothing.
+    if unsubstituted := [
+        key
+        for key, literal in _MCPB_PLACEHOLDERS.items()
+        if os.environ.get(key) == literal
+    ]:
         logger.warning(
             "Ignoring %s: the value is an unsubstituted MCPB placeholder, not a "
             "setting. Reinstall the extension bundle to clear it. No proxy is "

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -175,8 +175,12 @@ def _env(key: str) -> str | None:
 
     The ``default`` entries in ``manifest.json`` are what keep the placeholders
     out of the environment in the first place, and a manifest test holds that
-    line. This is the second half, for hosts that resolve ``user_config``
-    differently and for the bundles already installed with the broken manifest.
+    line. This does not reach the bundles already installed with the broken
+    manifest: a bundle carries this source and that manifest together, so
+    whatever fixes one fixes the other. What it covers is a host that resolves
+    ``user_config`` by some other rule or ignores ``default``, and a variable
+    somebody set by hand after reading one out of an extension's own settings
+    pane.
 
     Both failure modes are worth refusing. A literal in ``PROXY_SERVER`` aborts
     startup, which is loud. A literal in ``PROXY_USERNAME`` is not: the browser

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -8,6 +8,7 @@ import argparse
 import logging
 import math
 import os
+import re
 import sys
 from typing import Literal, cast
 from urllib.parse import unquote, urlsplit
@@ -29,6 +30,47 @@ FALSY_VALUES = ("0", "false", "no", "off")
 def _normalize_env(value: str) -> str:
     """Normalize environment variable values for tolerant parsing."""
     return value.strip().lower()
+
+
+# An MCPB host substitutes ``${user_config.NAME}`` in the extension's
+# ``mcp_config`` from the values the user entered, plus whatever ``default`` the
+# manifest declares. A field with neither is not in that table at all, so the
+# placeholder is handed to the process verbatim. Measured against Claude
+# Desktop's own substitution routine, which builds its replacement map from
+# ``default`` first and the user's answers second, then leaves every unknown
+# ``${...}`` untouched.
+_MCPB_PLACEHOLDER = re.compile(r"^\$\{user_config\.[^}]*\}$")
+
+
+def _env(key: str) -> str | None:
+    """Read an environment variable, treating an MCPB placeholder as unset.
+
+    The ``default`` entries in ``manifest.json`` are what keep the placeholders
+    out of the environment in the first place, and a manifest test holds that
+    line. This is the second half, for hosts that resolve ``user_config``
+    differently and for the bundles already installed with the broken manifest.
+
+    Both failure modes are worth refusing. A literal in ``PROXY_SERVER`` aborts
+    startup, which is loud. A literal in ``PROXY_USERNAME`` is not: the browser
+    offers ``${user_config.proxy_username}`` to the proxy as a credential, and
+    an authentication that fails that way surfaces as a timeout or an expired
+    session, never as a configuration problem.
+
+    Deliberately no ``strip()``: a proxy password may legitimately begin or end
+    with a space, and silently trimming it would be a wrong password nobody can
+    see.
+    """
+    value = os.environ.get(key)
+    if not value or _MCPB_PLACEHOLDER.fullmatch(value):
+        return None
+    return value
+
+
+def _mcpb_placeholder_keys(*keys: str) -> list[str]:
+    """The names among *keys* that hold an unsubstituted MCPB placeholder."""
+    return [
+        key for key in keys if _MCPB_PLACEHOLDER.fullmatch(os.environ.get(key) or "")
+    ]
 
 
 def positive_int(value: str) -> int:
@@ -316,16 +358,39 @@ def load_from_env(config: AppConfig) -> AppConfig:
     # Browser proxy (validated and split in BrowserConfig.validate()). Unlike
     # the CLI flag, PROXY_SERVER may carry the credentials a provider hands out:
     # the environment is not world-readable the way a process argument list is.
-    if proxy_server_env := os.environ.get(EnvironmentKeys.PROXY_SERVER):
+    #
+    # Read through _env(), which drops an MCPB placeholder an older bundle left
+    # behind. Said once and by name rather than in silence: if a host ever fails
+    # to substitute a field the user *did* fill in, the proxy is skipped and the
+    # browser goes out on the real address, and that is the direction worth a
+    # line in the log. The values are placeholders, so naming them leaks nothing.
+    #
+    # These four and no others, because these are the only variables
+    # `manifest.json` fills from `user_config`. `tests/test_manifest.py` keeps
+    # that true, and a fifth would have to be added here as well as there.
+    if unsubstituted := _mcpb_placeholder_keys(
+        EnvironmentKeys.PROXY_SERVER,
+        EnvironmentKeys.PROXY_USERNAME,
+        EnvironmentKeys.PROXY_PASSWORD,
+        EnvironmentKeys.PROXY_BYPASS,
+    ):
+        logger.warning(
+            "Ignoring %s: the value is an unsubstituted MCPB placeholder, not a "
+            "setting. Reinstall the extension bundle to clear it. No proxy is "
+            "configured from these.",
+            ", ".join(unsubstituted),
+        )
+
+    if proxy_server_env := _env(EnvironmentKeys.PROXY_SERVER):
         config.browser.proxy_server = proxy_server_env
 
-    if proxy_username_env := os.environ.get(EnvironmentKeys.PROXY_USERNAME):
+    if proxy_username_env := _env(EnvironmentKeys.PROXY_USERNAME):
         config.browser.proxy_username = proxy_username_env
 
-    if proxy_password_env := os.environ.get(EnvironmentKeys.PROXY_PASSWORD):
+    if proxy_password_env := _env(EnvironmentKeys.PROXY_PASSWORD):
         config.browser.proxy_password = proxy_password_env
 
-    if proxy_bypass_env := os.environ.get(EnvironmentKeys.PROXY_BYPASS):
+    if proxy_bypass_env := _env(EnvironmentKeys.PROXY_BYPASS):
         config.browser.proxy_bypass = proxy_bypass_env
 
     # Import a LinkedIn session from a locally logged-in browser (validated in

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -372,20 +372,21 @@ def load_from_env(config: AppConfig) -> AppConfig:
     # the CLI flag, PROXY_SERVER may carry the credentials a provider hands out:
     # the environment is not world-readable the way a process argument list is.
     #
-    # Read through _env(), which drops an MCPB placeholder an older bundle left
-    # behind. That is a fail-open path and it says so: a host that fails to
-    # substitute a field the user *did* fill in skips the proxy, and the browser
-    # then goes out on the real address. So the variables are named in the log
-    # once. They hold placeholders, so naming them leaks nothing.
+    # Read through _env(), which drops a placeholder the host left behind.
+    # That is a fail-open path and it says so: a host that fails to substitute
+    # a field the user *did* fill in skips the proxy, and the browser then goes
+    # out on the real address. So the variables are named in the log once. They
+    # hold placeholders, so naming them leaks nothing.
     if unsubstituted := [
         key
         for key, literal in _MCPB_PLACEHOLDERS.items()
         if os.environ.get(key) == literal
     ]:
         logger.warning(
-            "Ignoring %s: the value is an unsubstituted MCPB placeholder, not a "
-            "setting. Reinstall the extension bundle to clear it. No proxy is "
-            "configured from these.",
+            "Ignoring %s: the value is an unsubstituted MCPB placeholder, not "
+            "a setting, so no proxy is configured from these. Update the "
+            "extension bundle, and clear the variable from any environment "
+            "override set by hand.",
             ", ".join(unsubstituted),
         )
 

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -162,6 +162,10 @@ class EnvironmentKeys:
 # Spelling the mapping out costs a line each and cannot do that.
 # ``tests/test_manifest.py`` checks this table against the manifest itself, so
 # the two cannot drift.
+#
+# One collision survives and is not fixable here: a password whose value is
+# its own variable's literal. Substituted and unsubstituted are then the same
+# string, and nothing downstream can tell them apart.
 _MCPB_PLACEHOLDERS = {
     EnvironmentKeys.PROXY_SERVER: "${user_config.proxy_server}",
     EnvironmentKeys.PROXY_USERNAME: "${user_config.proxy_username}",

--- a/manifest.json
+++ b/manifest.json
@@ -130,6 +130,7 @@
       "title": "Proxy server",
       "description": "Optional. Route the browser through a proxy, as scheme://host:port (http, https, socks4 or socks5). May also include credentials, as http://user:password@host:port. Only browser traffic is routed.",
       "required": false,
+      "default": "",
       "sensitive": true
     },
     "proxy_username": {
@@ -137,6 +138,7 @@
       "title": "Proxy username",
       "description": "Optional. Username for the proxy, if it requires one.",
       "required": false,
+      "default": "",
       "sensitive": true
     },
     "proxy_password": {
@@ -144,13 +146,15 @@
       "title": "Proxy password",
       "description": "Optional. Password for the proxy. Chromium cannot authenticate to a SOCKS proxy, so credentials require an http or https endpoint.",
       "required": false,
+      "default": "",
       "sensitive": true
     },
     "proxy_bypass": {
       "type": "string",
       "title": "Proxy bypass list",
       "description": "Optional. Comma-separated hosts to reach directly instead of through the proxy.",
-      "required": false
+      "required": false,
+      "default": ""
     }
   },
   "compatibility": {

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import linkedin_mcp_server.cli_main as cli_main
-from linkedin_mcp_server.config.schema import AppConfig
+from linkedin_mcp_server.config.schema import AppConfig, ConfigurationError
 from linkedin_mcp_server.exceptions import ProfileRootRefusedError
 
 
@@ -981,3 +981,44 @@ class TestForwardingToASharedOwner:
         cli_main.main()
 
         assert called == [], "an HTTP server must not elect a daemon"
+
+
+class TestConfigurationErrorAtStartup:
+    """A bad setting has to name itself, not arrive as a stack trace.
+
+    Under a stdio host the process has no console: stderr is the log file and
+    stdout is the protocol. An unhandled ConfigurationError put eleven frames
+    of this package into that log and the actual problem on the last line,
+    behind a "Server disconnected" the host reports for any early exit.
+    """
+
+    def _raise(self, monkeypatch: pytest.MonkeyPatch, message: str) -> None:
+        def boom() -> AppConfig:
+            raise ConfigurationError(message)
+
+        monkeypatch.setattr("linkedin_mcp_server.cli_main.get_config", boom)
+
+    def test_it_exits_with_the_message_and_no_traceback(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._raise(monkeypatch, "proxy_server needs a host and an explicit port")
+
+        with pytest.raises(SystemExit) as exit_info:
+            cli_main.main()
+
+        assert exit_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "proxy_server needs a host and an explicit port" in captured.err
+        assert "Traceback" not in captured.err
+
+    def test_it_leaves_stdout_to_the_protocol(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A stdio client parses stdout as JSON-RPC. A diagnostic there is worse
+        # than no diagnostic: it corrupts the stream it is trying to explain.
+        self._raise(monkeypatch, "PORT must be an integer")
+
+        with pytest.raises(SystemExit):
+            cli_main.main()
+
+        assert capsys.readouterr().out == ""

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1011,6 +1011,35 @@ class TestConfigurationErrorAtStartup:
         assert "proxy_server needs a host and an explicit port" in captured.err
         assert "Traceback" not in captured.err
 
+    def test_the_interactive_transport_choice_gets_the_same_answer(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A setting that only applies to HTTP passes the startup validation and
+        # fails the second one, after the user picks a transport. That call
+        # sits inside the runtime handler, which would log it as an unexpected
+        # error with its traceback.
+        config = _make_config(
+            is_interactive=True, transport="stdio", transport_explicitly_set=False
+        )
+        _patch_main_dependencies(monkeypatch, config)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.choose_transport_interactive",
+            lambda: "streamable-http",
+        )
+
+        def boom() -> None:
+            raise ConfigurationError("HTTP_PATH must start with a slash")
+
+        monkeypatch.setattr(config, "validate", boom)
+
+        with pytest.raises(SystemExit) as exit_info:
+            cli_main.main()
+
+        assert exit_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "HTTP_PATH must start with a slash" in captured.err
+        assert "Traceback" not in captured.err
+
     def test_it_leaves_stdout_to_the_protocol(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1124,6 +1124,106 @@ class TestProxyLoaders:
         assert self.SECRET not in capsys.readouterr().err
 
 
+class TestProxyMcpbPlaceholders:
+    """An MCPB host that left ``${user_config.NAME}`` in place means "blank".
+
+    Claude Desktop builds its substitution map from the manifest's ``default``
+    values and the user's answers. A field with neither is missing from that
+    map, so the placeholder reaches the process verbatim. The manifest now
+    declares a ``default`` for each optional field, which is what stops this at
+    the source; these cover the bundles installed before that and any host that
+    resolves user configuration differently.
+    """
+
+    PLACEHOLDERS = {
+        "PROXY_SERVER": "${user_config.proxy_server}",
+        "PROXY_USERNAME": "${user_config.proxy_username}",
+        "PROXY_PASSWORD": "${user_config.proxy_password}",
+        "PROXY_BYPASS": "${user_config.proxy_bypass}",
+    }
+
+    def test_all_four_placeholders_leave_no_proxy_configured(self, monkeypatch):
+        # The reported crash: validate() read the literal as an address, found
+        # no port, and took the whole server down at startup.
+        for key, value in self.PLACEHOLDERS.items():
+            monkeypatch.setenv(key, value)
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        config.validate()
+        assert config.browser.proxy_settings() is None
+
+    @pytest.mark.parametrize("key", sorted(PLACEHOLDERS))
+    def test_each_placeholder_alone_leaves_no_proxy_configured(
+        self, monkeypatch, key: str
+    ):
+        # Each one on its own is fatal too: without a server the other three
+        # raise "is set without proxy_server" instead.
+        monkeypatch.setenv(key, self.PLACEHOLDERS[key])
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        config.validate()
+        assert config.browser.proxy_settings() is None
+
+    def test_a_configured_proxy_is_not_given_placeholder_credentials(self, monkeypatch):
+        # The quieter half. With only the server filled in, the remaining three
+        # placeholders used to reach Chromium as a username, a password and a
+        # bypass list. That does not crash; it fails as a 407 the browser
+        # retries until the page times out, which reads as an expired session.
+        monkeypatch.setenv("PROXY_SERVER", "http://gate.example:7000")
+        for key in ("PROXY_USERNAME", "PROXY_PASSWORD", "PROXY_BYPASS"):
+            monkeypatch.setenv(key, self.PLACEHOLDERS[key])
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        config.validate()
+        assert config.browser.proxy_settings() == {"server": "http://gate.example:7000"}
+
+    def test_dropped_placeholders_are_named_once(self, monkeypatch, caplog):
+        # Silence would be the wrong default here: if a host ever failed to
+        # substitute a field the user did fill in, the browser would go out on
+        # the real address with no trace of why.
+        for key, value in self.PLACEHOLDERS.items():
+            monkeypatch.setenv(key, value)
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        with caplog.at_level(logging.WARNING, logger="linkedin_mcp_server.config"):
+            load_from_env(AppConfig())
+
+        warnings = [
+            record
+            for record in caplog.records
+            if "unsubstituted MCPB placeholder" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        for key in self.PLACEHOLDERS:
+            assert key in message
+
+    def test_a_real_setting_that_merely_resembles_one_is_kept(self, monkeypatch):
+        # The match is anchored, so only a bare placeholder counts. Anything
+        # else stays a value and reaches validation, which can explain it.
+        monkeypatch.setenv("PROXY_SERVER", "http://user-config.example:7000")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        config.validate()
+        assert config.browser.proxy_server == "http://user-config.example:7000"
+
+    def test_a_password_keeps_its_surrounding_whitespace(self, monkeypatch):
+        # Guards the decision not to strip: trimming a password would be a
+        # wrong credential with nothing in the logs to show for it.
+        monkeypatch.setenv("PROXY_SERVER", "http://gate.example:7000")
+        monkeypatch.setenv("PROXY_USERNAME", "envuser")
+        monkeypatch.setenv("PROXY_PASSWORD", "  padded  ")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        config.validate()
+        assert config.browser.proxy_password == "  padded  "
+
+
 class TestProxyEmptyPassword:
     """A username with an empty password is a legitimate proxy credential.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1202,14 +1202,30 @@ class TestProxyMcpbPlaceholders:
             assert key in message
 
     def test_a_real_setting_that_merely_resembles_one_is_kept(self, monkeypatch):
-        # The match is anchored, so only a bare placeholder counts. Anything
-        # else stays a value and reaches validation, which can explain it.
+        # Anything that is not the exact literal stays a value and reaches
+        # validation, which can explain it.
         monkeypatch.setenv("PROXY_SERVER", "http://user-config.example:7000")
         from linkedin_mcp_server.config.loaders import load_from_env
 
         config = load_from_env(AppConfig())
         config.validate()
         assert config.browser.proxy_server == "http://user-config.example:7000"
+
+    def test_a_password_shaped_like_another_placeholder_survives(self, monkeypatch):
+        # Why the comparison is against one exact string per variable and not
+        # against the shape of a placeholder. "${user_config.token}" is a legal
+        # password, and a host that never wrote it cannot be the reason it is
+        # there. Dropping it would leave the browser authenticating with
+        # nothing against a proxy that requires it.
+        secret = "${user_config.token}"
+        monkeypatch.setenv("PROXY_SERVER", "http://gate.example:7000")
+        monkeypatch.setenv("PROXY_USERNAME", "envuser")
+        monkeypatch.setenv("PROXY_PASSWORD", secret)
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        config.validate()
+        assert config.browser.proxy_password == secret
 
     def test_a_password_keeps_its_surrounding_whitespace(self, monkeypatch):
         # Guards the decision not to strip: trimming a password would be a

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,95 @@
+"""Rules about ``manifest.json`` that only a reader of the host can know.
+
+``mcpb validate`` in the release workflow checks the manifest against its
+schema. A manifest can pass that and still produce a bundle that cannot start,
+because the schema says nothing about how a host resolves ``${user_config.X}``.
+
+Measured against Claude Desktop's own substitution routine: it builds one
+replacement map from the manifest's ``default`` values, overlays the answers
+the user gave, and then rewrites ``${...}`` occurrences for the keys in that
+map. A key in neither source is not in the map, and the placeholder is passed
+to the process verbatim.
+
+So an optional field with no ``default`` hands the server the string
+``${user_config.proxy_server}`` as if it were an address. That shipped in
+4.20.0 and stopped every bundle where the proxy fields were left blank, which
+is the default for anyone not using a proxy. The rules below are that failure
+written down.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PLACEHOLDER = re.compile(r"\$\{user_config\.([^}]*)\}")
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict[str, Any]:
+    return json.loads((_REPO_ROOT / "manifest.json").read_text(encoding="utf-8"))
+
+
+def _referenced_keys(node: Any) -> set[str]:
+    """Every ``user_config`` key named anywhere below *node*.
+
+    Walks rather than reading ``env`` directly, because a placeholder is just as
+    valid inside ``args`` or a ``platform_overrides`` block, and a rule that
+    only covers where the placeholders happen to sit today is a rule that stops
+    holding the first time one moves.
+    """
+    if isinstance(node, str):
+        return set(_PLACEHOLDER.findall(node))
+    if isinstance(node, list):
+        return set().union(*(_referenced_keys(item) for item in node), set())
+    if isinstance(node, dict):
+        return set().union(*(_referenced_keys(value) for value in node.values()), set())
+    return set()
+
+
+def test_every_referenced_key_is_declared(manifest: dict[str, Any]) -> None:
+    declared = set(manifest.get("user_config", {}))
+    referenced = _referenced_keys(manifest["server"]["mcp_config"])
+    assert referenced <= declared, (
+        f"mcp_config names user_config keys that do not exist: "
+        f"{sorted(referenced - declared)}. A host cannot substitute those, so "
+        f"the literal placeholder reaches the server as a setting."
+    )
+
+
+def test_every_optional_referenced_key_has_a_default(manifest: dict[str, Any]) -> None:
+    """The rule that #678 exists for.
+
+    ``required`` is the other way to be safe: a host skips the whole MCP config
+    while a required field is empty, so no placeholder is ever handed over. An
+    optional field has no such protection and needs a ``default`` — an empty
+    string is enough, since it substitutes to nothing and the loader reads that
+    as unset.
+    """
+    user_config = manifest.get("user_config", {})
+    offenders = sorted(
+        key
+        for key in _referenced_keys(manifest["server"]["mcp_config"])
+        if key in user_config
+        and not user_config[key].get("required")
+        and user_config[key].get("default") is None
+    )
+    assert not offenders, (
+        f"Optional user_config fields referenced without a default: {offenders}. "
+        f'Add "default": "" to each. Without it a host that leaves the field '
+        f"blank passes the literal ${{user_config.NAME}} through, and the "
+        f"server either refuses to start or treats it as a real value."
+    )
+
+
+def test_every_declared_key_is_referenced(manifest: dict[str, Any]) -> None:
+    """A field nobody reads is a setting the user fills in for nothing."""
+    declared = set(manifest.get("user_config", {}))
+    referenced = _referenced_keys(manifest["server"]["mcp_config"])
+    assert declared <= referenced, (
+        f"user_config declares keys that mcp_config never uses: "
+        f"{sorted(declared - referenced)}."
+    )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -210,36 +210,55 @@ def test_the_loader_knows_the_same_mapping(manifest: dict[str, Any]) -> None:
     )
 
 
+def _named_variable(node: ast.expr, environment_keys: Any) -> str | None:
+    """The variable name *node* stands for, if it names one at all.
+
+    Both spellings the loader could use: the constant off ``EnvironmentKeys``,
+    which is the house style, and a bare string, which is what somebody writes
+    who has not noticed the class.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Attribute) and ast.unparse(node.value) == "EnvironmentKeys":
+        value = getattr(environment_keys, node.attr, None)
+        return value if isinstance(value, str) else None
+    return None
+
+
 def test_a_mapped_variable_is_never_read_raw() -> None:
     """Knowing the mapping is worth nothing if the read goes around it.
 
     ``_MCPB_PLACEHOLDERS`` is a table, and a table can be extended while the
-    branch that reads the variable still calls ``os.environ.get``. Every test
-    above would stay green and the literal would be taken for the setting, so
-    the check is on the reading code itself.
+    branch that reads the variable still reaches into ``os.environ`` directly.
+    Every test above would stay green and the literal would be taken for the
+    setting, so the check is on the reading code itself.
+
+    Every way of asking ``os.environ`` for one name counts, since a rule that
+    only knew ``.get`` would be satisfied by a subscript.
     """
     from linkedin_mcp_server.config import loaders
 
     guarded = set(loaders._MCPB_PLACEHOLDERS)
-    source = Path(loaders.__file__).read_text(encoding="utf-8")
-    offenders = []
-    for node in ast.walk(ast.parse(source)):
-        if not isinstance(node, ast.Call) or not node.args:
-            continue
-        function = node.func
-        if not (isinstance(function, ast.Attribute) and function.attr == "get"):
-            continue
-        if ast.unparse(function.value) != "os.environ":
-            continue
-        argument = node.args[0]
-        if not isinstance(argument, ast.Attribute):
-            continue
-        if ast.unparse(argument.value) != "EnvironmentKeys":
-            continue
-        if getattr(loaders.EnvironmentKeys, argument.attr, None) in guarded:
-            offenders.append(argument.attr)
+    keys = loaders.EnvironmentKeys
+    offenders = set()
+    for node in ast.walk(ast.parse(Path(loaders.__file__).read_text(encoding="utf-8"))):
+        named = None
+        if (
+            isinstance(node, ast.Call)
+            and node.args
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in ("get", "pop", "setdefault")
+            and ast.unparse(node.func.value) == "os.environ"
+        ):
+            named = _named_variable(node.args[0], keys)
+        elif (
+            isinstance(node, ast.Subscript) and ast.unparse(node.value) == "os.environ"
+        ):
+            named = _named_variable(node.slice, keys)
+        if named in guarded:
+            offenders.add(named)
     assert not offenders, (
-        f"These carry a user_config placeholder but are read with "
-        f"os.environ.get: {sorted(offenders)}. Read them through _env(), which "
-        f"is what turns an unsubstituted placeholder back into an unset value."
+        f"These carry a user_config placeholder but are read straight out of "
+        f"os.environ: {sorted(offenders)}. Read them through _env(), which is "
+        f"what turns an unsubstituted placeholder back into an unset value."
     )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -116,3 +116,21 @@ def test_the_loader_knows_the_same_mapping(manifest: dict[str, Any]) -> None:
         "A variable the loader does not know keeps its literal; a string that "
         "does not match is compared against nothing."
     )
+
+
+def test_no_default_is_itself_a_placeholder(manifest: dict[str, Any]) -> None:
+    """A default that names another field only moves the problem.
+
+    The host resolves a default the same way it resolves anything else, so
+    ``"default": "${user_config.missing}"`` satisfies the rule above while
+    still handing a literal to the server.
+    """
+    offenders = sorted(
+        key
+        for key, entry in manifest.get("user_config", {}).items()
+        if isinstance(entry.get("default"), str)
+        and _PLACEHOLDER.search(entry["default"])
+    )
+    assert not offenders, (
+        f"user_config defaults that are themselves placeholders: {offenders}."
+    )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -36,10 +36,10 @@ def manifest() -> dict[str, Any]:
 def _referenced_keys(node: Any) -> set[str]:
     """Every ``user_config`` key named anywhere below *node*.
 
-    Walks rather than reading ``env`` directly, because a placeholder is just as
-    valid inside ``args`` or a ``platform_overrides`` block, and a rule that
-    only covers where the placeholders happen to sit today is a rule that stops
-    holding the first time one moves.
+    A full walk, because a placeholder is just as valid inside ``args`` or a
+    ``platform_overrides`` block as it is in ``env``. A rule that only covers
+    where the placeholders happen to sit today stops holding the first time one
+    moves.
     """
     if isinstance(node, str):
         return set(_PLACEHOLDER.findall(node))
@@ -65,7 +65,7 @@ def test_every_optional_referenced_key_has_a_default(manifest: dict[str, Any]) -
 
     ``required`` is the other way to be safe: a host skips the whole MCP config
     while a required field is empty, so no placeholder is ever handed over. An
-    optional field has no such protection and needs a ``default`` — an empty
+    optional field has no such protection and needs a ``default``. An empty
     string is enough, since it substitutes to nothing and the loader reads that
     as unset.
     """
@@ -92,4 +92,27 @@ def test_every_declared_key_is_referenced(manifest: dict[str, Any]) -> None:
     assert declared <= referenced, (
         f"user_config declares keys that mcp_config never uses: "
         f"{sorted(declared - referenced)}."
+    )
+
+
+def test_the_loader_knows_the_same_mapping(manifest: dict[str, Any]) -> None:
+    """``_MCPB_PLACEHOLDERS`` has to say what the manifest says.
+
+    The loader drops a leftover placeholder by comparing against the exact
+    string, which is what stops it from also eating a password that happens to
+    read like one. Exactness is only worth anything while the two agree, and
+    they are edited in different files.
+    """
+    from linkedin_mcp_server.config.loaders import _MCPB_PLACEHOLDERS
+
+    from_manifest = {
+        variable: value
+        for variable, value in manifest["server"]["mcp_config"]["env"].items()
+        if _PLACEHOLDER.fullmatch(value)
+    }
+    assert _MCPB_PLACEHOLDERS == from_manifest, (
+        "config/loaders.py and manifest.json disagree about which environment "
+        "variables carry user_config placeholders, or about their exact text. "
+        "A variable the loader does not know keeps its literal; a string that "
+        "does not match is compared against nothing."
     )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -4,7 +4,7 @@
 schema. A manifest can pass that and still produce a bundle that cannot start,
 because the schema says nothing about how a host resolves ``${user_config.X}``.
 
-Measured against Claude Desktop's own substitution routine: it builds one
+Measured against Claude Desktop's own substitution routine. It builds one
 replacement map from the manifest's ``default`` values, overlays the answers
 the user gave, and then rewrites ``${...}`` occurrences for the keys in that
 map. A key in neither source is not in the map, and the placeholder is passed
@@ -15,17 +15,40 @@ So an optional field with no ``default`` hands the server the string
 4.20.0 and stopped every bundle where the proxy fields were left blank, which
 is the default for anyone not using a proxy. The rules below are that failure
 written down.
+
+Position decides what a sufficient default is, and the two positions do not
+agree. Measured by replaying the routine over a manifest built for the
+question:
+
+* In a string, the value is interpolated whatever it is, so ``""`` disappears
+  and leaves nothing behind. That is where the four proxy variables sit.
+* As an entire element of ``args``, the substitution is guarded by a
+  truthiness test on the replacement. ``""`` is falsy, so the element keeps its
+  literal and the browser is started with ``${user_config.NAME}`` as an
+  argument.
+* An array-valued default reached from a string is refused outright: the
+  routine logs "Cannot replace with array value" and leaves the literal.
+
+A rule that only knew the first case would bless the other two.
 """
 
+import ast
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _PLACEHOLDER = re.compile(r"\$\{user_config\.([^}]*)\}")
+
+# What counts as an entire element, which is the form the host's array branch
+# looks for. Anything else in a list is treated as a string.
+_WHOLE_PLACEHOLDER = re.compile(r"\$\{user_config\.([^}]*)\}\Z")
+
+STRING = "string"
+ARRAY_ELEMENT = "array element"
 
 
 @pytest.fixture(scope="module")
@@ -33,26 +56,62 @@ def manifest() -> dict[str, Any]:
     return json.loads((_REPO_ROOT / "manifest.json").read_text(encoding="utf-8"))
 
 
-def _referenced_keys(node: Any) -> set[str]:
-    """Every ``user_config`` key named anywhere below *node*.
+def _references(node: Any) -> Iterator[tuple[str, str]]:
+    """Every ``user_config`` key named below *node*, with where it is named.
 
     A full walk, because a placeholder is just as valid inside ``args`` or a
     ``platform_overrides`` block as it is in ``env``. A rule that only covers
     where the placeholders happen to sit today stops holding the first time one
     moves.
+
+    The shape mirrors the host's own traversal: lists check each element for a
+    whole placeholder first and fall back to the string rule, dictionaries
+    descend into values and never into keys.
     """
     if isinstance(node, str):
-        return set(_PLACEHOLDER.findall(node))
-    if isinstance(node, list):
-        return set().union(*(_referenced_keys(item) for item in node), set())
-    if isinstance(node, dict):
-        return set().union(*(_referenced_keys(value) for value in node.values()), set())
-    return set()
+        for key in _PLACEHOLDER.findall(node):
+            yield key, STRING
+    elif isinstance(node, list):
+        for item in node:
+            whole = (
+                _WHOLE_PLACEHOLDER.fullmatch(item) if isinstance(item, str) else None
+            )
+            if whole is not None:
+                yield whole.group(1), ARRAY_ELEMENT
+            else:
+                yield from _references(item)
+    elif isinstance(node, dict):
+        for value in node.values():
+            yield from _references(value)
+
+
+def _mcp_config(manifest: dict[str, Any]) -> Any:
+    return manifest["server"]["mcp_config"]
+
+
+def _env_mappings(manifest: dict[str, Any]) -> dict[str, str]:
+    """The environment mapping of the root config and of every platform.
+
+    A platform override replaces the root ``env`` wholesale, so a placeholder
+    that only appears under one platform is as real as one in the root.
+    """
+    config = _mcp_config(manifest)
+    blocks = [config.get("env", {})]
+    blocks += [
+        override.get("env", {})
+        for override in config.get("platform_overrides", {}).values()
+    ]
+    return {
+        variable: value
+        for block in blocks
+        for variable, value in block.items()
+        if _PLACEHOLDER.fullmatch(value)
+    }
 
 
 def test_every_referenced_key_is_declared(manifest: dict[str, Any]) -> None:
     declared = set(manifest.get("user_config", {}))
-    referenced = _referenced_keys(manifest["server"]["mcp_config"])
+    referenced = {key for key, _ in _references(_mcp_config(manifest))}
     assert referenced <= declared, (
         f"mcp_config names user_config keys that do not exist: "
         f"{sorted(referenced - declared)}. A host cannot substitute those, so "
@@ -60,38 +119,76 @@ def test_every_referenced_key_is_declared(manifest: dict[str, Any]) -> None:
     )
 
 
-def test_every_optional_referenced_key_has_a_default(manifest: dict[str, Any]) -> None:
+def test_every_optional_reference_survives_a_blank_field(
+    manifest: dict[str, Any],
+) -> None:
     """The rule that #678 exists for.
 
     ``required`` is the other way to be safe: a host skips the whole MCP config
-    while a required field is empty, so no placeholder is ever handed over. An
-    optional field has no such protection and needs a ``default``. An empty
-    string is enough, since it substitutes to nothing and the loader reads that
-    as unset.
+    while a required field is empty, so no placeholder is ever handed over.
+
+    An optional field needs a ``default`` the host will actually substitute,
+    and what qualifies depends on where the placeholder sits. In a string any
+    default works and ``""`` is the natural one. As a whole element of ``args``
+    the substitution is guarded by a truthiness test, so ``""`` and ``0`` leave
+    the literal in place.
     """
     user_config = manifest.get("user_config", {})
-    offenders = sorted(
-        key
-        for key in _referenced_keys(manifest["server"]["mcp_config"])
-        if key in user_config
-        and not user_config[key].get("required")
-        and user_config[key].get("default") is None
-    )
+    offenders = []
+    for key, position in _references(_mcp_config(manifest)):
+        entry = user_config.get(key)
+        if entry is None or entry.get("required"):
+            continue
+        default = entry.get("default")
+        if default is None:
+            offenders.append(f"{key} ({position}): no default")
+        elif position == STRING and isinstance(default, list):
+            # The host refuses to interpolate an array into a string and keeps
+            # the literal, with "Cannot replace with array value" on its console.
+            offenders.append(f"{key} ({position}): default is a list")
+        elif position == ARRAY_ELEMENT and default in ("", 0, False):
+            offenders.append(f"{key} ({position}): default is falsy")
     assert not offenders, (
-        f"Optional user_config fields referenced without a default: {offenders}. "
-        f'Add "default": "" to each. Without it a host that leaves the field '
-        f"blank passes the literal ${{user_config.NAME}} through, and the "
-        f"server either refuses to start or treats it as a real value."
+        f"Optional user_config references a blank field would not survive: "
+        f'{sorted(offenders)}. In a string give the field a default; "" is '
+        f"enough. As a whole args element give it a non-empty one, or drop the "
+        f"argument instead of passing an empty value."
     )
 
 
 def test_every_declared_key_is_referenced(manifest: dict[str, Any]) -> None:
     """A field nobody reads is a setting the user fills in for nothing."""
     declared = set(manifest.get("user_config", {}))
-    referenced = _referenced_keys(manifest["server"]["mcp_config"])
+    referenced = {key for key, _ in _references(_mcp_config(manifest))}
     assert declared <= referenced, (
         f"user_config declares keys that mcp_config never uses: "
         f"{sorted(declared - referenced)}."
+    )
+
+
+def test_no_default_is_itself_a_placeholder(manifest: dict[str, Any]) -> None:
+    """A default that names another field only moves the problem.
+
+    The host resolves a default the same way it resolves anything else, so
+    ``"default": "${user_config.missing}"`` satisfies the rule above while
+    still handing a literal to the server. A list default is checked element by
+    element, since ``["${user_config.missing}"]`` hides the same thing.
+    """
+
+    def names_a_placeholder(default: Any) -> bool:
+        if isinstance(default, str):
+            return _PLACEHOLDER.search(default) is not None
+        if isinstance(default, list):
+            return any(names_a_placeholder(item) for item in default)
+        return False
+
+    offenders = sorted(
+        key
+        for key, entry in manifest.get("user_config", {}).items()
+        if names_a_placeholder(entry.get("default"))
+    )
+    assert not offenders, (
+        f"user_config defaults that are themselves placeholders: {offenders}."
     )
 
 
@@ -105,12 +202,7 @@ def test_the_loader_knows_the_same_mapping(manifest: dict[str, Any]) -> None:
     """
     from linkedin_mcp_server.config.loaders import _MCPB_PLACEHOLDERS
 
-    from_manifest = {
-        variable: value
-        for variable, value in manifest["server"]["mcp_config"]["env"].items()
-        if _PLACEHOLDER.fullmatch(value)
-    }
-    assert _MCPB_PLACEHOLDERS == from_manifest, (
+    assert _MCPB_PLACEHOLDERS == _env_mappings(manifest), (
         "config/loaders.py and manifest.json disagree about which environment "
         "variables carry user_config placeholders, or about their exact text. "
         "A variable the loader does not know keeps its literal; a string that "
@@ -118,19 +210,36 @@ def test_the_loader_knows_the_same_mapping(manifest: dict[str, Any]) -> None:
     )
 
 
-def test_no_default_is_itself_a_placeholder(manifest: dict[str, Any]) -> None:
-    """A default that names another field only moves the problem.
+def test_a_mapped_variable_is_never_read_raw() -> None:
+    """Knowing the mapping is worth nothing if the read goes around it.
 
-    The host resolves a default the same way it resolves anything else, so
-    ``"default": "${user_config.missing}"`` satisfies the rule above while
-    still handing a literal to the server.
+    ``_MCPB_PLACEHOLDERS`` is a table, and a table can be extended while the
+    branch that reads the variable still calls ``os.environ.get``. Every test
+    above would stay green and the literal would be taken for the setting, so
+    the check is on the reading code itself.
     """
-    offenders = sorted(
-        key
-        for key, entry in manifest.get("user_config", {}).items()
-        if isinstance(entry.get("default"), str)
-        and _PLACEHOLDER.search(entry["default"])
-    )
+    from linkedin_mcp_server.config import loaders
+
+    guarded = set(loaders._MCPB_PLACEHOLDERS)
+    source = Path(loaders.__file__).read_text(encoding="utf-8")
+    offenders = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        function = node.func
+        if not (isinstance(function, ast.Attribute) and function.attr == "get"):
+            continue
+        if ast.unparse(function.value) != "os.environ":
+            continue
+        argument = node.args[0]
+        if not isinstance(argument, ast.Attribute):
+            continue
+        if ast.unparse(argument.value) != "EnvironmentKeys":
+            continue
+        if getattr(loaders.EnvironmentKeys, argument.attr, None) in guarded:
+            offenders.append(argument.attr)
     assert not offenders, (
-        f"user_config defaults that are themselves placeholders: {offenders}."
+        f"These carry a user_config placeholder but are read with "
+        f"os.environ.get: {sorted(offenders)}. Read them through _env(), which "
+        f"is what turns an unsubstituted placeholder back into an unset value."
     )


### PR DESCRIPTION
Closes #678

A bundle installed from 4.20.0 onwards does not start unless a proxy is configured. Claude Desktop builds its substitution map from the manifest's `default` values and the answers the user gave; an optional field with neither is absent from that map, so `${user_config.proxy_server}` is handed to the server as if it were an address. Validation finds no port and takes the process down before it can say why.

The quieter half of the same bug hits the people the feature was built for. With only the server filled in, the remaining three placeholders reached Chromium as a username, a password and a bypass list. That does not crash: the browser retries the authentication challenge until the page times out, which the README itself describes as the failure that reads like an expired session.

Every optional field now declares `"default": ""`, which substitutes to nothing and is read as unset. The loader drops a placeholder that reaches it anyway, comparing against one exact string per variable so that a password which happens to read `${user_config.token}` survives, and naming the variables in the log once because a proxy silently skipped means the browser goes out on the real address. A `ConfigurationError` now prints its message to stderr and exits, at startup and at the second validation an interactively chosen transport triggers, instead of arriving as the stack that reads like a crash.

`mcpb validate` cannot catch this class, because the schema knows nothing about substitution. So a test holds the line instead: every `${user_config.X}` named anywhere in `mcp_config` has to resolve to a field that is required or carries a default, no default may itself be a placeholder, no field may be named that does not exist, no field may be declared that nothing reads, and the loader's table has to agree with the manifest string for string. `AGENTS.md` states the rule alongside it.

Verified by reproducing the reporter's one-liner against the fix, by replaying Claude Desktop's substitution routine over the new manifest for the blank, server-only and full-credential cases, against `mcpb validate` at the version the release workflow pins, and by mutating each guard to confirm the tests fail without it.

## Synthetic prompt

> Issue #678: MCPB bundles fail to start because Claude Desktop passes the literal `${user_config.proxy_server}` for optional fields left blank. Find out how the host actually resolves those placeholders, fix it at the source and in the loader, and add a test that makes this class of manifest mistake impossible to ship again.

Generated with Claude Opus 5 high + Sol 5.6 xhigh