### PR TITLE
fix(jobs): support redesigned search results

### DIFF
--- a/linkedin_mcp_server/core/utils.py
+++ b/linkedin_mcp_server/core/utils.py
@@ -92,28 +92,29 @@ async def scroll_job_sidebar(
     """Scroll the job search sidebar to load all job cards.
 
     LinkedIn renders job search results in a scrollable sidebar container,
-    not the main page body. This function finds that container by locating
-    a job card link and walking up to its scrollable ancestor, then scrolls
-    it iteratively until no new content loads.
+    not the main page body. This function finds that container through a job
+    card, then scrolls it iteratively until no new content loads.
 
     Args:
         page: Patchright page object
         pause_time: Time to pause between scrolls (seconds)
         max_scrolls: Maximum number of scroll attempts
     """
-    # Wait for at least one job card link to render before scrolling
+    card_selector = 'a[href*="/jobs/view/"], [componentkey^="job-card-component-ref-"]'
     try:
-        await page.wait_for_selector('a[href*="/jobs/view/"]', timeout=5000)
+        await page.wait_for_selector(card_selector, timeout=5000)
     except PlaywrightTimeoutError:
-        logger.debug("No job card links found, skipping sidebar scroll")
+        logger.debug("No job cards found, skipping sidebar scroll")
         return
 
     scrolled = await page.evaluate(
         """async ({pauseTime, maxScrolls}) => {
-            const link = document.querySelector('a[href*="/jobs/view/"]');
-            if (!link) return -2;
+            const card = document.querySelector(
+                'a[href*="/jobs/view/"], [componentkey^="job-card-component-ref-"]'
+            );
+            if (!card) return -2;
 
-            let container = link.parentElement;
+            let container = card.parentElement;
             while (container && container !== document.body) {
                 const style = window.getComputedStyle(container);
                 const overflowY = style.overflowY;
@@ -141,7 +142,7 @@ async def scroll_job_sidebar(
         {"pauseTime": pause_time, "maxScrolls": max_scrolls},
     )
     if scrolled == -2:
-        logger.debug("Job card link disappeared before evaluate, skipping scroll")
+        logger.debug("Job card disappeared before evaluate, skipping scroll")
     elif scrolled == -1:
         logger.debug("No scrollable container found for job sidebar")
     elif scrolled:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3054,18 +3054,19 @@ class LinkedInExtractor:
         return result
 
     async def _extract_job_ids(self) -> list[str]:
-        """Extract unique job IDs from job card links on the current page.
-
-        Finds all `a[href*="/jobs/view/"]` links and extracts the numeric
-        job ID from each href. Returns deduplicated IDs in DOM order.
-        """
+        """Extract unique job IDs from job cards on the current page."""
         return await self._page.evaluate(
             """() => {
-                const links = document.querySelectorAll('a[href*="/jobs/view/"]');
+                const cards = document.querySelectorAll(
+                    'a[href*="/jobs/view/"], [componentkey^="job-card-component-ref-"]'
+                );
                 const seen = new Set();
                 const ids = [];
-                for (const a of links) {
-                    const match = a.href.match(/\\/jobs\\/view\\/(\\d+)/);
+                for (const card of cards) {
+                    const source = card.href || card.getAttribute('componentkey') || '';
+                    const match = source.match(
+                        /(?:\\/jobs\\/view\\/|job-card-component-ref-)(\\d+)/
+                    );
                     if (match && !seen.has(match[1])) {
                         seen.add(match[1]);
                         ids.push(match[1]);
@@ -3203,7 +3204,8 @@ class LinkedInExtractor:
         Comma-separated values are normalized individually.
         Unknown values pass through unchanged.
         """
-        params = f"keywords={quote_plus(keywords)}"
+        search_keywords = f"{keywords} in {location}" if location else keywords
+        params = f"keywords={quote_plus(search_keywords)}"
         if location:
             params += f"&location={quote_plus(location)}"
 
@@ -3316,10 +3318,8 @@ class LinkedInExtractor:
                         if total_pages is not None:
                             logger.debug("LinkedIn reports %d total pages", total_pages)
 
-                # Extract job IDs from hrefs (page is already loaded)
-                if not self._page.url.startswith(
-                    "https://www.linkedin.com/jobs/search/"
-                ):
+                search_path = urlparse(self._page.url).path.rstrip("/")
+                if search_path not in {"/jobs/search", "/jobs/search-results"}:
                     logger.debug(
                         "Unexpected page URL after extraction: %s — "
                         "skipping job ID extraction",

--- a/tests/test_job_search_dom.py
+++ b/tests/test_job_search_dom.py
@@ -1,0 +1,64 @@
+"""Browser-DOM tests for LinkedIn job search cards."""
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.core.utils import scroll_job_sidebar
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+
+pytestmark = pytest.mark.browser_dom
+
+
+@pytest.fixture
+async def dom_page():
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(
+                channel="chromium", headless=True
+            )
+            page = await browser.new_page()
+        except Exception as exc:
+            pytest.skip(f"chromium unavailable: {exc}")
+        try:
+            yield page
+        finally:
+            await browser.close()
+
+
+class TestJobSearchCards:
+    async def test_extracts_redesigned_cards(self, dom_page):
+        await dom_page.set_content(
+            """
+            <main>
+              <div componentkey="job-card-component-ref-111" role="button">One</div>
+              <div componentkey="job-card-component-ref-222" role="button">Two</div>
+            </main>
+            """
+        )
+
+        assert await LinkedInExtractor(dom_page)._extract_job_ids() == ["111", "222"]
+
+    async def test_deduplicates_legacy_and_redesigned_cards(self, dom_page):
+        await dom_page.set_content(
+            """
+            <main>
+              <a href="https://www.linkedin.com/jobs/view/111/">One</a>
+              <div componentkey="job-card-component-ref-111" role="button">One</div>
+              <div componentkey="job-card-component-ref-222" role="button">Two</div>
+            </main>
+            """
+        )
+
+        assert await LinkedInExtractor(dom_page)._extract_job_ids() == ["111", "222"]
+
+    async def test_scroll_finds_redesigned_cards(self, dom_page):
+        await dom_page.set_content(
+            """
+            <main style="height: 30px; overflow-y: scroll">
+              <div componentkey="job-card-component-ref-111" role="button">One</div>
+              <div style="height: 100px"></div>
+            </main>
+            """
+        )
+
+        await scroll_job_sidebar(dom_page, pause_time=0, max_scrolls=1)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -45,7 +45,7 @@ class TestBuildJobSearchUrl:
 
     def test_with_location(self):
         url = LinkedInExtractor._build_job_search_url("python", location="Remote")
-        assert "keywords=python" in url
+        assert "keywords=python+in+Remote" in url
         assert "location=Remote" in url
 
     def test_date_posted_normalization(self):
@@ -114,7 +114,7 @@ class TestBuildJobSearchUrl:
             easy_apply=True,
             sort_by="date",
         )
-        assert "keywords=python" in url
+        assert "keywords=python+in+Berlin" in url
         assert "location=Berlin" in url
         assert "f_TPR=r604800" in url
         assert "f_E=2,4" in url
@@ -2605,8 +2605,39 @@ class TestSearchJobs:
         assert result["job_ids"] == []
         assert result["sections"]["search_results"] == "No matching jobs found"
 
-    async def test_url_redirect_skips_id_extraction(self, mock_page):
-        """Unexpected page URL should skip ID extraction but capture text."""
+    async def test_search_results_redirect_extracts_ids(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.url = "https://www.linkedin.com/jobs/search-results/?keywords=python"
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Job results"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111", "222"],
+            ) as mock_ids,
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_jobs("python", max_pages=1)
+
+        mock_ids.assert_awaited_once()
+        assert result["job_ids"] == ["111", "222"]
+
+    async def test_non_search_redirect_skips_id_extraction(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         mock_page.url = "https://www.linkedin.com/uas/login"
         with (


### PR DESCRIPTION
Hey, sorry for the vibed PR, the MCP server broke today and this fix helped me locally, so I figured I might as well share it. Please let me know if I should close it instead. Thanks!

## Summary

- Support LinkedIn's new `/jobs/search-results/` route.
- Extract job IDs from the new `componentkey` job cards.
- Support the new cards during sidebar scrolling.
- Add the requested location to the AI search query.
- Keep the classic `location` parameter for older search pages.

## Problem

LinkedIn now redirects job searches to `/jobs/search-results/`.

The existing URL guard rejects this route and skips job ID extraction.

The redesigned cards use `componentkey` instead of `/jobs/view/` links.

The redirect also drops the location parameter. LinkedIn then uses the account location.

## Verification

- Add unit tests for the redirected route.
- Add browser-DOM tests for both job card formats.
- Verify a live Europe search returns 99+ results and 25 job IDs.
- Run the full test suite: 1,972 passed and 11 skipped.
- Run Ruff and ty successfully.

Fixes #725

## Synthetic prompt

> Update `search_jobs` for LinkedIn's redesigned results page. Support the new route and cards, preserve location filtering, and add regression tests.

Generated with OpenAI GPT-5.6 Sol.