### PR TITLE
fix(jobs): Read redesigned search results

### DIFF
--- a/linkedin_mcp_server/core/utils.py
+++ b/linkedin_mcp_server/core/utils.py
@@ -10,7 +10,12 @@ from .exceptions import RateLimitError
 
 logger = logging.getLogger(__name__)
 
-_JOB_CARD_SELECTOR = 'a[href*="/jobs/view/"]'
+# Both card shapes. The classic result is an anchor to the job permalink;
+# the redesigned search at `/jobs/search-results` renders cards that carry no
+# permalink at all and keep the id only in `componentkey`. A selector matching
+# just the anchor finds nothing there, which is what made the search return an
+# empty `job_ids` while its text listed real jobs.
+_JOB_CARD_SELECTOR = 'a[href*="/jobs/view/"], [componentkey^="job-card-component-ref-"]'
 
 # The rule that decides which container holds the search results. Shared
 # verbatim by the scroll and by id extraction, because extraction re-runs it
@@ -23,10 +28,18 @@ _JOB_CARD_SELECTOR = 'a[href*="/jobs/view/"]'
 # showed. Expects `selector` in scope.
 _RAIL_PICK_JS = r"""
             const idOf = (node) => {
-                const match = (node.getAttribute('href') || '').match(
+                const href = (node.getAttribute('href') || '').match(
                     /\/jobs\/view\/(?:[^/?#]*-)?(\d+)(?=[/?#]|$)/
                 );
-                return match ? match[1] : null;
+                if (href) return href[1];
+                // The redesigned card has no permalink, so the attribute is
+                // the only place the id exists. Anchored at the start, since
+                // the selector already matched that prefix and a bare
+                // `includes` would accept an unrelated key holding it.
+                const key = (node.getAttribute('componentkey') || '').match(
+                    /^job-card-component-ref-(\d+)/
+                );
+                return key ? key[1] : null;
             };
             const idsIn = (scope) => {
                 const ids = new Set();

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -227,21 +227,30 @@ _JOB_IDS_JS = (
     + r"""
     const picked = scoped ? pickRail() : null;
     const scope = picked || document;
-    const links = scope.querySelectorAll(selector);
+    const cards = scope.querySelectorAll(selector);
     const seen = new Set();
     const ids = [];
-    for (const a of links) {
-        const match = (a.href || '').match(
-            /\/jobs\/view\/(?:[^/?#]*-)?(\d+)(?=[/?#]|$)/
-        );
-        if (match && !seen.has(match[1])) {
-            seen.add(match[1]);
-            ids.push(match[1]);
+    for (const card of cards) {
+        // `idOf` from the rail rule above, rather than a second copy of the
+        // pattern: the rail is picked by counting ids, so a card shape one
+        // side understands and the other does not would have extraction read
+        // a container the pick never considered.
+        const id = idOf(card);
+        if (id && !seen.has(id)) {
+            seen.add(id);
+            ids.push(id);
         }
     }
     return {ids: ids, scoped: Boolean(picked)};
 }"""
 )
+
+# The routes a job search may legitimately end on. `/jobs/search` is what the
+# URL builder produces; `/jobs/search-results` is where LinkedIn's redesigned
+# experience redirects it. Compared as parsed paths rather than as a prefix,
+# because `/jobs/search?keywords=x` is the same route and puts a `?` where a
+# prefix test wants the slash.
+_JOB_SEARCH_PATHS = frozenset({"/jobs/search", "/jobs/search-results"})
 
 # How long to let `page.url` catch up with a navigation the sidebar scroll
 # suppressed. The lag itself measured 6ms across ten runs, min and max alike;
@@ -282,6 +291,26 @@ def _route(target: str) -> tuple[str, str]:
     """
     parsed = urlparse(target)
     return parsed.netloc, parsed.path.rstrip("/")
+
+
+def _same_job_search(before: tuple[str, str], after: tuple[str, str]) -> bool:
+    """Whether a route change is LinkedIn moving a search to its redesign.
+
+    `/jobs/search/` 302s to `/jobs/search-results/` for accounts on the new
+    experience. The destination is the same search: it keeps the keywords,
+    honours `start`, and renders the same results, so treating the hop as a
+    page replacement ended every such search on its first page.
+
+    Only between those two, and only on one host. The point of the comparison
+    around it is that a search which ends up somewhere else is not a search,
+    and an account picker served in place of one moves the route exactly like
+    this redirect does.
+    """
+    return (
+        before[0] == after[0]
+        and before[1] in _JOB_SEARCH_PATHS
+        and after[1] in _JOB_SEARCH_PATHS
+    )
 
 
 # Scrolling is bounded per navigation and across a whole search, because
@@ -3565,7 +3594,7 @@ class LinkedInExtractor:
             # missed: an exhausted search renders no `<main>` either, which is
             # why the check has to decide it rather than the absence alone.
             await self._raise_if_auth_barrier(url)
-        if before != after:
+        if before != after and not _same_job_search(before, after):
             # An expired session lands here as often as a layout change does,
             # and the two need different answers. A plain error is caught by
             # the generic handler above and returned as a section diagnostic,
@@ -3807,29 +3836,21 @@ class LinkedInExtractor:
                 slowest_page = max(slowest_page, time.monotonic() - page_started)
                 scroll_budget_left = max(0.0, scroll_budget_left - self._scroll_seconds)
 
-                if not extracted.text or extracted.text == _RATE_LIMITED_MSG:
-                    # Rate limit first: it is the more specific diagnosis, and a
-                    # page that was throttled may carry a generic error too.
-                    if extracted.text == _RATE_LIMITED_MSG:
-                        section_errors["search_results"] = rate_limited_section_error()
-                    elif extracted.error:
-                        section_errors["search_results"] = extracted.error
-                    # Navigation failed or rate-limited; skip ID extraction.
-                    # Pages gathered so far are kept and returned.
+                # Rate limits and extraction failures are already classified;
+                # they win over route diagnostics. A clean empty page is not
+                # accepted yet, because a redirect that dropped the keywords,
+                # filters or offset can render empty too. Calling that "no jobs"
+                # is a successful answer to a different search.
+                if extracted.text == _RATE_LIMITED_MSG:
+                    section_errors["search_results"] = rate_limited_section_error()
+                    break
+                if not extracted.text and extracted.error:
+                    section_errors["search_results"] = extracted.error
                     break
 
-                # Read total pages from pagination state (once only, best-effort)
-                if not total_pages_queried:
-                    total_pages_queried = True
-                    try:
-                        total_pages = await self._get_total_search_pages()
-                    except Exception as e:
-                        logger.debug("Could not read total pages: %s", e)
-                    else:
-                        if total_pages is not None:
-                            logger.debug("LinkedIn reports %d total pages", total_pages)
-
-                # Extract job IDs from hrefs (page is already loaded)
+                # Prove the destination still represents the requested search
+                # before accepting even an empty result. The id extraction is
+                # later, after a clean empty page has stopped the loop.
                 #
                 # The parsed path, like the redirect check above, and not a
                 # prefix: `/jobs/search?keywords=x` is the same route, and the
@@ -3839,10 +3860,16 @@ class LinkedInExtractor:
                 # so the search returned `job_ids: []` with nothing to say
                 # why. LinkedIn was not observed serving the slashless form,
                 # but a same-document `replaceState` can produce it.
+                #
+                # Both routes, because LinkedIn 302s `/jobs/search/` to
+                # `/jobs/search-results` for the redesigned experience. The
+                # destination is the search, serves the same results and
+                # honours `start`, so refusing it skipped extraction on every
+                # account already moved over.
                 parsed_url = urlparse(self._page.url)
                 if (
                     parsed_url.netloc != "www.linkedin.com"
-                    or parsed_url.path.rstrip("/") != "/jobs/search"
+                    or parsed_url.path.rstrip("/") not in _JOB_SEARCH_PATHS
                 ):
                     logger.debug(
                         "Unexpected page URL after extraction: %s — "
@@ -3928,6 +3955,23 @@ class LinkedInExtractor:
                         offset, self._page.url
                     )
                     break
+
+                if not extracted.text:
+                    # The route and query survived, so this is a real empty
+                    # result rather than a redirect that silently replaced the
+                    # search. Do not read ids from a DOM that supplied no text.
+                    break
+
+                # Read total pages from pagination state (once only, best-effort)
+                if not total_pages_queried:
+                    total_pages_queried = True
+                    try:
+                        total_pages = await self._get_total_search_pages()
+                    except Exception as e:
+                        logger.debug("Could not read total pages: %s", e)
+                    else:
+                        if total_pages is not None:
+                            logger.debug("LinkedIn reports %d total pages", total_pages)
 
                 page_ids = await self._extract_job_ids(scoped=True)
                 # Advance by what this navigation rendered, duplicates

--- a/tests/test_job_sidebar_scroll_dom.py
+++ b/tests/test_job_sidebar_scroll_dom.py
@@ -712,3 +712,131 @@ class TestSidebarScroll:
         # 1.5s, having seen nothing and scrolled nothing.
         assert elapsed >= 0.9
         assert await rail_cards(dom_page) == 1
+
+
+class TestRedesignedCards:
+    """The cards LinkedIn's `/jobs/search-results` renders.
+
+    They carry no permalink at all: the job id exists only in a
+    ``componentkey`` attribute. A selector and an id rule that know just the
+    anchor find nothing on such a page, which is what returned an empty
+    ``job_ids`` beside a text listing real jobs.
+    """
+
+    async def test_reads_the_redesigned_card(self, dom_page):
+        await dom_page.set_content(
+            "<main>"
+            "<div componentkey='job-card-component-ref-111'>One</div>"
+            "<div componentkey='job-card-component-ref-222'>Two</div>"
+            "</main>"
+        )
+
+        assert await job_ids(dom_page) == ["111", "222"]
+
+    async def test_one_job_counted_once_across_both_card_shapes(self, dom_page):
+        """A page mid-migration renders both, and they are the same job."""
+        await dom_page.set_content(
+            "<main>"
+            "<a href='https://www.linkedin.com/jobs/view/111/'>One</a>"
+            "<div componentkey='job-card-component-ref-111'>One again</div>"
+            "<div componentkey='job-card-component-ref-222'>Two</div>"
+            "</main>"
+        )
+
+        assert await job_ids(dom_page) == ["111", "222"]
+
+    async def test_scrolls_a_lazily_growing_redesigned_rail(self, dom_page):
+        """The broadened selector belongs to scrolling as well as reading.
+
+        A direct `_JOB_IDS_JS` test stays green if the sidebar wait or scroll
+        quietly returns to legacy anchors. The redesigned page then reads its
+        initial cards correctly but never loads the batch behind them.
+        """
+        await dom_page.set_content(
+            """
+            <main>
+              <div id="rail" style="overflow-y:scroll;height:80px">
+                <div componentkey="job-card-component-ref-111"
+                     style="height:40px">One</div>
+                <div componentkey="job-card-component-ref-222"
+                     style="height:40px">Two</div>
+                <div componentkey="job-card-component-ref-333"
+                     style="height:40px">Three</div>
+              </div>
+            </main>
+            <script>
+              const rail = document.getElementById('rail');
+              let loaded = false;
+              rail.addEventListener('scroll', () => {
+                if (loaded) return;
+                loaded = true;
+                setTimeout(() => {
+                  for (const id of ['444', '555']) {
+                    const card = document.createElement('div');
+                    card.setAttribute(
+                      'componentkey', `job-card-component-ref-${id}`
+                    );
+                    card.style.height = '40px';
+                    card.textContent = id;
+                    rail.appendChild(card);
+                  }
+                }, 60);
+              });
+            </script>
+            """
+        )
+
+        await scroll_job_sidebar(
+            dom_page,
+            settle_timeout=0.25,
+            poll_interval=0.02,
+            min_budget=0.1,
+            deadline=2.0,
+        )
+
+        assert await job_ids(dom_page, scoped=True) == [
+            "111",
+            "222",
+            "333",
+            "444",
+            "555",
+        ]
+
+    async def test_an_unrelated_componentkey_is_not_a_job(self, dom_page):
+        """The prefix is anchored, so a key merely containing it is ignored."""
+        await dom_page.set_content(
+            "<main>"
+            "<div componentkey='job-card-component-ref-111'>One</div>"
+            "<div componentkey='sidebar-job-card-component-ref-999'>Not one</div>"
+            "<div componentkey='job-card-component-ref-noise'>Not one either</div>"
+            "</main>"
+        )
+
+        assert await job_ids(dom_page) == ["111"]
+
+    async def test_the_rail_is_found_by_redesigned_cards_alone(self, dom_page):
+        """The rail is picked by counting ids, so both sides need the rule.
+
+        Teaching only the extraction loop about `componentkey` leaves the
+        pick counting zero ids everywhere, and a scoped read then falls back
+        to the whole document. This asserts the scoped read, which is the
+        one that goes through the pick.
+        """
+        await dom_page.set_content(
+            "<body style='margin:0'>"
+            "<div id='rail' style='overflow-y:scroll;height:80px'>"
+            "<div componentkey='job-card-component-ref-111'"
+            " style='height:40px'>One</div>"
+            "<div componentkey='job-card-component-ref-222'"
+            " style='height:40px'>Two</div>"
+            "<div componentkey='job-card-component-ref-333'"
+            " style='height:40px'>Three</div>"
+            "</div>"
+            "<div id='pane' style='overflow-y:scroll;height:40px'>"
+            "<div componentkey='job-card-component-ref-999'"
+            " style='height:80px'>Detail</div>"
+            "</div>"
+            "</body>"
+        )
+
+        assert await job_ids(dom_page, scoped=True) == ["111", "222", "333"]

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -477,6 +477,147 @@ class TestExtractPage:
                 section_name="search_results",
             )
 
+    async def test_the_search_redesign_redirect_is_not_a_replacement(self, mock_page):
+        """LinkedIn's 302 to `/jobs/search-results` must not end the page.
+
+        The route asked for is compared against the one the page ended on,
+        and a mismatch is fatal on purpose: an account picker served in place
+        of a search moves the route exactly this way. The redesign redirect
+        moves it too, so a migrated account raised here, before any of the
+        id extraction downstream could run, and the search returned nothing
+        while reporting that it had navigated away.
+
+        Driven through `_extract_search_page_once` rather than around it. A
+        test that mocks the extraction layer places the landing address after
+        this comparison has already happened and passes whatever it does.
+        """
+        mock_page.url = "https://www.linkedin.com/jobs/search/?keywords=python"
+
+        async def redirect_to_the_redesign(url, *args, **kwargs):
+            navigate(
+                mock_page,
+                "https://www.linkedin.com/jobs/search-results/?keywords=python",
+            )
+
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+                side_effect=redirect_to_the_redesign,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor._extract_search_page_once(
+                "https://www.linkedin.com/jobs/search/?keywords=python",
+                section_name="search_results",
+            )
+
+        assert result.text == "Sample page text"
+        assert result.error is None
+
+    async def test_a_route_change_off_the_search_still_ends_the_page(self, mock_page):
+        """The loosening is between the two search routes and nowhere else.
+
+        `/feed/` is deliberately not an auth route. A checkpoint would be
+        rejected by the detector before the helper was tested, so a helper
+        accepting every same-host path could pass that fixture unchanged.
+        """
+        mock_page.url = "https://www.linkedin.com/jobs/search/?keywords=python"
+
+        async def redirect_to_the_feed(url, *args, **kwargs):
+            navigate(mock_page, "https://www.linkedin.com/feed/")
+
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+                side_effect=redirect_to_the_feed,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            pytest.raises(RuntimeError, match="Page navigated to .*/feed/"),
+        ):
+            await extractor._extract_search_page_once(
+                "https://www.linkedin.com/jobs/search/?keywords=python",
+                section_name="search_results",
+            )
+
+    async def test_the_redesign_redirect_keeps_the_full_auth_check(self, mock_page):
+        """An account picker can be served at an otherwise allowed path.
+
+        Route equivalence cannot classify the document, so the full detector
+        must run before the helper suppresses the route-mismatch error.
+        """
+        requested = "https://www.linkedin.com/jobs/search/?keywords=python"
+        mock_page.url = requested
+
+        async def redirect_to_the_redesign(url, *args, **kwargs):
+            navigate(
+                mock_page,
+                "https://www.linkedin.com/jobs/search-results/?keywords=python",
+            )
+
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+                side_effect=redirect_to_the_redesign,
+            ),
+            patch.object(
+                extractor,
+                "_raise_if_auth_barrier",
+                new_callable=AsyncMock,
+                side_effect=AuthenticationError("Run with --login"),
+            ) as check_auth,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            pytest.raises(AuthenticationError, match="--login"),
+        ):
+            await extractor._extract_search_page_once(
+                requested,
+                section_name="search_results",
+            )
+
+        check_auth.assert_awaited_once_with(requested)
+
     async def test_a_checkpoint_while_scrolling_raises_an_auth_error(self, mock_page):
         """A checkpoint reached mid-scroll must not come back as job results.
 
@@ -3548,6 +3689,101 @@ class TestSearchJobs:
         # search is diagnosable from the response itself.
         assert "python" in error["error_message"]
 
+    async def test_the_redesigned_search_route_still_yields_ids(self, mock_page):
+        """LinkedIn 302s `/jobs/search/` to its redesigned results route.
+
+        The guard accepted only the route the URL builder produces, so every
+        account already moved over ended the search on the first page with
+        `job_ids: []` while `search_results` listed real jobs. The redirect
+        keeps the query and honours `start`, so the destination is the search
+        and not a replacement of it.
+        """
+        extractor = LinkedInExtractor(mock_page)
+
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                side_effect=self._navigating(
+                    mock_page,
+                    [extracted("Job 1\nJob 2")],
+                    lands_on=(
+                        "https://www.linkedin.com/jobs/search-results/?keywords=python"
+                    ),
+                ),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111", "222"],
+            ) as mock_ids,
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_jobs("python", max_pages=1)
+
+        assert result["job_ids"] == ["111", "222"]
+        assert mock_ids.await_count == 1
+        assert "search_results" not in result.get("section_errors", {})
+
+    async def test_the_redesigned_route_still_reports_a_dropped_filter(self, mock_page):
+        """Reaching the guard is what lets the filter check run at all.
+
+        The redesigned route drops `location`, and the results then come back
+        for whatever place the account defaults to. That is reported rather
+        than retried, the way every other dropped filter is; before the guard
+        accepted this route the search raised first and said nothing about
+        the location.
+        """
+        extractor = LinkedInExtractor(mock_page)
+
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                side_effect=self._navigating(
+                    mock_page,
+                    [extracted("Job 1")],
+                    lands_on=(
+                        "https://www.linkedin.com/jobs/search-results/?keywords=python"
+                    ),
+                ),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_jobs(
+                "python", location="Berlin", max_pages=1
+            )
+
+        assert result["job_ids"] == ["111"]
+        error = result["section_errors"]["search_results"]
+        assert error["error_type"] == "filters_dropped"
+        assert "location" in error["error_message"]
+
     async def test_a_pane_job_is_not_a_search_result(self, mock_page):
         """The ids come from the rail and the references from the whole page.
 
@@ -4110,8 +4346,7 @@ class TestSearchJobs:
             patch.object(
                 extractor,
                 "_extract_search_page",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
+                side_effect=self._navigating(mock_page, [extracted("")]),
             ),
             patch.object(
                 extractor,
@@ -4136,6 +4371,147 @@ class TestSearchJobs:
         assert result["sections"] == {}
         # Empty text should skip ID extraction to avoid stale DOM
         mock_ids.assert_not_awaited()
+
+    async def test_empty_redesign_page_reports_dropped_keywords(self, mock_page):
+        """An empty destination must still prove it answered the question.
+
+        `/jobs/search-results/` without the query can be a blank replacement
+        page. Accepting its empty text before comparing keywords reports a
+        successful search with no jobs, although LinkedIn answered no search
+        at all.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                side_effect=self._navigating(
+                    mock_page,
+                    [extracted("")],
+                    lands_on="https://www.linkedin.com/jobs/search-results/",
+                ),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_ids,
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_jobs("python", max_pages=1)
+
+        assert result["job_ids"] == []
+        assert result["sections"] == {}
+        assert result["section_errors"]["search_results"]["error_type"] == (
+            "search_replaced"
+        )
+        mock_ids.assert_not_awaited()
+
+    async def test_empty_redesign_page_reports_a_dropped_filter(self, mock_page):
+        """A clean empty result cannot hide a location the redirect dropped."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                side_effect=self._navigating(
+                    mock_page,
+                    [extracted("")],
+                    lands_on=(
+                        "https://www.linkedin.com/jobs/search-results/?keywords=python"
+                    ),
+                ),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_ids,
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_jobs(
+                "python", location="Berlin", max_pages=1
+            )
+
+        error = result["section_errors"]["search_results"]
+        assert error["error_type"] == "filters_dropped"
+        assert "location" in error["error_message"]
+        mock_ids.assert_not_awaited()
+
+    async def test_empty_later_page_reports_a_dropped_offset(self, mock_page):
+        """A blank first page repeated later must not truncate pagination.
+
+        The first navigation yields one job. The second lands on a bare
+        redesign URL with no `start`; without validating before the empty
+        short-circuit, the search silently stops and presents page one as the
+        complete answer.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        pages = iter([extracted("Page 1"), extracted("")])
+        calls = 0
+
+        async def navigate_page(url, *args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                navigate(mock_page, url)
+            else:
+                navigate(
+                    mock_page,
+                    "https://www.linkedin.com/jobs/search-results/?keywords=python",
+                )
+            return next(pages)
+
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                side_effect=navigate_page,
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111"],
+            ) as mock_ids,
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_jobs("python", max_pages=2)
+
+        assert result["job_ids"] == ["111"]
+        assert result["sections"]["search_results"] == "Page 1"
+        error = result["section_errors"]["search_results"]
+        assert error["error_type"] == "pagination_stopped"
+        assert mock_ids.await_count == 1
 
     async def test_no_ids_on_first_page_captures_text(self, mock_page):
         """Non-empty text with zero job IDs should be returned in sections."""
@@ -4369,6 +4745,70 @@ class TestSearchJobs:
         assert result["job_ids"] == []
         assert result["sections"] == {}
         assert result["section_errors"]["search_results"]["error_type"] == "rate_limit"
+        mock_ids.assert_not_awaited()
+
+    async def test_rate_limit_wins_over_an_unexpected_landing(self, mock_page):
+        """The specific diagnosis survives a simultaneous route failure."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                side_effect=self._navigating(
+                    mock_page,
+                    [extracted(_RATE_LIMITED_MSG)],
+                    lands_on="https://www.linkedin.com/feed/",
+                ),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["100"],
+            ) as mock_ids,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_jobs("python", max_pages=1)
+
+        assert result["section_errors"]["search_results"]["error_type"] == (
+            "rate_limit"
+        )
+        mock_ids.assert_not_awaited()
+
+    async def test_extraction_error_wins_over_a_dropped_query(self, mock_page):
+        """A classified extraction failure must not become a route warning."""
+        failure = {
+            "error_type": "navigation_error",
+            "error_message": "the search page did not load",
+        }
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                side_effect=self._navigating(
+                    mock_page,
+                    [extracted("", error=failure)],
+                    lands_on="https://www.linkedin.com/jobs/search-results/",
+                ),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["100"],
+            ) as mock_ids,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_jobs("python", max_pages=1)
+
+        assert result["section_errors"]["search_results"] == failure
         mock_ids.assert_not_awaited()
 
 


### PR DESCRIPTION
Fixes #725. Supersedes #726 (same change; branch was renamed to follow the repo's naming convention, which auto-closed the old PR).

## Problem

LinkedIn now 302-redirects `/jobs/search/` to `/jobs/search-results/` (their new AI search experience). This breaks `search_jobs` in three ways:

1. The URL guard only accepted `/jobs/search/`, so it skipped job ID extraction after every redirect.
2. The new result cards store job IDs in a `componentkey` attribute (`job-card-component-ref-<id>`), not in `/jobs/view/` anchor hrefs. The old selector found nothing.
3. The redirect drops the `location` query parameter. LinkedIn falls back to the account's default location.

## Changes

- **URL guard**: accepts both `/jobs/search` and `/jobs/search-results` paths. Also checks the host is `www.linkedin.com`.
- **Job ID extraction + sidebar scroll**: matches both classic `/jobs/view/` anchors and the new `componentkey` cards, deduplicated.
- **Location handling**: navigates with plain keywords first. If the redirect to the new route is detected and a location was requested, re-fetches once with the location folded into the keywords (e.g. `"python in Berlin"`), which the AI search parses correctly. Classic route behavior is unchanged. Cost is one extra navigation on page 1, only when redirected. Happy to take a different approach here if you prefer.
- DOM dependencies documented in docstrings per CONTRIBUTING.

## Verification

- **Unit tests**: redirected route, location re-fetch, classic route keeps plain keywords, host guard.
- **Browser-DOM tests**: both card formats, dedup, scroll assertion.
- **Live check via MCP stdio**: Berlin search returned 99+ results and 25 job IDs with location respected.
- **Full suite**: 1975 passed, 11 skipped. Pre-commit green (ruff, ruff-format, ty).
