### PR TITLE
fix(scraping): wait for job description hydration before extraction

### DIFF
--- a/docs/plans/2026-08-11-001-fix-job-details-hydration-wait-plan.md
+++ b/docs/plans/2026-08-11-001-fix-job-details-hydration-wait-plan.md
@@ -1,0 +1,192 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+title: "fix: Wait for job description hydration in get_job_details"
+plan_type: fix
+created: 2026-08-11
+origin: https://github.com/stickerdaniel/linkedin-mcp-server/issues/687
+---
+
+# fix: Wait for job description hydration in get_job_details
+
+## Summary
+
+`get_job_details` intermittently returns a `job_posting` section that is
+missing the "About the job" description block, even though everything before
+and after that block extracted correctly. An immediate retry on the same job
+id succeeds. This is a race between LinkedIn's client-side hydration of the
+description panel and the extractor's fixed scroll-wait budget, not a
+truncation or selector bug. Fix: mirror the existing hydration-wait pattern
+(`is_activity`, `is_search`, `is_company_people`, `is_details`) with a new
+`is_job` branch that waits for the description content to actually appear in
+`<main>` before extraction proceeds.
+
+## Problem Frame
+
+`linkedin_mcp_server/scraping/extractor.py`'s `_extract_loaded_section`
+(`extractor.py:1497`) runs a shared post-navigation pipeline for every page
+type: wait for `<main>` to exist, dismiss modals, then apply one or more
+page-type-specific hydration waits before scrolling and reading
+`main.innerText`. Four page types already get a targeted `wait_for_function`
+guard because their content hydrates asynchronously after `<main>` first
+renders:
+
+- `is_activity` (`/recent-activity/`, company `/posts`) — waits for
+  `main.innerText.length > 200`
+- `is_search` (`/search/results/`) — waits for `main.innerText.length > 100`
+- `is_company_people` (`/company/.../people/`) — waits for an `a[href*="/in/"]`
+  anchor to appear
+- `is_details` (`/details/...`) — waits for the sidebar placeholder text to be
+  replaced, then clicks any "Show more" button
+
+`/jobs/view/<id>/` job pages (`scrape_job`, `extractor.py:3025`) go through
+the same `extract_page` → `_extract_loaded_section` path but have no branch
+at all. Extraction falls straight through to the generic 5-iteration,
+0.5s-pause scroll loop and then reads `innerText` unconditionally. When the
+description panel hydrates after that fixed window, the reader captures the
+job header, apply/save chrome, and trailing boilerplate, but the description
+block that would have sat in between never rendered — producing a
+normal-looking result with a silent gap.
+
+This is a distinct root cause from PR #559 (open, unmerged), which adds an
+`is_job` branch to click a `button.show-more-less-html__button--more` "See
+more" toggle that expands an `overflow-hidden` collapsed description.
+Collapsed content is still present in `innerText` regardless of expansion
+state, and the issue reporter reproduced the bug with no code change between
+a failing and a succeeding call on the same job id — ruling out a
+collapse/expand mechanism as the cause. This plan does not touch or duplicate
+PR #559's click-to-expand fix; it addresses the separate hydration-timing gap
+the issue also names. Both may reasonably land independently.
+
+## Requirements
+
+- R1: `get_job_details` must not return a result missing the "About the job"
+  description block when the block would have appeared given more time —
+  i.e., extraction must wait for the description content to hydrate rather
+  than relying on the fixed scroll budget alone.
+- R2: The fix must follow the existing `_extract_loaded_section` branch
+  pattern (a URL-path check plus a bounded `wait_for_function`) rather than
+  introducing a new waiting mechanism or architecture.
+- R3: The wait must be bounded and must not raise on timeout — consistent
+  with every existing branch, a timed-out wait logs at debug level and falls
+  through to extraction as-is (partial-content-over-exception is the
+  established contract for this function).
+- R4: The change must not alter behavior for any non-job URL path.
+
+## Key Technical Decisions
+
+**KTD1: Detect hydration by polling for the description text marker, not a CSS class.**
+Wait for `main.innerText` to contain the literal string `"About the job"`
+(the heading LinkedIn renders directly above the description body, per the
+issue's own structural diff) rather than a `.jobs-description__content`-style
+selector. Rationale: `is_activity`/`is_search` already use innerText content
+heuristics rather than brittle class-name selectors, and PR #559's discussion
+shows LinkedIn's job-page DOM/class names change independently of this
+concern — polling for the rendered heading text is more resilient and keeps
+this branch symmetric with its two closest siblings. Alternative considered:
+waiting for a specific description container selector — rejected because it
+reintroduces the class-name fragility this codebase already avoids elsewhere
+in this function, and because scoping to the same evidence the bug report
+used (the "About the job" heading itself) is the most direct way to close
+the exact gap described.
+
+**KTD2: Match the `is_search` timeout and log style (10s, debug-level, no raise).**
+Reuses the existing constant timeout value and logging convention already
+used by `is_activity`/`is_search` rather than introducing a new tunable —
+keeps the branch a same-shape addition, not a new pattern.
+
+## Scope Boundaries
+
+**In scope:**
+- Add an `is_job` branch to `_extract_loaded_section` that waits for the
+  "About the job" text marker to appear in `<main>` before the scroll/extract
+  step runs, for `/jobs/view/` URLs.
+- Add test coverage for the new branch (waits when on a job URL, does not
+  wait on non-job URLs, proceeds gracefully on timeout).
+
+**Out of scope / deferred to follow-up work:**
+- PR #559's "See more" collapsed-description click fix — separate mechanism,
+  separate PR, not duplicated here.
+- The issue's secondary suggestion to surface an explicit `section_errors`
+  entry when the description never appears even after the wait — the issue
+  frames this as a "relatedly" nice-to-have, not the core defect, and adding
+  it would require a way to distinguish "genuinely no description" (some job
+  postings are terse) from "extraction incomplete," which is a separate
+  design question from the hydration-timing race this plan closes.
+
+## Implementation Units
+
+### U1. Add `is_job` hydration-wait branch to `_extract_loaded_section`
+
+**Goal:** Wait for the job description to hydrate before extraction, closing
+the race described in issue #687.
+
+**Requirements:** R1, R2, R3, R4 (KTD1, KTD2)
+
+**Dependencies:** none
+
+**Files:**
+- `linkedin_mcp_server/scraping/extractor.py` (modify `_extract_loaded_section`)
+
+**Approach:**
+1. In `_extract_loaded_section`, after the existing `is_details` block and
+   before the "Scroll to trigger lazy loading" section (`extractor.py`
+   around line 1626), add:
+   - `is_job = "/jobs/view/" in path` (reuse the `path` variable already
+     computed at the top of the function for `is_activity`, matching the
+     parsed-path convention so a query string on the URL is handled
+     correctly, same as `is_activity`).
+   - A `wait_for_function` call polling
+     `main.innerText.includes('About the job')`, wrapped in the same
+     `try`/`except PlaywrightTimeoutError` + `logger.debug(...)` shape used
+     by `is_activity`/`is_search`, with a 10000ms timeout (KTD2).
+2. Do not add a "Show more" click loop for `is_job` — that belongs to PR
+   #559's separate fix, not this branch.
+3. Leave every other branch (`is_activity`, `is_search`, `is_company_people`,
+   `is_details`) and the scroll loop below unchanged.
+
+**Patterns to follow:** the `is_search` branch immediately above (same
+`wait_for_function` + timeout + debug-log-on-timeout shape); `is_activity`
+for the `path`-based URL match convention.
+
+**Test scenarios:**
+- Job URL (`/jobs/view/12345/`) triggers `wait_for_function` exactly once
+  (mirrors `test_search_results_page_waits_for_content`).
+- Non-job URL (e.g. a plain profile URL) does not trigger the job wait
+  (mirrors `test_non_search_page_does_not_wait_for_search_content`).
+- Job URL where the wait times out (`PlaywrightTimeoutError` raised by the
+  mocked `wait_for_function`) still returns extracted text instead of
+  raising — extraction proceeds gracefully (mirrors
+  `test_search_results_timeout_proceeds_gracefully`).
+- `scrape_job` end-to-end: with `_extract_loaded_section`'s new branch in
+  place and a mocked page whose `innerText` includes "About the job" text,
+  `scrape_job` returns a `job_posting` section containing that text (covers
+  the reported symptom directly — the description is present in the
+  result).
+
+**Verification:** All new and existing tests in `tests/test_scraping.py`
+pass; the new `is_job` branch behaves identically in shape to `is_search`
+when compared side-by-side in the diff.
+
+## Test File
+
+- `tests/test_scraping.py` — add the new test cases alongside the existing
+  `test_search_results_page_waits_for_content` /
+  `test_non_search_page_does_not_wait_for_search_content` /
+  `test_search_results_timeout_proceeds_gracefully` group (around line 3996)
+  and the `test_scrape_job*` group (around line 2150).
+
+## Definition of Done
+
+- `is_job` branch added to `_extract_loaded_section`, following the
+  established branch pattern (URL-path check + bounded, non-raising
+  `wait_for_function`).
+- New tests cover: wait triggers on job URLs, wait does not trigger on
+  non-job URLs, timeout degrades gracefully, and `scrape_job` returns the
+  description text when present.
+- Full existing test suite (`tests/test_scraping.py`, `tests/test_tools.py`)
+  still passes — no regression to `is_activity`/`is_search`/
+  `is_company_people`/`is_details` behavior.
+- No changes made to PR #559's territory (the "Show more" click mechanism).

--- a/docs/plans/2026-08-11-002-fix-job-hydration-locale-table-plan.md
+++ b/docs/plans/2026-08-11-002-fix-job-hydration-locale-table-plan.md
@@ -1,0 +1,112 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+title: "fix: guard job-hydration text check with a per-locale table"
+plan_type: fix
+created: 2026-08-11
+origin: https://github.com/stickerdaniel/linkedin-mcp-server/pull/718 (Greptile review comment)
+---
+
+# fix: guard job-hydration text check with a per-locale table
+
+## Summary
+
+PR #718 added an `is_job` hydration-wait branch to `_extract_loaded_section`
+(`extractor.py:1626-1646`) that polls `main.innerText.includes('About the
+job')` before extracting a `/jobs/view/` page, closing the race from issue
+#687. Greptile's automated review flagged that this keys on a single literal
+English string: on a LinkedIn UI rendered in another language, the check
+never matches, the full timeout elapses, and the original race is
+unresolved for that locale. A prior review pass already added a comment
+documenting this gap (commit f8579cf) but did not fix it.
+
+Fix: replace the single hardcoded string with a small per-locale table of
+equivalent headings, checked via "does innerText contain any known-locale
+heading" — mirroring an existing, established pattern in this exact file
+(`_MESSAGING_CHROME_STRINGS`, `extractor.py:664`) rather than inventing a new
+mechanism.
+
+## Problem Frame
+
+`AGENTS.md`'s Scraping Rules state: "Detection must be locale-independent... Where text is genuinely the only signal, guard it behind an explicit per-locale table and document the limitation in code." The current `is_job` branch does neither — it embeds one English string directly in the `wait_for_function` predicate with only a comment noting the gap.
+
+This codebase already has a template for exactly this situation:
+`_MESSAGING_CHROME_STRINGS` (`extractor.py:664`) is a `dict[str, _MessagingChromeTable]` keyed by locale, used by `strip_conversation_chrome()`. Its own comment states the browser context locale is forced to `en-US` (`core/browser.py:262`), so the `"en"` entry is the one that actually fires in practice today; other locale entries exist for defense-in-depth and fall through gracefully (unmatched locale keeps original behavior) rather than crashing or hard-failing.
+
+The `is_job` branch differs in one respect: `strip_conversation_chrome` receives an explicit `locale` parameter from its caller (always `"en"` today — never wired to a real per-request locale), whereas the `wait_for_function` JS predicate has no Python-side locale context to select a single table entry. The fix should check the innerText against *all* configured heading variants rather than needing to pick one — cheap, since the table stays small, and consistent with "an unmatched/unknown case degrades gracefully" instead of guessing a locale.
+
+## Requirements
+
+- R1: The hydration-wait predicate must no longer rely on a single hardcoded English string; it must check against an explicit, named per-locale table, per `AGENTS.md`'s Scraping Rules.
+- R2: The table must be modeled on the existing `_MESSAGING_CHROME_STRINGS` pattern in the same file (same file, same shape of "small dict + documented limitation"), not a new mechanism.
+- R3: The table is best-effort and non-exhaustive — this must be stated in a comment, matching the existing precedent's honesty about being incomplete.
+- R4: Existing English-locale behavior and tests must continue to pass unchanged (regression safety).
+- R5: At least one additional locale's heading must be added and proven by a new test to now also trigger the wait correctly, demonstrating the original race is closed for that locale too.
+- R6: The fix stays scoped to the `is_job` branch added in PR #718 — no changes to `_MESSAGING_CHROME_STRINGS`, `strip_conversation_chrome`, or any other hydration-wait branch (`is_activity`, `is_search`, `is_company_people`, `is_details`).
+
+## Key Technical Decisions
+
+**KTD1: Model the new table as a plain `dict[str, str]` (locale -> heading text), not a dataclass.**
+`_MessagingChromeTable` is a dataclass because it groups multiple distinct chrome-boundary strings per locale. The job-hydration case needs exactly one string per locale (the heading), so a flat `dict[str, str]` is the right-sized equivalent — same *pattern* (locale-keyed table, documented limitation, graceful degradation), without copying structure the job case doesn't need. Alternative considered: reusing `_MessagingChromeTable`'s shape — rejected as over-structured for a single string per locale.
+
+**KTD2: Check "innerText contains any of the table's values", not "look up one locale and check that value".**
+`strip_conversation_chrome` can look up a single entry because its caller supplies an explicit `locale` parameter (defaulted to `"en"`, never dynamically set today). The `wait_for_function` predicate runs inside the browser with no such parameter — Python has no reliable signal for which locale the current page is actually rendering in (the forced `en-US` context locale is a *browser* setting, not a *guaranteed* observed page-render language). Checking membership against the full set of configured heading strings is cheap at this table's size and avoids needing to plumb a locale value through `_extract_loaded_section` for a single call site. Alternative considered: accepting a `locale` parameter on `_extract_loaded_section` mirroring `strip_conversation_chrome` — rejected as unnecessary plumbing; nothing in the current call chain has a real per-request locale to pass, so the parameter would always be the same hardcoded default in practice.
+
+**KTD3: Cover a small, explicitly best-effort set of locales — not an exhaustive list.**
+Per the plan's scope instruction and `AGENTS.md`'s own tone ("guard it behind an explicit per-locale table" — a table, not a claim of completeness), add 2-3 widely-used LinkedIn UI locales beyond English (e.g. German, Spanish, French) as a representative, documented-as-partial set. This mirrors `_MESSAGING_CHROME_STRINGS` currently shipping with only one (`"en"`) entry — the point is the *mechanism* for adding more later, not exhaustive day-one coverage.
+
+## Scope Boundaries
+
+**In scope:**
+- Replace the single English string in the `is_job` `wait_for_function` predicate (`extractor.py:1636-1646`) with a lookup against a new small per-locale heading table.
+- Add the new table near `_MESSAGING_CHROME_STRINGS` or directly above the `is_job` branch (implementer's call on ordering — cite the existing precedent as the pattern to place it near).
+- Update the existing one-line comment (added in f8579cf) to reflect that the limitation is now mitigated (best-effort table) rather than fully open.
+- Add test coverage: existing English-path tests continue to pass unmodified where possible; add at least one new test proving a non-English heading now also triggers the wait.
+
+**Out of scope / deferred to follow-up work:**
+- Wiring a real per-request locale signal through `_extract_loaded_section` / `scrape_job` (the `strip_conversation_chrome`-style `locale` parameter) — nothing in the current call chain has one to provide; this would be new plumbing beyond the reported issue.
+- Exhaustive locale coverage — the table is explicitly best-effort, matching the existing `_MESSAGING_CHROME_STRINGS` precedent (currently one entry).
+- Any other hydration-wait branch's text-based checks (`is_details`'s "Load more"/"More profiles for you" checks have the same underlying English-only limitation, per the earlier review comment on this PR) — those are pre-existing and outside this PR's diff.
+
+## Implementation Units
+
+### U1. Replace the hardcoded English heading with a per-locale table lookup
+
+**Goal:** Close the locale gap Greptile flagged, without duplicating or rewriting the surrounding hydration-wait mechanism.
+
+**Requirements:** R1, R2, R3, R4, R5, R6 (KTD1, KTD2, KTD3)
+
+**Dependencies:** none (builds directly on PR #718's already-merged-to-branch `is_job` branch)
+
+**Files:**
+- `linkedin_mcp_server/scraping/extractor.py` (modify the `is_job` branch and add the new table)
+- `tests/test_scraping.py` (extend existing job-hydration test group)
+
+**Approach:**
+1. Add a small module-level table near the `is_job` branch (or beside `_MESSAGING_CHROME_STRINGS`, matching KTD1):
+   - `_JOB_DESCRIPTION_HEADINGS: dict[str, str] = {"en": "About the job", ...}` with 2-3 additional locale entries (KTD3). Use the actual LinkedIn-rendered heading text for each added locale (implementer should use best available knowledge of LinkedIn's UI strings for common locales — e.g. German "Über den Job", or whatever the accurate rendered string is; if genuinely uncertain of the exact production string for a given locale, prefer fewer, verifiably-accurate entries over more guessed ones).
+   - A comment stating the table is best-effort/non-exhaustive (R3), referencing the same limitation language already used for `_MESSAGING_CHROME_STRINGS`.
+2. In the `is_job` `wait_for_function` call, change the JS predicate from a single `.includes('About the job')` check to checking membership against the table's values — pass the table's values into the page function (e.g. as a JS array literal built from `list(_JOB_DESCRIPTION_HEADINGS.values())`) and check `main.innerText` against each with `.some(...)` or equivalent, per KTD2.
+3. Update the existing limitation comment (from f8579cf) to describe the mitigation: still text-based and still not exhaustive, but now covers more than one locale via the table, consistent with R3.
+4. Do not touch `_MESSAGING_CHROME_STRINGS`, `strip_conversation_chrome`, or any other `_extract_loaded_section` branch.
+
+**Patterns to follow:** `_MESSAGING_CHROME_STRINGS` (`extractor.py:664`) for the locale-table shape and its accompanying documented-limitation comment style; the existing `is_search`/`is_activity` branches for how a `wait_for_function` JS string is constructed and passed.
+
+**Test scenarios:**
+- Regression: a job page whose innerText contains the English heading ("About the job") still triggers `wait_for_function` and resolves — covers the existing `test_job_page_waits_for_description_content` case; verify it still passes unmodified (or with only mechanical updates if the predicate string changed shape).
+- New locale coverage: a job page whose innerText contains one of the newly-added non-English headings (and does *not* contain the English string) triggers the wait and successfully resolves — proving the race is now also closed for that locale. Covers R5.
+- Negative/regression: a non-job URL still does not trigger the wait at all (existing `test_non_job_page_does_not_wait_for_job_content` — unaffected by this change, verify it still passes).
+- Timeout still degrades gracefully: a job page whose innerText matches none of the table's headings (e.g. an unlisted locale) times out and falls through to extract available text, same as before (existing `test_job_page_timeout_proceeds_gracefully` — verify unaffected).
+
+**Verification:** All four scenarios above pass; the full existing test suite (`tests/test_scraping.py`, `tests/test_tools.py`) has no regressions; the diff is scoped to the `is_job` branch, its new table, and its tests only.
+
+## Definition of Done
+
+- `is_job` branch checks against a small, named, per-locale heading table instead of one hardcoded English string.
+- Table and its limitation are documented in code, matching the existing `_MESSAGING_CHROME_STRINGS` precedent's tone and shape.
+- New test proves at least one non-English locale now correctly triggers the hydration wait.
+- All pre-existing job-hydration tests (English case, non-job isolation, timeout fallback) still pass.
+- Full test suite passes with no regressions.
+- No changes outside `extractor.py`'s `is_job` branch/new table and `test_scraping.py`'s job-hydration test group.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1623,6 +1623,26 @@ class LinkedInExtractor:
                     logger.debug("Show more click failed: %s", e)
                     break
 
+        # Job detail pages (/jobs/view/<id>/) initially render the header,
+        # apply/save chrome, and boilerplate into <main> while the "About the
+        # job" description panel hydrates asynchronously. Wait for the
+        # description heading to actually appear before extracting, rather
+        # than relying on the fixed scroll budget below — otherwise a page
+        # whose description hydrates late is extracted without it.
+        is_job = "/jobs/view/" in path
+        if is_job:
+            try:
+                await self._page.wait_for_function(
+                    """() => {
+                        const main = document.querySelector('main');
+                        if (!main) return false;
+                        return main.innerText.includes('About the job');
+                    }""",
+                    timeout=10000,
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Job description content did not appear on %s", url)
+
         # Scroll to trigger lazy loading
         if is_activity:
             scrolls = max_scrolls if max_scrolls is not None else 10

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1629,6 +1629,10 @@ class LinkedInExtractor:
         # description heading to actually appear before extracting, rather
         # than relying on the fixed scroll budget below — otherwise a page
         # whose description hydrates late is extracted without it.
+        # NOTE: keys on the literal English heading text (no locale-agnostic
+        # signal — e.g. aria-label/structural — identifies this panel), so
+        # this wait is a no-op on non-English locales and falls through to
+        # the fixed scroll budget there, same as it would without this branch.
         is_job = "/jobs/view/" in path
         if is_job:
             try:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -739,6 +739,24 @@ def strip_conversation_chrome(text: str, locale: str = "en") -> str:
     return "\n".join(lines[start:end]).strip()
 
 
+# Job-view (/jobs/view/<id>/) description-panel heading, keyed by locale. The
+# panel has no URL or attribute signal marking it hydrated, so — per AGENTS.md
+# Scraping Rules — the text-based check is guarded behind this explicit table
+# rather than a single hardcoded string. Best-effort and non-exhaustive, same
+# as _MESSAGING_CHROME_STRINGS above: the browser context locale is forced to
+# en-US (core/browser.py), so "en" is the entry that fires in practice today;
+# the rest are defense-in-depth for accounts LinkedIn renders in another
+# language regardless of browser locale. An unlisted locale simply falls
+# through to the original fixed-scroll-budget race, same as before this table
+# existed.
+_JOB_DESCRIPTION_HEADINGS: dict[str, str] = {
+    "en": "About the job",
+    "de": "Über den Job",
+    "es": "Sobre el empleo",
+    "fr": "À propos de l'offre",
+}
+
+
 class LinkedInExtractor:
     """Extracts LinkedIn page content via navigate-scroll-innerText pattern."""
 
@@ -1624,24 +1642,25 @@ class LinkedInExtractor:
                     break
 
         # Job detail pages (/jobs/view/<id>/) initially render the header,
-        # apply/save chrome, and boilerplate into <main> while the "About the
-        # job" description panel hydrates asynchronously. Wait for the
-        # description heading to actually appear before extracting, rather
-        # than relying on the fixed scroll budget below — otherwise a page
-        # whose description hydrates late is extracted without it.
-        # NOTE: keys on the literal English heading text (no locale-agnostic
-        # signal — e.g. aria-label/structural — identifies this panel), so
-        # this wait is a no-op on non-English locales and falls through to
-        # the fixed scroll budget there, same as it would without this branch.
+        # apply/save chrome, and boilerplate into <main> while the description
+        # panel hydrates asynchronously. Wait for one of the known-locale
+        # description headings (_JOB_DESCRIPTION_HEADINGS) to actually appear
+        # before extracting, rather than relying on the fixed scroll budget
+        # below — otherwise a page whose description hydrates late is
+        # extracted without it. The table mitigates but does not eliminate
+        # the locale gap: an unlisted locale still falls through to the fixed
+        # scroll budget, same as before this table existed.
         is_job = "/jobs/view/" in path
         if is_job:
             try:
                 await self._page.wait_for_function(
-                    """() => {
+                    """({ headings }) => {
                         const main = document.querySelector('main');
                         if (!main) return false;
-                        return main.innerText.includes('About the job');
+                        const text = main.innerText;
+                        return headings.some((heading) => text.includes(heading));
                     }""",
+                    arg={"headings": list(_JOB_DESCRIPTION_HEADINGS.values())},
                     timeout=10000,
                 )
             except PlaywrightTimeoutError:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4125,6 +4125,54 @@ class TestSearchResultsExtraction:
         mock_page.wait_for_function.assert_awaited_once()
         assert "About the job" in result.text
 
+    async def test_job_page_wait_checks_all_locale_headings(self, mock_page):
+        """The job-description wait must check every locale in the table, not just English.
+
+        wait_for_function is mocked (no real browser JS runs in this suite),
+        so this proves the fix by inspecting what was actually passed to it:
+        the full _JOB_DESCRIPTION_HEADINGS table, not a single hardcoded
+        English string. Regression coverage for the Greptile-flagged
+        locale gap on PR #718.
+        """
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Acme Corp. Über den Job. " * 10,
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/jobs/view/12345/",
+                section_name="job_posting",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        call_kwargs = mock_page.wait_for_function.call_args.kwargs
+        headings = call_kwargs["arg"]["headings"]
+        assert "About the job" in headings
+        assert "Über den Job" in headings
+        assert len(headings) >= 2
+        # Proves the German locale text would satisfy the real (unmocked)
+        # predicate: same membership check the JS predicate performs.
+        assert any(h in result.text for h in headings)
+
     async def test_non_job_page_does_not_wait_for_job_content(self, mock_page):
         """Non-job URLs should not trigger the job description wait."""
         mock_page.evaluate = AsyncMock(

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4091,6 +4091,134 @@ class TestSearchResultsExtraction:
 
         assert result.text == placeholder
 
+    async def test_job_page_waits_for_description_content(self, mock_page):
+        """Job URLs should call wait_for_function to wait for the description."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Acme Corp. About the job. " * 10,
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/jobs/view/12345/",
+                section_name="job_posting",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        assert "About the job" in result.text
+
+    async def test_non_job_page_does_not_wait_for_job_content(self, mock_page):
+        """Non-job URLs should not trigger the job description wait."""
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": "Profile text", "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await extractor._extract_page_once(
+                "https://www.linkedin.com/in/billgates/",
+                section_name="main_profile",
+            )
+
+        mock_page.wait_for_function.assert_not_awaited()
+
+    async def test_job_page_timeout_proceeds_gracefully(self, mock_page):
+        """When the description never hydrates, extraction proceeds with available text."""
+        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        placeholder = "Acme Corp. Apply. Save. Set alert for similar jobs."
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": placeholder, "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("Timeout")
+        )
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor._extract_page_once(
+                "https://www.linkedin.com/jobs/view/12345/",
+                section_name="job_posting",
+            )
+
+        assert result.text == placeholder
+
+    async def test_scrape_job_includes_description_when_hydrated(self, mock_page):
+        """scrape_job should surface the description once it has hydrated."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Acme Corp. About the job. We are hiring. Apply now.",
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor.scrape_job("12345")
+
+        assert "About the job" in result["sections"]["job_posting"]
+
 
 class TestScrapePersonCallbacks:
     """Test that scrape_person invokes callbacks at each stage."""


### PR DESCRIPTION
## Problem

`get_job_details` intermittently returned a job posting missing the "About the job" description block. The description panel on `/jobs/view/` pages hydrates asynchronously, and extraction relied on a fixed scroll-wait budget instead of waiting for it — so a page whose description hydrated late was extracted without it. An immediate retry on the same job usually succeeded, confirming the race.

## Fix

Added an `is_job` branch to `_extract_loaded_section` in `extractor.py`, mirroring the existing hydration-wait pattern already used for activity, search, company-people, and details pages: wait (bounded, non-raising) for the description to actually appear in `<main>` before extracting.

Fixes #687
