### PR TITLE
fix(search): location filter is silently ignored — emit geoUrn and validate the URN

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3613,7 +3613,11 @@ class LinkedInExtractor:
 
         Args:
             keywords: Free-text query ("software engineer", "recruiter at Google").
-            location: Optional location filter ("New York", "Remote").
+            location: Optional location filter. LinkedIn's people-search
+                ``geoUrn`` facet only filters on the numeric geo URN id
+                (e.g. ``"103644278"`` for the United States); plain-text place
+                names are accepted by the URL but ignored by LinkedIn and
+                return the unfiltered result set.
             network: Optional connection-degree filter. Each element is one of
                 ``"F"`` (1st-degree), ``"S"`` (2nd-degree), ``"O"`` (3rd-degree
                 and beyond). Example: ``["F"]`` to only return 1st-degree
@@ -3637,6 +3641,16 @@ class LinkedInExtractor:
                     f"{invalid!r}; expected any of {list(_NETWORK_TOKENS)!r}"
                 )
 
+        if location and not re.fullmatch(r"[0-9]+", location):
+            raise FilterValidationError(
+                f"location must be a numeric LinkedIn geo URN id "
+                f"(e.g. '103644278' for the United States); got {location!r}. "
+                f"LinkedIn's people-search geo facet only filters on the URN id; "
+                f"plain-text place names are silently ignored and return the "
+                f"unfiltered result set. Omit the filter and put the place name "
+                f"in `keywords` if you do not have the URN."
+            )
+
         if current_company and not re.fullmatch(r"[0-9]+", current_company):
             raise FilterValidationError(
                 f"current_company must be a numeric LinkedIn company URN id "
@@ -3647,7 +3661,7 @@ class LinkedInExtractor:
 
         params = f"keywords={quote_plus(keywords)}"
         if location:
-            params += f"&location={quote_plus(location)}"
+            params += f"&geoUrn={_encode_list_facet([location])}"
         if network:
             params += f"&network={_encode_list_facet(network)}"
         if current_company:

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -122,7 +122,12 @@ def register_person_tools(
         Args:
             keywords: Search keywords (e.g., "software engineer", "recruiter at Google")
             ctx: FastMCP context for progress reporting
-            location: Optional location filter (e.g., "New York", "Remote")
+            location: Optional location filter. LinkedIn's geoUrn facet only
+                filters on the numeric geo URN id (e.g. "103644278" for the
+                United States); plain-text place names are accepted by the URL
+                but ignored by LinkedIn and return the unfiltered result set.
+                If you do not have the URN, omit this and put the place name in
+                `keywords` instead.
             network: Optional connection-degree filter. Each element is one of
                 "F" (1st-degree), "S" (2nd-degree), "O" (3rd-degree and beyond).
                 Example: ["F"] to only return 1st-degree connections.

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3085,6 +3085,45 @@ class TestSearchPeople:
         with pytest.raises(ValueError, match="must be a numeric"):
             await extractor.search_people("engineer", current_company="١١١٥")
 
+    async def test_search_people_location_filter_emits_geo_urn(self, mock_page):
+        """LinkedIn's geo facet is ``geoUrn``, not ``location``; a bare
+        ``location=`` param is accepted by the URL and silently ignored."""
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("Jane Doe"),
+        ):
+            result = await extractor.search_people("engineer", location="103644278")
+
+        assert "geoUrn=%5B%22103644278%22%5D" in result["url"]
+        assert "&location=" not in result["url"]
+
+    async def test_search_people_rejects_plain_location_name(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with pytest.raises(ValueError, match="must be a numeric"):
+            await extractor.search_people("engineer", location="New York")
+
+    async def test_search_people_rejects_unicode_digit_location(self, mock_page):
+        """Geo URN ids are ASCII decimal; reject Unicode digits even though
+        ``str.isdigit()`` would accept them."""
+        extractor = LinkedInExtractor(mock_page)
+        with pytest.raises(ValueError, match="must be a numeric"):
+            await extractor.search_people("engineer", location="١٠٣٦٤٤٢٧٨")
+
+    async def test_search_people_empty_location_is_noop(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("Jane Doe"),
+        ):
+            result = await extractor.search_people("engineer", location="")
+
+        assert "geoUrn" not in result["url"]
+
     async def test_search_people_empty_current_company_is_noop(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         with patch.object(
@@ -3107,13 +3146,13 @@ class TestSearchPeople:
         ):
             result = await extractor.search_people(
                 "engineer",
-                location="Seattle",
+                location="104116203",
                 network=["F"],
                 current_company="1115",
             )
 
         assert "keywords=engineer" in result["url"]
-        assert "location=Seattle" in result["url"]
+        assert "geoUrn=%5B%22104116203%22%5D" in result["url"]
         assert "network=%5B%22F%22%5D" in result["url"]
         assert "currentCompany=%5B%221115%22%5D" in result["url"]
 


### PR DESCRIPTION
## The bug

`search_people` accepts a plain-text `location` and appends it as `&location=<text>`:

```python
params = f"keywords={quote_plus(keywords)}"
if location:
    params += f"&location={quote_plus(location)}"      # no validation
if network:
    params += f"&network={_encode_list_facet(network)}"
if current_company:
    params += f"&currentCompany={_encode_list_facet([current_company])}"
```

LinkedIn's people-search backend has no `location` facet. The geo facet is **`geoUrn`**, a JSON-list of numeric geo URN ids. The URL is well-formed, LinkedIn accepts it, and returns the **completely unfiltered** result set. `grep -rn "geoUrn"` across the repo currently returns nothing.

## Why it matters

The failure is silent. Searching `location="Washington DC-Baltimore Area"` returns people in Philadelphia, New Hampshire, North Carolina, Colorado, Missouri and Ohio — with nothing signalling that the filter did not apply. A caller reasonably reads those results as location-filtered and acts on them.

This is the **same defect class already handled for `current_company`**, whose guard and docstring state that plain-text company names are silently ignored by LinkedIn and must be numeric URN ids. `location` was simply left on the old path.

## The fix

Mirrors the existing `currentCompany` treatment exactly:

- emit `geoUrn=` via `_encode_list_facet` instead of a bare `location=`
- raise `FilterValidationError` on non-numeric input, pointing callers at `keywords` as the fallback when they don't have a URN
- update both docstrings (extractor + tool) to describe real behaviour

## Test changes

`test_search_people_combines_all_filters` used `location="Seattle"` and asserted `location=Seattle` appeared in the URL — it was asserting the broken behaviour. It now uses a geo URN and asserts the `geoUrn` facet.

Four regression tests added, mirroring the `currentCompany` set:

| test | asserts |
|---|---|
| `..._location_filter_emits_geo_urn` | `geoUrn=%5B%22103644278%22%5D` present, `&location=` absent |
| `..._rejects_plain_location_name` | `"New York"` raises |
| `..._rejects_unicode_digit_location` | Unicode digits raise (`str.isdigit()` would accept) |
| `..._empty_location_is_noop` | empty string adds no facet |

## Verification

```
uv run pytest -q
1925 passed, 58 skipped
```

## Note on the breaking change

Callers currently passing plain place names will now get a `FilterValidationError` instead of silently-unfiltered results. That seemed right given the precedent `current_company` sets — a loud error beats a filter that quietly does nothing — but happy to switch it to a warning that drops the facet if you'd prefer a softer migration.