### PR TITLE
fix(docker): Run Chromium under Xvfb

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,9 @@
 # session from this server; otherwise start once with --claim-profile-root.
 USER_DATA_DIR=~/.linkedin-mcp/profile
 
-# Browser mode (default: true)
-# true = headless, false = visible window
+# Browser mode (default: true outside Docker; the image overrides it to false)
+# true = Chromium's headless mode; false = headed. Docker's headed window lives
+# on a virtual display and never appears on the host.
 HEADLESS=true
 
 # Logging level (default: WARNING)

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,27 @@ ENV PATH="/app/.venv/bin:$PATH"
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/patchright
 
 RUN patchright install-deps chromium && \
-    patchright install chromium && \
+    patchright install chromium --no-shell && \
     apt-get update && apt-get install -y --no-install-recommends tini && \
     chmod -R 755 /opt/patchright && \
     rm -rf /var/lib/apt/lists/*
 
+COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/linkedin-mcp-entrypoint
+
+# A full headed browser on a virtual display. No window reaches the host, and
+# HEADLESS stays overridable for anyone who deliberately wants Chromium's real
+# headless mode. DISPLAY is fixed inside one container, where there is only one
+# X server to collide with.
+ENV DISPLAY=:99
+ENV HEADLESS=false
+
 USER pwuser
 
-# tini reaps the chromium subprocesses Patchright orphans onto PID 1; without an
-# init the container leaks zombie chrome-headless processes over its lifetime.
-ENTRYPOINT ["tini", "--", "python", "-m", "linkedin_mcp_server"]
+# -g sends TERM to the whole process group: Python gets to run FastMCP's
+# graceful shutdown, and Xvfb leaves with it. The entrypoint supervises both in
+# that group, so either one dying terminates the other instead of leaving a live
+# server with no display. A handled SIGTERM can still report 143, so -e maps
+# that expected `docker stop` path to success. Without an init, Chromium
+# subprocesses orphaned onto PID 1 would also accumulate as zombies.
+ENTRYPOINT ["tini", "-g", "-e", "143", "--", "linkedin-mcp-entrypoint", "python", "-m", "linkedin_mcp_server"]
 CMD []

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ On startup, the MCP Bundle starts preparing the shared Patchright Chromium brows
 
 ### Authentication
 
-Docker runs headless (no browser window), so you need to create a browser profile locally first and mount it into the container.
+Docker runs full Chromium headed on a virtual display. No browser window reaches the host, so you still need to create a browser profile locally first and mount it into the container.
 
 **Step 1: Create profile on the host (one-time setup)**
 
@@ -334,7 +334,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 > Docker creates a fresh session on each startup. Sessions may expire over time — run `uvx mcp-server-linkedin@latest --login` again if you encounter authentication issues.
 
 > [!NOTE]
-> **Why can't I run `--login` in Docker?** Docker containers don't have a display server. Create a profile on your host using the [uvx setup](#-uvx-setup-recommended---universal) and mount it into Docker.
+> **Why can't I run `--login` in Docker?** The container has a virtual display for Chromium, but no viewer that can show it to you or accept the form, 2FA, or captcha. Create a profile on your host using the [uvx setup](#-uvx-setup-recommended---universal) and mount it into Docker.
 
 ### Docker Setup Help
 
@@ -370,7 +370,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 - `--proxy-server URL` - Route the browser through a proxy, as `scheme://host:port`. Set the password via `PROXY_PASSWORD` (no flag, so it stays out of the process list)
 
 > [!NOTE]
-> `--login` and `--no-headless` are not available in Docker (no display server). Use the [uvx setup](#-uvx-setup-recommended---universal) to create profiles.
+> `--login` is not usable in Docker yet: Chromium has a virtual display, but the image has no viewer for completing the login. Docker is already headed by default; `--no-headless` therefore changes nothing. Use the [uvx setup](#-uvx-setup-recommended---universal) to create profiles. The experimental `--daemon` is also ignored in Docker because its owner can outlive the virtual display.
 
 **HTTP Mode Example (for web-based MCP clients):**
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -euo pipefail
+
+# Xvfb, Python and this supervisor stay in one process group. `tini -g` then
+# delivers SIGTERM to all three, so FastMCP runs its graceful shutdown before
+# the display goes away. `xvfb-run` is not a substitute: measured under
+# `docker stop`, its EXIT trap cleaned up Xvfb but it never forwarded TERM to
+# Python; the container exited 143 without the server's shutdown path.
+: "${DISPLAY:=:99}"
+export DISPLAY
+
+# This container owns a local X server. A host prefix means a remote display,
+# which Xvfb cannot create and `-nolisten tcp` could not serve. Accept the local
+# X11 forms only, with an optional screen suffix.
+if [[ $DISPLAY =~ ^:([0-9]+)(\.[0-9]+)?$ ]]; then
+    display_number=${BASH_REMATCH[1]}
+else
+    printf 'DISPLAY must be a local X display such as :99 or :99.0, got %q\n' \
+        "$DISPLAY" >&2
+    exit 2
+fi
+
+socket_path="/tmp/.X11-unix/X${display_number}"
+lock_path="/tmp/.X${display_number}-lock"
+
+# A SIGKILL leaves both names in the container's writable layer. Docker restart
+# reuses that layer, so accepting the old socket as readiness starts Python
+# against a display that never came up and traps the container in a restart loop.
+rm -f -- "$socket_path" "$lock_path"
+
+Xvfb "$DISPLAY" -screen 0 1920x1080x24 -nolisten tcp >/tmp/xvfb.log 2>&1 &
+xvfb_pid=$!
+
+# Starting Chromium against a display whose process exists but whose socket is
+# not ready fails exactly like having no display. Bounded and with Xvfb's own log
+# on failure, so a broken image exits with the useful error instead of hanging.
+attempt=0
+while [[ $attempt -lt 100 ]]; do
+    if [[ -S "$socket_path" ]]; then
+        break
+    fi
+    if ! kill -0 "$xvfb_pid" 2>/dev/null; then
+        wait "$xvfb_pid" || true
+        cat /tmp/xvfb.log >&2
+        exit 1
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.1
+done
+
+if [[ ! -S "$socket_path" ]]; then
+    kill -TERM "$xvfb_pid" 2>/dev/null || true
+    wait "$xvfb_pid" || true
+    cat /tmp/xvfb.log >&2
+    exit 1
+fi
+
+"$@" &
+server_pid=$!
+
+terminate() {
+    trap - TERM INT HUP
+    kill -TERM "$server_pid" "$xvfb_pid" 2>/dev/null || true
+
+    # Preserve the server's status. Xvfb receives TERM by design and commonly
+    # reports 143; it is infrastructure for the server rather than the result
+    # Docker should expose.
+    server_status=0
+    wait "$server_pid" || server_status=$?
+    wait "$xvfb_pid" || true
+    exit "$server_status"
+}
+trap terminate TERM INT HUP
+
+# `wait -n -p` is why this is Bash rather than POSIX sh. Whichever child dies
+# first decides the container: if Xvfb disappears, stop the server so Docker's
+# restart policy sees a failed container instead of a live MCP endpoint with no
+# display; if the server exits, stop Xvfb and return the server's status.
+set +e
+wait -n -p first_child "$xvfb_pid" "$server_pid"
+first_status=$?
+set -e
+
+if [[ $first_child == "$xvfb_pid" ]]; then
+    kill -TERM "$server_pid" 2>/dev/null || true
+    wait "$server_pid" || true
+    cat /tmp/xvfb.log >&2
+    [[ $first_status -ne 0 ]] || first_status=1
+    exit "$first_status"
+fi
+
+kill -TERM "$xvfb_pid" 2>/dev/null || true
+wait "$xvfb_pid" || true
+exit "$first_status"

--- a/docs/browser-fingerprint.md
+++ b/docs/browser-fingerprint.md
@@ -78,8 +78,8 @@ headless".
 | Full Chromium headless (`channel="chromium"`) | 67% / 50% | Two high-severity fpscanner rules from the headless token |
 | Headless shell (the old default) | — | `plugins.length = 0`, no `window.chrome`, notification permission incoherent |
 | Hidden target, windowless mode (macOS) | — | No headless token in UA or brands; `visible` / focused; rAF at 100% of a control window |
-| Docker, headed under Xvfb | 0% / 44% | No headless token, native hints; needs `xauth` |
-| Docker, Xvfb + Mesa llvmpipe | 0% / 44% | Restores WebGL; renderer string is a known software renderer |
+| Docker, headed under Xvfb | 0% / 44% | No headless token, native hints; Xvfb is started directly in Python's process group |
+| Docker, Xvfb + Mesa llvmpipe | 0% / 44% | WebGL1 and WebGL2; byte-identical renderer across both published architectures |
 
 The windowless mode, measured end to end through `BrowserManager`:
 
@@ -111,6 +111,66 @@ like Linux, so it is not claimed.
 Linux is less a gap than a different answer: under a virtual display nobody is
 looking at the screen, so an ordinary window is already invisible and there is
 nothing to hide.
+
+### Docker WebGL on the virtual display
+
+Measured in the candidate image on Linux amd64 and arm64, ten cold browser
+launches per architecture. Headed Chromium under Xvfb started with no WebGL1 or
+WebGL2 context even though Mesa's `swrast_dri.so` and `kms_swrast_dri.so` were
+present. The result was 0/10 on both architectures, and every explicit renderer
+selector tried stayed there: `--use-gl=angle --use-angle=gl`, `--use-gl=egl`,
+`--use-gl=desktop` and ANGLE Vulkan.
+
+The working configuration is the simpler one:
+
+```
+--enable-webgl --ignore-gpu-blocklist
+```
+
+It does not choose a renderer. It lets Chromium use the Mesa path already in the
+image. Results, across all twenty cold launches:
+
+| | amd64 | arm64 |
+|---|---|---|
+| WebGL1 context | 10/10 | 10/10 |
+| WebGL2 context | 10/10 | 10/10 |
+| Unmasked renderer | `ANGLE (Mesa/X.org, llvmpipe (LLVM 15.0.6 128 bits), OpenGL 4.5)` | same, byte-identical |
+| SwiftShader | absent | absent |
+| GPU-process crash | none | none |
+| High-entropy architecture / bitness | `x86` / `64` | `arm` / `64` |
+| Headless token | absent | absent |
+| Page, workers and cross-origin frame agree | yes | yes |
+| `outer <= screen` | yes | yes |
+
+SwiftShader was measured as the one other path that creates both contexts. It is
+excluded: its renderer names `SwiftShader` explicitly, and Patchright strips the
+unsafe fallback on purpose because that string is an automation signal in its
+own right. `LIBGL_ALWAYS_SOFTWARE=1` changed none of the failed explicit-selector
+results and is not set.
+
+The display adds no package of its own: Xvfb already comes from Patchright's
+Chromium dependency set, and starting it directly needs no `xauth`. Installing
+only full Chromium with `--no-shell` makes the resulting image smaller than the
+previous full-plus-shell image, not larger. Measured from clean builds of the
+same source: 543.5 to 429.6 MiB on arm64 (-113.9 MiB), and 512.4 to 406.2 MiB on
+amd64 (-106.2 MiB), using Docker's uncompressed image size.
+
+### Docker shutdown and display lifetime
+
+`xvfb-run` is not the image supervisor. Measured under `docker stop`,
+`tini -g -- xvfb-run ... python` exited 143 without Python running its shutdown
+path: `xvfb-run` has an EXIT trap for Xvfb and no TERM forwarder for its child.
+Starting Xvfb and Python under one small supervisor in the same process group
+lets `tini -g` deliver TERM to all three. The supervisor also makes display
+liveness container liveness: if Xvfb dies, it terminates Python and exits
+non-zero instead of leaving a live MCP endpoint whose next browser cannot open.
+Uvicorn logged its complete application shutdown before the container exited,
+in 0.50 seconds.
+
+The experimental daemon is refused in a container. Its owner deliberately
+starts a new session so it can outlive a stdio frontend; measured there, it had
+a distinct process group while Xvfb remained the frontend's child. Letting that
+owner survive would give the browser a lifetime the display does not share.
 
 Two things this does not claim. The half second of visible window on every
 browser start cannot be shortened from here — roughly 250 ms passes before

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -24,7 +24,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 
 ## Quick Start
 
-Create a browser profile locally, then mount it into Docker. You still need [uv](https://docs.astral.sh/uv/getting-started/installation/) installed on the host for the one-time `uvx mcp-server-linkedin@latest --login` step. Docker already includes its own Chromium runtime, so the managed Patchright Chromium browser download used by MCPB/`uvx` is not needed here.
+Create a browser profile locally, then mount it into Docker. You still need [uv](https://docs.astral.sh/uv/getting-started/installation/) installed on the host for the one-time `uvx mcp-server-linkedin@latest --login` step. Docker already includes its own full Chromium runtime, running headed on a virtual display with no window exposed to the host, so the managed Patchright Chromium browser download used by MCPB/`uvx` is not needed here.
 
 **Step 1: Create profile on the host (one-time setup)**
 
@@ -53,7 +53,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 }
 ```
 
-> **Note:** Docker containers don't have a display server, so you can't use the `--login` command in Docker. Create a source profile on your host first.
+> **Note:** The container has a virtual display for Chromium, but no viewer that can show it to you or accept the login form, 2FA, or captcha. Create a source profile on your host first. The experimental shared-browser daemon is ignored in Docker because its owner can outlive the virtual display.
 >
 > **Note:** `stdio` is the default transport. Add `--transport streamable-http` only when you specifically want HTTP mode.
 >
@@ -94,7 +94,9 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 | `PORT` | `8000` | HTTP server port (for streamable-http transport) |
 | `HTTP_PATH` | `/mcp` | HTTP server path (for streamable-http transport) |
 | `SLOW_MO` | `0` | Delay between browser actions in ms (debugging) |
-| `VIEWPORT` | `1280x720` | Browser viewport size as WIDTHxHEIGHT. Applies to the normal windowless mode only; a headed launch uses the real window size. |
+| `HEADLESS` | `false` | Docker defaults to full headed Chromium on its virtual display. Set `true` only to deliberately use Chromium's real headless mode, which identifies itself as `HeadlessChrome`. |
+| `DAEMON_ENABLED` | `false` | The experimental shared-browser daemon is ignored in Docker. Its owner is designed to outlive a stdio frontend, while the virtual display belongs to that frontend's process group. |
+| `VIEWPORT` | `1280x720` | Browser viewport size as WIDTHxHEIGHT. Docker is headed by default and therefore uses its real Xvfb window size; this applies only when `HEADLESS=true`. |
 | `CHROME_PATH` | - | Path to Chrome/Chromium executable (rarely needed in Docker) |
 | `PROXY_SERVER` | - | Optional, and most setups are better off without one: LinkedIn advises against proxies and scores the addresses a session signs in from, so a stable known address beats a commercial exit node. Worth it when the container runs somewhere its address is obviously a data centre, and even then a WireGuard or Tailscale exit node on your own network is preferable. Route the browser through a proxy, as `scheme://host:port` (`http`, `https`, `socks4`, `socks5`). May also carry credentials directly (`http://user:pass@host:port`), which is how most providers hand them out. Inside a container `127.0.0.1` is the container itself: for a relay running on the host use `host.docker.internal` (on native Linux Docker, add `--add-host=host.docker.internal:host-gateway`). Only browser traffic is routed, not the MCP transport. |
 | `PROXY_USERNAME` | - | Username for the proxy |

--- a/linkedin_mcp_server/browser_launch.py
+++ b/linkedin_mcp_server/browser_launch.py
@@ -10,6 +10,8 @@ since the moment it existed.
 import logging
 from typing import TYPE_CHECKING, Any
 
+from linkedin_mcp_server.session_state import get_runtime_id
+
 if TYPE_CHECKING:
     from linkedin_mcp_server.config.schema import BrowserConfig
 
@@ -42,6 +44,20 @@ _WEBRTC_STAYS_ON_THE_PROXY = (
     "--webrtc-ip-handling-policy=disable_non_proxied_udp",
     "--force-webrtc-ip-handling-policy=disable_non_proxied_udp",
 )
+
+#: Headed Chromium under the image's Xvfb display starts with WebGL disabled,
+#: despite Mesa's software rasteriser being present. Measured on both published
+#: architectures: every one of ten cold launches per architecture produced no
+#: WebGL1 or WebGL2 context without these two switches, and 10/10 of each with
+#: them. The unmasked renderer was byte-identical across all twenty:
+#: ``ANGLE (Mesa/X.org, llvmpipe (LLVM 15.0.6 128 bits), OpenGL 4.5)``.
+#:
+#: These do not select a renderer; Mesa/llvmpipe is what the image provides.
+#: Every explicit selector tried instead (ANGLE GL, EGL, desktop GL, Vulkan)
+#: produced no context. SwiftShader worked, and stays excluded: Patchright
+#: strips its unsafe fallback deliberately because that renderer string is an
+#: automation signal in its own right.
+_DOCKER_WEBGL = ("--enable-webgl", "--ignore-gpu-blocklist")
 
 
 def build_launch_options(
@@ -86,13 +102,24 @@ def build_launch_options(
         # binary, and is dealt with separately.
         launch_options["channel"] = "chromium"
 
+    args: list[str] = []
+    if get_runtime_id().endswith("-container"):
+        # Image-only. A desktop browser gets a hardware renderer on its own;
+        # forcing these there would change an identity that was already
+        # coherent. Under Xvfb, measured, they are what lets the existing Mesa
+        # llvmpipe path create WebGL1 and WebGL2 contexts at all.
+        args.extend(_DOCKER_WEBGL)
+
     proxy = browser.proxy_settings()
     if proxy:
         launch_options["proxy"] = proxy
         # Only where a proxy exists: with a direct connection there is no
         # bypass to prevent, and the switches would disable a working browser
         # capability for nothing.
-        launch_options["args"] = list(_WEBRTC_STAYS_ON_THE_PROXY)
+        args.extend(_WEBRTC_STAYS_ON_THE_PROXY)
+
+    if args:
+        launch_options["args"] = args
 
     return launch_options, viewport
 

--- a/linkedin_mcp_server/daemon.py
+++ b/linkedin_mcp_server/daemon.py
@@ -252,6 +252,24 @@ def daemon_would_be_used(config: AppConfig) -> bool:
     if not config.server.daemon_enabled:
         return False
     # An explicit HTTP bind is already one server for many clients, so there is
-    # nothing for a daemon to deduplicate. Only stdio spawns a process per
-    # client, which is the whole reason this exists.
-    return config.server.transport == "stdio"
+    # nothing for a daemon to deduplicate. Settle that before container policy:
+    # DAEMON_ENABLED on HTTP is inert everywhere, and warning that Docker
+    # ignored it because of the display would describe a refusal that never
+    # happened.
+    if config.server.transport != "stdio":
+        return False
+    if get_runtime_id().endswith("-container"):
+        # Xvfb belongs to PID 1's process group. The daemon owner deliberately
+        # starts a new session so it can outlive an ordinary stdio frontend;
+        # inside the image that gives the browser an owner which outlives the
+        # display it needs. Measured: the owner had a distinct process group and
+        # was still alive when EOF ended the frontend, then the container's PID
+        # namespace killed it with the display. A display supervisor would make
+        # the experimental daemon much larger than the problem it solves here,
+        # so the container keeps one browser per frontend instead.
+        logger.warning(
+            "DAEMON_ENABLED is ignored in a container; the shared-browser "
+            "daemon cannot outlive the virtual display owned by this server"
+        )
+        return False
+    return True

--- a/tests/test_browser_launch.py
+++ b/tests/test_browser_launch.py
@@ -55,10 +55,51 @@ def test_viewport_comes_from_configuration():
     assert viewport == {"width": 1920, "height": 1080}
 
 
-def test_no_proxy_switches_without_a_proxy():
+def test_no_proxy_switches_without_a_proxy(monkeypatch):
     """The WebRTC switches change an observable capability, so they are
     conditional on there being something to contain."""
+    monkeypatch.setattr(
+        "linkedin_mcp_server.browser_launch.get_runtime_id",
+        lambda: "macos-arm64-host",
+    )
+
     options, _ = build_launch_options(BrowserConfig())
 
     assert "args" not in options
     assert "proxy" not in options
+
+
+def test_container_launch_enables_the_measured_mesa_path(monkeypatch):
+    """Xvfb exposes Mesa but WebGL stays disabled until these are present.
+
+    Measured, not inferred: on amd64 and arm64 every one of ten cold launches
+    produced WebGL1 and WebGL2 through llvmpipe with the switches, and none
+    without them. Pin both so a cleanup cannot silently put the image back in
+    the no-context state.
+    """
+    monkeypatch.setattr(
+        "linkedin_mcp_server.browser_launch.get_runtime_id",
+        lambda: "docker-arm64-container",
+    )
+
+    options, _ = build_launch_options(BrowserConfig())
+
+    assert options["args"] == ["--enable-webgl", "--ignore-gpu-blocklist"]
+
+
+def test_container_webgl_and_proxy_containment_share_one_argument_list(monkeypatch):
+    """One feature must not overwrite the other's switches."""
+    monkeypatch.setattr(
+        "linkedin_mcp_server.browser_launch.get_runtime_id",
+        lambda: "docker-amd64-container",
+    )
+    browser = BrowserConfig(proxy_server="http://proxy.example:8080")
+
+    options, _ = build_launch_options(browser)
+
+    assert options["args"] == [
+        "--enable-webgl",
+        "--ignore-gpu-blocklist",
+        "--webrtc-ip-handling-policy=disable_non_proxied_udp",
+        "--force-webrtc-ip-handling-policy=disable_non_proxied_udp",
+    ]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -535,9 +535,45 @@ class TestWhetherTheDaemonAppliesAtAll:
 
         assert daemon_would_be_used(config) is False
 
-    def test_stdio_with_the_flag_on_uses_a_daemon(self):
+    def test_stdio_with_the_flag_on_uses_a_daemon(self, monkeypatch):
         config = AppConfig()
         config.server.daemon_enabled = True
+        monkeypatch.setattr(
+            "linkedin_mcp_server.daemon.get_runtime_id",
+            lambda: "linux-amd64-host",
+        )
 
         assert config.server.transport == "stdio"
         assert daemon_would_be_used(config) is True
+
+    def test_a_container_refuses_the_daemon_and_says_why(self, monkeypatch, caplog):
+        """An owner outliving its frontend would also outlive its X display."""
+        config = AppConfig()
+        config.server.daemon_enabled = True
+        monkeypatch.setattr(
+            "linkedin_mcp_server.daemon.get_runtime_id",
+            lambda: "docker-amd64-container",
+        )
+
+        with caplog.at_level("WARNING", logger="linkedin_mcp_server.daemon"):
+            applies = daemon_would_be_used(config)
+
+        assert applies is False
+        assert "DAEMON_ENABLED is ignored in a container" in caplog.text
+        assert "virtual display" in caplog.text
+
+    def test_container_http_needs_no_daemon_warning(self, monkeypatch, caplog):
+        """HTTP is one shared server already, in every runtime."""
+        config = AppConfig()
+        config.server.daemon_enabled = True
+        config.server.transport = "streamable-http"
+        monkeypatch.setattr(
+            "linkedin_mcp_server.daemon.get_runtime_id",
+            lambda: "docker-arm64-container",
+        )
+
+        with caplog.at_level("WARNING", logger="linkedin_mcp_server.daemon"):
+            applies = daemon_would_be_used(config)
+
+        assert applies is False
+        assert caplog.text == ""

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -1,0 +1,197 @@
+"""The image's browser and process topology are part of its behaviour.
+
+A Docker build is too expensive for the ordinary unit suite, and string checks
+are enough for the pieces that can disappear silently: the browser product, the
+launch mode, and who receives SIGTERM. The supervisor itself is exercised with
+fake Xvfb and server processes, because child liveness is behaviour a string
+check cannot prove.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DOCKERFILE = (_REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+_ENTRYPOINT_PATH = _REPO_ROOT / "docker-entrypoint.sh"
+_ENTRYPOINT = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+
+
+def test_the_image_installs_only_the_full_browser() -> None:
+    """The shell is a different product and nothing in the image launches it."""
+    assert "patchright install chromium --no-shell" in _DOCKERFILE
+
+
+def test_the_image_defaults_to_headed_on_a_virtual_display() -> None:
+    assert "ENV HEADLESS=false" in _DOCKERFILE
+    assert "ENV DISPLAY=:99" in _DOCKERFILE
+    assert 'Xvfb "$DISPLAY" -screen 0 1920x1080x24 -nolisten tcp' in _ENTRYPOINT
+
+
+def test_tini_signals_the_whole_display_group() -> None:
+    """Python must receive TERM before the PID namespace tears it down."""
+    assert 'ENTRYPOINT ["tini", "-g"' in _DOCKERFILE
+    assert "wait -n -p first_child" in _ENTRYPOINT
+    assert 'kill -TERM "$server_pid" "$xvfb_pid"' in _ENTRYPOINT
+    assert "xvfb-run" not in _DOCKERFILE
+
+
+def test_the_entrypoint_waits_for_the_display_socket() -> None:
+    """An Xvfb process existing does not mean its socket is ready yet."""
+    assert "display_number=${BASH_REMATCH[1]}" in _ENTRYPOINT
+    assert 'socket_path="/tmp/.X11-unix/X${display_number}"' in _ENTRYPOINT
+    assert 'rm -f -- "$socket_path" "$lock_path"' in _ENTRYPOINT
+    assert "$attempt -lt 100" in _ENTRYPOINT
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the image entrypoint is Bash on Linux")
+def test_a_host_prefixed_display_is_refused_before_xvfb_starts() -> None:
+    """The image owns a Unix-socket display and never starts a TCP X server."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise the Linux image entrypoint")
+
+    process = subprocess.run(
+        [bash, str(_ENTRYPOINT_PATH), "/usr/bin/true"],
+        env={**os.environ, "DISPLAY": "localhost:99.0"},
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+    assert process.returncode == 2
+    assert "DISPLAY must be a local X display such as :99 or :99.0" in process.stderr
+    assert "Xvfb" not in process.stderr
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the image entrypoint is Bash on Linux")
+def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
+    tmp_path: Path,
+) -> None:
+    """A hard-stopped container must restart and keep display liveness coupled.
+
+    The stale socket and lock are what a SIGKILL leaves in the writable layer.
+    Fake Xvfb refuses to start while either exists, then creates the real socket
+    spelling for ``:N.0`` (``XN``) and dies cleanly. The supervisor must remove
+    the stale state, notice the later death despite the child becoming a zombie,
+    terminate the server, and return non-zero. ``kill -0`` keeps succeeding for
+    a zombie, which is why waiting for either child is part of the contract.
+    """
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise the Linux image entrypoint")
+    major = int(
+        subprocess.check_output(
+            [bash, "-c", 'printf "%s" "${BASH_VERSINFO[0]}"'], text=True
+        )
+    )
+    if major < 5:
+        pytest.skip("wait -n -p requires the Bash 5 shipped by the image")
+
+    display_number = 10_000 + (os.getpid() % 10_000)
+    display = f":{display_number}.0"
+    socket_path = Path(f"/tmp/.X11-unix/X{display_number}")
+    lock_path = Path(f"/tmp/.X{display_number}-lock")
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    socket_path.unlink(missing_ok=True)
+    lock_path.unlink(missing_ok=True)
+    stale_socket = socket.socket(socket.AF_UNIX)
+    stale_socket.bind(str(socket_path))
+    stale_socket.close()
+    lock_path.write_text("stale", encoding="utf-8")
+
+    fake_xvfb = tmp_path / "Xvfb"
+    fake_xvfb.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import pathlib
+            import socket
+            import sys
+            import time
+
+            number = sys.argv[1].removeprefix(":").split(".", 1)[0]
+            path = pathlib.Path(f"/tmp/.X11-unix/X{number}")
+            lock = pathlib.Path(f"/tmp/.X{number}-lock")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if path.exists() or lock.exists():
+                raise SystemExit(91)
+            server = socket.socket(socket.AF_UNIX)
+            server.bind(str(path))
+            server.listen()
+            lock.write_text("owned", encoding="utf-8")
+            time.sleep(0.3)
+            server.close()
+            path.unlink(missing_ok=True)
+            lock.unlink(missing_ok=True)
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_xvfb.chmod(0o755)
+
+    term_marker = tmp_path / "server-received-term"
+    fake_server = tmp_path / "server"
+    fake_server.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import os
+            import pathlib
+            import signal
+            import time
+
+            marker = pathlib.Path(os.environ["SERVER_TERM_MARKER"])
+
+            def stop(*_args):
+                marker.write_text("term", encoding="utf-8")
+                raise SystemExit(0)
+
+            signal.signal(signal.SIGTERM, stop)
+            while True:
+                time.sleep(0.1)
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_server.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "DISPLAY": display,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "SERVER_TERM_MARKER": str(term_marker),
+    }
+    process = subprocess.Popen(
+        [bash, str(_ENTRYPOINT_PATH), str(fake_server)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        try:
+            stdout, stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            # Kill the whole fake process group, which is exactly what a bare
+            # subprocess.run(timeout=...) fails to do. A broken supervisor must
+            # not leave the fake server sleeping after the test has failed.
+            os.killpg(process.pid, signal.SIGKILL)
+            process.communicate()
+            raise
+    finally:
+        socket_path.unlink(missing_ok=True)
+        lock_path.unlink(missing_ok=True)
+
+    assert process.returncode != 0, (stdout, stderr)
+    assert term_marker.read_text(encoding="utf-8") == "term"


### PR DESCRIPTION
Closes #704

Docker was the one shipped runtime still using Chromium's real headless mode. The image installed full Chromium and the headless shell, left `HEADLESS=true`, and started Python with no display. That made the same saved session identify as a stripped browser in Docker: `HeadlessChrome` in the user agent and brand list, no plugins, no `window.chrome`, and no WebGL context.

The image now runs full Chromium headed on Xvfb at 1920×1080×24. Nothing appears on the host. `HEADLESS=false` is an image default and remains overridable; `true` deliberately returns to Chromium's headless mode. The `--no-shell` install reduces the uncompressed image from 543.5 to 429.6 MiB on arm64 (-113.9 MiB), and from 512.4 to 406.2 MiB on amd64 (-106.2 MiB), in clean builds of the same source.

WebGL was measured across the available renderer configurations. Headed Chromium under Xvfb produced no WebGL1 or WebGL2 context on either architecture, despite Mesa's software rasteriser being present. Explicit ANGLE GL, EGL, desktop GL and Vulkan selectors all stayed there. `--enable-webgl --ignore-gpu-blocklist` lets Chromium use the existing Mesa path without choosing one: ten cold launches on each architecture produced WebGL1 and WebGL2 every time, with one byte-identical renderer across all twenty runs, `ANGLE (Mesa/X.org, llvmpipe (LLVM 15.0.6 128 bits), OpenGL 4.5)`. No SwiftShader and no GPU-process crash. The same runs kept every identity relation green: no headless token, native `x86/64` and `arm/64` hints, all four realms agreeing, plugins and `window.chrome` present, and the window fitting its screen.

The process topology is part of the fix. `tini -g -- xvfb-run ... python` failed the signal test: `docker stop` exited 143 without Python's shutdown path because `xvfb-run` has an EXIT trap for Xvfb and no TERM forwarder for its child. A small entrypoint starts Xvfb directly, waits for its socket, then supervises it alongside Python. It delivers TERM to both children, waits for Python's graceful shutdown, cleans up Xvfb when Python exits, and fails the container when the display dies first. `tini -g` signals the whole process group, and `-e 143` maps the expected handled-SIGTERM status to success. In the final amd64 and arm64 images, Uvicorn logged `Application shutdown complete`; both containers exited 0 within two seconds.

The experimental shared-browser daemon is ignored in Docker. Its owner deliberately starts a new session so it can outlive a stdio frontend; measured in the candidate, the owner remained separate while Xvfb belonged to the frontend's process group. The owner would lose its display when the frontend exits. The container keeps one browser per frontend.

The final images were built and exercised on both architectures. The production launch path passed ten cold WebGL and identity runs per architecture, including the `DISPLAY=:99.0` screen suffix. After a `SIGKILL`, each architecture restarted successfully in the same container writable layer, then shut down gracefully; host-prefixed displays fail immediately with a precise diagnostic. The updated commit passed every CI check on Linux amd64, macOS, Windows and Linux arm64. Locally, 1,915 tests passed and 11 platform-dependent tests skipped; one daemon-turnover timing bound failed under a load average above 180 and reproduced on a detached `origin/main` checkout. Targeted Docker, launch and daemon tests passed 43/43 with the Bash-5-only supervisor case skipped on macOS Bash 3. Ruff, formatting, Ty, shell syntax and pre-commit checks are clean.

The login flow is unchanged. The container has a virtual display but no viewer for its form, 2FA, or captcha, so profiles are still created on the host until the separate login-viewer work ships.

## Synthetic prompt

> Run Docker Chromium headed on an invisible Xvfb display. Install only the full browser, preserve coherent geometry and Mesa llvmpipe WebGL on amd64 and arm64, deliver `docker stop` to both Python and Xvfb without `xvfb-run`, and refuse the shared-browser daemon whose owner cannot share the display lifetime. Update tests and Docker documentation with the measured results.

Generated with Claude Opus 5 high + Sol 5.6 xhigh

