### PR TITLE
fix(docker): Protect viewer session mounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,8 +34,9 @@ TOOL_TIMEOUT=180.0
 # Manual login wait timeout in seconds (default: 1800; 0 = no limit)
 # How long the --login browser window waits for you to finish signing in
 # (including 2FA, captcha, and security challenges) before giving up.
-# Docker --login-viewer closes remote control after 1800 seconds even when this
-# is 0. Protected profile restoration may finish after the viewer has closed.
+# Docker --login-viewer caps the effective limit at its 1800-second viewer wall.
+# A value of 0 therefore reports 30 minutes in viewer mode. Protected restoration
+# may finish after remote control has closed.
 # The viewer is CLI-only so an ordinary container startup cannot expose it.
 LOGIN_TIMEOUT=1800
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ RUN patchright install-deps chromium && \
     chmod -R 755 /opt/patchright && \
     rm -rf /var/lib/apt/lists/*
 
+# Docker seeds a fresh named volume from this directory. Bind mounts retain the
+# host directory's ownership and are prepared by the documented login command.
+RUN install -d -m 0700 -o pwuser -g pwuser /home/pwuser/.linkedin-mcp
+
 COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/linkedin-mcp-entrypoint
 
 # A full headed browser on a virtual display. No window reaches the host, and

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ When you set up or maintain this server, verify its entry in the MCP client conf
 - `--logout` - Clear stored LinkedIn browser profile
 - `--timeout MS` - Browser timeout for page operations in milliseconds (default: 5000)
 - `--tool-timeout SECONDS` - Per-tool MCP execution timeout in seconds (default: 180.0). Increase further for heavy scrapes / cold-start Chromium / slow networks.
-- `--login-timeout SECONDS` - Manual login wait timeout in seconds (default: 1800; 0 = no limit). How long the `--login` browser waits for you to finish signing in. `--login-viewer` closes remote control after a hard 1,800 seconds; protected profile restoration may finish afterward.
-- `--login-viewer` - With `--login` inside Docker, expose the login browser through one token-authenticated noVNC URL on port 6080. Requires a distinct persistent mount containing the configured profile.
+- `--login-timeout SECONDS` - Manual login wait timeout in seconds (default: 1800; 0 = no limit). How long the `--login` browser waits for you to finish signing in. `--login-viewer` caps the effective limit at its 1,800-second viewer wall, so `0` becomes 30 minutes in viewer mode; protected profile restoration may finish afterward.
+- `--login-viewer` - With `--login` inside Docker, expose the login browser through one token-authenticated noVNC URL on port 6080. Requires a writable, non-memory mount covering the authentication root above the configured profile.
 - `--login-inline-wait SECONDS` - Bounded inline wait for a tool call to resume after login completes, in seconds (default: 25, max 45; 0 = return immediately).
 - `--browser-wait SECONDS` - How long to wait for another server process to hand over the shared browser (default: 25, max 45; 0 = report busy at once). Only matters when several MCP clients run at the same time.
 - `--browser-min-hold SECONDS` - Shortest time this process keeps the shared browser before handing it to a waiting process (default: 20, clamped below `--browser-wait` so a waiting client is served before its own timeout; 0 = hand over after every tool call). Raising it means fewer browser restarts but longer waits for other clients.
@@ -306,9 +306,10 @@ On startup, the MCP Bundle starts preparing the shared Patchright Chromium brows
 
 ### Authentication
 
-Docker includes an authenticated, short-lived browser viewer for explicit login. Create the profile directly in the mounted directory:
+Docker includes an authenticated, short-lived browser viewer for explicit login. Create the host directory before mounting it so the unprivileged container user can write the session:
 
 ```bash
+mkdir -p ~/.linkedin-mcp
 docker run -it --rm \
   -v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp \
   -p 127.0.0.1:6080:6080 \
@@ -316,9 +317,9 @@ docker run -it --rm \
   --login --login-viewer
 ```
 
-Open the complete loopback URL printed by the command. Its token stays in the URL fragment, so the initial HTTP request does not carry it. Static viewer files are public on port 6080; the token protects the WebSocket that controls the browser. The viewer fixes client-side scaling, keeps remote resize disabled, and closes after login, failure, a stop signal, or 1,800 seconds. Protected profile restoration may finish after remote control has closed, because interrupting a move on the mounted auth root could split the previous session. The profile mount is required before any existing session can be rotated. For the default profile, use the exact `-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp` mapping above.
+Open the complete loopback URL printed by the command. Its token stays in the URL fragment, so the initial HTTP request does not carry it. Static viewer files are public on port 6080; the token protects the WebSocket that controls the browser. The viewer fixes client-side scaling, keeps remote resize disabled, and closes after login, failure, a stop signal, or 1,800 seconds. Protected profile restoration may finish after remote control has closed, because interrupting a move on the mounted auth root could split the previous session. The profile mount is required before any existing session can be rotated. For the default profile, use the exact `-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp` mapping above. If an older rootful Docker run created that host directory as root, repair it with `sudo chown -R "$(id -u):$(id -g)" ~/.linkedin-mcp`.
 
-You can still create the profile on the host with `uvx mcp-server-linkedin@latest --login` and mount `~/.linkedin-mcp` into Docker. On startup, Docker derives a Linux browser profile from the source cookies and creates a fresh session each time.
+A profile created by the Docker viewer belongs to the container runtime and is reused directly on later Docker startups with the same runtime identity. A profile created on the host with `uvx mcp-server-linkedin@latest --login` or `--import-from-browser` belongs to a foreign runtime, so Docker derives a fresh Linux bridge from its source cookies on each startup.
 
 **Configure Claude Desktop with Docker**
 
@@ -338,7 +339,7 @@ You can still create the profile on the host with `uvx mcp-server-linkedin@lates
 ```
 
 > [!NOTE]
-> Docker creates a fresh session on each startup. Sessions may expire over time. Repeat the Docker viewer command above or run `uvx mcp-server-linkedin@latest --login` on the host.
+> Docker reuses a source profile created by the viewer under the same runtime identity. Host-created and otherwise foreign source profiles use a fresh Linux bridge on each startup. Sessions may expire over time; repeat the Docker viewer command above or run `uvx mcp-server-linkedin@latest --login` on the host.
 
 ### Docker Setup Help
 
@@ -362,8 +363,8 @@ You can still create the profile on the host with `uvx mcp-server-linkedin@lates
 - `--logout` - Clear all stored LinkedIn auth state, including source and derived runtime profiles and any retired sessions
 - `--timeout MS` - Browser timeout for page operations in milliseconds (default: 5000)
 - `--tool-timeout SECONDS` - Per-tool MCP execution timeout in seconds (default: 180.0). Increase further for heavy scrapes / cold-start Chromium / slow networks.
-- `--login-timeout SECONDS` - Manual login wait timeout in seconds (default: 1800; 0 = no limit). How long the `--login` browser waits for you to finish signing in. `--login-viewer` closes remote control after a hard 1,800 seconds; protected profile restoration may finish afterward.
-- `--login-viewer` - With `--login` inside Docker, expose the login browser through one token-authenticated noVNC URL on port 6080. Requires a distinct persistent mount containing the configured profile.
+- `--login-timeout SECONDS` - Manual login wait timeout in seconds (default: 1800; 0 = no limit). How long the `--login` browser waits for you to finish signing in. `--login-viewer` caps the effective limit at its 1,800-second viewer wall, so `0` becomes 30 minutes in viewer mode; protected profile restoration may finish afterward.
+- `--login-viewer` - With `--login` inside Docker, expose the login browser through one token-authenticated noVNC URL on port 6080. Requires a writable, non-memory mount covering the authentication root above the configured profile.
 - `--login-inline-wait SECONDS` - Bounded inline wait for a tool call to resume after login completes, in seconds (default: 25, max 45; 0 = return immediately).
 - `--browser-wait SECONDS` - How long to wait for another server process to hand over the shared browser (default: 25, max 45; 0 = report busy at once). Only matters when several MCP clients run at the same time.
 - `--browser-min-hold SECONDS` - Shortest time this process keeps the shared browser before handing it to a waiting process (default: 20, clamped below `--browser-wait` so a waiting client is served before its own timeout; 0 = hand over after every tool call). Raising it means fewer browser restarts but longer waits for other clients.

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -24,9 +24,10 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 
 ## Quick Start
 
-Docker includes full Chromium and an authenticated viewer for an explicit one-shot login. Create the profile directly in its persistent mount:
+Docker includes full Chromium and an authenticated viewer for an explicit one-shot login. Create the host directory before mounting it so the unprivileged container user can write the session:
 
 ```bash
+mkdir -p ~/.linkedin-mcp
 docker run -it --rm \
   -v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp \
   -p 127.0.0.1:6080:6080 \
@@ -34,9 +35,9 @@ docker run -it --rm \
   --login --login-viewer
 ```
 
-Open the complete loopback URL printed once by the command. The token is generated for that run, stored in a mode-0600 file, and carried in the URL fragment so the initial HTTP request remains token-free. Static noVNC files remain public; the token protects WebSocket control. Remote resize stays disabled, client-side scaling is fixed on, and the viewer closes after login, failure, a stop signal, or 1,800 seconds. Protected profile restoration may finish after remote control has closed, because interrupting a move on the mounted auth root could split the previous session. The command refuses to rotate any existing session unless the configured profile is on a distinct mount.
+Open the complete loopback URL printed once by the command. The token is generated for that run, stored in a mode-0600 file, and carried in the URL fragment so the initial HTTP request remains token-free. Static noVNC files remain public; the token protects WebSocket control. Remote resize stays disabled, client-side scaling is fixed on, and the viewer closes after login, failure, a stop signal, or 1,800 seconds. Protected profile restoration may finish after remote control has closed, because interrupting a move on the mounted auth root could split the previous session. The command refuses to rotate any existing session unless the authentication root above the profile is on a writable, non-memory mount. If an older rootful Docker run created that host directory as root, repair it with `sudo chown -R "$(id -u):$(id -g)" ~/.linkedin-mcp`.
 
-You can alternatively run `uvx mcp-server-linkedin@latest --login` or `--import-from-browser` on the host and mount the resulting `~/.linkedin-mcp` directory. On startup, Docker derives a Linux profile from the source cookies and creates a fresh session each time.
+A profile created by the Docker viewer belongs to the container runtime and is reused directly on later Docker startups with the same runtime identity. A profile created on the host with `uvx mcp-server-linkedin@latest --login` or `--import-from-browser` belongs to a foreign runtime, so Docker derives a fresh Linux bridge from its source cookies on each startup.
 
 **Configure Claude Desktop with Docker**
 
@@ -85,7 +86,7 @@ You can alternatively run `uvx mcp-server-linkedin@latest --login` or `--import-
 | `LOG_LEVEL` | `WARNING` | Logging level: DEBUG, INFO, WARNING, ERROR |
 | `TIMEOUT` | `5000` | Browser timeout in milliseconds |
 | `TOOL_TIMEOUT` | `180` | Per-tool MCP execution timeout in seconds. Increase further for heavy scrapes (multi-section profiles, cold-start Chromium, slow networks/containers). |
-| `LOGIN_TIMEOUT` | `1800` | Manual login wait timeout in seconds (`0` = no ordinary limit). Docker remote control closes after a hard 1,800 seconds; protected profile restoration may finish afterward. |
+| `LOGIN_TIMEOUT` | `1800` | Manual login wait timeout in seconds (`0` = no ordinary limit). The Docker viewer caps the effective limit at its 1,800-second wall, so `0` becomes 30 minutes in viewer mode. Protected profile restoration may finish afterward. |
 | `LOGIN_INLINE_WAIT` | `25` | Bounded inline wait (seconds, max 45) for a tool call to resume after login completes. No effect in normal container server mode; the explicit `--login --login-viewer` command is the Docker login path. |
 | `BROWSER_WAIT` | `25` | How long (seconds, max 45) to wait for another server process to hand over the shared browser before reporting that it is busy. `0` reports busy immediately. |
 | `BROWSER_MIN_HOLD` | `20` | Shortest time (seconds) a process keeps the shared browser before handing it to a waiting process. Higher means fewer browser restarts but longer waits for other clients; clamped below `BROWSER_WAIT` so a waiting client is served before its own timeout. `0` hands over after every tool call. |

--- a/linkedin_mcp_server/login_viewer.py
+++ b/linkedin_mcp_server/login_viewer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import os
 from pathlib import Path
 import re
@@ -19,10 +20,23 @@ from linkedin_mcp_server.session_state import canonical
 VIEWER_WALL_SECONDS = 1800.0
 VIEWER_PORT = 6080
 _MOUNT_ESCAPE = re.compile(r"\\([0-7]{3})")
+# A filesystem held in RAM answers every question a bind mount answers: it is a
+# distinct mount, it is writable, and it is not the container root. It still
+# loses the session when the container stops, which is the one thing the
+# preflight exists to prevent.
+_MEMORY_FILESYSTEMS = frozenset({"tmpfs", "ramfs"})
 
 
 class LoginViewerError(RuntimeError):
     """The Docker login viewer could not be started safely."""
+
+
+@dataclass(frozen=True)
+class MountRecord:
+    """One Linux mountinfo line, reduced to what the preflight judges."""
+
+    point: Path
+    filesystem: str
 
 
 def _decode_mount_field(value: str) -> str:
@@ -30,14 +44,39 @@ def _decode_mount_field(value: str) -> str:
     return _MOUNT_ESCAPE.sub(lambda match: chr(int(match.group(1), 8)), value)
 
 
-def mount_points(mountinfo: str) -> tuple[Path, ...]:
-    """Return canonical-looking mount points from Linux mountinfo text."""
-    points: list[Path] = []
+def mount_records(mountinfo: str) -> tuple[MountRecord, ...]:
+    """Parse Linux mountinfo text into mount points and filesystem types."""
+    records: list[MountRecord] = []
     for line in mountinfo.splitlines():
         fields = line.split()
-        if len(fields) >= 5 and "-" in fields:
-            points.append(Path(_decode_mount_field(fields[4])))
-    return tuple(points)
+        # Fields 0-5 are fixed, then a variable number of optional tags, then
+        # the "-" separator with the filesystem type directly behind it.
+        # Searching from index 6 keeps a mount point spelled "-" from being
+        # mistaken for that separator.
+        separator = next(
+            (index for index in range(6, len(fields)) if fields[index] == "-"), None
+        )
+        if separator is None or separator + 1 >= len(fields):
+            continue
+        records.append(
+            MountRecord(
+                point=Path(_decode_mount_field(fields[4])),
+                filesystem=fields[separator + 1],
+            )
+        )
+    return tuple(records)
+
+
+def mount_points(mountinfo: str) -> tuple[Path, ...]:
+    """Return canonical-looking mount points from Linux mountinfo text."""
+    return tuple(record.point for record in mount_records(mountinfo))
+
+
+def _remedy(profile: Path) -> str:
+    """Name the mount that would make this profile survive the container."""
+    if profile == canonical(Path(DEFAULT_USER_DATA_DIR)):
+        return "Use -v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp and try again."
+    return f"Mount a host directory or named volume at {profile.parent} and try again."
 
 
 def require_persistent_profile_mount(
@@ -45,30 +84,89 @@ def require_persistent_profile_mount(
     *,
     mountinfo_path: Path = Path("/proc/self/mountinfo"),
 ) -> None:
-    """Refuse a viewer login whose result would die with the container."""
+    """Refuse a viewer login whose result would die with the container.
+
+    The authentication root one level above the profile has to persist:
+    ``cookies.json``, ``source-state.json`` and the retired sessions all live
+    there, and a rotation moves the profile *within* that directory.
+    """
     profile = canonical(profile_dir)
+    auth_root = profile.parent
     try:
-        points = mount_points(mountinfo_path.read_text(encoding="utf-8"))
+        records = mount_records(mountinfo_path.read_text(encoding="utf-8"))
     except OSError as exc:
         raise LoginViewerError(
             f"Cannot verify the Docker profile mount from {mountinfo_path}: {exc}"
         ) from exc
+    remedy = _remedy(profile)
 
-    persistent = any(
-        point != Path("/") and (point == profile or point in profile.parents)
-        for point in points
-    )
-    if persistent:
+    # A mount on the profile, or anywhere inside it, is worse than no mount at
+    # all. Rotation moves that directory aside, and a mountpoint cannot be
+    # moved: `shutil.move` falls back to copy-then-delete across devices, so the
+    # session is duplicated and emptied before the rename fails with EBUSY.
+    for record in records:
+        if record.point == profile or profile in record.point.parents:
+            raise LoginViewerError(
+                f"--login-viewer cannot rotate the profile: {record.point} is "
+                "itself a mount point, and retiring a session moves that "
+                "directory. Mount the authentication root "
+                f"{auth_root} instead, so the profile can move inside it. "
+                f"{remedy}"
+            )
+
+    # The nearest covering mount is the one the authentication root lives on. An
+    # ancestor further up describes a different filesystem once something closer
+    # is mounted over it, so it cannot answer for this directory.
+    covering = [
+        record
+        for record in records
+        if record.point == auth_root or record.point in auth_root.parents
+    ]
+    boundary = max(covering, key=lambda record: len(record.point.parts), default=None)
+    if boundary is None or boundary.point == Path("/"):
+        raise LoginViewerError(
+            "--login-viewer requires the configured profile to be on a distinct "
+            f"persistent mount, but {auth_root} is part of the container "
+            f"filesystem and is discarded with it. {remedy}"
+        )
+    if boundary.filesystem in _MEMORY_FILESYSTEMS:
+        raise LoginViewerError(
+            "--login-viewer requires the configured profile to be on a distinct "
+            f"persistent mount, but {boundary.point} is a {boundary.filesystem} "
+            f"filesystem held in memory and discarded with the container. "
+            f"{remedy}"
+        )
+    _require_a_writable_auth_root(auth_root, profile=profile)
+
+
+def _require_a_writable_auth_root(auth_root: Path, *, profile: Path) -> None:
+    """Refuse before rotation when the persistent root cannot be written.
+
+    Docker seeds a named volume from the image, so a volume for a path the image
+    never created arrives as ``root:root``. So does a host directory that an
+    earlier rootful ``docker run`` created. Either way the unprivileged runtime
+    only finds out on its first write, which happens after the previous session
+    has already been moved aside.
+    """
+    existing = auth_root
+    while not existing.exists() and existing != existing.parent:
+        existing = existing.parent
+    if existing.is_dir() and os.access(existing, os.W_OK | os.X_OK):
         return
 
-    default_profile = canonical(Path(DEFAULT_USER_DATA_DIR))
-    if profile == default_profile:
-        remedy = "-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp"
+    identity = ""
+    repair = "give the mounted host directory to the container user"
+    if hasattr(os, "geteuid"):
+        identity = f" by uid {os.geteuid()}"
+        repair = f"sudo chown -R {os.geteuid()}:{os.getegid()} <host directory>"
+    if profile == canonical(Path(DEFAULT_USER_DATA_DIR)):
+        create = "Create it first with mkdir -p ~/.linkedin-mcp"
     else:
-        remedy = f"mount a host directory or named volume at {profile.parent}"
+        create = "Create the mounted host directory before starting the container"
     raise LoginViewerError(
-        "--login-viewer requires the configured profile to be on a distinct "
-        f"persistent mount. Use {remedy} and try again."
+        f"--login-viewer cannot write the authentication root {auth_root}: "
+        f"{existing} is not writable{identity}. {create}, or repair a root-owned "
+        f"one with {repair}."
     )
 
 

--- a/linkedin_mcp_server/setup.py
+++ b/linkedin_mcp_server/setup.py
@@ -238,10 +238,16 @@ async def _login_into_fresh_profile(
     caller must not release the profile when it was not: Chromium may still be
     holding it.
     """
-    login_timeout_ms = int(config.browser.login_timeout_seconds * 1000)
+    login_timeout_seconds = config.browser.login_timeout_seconds
+    login_timeout_ms = int(login_timeout_seconds * 1000)
 
-    if config.browser.login_timeout_seconds:
-        budget = f"{config.browser.login_timeout_seconds / 60:.0f} minutes"
+    effective_timeout = login_timeout_seconds
+    if login_viewer and (
+        not effective_timeout or VIEWER_WALL_SECONDS < effective_timeout
+    ):
+        effective_timeout = VIEWER_WALL_SECONDS
+    if effective_timeout:
+        budget = f"{effective_timeout / 60:.0f} minutes"
     else:
         budget = "no time limit"
 

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -23,6 +23,8 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _DOCKERFILE = (_REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
 _ENTRYPOINT_PATH = _REPO_ROOT / "docker-entrypoint.sh"
 _ENTRYPOINT = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+_README = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
+_DOCKER_GUIDE = (_REPO_ROOT / "docs" / "docker-hub.md").read_text(encoding="utf-8")
 
 
 def test_the_image_installs_only_the_full_browser() -> None:
@@ -34,6 +36,23 @@ def test_the_image_defaults_to_headed_on_a_virtual_display() -> None:
     assert "ENV HEADLESS=false" in _DOCKERFILE
     assert "ENV DISPLAY=:99" in _DOCKERFILE
     assert 'Xvfb "$DISPLAY" -screen 0 1920x1080x24 -nolisten tcp' in _ENTRYPOINT
+
+
+def test_the_image_seeds_the_default_authentication_root_for_named_volumes() -> None:
+    creation = _DOCKERFILE.index(
+        "RUN install -d -m 0700 -o pwuser -g pwuser /home/pwuser/.linkedin-mcp"
+    )
+    unprivileged_runtime = _DOCKERFILE.index("USER pwuser")
+
+    assert creation < unprivileged_runtime
+
+
+def test_the_documented_bind_mount_is_created_by_the_host_user() -> None:
+    for document in (_README, _DOCKER_GUIDE):
+        assert "mkdir -p ~/.linkedin-mcp" in document
+        assert 'sudo chown -R "$(id -u):$(id -g)" ~/.linkedin-mcp' in document
+        assert "created by the Docker viewer" in document
+        assert "belongs to a foreign runtime" in document
 
 
 def test_the_supervisor_stops_python_before_the_display() -> None:

--- a/tests/test_login_viewer.py
+++ b/tests/test_login_viewer.py
@@ -75,6 +75,88 @@ def test_mount_preflight_accepts_a_distinct_ancestor_mount(tmp_path: Path) -> No
     require_persistent_profile_mount(profile, mountinfo_path=mountinfo)
 
 
+def test_mount_preflight_accepts_the_authentication_root_mount(tmp_path: Path) -> None:
+    profile = tmp_path / "auth-root" / "profile"
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text(
+        f"36 25 0:31 / / rw - overlay overlay rw\n"
+        f"51 36 8:1 / {profile.parent} rw - ext4 /dev/sda rw\n",
+        encoding="utf-8",
+    )
+
+    require_persistent_profile_mount(profile, mountinfo_path=mountinfo)
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_mount_preflight_rejects_mounts_at_or_inside_the_profile(
+    tmp_path: Path, nested: bool
+) -> None:
+    profile = tmp_path / "auth-root" / "profile"
+    mount_point = profile / "Default" if nested else profile
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text(
+        f"36 25 0:31 / / rw - overlay overlay rw\n"
+        f"50 36 8:1 / {profile.parent} rw - ext4 /dev/sda rw\n"
+        f"51 50 8:2 / {mount_point} rw - ext4 /dev/sdb rw\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(LoginViewerError, match="cannot rotate the profile"):
+        require_persistent_profile_mount(profile, mountinfo_path=mountinfo)
+
+
+@pytest.mark.parametrize("filesystem", ["tmpfs", "ramfs"])
+def test_mount_preflight_rejects_a_memory_backed_authentication_root(
+    tmp_path: Path, filesystem: str
+) -> None:
+    profile = tmp_path / "persistent" / "auth-root" / "profile"
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text(
+        f"36 25 0:31 / / rw - overlay overlay rw\n"
+        f"50 36 8:1 / {profile.parents[1]} rw - ext4 /dev/sda rw\n"
+        f"51 50 0:51 / {profile.parent} rw - {filesystem} {filesystem} rw\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(LoginViewerError, match=filesystem):
+        require_persistent_profile_mount(profile, mountinfo_path=mountinfo)
+
+
+def test_mount_preflight_uses_the_most_specific_covering_mount(tmp_path: Path) -> None:
+    profile = tmp_path / "persistent" / "auth-root" / "nested" / "profile"
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text(
+        f"36 25 0:31 / / rw - overlay overlay rw\n"
+        f"50 36 0:51 / {profile.parents[2]} rw - tmpfs tmpfs rw\n"
+        f"51 50 8:1 / {profile.parents[1]} rw - ext4 /dev/sda rw\n",
+        encoding="utf-8",
+    )
+
+    require_persistent_profile_mount(profile, mountinfo_path=mountinfo)
+
+
+def test_mount_preflight_rejects_an_unwritable_authentication_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile = tmp_path / "auth-root" / "profile"
+    profile.mkdir(parents=True)
+    marker = profile / "session-marker"
+    marker.write_text("unchanged", encoding="utf-8")
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text(
+        f"36 25 0:31 / / rw - overlay overlay rw\n"
+        f"51 36 8:1 / {profile.parent} rw - ext4 /dev/sda rw\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(viewer_module.os, "access", lambda *_args: False)
+
+    with pytest.raises(LoginViewerError, match="is not writable") as error:
+        require_persistent_profile_mount(profile, mountinfo_path=mountinfo)
+
+    assert "mkdir -p ~/.linkedin-mcp" not in str(error.value)
+    assert marker.read_text(encoding="utf-8") == "unchanged"
+
+
 def test_mount_preflight_rejects_only_the_container_root(tmp_path: Path) -> None:
     mountinfo = tmp_path / "mountinfo"
     mountinfo.write_text("36 25 0:31 / / rw - overlay overlay rw\n", encoding="utf-8")
@@ -286,6 +368,61 @@ async def test_viewer_signal_cancels_and_awaits_login_cleanup() -> None:
 
     assert interrupted.value.signum == signal.SIGTERM
     assert cleaned is True
+
+
+@pytest.mark.parametrize(
+    ("login_timeout", "login_viewer", "expected_budget"),
+    [
+        (0, False, "no time limit"),
+        (3600, False, "60 minutes"),
+        (0, True, "30 minutes"),
+        (600, True, "10 minutes"),
+        (3600, True, "30 minutes"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_login_prompt_reports_the_effective_viewer_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    login_timeout: float,
+    login_viewer: bool,
+    expected_budget: str,
+) -> None:
+    import linkedin_mcp_server.setup as setup
+
+    class Manager:
+        close_confirmed = True
+
+    class Viewer:
+        def start_window_manager(self) -> None:
+            pass
+
+        def stop_window_manager(self) -> None:
+            pass
+
+    async def login_succeeds(*_args: object, **_kwargs: object) -> bool:
+        return True
+
+    config = SimpleNamespace(
+        browser=SimpleNamespace(login_timeout_seconds=login_timeout, slow_mo=0)
+    )
+    monkeypatch.setattr(setup, "build_launch_options", lambda _config: ({}, None))
+    monkeypatch.setattr(setup, "describe_launch", lambda _options: None)
+    monkeypatch.setattr(setup, "BrowserManager", lambda **_kwargs: Manager())
+    monkeypatch.setattr(setup, "LoginViewer", Viewer)
+    monkeypatch.setattr(setup, "_run_login", login_succeeds)
+
+    assert await setup._login_into_fresh_profile(
+        tmp_path / "profile",
+        config=config,
+        state=setup._LoginState(),
+        login_viewer=login_viewer,
+    )
+
+    assert f"You have {expected_budget} to complete authentication" in (
+        capsys.readouterr().out
+    )
 
 
 def test_viewer_hard_cap_applies_when_login_timeout_is_unlimited(


### PR DESCRIPTION
Closes #713

The Docker login viewer accepted mount layouts that could lose the session or damage an existing mounted profile. A mount exactly on `USER_DATA_DIR` left the required sidecars outside the mount and could be emptied during rotation before `rmtree()` failed on the mountpoint. Memory-backed authentication roots also passed as persistent, while a fresh named volume was root-owned and unwritable by the image's `pwuser`.

The preflight now parses filesystem types from Linux mountinfo, requires the effective mount covering the complete authentication root, rejects `tmpfs`, `ramfs`, and mounts at or below the profile, and checks writability before logging or profile mutation. The image seeds `/home/pwuser/.linkedin-mcp` as `pwuser:pwuser` mode `0700`, so fresh named volumes inherit usable ownership. The documented bind-mount flow creates the host directory first and includes recovery for directories created by older rootful Docker runs.

The login prompt now reports the effective viewer budget: the configured login timeout capped at the 1,800-second viewer wall, with `LOGIN_TIMEOUT=0` shown as 30 minutes in viewer mode. Docker documentation now distinguishes same-runtime profiles created by the viewer, which are reused directly, from foreign host profiles, which receive a fresh Linux bridge on startup.

Verified with 1,968 tests passing and 11 platform skips, 17 slow tests passing, clean Ruff, formatting, Ty, and pre-commit checks, plus a fresh Docker image proving that a named volume is writable, an exact profile mount is rejected without mutation, `tmpfs` is rejected, an authentication-root bind mount is accepted, and ordinary HTTP shutdown exits cleanly.

## Synthetic prompt

> Fix #713 by requiring Docker login viewer mounts to cover the writable, non-memory authentication root, rejecting mounts at or below the profile, seeding fresh named-volume ownership, reporting the effective wall-capped login budget, and correcting Docker session lifecycle documentation. Add focused regression tests and disposable Docker probes.

Generated with Sol 5.6 high + Sol 5.6 medium
