### PR TITLE
fix(messaging): confirm real delivery, keep a message whole, clear the composer

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2739,20 +2739,62 @@ class LinkedInExtractor:
         )
         return bool(matched)
 
-    async def _message_text_visible(self, message: str) -> bool:
-        """Wait until the compose page visibly contains the just-sent message text.
+    # Counts occurrences of the message text outside the composer. The composer
+    # is contenteditable, so its own draft text is part of document.body.innerText:
+    # a plain `bodyText.includes(message)` is satisfied by the text we just typed
+    # and reports a send that never happened. Only a new occurrence *outside* the
+    # composer means LinkedIn actually rendered the message into the thread.
+    _MESSAGE_OCCURRENCES_JS = """({ expected }) => {
+        const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
+        const needle = normalize(expected);
+        if (!needle) return 0;
+        const count = haystack => {
+            let seen = 0;
+            let at = 0;
+            while ((at = haystack.indexOf(needle, at)) !== -1) {
+                seen += 1;
+                at += needle.length;
+            }
+            return seen;
+        };
+        const bodyText = normalize(document.body?.innerText || '');
+        let composerText = '';
+        for (const el of document.querySelectorAll(
+            'div[role="textbox"][contenteditable="true"]'
+        )) {
+            composerText += ' ' + normalize(el.innerText || '');
+        }
+        return Math.max(0, count(bodyText) - count(normalize(composerText)));
+    }"""
+
+    async def _count_message_occurrences(self, message: str) -> int:
+        """Count occurrences of the message in the thread, ignoring the composer."""
+        try:
+            return int(
+                await self._page.evaluate(
+                    self._MESSAGE_OCCURRENCES_JS, {"expected": message}
+                )
+            )
+        except Exception:
+            logger.debug("Could not count message occurrences", exc_info=True)
+            return 0
+
+    async def _message_delivered(self, message: str, baseline: int) -> bool:
+        """Wait until the thread shows one more copy of the message than before.
+
+        ``baseline`` is the occurrence count captured *before* the send attempt,
+        so a message that was already in the visible thread (a resend, or a quote
+        of an earlier message) does not count as confirmation on its own.
 
         Uses the page-level default timeout (``BrowserConfig.default_timeout``).
         """
         try:
             await self._page.wait_for_function(
-                """({ expected }) => {
-                    const normalize = value =>
-                        (value || '').replace(/\\s+/g, ' ').trim();
-                    const bodyText = normalize(document.body?.innerText || '');
-                    return bodyText.includes(normalize(expected));
-                }""",
-                arg={"expected": message},
+                f"""({{ expected, baseline }}) => {{
+                    const occurrences = ({self._MESSAGE_OCCURRENCES_JS})({{ expected }});
+                    return occurrences > baseline;
+                }}""",
+                arg={"expected": message, "baseline": baseline},
             )
             return True
         except PlaywrightTimeoutError:
@@ -4113,6 +4155,10 @@ class LinkedInExtractor:
 
         await handle_modal_close(self._page)
         display_name = await self._read_profile_display_name()
+        # A composer left open by an earlier call — one that returned sent, or died
+        # mid-flight — is still mounted and pointed at the previous recipient, which
+        # is what makes the second send_message of a session fail. Clear it first.
+        await self._dismiss_message_ui()
         if profile_urn:
             # Build the full compose URL that LinkedIn's own Message button
             # generates. The minimal ?recipient=<URN> form works for established
@@ -4248,8 +4294,21 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
         await asyncio.sleep(0.1)
-        await self._page.keyboard.type(message, delay=15)
+        # keyboard.type() translates "\n" into an Enter press, and Enter is how
+        # LinkedIn's composer submits — so typing a multi-paragraph message raw
+        # sends each paragraph as its own message and strands the last one in the
+        # composer. Type line by line and use Shift+Enter, the composer's own
+        # newline gesture, so the whole text lands as a single message.
+        for position, line in enumerate(message.split("\n")):
+            if position:
+                await self._page.keyboard.press("Shift+Enter")
+            if line:
+                await self._page.keyboard.type(line, delay=15)
         await asyncio.sleep(0.3)
+
+        # Count what the thread already shows before sending, so confirmation can
+        # require a *new* occurrence rather than accepting the draft we just typed.
+        baseline_occurrences = await self._count_message_occurrences(message)
 
         # patchright actionability also blocks send_button.click(). Use JS click
         # on any visible, enabled send button; fall back to Enter key which
@@ -4273,7 +4332,7 @@ class LinkedInExtractor:
         if not sent_via_js:
             await self._page.keyboard.press("Enter")
 
-        if not await self._message_text_visible(message):
+        if not await self._message_delivered(message, baseline_occurrences):
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
@@ -4281,6 +4340,11 @@ class LinkedInExtractor:
                 "LinkedIn did not confirm that the message was sent.",
                 recipient_selected=recipient_selected,
             )
+
+        # Leave no composer overlay behind: a stale one makes the next
+        # send_message in the same session resolve a dead compose box and fail
+        # with composer_unavailable.
+        await self._dismiss_message_ui()
 
         return self._message_action_result(
             self._page.url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2744,7 +2744,11 @@ class LinkedInExtractor:
     # a plain `bodyText.includes(message)` is satisfied by the text we just typed
     # and reports a send that never happened. Only a new occurrence *outside* the
     # composer means LinkedIn actually rendered the message into the thread.
-    _MESSAGE_OCCURRENCES_JS = """({ expected }) => {
+    # ``composerSelectors`` is passed in from _MESSAGING_COMPOSE_FALLBACK_SELECTORS
+    # rather than hardcoded here: whatever _resolve_message_compose_box is willing
+    # to type into has to be subtracted, or that composer's draft counts as thread
+    # text and we are back to confirming sends that never happened.
+    _MESSAGE_OCCURRENCES_JS = """({ expected, composerSelectors }) => {
         const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
         const needle = normalize(expected);
         if (!needle) return 0;
@@ -2758,43 +2762,78 @@ class LinkedInExtractor:
             return seen;
         };
         const bodyText = normalize(document.body?.innerText || '');
+        const composers = new Set();
+        for (const selector of composerSelectors) {
+            for (const el of document.querySelectorAll(selector)) {
+                composers.add(el);
+            }
+        }
+        // Drop any composer nested in another, so shared text is not subtracted twice.
         let composerText = '';
-        for (const el of document.querySelectorAll(
-            'div[role="textbox"][contenteditable="true"]'
-        )) {
-            composerText += ' ' + normalize(el.innerText || '');
+        for (const el of composers) {
+            let nested = false;
+            for (const other of composers) {
+                if (other !== el && other.contains(el)) {
+                    nested = true;
+                    break;
+                }
+            }
+            if (!nested) composerText += ' ' + normalize(el.innerText || '');
         }
         return Math.max(0, count(bodyText) - count(normalize(composerText)));
     }"""
 
-    async def _count_message_occurrences(self, message: str) -> int:
-        """Count occurrences of the message in the thread, ignoring the composer."""
+    async def _count_message_occurrences(self, message: str) -> int | None:
+        """Count occurrences of the message in the thread, ignoring the composer.
+
+        Returns ``None`` when the page could not be evaluated at all. That is not
+        the same as a count of zero, and the caller must not treat it as one: a
+        zero baseline on a resend would let the copy already in the thread confirm
+        a send that never happened.
+        """
         try:
             return int(
                 await self._page.evaluate(
-                    self._MESSAGE_OCCURRENCES_JS, {"expected": message}
+                    self._MESSAGE_OCCURRENCES_JS,
+                    {
+                        "expected": message,
+                        "composerSelectors": list(
+                            _MESSAGING_COMPOSE_FALLBACK_SELECTORS
+                        ),
+                    },
                 )
             )
         except Exception:
             logger.debug("Could not count message occurrences", exc_info=True)
-            return 0
+            return None
 
-    async def _message_delivered(self, message: str, baseline: int) -> bool:
+    async def _message_delivered(self, message: str, baseline: int | None) -> bool:
         """Wait until the thread shows one more copy of the message than before.
 
         ``baseline`` is the occurrence count captured *before* the send attempt,
         so a message that was already in the visible thread (a resend, or a quote
-        of an earlier message) does not count as confirmation on its own.
+        of an earlier message) does not count as confirmation on its own. A
+        ``None`` baseline means the count never happened, and an unverifiable send
+        is reported as unconfirmed rather than guessed either way.
 
         Uses the page-level default timeout (``BrowserConfig.default_timeout``).
         """
+        if baseline is None:
+            logger.debug("No pre-send baseline; cannot confirm delivery")
+            return False
         try:
             await self._page.wait_for_function(
-                f"""({{ expected, baseline }}) => {{
-                    const occurrences = ({self._MESSAGE_OCCURRENCES_JS})({{ expected }});
+                f"""({{ expected, baseline, composerSelectors }}) => {{
+                    const occurrences = ({self._MESSAGE_OCCURRENCES_JS})(
+                        {{ expected, composerSelectors }}
+                    );
                     return occurrences > baseline;
                 }}""",
-                arg={"expected": message, "baseline": baseline},
+                arg={
+                    "expected": message,
+                    "baseline": baseline,
+                    "composerSelectors": list(_MESSAGING_COMPOSE_FALLBACK_SELECTORS),
+                },
             )
             return True
         except PlaywrightTimeoutError:
@@ -4337,7 +4376,13 @@ class LinkedInExtractor:
             return self._message_action_result(
                 self._page.url,
                 "send_unavailable",
-                "LinkedIn did not confirm that the message was sent.",
+                "LinkedIn did not confirm that the message was sent."
+                if baseline_occurrences is not None
+                else (
+                    "The message may or may not have been sent: the page could not "
+                    "be read before sending, so delivery could not be verified. "
+                    "Check the conversation before sending it again."
+                ),
                 recipient_selected=recipient_selected,
             )
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,5 +1,6 @@
 """Tests for the LinkedInExtractor scraping engine."""
 
+from contextlib import ExitStack
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
@@ -5662,7 +5663,13 @@ class TestSendMessageComposerInteraction:
             patches[9],
             patch.object(
                 extractor,
-                "_message_text_visible",
+                "_count_message_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
+                "_message_delivered",
                 new_callable=AsyncMock,
                 return_value=True,
             ),
@@ -5729,7 +5736,13 @@ class TestSendMessageComposerInteraction:
             patches[9],
             patch.object(
                 extractor,
-                "_message_text_visible",
+                "_count_message_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
+                "_message_delivered",
                 new_callable=AsyncMock,
                 return_value=True,
             ),
@@ -5741,6 +5754,220 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "sent"
         # Enter was pressed as fallback
         mock_keyboard.press.assert_awaited_once_with("Enter")
+
+
+class TestSendMessageDeliveryConfirmation:
+    """The composer's own draft text must never count as proof of delivery (#573)."""
+
+    def _occurrence_counter(self, page_text, composer_text):
+        """Run the real occurrence-counting JS against a fake page."""
+
+        async def evaluate(script, arg=None):
+            expected = (arg or {}).get("expected", "")
+            needle = " ".join(expected.split())
+            body = " ".join(page_text.split())
+            composer = " ".join(composer_text.split())
+            return max(0, body.count(needle) - composer.count(needle))
+
+        return evaluate
+
+    async def test_draft_still_in_composer_is_not_delivery(self, mock_page):
+        """Text typed but never sent lives in body.innerText — it must not confirm."""
+        extractor = LinkedInExtractor(mock_page)
+        message = "Oi Rafael, tudo certo?"
+        # The page shows the message only because it sits in the composer.
+        mock_page.evaluate = AsyncMock(
+            side_effect=self._occurrence_counter(message, message)
+        )
+
+        assert await extractor._count_message_occurrences(message) == 0
+
+    async def test_message_rendered_into_thread_is_delivery(self, mock_page):
+        """Once LinkedIn echoes the message into the thread, it counts."""
+        extractor = LinkedInExtractor(mock_page)
+        message = "Oi Rafael, tudo certo?"
+        # Thread copy present, composer cleared by LinkedIn after the send.
+        mock_page.evaluate = AsyncMock(
+            side_effect=self._occurrence_counter(f"Rafael\n{message}\nSend", "")
+        )
+
+        assert await extractor._count_message_occurrences(message) == 1
+
+    async def test_resend_needs_a_new_occurrence_not_just_presence(self, mock_page):
+        """A message already in the thread does not confirm a later resend."""
+        extractor = LinkedInExtractor(mock_page)
+        message = "ping"
+        mock_page.evaluate = AsyncMock(
+            side_effect=self._occurrence_counter(f"{message} ... {message}", message)
+        )
+
+        # One copy in the thread, one in the composer: baseline for the resend is 1.
+        assert await extractor._count_message_occurrences(message) == 1
+
+    async def test_send_unavailable_when_nothing_new_appears(self, mock_page):
+        """send_message reports failure — not success — when delivery is unconfirmed."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        interaction = TestSendMessageComposerInteraction()
+        patches = interaction._patch_send_message_to_compose(extractor, mock_page)
+
+        with ExitStack() as stack:
+            for context in patches:
+                stack.enter_context(context)
+            stack.enter_context(
+                patch.object(
+                    extractor,
+                    "_count_message_occurrences",
+                    new_callable=AsyncMock,
+                    return_value=0,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    extractor,
+                    "_message_delivered",
+                    new_callable=AsyncMock,
+                    return_value=False,
+                )
+            )
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert result["sent"] is False
+
+
+class TestSendMessageMultiline:
+    """A multi-paragraph message must land as one message, not several (#441)."""
+
+    async def _send(self, extractor, mock_page, message):
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        interaction = TestSendMessageComposerInteraction()
+        patches = interaction._patch_send_message_to_compose(extractor, mock_page)
+
+        with ExitStack() as stack:
+            for context in patches:
+                stack.enter_context(context)
+            stack.enter_context(
+                patch.object(
+                    extractor,
+                    "_count_message_occurrences",
+                    new_callable=AsyncMock,
+                    return_value=0,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    extractor,
+                    "_message_delivered",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                )
+            )
+            result = await extractor.send_message(
+                "testuser", message, confirm_send=True
+            )
+        return result, mock_keyboard
+
+    async def test_newlines_never_reach_keyboard_type(self, mock_page):
+        """keyboard.type turns \\n into Enter, and Enter submits — so never type one."""
+        extractor = LinkedInExtractor(mock_page)
+        message = "Primeiro paragrafo.\n\nSegundo paragrafo.\n\nAbraco, Ricardo"
+
+        result, keyboard = await self._send(extractor, mock_page, message)
+
+        assert result["status"] == "sent"
+        typed = [call.args[0] for call in keyboard.type.await_args_list]
+        assert all("\n" not in chunk for chunk in typed)
+        # Every paragraph is typed; none is stranded in the composer.
+        assert "Primeiro paragrafo." in typed
+        assert "Segundo paragrafo." in typed
+        assert "Abraco, Ricardo" in typed
+
+    async def test_line_breaks_use_shift_enter(self, mock_page):
+        """Shift+Enter is the composer's newline; plain Enter would send."""
+        extractor = LinkedInExtractor(mock_page)
+        message = "linha um\nlinha dois"
+
+        _, keyboard = await self._send(extractor, mock_page, message)
+
+        presses = [call.args[0] for call in keyboard.press.await_args_list]
+        assert presses.count("Shift+Enter") == 1
+        assert "Enter" not in presses  # the send button was found, so no Enter send
+
+    async def test_blank_line_produces_two_breaks_and_no_empty_type(self, mock_page):
+        """A blank line is two Shift+Enters, not a typed empty string."""
+        extractor = LinkedInExtractor(mock_page)
+
+        _, keyboard = await self._send(extractor, mock_page, "um\n\ndois")
+
+        presses = [call.args[0] for call in keyboard.press.await_args_list]
+        assert presses.count("Shift+Enter") == 2
+        typed = [call.args[0] for call in keyboard.type.await_args_list]
+        assert typed == ["um", "dois"]
+
+    async def test_single_line_message_types_once(self, mock_page):
+        """The common case stays a single type call with no line-break presses."""
+        extractor = LinkedInExtractor(mock_page)
+
+        _, keyboard = await self._send(extractor, mock_page, "Hello!")
+
+        keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        assert "Shift+Enter" not in [
+            call.args[0] for call in keyboard.press.await_args_list
+        ]
+
+
+class TestSendMessageOverlayHygiene:
+    """A composer left mounted breaks the next send of the session (#433)."""
+
+    async def test_successful_send_dismisses_the_composer(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        interaction = TestSendMessageComposerInteraction()
+        patches = interaction._patch_send_message_to_compose(extractor, mock_page)
+        dismiss = AsyncMock()
+
+        with ExitStack() as stack:
+            for context in (*patches[:8], patches[9]):
+                stack.enter_context(context)
+            stack.enter_context(patch.object(extractor, "_dismiss_message_ui", dismiss))
+            stack.enter_context(
+                patch.object(
+                    extractor,
+                    "_count_message_occurrences",
+                    new_callable=AsyncMock,
+                    return_value=0,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    extractor,
+                    "_message_delivered",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                )
+            )
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "sent"
+        # Once on entry (clearing any stale overlay) and once after the send.
+        assert dismiss.await_count == 2
 
 
 class TestBuildFeedReferences:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -19,6 +19,7 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _CONTENT_DATE_POSTED_MAP,
+    _MESSAGING_COMPOSE_FALLBACK_SELECTORS,
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
@@ -5803,6 +5804,38 @@ class TestSendMessageDeliveryConfirmation:
 
         # One copy in the thread, one in the composer: baseline for the resend is 1.
         assert await extractor._count_message_occurrences(message) == 1
+
+    async def test_unreadable_page_yields_none_not_zero(self, mock_page):
+        """A failed count must not look like "nothing in the thread yet"."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(side_effect=RuntimeError("page gone"))
+
+        assert await extractor._count_message_occurrences("ping") is None
+
+    async def test_none_baseline_never_confirms(self, mock_page):
+        """Without a baseline, a copy already in the thread must not confirm a resend."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(return_value=None)
+
+        assert await extractor._message_delivered("ping", None) is False
+        # The page is never even asked: there is nothing to compare against.
+        mock_page.wait_for_function.assert_not_awaited()
+
+    async def test_every_accepted_composer_shape_is_subtracted(self, mock_page):
+        """The selectors excluded here must match the ones send_message types into."""
+        extractor = LinkedInExtractor(mock_page)
+        captured = {}
+
+        async def evaluate(script, arg=None):
+            captured.update(arg or {})
+            return 0
+
+        mock_page.evaluate = AsyncMock(side_effect=evaluate)
+        await extractor._count_message_occurrences("ping")
+
+        assert captured["composerSelectors"] == list(
+            _MESSAGING_COMPOSE_FALLBACK_SELECTORS
+        )
 
     async def test_send_unavailable_when_nothing_new_appears(self, mock_page):
         """send_message reports failure — not success — when delivery is unconfirmed."""


### PR DESCRIPTION
Fixes #573, #441, #433.

Three defects in `send_message` that compound. A three-paragraph message goes out as two messages, the third paragraph never leaves the composer, and the tool still returns `"Message sent."`.

### Delivery confirmation (#573)

`_message_text_visible()` checked whether `document.body.innerText` contains the message. The composer is `contenteditable`, so the draft we just typed is part of that text. The check passes before the send button is clicked and cannot fail, which turns every failed send into a reported success.

Now the occurrences are counted outside the composer, and confirmation requires one more than the baseline captured just before sending. That also stops a resend from being confirmed by the copy already sitting in the thread.

### Multi-paragraph messages (#441)

`keyboard.type()` translates `\n` into an Enter press, and Enter is how the composer submits. It is the same gesture this code already uses as its send fallback. So each blank line sent whatever was typed so far, and the final paragraph was left behind in the composer.

Now it types line by line and uses Shift+Enter for the breaks, so the whole text lands as one message.

### Stale composer (#433)

The success path returned without dismissing the composer, leaving it mounted and pointed at the previous recipient. That is what makes the second send of a session fail with `composer_unavailable`. It now dismisses after a send, and again on entry, to cover a call that died mid-flight.

### Tests

12 new tests in `tests/test_scraping.py` covering all three, including the case that matters most: a draft still in the composer must not count as delivery. Two existing tests were updated for the renamed helper. Full suite passes (1930 passed, 58 skipped).

Also verified live against a real 1st-degree conversation. Before the fix, a three-paragraph message arrived as two messages with the signature missing. After, it arrives as a single message with all three paragraphs and accented characters intact.

### Note

The three fixes are in the same code path and the interaction between them is the actual user-visible bug, so they are together here. Happy to split into three PRs if you prefer.

There are older PRs open against some of this (#574, #482). I did not build on them, since they had drifted from main. Close this if either one is closer to what you want.
