### PR TITLE
feat(docker): Show the login in a browser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ TOOL_TIMEOUT=180.0
 # Manual login wait timeout in seconds (default: 1800; 0 = no limit)
 # How long the --login browser window waits for you to finish signing in
 # (including 2FA, captcha, and security challenges) before giving up.
+# Docker --login-viewer closes remote control after 1800 seconds even when this
+# is 0. Protected profile restoration may finish after the viewer has closed.
+# The viewer is CLI-only so an ordinary container startup cannot expose it.
 LOGIN_TIMEOUT=1800
 
 # Bounded inline wait in seconds for a tool call to resume after login
@@ -41,7 +44,8 @@ LOGIN_TIMEOUT=1800
 # When a tool call finds no session it opens the login window and waits up to
 # this long, so a quick sign-in resolves in a single call. If the wait elapses
 # the tool returns a pending signal and the model re-calls in about 30 seconds.
-# No effect under Docker (login must be created on the host with --login).
+# No effect during normal Docker server mode. Use the explicit one-shot
+# --login --login-viewer command to create a session inside the mounted profile.
 LOGIN_INLINE_WAIT=25
 
 # Auto-import a LinkedIn session from a locally logged-in browser on the first

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,14 @@ COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/patchright
 
+# One-shot CLI modes re-run the installer to record profile-local metadata. It
+# exits without downloading when this exact revision is present, but still needs
+# to acquire its cache lock as pwuser.
 RUN patchright install-deps chromium && \
     patchright install chromium --no-shell && \
-    apt-get update && apt-get install -y --no-install-recommends tini && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        tini openbox x11vnc novnc websockify && \
+    chown -R pwuser:pwuser /opt/patchright && \
     chmod -R 755 /opt/patchright && \
     rm -rf /var/lib/apt/lists/*
 
@@ -39,11 +44,10 @@ ENV HEADLESS=false
 
 USER pwuser
 
-# -g sends TERM to the whole process group: Python gets to run FastMCP's
-# graceful shutdown, and Xvfb leaves with it. The entrypoint supervises both in
-# that group, so either one dying terminates the other instead of leaving a live
-# server with no display. A handled SIGTERM can still report 143, so -e maps
-# that expected `docker stop` path to success. Without an init, Chromium
-# subprocesses orphaned onto PID 1 would also accumulate as zombies.
-ENTRYPOINT ["tini", "-g", "-e", "143", "--", "linkedin-mcp-entrypoint", "python", "-m", "linkedin_mcp_server"]
+# Tini signals the supervisor, which gives Python its graceful shutdown before
+# stopping Xvfb. Keeping the display alive is required while an active login
+# browser closes. A handled SIGTERM can still report 143, so -e maps that
+# expected `docker stop` path to success. Without an init, Chromium subprocesses
+# orphaned onto PID 1 would also accumulate as zombies.
+ENTRYPOINT ["tini", "-e", "143", "--", "linkedin-mcp-entrypoint", "python", "-m", "linkedin_mcp_server"]
 CMD []

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ When you set up or maintain this server, verify its entry in the MCP client conf
 - `--logout` - Clear stored LinkedIn browser profile
 - `--timeout MS` - Browser timeout for page operations in milliseconds (default: 5000)
 - `--tool-timeout SECONDS` - Per-tool MCP execution timeout in seconds (default: 180.0). Increase further for heavy scrapes / cold-start Chromium / slow networks.
-- `--login-timeout SECONDS` - Manual login wait timeout in seconds (default: 1800; 0 = no limit). How long the `--login` browser waits for you to finish signing in.
+- `--login-timeout SECONDS` - Manual login wait timeout in seconds (default: 1800; 0 = no limit). How long the `--login` browser waits for you to finish signing in. `--login-viewer` closes remote control after a hard 1,800 seconds; protected profile restoration may finish afterward.
+- `--login-viewer` - With `--login` inside Docker, expose the login browser through one token-authenticated noVNC URL on port 6080. Requires a distinct persistent mount containing the configured profile.
 - `--login-inline-wait SECONDS` - Bounded inline wait for a tool call to resume after login completes, in seconds (default: 25, max 45; 0 = return immediately).
 - `--browser-wait SECONDS` - How long to wait for another server process to hand over the shared browser (default: 25, max 45; 0 = report busy at once). Only matters when several MCP clients run at the same time.
 - `--browser-min-hold SECONDS` - Shortest time this process keeps the shared browser before handing it to a waiting process (default: 20, clamped below `--browser-wait` so a waiting client is served before its own timeout; 0 = hand over after every tool call). Raising it means fewer browser restarts but longer waits for other clients.
@@ -210,7 +211,7 @@ while a container is running.
 
 - *Page operations failing* (elements not found, navigation hangs): increase the browser page-op timeout — `--timeout 10000` or `TIMEOUT=10000` (milliseconds, default 5000).
 - *Entire tool calls timing out* (e.g. multi-section profiles, cold-start Chromium, slow containers): increase the per-tool execution timeout — `--tool-timeout 300` or `TOOL_TIMEOUT=300` (seconds, default 180).
-- *First tool call with no session*: if a locally logged-in browser has a live LinkedIn session, the server auto-imports it (see `AUTO_IMPORT_FROM_BROWSER` / `--auto-import`) instead of forcing a manual login. On macOS the keychain may prompt once for Safe Storage access. If no importable browser session exists, it falls back to opening a login window and waits up to `LOGIN_INLINE_WAIT` seconds (default 25, max 45; `--login-inline-wait`) so a quick sign-in resolves in one call. If the wait elapses, the tool returns a pending signal and the model retries in about 30 seconds. Neither the auto-import nor the inline wait applies under Docker or when the server is bound to a non-loopback HTTP host; create the session on the host with `--login`.
+- *First tool call with no session*: if a locally logged-in browser has a live LinkedIn session, the server auto-imports it (see `AUTO_IMPORT_FROM_BROWSER` / `--auto-import`) instead of forcing a manual login. On macOS the keychain may prompt once for Safe Storage access. If no importable browser session exists, it falls back to opening a login window and waits up to `LOGIN_INLINE_WAIT` seconds (default 25, max 45; `--login-inline-wait`) so a quick sign-in resolves in one call. If the wait elapses, the tool returns a pending signal and the model retries in about 30 seconds. Neither the auto-import nor the inline wait applies under Docker or when the server is bound to a non-loopback HTTP host. Create the session on the host with `--login`, or use the explicit Docker `--login --login-viewer` command.
 - Users on slow connections may need higher values for either.
 
 **Told to run `--login` on the host when you already did:**
@@ -285,7 +286,7 @@ On startup, the MCP Bundle starts preparing the shared Patchright Chromium brows
 
 - *Page operations failing* (elements not found, navigation hangs): increase the browser page-op timeout — `--timeout 10000` or `TIMEOUT=10000` (milliseconds, default 5000).
 - *Entire tool calls timing out* (e.g. multi-section profiles, cold-start Chromium, slow containers): increase the per-tool execution timeout — `--tool-timeout 300` or `TOOL_TIMEOUT=300` (seconds, default 180).
-- *First tool call with no session*: if a locally logged-in browser has a live LinkedIn session, the server auto-imports it (see `AUTO_IMPORT_FROM_BROWSER` / `--auto-import`) instead of forcing a manual login. On macOS the keychain may prompt once for Safe Storage access. If no importable browser session exists, it falls back to opening a login window and waits up to `LOGIN_INLINE_WAIT` seconds (default 25, max 45; `--login-inline-wait`) so a quick sign-in resolves in one call. If the wait elapses, the tool returns a pending signal and the model retries in about 30 seconds. Neither the auto-import nor the inline wait applies under Docker or when the server is bound to a non-loopback HTTP host; create the session on the host with `--login`.
+- *First tool call with no session*: if a locally logged-in browser has a live LinkedIn session, the server auto-imports it (see `AUTO_IMPORT_FROM_BROWSER` / `--auto-import`) instead of forcing a manual login. On macOS the keychain may prompt once for Safe Storage access. If no importable browser session exists, it falls back to opening a login window and waits up to `LOGIN_INLINE_WAIT` seconds (default 25, max 45; `--login-inline-wait`) so a quick sign-in resolves in one call. If the wait elapses, the tool returns a pending signal and the model retries in about 30 seconds. Neither the auto-import nor the inline wait applies under Docker or when the server is bound to a non-loopback HTTP host. Create the session on the host with `--login`, or use the explicit Docker `--login --login-viewer` command.
 - Users on slow connections may need higher values for either.
 
 **Told to run `--login` on the host when you already did:**
@@ -299,21 +300,25 @@ On startup, the MCP Bundle starts preparing the shared Patchright Chromium brows
 
 ## 🐳 Docker Setup
 
-**Prerequisites:** Make sure you have [Docker](https://www.docker.com/get-started/) installed and running, and [uv](https://docs.astral.sh/uv/getting-started/installation/) installed on the host for the one-time `--login` step.
+**Prerequisites:** Make sure [Docker](https://www.docker.com/get-started/) is installed and running.
 
 ### Authentication
 
-Docker runs full Chromium headed on a virtual display. No browser window reaches the host, so you still need to create a browser profile locally first and mount it into the container.
-
-**Step 1: Create profile on the host (one-time setup)**
+Docker includes an authenticated, short-lived browser viewer for explicit login. Create the profile directly in the mounted directory:
 
 ```bash
-uvx mcp-server-linkedin@latest --login
+docker run -it --rm \
+  -v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp \
+  -p 127.0.0.1:6080:6080 \
+  stickerdaniel/linkedin-mcp-server:latest \
+  --login --login-viewer
 ```
 
-This opens a browser window where you log in manually (5 minute timeout for 2FA, captcha, etc.). The browser profile and cookies are saved under `~/.linkedin-mcp/`. On startup, Docker derives a Linux browser profile from your host cookies and creates a fresh session each time. If you experience stability issues with Docker, consider using the [uvx setup](#-uvx-setup-recommended---universal) instead.
+Open the complete loopback URL printed by the command. Its token stays in the URL fragment, so the initial HTTP request does not carry it. Static viewer files are public on port 6080; the token protects the WebSocket that controls the browser. The viewer fixes client-side scaling, keeps remote resize disabled, and closes after login, failure, a stop signal, or 1,800 seconds. Protected profile restoration may finish after remote control has closed, because interrupting a move on the mounted auth root could split the previous session. The profile mount is required before any existing session can be rotated. For the default profile, use the exact `-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp` mapping above.
 
-**Step 2: Configure Claude Desktop with Docker**
+You can still create the profile on the host with `uvx mcp-server-linkedin@latest --login` and mount `~/.linkedin-mcp` into Docker. On startup, Docker derives a Linux browser profile from the source cookies and creates a fresh session each time.
+
+**Configure Claude Desktop with Docker**
 
 ```json
 {
@@ -331,10 +336,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 ```
 
 > [!NOTE]
-> Docker creates a fresh session on each startup. Sessions may expire over time — run `uvx mcp-server-linkedin@latest --login` again if you encounter authentication issues.
-
-> [!NOTE]
-> **Why can't I run `--login` in Docker?** The container has a virtual display for Chromium, but no viewer that can show it to you or accept the form, 2FA, or captcha. Create a profile on your host using the [uvx setup](#-uvx-setup-recommended---universal) and mount it into Docker.
+> Docker creates a fresh session on each startup. Sessions may expire over time. Repeat the Docker viewer command above or run `uvx mcp-server-linkedin@latest --login` on the host.
 
 ### Docker Setup Help
 
@@ -358,7 +360,8 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 - `--logout` - Clear all stored LinkedIn auth state, including source and derived runtime profiles and any retired sessions
 - `--timeout MS` - Browser timeout for page operations in milliseconds (default: 5000)
 - `--tool-timeout SECONDS` - Per-tool MCP execution timeout in seconds (default: 180.0). Increase further for heavy scrapes / cold-start Chromium / slow networks.
-- `--login-timeout SECONDS` - Manual login wait timeout in seconds (default: 1800; 0 = no limit). How long the `--login` browser waits for you to finish signing in.
+- `--login-timeout SECONDS` - Manual login wait timeout in seconds (default: 1800; 0 = no limit). How long the `--login` browser waits for you to finish signing in. `--login-viewer` closes remote control after a hard 1,800 seconds; protected profile restoration may finish afterward.
+- `--login-viewer` - With `--login` inside Docker, expose the login browser through one token-authenticated noVNC URL on port 6080. Requires a distinct persistent mount containing the configured profile.
 - `--login-inline-wait SECONDS` - Bounded inline wait for a tool call to resume after login completes, in seconds (default: 25, max 45; 0 = return immediately).
 - `--browser-wait SECONDS` - How long to wait for another server process to hand over the shared browser (default: 25, max 45; 0 = report busy at once). Only matters when several MCP clients run at the same time.
 - `--browser-min-hold SECONDS` - Shortest time this process keeps the shared browser before handing it to a waiting process (default: 20, clamped below `--browser-wait` so a waiting client is served before its own timeout; 0 = hand over after every tool call). Raising it means fewer browser restarts but longer waits for other clients.
@@ -370,7 +373,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 - `--proxy-server URL` - Route the browser through a proxy, as `scheme://host:port`. Set the password via `PROXY_PASSWORD` (no flag, so it stays out of the process list)
 
 > [!NOTE]
-> `--login` is not usable in Docker yet: Chromium has a virtual display, but the image has no viewer for completing the login. Docker is already headed by default; `--no-headless` therefore changes nothing. Use the [uvx setup](#-uvx-setup-recommended---universal) to create profiles. The experimental `--daemon` is also ignored in Docker because its owner can outlive the virtual display.
+> Plain `--login` still has no visible window in Docker. Add `--login-viewer` and publish `127.0.0.1:6080:6080` only for the one-shot login command. Docker is already headed by default, so `--no-headless` changes nothing. The experimental `--daemon` is ignored in Docker because its owner can outlive the virtual display.
 
 **HTTP Mode Example (for web-based MCP clients):**
 
@@ -445,7 +448,7 @@ belongs behind something that provides it.
 
 - *Page operations failing* (elements not found, navigation hangs): increase the browser page-op timeout — `--timeout 10000` or `TIMEOUT=10000` (milliseconds, default 5000).
 - *Entire tool calls timing out* (e.g. multi-section profiles, cold-start Chromium, slow containers): increase the per-tool execution timeout — `--tool-timeout 300` or `TOOL_TIMEOUT=300` (seconds, default 180).
-- *First tool call with no session*: if a locally logged-in browser has a live LinkedIn session, the server auto-imports it (see `AUTO_IMPORT_FROM_BROWSER` / `--auto-import`) instead of forcing a manual login. On macOS the keychain may prompt once for Safe Storage access. If no importable browser session exists, it falls back to opening a login window and waits up to `LOGIN_INLINE_WAIT` seconds (default 25, max 45; `--login-inline-wait`) so a quick sign-in resolves in one call. If the wait elapses, the tool returns a pending signal and the model retries in about 30 seconds. Neither the auto-import nor the inline wait applies under Docker or when the server is bound to a non-loopback HTTP host; create the session on the host with `--login`.
+- *First tool call with no session*: if a locally logged-in browser has a live LinkedIn session, the server auto-imports it (see `AUTO_IMPORT_FROM_BROWSER` / `--auto-import`) instead of forcing a manual login. On macOS the keychain may prompt once for Safe Storage access. If no importable browser session exists, it falls back to opening a login window and waits up to `LOGIN_INLINE_WAIT` seconds (default 25, max 45; `--login-inline-wait`) so a quick sign-in resolves in one call. If the wait elapses, the tool returns a pending signal and the model retries in about 30 seconds. Neither the auto-import nor the inline wait applies under Docker or when the server is bound to a non-loopback HTTP host. Create the session on the host with `--login`, or use the explicit Docker `--login --login-viewer` command.
 - Users on slow connections may need higher values for either.
 
 **Told to run `--login` on the host when you already did:**
@@ -597,7 +600,7 @@ uv run -m linkedin_mcp_server --transport streamable-http --host 127.0.0.1 --por
 
 - *Page operations failing* (elements not found, navigation hangs): increase the browser page-op timeout — `--timeout 10000` or `TIMEOUT=10000` (milliseconds, default 5000).
 - *Entire tool calls timing out* (e.g. multi-section profiles, cold-start Chromium, slow containers): increase the per-tool execution timeout — `--tool-timeout 300` or `TOOL_TIMEOUT=300` (seconds, default 180).
-- *First tool call with no session*: if a locally logged-in browser has a live LinkedIn session, the server auto-imports it (see `AUTO_IMPORT_FROM_BROWSER` / `--auto-import`) instead of forcing a manual login. On macOS the keychain may prompt once for Safe Storage access. If no importable browser session exists, it falls back to opening a login window and waits up to `LOGIN_INLINE_WAIT` seconds (default 25, max 45; `--login-inline-wait`) so a quick sign-in resolves in one call. If the wait elapses, the tool returns a pending signal and the model retries in about 30 seconds. Neither the auto-import nor the inline wait applies under Docker or when the server is bound to a non-loopback HTTP host; create the session on the host with `--login`.
+- *First tool call with no session*: if a locally logged-in browser has a live LinkedIn session, the server auto-imports it (see `AUTO_IMPORT_FROM_BROWSER` / `--auto-import`) instead of forcing a manual login. On macOS the keychain may prompt once for Safe Storage access. If no importable browser session exists, it falls back to opening a login window and waits up to `LOGIN_INLINE_WAIT` seconds (default 25, max 45; `--login-inline-wait`) so a quick sign-in resolves in one call. If the wait elapses, the tool returns a pending signal and the model retries in about 30 seconds. Neither the auto-import nor the inline wait applies under Docker or when the server is bound to a non-loopback HTTP host. Create the session on the host with `--login`, or use the explicit Docker `--login --login-viewer` command.
 - Users on slow connections may need higher values for either.
 
 **Told to run `--login` on the host when you already did:**

--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -92,6 +92,34 @@
       "url": "https://github.com/pypa/packaging",
       "branch": "main",
       "specialNotes": "PyPA packaging. version.Version parsing/comparison for the PyPI update check (update_check.py)."
+    },
+    {
+      "type": "git",
+      "name": "openbox",
+      "url": "https://github.com/danakj/openbox",
+      "branch": "main",
+      "specialNotes": "Openbox window manager used to place and focus the Docker login browser."
+    },
+    {
+      "type": "git",
+      "name": "x11vnc",
+      "url": "https://github.com/LibVNC/x11vnc",
+      "branch": "master",
+      "specialNotes": "Loopback-only VNC server for the Docker login viewer."
+    },
+    {
+      "type": "git",
+      "name": "noVNC",
+      "url": "https://github.com/novnc/noVNC",
+      "branch": "master",
+      "specialNotes": "Browser client for the Docker login viewer. Debian Bookworm ships vnc_lite.html from this project."
+    },
+    {
+      "type": "git",
+      "name": "websockify",
+      "url": "https://github.com/novnc/websockify",
+      "branch": "master",
+      "specialNotes": "Token-authenticated WebSocket proxy between noVNC and x11vnc."
     }
   ]
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# Xvfb, Python and this supervisor stay in one process group. `tini -g` then
-# delivers SIGTERM to all three, so FastMCP runs its graceful shutdown before
-# the display goes away. `xvfb-run` is not a substitute: measured under
-# `docker stop`, its EXIT trap cleaned up Xvfb but it never forwarded TERM to
-# Python; the container exited 143 without the server's shutdown path.
+# Tini delivers SIGTERM to this supervisor, which stops Python before Xvfb so
+# browser cleanup keeps a live display. `xvfb-run` is not a substitute: measured
+# under `docker stop`, its EXIT trap cleaned up Xvfb but it never forwarded TERM
+# to Python; the container exited 143 without the server's shutdown path.
 : "${DISPLAY:=:99}"
 export DISPLAY
 
@@ -60,13 +59,14 @@ server_pid=$!
 
 terminate() {
     trap - TERM INT HUP
-    kill -TERM "$server_pid" "$xvfb_pid" 2>/dev/null || true
+    kill -TERM "$server_pid" 2>/dev/null || true
 
-    # Preserve the server's status. Xvfb receives TERM by design and commonly
-    # reports 143; it is infrastructure for the server rather than the result
-    # Docker should expose.
+    # Keep the display alive until browser and viewer cleanup completes. Killing
+    # Xvfb alongside Python can wedge Chromium teardown until Docker resorts to
+    # SIGKILL, leaving the profile unrestored and the token file behind.
     server_status=0
     wait "$server_pid" || server_status=$?
+    kill -TERM "$xvfb_pid" 2>/dev/null || true
     wait "$xvfb_pid" || true
     exit "$server_status"
 }

--- a/docs/browser-fingerprint.md
+++ b/docs/browser-fingerprint.md
@@ -112,6 +112,30 @@ Linux is less a gap than a different answer: under a virtual display nobody is
 looking at the screen, so an ordinary window is already invisible and there is
 nothing to hide.
 
+### Docker login viewer
+
+The Openbox, x11vnc and noVNC candidate passed the G4 interaction check on both
+published architectures. Measurements were stable before connection, after
+connection, after a trusted click, and after disconnect:
+
+| | amd64 | arm64 |
+|---|---|---|
+| Focus / visibility | `true` / `visible` | `true` / `visible` |
+| Screen | 1920x1080 | 1920x1080 |
+| Outer window | 945x1060 | 945x1060 |
+| Inner height | 969 | 913 |
+| Device pixel ratio | 1 | 1 |
+| Chromium active | yes | yes |
+| Trusted click reached page | yes | yes |
+
+The client scales the fixed framebuffer locally. x11vnc remote resize remains
+disabled, so connecting cannot change Chromium's reported screen. The package
+closure adds 107.2 MiB to Docker's image-inspect content size on amd64 and
+102.8 MiB on arm64. The uncompressed new layer shown by `docker history` is
+383 MB on amd64 and 362 MB on arm64. Those metrics describe different things
+and should not be compared as though the history layer were the downloadable
+image delta.
+
 ### Docker WebGL on the virtual display
 
 Measured in the candidate image on Linux amd64 and arm64, ten cold browser

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -24,19 +24,21 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 
 ## Quick Start
 
-Create a browser profile locally, then mount it into Docker. You still need [uv](https://docs.astral.sh/uv/getting-started/installation/) installed on the host for the one-time `uvx mcp-server-linkedin@latest --login` step. Docker already includes its own full Chromium runtime, running headed on a virtual display with no window exposed to the host, so the managed Patchright Chromium browser download used by MCPB/`uvx` is not needed here.
-
-**Step 1: Create profile on the host (one-time setup)**
+Docker includes full Chromium and an authenticated viewer for an explicit one-shot login. Create the profile directly in its persistent mount:
 
 ```bash
-uvx mcp-server-linkedin@latest --login
+docker run -it --rm \
+  -v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp \
+  -p 127.0.0.1:6080:6080 \
+  stickerdaniel/linkedin-mcp-server:latest \
+  --login --login-viewer
 ```
 
-This opens a browser window where you log in manually (5 minute timeout for 2FA, captcha, etc.). The browser profile and cookies are saved under `~/.linkedin-mcp/`. On startup, Docker derives a Linux browser profile from your host cookies and creates a fresh session each time. For better stability, consider the [uvx setup](https://github.com/stickerdaniel/linkedin-mcp-server#-uvx-setup-recommended---universal).
+Open the complete loopback URL printed once by the command. The token is generated for that run, stored in a mode-0600 file, and carried in the URL fragment so the initial HTTP request remains token-free. Static noVNC files remain public; the token protects WebSocket control. Remote resize stays disabled, client-side scaling is fixed on, and the viewer closes after login, failure, a stop signal, or 1,800 seconds. Protected profile restoration may finish after remote control has closed, because interrupting a move on the mounted auth root could split the previous session. The command refuses to rotate any existing session unless the configured profile is on a distinct mount.
 
-> **Already signed into LinkedIn in a browser on the host?** Run `uvx mcp-server-linkedin@latest --import-from-browser` on the host to reuse that session instead of `--login`. It supports Chrome, Chromium, Brave, Edge, Arc, Vivaldi, Helium, Yandex, and Naver Whale, auto-picks the most recently used browser with a live LinkedIn session (pass a browser name to target one), writes the same `~/.linkedin-mcp/` profile Docker mounts, and the Docker bridge still narrows to the minimal auth cookie subset it uses for a normal session. Cookies under Chrome 127+ app-bound encryption cannot be imported; use `--login` in that case.
+You can alternatively run `uvx mcp-server-linkedin@latest --login` or `--import-from-browser` on the host and mount the resulting `~/.linkedin-mcp` directory. On startup, Docker derives a Linux profile from the source cookies and creates a fresh session each time.
 
-**Step 2: Configure Claude Desktop with Docker**
+**Configure Claude Desktop with Docker**
 
 ```json
 {
@@ -53,7 +55,7 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 }
 ```
 
-> **Note:** The container has a virtual display for Chromium, but no viewer that can show it to you or accept the login form, 2FA, or captcha. Create a source profile on your host first. The experimental shared-browser daemon is ignored in Docker because its owner can outlive the virtual display.
+> **Note:** Plain `--login` does not publish a viewer. Use `--login --login-viewer` only for the one-shot login container, with port 6080 published to loopback. The experimental shared-browser daemon is ignored in Docker because its owner can outlive the virtual display.
 >
 > **Note:** `stdio` is the default transport. Add `--transport streamable-http` only when you specifically want HTTP mode.
 >
@@ -83,8 +85,8 @@ This opens a browser window where you log in manually (5 minute timeout for 2FA,
 | `LOG_LEVEL` | `WARNING` | Logging level: DEBUG, INFO, WARNING, ERROR |
 | `TIMEOUT` | `5000` | Browser timeout in milliseconds |
 | `TOOL_TIMEOUT` | `180` | Per-tool MCP execution timeout in seconds. Increase further for heavy scrapes (multi-section profiles, cold-start Chromium, slow networks/containers). |
-| `LOGIN_TIMEOUT` | `1800` | Manual login wait timeout in seconds (`0` = no limit). Applies to the host-side `--login` browser; the container itself never opens one. |
-| `LOGIN_INLINE_WAIT` | `25` | Bounded inline wait (seconds, max 45) for a tool call to resume after login completes. No effect in containers: the Docker runtime never opens a login window and raises a host-login-required error instead, so the session must be created on the host with `--login`. |
+| `LOGIN_TIMEOUT` | `1800` | Manual login wait timeout in seconds (`0` = no ordinary limit). Docker remote control closes after a hard 1,800 seconds; protected profile restoration may finish afterward. |
+| `LOGIN_INLINE_WAIT` | `25` | Bounded inline wait (seconds, max 45) for a tool call to resume after login completes. No effect in normal container server mode; the explicit `--login --login-viewer` command is the Docker login path. |
 | `BROWSER_WAIT` | `25` | How long (seconds, max 45) to wait for another server process to hand over the shared browser before reporting that it is busy. `0` reports busy immediately. |
 | `BROWSER_MIN_HOLD` | `20` | Shortest time (seconds) a process keeps the shared browser before handing it to a waiting process. Higher means fewer browser restarts but longer waits for other clients; clamped below `BROWSER_WAIT` so a waiting client is served before its own timeout. `0` hands over after every tool call. |
 | `BROWSER_IDLE_TIMEOUT` | `600` | Close an idle browser and release the shared profile after this many seconds without a tool call. `0` keeps it open until the server exits. |

--- a/linkedin_mcp_server/authentication.py
+++ b/linkedin_mcp_server/authentication.py
@@ -51,8 +51,9 @@ def get_authentication_source() -> bool:
         "  1. Run with --login to create a source browser profile (recommended)\n"
         "  2. Run with --no-headless to login interactively\n\n"
         "For Docker users:\n"
-        "  Create profile on host first: uv run -m linkedin_mcp_server --login\n"
-        "  Then mount into Docker: -v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp"
+        "  Create the mounted profile with --login --login-viewer, or create it "
+        "on the host with --login.\n"
+        "  Mount it into Docker: -v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp"
     )
 
 

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -594,7 +594,9 @@ def _raise_if_docker_auth_missing() -> None:
     if _auth_ready():
         return
     raise DockerHostLoginRequiredError(
-        "No valid LinkedIn session is available in Docker. Run --login on the host machine to create a session, then retry this tool."
+        "No valid LinkedIn session is available in Docker. Create one with "
+        "the explicit --login --login-viewer Docker command, or run --login "
+        "on the host, then retry this tool."
     )
 
 

--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -30,9 +30,14 @@ from linkedin_mcp_server.drivers.browser import (
 )
 from linkedin_mcp_server.debug_trace import should_keep_traces
 from linkedin_mcp_server.logging_config import configure_logging, teardown_trace_logging
+from linkedin_mcp_server.login_viewer import (
+    LoginViewerError,
+    require_persistent_profile_mount,
+)
 from linkedin_mcp_server.profile_claim import ensure_profile_claim
 from linkedin_mcp_server.session_state import (
     get_runtime_id,
+    is_container_runtime,
     load_runtime_state,
     load_source_state,
     portable_cookie_path,
@@ -128,7 +133,9 @@ def get_profile_and_exit() -> None:
     logger.info(f"LinkedIn MCP Server v{version} - Session Creation mode")
 
     user_data_dir = config.browser.user_data_dir
-    success = run_profile_creation(user_data_dir)
+    success = run_profile_creation(
+        user_data_dir, login_viewer=config.server.login_viewer
+    )
 
     sys.exit(0 if success else 1)
 
@@ -423,10 +430,23 @@ def _exit_on_a_bad_setting(error: ConfigurationError) -> NoReturn:
     sys.exit(1)
 
 
+def _preflight_login_viewer(config: AppConfig) -> None:
+    """Validate the container boundary and persistent mount before mutation."""
+    if not config.server.login_viewer:
+        return
+    if not is_container_runtime():
+        raise ConfigurationError("--login-viewer is available only inside a container")
+    try:
+        require_persistent_profile_mount(Path(config.browser.user_data_dir))
+    except LoginViewerError as exc:
+        raise ConfigurationError(str(exc)) from exc
+
+
 def main() -> None:
     """Main application entry point."""
     try:
         config = get_config()
+        _preflight_login_viewer(config)
     except ConfigurationError as e:
         # A bad setting used to leave the loader as an exception nothing
         # caught, so Python printed the whole stack down through the loader and

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -625,6 +625,15 @@ def load_from_args(config: AppConfig) -> AppConfig:
     )
 
     parser.add_argument(
+        "--login-viewer",
+        action="store_true",
+        help=(
+            "Expose the --login browser at an authenticated noVNC URL in Docker "
+            "(requires --login and -p 127.0.0.1:6080:6080)"
+        ),
+    )
+
+    parser.add_argument(
         "--status",
         action="store_true",
         help="Check if current session is valid and exit",
@@ -810,6 +819,9 @@ def load_from_args(config: AppConfig) -> AppConfig:
     # Session management
     if args.login:
         config.server.login = True
+
+    if args.login_viewer:
+        config.server.login_viewer = True
 
     if args.status:
         config.server.status = True

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -415,6 +415,10 @@ class ServerConfig:
     transport_explicitly_set: bool = False
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "WARNING"
     login: bool = False
+    # Expose the Docker login browser through a short-lived authenticated noVNC
+    # endpoint. CLI-only: there is deliberately no environment switch that could
+    # expose browser control on an ordinary container startup.
+    login_viewer: bool = False
     status: bool = False  # Check session validity and exit
     logout: bool = False
     # Take over a USER_DATA_DIR that is neither the default nor already ours.
@@ -444,6 +448,20 @@ class ServerConfig:
             raise ConfigurationError(
                 f"tool_timeout_seconds must be a positive finite number, got {self.tool_timeout_seconds}"
             )
+        if self.login_viewer:
+            if not self.login:
+                raise ConfigurationError("--login-viewer requires --login")
+            incompatible = []
+            if self.status:
+                incompatible.append("--status")
+            if self.logout:
+                incompatible.append("--logout")
+            if self.import_from_browser is not None:
+                incompatible.append("--import-from-browser")
+            if incompatible:
+                raise ConfigurationError(
+                    "--login-viewer cannot be combined with " + ", ".join(incompatible)
+                )
         if self.import_from_browser is not None:
             # Import the submodule, NOT the package, to avoid a config ->
             # browser_import -> drivers.browser -> config import cycle.

--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -82,9 +82,9 @@ async def handle_auth_error(
     """
     if get_runtime_policy() == RuntimePolicy.DOCKER:
         raise DockerHostLoginRequiredError(
-            "No valid LinkedIn session is available in Docker. "
-            "Run --login on the host machine to create a session, "
-            "then retry this tool."
+            "No valid LinkedIn session is available in Docker. Create one with "
+            "the explicit --login --login-viewer Docker command, or run --login "
+            "on the host, then retry this tool."
         ) from error
 
     # Read before the close rather than after it, deliberately, though the

--- a/linkedin_mcp_server/login_viewer.py
+++ b/linkedin_mcp_server/login_viewer.py
@@ -1,0 +1,259 @@
+"""Short-lived noVNC access to the Docker login browser."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import secrets
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from urllib.parse import quote
+
+from linkedin_mcp_server.config.schema import DEFAULT_USER_DATA_DIR
+from linkedin_mcp_server.session_state import canonical
+
+VIEWER_WALL_SECONDS = 1800.0
+VIEWER_PORT = 6080
+_MOUNT_ESCAPE = re.compile(r"\\([0-7]{3})")
+
+
+class LoginViewerError(RuntimeError):
+    """The Docker login viewer could not be started safely."""
+
+
+def _decode_mount_field(value: str) -> str:
+    """Decode the octal escapes used by procfs mountinfo fields."""
+    return _MOUNT_ESCAPE.sub(lambda match: chr(int(match.group(1), 8)), value)
+
+
+def mount_points(mountinfo: str) -> tuple[Path, ...]:
+    """Return canonical-looking mount points from Linux mountinfo text."""
+    points: list[Path] = []
+    for line in mountinfo.splitlines():
+        fields = line.split()
+        if len(fields) >= 5 and "-" in fields:
+            points.append(Path(_decode_mount_field(fields[4])))
+    return tuple(points)
+
+
+def require_persistent_profile_mount(
+    profile_dir: Path,
+    *,
+    mountinfo_path: Path = Path("/proc/self/mountinfo"),
+) -> None:
+    """Refuse a viewer login whose result would die with the container."""
+    profile = canonical(profile_dir)
+    try:
+        points = mount_points(mountinfo_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise LoginViewerError(
+            f"Cannot verify the Docker profile mount from {mountinfo_path}: {exc}"
+        ) from exc
+
+    persistent = any(
+        point != Path("/") and (point == profile or point in profile.parents)
+        for point in points
+    )
+    if persistent:
+        return
+
+    default_profile = canonical(Path(DEFAULT_USER_DATA_DIR))
+    if profile == default_profile:
+        remedy = "-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp"
+    else:
+        remedy = f"mount a host directory or named volume at {profile.parent}"
+    raise LoginViewerError(
+        "--login-viewer requires the configured profile to be on a distinct "
+        f"persistent mount. Use {remedy} and try again."
+    )
+
+
+def viewer_url(token: str) -> str:
+    """Build the token-private noVNC URL understood by Debian vnc_lite.html."""
+    path = quote(f"websockify?token={token}", safe="")
+    return f"http://127.0.0.1:{VIEWER_PORT}/vnc_lite.html#?path={path}&scale=true"
+
+
+class LoginViewer:
+    """Supervise Openbox and the two remote-control exposure layers."""
+
+    def __init__(self, *, display: str | None = None) -> None:
+        self.display = display or os.environ.get("DISPLAY", ":99")
+        self._directory: Path | None = None
+        self._token_file: Path | None = None
+        self._logs: dict[str, Path] = {}
+        self._processes: dict[str, subprocess.Popen[bytes]] = {}
+
+    def start_window_manager(self) -> None:
+        """Start Openbox and wait until it owns the X11 root window."""
+        self._ensure_directory()
+        self._start("openbox", ["openbox", "--sm-disable"])
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            self._require_alive("openbox")
+            result = subprocess.run(
+                ["obxprop", "--root", "_NET_SUPPORTING_WM_CHECK"],
+                env={**os.environ, "DISPLAY": self.display},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return
+            time.sleep(0.1)
+        raise self._failure("openbox", "did not become ready")
+
+    def start_remote_control(self) -> str:
+        """Start loopback VNC and token-authenticated WebSocket access."""
+        directory = self._ensure_directory()
+        token = secrets.token_urlsafe(32)
+        token_file = directory / "tokens"
+        descriptor = os.open(token_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(f"{token}: 127.0.0.1:5900\n")
+        self._token_file = token_file
+
+        try:
+            self._start(
+                "x11vnc",
+                [
+                    "x11vnc",
+                    "-display",
+                    self.display,
+                    "-rfbport",
+                    "5900",
+                    "-listen",
+                    "127.0.0.1",
+                    "-allow",
+                    "127.0.0.1",
+                    "-no6",
+                    "-shared",
+                    "-forever",
+                    "-nopw",
+                    "-noremote",
+                ],
+            )
+            self._wait_for_port("x11vnc", 5900)
+            self._start(
+                "websockify",
+                [
+                    "websockify",
+                    "--web=/usr/share/novnc",
+                    "--token-plugin=ReadOnlyTokenFile",
+                    f"--token-source={token_file}",
+                    "0.0.0.0:6080",
+                ],
+            )
+            self._wait_for_port("websockify", VIEWER_PORT)
+        except BaseException:
+            try:
+                self.stop_remote_control()
+            except Exception:
+                # Preserve the launch/readiness error, whose component log is the
+                # useful diagnosis. Final cleanup gets another attempt.
+                pass
+            raise
+        return viewer_url(token)
+
+    def stop_remote_control(self) -> None:
+        """Remove network exposure in reverse order, attempting every layer."""
+        failure: Exception | None = None
+        for name in ("websockify", "x11vnc"):
+            try:
+                self._stop(name)
+            except Exception as exc:
+                failure = failure or exc
+        if failure is not None:
+            raise failure
+
+    def stop_window_manager(self) -> None:
+        """Stop Openbox and remove the per-run credential and logs."""
+        failure: Exception | None = None
+        try:
+            self.stop_remote_control()
+        except Exception as exc:
+            failure = exc
+        try:
+            self._stop("openbox")
+        except Exception as exc:
+            failure = failure or exc
+        finally:
+            if self._token_file is not None:
+                self._token_file.unlink(missing_ok=True)
+                self._token_file = None
+            if self._directory is not None:
+                shutil.rmtree(self._directory, ignore_errors=True)
+                self._directory = None
+        if failure is not None:
+            raise failure
+
+    def _ensure_directory(self) -> Path:
+        if self._directory is None:
+            self._directory = Path(tempfile.mkdtemp(prefix="linkedin-mcp-viewer-"))
+            self._directory.chmod(0o700)
+        return self._directory
+
+    def _start(self, name: str, command: list[str]) -> None:
+        log_path = self._ensure_directory() / f"{name}.log"
+        self._logs[name] = log_path
+        log = log_path.open("wb")
+        try:
+            try:
+                process = subprocess.Popen(
+                    command,
+                    env={**os.environ, "DISPLAY": self.display},
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                )
+            except OSError as exc:
+                raise LoginViewerError(
+                    f"Docker login viewer could not launch {name}: {exc}"
+                ) from exc
+        finally:
+            log.close()
+        self._processes[name] = process
+        time.sleep(0.05)
+        self._require_alive(name)
+
+    def _wait_for_port(self, name: str, port: int) -> None:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            self._require_alive(name)
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                    return
+            except OSError:
+                time.sleep(0.1)
+        raise self._failure(name, f"did not listen on 127.0.0.1:{port}")
+
+    def _require_alive(self, name: str) -> None:
+        process = self._processes[name]
+        status = process.poll()
+        if status is not None:
+            raise self._failure(name, f"exited early with status {status}")
+
+    def _failure(self, name: str, reason: str) -> LoginViewerError:
+        log_path = self._logs.get(name)
+        details = ""
+        if log_path is not None:
+            try:
+                details = log_path.read_text(encoding="utf-8", errors="replace").strip()
+            except OSError:
+                pass
+        suffix = f"\n{name} log:\n{details}" if details else ""
+        return LoginViewerError(f"Docker login viewer {name} {reason}.{suffix}")
+
+    def _stop(self, name: str) -> None:
+        process = self._processes.pop(name, None)
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()

--- a/linkedin_mcp_server/session_state.py
+++ b/linkedin_mcp_server/session_state.py
@@ -228,6 +228,11 @@ def _is_container_runtime() -> bool:
     return False
 
 
+def is_container_runtime() -> bool:
+    """Public container-runtime answer for feature gates."""
+    return _is_container_runtime()
+
+
 #: Escape hatch for a machine this detection gets wrong. Spelled the same way
 #: as every other boolean environment variable this server reads
 #: (``config/loaders.py``), but read here rather than through the config

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -6,9 +6,12 @@ with persistent context. Profile state auto-persists to user_data_dir.
 """
 
 import asyncio
-import functools
+from collections.abc import Callable, Coroutine, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
+import functools
 from pathlib import Path
+import signal
 from typing import Any
 
 from linkedin_mcp_server.browser_launch import build_launch_options, describe_launch
@@ -21,6 +24,7 @@ from linkedin_mcp_server.core import (
     wait_for_manual_login,
 )
 from linkedin_mcp_server.exceptions import BrowserBusyError
+from linkedin_mcp_server.login_viewer import LoginViewer, VIEWER_WALL_SECONDS
 from linkedin_mcp_server.profile_lease import ProfileLease, get_profile_lease
 from linkedin_mcp_server.session_state import (
     UNGUARDED,
@@ -39,6 +43,7 @@ async def interactive_login(
     user_data_dir: Path | None = None,
     *,
     superseded_by: str | None | object = UNGUARDED,
+    login_viewer: bool = False,
 ) -> bool:
     """
     Open browser for manual LinkedIn login with persistent profile.
@@ -115,7 +120,10 @@ async def interactive_login(
             print("   Another client already signed in; using its session.")
             return True
 
-        return await _login_holding_the_profile(user_data_dir, lease, state)
+        login_kwargs = {"login_viewer": True} if login_viewer else {}
+        return await _login_holding_the_profile(
+            user_data_dir, lease, state, **login_kwargs
+        )
     finally:
         if state.close_confirmed:
             # Only clear liveness this login actually set. A pre-launch failure
@@ -151,7 +159,11 @@ class _LoginState:
 
 
 async def _login_holding_the_profile(
-    user_data_dir: Path, lease: ProfileLease, state: _LoginState
+    user_data_dir: Path,
+    lease: ProfileLease,
+    state: _LoginState,
+    *,
+    login_viewer: bool = False,
 ) -> bool:
     """Rotate and log in; the caller owns the profile for the whole flow."""
     # Rotation must happen before the browser is marked open: the exclusivity
@@ -166,8 +178,12 @@ async def _login_holding_the_profile(
     state.browser_opened = True
     state.close_confirmed = False
     try:
+        login_kwargs = {"login_viewer": True} if login_viewer else {}
         succeeded = await _login_into_fresh_profile(
-            user_data_dir, config=get_config(), state=state
+            user_data_dir,
+            config=get_config(),
+            state=state,
+            **login_kwargs,
         )
         return succeeded
     finally:
@@ -210,7 +226,11 @@ async def _login_holding_the_profile(
 
 
 async def _login_into_fresh_profile(
-    user_data_dir: Path, *, config: Any, state: _LoginState
+    user_data_dir: Path,
+    *,
+    config: Any,
+    state: _LoginState,
+    login_viewer: bool = False,
 ) -> bool:
     """Drive the manual login against a freshly retired profile directory.
 
@@ -244,8 +264,20 @@ async def _login_into_fresh_profile(
         viewport=viewport,
         **launch_options,
     )
+    viewer = LoginViewer() if login_viewer else None
+    failure: BaseException | None = None
     try:
-        return await _run_login(manager, user_data_dir, config, login_timeout_ms)
+        if viewer is not None:
+            viewer.start_window_manager()
+        result = await _run_login(
+            manager, user_data_dir, config, login_timeout_ms, viewer=viewer
+        )
+        if not result:
+            failure = RuntimeError("login did not produce a portable session")
+        return result
+    except BaseException as exc:
+        failure = exc
+        raise
     finally:
         # In a finally so a login that times out or is cancelled still records a
         # teardown that did complete; otherwise an ordinary timeout would leave
@@ -253,6 +285,13 @@ async def _login_into_fresh_profile(
         # confirmed for a manager that does not report it, so a stand-in cannot
         # wedge the profile.
         state.close_confirmed = bool(getattr(manager, "close_confirmed", True))
+        if viewer is not None:
+            try:
+                viewer.stop_window_manager()
+            except Exception as teardown_error:
+                if failure is None:
+                    raise
+                print(f"   Warning: viewer teardown failed: {teardown_error}")
 
 
 async def _run_login(
@@ -260,62 +299,149 @@ async def _run_login(
     user_data_dir: Path,
     config: Any,
     login_timeout_ms: int,
+    *,
+    viewer: LoginViewer | None = None,
 ) -> bool:
     async with manager as browser:
-        # Navigate to LinkedIn login
-        await goto_reporting_proxy_errors(
-            browser.page, "https://www.linkedin.com/login"
-        )
-        # Let LinkedIn finish rendering the saved-account chooser, then retry the
-        # same exact click target a few times before falling back to the normal
-        # manual-login wait loop.
-        for _ in range(3):
-            await asyncio.sleep(2)
-            if await resolve_remember_me_prompt(browser.page):
-                break
-
-        # Wait for manual login completion. The budget comes from
-        # LOGIN_TIMEOUT (config.browser.login_timeout_seconds); 0 = unlimited.
-        await wait_for_manual_login(browser.page, timeout=login_timeout_ms)
-
-        # Wait for persistent context to flush cookies to disk
-        await asyncio.sleep(2)
-
-        # Verify session cookie was persisted
-        cookies = await browser.context.cookies()
-        li_at = [c for c in cookies if c["name"] == "li_at"]
-        if not li_at:
-            print("   Warning: Session cookie not found. Login may not have persisted.")
-            print("   Waiting longer for cookie propagation...")
-            await asyncio.sleep(5)
-
-        # Export source-session cookies for the one-time foreign-runtime bridge.
-        # Docker now checkpoint-commits its own derived runtime profile after the
-        # first successful /feed/ recovery instead of relying on browser teardown.
-        if await browser.export_cookies(portable_cookie_path(user_data_dir)):
-            print("   Cookies exported for Docker portability")
-            source_state = write_source_state(user_data_dir)
-            print(f"   Source session generation: {source_state.login_generation}")
-        else:
+        if viewer is not None:
+            url = viewer.start_remote_control()
             print(
-                "   Warning: cookie export failed; Docker bridge may not work. "
-                "Run --login again to retry."
+                f"Open this loopback URL to control the login browser:\n{url}",
+                flush=True,
             )
-            return False
-        print(f"Profile saved to {user_data_dir}")
-        return True
+        failure: BaseException | None = None
+        try:
+            # Navigate to LinkedIn login
+            await goto_reporting_proxy_errors(
+                browser.page, "https://www.linkedin.com/login"
+            )
+            # Let LinkedIn finish rendering the saved-account chooser, then retry
+            # the same exact click target before the normal manual-login wait.
+            for _ in range(3):
+                await asyncio.sleep(2)
+                if await resolve_remember_me_prompt(browser.page):
+                    break
+
+            # Wait for manual login completion. The budget comes from
+            # LOGIN_TIMEOUT (config.browser.login_timeout_seconds); 0 = unlimited.
+            await wait_for_manual_login(browser.page, timeout=login_timeout_ms)
+
+            # Wait for persistent context to flush cookies to disk
+            await asyncio.sleep(2)
+
+            # Verify session cookie was persisted
+            cookies = await browser.context.cookies()
+            li_at = [c for c in cookies if c["name"] == "li_at"]
+            if not li_at:
+                print(
+                    "   Warning: Session cookie not found. Login may not have persisted."
+                )
+                print("   Waiting longer for cookie propagation...")
+                await asyncio.sleep(5)
+
+            # Export source-session cookies for the one-time foreign-runtime bridge.
+            if await browser.export_cookies(portable_cookie_path(user_data_dir)):
+                print("   Cookies exported for Docker portability")
+                source_state = write_source_state(user_data_dir)
+                print(f"   Source session generation: {source_state.login_generation}")
+            else:
+                print(
+                    "   Warning: cookie export failed; Docker bridge may not work. "
+                    "Run --login again to retry."
+                )
+                failure = RuntimeError("cookie export failed")
+                return False
+            print(f"Profile saved to {user_data_dir}")
+            return True
+        except BaseException as exc:
+            failure = exc
+            raise
+        finally:
+            # Close the public WebSocket and then loopback VNC before Chromium's
+            # context manager closes the browser. Openbox follows outside it.
+            if viewer is not None:
+                try:
+                    viewer.stop_remote_control()
+                except Exception as teardown_error:
+                    if failure is None:
+                        raise
+                    print(f"   Warning: viewer teardown failed: {teardown_error}")
 
 
-def run_profile_creation(user_data_dir: str | None = None) -> bool:
-    """
-    Create profile via interactive login with persistent context.
+class _ViewerInterrupted(Exception):
+    """A container stop signal received after viewer cleanup completed."""
 
-    Args:
-        user_data_dir: Path to profile directory. Defaults to config's user_data_dir.
+    def __init__(self, signum: int) -> None:
+        self.signum = signum
+        super().__init__(f"Docker login viewer interrupted by signal {signum}")
 
-    Returns:
-        True if profile was created successfully
-    """
+
+@contextmanager
+def _viewer_signal_handlers(notify: Callable[[int], None]) -> Iterator[None]:
+    """Schedule viewer cancellation without raising inside asyncio internals."""
+    watched = [signal.SIGTERM, signal.SIGINT]
+    if sighup := getattr(signal, "SIGHUP", None):
+        watched.append(sighup)
+    previous = {signum: signal.getsignal(signum) for signum in watched}
+
+    def interrupted(signum: int, _frame: object) -> None:
+        notify(signum)
+
+    try:
+        for signum in watched:
+            signal.signal(signum, interrupted)
+        yield
+    finally:
+        for signum, handler in previous.items():
+            signal.signal(signum, handler)
+
+
+async def _run_bounded_viewer_login(
+    login: Coroutine[Any, Any, bool],
+) -> bool:
+    """Cancel the login cleanly at the hard deadline or on a stop signal."""
+    loop = asyncio.get_running_loop()
+    interrupted: asyncio.Future[int] = loop.create_future()
+
+    def record_signal(signum: int) -> None:
+        if not interrupted.done():
+            interrupted.set_result(signum)
+
+    def notify(signum: int) -> None:
+        loop.call_soon_threadsafe(record_signal, signum)
+
+    login_task = asyncio.create_task(login)
+    cleanup_error: BaseException | None = None
+    with _viewer_signal_handlers(notify):
+        try:
+            done, _pending = await asyncio.wait(
+                {login_task, interrupted},
+                timeout=VIEWER_WALL_SECONDS,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if login_task in done:
+                return await login_task
+        finally:
+            if not login_task.done():
+                login_task.cancel()
+                try:
+                    await login_task
+                except asyncio.CancelledError:
+                    pass
+                except BaseException as exc:
+                    cleanup_error = exc
+
+    if cleanup_error is not None:
+        print(f"   Warning: login cleanup failed: {cleanup_error}")
+    if interrupted.done():
+        raise _ViewerInterrupted(interrupted.result())
+    raise TimeoutError
+
+
+def run_profile_creation(
+    user_data_dir: str | None = None, *, login_viewer: bool = False
+) -> bool:
+    """Create a persistent profile through an interactive browser login."""
     if user_data_dir:
         profile_dir = Path(user_data_dir).expanduser()
     else:
@@ -324,9 +450,25 @@ def run_profile_creation(user_data_dir: str | None = None) -> bool:
     print("LinkedIn MCP Server - Profile Creation")
     print(f"   Profile will be saved to: {profile_dir}")
 
+    async def create() -> bool:
+        login = interactive_login(profile_dir, login_viewer=login_viewer)
+        if login_viewer:
+            # This bounds the remote-control exposure even when LOGIN_TIMEOUT=0.
+            # Cancellation still awaits profile restoration: abandoning a move on
+            # the mounted auth root can leave the previous session split in two.
+            return await _run_bounded_viewer_login(login)
+        return await login
+
     try:
-        success = asyncio.run(interactive_login(profile_dir))
-        return success
+        return asyncio.run(create())
+    except _ViewerInterrupted as exc:
+        raise SystemExit(128 + exc.signum) from None
+    except TimeoutError:
+        print(
+            f"Profile creation failed: Docker login viewer reached its hard "
+            f"{VIEWER_WALL_SECONDS:.0f}-second limit"
+        )
+        return False
     except Exception as e:
         print(f"Profile creation failed: {e}")
         return False

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -63,7 +63,9 @@ class TestHandleAuthError:
             "linkedin_mcp_server.dependencies.get_runtime_policy",
             return_value="docker",
         ):
-            with pytest.raises(DockerHostLoginRequiredError, match="host machine"):
+            with pytest.raises(
+                DockerHostLoginRequiredError, match="--login --login-viewer"
+            ):
                 await handle_auth_error(
                     AuthenticationError("Session expired"), ctx=None
                 )

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -36,11 +36,15 @@ def test_the_image_defaults_to_headed_on_a_virtual_display() -> None:
     assert 'Xvfb "$DISPLAY" -screen 0 1920x1080x24 -nolisten tcp' in _ENTRYPOINT
 
 
-def test_tini_signals_the_whole_display_group() -> None:
-    """Python must receive TERM before the PID namespace tears it down."""
-    assert 'ENTRYPOINT ["tini", "-g"' in _DOCKERFILE
+def test_the_supervisor_stops_python_before_the_display() -> None:
+    """Browser cleanup must retain Xvfb until Python has exited."""
+    assert 'ENTRYPOINT ["tini", "-e", "143"' in _DOCKERFILE
+    assert 'ENTRYPOINT ["tini", "-g"' not in _DOCKERFILE
     assert "wait -n -p first_child" in _ENTRYPOINT
-    assert 'kill -TERM "$server_pid" "$xvfb_pid"' in _ENTRYPOINT
+    server_term = _ENTRYPOINT.index('kill -TERM "$server_pid"')
+    server_wait = _ENTRYPOINT.index('wait "$server_pid"', server_term)
+    display_term = _ENTRYPOINT.index('kill -TERM "$xvfb_pid"', server_wait)
+    assert server_term < server_wait < display_term
     assert "xvfb-run" not in _DOCKERFILE
 
 

--- a/tests/test_login_viewer.py
+++ b/tests/test_login_viewer.py
@@ -1,0 +1,440 @@
+"""Contracts for the short-lived Docker login viewer."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from pathlib import Path
+import re
+import signal
+import stat
+from types import SimpleNamespace
+from typing import Any, cast
+from urllib.parse import unquote
+
+import pytest
+
+import linkedin_mcp_server.login_viewer as viewer_module
+from linkedin_mcp_server.login_viewer import (
+    LoginViewer,
+    LoginViewerError,
+    mount_points,
+    require_persistent_profile_mount,
+    viewer_url,
+)
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        (
+            "abc_123-XYZ",
+            "http://127.0.0.1:6080/vnc_lite.html#?"
+            "path=websockify%3Ftoken%3Dabc_123-XYZ&scale=true",
+        )
+    ],
+)
+def test_viewer_url_is_an_exact_token_private_fragment(
+    token: str, expected: str
+) -> None:
+    assert viewer_url(token) == expected
+    assert "?token=" not in expected.split("#", 1)[0]
+    assert "scale=true" in expected
+    assert "resize=" not in expected
+
+    # Debian Bookworm's vnc_lite.html uses this exact `[?&]` parser. The `?`
+    # after `#` is load-bearing: a fragment beginning with bare `#path=` does
+    # not match even though the upstream source comment suggests it does.
+    match = re.match(r".*[?&]path=([^&#]*)", expected)
+    assert match is not None
+    assert unquote(match.group(1)) == f"websockify?token={token}"
+
+
+def test_mountinfo_decodes_escaped_mount_paths() -> None:
+    text = (
+        "36 25 0:31 / / rw,relatime - overlay overlay rw\n"
+        "51 36 8:1 /profile /home/pwuser/My\\040Auth\\134Root rw - ext4 /dev/sda rw\n"
+    )
+
+    assert mount_points(text) == (
+        Path("/"),
+        Path("/home/pwuser/My Auth\\Root"),
+    )
+
+
+def test_mount_preflight_accepts_a_distinct_ancestor_mount(tmp_path: Path) -> None:
+    profile = tmp_path / "mounted root" / "nested" / "profile"
+    mountinfo = tmp_path / "mountinfo"
+    escaped = str(profile.parents[1]).replace(" ", r"\040")
+    mountinfo.write_text(
+        f"36 25 0:31 / / rw - overlay overlay rw\n"
+        f"51 36 8:1 / {escaped} rw - ext4 /dev/sda rw\n",
+        encoding="utf-8",
+    )
+
+    require_persistent_profile_mount(profile, mountinfo_path=mountinfo)
+
+
+def test_mount_preflight_rejects_only_the_container_root(tmp_path: Path) -> None:
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text("36 25 0:31 / / rw - overlay overlay rw\n", encoding="utf-8")
+
+    with pytest.raises(LoginViewerError, match="distinct persistent mount"):
+        require_persistent_profile_mount(
+            tmp_path / "unmounted" / "profile", mountinfo_path=mountinfo
+        )
+
+
+def test_default_mount_remedy_is_exact(tmp_path: Path) -> None:
+    from linkedin_mcp_server.config.schema import DEFAULT_USER_DATA_DIR
+
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text("36 25 0:31 / / rw - overlay overlay rw\n", encoding="utf-8")
+
+    with pytest.raises(
+        LoginViewerError,
+        match=r"\-v ~[/]\.linkedin-mcp:/home/pwuser/\.linkedin-mcp",
+    ):
+        require_persistent_profile_mount(
+            Path(DEFAULT_USER_DATA_DIR), mountinfo_path=mountinfo
+        )
+
+
+class _FakeProcess:
+    def __init__(self, name: str, events: list[str]) -> None:
+        self.name = name
+        self.events = events
+        self.status: int | None = None
+
+    def poll(self) -> int | None:
+        return self.status
+
+    def terminate(self) -> None:
+        self.events.append(f"terminate:{self.name}")
+        self.status = 0
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        return self.status or 0
+
+    def kill(self) -> None:
+        self.events.append(f"kill:{self.name}")
+        self.status = -9
+
+
+class _Connection:
+    def __enter__(self) -> "_Connection":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def test_exact_commands_token_mode_secrecy_and_teardown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    commands: list[list[str]] = []
+    events: list[str] = []
+    directory = tmp_path / "viewer"
+    token = "fixed-secret-token"
+
+    def fake_popen(command: list[str], **_kwargs: Any) -> _FakeProcess:
+        commands.append(command)
+        return _FakeProcess(Path(command[0]).name, events)
+
+    def fake_mkdtemp(**_kwargs: Any) -> str:
+        directory.mkdir()
+        return str(directory)
+
+    monkeypatch.setattr(viewer_module.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(viewer_module.secrets, "token_urlsafe", lambda _bytes: token)
+    monkeypatch.setattr(viewer_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        viewer_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0, stdout="_NET_SUPPORTING_WM_CHECK: window # 0x1"
+        ),
+    )
+    monkeypatch.setattr(
+        viewer_module.socket,
+        "create_connection",
+        lambda *_args, **_kwargs: _Connection(),
+    )
+    monkeypatch.setattr(viewer_module.time, "sleep", lambda _seconds: None)
+
+    viewer = LoginViewer(display=":99")
+    viewer.start_window_manager()
+    url = viewer.start_remote_control()
+    token_file = directory / "tokens"
+
+    assert commands == [
+        ["openbox", "--sm-disable"],
+        [
+            "x11vnc",
+            "-display",
+            ":99",
+            "-rfbport",
+            "5900",
+            "-listen",
+            "127.0.0.1",
+            "-allow",
+            "127.0.0.1",
+            "-no6",
+            "-shared",
+            "-forever",
+            "-nopw",
+            "-noremote",
+        ],
+        [
+            "websockify",
+            "--web=/usr/share/novnc",
+            "--token-plugin=ReadOnlyTokenFile",
+            f"--token-source={token_file}",
+            "0.0.0.0:6080",
+        ],
+    ]
+    assert token_file.read_text(encoding="utf-8") == (f"{token}: 127.0.0.1:5900\n")
+    assert stat.S_IMODE(token_file.stat().st_mode) == 0o600
+    assert token not in " ".join(part for command in commands for part in command)
+    assert url == viewer_url(token)
+
+    viewer.stop_remote_control()
+    assert events == ["terminate:websockify", "terminate:x11vnc"]
+    assert token_file.exists()
+    viewer.stop_window_manager()
+    assert events[-1] == "terminate:openbox"
+    assert not directory.exists()
+
+
+def test_dockerfile_installs_viewer_packages_without_x11_utils() -> None:
+    dockerfile = (Path(__file__).resolve().parent.parent / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
+    for package in ("openbox", "x11vnc", "novnc", "websockify"):
+        assert package in dockerfile
+    assert "--no-install-recommends" in dockerfile
+    assert "chown -R pwuser:pwuser /opt/patchright" in dockerfile
+    assert "x11-utils" not in dockerfile
+
+
+def test_config_requires_login_and_rejects_other_one_shot_modes() -> None:
+    from linkedin_mcp_server.config.schema import AppConfig, ConfigurationError
+
+    config = AppConfig()
+    config.server.login_viewer = True
+    with pytest.raises(ConfigurationError, match="requires --login"):
+        config.validate()
+
+    config.server.login = True
+    config.server.status = True
+    with pytest.raises(ConfigurationError, match="--status"):
+        config.validate()
+
+
+def test_cli_preflight_rejects_a_host_before_mount_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from linkedin_mcp_server import cli_main
+    from linkedin_mcp_server.config.schema import AppConfig, ConfigurationError
+
+    config = AppConfig()
+    config.server.login = True
+    config.server.login_viewer = True
+    monkeypatch.setattr(cli_main, "is_container_runtime", lambda: False)
+    mount_check = pytest.fail
+    monkeypatch.setattr(cli_main, "require_persistent_profile_mount", mount_check)
+
+    with pytest.raises(ConfigurationError, match="only inside a container"):
+        cli_main._preflight_login_viewer(config)
+
+
+def test_viewer_signal_notifies_the_async_login_and_restores_handlers() -> None:
+    import linkedin_mcp_server.setup as setup
+
+    received: list[int] = []
+    previous = signal.getsignal(signal.SIGTERM)
+    with setup._viewer_signal_handlers(received.append):
+        handler = signal.getsignal(signal.SIGTERM)
+        assert callable(handler)
+        cast(Callable[[int, object], None], handler)(signal.SIGTERM, None)
+
+    assert received == [signal.SIGTERM]
+    assert signal.getsignal(signal.SIGTERM) == previous
+
+
+@pytest.mark.asyncio
+async def test_viewer_signal_cancels_and_awaits_login_cleanup() -> None:
+    import linkedin_mcp_server.setup as setup
+
+    cleaned = False
+
+    async def login() -> bool:
+        nonlocal cleaned
+        try:
+            await asyncio.sleep(0)
+            handler = signal.getsignal(signal.SIGTERM)
+            assert callable(handler)
+            cast(Callable[[int, object], None], handler)(signal.SIGTERM, None)
+            await asyncio.Future()
+            return True
+        finally:
+            cleaned = True
+
+    with pytest.raises(setup._ViewerInterrupted) as interrupted:
+        await setup._run_bounded_viewer_login(login())
+
+    assert interrupted.value.signum == signal.SIGTERM
+    assert cleaned is True
+
+
+def test_viewer_hard_cap_applies_when_login_timeout_is_unlimited(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import linkedin_mcp_server.setup as setup
+
+    started = False
+
+    async def never_finishes(*_args: object, **_kwargs: object) -> bool:
+        nonlocal started
+        started = True
+        await asyncio.Future()
+        return True
+
+    monkeypatch.setattr(setup, "interactive_login", never_finishes)
+    monkeypatch.setattr(setup, "VIEWER_WALL_SECONDS", 0.01)
+
+    assert (
+        setup.run_profile_creation(str(tmp_path / "profile"), login_viewer=True)
+        is False
+    )
+    assert started is True
+    assert "hard 0-second limit" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_deadline_closes_exposure_before_waiting_for_profile_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linkedin_mcp_server.setup as setup
+
+    exposure_closed = asyncio.Event()
+    release_profile_cleanup = asyncio.Event()
+
+    async def login() -> bool:
+        try:
+            await asyncio.Future()
+        finally:
+            # Models _run_login closing websockify and x11vnc before the outer
+            # login flow restores the retired profile.
+            exposure_closed.set()
+            await release_profile_cleanup.wait()
+        return False
+
+    monkeypatch.setattr(setup, "VIEWER_WALL_SECONDS", 0.01)
+    bounded_login = asyncio.create_task(setup._run_bounded_viewer_login(login()))
+
+    await asyncio.wait_for(exposure_closed.wait(), timeout=0.2)
+    assert bounded_login.done() is False
+
+    release_profile_cleanup.set()
+    with pytest.raises(TimeoutError):
+        await bounded_login
+
+
+@pytest.mark.asyncio
+async def test_remote_teardown_precedes_chromium_and_preserves_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import linkedin_mcp_server.setup as setup
+
+    events: list[str] = []
+
+    class Manager:
+        async def __aenter__(self) -> Any:
+            events.append("chromium:start")
+            return SimpleNamespace(page=object())
+
+        async def __aexit__(self, *_args: object) -> None:
+            events.append("chromium:stop")
+
+    class Viewer:
+        def start_remote_control(self) -> str:
+            events.extend(("x11vnc:start", "websockify:start"))
+            return viewer_url("token")
+
+        def stop_remote_control(self) -> None:
+            events.extend(("websockify:stop", "x11vnc:stop"))
+            raise RuntimeError("teardown failed")
+
+    async def launch_failed(*_args: object, **_kwargs: object) -> None:
+        raise ValueError("navigation failed")
+
+    monkeypatch.setattr(setup, "goto_reporting_proxy_errors", launch_failed)
+
+    with pytest.raises(ValueError, match="navigation failed"):
+        await setup._run_login(
+            cast(setup.BrowserManager, Manager()),
+            tmp_path / "profile",
+            SimpleNamespace(),
+            0,
+            viewer=cast(LoginViewer, Viewer()),
+        )
+
+    assert capsys.readouterr().out.count(viewer_url("token")) == 1
+    assert events == [
+        "chromium:start",
+        "x11vnc:start",
+        "websockify:start",
+        "websockify:stop",
+        "x11vnc:stop",
+        "chromium:stop",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_window_manager_teardown_does_not_mask_cookie_export_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import linkedin_mcp_server.setup as setup
+
+    events: list[str] = []
+
+    class Manager:
+        close_confirmed = True
+
+    class Viewer:
+        def start_window_manager(self) -> None:
+            events.append("openbox:start")
+
+        def stop_window_manager(self) -> None:
+            events.append("openbox:stop")
+            raise RuntimeError("openbox teardown failed")
+
+    async def cookie_export_failed(*_args: object, **_kwargs: object) -> bool:
+        return False
+
+    monkeypatch.setattr(setup, "build_launch_options", lambda _config: ({}, None))
+    monkeypatch.setattr(setup, "describe_launch", lambda _options: None)
+    monkeypatch.setattr(setup, "BrowserManager", lambda **_kwargs: Manager())
+    monkeypatch.setattr(setup, "LoginViewer", Viewer)
+    monkeypatch.setattr(setup, "_run_login", cookie_export_failed)
+    config = SimpleNamespace(
+        browser=SimpleNamespace(login_timeout_seconds=1800, slow_mo=0)
+    )
+    state = setup._LoginState()
+
+    result = await setup._login_into_fresh_profile(
+        tmp_path / "profile", config=config, state=state, login_viewer=True
+    )
+
+    assert result is False
+    assert state.close_confirmed is True
+    assert events == ["openbox:start", "openbox:stop"]
+    assert "Warning: viewer teardown failed: openbox teardown failed" in (
+        capsys.readouterr().out
+    )


### PR DESCRIPTION
Closes #707

Docker already ran headed Chromium on Xvfb, but its login window remained inaccessible. Creating a session still required installing the package and browser on the host, then moving the resulting source profile into the container mount.

`--login --login-viewer` now creates that session directly in Docker. It starts Openbox before Chromium, binds x11vnc to container loopback, and serves noVNC through websockify on port 6080. The documented command publishes that port on host loopback. Each run gets a 256-bit token in a mode-0600 file; the printed URL carries it in the fragment, while websockify receives it on the authenticated WebSocket path. Client-side scaling stays enabled and remote resize stays disabled.

The command refuses to rotate a profile until `/proc/self/mountinfo` proves that the configured path sits under a distinct mount. The default error includes the exact `-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp` remedy. The viewer is CLI-only, requires `--login`, rejects the other one-shot modes, and closes remote control after a hard 1,800 seconds even when `LOGIN_TIMEOUT=0`. Protected profile restoration may finish afterward because abandoning a move on the mounted auth root could split the previous session.

Viewer teardown runs in reverse exposure order: websockify, x11vnc, Chromium, Openbox, then Xvfb through the image supervisor. Stop signals are scheduled into the asyncio loop so the login task can cancel and finish its cleanup before the process exits with the signal status. Tini now signals the supervisor alone, and the supervisor keeps Xvfb alive until Python has finished. This ordering fixed the active-viewer stop case, where group-wide TERM removed the display while Chromium was closing and Docker eventually used SIGKILL. The bundled browser cache is owned by `pwuser` because one-shot CLI modes reacquire Patchright's installer lock while recording profile-local metadata.

The Openbox and noVNC candidate passed the four-stage G4 check on amd64 and arm64: focus stayed true, visibility stayed visible, Chromium remained the active window, a trusted click reached the page, and screen, window, and DPR geometry stayed unchanged before connection, after connection, after the click, and after disconnect. The package closure adds 107.2 MiB to Docker's image-inspect content size on amd64 and 102.8 MiB on arm64. `docker history` reports a separate uncompressed-layer metric of 383 MB and 362 MB.

<!-- pr-media:start -->
| amd64 login viewer | arm64 login viewer |
| --- | --- |
| <img width="900" alt="amd64 login viewer" src="https://github.com/user-attachments/assets/7b6cea8f-90df-4c18-a719-1ca77250b516" /> | <img width="900" alt="arm64 login viewer" src="https://github.com/user-attachments/assets/5a2d1fc0-12cb-42da-bd6a-f7abd3fb3df4" /> |
<!-- pr-media:end -->

Verified with 1,931 tests passing and 11 platform-dependent skips, 17 slow tests passing, clean Ruff, formatting, Ty and pre-commit checks, final amd64 and arm64 image builds, live noVNC rendering of the login page on both architectures, token absence from `docker inspect` and process argv, active-WebSocket SIGTERM teardown with exit 0, and graceful HTTP-server shutdown with exit 0.

## Synthetic prompt

> Add an explicit `--login --login-viewer` Docker flow that exposes the Xvfb login browser through a token-authenticated noVNC URL on loopback. Require a persistent profile mount before rotation, enforce a hard 1,800-second lifetime, keep remote resize disabled, preserve the original failure through reverse-order cleanup, and verify focus, geometry, image size, token secrecy, normal shutdown, and stop-signal teardown on amd64 and arm64. Update the Docker documentation and authentication guidance.

Generated with Claude Opus 5 high + Sol 5.6 medium/xhigh
