### PR TITLE
chore: Bump version to 4.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-linkedin"
-version = "4.20.1"
+version = "4.21.0"
 description = "MCP server that gives AI assistants like Claude access to LinkedIn profiles, companies, and job postings through the user's own browser session."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-linkedin"
-version = "4.20.1"
+version = "4.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1069,7 +1069,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=3.4.4" },
     { name = "inquirer", specifier = ">=3.4.0" },
     { name = "packaging", specifier = ">=26.2" },
-    { name = "patchright", specifier = ">=1.55" },
+    { name = "patchright", specifier = ">=1.55.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
 ]
 


### PR DESCRIPTION
Releases the 37 commits that have accumulated on `main` since v4.20.1 on 29 July. Minor rather than patch because six of them are features, five of those the daemon-election subsystem that lets one owner hold the browser and serve every other client over loopback.

The fix people are waiting for is #678: since v4.20.0 an MCPB bundle refused to start unless a proxy was configured, because a host hands the literal `${user_config.proxy_server}` to the server for an optional field left blank. That is the whole of what the extension has been doing for anyone who installed it and does not use a proxy.

Version bump only; the release workflow updates `manifest.json` and `docker-compose.yml` itself.