### PR TITLE
fix(browser): Report retained cache revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ while a container is running.
 
 - Browser profile is stored at `~/.linkedin-mcp/profile/`
 - Managed browser downloads are cached at `~/.linkedin-mcp/patchright-browsers/`
+- *The browser cache keeps growing*: a server upgrade can bring a new Chromium revision, and Patchright keeps the old one for as long as any installed version still references it. `uvx` keeps one archive per version you have ever run, so every one of them holds such a reference and the old revisions stay. The server logs a warning naming the revisions it is holding and how much space they take. To reclaim it, stop every LinkedIn MCP Server instance, delete `~/.linkedin-mcp/patchright-browsers/`, and let the next launch download the current browser.
 - Make sure you have only one active LinkedIn session at a time
 
 **Login issues:**
@@ -274,6 +275,7 @@ On startup, the MCP Bundle starts preparing the shared Patchright Chromium brows
 - Claude Desktop starts the bundle immediately; browser setup continues in the background
 - If the Patchright Chromium browser is still downloading, retry the tool after a short wait
 - Managed browser downloads are shared under `~/.linkedin-mcp/patchright-browsers/`
+- *The browser cache keeps growing*: Patchright keeps an old Chromium revision for as long as any installed version still references it, so an upgrade can leave both on disk. The server logs a warning naming what it holds. To reclaim the space, stop every LinkedIn MCP Server instance, delete `~/.linkedin-mcp/patchright-browsers/`, and let the next launch download the current browser.
 - *Windows, the bundle exits with `DLL load failed while importing _greenlet`*: install the [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist). The published Windows wheels for greenlet 3.3.1 through 3.5.4 need `MSVCP140.dll` from it, and neither the python.org installer nor the `uv`-managed builds carry that DLL. A greenlet built from source can need it at any version. The server names this itself on startup, and only after checking that the loader cannot produce that DLL. Tracked upstream as [greenlet#525](https://github.com/python-greenlet/greenlet/issues/525).
 
 **Login issues:**
@@ -588,6 +590,8 @@ uv run -m linkedin_mcp_server --transport streamable-http --host 127.0.0.1 --por
 **Session issues:**
 
 - Browser profile is stored at `~/.linkedin-mcp/profile/`
+- Managed browser downloads are cached at `~/.linkedin-mcp/patchright-browsers/`, shared with the `uvx` and MCP Bundle installations
+- *The browser cache keeps growing*: Patchright keeps an old Chromium revision for as long as any installed version still references it, and a `uv` archive or a second worktree is such a reference. The server logs a warning naming what it holds. To reclaim the space, stop every LinkedIn MCP Server instance, delete `~/.linkedin-mcp/patchright-browsers/`, and let the next launch download the current browser.
 - Use `--logout` to clear the profile and start fresh
 
 **Python/Patchright issues:**

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import stat
 import sys
 from typing import NoReturn
 
@@ -34,6 +35,11 @@ from linkedin_mcp_server.exceptions import (
     BrowserSetupFailedError,
     BrowserSetupInProgressError,
     DockerHostLoginRequiredError,
+)
+from linkedin_mcp_server.profile_lease import (
+    ProfileLeaseUnavailableError,
+    _release_locked_fd,
+    acquire_locked_fd,
 )
 from linkedin_mcp_server.server_role import ServerRole, process_role
 from linkedin_mcp_server.session_state import (
@@ -73,6 +79,15 @@ _SHELL_DIR_PREFIX = "chromium_headless_shell-"
 # in either mode.
 _FULL_DIR_PREFIX = "chromium-"
 
+# Sidecar recording the cache state the retained-revision warning last named. It
+# lives inside the configured browsers path so it travels with the cache it
+# describes, and its name starts with a dot so patchright's own collector passes
+# over it: that collector deletes directories whose name begins with a browser
+# name, and link files under `.links`, and nothing else.
+_CACHE_REPORT_MARKER = ".linkedin-mcp-cache-report.json"
+_CACHE_REPORT_LOCK = ".linkedin-mcp-cache-report.lock"
+_CACHE_REPORT_SCHEMA = 1
+
 
 class RuntimePolicy(str, Enum):
     MANAGED = "managed"
@@ -105,6 +120,7 @@ class BootstrapState:
     auth_started_at: str | None = None
     auth_completed_at: str | None = None
     setup_task: asyncio.Task[None] | None = None
+    cache_report_task: asyncio.Task[None] | None = None
     login_task: asyncio.Task[None] | None = None
     import_task: asyncio.Task[bool] | None = None
     import_attempted: bool = False
@@ -133,7 +149,12 @@ def reset_bootstrap_for_testing() -> None:
     """Reset bootstrap singleton state for test isolation."""
     global _state, _lock, _AUTO_IMPORT_ANNOUNCED
     global _auth_quiescent, _auth_quiescent_generation
-    for task in (_state.setup_task, _state.login_task, _state.import_task):
+    for task in (
+        _state.setup_task,
+        _state.cache_report_task,
+        _state.login_task,
+        _state.import_task,
+    ):
         if task is not None and not task.done():
             task.cancel()
     _state = BootstrapState()
@@ -241,6 +262,185 @@ def _uses_custom_chrome() -> bool:
     return bool(get_config().browser.chrome_path)
 
 
+def _revision_dir_prefix(name: str) -> str | None:
+    """Return the browser prefix of a revision directory, or ``None``.
+
+    Only a numeric suffix counts, and only for the two browsers this server
+    installs. Patchright can leave other directories in the same cache
+    (``chromium_tip_of_tree-``, ``ffmpeg-``, a partially downloaded
+    ``*.downloads-`` staging dir), and a report has nothing to say about a
+    browser it never asked for.
+    """
+    for prefix in (_FULL_DIR_PREFIX, _SHELL_DIR_PREFIX):
+        if name.startswith(prefix) and name[len(prefix) :].isdigit():
+            return prefix
+    return None
+
+
+def _retained_revision_dirs(configured: Path, current_revision: str) -> list[Path]:
+    """Return the browser directories in *configured* that will never launch again.
+
+    The full Chromium at *current_revision* is the one every launch names, so it
+    is active. Every older full revision is retained, and so is every headless
+    shell at any revision: nothing launches the shell since the install became
+    single-stage, and a cache written before that still holds one.
+
+    Symlinks are skipped before anything else. A link is not the storage it
+    points at, so counting it would attribute somebody else's bytes to this
+    cache and name a directory the remedy below would not free.
+    """
+    retained: list[Path] = []
+    for entry in sorted(configured.iterdir()):
+        if entry.is_symlink() or not entry.is_dir():
+            continue
+        prefix = _revision_dir_prefix(entry.name)
+        if prefix is None:
+            continue
+        if prefix == _FULL_DIR_PREFIX and entry.name[len(prefix) :] == current_revision:
+            continue
+        retained.append(entry)
+    return retained
+
+
+def _directory_size(path: Path) -> int:
+    """Sum the bytes of the real files under *path*, following no symlink.
+
+    A file that vanishes or turns unreadable mid-walk is skipped: an install
+    running in another process may be writing into the same cache, and an
+    approximate figure beats a diagnostic that raises.
+    """
+    total = 0
+    for root, _dirs, files in os.walk(path, followlinks=False):
+        for name in files:
+            try:
+                info = os.lstat(os.path.join(root, name))
+            except OSError:
+                continue
+            if stat.S_ISREG(info.st_mode):
+                total += info.st_size
+    return total
+
+
+def _format_size(num_bytes: int) -> str:
+    """Render a logical byte count in binary units."""
+    size = float(num_bytes)
+    for unit in ("B", "KiB", "MiB"):
+        if size < 1024:
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} GiB"
+
+
+def _cache_report_signature(
+    current_revision: str, retained: list[Path]
+) -> dict[str, object]:
+    """Describe a cache state precisely enough to know when it has changed."""
+    return {
+        "version": _CACHE_REPORT_SCHEMA,
+        "current_revision": current_revision,
+        "retained": sorted(entry.name for entry in retained),
+    }
+
+
+def _cache_report_is_current(marker: Path, signature: dict[str, object]) -> bool:
+    """Whether *marker* already records exactly this cache state.
+
+    An unreadable or malformed marker answers False, so the report is made
+    again. Warning twice costs a log line; staying silent about a gigabyte
+    because a file could not be parsed costs the whole point of the report.
+    """
+    try:
+        payload = json.loads(marker.read_text())
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return False
+    return payload == signature
+
+
+def _report_retained_browser_revisions() -> None:
+    """Warn about retained revisions and suppress later reports of the same state.
+
+    Patchright preserves every revision named by a valid reference under
+    ``.links``, and uv keeps one readable archive per version anyone has ever
+    resolved, so a browser downloaded by an older installation survives every
+    later install (#686). Deleting either side of that would break an
+    installation that can still be launched, so this reports the cache and
+    leaves it exactly as it found it.
+
+    The warning is bound to the cache state rather than to the process: the
+    marker records the current revision together with the retained directory
+    names, so a restart on the same cache stays quiet while the next patchright
+    bump says its piece. A cache-local kernel lock makes the read, warning, and
+    marker replacement one cross-process operation. Measuring the size comes
+    after the marker check, so the walk over a multi-gigabyte cache happens once
+    per state.
+
+    Diagnostics, never a gate. Every failure is swallowed at debug level;
+    browser setup must not depend on being able to measure a directory.
+    """
+    lock_fd: int | None = None
+    try:
+        configured = configure_browser_environment()
+        if not configured.is_dir():
+            return
+        targets = _patchright_install_targets()
+        current_revision = (targets or {}).get(_FULL_DIR_PREFIX)
+        if current_revision is None:
+            # Without the registry there is no way to tell the active revision
+            # from a superseded one, and reporting the running browser as dead
+            # weight is worse than reporting nothing.
+            logger.debug("No patchright registry; skipping the browser cache report")
+            return
+        lock_fd = acquire_locked_fd(configured / _CACHE_REPORT_LOCK, exclusive=True)
+        if lock_fd is None:
+            # Another process is already reporting this shared cache. Its marker
+            # will suppress later runs once it finishes.
+            return
+        retained = _retained_revision_dirs(configured, current_revision)
+        if not retained:
+            return
+        signature = _cache_report_signature(current_revision, retained)
+        marker = configured / _CACHE_REPORT_MARKER
+        if _cache_report_is_current(marker, signature):
+            return
+        total = sum(_directory_size(entry) for entry in retained)
+        logger.warning(
+            "The managed browser cache at %s holds %s in browser revisions this "
+            "server no longer launches: %s. Patchright keeps a revision for as "
+            "long as any installed package still references it, and each "
+            "installed server version that has run its browser installer leaves "
+            "such a reference behind, so old revisions can stay indefinitely. "
+            "To reclaim the "
+            "space: stop every LinkedIn MCP Server instance, delete %s, and let "
+            "the next launch download the current browser.",
+            configured,
+            _format_size(total),
+            ", ".join(entry.name for entry in retained),
+            configured,
+        )
+        try:
+            secure_write_text(
+                marker, json.dumps(signature, indent=2, sort_keys=True) + "\n"
+            )
+        except OSError:
+            logger.debug("Could not record the browser cache report", exc_info=True)
+    except (OSError, ProfileLeaseUnavailableError):
+        logger.debug("Could not inventory the managed browser cache", exc_info=True)
+    finally:
+        if lock_fd is not None:
+            _release_locked_fd(lock_fd)
+
+
+def _schedule_retained_browser_revision_report() -> None:
+    """Run the cache inventory off the event loop without delaying startup."""
+    task = _state.cache_report_task
+    if task is not None and not task.done():
+        return
+    _state.cache_report_task = asyncio.create_task(
+        asyncio.to_thread(_report_retained_browser_revisions),
+        name="browser-cache-report",
+    )
+
+
 def initialize_bootstrap(runtime_policy: RuntimePolicy | str | None = None) -> None:
     """Initialize bootstrap state and configure the shared browser cache."""
     if _state.initialized:
@@ -268,6 +468,7 @@ async def start_background_browser_setup_if_needed() -> None:
 
     async with _lock:
         if _browser_setup_ready():
+            _schedule_retained_browser_revision_report()
             _state.setup_state = SetupState.READY
             _state.setup_completed_at = _state.setup_completed_at or utcnow_iso()
             return
@@ -446,6 +647,11 @@ async def _run_browser_setup() -> None:
         browser_dir,
         {_SHELL_DIR_PREFIX: False, _FULL_DIR_PREFIX: True},
     )
+    # After the installer, because that is the moment a bump has just added a
+    # revision beside the old one and patchright has already had its chance to
+    # collect what it could. The inventory is diagnostic, so it runs separately
+    # and does not delay browser readiness.
+    _schedule_retained_browser_revision_report()
 
 
 async def _ensure_browser_installed() -> None:
@@ -473,6 +679,7 @@ def ensure_browser_installed() -> None:
     if _uses_custom_chrome():
         return
     if browser_ready():
+        _report_retained_browser_revisions()
         return
     print("   Installing Patchright Chromium browser...")
     try:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,8 +1,10 @@
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import json
 import logging
 import os
 from pathlib import Path
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -11,9 +13,11 @@ import pytest
 from linkedin_mcp_server.bootstrap import (
     AuthState,
     _auto_import_allowed,
+    _CACHE_REPORT_MARKER,
     _force_move_auth_state_aside,
     _has_install_for,
     _patchright_install_targets,
+    _report_retained_browser_revisions,
     _start_login_if_needed,
     browser_setup_ready,
     browsers_path,
@@ -180,17 +184,21 @@ class TestBootstrap:
     def test_reset_bootstrap_cancels_running_tasks(self):
         setup_task = MagicMock()
         setup_task.done.return_value = False
+        cache_report_task = MagicMock()
+        cache_report_task.done.return_value = False
         login_task = MagicMock()
         login_task.done.return_value = False
 
         initialize_bootstrap("managed")
         state = get_bootstrap_state()
         state.setup_task = setup_task
+        state.cache_report_task = cache_report_task
         state.login_task = login_task
 
         reset_bootstrap_for_testing()
 
         setup_task.cancel.assert_called_once_with()
+        cache_report_task.cancel.assert_called_once_with()
         login_task.cancel.assert_called_once_with()
 
     def test_managed_browser_path_defaults_under_auth_root(self, isolate_profile_dir):
@@ -529,6 +537,419 @@ class TestBrowserReady:
         _materialize_install(bdir, ["chromium-1217", "chromium_headless_shell-1217"])
         _write_metadata(install_metadata_path(), bdir, version=2)
         assert browser_ready() is False
+
+
+def _fill(directory: Path, num_bytes: int) -> None:
+    """Give *directory* a payload file of a known size."""
+    (directory / "payload.bin").write_bytes(b"\0" * num_bytes)
+
+
+class TestRetainedRevisionReport:
+    """The managed cache is inventoried and reported, never pruned (#686).
+
+    Patchright keeps every revision a valid `.links` reference names, and uv
+    keeps one readable archive per version anyone has run, so old browsers stay
+    on disk for good. Deleting a link or a browser directory would break an
+    installation that can still be launched, so the server says what it is
+    holding and how to reclaim it by hand.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _headless_config(self, monkeypatch):
+        _set_headless(monkeypatch, True)
+
+    def _report(self, caplog) -> str:
+        with caplog.at_level(logging.WARNING, logger="linkedin_mcp_server.bootstrap"):
+            _report_retained_browser_revisions()
+        return caplog.text
+
+    def test_current_revision_alone_is_silent(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        """A fresh install holds nothing it will not launch."""
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217"])
+
+        assert self._report(caplog) == ""
+        assert not (bdir / _CACHE_REPORT_MARKER).exists()
+
+    def test_old_full_and_every_shell_are_reported(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        """The running revision is active; the older one and the shells are not."""
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(
+            bdir,
+            [
+                "chromium-1208",
+                "chromium-1217",
+                "chromium_headless_shell-1208",
+                "chromium_headless_shell-1217",
+            ],
+        )
+
+        text = self._report(caplog)
+
+        assert "chromium-1208" in text
+        assert "chromium_headless_shell-1208" in text
+        assert "chromium_headless_shell-1217" in text
+        assert "chromium-1217" not in text
+
+    def test_unrelated_directories_are_left_out(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        """Only the two browsers this server installs are the report's business."""
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(
+            bdir,
+            [
+                "chromium-1217",
+                "chromium-1208",
+                "chromium_tip_of_tree-1208",
+                "ffmpeg-1011",
+            ],
+        )
+
+        text = self._report(caplog)
+
+        assert "chromium-1208" in text
+        assert "chromium_tip_of_tree" not in text
+        assert "ffmpeg" not in text
+
+    def test_symlinked_revisions_are_neither_named_nor_measured(
+        self, isolate_profile_dir, monkeypatch, tmp_path, caplog
+    ):
+        """A link is not the storage it points at.
+
+        Counting it would attribute another directory's bytes to this cache and
+        name something the remedy would not free.
+        """
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium_headless_shell-1217"])
+        _fill(bdir / "chromium_headless_shell-1217", 2048)
+
+        elsewhere = tmp_path / "elsewhere" / "chromium-1208"
+        elsewhere.mkdir(parents=True)
+        _fill(elsewhere, 4 * 1024 * 1024)
+        (bdir / "chromium-1208").symlink_to(elsewhere, target_is_directory=True)
+
+        text = self._report(caplog)
+
+        assert "chromium_headless_shell-1217" in text
+        assert "chromium-1208" not in text
+        assert "2.0 KiB" in text
+
+    def test_warning_carries_size_path_and_remedy(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+        _fill(bdir / "chromium-1208", 3 * 1024 * 1024)
+
+        text = self._report(caplog)
+
+        assert "3.0 MiB" in text
+        assert "chromium-1208" in text
+        assert str(bdir) in text
+        assert "stop every LinkedIn MCP Server instance" in text
+
+    def test_the_same_cache_state_warns_once(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        """A restart on an unchanged cache has nothing new to say."""
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+
+        assert "chromium-1208" in self._report(caplog)
+        caplog.clear()
+        assert self._report(caplog) == ""
+        assert (bdir / _CACHE_REPORT_MARKER).is_file()
+
+    def test_concurrent_process_report_is_suppressed_by_the_cache_lock(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        """A second process stays quiet while the first records this state."""
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+        scan_started = threading.Event()
+        finish_scan = threading.Event()
+
+        def blocked_size(_path: Path) -> int:
+            scan_started.set()
+            assert finish_scan.wait(timeout=1)
+            return 1024
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._directory_size", blocked_size
+        )
+        with (
+            caplog.at_level(logging.WARNING, logger="linkedin_mcp_server.bootstrap"),
+            ThreadPoolExecutor(max_workers=2) as pool,
+        ):
+            first = pool.submit(_report_retained_browser_revisions)
+            assert scan_started.wait(timeout=1)
+            second = pool.submit(_report_retained_browser_revisions)
+            second.result(timeout=1)
+            finish_scan.set()
+            first.result(timeout=1)
+
+        assert caplog.text.count("The managed browser cache") == 1
+
+    def test_a_changed_retained_set_warns_again(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        """The next patchright bump is exactly what the user needs to hear about."""
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+        self._report(caplog)
+        caplog.clear()
+
+        _materialize_install(bdir, ["chromium_headless_shell-1208"])
+
+        assert "chromium_headless_shell-1208" in self._report(caplog)
+
+    def test_a_new_current_revision_warns_again(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        """Same directories on disk, and the one that runs them has moved on."""
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+        self._report(caplog)
+        caplog.clear()
+
+        _patch_targets_and_version(
+            monkeypatch,
+            targets={"chromium-": "1228", "chromium_headless_shell-": "1228"},
+        )
+
+        assert "chromium-1217" in self._report(caplog)
+
+    def test_a_malformed_marker_reports_again(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        """Silence about a gigabyte is the worse answer to an unparsable file."""
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+        (bdir / _CACHE_REPORT_MARKER).write_text("not json {{{")
+
+        assert "chromium-1208" in self._report(caplog)
+        assert json.loads((bdir / _CACHE_REPORT_MARKER).read_text())["retained"] == [
+            "chromium-1208"
+        ]
+
+    def test_an_invalid_utf8_marker_reports_again(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+        (bdir / _CACHE_REPORT_MARKER).write_bytes(b"\xff\xfe")
+
+        assert "chromium-1208" in self._report(caplog)
+
+    def test_a_marker_write_failure_is_survivable(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+
+        def boom(*args, **kwargs):
+            raise OSError("read-only cache")
+
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap.secure_write_text", boom)
+
+        assert "chromium-1208" in self._report(caplog)
+
+    def test_files_that_vanish_mid_scan_are_skipped(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        """Another process may be installing into the same cache."""
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+        _fill(bdir / "chromium-1208", 4096)
+
+        def vanish(_path):
+            raise FileNotFoundError(_path)
+
+        monkeypatch.setattr(os, "lstat", vanish)
+
+        text = self._report(caplog)
+
+        assert "chromium-1208" in text
+        assert "0.0 B" in text
+
+    def test_an_unreadable_scan_never_raises(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+
+        def denied(*args, **kwargs):
+            raise PermissionError("no access")
+
+        monkeypatch.setattr(os, "walk", denied)
+
+        assert self._report(caplog) == ""
+
+    def test_an_unreadable_registry_reports_nothing(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        """Without the registry, the running browser is indistinguishable from dead weight."""
+        _patch_targets_and_version(monkeypatch, targets=None)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217", "chromium-1208"])
+
+        assert self._report(caplog) == ""
+
+    def test_a_missing_cache_reports_nothing(
+        self, isolate_profile_dir, monkeypatch, caplog
+    ):
+        _patch_targets_and_version(monkeypatch)
+
+        assert self._report(caplog) == ""
+
+    def test_a_custom_browsers_path_is_inventoried(
+        self, isolate_profile_dir, monkeypatch, tmp_path, caplog
+    ):
+        """The report follows the path patchright actually uses."""
+        _patch_targets_and_version(monkeypatch)
+        custom = tmp_path / "operator-cache"
+        _materialize_install(custom, ["chromium-1217", "chromium-1208"])
+        monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(custom))
+
+        text = self._report(caplog)
+
+        assert str(custom) in text
+        assert "chromium-1208" in text
+        assert (custom / _CACHE_REPORT_MARKER).is_file()
+        assert not (browsers_path() / _CACHE_REPORT_MARKER).exists()
+
+
+class TestRetainedRevisionReportCallSites:
+    """Every managed path that concludes the browser is in place reports it."""
+
+    def _record(self, monkeypatch) -> list[int]:
+        calls: list[int] = []
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._report_retained_browser_revisions",
+            lambda: calls.append(1),
+        )
+        return calls
+
+    async def test_ready_background_setup_reports(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        _patch_targets_and_version(monkeypatch)
+        _set_headless(monkeypatch, True)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217"])
+        _write_metadata(install_metadata_path(), bdir)
+        calls = self._record(monkeypatch)
+
+        initialize_bootstrap("managed")
+        await start_background_browser_setup_if_needed()
+        report_task = get_bootstrap_state().cache_report_task
+        assert report_task is not None
+        await report_task
+
+        assert get_bootstrap_state().setup_state is SetupState.READY
+        assert calls == [1]
+
+    async def test_ready_background_setup_does_not_wait_for_the_scan(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """A slow cache filesystem cannot hold up the server lifespan."""
+        _patch_targets_and_version(monkeypatch)
+        _set_headless(monkeypatch, True)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217"])
+        _write_metadata(install_metadata_path(), bdir)
+        scan_started = threading.Event()
+        finish_scan = threading.Event()
+
+        def blocked_report() -> None:
+            scan_started.set()
+            assert finish_scan.wait(timeout=1)
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._report_retained_browser_revisions",
+            blocked_report,
+        )
+
+        initialize_bootstrap("managed")
+        await start_background_browser_setup_if_needed()
+
+        assert get_bootstrap_state().setup_state is SetupState.READY
+        assert await asyncio.to_thread(scan_started.wait, 1)
+        report_task = get_bootstrap_state().cache_report_task
+        assert report_task is not None
+        assert report_task.done() is False
+        finish_scan.set()
+        await report_task
+
+    async def test_a_custom_chrome_skips_the_report(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """No managed cache is involved, so there is nothing to inventory."""
+        config = SimpleNamespace(
+            browser=SimpleNamespace(headless=True, chrome_path="/usr/bin/chromium"),
+        )
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
+        calls = self._record(monkeypatch)
+
+        initialize_bootstrap("managed")
+        await start_background_browser_setup_if_needed()
+        ensure_browser_installed()
+
+        assert calls == []
+
+    async def test_a_finished_install_reports(self, isolate_profile_dir, monkeypatch):
+        _patch_targets_and_version(monkeypatch)
+        config = SimpleNamespace(
+            browser=SimpleNamespace(headless=True, eager_full_chromium=False)
+        )
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap.get_config", lambda: config)
+
+        async def fake_install(extra_arg: str) -> None:
+            return None
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._run_patchright_install", fake_install
+        )
+        calls = self._record(monkeypatch)
+
+        from linkedin_mcp_server.bootstrap import _run_browser_setup
+
+        await _run_browser_setup()
+        report_task = get_bootstrap_state().cache_report_task
+        assert report_task is not None
+        await report_task
+
+        assert calls == [1]
+
+    def test_a_ready_cli_setup_reports(self, isolate_profile_dir, monkeypatch):
+        monkeypatch.setattr(
+            "linkedin_mcp_server.bootstrap._uses_custom_chrome", lambda: False
+        )
+        monkeypatch.setattr("linkedin_mcp_server.bootstrap.browser_ready", lambda: True)
+        calls = self._record(monkeypatch)
+
+        ensure_browser_installed()
+
+        assert calls == [1]
 
 
 class TestSetupGate:


### PR DESCRIPTION
Closes #686

Every Patchright install writes a `.links/<package-path-hash>` reference into the shared browser cache. Its collector reads every referenced `browsers.json` and preserves every revision that any valid package path names. `uvx` keeps old package archives readable, so those references never become broken and old Chromium downloads stay indefinitely. The measured cache had 24 valid references and four browser directories across revisions 1223 and 1228, about 1.07 GB.

The server now inventories the managed cache after a successful install and whenever an existing browser is accepted as ready. It treats the current full Chromium as active, reports older full-browser revisions and every headless-shell revision, measures their logical size without following symlinks, and logs the exact directory names, cache path, and reclamation steps. The safe remedy is to stop every LinkedIn MCP Server instance, remove the managed cache directory, and let the next launch download current Chromium.

A versioned marker inside the configured cache records the current revision and retained-directory set. Later processes stay quiet while that state is unchanged, and a new Patchright revision or retained set warns again. A cache-local kernel lock serializes the marker check, warning, and replacement across processes. Managed async setup schedules the inventory off the event loop and does not delay browser readiness. Malformed markers, unreadable files, concurrent file disappearance, lock failures, and marker-write failures remain diagnostics and never block browser setup. An operator-supplied `PLAYWRIGHT_BROWSERS_PATH` is inventoried; `CHROME_PATH` keeps skipping managed-cache work.

The implementation leaves Patchright's `.links`, `__dirlock`, and browser directories untouched. Older uvx, MCPB, and worktree installations can still launch the revisions they reference. README troubleshooting now explains the growth mechanism and the same stop-delete-redownload recovery path for uvx, MCP Bundle, and local development.

Verified with 142 bootstrap tests, 17 slow tests, 20 repeated concurrency and non-blocking scan runs, clean Ruff, formatting, Ty and pre-commit checks, and an end-to-end temporary cache matching the measured current-plus-retained shape. The full suite reached 1,953 passes and 11 platform skips; the known daemon turnover timing check exceeded its 30-second load bound once at 41.6 seconds under concurrent verification load and passed alone at 14.9 seconds.

## Synthetic prompt

> Resolve #686 without deleting browser revisions that older installations may still use. Inventory the managed Patchright cache against the current registry revision, report older full Chromium and every obsolete headless shell with their retained size, suppress repeated warnings for an unchanged cache state, keep all diagnostics non-fatal, and give a safe stop-all-instances/delete-cache/redownload remedy. Cover symlinks, malformed markers, concurrent file changes, custom browser paths, setup call sites, and documentation.

Generated with Claude Opus 5 high + Sol 5.6 high

