### PR TITLE
chore: Bump version to 4.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-linkedin"
-version = "4.21.0"
+version = "4.22.0"
 description = "MCP server that gives AI assistants like Claude access to LinkedIn profiles, companies, and job postings through the user's own browser session."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-linkedin"
-version = "4.21.0"
+version = "4.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Ships the greenlet 3.5.5 pin (#716), so the MCPB bundle stops installing an extension that needs `MSVCP140.dll` on Windows, alongside the Docker login viewer (#711), the Xvfb fix (#705), the viewer session mount protection (#714), and the retained browser cache warning (#712).

The release workflow updates `manifest.json` and `docker-compose.yml`.