### PR TITLE
build(docker): Pin the image build backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -165,3 +165,11 @@ assets/*
 .claude
 .github
 .docker
+.agents
+.gemini
+
+# Local working notes and private context. None of it is a build input, and
+# `COPY . .` otherwise keeps all of it in the builder layer, which the release
+# exports through `cache-to: type=gha,mode=max`.
+.debug
+CLAUDE.local.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -103,8 +103,12 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
-# Environments
-.env
+# Environments. The pattern has to cover the suffixed variants and every
+# directory, because `COPY . .` keeps whatever the context carries in the
+# builder layer, and a `.env.local` holds the same session cookie and proxy
+# credentials as the plain file. That layer is not published, the runtime stage
+# takes only `/app/.venv`, but it is exported by `cache-to: type=gha,mode=max`.
+**/.env*
 .venv
 env/
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,10 @@ celerybeat.pid
 
 # Environments. The suffixed variants hold the same session cookie and proxy
 # credentials as the plain file, and the template is the one that belongs here.
-.env*
+# `.env.*` rather than `.env*`, which also swallowed `.envrc` and left a
+# contributor adding one to wonder why it never showed up in `git status`.
+.env
+.env.*
 !.env.example
 .venv
 env/

--- a/.gitignore
+++ b/.gitignore
@@ -127,8 +127,10 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
-# Environments
-.env
+# Environments. The suffixed variants hold the same session cookie and proxy
+# credentials as the plain file, and the template is the one that belongs here.
+.env*
+!.env.example
 .venv
 env/
 venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,16 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --frozen --no-install-project --no-dev --no-editable --compile-bytecode
 
+# The project itself is installed separately, because installing it runs
+# `setuptools.build_meta` and `uv sync` has no way to constrain that build. The
+# distributions published from CI pin the backend against this same hashed file
+# (#654); without this the image would resolve setuptools fresh from PyPI in the
+# one job that holds the Docker Hub credentials. `--no-deps` keeps the runtime
+# dependencies exactly as the frozen lock installed them above, so this adds the
+# project and nothing else.
 COPY . .
-RUN uv sync --frozen --no-dev --no-editable --compile-bytecode
+RUN uv pip install --python /app/.venv/bin/python --no-deps --compile-bytecode \
+    --build-constraints build-constraints.txt .
 
 
 # -- Stage 2: Production runtime --

--- a/linkedin_mcp_server/debug_trace.py
+++ b/linkedin_mcp_server/debug_trace.py
@@ -188,21 +188,3 @@ async def record_page_trace(
         pass
     with trace_jsonl.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(payload, ensure_ascii=True) + "\n")
-
-
-def reset_trace_for_testing() -> None:
-    """Forget the cached trace directory, for test isolation.
-
-    The directory is resolved once and kept, which is right for a process that
-    serves one session and wrong for a suite. It is derived from the profile
-    root, so a test pointing ``USER_DATA_DIR`` at its own ``tmp_path`` leaves
-    every later test on the same worker writing into that directory, long
-    after pytest has torn it down. Measured in CI: a test that asserts the
-    suggested gist command omits a missing ``server.log`` failed, because a
-    daemon test earlier on the same worker had started a real server whose log
-    landed in the directory still cached here.
-    """
-    global _TRACE_DIR, _TRACE_KEEP, _EXPLICIT_TRACE_DIR
-    _TRACE_DIR = None
-    _TRACE_KEEP = False
-    _EXPLICIT_TRACE_DIR = False

--- a/linkedin_mcp_server/debug_trace.py
+++ b/linkedin_mcp_server/debug_trace.py
@@ -188,3 +188,21 @@ async def record_page_trace(
         pass
     with trace_jsonl.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(payload, ensure_ascii=True) + "\n")
+
+
+def reset_trace_for_testing() -> None:
+    """Forget the cached trace directory, for test isolation.
+
+    The directory is resolved once and kept, which is right for a process that
+    serves one session and wrong for a suite. It is derived from the profile
+    root, so a test pointing ``USER_DATA_DIR`` at its own ``tmp_path`` leaves
+    every later test on the same worker writing into that directory, long
+    after pytest has torn it down. Measured in CI: a test that asserts the
+    suggested gist command omits a missing ``server.log`` failed, because a
+    daemon test earlier on the same worker had started a real server whose log
+    landed in the directory still cached here.
+    """
+    global _TRACE_DIR, _TRACE_KEEP, _EXPLICIT_TRACE_DIR
+    _TRACE_DIR = None
+    _TRACE_KEEP = False
+    _EXPLICIT_TRACE_DIR = False

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,5 @@ addopts = -v --strict-markers -ra
 markers =
     browser_dom: evaluates extractor JS against a real chromium DOM; skipped when no browser is installed
     slow: spawns real server processes; each case starts the full server graph
-    image_build: builds the real image; needs a docker daemon and the full context
+    image_build: shells out to a docker daemon; skipped where there is none
     browser_identity: the identity gate; fails rather than skips in CI

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,5 @@ addopts = -v --strict-markers -ra
 markers =
     browser_dom: evaluates extractor JS against a real chromium DOM; skipped when no browser is installed
     slow: spawns real server processes; each case starts the full server graph
+    image_build: builds the real image; needs a docker daemon and the full context
     browser_identity: the identity gate; fails rather than skips in CI

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ def reset_singletons():
     from linkedin_mcp_server.bootstrap import reset_bootstrap_for_testing
     from linkedin_mcp_server.config import reset_config
     from linkedin_mcp_server.daemon_liveness import reset_liveness_for_testing
+    from linkedin_mcp_server.debug_trace import reset_trace_for_testing
     from linkedin_mcp_server.drivers.browser import reset_browser_for_testing
     from linkedin_mcp_server.profile_lease import reset_leases_for_testing
     from linkedin_mcp_server.server_role import reset_process_role_for_testing
@@ -25,6 +26,10 @@ def reset_singletons():
     # from process state. Left standing, one OWNER would refuse logins in every
     # test after it, in a suite where most never mention a role.
     reset_process_role_for_testing()
+    # The trace directory is derived from the profile root and cached, so a
+    # test pointing USER_DATA_DIR at its tmp_path otherwise leaves every
+    # later test on this worker writing into a directory pytest has removed.
+    reset_trace_for_testing()
     yield
     reset_bootstrap_for_testing()
     reset_browser_for_testing()
@@ -34,6 +39,7 @@ def reset_singletons():
     reset_config()
     reset_process_role_for_testing()
     reset_liveness_for_testing()
+    reset_trace_for_testing()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,8 @@ def reset_singletons():
     from linkedin_mcp_server.bootstrap import reset_bootstrap_for_testing
     from linkedin_mcp_server.config import reset_config
     from linkedin_mcp_server.daemon_liveness import reset_liveness_for_testing
-    from linkedin_mcp_server.debug_trace import reset_trace_for_testing
+    from linkedin_mcp_server.debug_trace import reset_trace_state_for_testing
+    from linkedin_mcp_server.logging_config import teardown_trace_logging
     from linkedin_mcp_server.drivers.browser import reset_browser_for_testing
     from linkedin_mcp_server.profile_lease import reset_leases_for_testing
     from linkedin_mcp_server.server_role import reset_process_role_for_testing
@@ -27,9 +28,14 @@ def reset_singletons():
     # test after it, in a suite where most never mention a role.
     reset_process_role_for_testing()
     # The trace directory is derived from the profile root and cached, so a
-    # test pointing USER_DATA_DIR at its tmp_path otherwise leaves every
-    # later test on this worker writing into a directory pytest has removed.
-    reset_trace_for_testing()
+    # test pointing USER_DATA_DIR at its tmp_path otherwise leaves every later
+    # test on this worker writing into a directory pytest has removed. The log
+    # handler holds the same path independently of that cache and has to be
+    # unbound with it, or records keep landing in the previous test's
+    # directory while a fresh one is resolved. `keep_traces` because removing
+    # a directory is a test's own business, not this fixture's.
+    teardown_trace_logging(keep_traces=True)
+    reset_trace_state_for_testing()
     yield
     reset_bootstrap_for_testing()
     reset_browser_for_testing()
@@ -39,7 +45,8 @@ def reset_singletons():
     reset_config()
     reset_process_role_for_testing()
     reset_liveness_for_testing()
-    reset_trace_for_testing()
+    teardown_trace_logging(keep_traces=True)
+    reset_trace_state_for_testing()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -137,7 +137,11 @@ _PROJECT_BUILDING_COMMANDS = (
     "uv pip install",
     "uv run",
     "uv build",
+    # `uvx` and `uv tool` are the same command under two spellings, and only
+    # the short one was here at first: `uv tool install .` built the project
+    # past a corrupted constraint file while this guard reported nothing.
     "uvx",
+    "uv tool",
     "pip install",
     "pip wheel",
     "python -m build",

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -1,32 +1,152 @@
 """The image's browser and process topology are part of its behaviour.
 
-A Docker build is too expensive for the ordinary unit suite, and string checks
-are enough for the pieces that can disappear silently: the browser product, the
-launch mode, and who receives SIGTERM. The supervisor itself is exercised with
-fake Xvfb and server processes, because child liveness is behaviour a string
-check cannot prove.
+Building the real image is too expensive for the ordinary unit suite, and
+string checks are enough for the pieces that can disappear silently: the
+browser product, the launch mode, and who receives SIGTERM. The supervisor
+itself is exercised with fake Xvfb and server processes, because child liveness
+is behaviour a string check cannot prove.
+
+Two things resist that treatment and are measured instead. Which paths reach
+the build context is decided by `.dockerignore` semantics that no
+reimplementation here matched without diverging silently, so a throwaway
+`busybox` probe asks the daemon; it costs about a second and skips where there
+is no daemon. And a flag is read out of the command that will run it rather
+than out of the file, because the file also holds the comment explaining the
+flag.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import signal
 import socket
 import subprocess
 import textwrap
+import tomllib
 from pathlib import Path
 
 import pytest
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+
+def _logical_lines(text: str) -> list[str]:
+    """Join backslash continuations and drop comments.
+
+    Both the Dockerfile and the compiled constraint file wrap one logical
+    statement across several physical lines. Matching a flag against the raw
+    text therefore also matches the comment that explains the flag, which is
+    how an assertion on ``--no-deps`` stayed green after the flag was removed
+    from the command it guards.
+
+    Line continuation is the whole of what this handles, and
+    `test_the_dockerfile_stays_within_the_syntax_this_file_parses` refuses the
+    constructs where that is not enough. A heredoc would otherwise present its
+    payload as instructions, and BuildKit reads a `\\\\` line ending and a
+    `# escape=` directive differently again.
+    """
+    statements: list[str] = []
+    pending = ""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.endswith("\\"):
+            pending += f"{stripped[:-1].strip()} "
+            continue
+        statements.append(f"{pending}{stripped}".strip())
+        pending = ""
+    if pending:
+        statements.append(pending.strip())
+    return statements
+
+
+def _shell_commands(instruction: str) -> list[str]:
+    """Split a `RUN` into the commands the shell will actually execute.
+
+    Searching the whole instruction for a flag asks whether the text contains
+    it, not whether the command runs with it. Docker joins continuations into
+    a single shell line, so `install foo; # --no-deps` leaves a comment that
+    swallows every flag written on the following lines while each substring
+    assertion still finds them, and `sync --no-install-project && sync` runs a
+    second, unguarded install that no substring reveals.
+    """
+    body = instruction.removeprefix("RUN ").strip()
+    body = re.split(r"(?:^|\s)#", body, maxsplit=1)[0]
+    return [part.strip() for part in re.split(r"&&|\|\||[;|]", body) if part.strip()]
+
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _DOCKERFILE = (_REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+_DOCKERFILE_INSTRUCTIONS = _logical_lines(_DOCKERFILE)
 _ENTRYPOINT_PATH = _REPO_ROOT / "docker-entrypoint.sh"
 _ENTRYPOINT = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
 _README = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
 _DOCKER_GUIDE = (_REPO_ROOT / "docs" / "docker-hub.md").read_text(encoding="utf-8")
 _BUILD_CONSTRAINTS_PATH = _REPO_ROOT / "build-constraints.txt"
-_DOCKERIGNORE = (_REPO_ROOT / ".dockerignore").read_text(encoding="utf-8")
+_PYPROJECT_PATH = _REPO_ROOT / "pyproject.toml"
+_IMAGE_PYTHON = re.search(r"^FROM python:(\d+)\.(\d+)\.(\d+)-slim", _DOCKERFILE, re.M)
+_CONTEXT_PROBE = "FROM busybox\nCOPY . /ctx\n"
+
+
+@pytest.fixture(scope="module")
+def build_context() -> frozenset[str]:
+    """The paths BuildKit really sends, read out of a throwaway probe build.
+
+    `.dockerignore` semantics cannot be recovered from the file alone. Every
+    reimplementation measured here disagreed with BuildKit while staying
+    silent about it: a leading slash anchors the pattern, `*` stops at a
+    separator, `\\!` escapes a negation, and a wildcard such as
+    `build-constraints.*` hides a file that a literal-name search still reads
+    as present. Each of those is a false pass, which is the direction that
+    costs something. The release publishes to PyPI and tags the repository
+    before the Docker job runs, so a version can end up on PyPI and as a tag
+    with no image behind it.
+
+    Asking the daemon costs about a second against this 9.6 MB context, and
+    the suite skips where there is none, the way the entrypoint tests skip
+    without Bash 5.
+    """
+    docker = shutil.which("docker")
+    if docker is None:
+        pytest.skip("docker is required to read the real build context")
+
+    tag = f"linkedin-mcp-context-probe:{os.getpid()}"
+    # A file under a directory proves the `**/` reach of the pattern; `.env`
+    # and the tracked `.env.example` only ever prove the root.
+    nested = _REPO_ROOT / "tests" / f".env.probe-{os.getpid()}"
+    try:
+        nested.write_text("PROBE=1\n", encoding="utf-8")
+        build = subprocess.run(
+            [docker, "build", "-q", "-t", tag, "-f", "-", str(_REPO_ROOT)],
+            input=_CONTEXT_PROBE,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+        if build.returncode != 0:
+            pytest.skip(f"no usable docker daemon: {build.stderr.strip()[:200]}")
+        listing = subprocess.run(
+            [docker, "run", "--rm", tag, "find", "/ctx", "-type", "f"],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=True,
+        )
+    finally:
+        nested.unlink(missing_ok=True)
+        subprocess.run(
+            [docker, "rmi", "-f", tag], capture_output=True, text=True, check=False
+        )
+
+    return frozenset(
+        line.removeprefix("/ctx/")
+        for line in listing.stdout.split("\n")
+        if line.startswith("/ctx/")
+    )
 
 
 def test_the_image_installs_only_the_full_browser() -> None:
@@ -42,26 +162,153 @@ def test_the_image_builds_the_project_against_the_hashed_backend() -> None:
     Hub credentials (#655). The project is installed on its own instead, against
     the same hashed file the published distributions use (#654).
     """
-    assert "--build-constraints build-constraints.txt ." in _DOCKERFILE
-    # The dependency sync is the only sync left. One that also installs the
-    # project would build it unconstrained and make the pin above dead weight.
-    assert "uv sync --frozen --no-install-project" in _DOCKERFILE
-    assert "uv sync --frozen --no-dev" not in _DOCKERFILE
+    commands = [
+        command
+        for instruction in _DOCKERFILE_INSTRUCTIONS
+        if instruction.startswith("RUN ")
+        for command in _shell_commands(instruction)
+    ]
+    installs = [command for command in commands if command.startswith("uv pip install")]
+    assert len(installs) == 1
+    project_install = installs[0]
+
+    assert "--build-constraints build-constraints.txt" in project_install
+    assert project_install.endswith(" .")
     # Without this the lock stops deciding the runtime dependencies: a bare
     # `uv pip install .` resolves them again from the index.
-    assert "--no-deps" in _DOCKERFILE
+    assert "--no-deps" in project_install
+    # uv verifies the hashes in a constraint file by default, and this switch
+    # turns that off while every other assertion here stays satisfied. A mirror
+    # workaround reaching for it would leave the pin as documentation only.
+    assert "--no-verify-hashes" not in project_install
+    # Every sync has to leave the project alone. One that installs it builds the
+    # backend unconstrained, and a later constrained install cannot undo a build
+    # that already ran.
+    syncs = [command for command in commands if command.startswith("uv sync")]
+    assert syncs
+    for sync in syncs:
+        assert "--no-install-project" in sync
+    # The switch above has an environment twin that reaches every uv invocation
+    # in the stage, including this one, and turns the same verification off.
+    assert "UV_NO_VERIFY_HASHES" not in _DOCKERFILE
 
 
-def test_the_hashed_build_constraint_reaches_the_build_context() -> None:
-    """A version without hashes, or an excluded file, silently drops the pin."""
-    constraints = _BUILD_CONSTRAINTS_PATH.read_text(encoding="utf-8")
+def test_the_dockerfile_stays_within_the_syntax_this_file_parses() -> None:
+    """`_logical_lines` handles line continuation, so nothing else may appear.
 
-    assert "setuptools==" in constraints
-    assert constraints.count("--hash=sha256:") >= 1
-    ignored = {
-        line.strip() for line in _DOCKERIGNORE.splitlines() if not line.startswith("#")
+    BuildKit reads three constructs differently, and each one lets an
+    assertion above pass while the build does something else. A heredoc is
+    data to BuildKit and instructions to this parser, so a payload line
+    reading `uv pip install ... .` satisfies the install assertions while no
+    install runs. A line ending in `\\\\` ends the instruction for BuildKit
+    and continues it here, importing flags from the next line. An `escape`
+    directive changes the continuation character entirely.
+    """
+    assert "<<" not in _DOCKERFILE
+    assert not re.search(r"^\s*#\s*escape\s*=", _DOCKERFILE, re.M)
+    assert not [
+        line for line in _DOCKERFILE.splitlines() if line.rstrip().endswith("\\\\")
+    ]
+
+
+def test_every_build_requirement_is_pinned_with_hashes() -> None:
+    """The constraint files have to cover all of `[build-system].requires`.
+
+    Asserting only that some hashed `setuptools==` entry exists let an added
+    `wheel` install unpinned while both files still read as pinned. The source
+    file is checked alongside the compiled one because it is what carries the
+    transitive closure: `uv pip compile` writes every dependency of what it is
+    given, so a requirement present there cannot bring an unhashed dependency
+    along, and one added only to the compiled file can. Nothing offline can
+    prove the compiled file is the current output of that command; Renovate's
+    `pip-compile` manager regenerates it, and the hash check below is what
+    catches a partial edit.
+    """
+    build_system = tomllib.loads(_PYPROJECT_PATH.read_text(encoding="utf-8"))[
+        "build-system"
+    ]
+    required = {
+        canonicalize_name(Requirement(entry).name) for entry in build_system["requires"]
     }
-    assert "build-constraints.txt" not in ignored
+    assert required
+
+    def named(path: Path) -> dict[str, str]:
+        return {
+            canonicalize_name(
+                Requirement(entry.split("--hash", 1)[0].strip()).name
+            ): entry
+            for entry in _logical_lines(path.read_text(encoding="utf-8"))
+        }
+
+    sources = named(_REPO_ROOT / "build-constraints.in")
+    compiled = named(_BUILD_CONSTRAINTS_PATH)
+
+    assert required <= sources.keys(), (
+        f"build requirements missing from build-constraints.in: "
+        f"{sorted(required - sources.keys())}"
+    )
+    assert sources.keys() <= compiled.keys(), (
+        f"sources missing from the compiled file: "
+        f"{sorted(sources.keys() - compiled.keys())}"
+    )
+    unhashed = sorted(
+        name for name, entry in compiled.items() if "--hash=sha256:" not in entry
+    )
+    assert not unhashed, f"compiled entries without a hash: {unhashed}"
+
+    # A marker that is false where the image builds pins nothing there while
+    # reading as a pin here. `platform_machine` is the live one: the release
+    # builds amd64 and arm64 from this same file, so an entry true for only one
+    # of them leaves the other resolving its backend from the index.
+    assert _IMAGE_PYTHON, "the base image no longer names a Python version"
+    major, minor, patch = _IMAGE_PYTHON.groups()
+    for name, entry in compiled.items():
+        marker = Requirement(entry.split("--hash", 1)[0].strip()).marker
+        if marker is None:
+            continue
+        for machine in ("x86_64", "aarch64"):
+            environment = {
+                "implementation_name": "cpython",
+                "os_name": "posix",
+                "platform_machine": machine,
+                "platform_system": "Linux",
+                "python_full_version": f"{major}.{minor}.{patch}",
+                "python_version": f"{major}.{minor}",
+                "sys_platform": "linux",
+            }
+            assert marker.evaluate(environment), (
+                f"{name} is constrained only outside the image: {marker} on {machine}"
+            )
+
+
+def test_the_hashed_build_constraint_reaches_the_build_context(
+    build_context: frozenset[str],
+) -> None:
+    """An excluded constraint file drops a pin the build never asked for."""
+    for name in ("build-constraints.txt", "pyproject.toml", "uv.lock", "README.md"):
+        assert name in build_context, name
+
+
+def test_the_build_context_carries_no_environment_file(
+    build_context: frozenset[str],
+) -> None:
+    """A suffixed `.env` carries the same secrets as the plain one.
+
+    `COPY . .` keeps the whole context in the builder layer, and the release
+    workflow exports that layer through `cache-to: type=gha,mode=max`. Ignoring
+    only `.env` let a local `.env.previous-proxy` through, holding a LinkedIn
+    session cookie and proxy credentials; a real build listed it inside `/app`.
+    The runtime stage takes only `/app/.venv`, so no published image carried it.
+    """
+    # The tracked `.env.example` is what keeps this from passing vacuously, and
+    # the fixture writes a nested one for the `**/` half of the pattern.
+    assert sorted(path.name for path in _REPO_ROOT.glob(".env*")), (
+        "no .env* file exists here, so an empty result would prove nothing"
+    )
+    leaked = sorted(
+        path for path in build_context if Path(path).name.startswith(".env")
+    )
+    assert not leaked, f"environment files reached the build context: {leaked}"
 
 
 def test_the_image_defaults_to_headed_on_a_virtual_display() -> None:

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -25,11 +25,43 @@ _ENTRYPOINT_PATH = _REPO_ROOT / "docker-entrypoint.sh"
 _ENTRYPOINT = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
 _README = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
 _DOCKER_GUIDE = (_REPO_ROOT / "docs" / "docker-hub.md").read_text(encoding="utf-8")
+_BUILD_CONSTRAINTS_PATH = _REPO_ROOT / "build-constraints.txt"
+_DOCKERIGNORE = (_REPO_ROOT / ".dockerignore").read_text(encoding="utf-8")
 
 
 def test_the_image_installs_only_the_full_browser() -> None:
     """The shell is a different product and nothing in the image launches it."""
     assert "patchright install chromium --no-shell" in _DOCKERFILE
+
+
+def test_the_image_builds_the_project_against_the_hashed_backend() -> None:
+    """Installing the project runs the build backend, so the image must pin it.
+
+    `uv sync` takes no build constraint, so a plain sync of the project resolves
+    setuptools fresh from PyPI inside the one release job that holds the Docker
+    Hub credentials (#655). The project is installed on its own instead, against
+    the same hashed file the published distributions use (#654).
+    """
+    assert "--build-constraints build-constraints.txt ." in _DOCKERFILE
+    # The dependency sync is the only sync left. One that also installs the
+    # project would build it unconstrained and make the pin above dead weight.
+    assert "uv sync --frozen --no-install-project" in _DOCKERFILE
+    assert "uv sync --frozen --no-dev" not in _DOCKERFILE
+    # Without this the lock stops deciding the runtime dependencies: a bare
+    # `uv pip install .` resolves them again from the index.
+    assert "--no-deps" in _DOCKERFILE
+
+
+def test_the_hashed_build_constraint_reaches_the_build_context() -> None:
+    """A version without hashes, or an excluded file, silently drops the pin."""
+    constraints = _BUILD_CONSTRAINTS_PATH.read_text(encoding="utf-8")
+
+    assert "setuptools==" in constraints
+    assert constraints.count("--hash=sha256:") >= 1
+    ignored = {
+        line.strip() for line in _DOCKERIGNORE.splitlines() if not line.startswith("#")
+    }
+    assert "build-constraints.txt" not in ignored
 
 
 def test_the_image_defaults_to_headed_on_a_virtual_display() -> None:

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -64,19 +64,21 @@ def _logical_lines(text: str) -> list[str]:
     return statements
 
 
-def _shell_commands(instruction: str) -> list[str]:
-    """Split a `RUN` into the commands the shell will actually execute.
-
-    Searching the whole instruction for a flag asks whether the text contains
-    it, not whether the command runs with it. Docker joins continuations into
-    a single shell line, so `install foo; # --no-deps` leaves a comment that
-    swallows every flag written on the following lines while each substring
-    assertion still finds them, and `sync --no-install-project && sync` runs a
-    second, unguarded install that no substring reveals.
-    """
-    body = instruction.removeprefix("RUN ").strip()
-    body = re.split(r"(?:^|\s)#", body, maxsplit=1)[0]
-    return [part.strip() for part in re.split(r"&&|\|\||[;|]", body) if part.strip()]
+# The two commands that decide which backend builds the project, written out
+# whole. Reading a flag out of them needs a shell parser, and every version of
+# that parser written here had a hole: a comment swallowing the rest of the
+# line, a `&` keeping two commands in one string, a `$(...)` hiding one inside
+# another, an `ENV=1` prefix moving the command name off the front. Comparing
+# the instruction entire needs no parser and has no hole. It also makes these
+# two lines deliberately awkward to change, which is the point.
+_DEPENDENCY_SYNC = (
+    "RUN uv sync --frozen --no-install-project --no-dev --no-editable "
+    "--compile-bytecode"
+)
+_PROJECT_INSTALL = (
+    "RUN uv pip install --python /app/.venv/bin/python --no-deps "
+    "--compile-bytecode --build-constraints build-constraints.txt ."
+)
 
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -89,55 +91,81 @@ _DOCKER_GUIDE = (_REPO_ROOT / "docs" / "docker-hub.md").read_text(encoding="utf-
 _BUILD_CONSTRAINTS_PATH = _REPO_ROOT / "build-constraints.txt"
 _PYPROJECT_PATH = _REPO_ROOT / "pyproject.toml"
 _IMAGE_PYTHON = re.search(r"^FROM python:(\d+)\.(\d+)\.(\d+)-slim", _DOCKERFILE, re.M)
-_CONTEXT_PROBE = "FROM busybox\nCOPY . /ctx\n"
+# Pinned: the probe runs against the developer's own machine, and `latest`
+# is whatever the registry serves that day.
+_PROBE_IMAGE = (
+    "busybox@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616"
+)
+
+
+# Sentinels stand in for the real tree. The names on the left have to reach the
+# build; the ones on the right must not, and they cover the root, a suffix and
+# a nested directory, which is the whole of what `**/.env*` claims.
+_CONTEXT_SENTINELS = (
+    "build-constraints.txt",
+    "build-constraints.in",
+    "pyproject.toml",
+    "uv.lock",
+    "README.md",
+    "linkedin_mcp_server/__init__.py",
+    ".env",
+    ".env.example",
+    ".env.local",
+    ".env.previous-proxy",
+    "tests/.env.probe",
+    "nested/deeper/.env.secret",
+)
 
 
 @pytest.fixture(scope="module")
-def build_context() -> frozenset[str]:
-    """The paths BuildKit really sends, read out of a throwaway probe build.
+def build_context(tmp_path_factory: pytest.TempPathFactory) -> frozenset[str]:
+    """Which sentinels this `.dockerignore` lets through, asked of BuildKit.
 
-    `.dockerignore` semantics cannot be recovered from the file alone. Every
+    The semantics are not recoverable from the file alone. Every
     reimplementation measured here disagreed with BuildKit while staying
     silent about it: a leading slash anchors the pattern, `*` stops at a
     separator, `\\!` escapes a negation, and a wildcard such as
     `build-constraints.*` hides a file that a literal-name search still reads
-    as present. Each of those is a false pass, which is the direction that
-    costs something. The release publishes to PyPI and tags the repository
-    before the Docker job runs, so a version can end up on PyPI and as a tag
-    with no image behind it.
+    as present. Each of those is a false pass, and a dropped constraint file
+    costs more than a red build: the release publishes to PyPI and tags the
+    repository before the Docker job runs, so a version can exist on PyPI and
+    as a tag with no image behind it.
 
-    Asking the daemon costs about a second against this 9.6 MB context, and
-    the suite skips where there is none, the way the entrypoint tests skip
-    without Bash 5.
+    The context is synthetic rather than the repository itself. Building the
+    real root sent 310 files to the daemon on a developer checkout, 32 of them
+    under `.debug/`, plus `CLAUDE.local.md`, and `docker rmi` does not
+    necessarily drop the cached `COPY` layer. An ordinary test run has no
+    business copying those anywhere. The probe image is pinned by digest and
+    runs without a network for the same reason.
     """
     docker = shutil.which("docker")
     if docker is None:
         pytest.skip("docker is required to read the real build context")
     # Unavailability is what may skip. Once the daemon answers and the base
     # image is local, a failing probe is a failing probe: treating every
-    # non-zero exit as absence turned a malformed `.dockerignore` into a
-    # green run that had checked nothing.
-    for unavailable in ([docker, "info"], [docker, "pull", "-q", "busybox"]):
+    # non-zero exit as absence turned a malformed `.dockerignore` into a green
+    # run that had checked nothing.
+    for available in ([docker, "info"], [docker, "pull", "-q", _PROBE_IMAGE]):
         probe = subprocess.run(
-            unavailable, capture_output=True, text=True, timeout=300, check=False
+            available, capture_output=True, text=True, timeout=300, check=False
         )
         if probe.returncode != 0:
             pytest.skip(f"no usable docker daemon: {probe.stderr.strip()[:200]}")
 
+    context = tmp_path_factory.mktemp("dockerignore-probe")
+    shutil.copyfile(_REPO_ROOT / ".dockerignore", context / ".dockerignore")
+    for sentinel in _CONTEXT_SENTINELS:
+        path = context / sentinel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("sentinel\n", encoding="utf-8")
+
     # The pid alone collides across clients sharing one daemon from separate
     # pid namespaces, where `rmi -f` would then remove another run's tag.
-    unique = f"{os.getpid()}-{uuid.uuid4().hex[:12]}"
-    tag = f"linkedin-mcp-context-probe:{unique}"
-    # A file under a directory proves the `**/` reach of the pattern; `.env`
-    # and the tracked `.env.example` only ever prove the root. `.gitignore`
-    # covers the name, so a crash between here and the cleanup cannot leave
-    # something a later `git add -A` would stage.
-    nested = _REPO_ROOT / "tests" / f".env.probe-{unique}"
+    tag = f"linkedin-mcp-context-probe:{os.getpid()}-{uuid.uuid4().hex[:12]}"
     try:
-        nested.write_text("PROBE=1\n", encoding="utf-8")
         build = subprocess.run(
-            [docker, "build", "-q", "-t", tag, "-f", "-", str(_REPO_ROOT)],
-            input=_CONTEXT_PROBE,
+            [docker, "build", "-q", "-t", tag, "-f", "-", str(context)],
+            input=f"FROM {_PROBE_IMAGE}\nCOPY . /ctx\n",
             capture_output=True,
             text=True,
             timeout=600,
@@ -145,14 +173,27 @@ def build_context() -> frozenset[str]:
         )
         assert build.returncode == 0, f"context probe failed: {build.stderr[-2000:]}"
         listing = subprocess.run(
-            [docker, "run", "--rm", tag, "find", "/ctx", "-type", "f"],
+            # fmt: off
+            [
+                docker,
+                "run",
+                "--rm",
+                "--network",
+                "none",
+                "--entrypoint",
+                "find",
+                tag,
+                "/ctx",
+                "-type",
+                "f",
+            ],
+            # fmt: on
             capture_output=True,
             text=True,
             timeout=300,
             check=True,
         )
     finally:
-        nested.unlink(missing_ok=True)
         subprocess.run(
             [docker, "rmi", "-f", tag], capture_output=True, text=True, check=False
         )
@@ -176,71 +217,50 @@ def test_the_image_builds_the_project_against_the_hashed_backend() -> None:
     setuptools fresh from PyPI inside the one release job that holds the Docker
     Hub credentials (#655). The project is installed on its own instead, against
     the same hashed file the published distributions use (#654).
-    """
-    commands = [
-        command
-        for instruction in _DOCKERFILE_INSTRUCTIONS
-        if instruction.startswith("RUN ")
-        for command in _shell_commands(instruction)
-    ]
-    installs = [command for command in commands if command.startswith("uv pip install")]
-    assert len(installs) == 1
-    project_install = installs[0]
 
-    assert "--build-constraints build-constraints.txt" in project_install
-    assert project_install.endswith(" .")
-    # Without this the lock stops deciding the runtime dependencies: a bare
-    # `uv pip install .` resolves them again from the index.
-    assert "--no-deps" in project_install
-    # uv verifies the hashes in a constraint file by default, and this switch
-    # turns that off while every other assertion here stays satisfied. A mirror
-    # workaround reaching for it would leave the pin as documentation only.
-    assert "--no-verify-hashes" not in project_install
-    # Every sync has to leave the project alone. One that installs it builds the
-    # backend unconstrained, and a later constrained install cannot undo a build
-    # that already ran.
-    syncs = [command for command in commands if command.startswith("uv sync")]
-    assert syncs
-    for sync in syncs:
-        assert "--no-install-project" in sync
-    # The switch above has an environment twin that reaches every uv invocation
-    # in the stage, including this one, and turns the same verification off.
+    Both commands are compared whole. A flag matched inside them says only that
+    the text contains it, and every attempt here to find out whether the
+    command *runs* with it needed a shell parser that turned out to have a
+    hole. Changing either line therefore fails this test on purpose: the
+    expected form is in the failure output, and a deliberate change updates it.
+    """
+    assert _DEPENDENCY_SYNC in _DOCKERFILE_INSTRUCTIONS, _DEPENDENCY_SYNC
+    assert _PROJECT_INSTALL in _DOCKERFILE_INSTRUCTIONS, _PROJECT_INSTALL
+    # Any further uv invocation is unaccounted for, whatever it is wrapped in.
+    # A second sync would build the backend unconstrained, and a constrained
+    # install afterwards cannot undo a build that already ran.
+    uv_instructions = [
+        instruction
+        for instruction in _DOCKERFILE_INSTRUCTIONS
+        if "uv sync" in instruction or "uv pip install" in instruction
+    ]
+    assert uv_instructions == [_DEPENDENCY_SYNC, _PROJECT_INSTALL], uv_instructions
+    # `--no-verify-hashes` has an environment twin that reaches every uv
+    # invocation in the stage and turns the same verification off.
     assert "UV_NO_VERIFY_HASHES" not in _DOCKERFILE
 
 
 def test_the_dockerfile_stays_within_the_syntax_this_file_parses() -> None:
     """`_logical_lines` handles line continuation, so nothing else may appear.
 
-    Every construct below lets an assertion above pass while the build does
-    something else, so the Dockerfile is held to the subset the parser can
-    read rather than the parser being grown to meet the Dockerfile. Growing it
-    is what failed twice already: a reimplementation of someone else's grammar
-    disagrees quietly, and the direction it disagrees in is a false pass.
+    Only the three constructs that change what an *instruction* is are refused,
+    because that is all the comparison above depends on. A heredoc is data to
+    BuildKit and instructions here, so a payload line spelling one of the two
+    commands would stand in for the real one. A line ending in `\\` ends the
+    instruction for BuildKit and continues it here. An `escape` directive
+    changes the continuation character entirely.
 
-    A heredoc is data to BuildKit and instructions here, so a payload line
-    reading `uv pip install ... .` satisfies the install assertions while no
-    install runs. A line ending in `\\\\` ends the instruction for BuildKit and
-    continues it here. An `escape` directive changes the continuation
-    character. A single `&` backgrounds the first command and leaves both in
-    one string, so `uv sync --no-install-project & uv sync` reads as guarded.
-    A quoted `#` truncates a command away, `$(...)` and backticks hide one
-    inside another, a JSON-form `RUN` executes no shell at all, and keywords
-    are case-insensitive to BuildKit but not here.
+    Nothing else about the shell is restricted. An earlier version refused
+    quotes, `$`, backticks and a single `&` so that a hand-written shell split
+    stayed sound; it was both incomplete, missing an `ENV=1 uv sync` prefix,
+    and in the way of ordinary things like a cache mount. Comparing the two
+    instructions whole removed the need for it.
     """
     assert "<<" not in _DOCKERFILE
     assert not re.search(r"^\s*#\s*escape\s*=", _DOCKERFILE, re.M)
     assert not [
         line for line in _DOCKERFILE.splitlines() if line.rstrip().endswith("\\\\")
     ]
-    for instruction in _DOCKERFILE_INSTRUCTIONS:
-        assert re.match(r"^[A-Z]+ ", instruction), instruction
-        if not instruction.startswith("RUN "):
-            continue
-        body = instruction.removeprefix("RUN ")
-        assert not body.startswith(("[", "--")), instruction
-        for character in ('"', "'", "$", "`"):
-            assert character not in body, (character, instruction)
-        assert not re.search(r"(?<!&)&(?!&)", body), instruction
 
 
 def test_every_build_requirement_is_pinned_with_hashes() -> None:
@@ -328,8 +348,11 @@ def test_the_hashed_build_constraint_reaches_the_build_context(
     build_context: frozenset[str],
 ) -> None:
     """An excluded constraint file drops a pin the build never asked for."""
-    for name in ("build-constraints.txt", "pyproject.toml", "uv.lock", "README.md"):
-        assert name in build_context, name
+    needed = [
+        name for name in _CONTEXT_SENTINELS if not Path(name).name.startswith(".env")
+    ]
+    missing = sorted(name for name in needed if name not in build_context)
+    assert not missing, f"the build needs these and .dockerignore drops them: {missing}"
 
 
 def test_the_build_context_carries_no_environment_file(
@@ -343,11 +366,12 @@ def test_the_build_context_carries_no_environment_file(
     session cookie and proxy credentials; a real build listed it inside `/app`.
     The runtime stage takes only `/app/.venv`, so no published image carried it.
     """
-    # The tracked `.env.example` is what keeps this from passing vacuously, and
-    # the fixture writes a nested one for the `**/` half of the pattern.
-    assert sorted(path.name for path in _REPO_ROOT.glob(".env*")), (
-        "no .env* file exists here, so an empty result would prove nothing"
-    )
+    # The fixture writes one of each shape, so an empty result is a real
+    # exclusion rather than an empty question.
+    offered = [
+        name for name in _CONTEXT_SENTINELS if Path(name).name.startswith(".env")
+    ]
+    assert len(offered) >= 4, offered
     leaked = sorted(
         path for path in build_context if Path(path).name.startswith(".env")
     )

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -128,15 +128,22 @@ _PROBE_IMAGE = (
 # green suite and a broken `docker build .`, so it is named here.
 _CONTEXT_INPUTS = ("build-constraints.txt", "docker-entrypoint.sh")
 
-# These must not reach the build. They cover the root, a suffix and a nested
-# directory, which is the whole of what `**/.env*` claims.
-_ENVIRONMENT_SENTINELS = (
+# These must not reach the build. The environment names cover the root, a
+# suffix and a nested directory, which is the whole of what `**/.env*` claims.
+# The rest is local working material that no build reads and that `COPY . .`
+# would otherwise put in a layer the release exports to the GitHub Actions
+# cache.
+_EXCLUDED_SENTINELS = (
     ".env",
     ".env.example",
     ".env.local",
     ".env.previous-proxy",
     "tests/.env.probe",
     "nested/deeper/.env.secret",
+    ".debug/notes.md",
+    "CLAUDE.local.md",
+    ".agents/notes.md",
+    ".claude/settings.json",
 )
 
 
@@ -177,7 +184,7 @@ def build_context(tmp_path_factory: pytest.TempPathFactory) -> frozenset[str]:
 
     context = tmp_path_factory.mktemp("dockerignore-probe")
     shutil.copyfile(_REPO_ROOT / ".dockerignore", context / ".dockerignore")
-    for sentinel in _CONTEXT_INPUTS + _ENVIRONMENT_SENTINELS:
+    for sentinel in _CONTEXT_INPUTS + _EXCLUDED_SENTINELS:
         path = context / sentinel
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("sentinel\n", encoding="utf-8")
@@ -341,7 +348,18 @@ def test_every_build_requirement_is_pinned_with_hashes() -> None:
     )
     assert not unhashed, f"compiled entries without a hash: {unhashed}"
 
+    # A half-applied bump moves the source and leaves the compiled file behind,
+    # and everything above still holds: the name is present and it has hashes.
+    # The build then keeps using the old version with a green suite.
+    drifted = {
+        name: (str(source.specifier), str(compiled[name][0].specifier))
+        for name, (source, _) in sources.items()
+        if compiled[name][0].specifier != source.specifier
+    }
+    assert not drifted, f"build-constraints.in and .txt disagree: {drifted}"
 
+
+@pytest.mark.image_build
 def test_the_hashed_build_constraint_reaches_the_build_context(
     build_context: frozenset[str],
 ) -> None:
@@ -350,7 +368,8 @@ def test_the_hashed_build_constraint_reaches_the_build_context(
     assert not missing, f"the build needs these and .dockerignore drops them: {missing}"
 
 
-def test_the_build_context_carries_no_environment_file(
+@pytest.mark.image_build
+def test_the_build_context_carries_nothing_it_should_not(
     build_context: frozenset[str],
 ) -> None:
     """A suffixed `.env` carries the same secrets as the plain one.
@@ -359,26 +378,30 @@ def test_the_build_context_carries_no_environment_file(
     workflow exports that layer through `cache-to: type=gha,mode=max`. Ignoring
     only `.env` let a local `.env.previous-proxy` through, holding a LinkedIn
     session cookie and proxy credentials; a real build listed it inside `/app`.
-    The runtime stage takes only `/app/.venv`, so no published image carried it.
+    The same build carried `.debug/` and `CLAUDE.local.md`, 9.7 MB of local
+    working material that nothing in the image reads. No published image
+    carried any of it: the runtime stage takes only `/app/.venv`.
     """
-    # The fixture writes one of each shape, so an empty result is a real
-    # exclusion rather than an empty question.
-    assert len(_ENVIRONMENT_SENTINELS) >= 4, _ENVIRONMENT_SENTINELS
-    leaked = sorted(
-        path for path in build_context if Path(path).name.startswith(".env")
-    )
-    assert not leaked, f"environment files reached the build context: {leaked}"
+    leaked = sorted(path for path in _EXCLUDED_SENTINELS if path in build_context)
+    assert not leaked, f"these reached the build context: {leaked}"
 
 
 @pytest.mark.image_build
 def test_the_built_project_records_the_pinned_backend() -> None:
     """Which setuptools built the project, read off the wheel it produced.
 
-    This is the property #655 is about, and the only check here that observes
-    it rather than inferring it from the Dockerfile. Six rounds of inferring
-    it produced six ways past the inference: a comment, a `&`, an `ENV=1`
-    prefix, an extra space, an inert marker, a second frontend. The wheel says
-    what actually ran.
+    This observes the property #655 is about rather than inferring it from the
+    Dockerfile, which six rounds of inferring showed the value of: a comment, a
+    `&`, an `ENV=1` prefix, an extra space, an inert marker and a second
+    frontend each passed an inference while the build did something else.
+
+    The version alone would not be enough. `build-constraints.txt` normally
+    pins whatever is current, and Renovate keeps it that way, so an
+    unconstrained build resolves the same number and produces the same wheel.
+    It reads as proof exactly when it proves nothing. The second build settles
+    it: the constraint is corrupted and the build has to fail on it, which no
+    build that ignores the file can do. Together they say the file was read and
+    that what it names is what ran.
 
     It also settles most of the context: a `COPY` source missing from this
     stage fails the build rather than passing a check that never knew to look
@@ -448,12 +471,34 @@ def test_the_built_project_records_the_pinned_backend() -> None:
             timeout=300,
             check=True,
         )
+        # Corrupt every hash and repeat the install off the stage that just
+        # ran it. A build reading the constraint file cannot get past this; one
+        # ignoring it finishes exactly as before.
+        # Not `-q`: the reason has to be readable. Without the build log, any
+        # failure at all would satisfy this, including a typo in the `sed`.
+        tampered = subprocess.run(
+            [docker, "build", "--progress", "plain", "-f", "-", str(_REPO_ROOT)],
+            input=(
+                f"FROM {tag}\n"
+                "RUN sed -i s/--hash=sha256:/--hash=sha256:0/g "
+                "build-constraints.txt\n"
+                f"{_PROJECT_INSTALL} --force-reinstall\n"
+            ),
+            capture_output=True,
+            text=True,
+            timeout=1800,
+            check=False,
+        )
     finally:
         subprocess.run(
             [docker, "rmi", "-f", tag], capture_output=True, text=True, check=False
         )
 
     assert f"Generator: setuptools ({expected})" in wheel.stdout, wheel.stdout
+    assert tampered.returncode != 0, (
+        "a corrupted constraint hash did not stop the build"
+    )
+    assert "Hash mismatch" in tampered.stderr, tampered.stderr[-3000:]
 
 
 def test_the_image_defaults_to_headed_on_a_virtual_display() -> None:

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -25,6 +25,7 @@ import socket
 import subprocess
 import textwrap
 import tomllib
+import uuid
 from pathlib import Path
 
 import pytest
@@ -112,11 +113,26 @@ def build_context() -> frozenset[str]:
     docker = shutil.which("docker")
     if docker is None:
         pytest.skip("docker is required to read the real build context")
+    # Unavailability is what may skip. Once the daemon answers and the base
+    # image is local, a failing probe is a failing probe: treating every
+    # non-zero exit as absence turned a malformed `.dockerignore` into a
+    # green run that had checked nothing.
+    for unavailable in ([docker, "info"], [docker, "pull", "-q", "busybox"]):
+        probe = subprocess.run(
+            unavailable, capture_output=True, text=True, timeout=300, check=False
+        )
+        if probe.returncode != 0:
+            pytest.skip(f"no usable docker daemon: {probe.stderr.strip()[:200]}")
 
-    tag = f"linkedin-mcp-context-probe:{os.getpid()}"
+    # The pid alone collides across clients sharing one daemon from separate
+    # pid namespaces, where `rmi -f` would then remove another run's tag.
+    unique = f"{os.getpid()}-{uuid.uuid4().hex[:12]}"
+    tag = f"linkedin-mcp-context-probe:{unique}"
     # A file under a directory proves the `**/` reach of the pattern; `.env`
-    # and the tracked `.env.example` only ever prove the root.
-    nested = _REPO_ROOT / "tests" / f".env.probe-{os.getpid()}"
+    # and the tracked `.env.example` only ever prove the root. `.gitignore`
+    # covers the name, so a crash between here and the cleanup cannot leave
+    # something a later `git add -A` would stage.
+    nested = _REPO_ROOT / "tests" / f".env.probe-{unique}"
     try:
         nested.write_text("PROBE=1\n", encoding="utf-8")
         build = subprocess.run(
@@ -127,8 +143,7 @@ def build_context() -> frozenset[str]:
             timeout=600,
             check=False,
         )
-        if build.returncode != 0:
-            pytest.skip(f"no usable docker daemon: {build.stderr.strip()[:200]}")
+        assert build.returncode == 0, f"context probe failed: {build.stderr[-2000:]}"
         listing = subprocess.run(
             [docker, "run", "--rm", tag, "find", "/ctx", "-type", "f"],
             capture_output=True,
@@ -196,19 +211,36 @@ def test_the_image_builds_the_project_against_the_hashed_backend() -> None:
 def test_the_dockerfile_stays_within_the_syntax_this_file_parses() -> None:
     """`_logical_lines` handles line continuation, so nothing else may appear.
 
-    BuildKit reads three constructs differently, and each one lets an
-    assertion above pass while the build does something else. A heredoc is
-    data to BuildKit and instructions to this parser, so a payload line
+    Every construct below lets an assertion above pass while the build does
+    something else, so the Dockerfile is held to the subset the parser can
+    read rather than the parser being grown to meet the Dockerfile. Growing it
+    is what failed twice already: a reimplementation of someone else's grammar
+    disagrees quietly, and the direction it disagrees in is a false pass.
+
+    A heredoc is data to BuildKit and instructions here, so a payload line
     reading `uv pip install ... .` satisfies the install assertions while no
-    install runs. A line ending in `\\\\` ends the instruction for BuildKit
-    and continues it here, importing flags from the next line. An `escape`
-    directive changes the continuation character entirely.
+    install runs. A line ending in `\\\\` ends the instruction for BuildKit and
+    continues it here. An `escape` directive changes the continuation
+    character. A single `&` backgrounds the first command and leaves both in
+    one string, so `uv sync --no-install-project & uv sync` reads as guarded.
+    A quoted `#` truncates a command away, `$(...)` and backticks hide one
+    inside another, a JSON-form `RUN` executes no shell at all, and keywords
+    are case-insensitive to BuildKit but not here.
     """
     assert "<<" not in _DOCKERFILE
     assert not re.search(r"^\s*#\s*escape\s*=", _DOCKERFILE, re.M)
     assert not [
         line for line in _DOCKERFILE.splitlines() if line.rstrip().endswith("\\\\")
     ]
+    for instruction in _DOCKERFILE_INSTRUCTIONS:
+        assert re.match(r"^[A-Z]+ ", instruction), instruction
+        if not instruction.startswith("RUN "):
+            continue
+        body = instruction.removeprefix("RUN ")
+        assert not body.startswith(("[", "--")), instruction
+        for character in ('"', "'", "$", "`"):
+            assert character not in body, (character, instruction)
+        assert not re.search(r"(?<!&)&(?!&)", body), instruction
 
 
 def test_every_build_requirement_is_pinned_with_hashes() -> None:
@@ -267,11 +299,22 @@ def test_every_build_requirement_is_pinned_with_hashes() -> None:
         if marker is None:
             continue
         for machine in ("x86_64", "aarch64"):
+            # Every key `default_environment()` defines has to be named here.
+            # `evaluate` overlays this mapping onto the host's, so anything
+            # omitted is answered by the machine running the test: the host is
+            # on 3.13.15 while the image pins 3.13.13, and a marker reading
+            # `implementation_version != "3.13.13"` evaluated true here and
+            # false in the image. The kernel-dependent pair is left empty
+            # rather than guessed, so a marker touching it fails loudly.
             environment = {
                 "implementation_name": "cpython",
+                "implementation_version": f"{major}.{minor}.{patch}",
                 "os_name": "posix",
                 "platform_machine": machine,
+                "platform_python_implementation": "CPython",
+                "platform_release": "",
                 "platform_system": "Linux",
+                "platform_version": "",
                 "python_full_version": f"{major}.{minor}.{patch}",
                 "python_version": f"{major}.{minor}",
                 "sys_platform": "linux",

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -13,9 +13,9 @@ the build did something else.
 Which backend builds the project is read off the wheel the builder stage
 produces. Which paths reach the build context is asked of BuildKit through a
 throwaway probe, since `.dockerignore` semantics survived no reimplementation
-here without diverging quietly. Both skip where there is no daemon, the way
-the entrypoint tests skip without Bash 5, and together they cost seconds
-against a warm cache.
+here without diverging quietly. Together they cost seconds against a warm
+cache, and they skip locally without a daemon while failing in CI, because a
+gate that skips itself is indistinguishable from one that passed.
 
 What stays a string check is what a build cannot show: that verification was
 not switched off, and that the constraint files still agree with each other.
@@ -33,10 +33,30 @@ import textwrap
 import tomllib
 import uuid
 from pathlib import Path
+from typing import NoReturn
 
 import pytest
 from packaging.requirements import Requirement
 from packaging.utils import NormalizedName, canonicalize_name
+
+
+def _no_daemon(reason: str) -> NoReturn:
+    """Fail in CI, skip locally. Never quietly pass.
+
+    These two are the only checks that observe what the build actually does,
+    so a run without a daemon has verified nothing about it. Locally that is a
+    fair trade and the reason says so. In CI it is the whole point, and a
+    silently skipped gate reads exactly like a passing one: the first CI run
+    of these tests could not be told apart from a run where they never
+    executed. Same reasoning as `tests/test_browser_identity.py`.
+    """
+    if os.environ.get("CI", "").lower() in {"1", "true", "yes"}:
+        pytest.fail(
+            f"{reason}. In CI this is a failure rather than a skip: these "
+            f"tests are the only ones that measure the build instead of "
+            f"reading the Dockerfile, so skipping them checks nothing."
+        )
+    pytest.skip(reason)
 
 
 def _pinned_requirements(path: Path) -> dict[NormalizedName, tuple[Requirement, str]]:
@@ -170,7 +190,7 @@ def build_context(tmp_path_factory: pytest.TempPathFactory) -> frozenset[str]:
     """
     docker = shutil.which("docker")
     if docker is None:
-        pytest.skip("docker is required to read the real build context")
+        _no_daemon("docker is required to read the real build context")
     # Unavailability is what may skip. Once the daemon answers and the base
     # image is local, a failing probe is a failing probe: treating every
     # non-zero exit as absence turned a malformed `.dockerignore` into a green
@@ -180,7 +200,7 @@ def build_context(tmp_path_factory: pytest.TempPathFactory) -> frozenset[str]:
             available, capture_output=True, text=True, timeout=300, check=False
         )
         if probe.returncode != 0:
-            pytest.skip(f"no usable docker daemon: {probe.stderr.strip()[:200]}")
+            _no_daemon(f"no usable docker daemon: {probe.stderr.strip()[:200]}")
 
     context = tmp_path_factory.mktemp("dockerignore-probe")
     shutil.copyfile(_REPO_ROOT / ".dockerignore", context / ".dockerignore")
@@ -414,9 +434,9 @@ def test_the_built_project_records_the_pinned_backend() -> None:
     """
     docker = shutil.which("docker")
     if docker is None:
-        pytest.skip("docker is required to build the image")
+        _no_daemon("docker is required to build the image")
     if subprocess.run([docker, "info"], capture_output=True, check=False).returncode:
-        pytest.skip("no usable docker daemon")
+        _no_daemon("no usable docker daemon")
 
     build_system = tomllib.loads(_PYPROJECT_PATH.read_text(encoding="utf-8"))[
         "build-system"

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -125,6 +125,25 @@ _PROJECT_INSTALL = (
 )
 
 
+# Anything that can build this project during the image build. `uv run` is the
+# one that does not look like an install: it syncs and installs the project
+# before running its command, so a smoke check added to the builder stage runs
+# the backend unconstrained. Measured against a real build, which resolved the
+# backend past a corrupted constraint file that the later install still failed
+# on. Naming frontends is a filter rather than a proof, and the comment on its
+# use says so; this is the ordinary-mistake half.
+_PROJECT_BUILDING_COMMANDS = (
+    "uv sync",
+    "uv pip install",
+    "uv run",
+    "uv build",
+    "uvx",
+    "pip install",
+    "pip wheel",
+    "python -m build",
+    "setup.py",
+)
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _DOCKERFILE = (_REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
 _DOCKERFILE_INSTRUCTIONS = _logical_lines(_DOCKERFILE)
@@ -282,13 +301,14 @@ def test_the_image_builds_the_project_against_the_hashed_backend() -> None:
     # proof; something determined to hide a build can. What it is here for is
     # the ordinary case, someone adding a second install without noticing that
     # the first one is load-bearing.
+    # `RUN` only: an instruction that executes nothing at build time cannot
+    # build the project. The `COPY` that brings the uv binaries in names `uvx`
+    # in its source path and would otherwise read as one of these.
     builders = [
         instruction
         for instruction in _DOCKERFILE_INSTRUCTIONS
-        if any(
-            frontend in instruction
-            for frontend in ("uv sync", "uv pip install", "pip install", "setup.py")
-        )
+        if instruction.startswith("RUN ")
+        and any(frontend in instruction for frontend in _PROJECT_BUILDING_COMMANDS)
     ]
     assert builders == [_DEPENDENCY_SYNC, _PROJECT_INSTALL], builders
     # `--no-verify-hashes` has an environment twin that reaches every uv

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -6,13 +6,19 @@ browser product, the launch mode, and who receives SIGTERM. The supervisor
 itself is exercised with fake Xvfb and server processes, because child liveness
 is behaviour a string check cannot prove.
 
-Two things resist that treatment and are measured instead. Which paths reach
-the build context is decided by `.dockerignore` semantics that no
-reimplementation here matched without diverging silently, so a throwaway
-`busybox` probe asks the daemon; it costs about a second and skips where there
-is no daemon. And a flag is read out of the command that will run it rather
-than out of the file, because the file also holds the comment explaining the
-flag.
+Two things resist that treatment and are measured instead, because inferring
+them from the Dockerfile was tried and kept producing checks that passed while
+the build did something else.
+
+Which backend builds the project is read off the wheel the builder stage
+produces. Which paths reach the build context is asked of BuildKit through a
+throwaway probe, since `.dockerignore` semantics survived no reimplementation
+here without diverging quietly. Both skip where there is no daemon, the way
+the entrypoint tests skip without Bash 5, and together they cost seconds
+against a warm cache.
+
+What stays a string check is what a build cannot show: that verification was
+not switched off, and that the constraint files still agree with each other.
 """
 
 from __future__ import annotations
@@ -30,7 +36,21 @@ from pathlib import Path
 
 import pytest
 from packaging.requirements import Requirement
-from packaging.utils import canonicalize_name
+from packaging.utils import NormalizedName, canonicalize_name
+
+
+def _pinned_requirements(path: Path) -> dict[NormalizedName, tuple[Requirement, str]]:
+    """The requirements a constraint file pins, by canonical name.
+
+    The second half of each value is the entry as written, which is where the
+    hashes are: they are not part of PEP 508 and `Requirement` cannot hold
+    them.
+    """
+    parsed = {}
+    for entry in _logical_lines(path.read_text(encoding="utf-8")):
+        requirement = Requirement(entry.split("--hash", 1)[0].strip())
+        parsed[canonicalize_name(requirement.name)] = (requirement, entry)
+    return parsed
 
 
 def _logical_lines(text: str) -> list[str]:
@@ -94,7 +114,6 @@ _README = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
 _DOCKER_GUIDE = (_REPO_ROOT / "docs" / "docker-hub.md").read_text(encoding="utf-8")
 _BUILD_CONSTRAINTS_PATH = _REPO_ROOT / "build-constraints.txt"
 _PYPROJECT_PATH = _REPO_ROOT / "pyproject.toml"
-_IMAGE_PYTHON = re.search(r"^FROM python:(\d+)\.(\d+)\.(\d+)-slim", _DOCKERFILE, re.M)
 # Pinned: the probe runs against the developer's own machine, and `latest`
 # is whatever the registry serves that day.
 _PROBE_IMAGE = (
@@ -102,35 +121,15 @@ _PROBE_IMAGE = (
 )
 
 
-def _named_context_inputs() -> tuple[str, ...]:
-    """Every context path the Dockerfile names, read out of the Dockerfile.
+# `test_the_built_project_records_the_pinned_backend` builds the builder stage,
+# so a missing input fails it: that stage is where the pin is decided and it is
+# cheap to build. `docker-entrypoint.sh` is the exception, copied in the second
+# stage, which only a full image build would reach. Excluding it produced a
+# green suite and a broken `docker build .`, so it is named here.
+_CONTEXT_INPUTS = ("build-constraints.txt", "docker-entrypoint.sh")
 
-    A hand-kept list drifts: this one did not have `docker-entrypoint.sh` on
-    it, so adding that name to `.dockerignore` left the context tests green
-    while the real build failed on the `COPY`. That failure is expensive in
-    the wrong place, because the release publishes to PyPI and tags the
-    repository before the Docker job runs.
-
-    `COPY --from=` reads out of an earlier stage rather than the context, and
-    a bare `.` is the whole tree rather than a name, so neither is a path to
-    check.
-    """
-    named = ["build-constraints.txt"]  # named by the install, not by a COPY
-    for instruction in _DOCKERFILE_INSTRUCTIONS:
-        if not instruction.startswith("COPY ") or "--from=" in instruction:
-            continue
-        arguments = [
-            argument
-            for argument in instruction.split()[1:]
-            if not argument.startswith("--")
-        ]
-        named.extend(source for source in arguments[:-1] if source != ".")
-    return tuple(dict.fromkeys(named))
-
-
-# The names above have to reach the build. These must not, and they cover the
-# root, a suffix and a nested directory, which is the whole of what `**/.env*`
-# claims.
+# These must not reach the build. They cover the root, a suffix and a nested
+# directory, which is the whole of what `**/.env*` claims.
 _ENVIRONMENT_SENTINELS = (
     ".env",
     ".env.example",
@@ -178,7 +177,7 @@ def build_context(tmp_path_factory: pytest.TempPathFactory) -> frozenset[str]:
 
     context = tmp_path_factory.mktemp("dockerignore-probe")
     shutil.copyfile(_REPO_ROOT / ".dockerignore", context / ".dockerignore")
-    for sentinel in _named_context_inputs() + _ENVIRONMENT_SENTINELS:
+    for sentinel in _CONTEXT_INPUTS + _ENVIRONMENT_SENTINELS:
         path = context / sentinel
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("sentinel\n", encoding="utf-8")
@@ -250,17 +249,25 @@ def test_the_image_builds_the_project_against_the_hashed_backend() -> None:
     """
     assert _DEPENDENCY_SYNC in _DOCKERFILE_INSTRUCTIONS, _DEPENDENCY_SYNC
     assert _PROJECT_INSTALL in _DOCKERFILE_INSTRUCTIONS, _PROJECT_INSTALL
-    # Any further uv invocation is unaccounted for, whatever it is wrapped in.
-    # A second sync would build the backend unconstrained, and a constrained
-    # install afterwards cannot undo a build that already ran.
-    uv_instructions = [
+    # Any further build of the project is unaccounted for: a second one runs
+    # the backend unconstrained, and a constrained install afterwards cannot
+    # undo a build that already ran. Naming the frontends is a filter, not a
+    # proof; something determined to hide a build can. What it is here for is
+    # the ordinary case, someone adding a second install without noticing that
+    # the first one is load-bearing.
+    builders = [
         instruction
         for instruction in _DOCKERFILE_INSTRUCTIONS
-        if "uv sync" in instruction or "uv pip install" in instruction
+        if any(
+            frontend in instruction
+            for frontend in ("uv sync", "uv pip install", "pip install", "setup.py")
+        )
     ]
-    assert uv_instructions == [_DEPENDENCY_SYNC, _PROJECT_INSTALL], uv_instructions
+    assert builders == [_DEPENDENCY_SYNC, _PROJECT_INSTALL], builders
     # `--no-verify-hashes` has an environment twin that reaches every uv
-    # invocation in the stage and turns the same verification off.
+    # invocation in the stage and turns the same verification off. The wheel
+    # this produces would still name the pinned version, so the measurement
+    # cannot see this one and the string check has to.
     assert "UV_NO_VERIFY_HASHES" not in _DOCKERFILE
 
 
@@ -303,21 +310,23 @@ def test_every_build_requirement_is_pinned_with_hashes() -> None:
     build_system = tomllib.loads(_PYPROJECT_PATH.read_text(encoding="utf-8"))[
         "build-system"
     ]
-    required = {
-        canonicalize_name(Requirement(entry).name) for entry in build_system["requires"]
-    }
+    requirements = [Requirement(entry) for entry in build_system["requires"]]
+    required = {canonicalize_name(requirement.name) for requirement in requirements}
     assert required
+    # An extra pulls its own dependencies into the isolated build environment,
+    # and the name alone says nothing about them. `setuptools[core]` resolved
+    # an unhashed wheel past a green run of this test.
+    extras = sorted(
+        f"{requirement.name}[{','.join(sorted(requirement.extras))}]"
+        for requirement in requirements
+        if requirement.extras
+    )
+    assert not extras, (
+        f"build requirements with extras need their own hashed entries: {extras}"
+    )
 
-    def named(path: Path) -> dict[str, str]:
-        return {
-            canonicalize_name(
-                Requirement(entry.split("--hash", 1)[0].strip()).name
-            ): entry
-            for entry in _logical_lines(path.read_text(encoding="utf-8"))
-        }
-
-    sources = named(_REPO_ROOT / "build-constraints.in")
-    compiled = named(_BUILD_CONSTRAINTS_PATH)
+    sources = _pinned_requirements(_REPO_ROOT / "build-constraints.in")
+    compiled = _pinned_requirements(_BUILD_CONSTRAINTS_PATH)
 
     assert required <= sources.keys(), (
         f"build requirements missing from build-constraints.in: "
@@ -328,68 +337,16 @@ def test_every_build_requirement_is_pinned_with_hashes() -> None:
         f"{sorted(sources.keys() - compiled.keys())}"
     )
     unhashed = sorted(
-        name for name, entry in compiled.items() if "--hash=sha256:" not in entry
+        name for name, (_, entry) in compiled.items() if "--hash=sha256:" not in entry
     )
     assert not unhashed, f"compiled entries without a hash: {unhashed}"
-
-    # A marker that is false where the image builds pins nothing there while
-    # reading as a pin here. `platform_machine` is the live one: the release
-    # builds amd64 and arm64 from this same file, so an entry true for only one
-    # of them leaves the other resolving its backend from the index.
-    assert _IMAGE_PYTHON, "the base image no longer names a Python version"
-    major, minor, patch = _IMAGE_PYTHON.groups()
-    for name, entry in compiled.items():
-        marker = Requirement(entry.split("--hash", 1)[0].strip()).marker
-        if marker is None:
-            continue
-        # These two describe the kernel the build happens to run on, which is
-        # unknown here and differs between a laptop and a release runner. An
-        # earlier version passed empty strings and called that loud; a marker
-        # reading `platform_release == ""` then satisfied the test and left the
-        # backend unconstrained in the image. Unknowable is refused instead.
-        unknowable = [
-            variable
-            for variable in ("platform_release", "platform_version")
-            if variable in str(marker)
-        ]
-        assert not unknowable, (
-            f"{name} is constrained by {unknowable}, which this test cannot "
-            f"evaluate for the image: {marker}"
-        )
-        for machine in ("x86_64", "aarch64"):
-            # Every key `default_environment()` defines has to be named here.
-            # `evaluate` overlays this mapping onto the host's, so anything
-            # omitted is answered by the machine running the test: the host is
-            # on 3.13.15 while the image pins 3.13.13, and a marker reading
-            # `implementation_version != "3.13.13"` evaluated true here and
-            # false in the image.
-            environment = {
-                "implementation_name": "cpython",
-                "implementation_version": f"{major}.{minor}.{patch}",
-                "os_name": "posix",
-                "platform_machine": machine,
-                "platform_python_implementation": "CPython",
-                "platform_release": "",
-                "platform_system": "Linux",
-                "platform_version": "",
-                "python_full_version": f"{major}.{minor}.{patch}",
-                "python_version": f"{major}.{minor}",
-                "sys_platform": "linux",
-            }
-            assert marker.evaluate(environment), (
-                f"{name} is constrained only outside the image: {marker} on {machine}"
-            )
 
 
 def test_the_hashed_build_constraint_reaches_the_build_context(
     build_context: frozenset[str],
 ) -> None:
     """An excluded constraint file drops a pin the build never asked for."""
-    needed = _named_context_inputs()
-    assert "build-constraints.txt" in needed and "docker-entrypoint.sh" in needed, (
-        needed
-    )
-    missing = sorted(name for name in needed if name not in build_context)
+    missing = sorted(name for name in _CONTEXT_INPUTS if name not in build_context)
     assert not missing, f"the build needs these and .dockerignore drops them: {missing}"
 
 
@@ -411,6 +368,92 @@ def test_the_build_context_carries_no_environment_file(
         path for path in build_context if Path(path).name.startswith(".env")
     )
     assert not leaked, f"environment files reached the build context: {leaked}"
+
+
+@pytest.mark.image_build
+def test_the_built_project_records_the_pinned_backend() -> None:
+    """Which setuptools built the project, read off the wheel it produced.
+
+    This is the property #655 is about, and the only check here that observes
+    it rather than inferring it from the Dockerfile. Six rounds of inferring
+    it produced six ways past the inference: a comment, a `&`, an `ENV=1`
+    prefix, an extra space, an inert marker, a second frontend. The wheel says
+    what actually ran.
+
+    It also settles most of the context: a `COPY` source missing from this
+    stage fails the build rather than passing a check that never knew to look
+    for it. Only the second stage's own input is left to `_CONTEXT_INPUTS`.
+
+    The builder stage alone, because the full image downloads Chromium and
+    this runs on every push. The whole repository is the context, as it is for
+    `docker build .`, which is why the cheap `.dockerignore` probe uses a
+    synthetic one instead.
+    """
+    docker = shutil.which("docker")
+    if docker is None:
+        pytest.skip("docker is required to build the image")
+    if subprocess.run([docker, "info"], capture_output=True, check=False).returncode:
+        pytest.skip("no usable docker daemon")
+
+    build_system = tomllib.loads(_PYPROJECT_PATH.read_text(encoding="utf-8"))[
+        "build-system"
+    ]
+    required = {
+        canonicalize_name(Requirement(entry).name) for entry in build_system["requires"]
+    }
+    backend, _ = next(
+        pinned
+        for name, pinned in _pinned_requirements(_BUILD_CONSTRAINTS_PATH).items()
+        if name in required
+    )
+    expected = str(backend.specifier).removeprefix("==")
+
+    tag = f"linkedin-mcp-backend-probe:{os.getpid()}-{uuid.uuid4().hex[:12]}"
+    try:
+        build = subprocess.run(
+            # fmt: off
+            [
+                docker,
+                "build",
+                "-q",
+                "--target",
+                "builder",
+                "-t",
+                tag,
+                str(_REPO_ROOT),
+            ],
+            # fmt: on
+            capture_output=True,
+            text=True,
+            timeout=1800,
+            check=False,
+        )
+        assert build.returncode == 0, f"image build failed: {build.stderr[-3000:]}"
+        wheel = subprocess.run(
+            # fmt: off
+            [
+                docker,
+                "run",
+                "--rm",
+                "--entrypoint",
+                "sh",
+                tag,
+                "-c",
+                "cat /app/.venv/lib/python*/site-packages/"
+                "mcp_server_linkedin-*.dist-info/WHEEL",
+            ],
+            # fmt: on
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=True,
+        )
+    finally:
+        subprocess.run(
+            [docker, "rmi", "-f", tag], capture_output=True, text=True, check=False
+        )
+
+    assert f"Generator: setuptools ({expected})" in wheel.stdout, wheel.stdout
 
 
 def test_the_image_defaults_to_headed_on_a_virtual_display() -> None:

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -42,7 +42,11 @@ def _logical_lines(text: str) -> list[str]:
     how an assertion on ``--no-deps`` stayed green after the flag was removed
     from the command it guards.
 
-    Line continuation is the whole of what this handles, and
+    Runs of whitespace collapse, because a shell reads `uv  sync` and
+    `uv sync` alike and a search for the second missed the first entirely,
+    letting a whole unconstrained sync hide behind one extra space.
+
+    Line continuation is the rest of what this handles, and
     `test_the_dockerfile_stays_within_the_syntax_this_file_parses` refuses the
     constructs where that is not enough. A heredoc would otherwise present its
     payload as instructions, and BuildKit reads a `\\\\` line ending and a
@@ -57,10 +61,10 @@ def _logical_lines(text: str) -> list[str]:
         if stripped.endswith("\\"):
             pending += f"{stripped[:-1].strip()} "
             continue
-        statements.append(f"{pending}{stripped}".strip())
+        statements.append(" ".join(f"{pending}{stripped}".split()))
         pending = ""
     if pending:
-        statements.append(pending.strip())
+        statements.append(" ".join(pending.split()))
     return statements
 
 
@@ -98,16 +102,36 @@ _PROBE_IMAGE = (
 )
 
 
-# Sentinels stand in for the real tree. The names on the left have to reach the
-# build; the ones on the right must not, and they cover the root, a suffix and
-# a nested directory, which is the whole of what `**/.env*` claims.
-_CONTEXT_SENTINELS = (
-    "build-constraints.txt",
-    "build-constraints.in",
-    "pyproject.toml",
-    "uv.lock",
-    "README.md",
-    "linkedin_mcp_server/__init__.py",
+def _named_context_inputs() -> tuple[str, ...]:
+    """Every context path the Dockerfile names, read out of the Dockerfile.
+
+    A hand-kept list drifts: this one did not have `docker-entrypoint.sh` on
+    it, so adding that name to `.dockerignore` left the context tests green
+    while the real build failed on the `COPY`. That failure is expensive in
+    the wrong place, because the release publishes to PyPI and tags the
+    repository before the Docker job runs.
+
+    `COPY --from=` reads out of an earlier stage rather than the context, and
+    a bare `.` is the whole tree rather than a name, so neither is a path to
+    check.
+    """
+    named = ["build-constraints.txt"]  # named by the install, not by a COPY
+    for instruction in _DOCKERFILE_INSTRUCTIONS:
+        if not instruction.startswith("COPY ") or "--from=" in instruction:
+            continue
+        arguments = [
+            argument
+            for argument in instruction.split()[1:]
+            if not argument.startswith("--")
+        ]
+        named.extend(source for source in arguments[:-1] if source != ".")
+    return tuple(dict.fromkeys(named))
+
+
+# The names above have to reach the build. These must not, and they cover the
+# root, a suffix and a nested directory, which is the whole of what `**/.env*`
+# claims.
+_ENVIRONMENT_SENTINELS = (
     ".env",
     ".env.example",
     ".env.local",
@@ -154,7 +178,7 @@ def build_context(tmp_path_factory: pytest.TempPathFactory) -> frozenset[str]:
 
     context = tmp_path_factory.mktemp("dockerignore-probe")
     shutil.copyfile(_REPO_ROOT / ".dockerignore", context / ".dockerignore")
-    for sentinel in _CONTEXT_SENTINELS:
+    for sentinel in _named_context_inputs() + _ENVIRONMENT_SENTINELS:
         path = context / sentinel
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("sentinel\n", encoding="utf-8")
@@ -318,14 +342,27 @@ def test_every_build_requirement_is_pinned_with_hashes() -> None:
         marker = Requirement(entry.split("--hash", 1)[0].strip()).marker
         if marker is None:
             continue
+        # These two describe the kernel the build happens to run on, which is
+        # unknown here and differs between a laptop and a release runner. An
+        # earlier version passed empty strings and called that loud; a marker
+        # reading `platform_release == ""` then satisfied the test and left the
+        # backend unconstrained in the image. Unknowable is refused instead.
+        unknowable = [
+            variable
+            for variable in ("platform_release", "platform_version")
+            if variable in str(marker)
+        ]
+        assert not unknowable, (
+            f"{name} is constrained by {unknowable}, which this test cannot "
+            f"evaluate for the image: {marker}"
+        )
         for machine in ("x86_64", "aarch64"):
             # Every key `default_environment()` defines has to be named here.
             # `evaluate` overlays this mapping onto the host's, so anything
             # omitted is answered by the machine running the test: the host is
             # on 3.13.15 while the image pins 3.13.13, and a marker reading
             # `implementation_version != "3.13.13"` evaluated true here and
-            # false in the image. The kernel-dependent pair is left empty
-            # rather than guessed, so a marker touching it fails loudly.
+            # false in the image.
             environment = {
                 "implementation_name": "cpython",
                 "implementation_version": f"{major}.{minor}.{patch}",
@@ -348,9 +385,10 @@ def test_the_hashed_build_constraint_reaches_the_build_context(
     build_context: frozenset[str],
 ) -> None:
     """An excluded constraint file drops a pin the build never asked for."""
-    needed = [
-        name for name in _CONTEXT_SENTINELS if not Path(name).name.startswith(".env")
-    ]
+    needed = _named_context_inputs()
+    assert "build-constraints.txt" in needed and "docker-entrypoint.sh" in needed, (
+        needed
+    )
     missing = sorted(name for name in needed if name not in build_context)
     assert not missing, f"the build needs these and .dockerignore drops them: {missing}"
 
@@ -368,10 +406,7 @@ def test_the_build_context_carries_no_environment_file(
     """
     # The fixture writes one of each shape, so an empty result is a real
     # exclusion rather than an empty question.
-    offered = [
-        name for name in _CONTEXT_SENTINELS if Path(name).name.startswith(".env")
-    ]
-    assert len(offered) >= 4, offered
+    assert len(_ENVIRONMENT_SENTINELS) >= 4, _ENVIRONMENT_SENTINELS
     leaked = sorted(
         path for path in build_context if Path(path).name.startswith(".env")
     )


### PR DESCRIPTION
Closes #655

#654 pinned the PEP 517 build backend for the published distributions: `uv build` runs against a hashed constraint file, so a tampered setuptools release cannot reach PyPI. The image was not covered. `uv sync --frozen --no-dev` installs the project and therefore invokes `setuptools.build_meta` again, `uv.lock` records no `[build-system].requires`, and `uv sync` accepts no build constraint, so setuptools resolved fresh from PyPI inside the one release job that holds the Docker Hub credentials.

The dependency sync keeps `--no-install-project` and the project is installed on its own with `uv pip install --no-deps --build-constraints build-constraints.txt .`, against the same hashed file the distributions use. `uv pip install` takes the constraint that `uv sync` has no flag for, and `--no-deps` leaves the runtime dependency set exactly as the frozen lock installed it. `--require-hashes` is not usable here, because the local directory requirement carries no hash of its own, and it is not needed: uv verifies the hashes a constraint file does carry. What it does not verify is a transitive build dependency with no entry of its own, so the constraint file has to keep carrying the full closure; `build-constraints.in` is what `uv pip compile` reads to produce it, and the tests hold `[build-system].requires` to it.

The issue weighed two other routes. Installing the published wheel would need it passed into the build context and would break a plain `docker build .` for contributors. `[tool.uv] build-constraint-dependencies` takes PEP 508 requirements, which have no hash syntax, so it pins a version without verifying the bytes; it would also need a custom Renovate manager and travels into the sdist. The compiled file stays with Renovate's `pip-compile` manager as it is.

`.dockerignore` now excludes `**/.env*` rather than `.env` alone, along with `.debug`, `CLAUDE.local.md`, `.agents` and `.gemini`. `COPY . .` keeps the whole context in the builder layer, which the release exports through `cache-to: type=gha,mode=max`, and a local `.env.previous-proxy` carries a session cookie and proxy credentials while 9.7 MB of working notes carry nothing the build reads. No published image was affected: the runtime stage takes only `/app/.venv`.

The tests measure this rather than reading it out of the Dockerfile, after several rounds of the latter passing while the build did something else. The builder stage is built and the wheel it produced is read for the setuptools that made it, then rebuilt with every constraint hash corrupted, which has to fail: the version alone proves nothing once the pin equals the current release, which is the state Renovate maintains. Which paths reach the context is asked of BuildKit through a throwaway probe against a synthetic tree, because no reimplementation of `.dockerignore` matching here agreed with it. What a build cannot show stays a string check: that hash verification was not switched off, and that the two constraint files still agree.

Verified by building both stages on `linux/amd64` and `linux/arm64`: the wheel records `setuptools 83.0.0` against `84.0.0` on `main`, corrupted hashes fail the build with `Hash mismatch`, and the runtime `/app/.venv` is byte-identical to the baseline apart from the backend version, the console-script shebang and uv's cache timestamp. Full suite 1973 passing.

The docker-backed tests fail in CI rather than skipping, the way the browser identity gate already does: they are the only checks here that observe the build instead of reading the Dockerfile, and a skipped gate is indistinguishable from a passing one. Enabling that surfaced an unrelated defect this branch was triggering, so one commit here is outside #655 and would otherwise have been filed on its own. `debug_trace` resolves the trace directory once and caches it for the process, and it is derived from the profile root, so a test pointing `USER_DATA_DIR` at its own `tmp_path` left every later test on that xdist worker writing into a directory pytest had removed. A daemon test's real `server.log` then landed where a diagnostics test asserts none exists. `reset_singletons` already resets six other modules for that reason; the trace directory joins them. Adding a docker build is what shifted the distribution enough to put those two tests on one worker.

## Synthetic prompt

> The Docker image rebuilds the project with an unconstrained setuptools, so #654's hashed build backend does not cover it. Install the project separately with `uv pip install --build-constraints`, and cover it with tests that fail when the pin, the flag, the constraint file's reach or the hash verification is removed. Extend `.dockerignore` so no environment file or local working directory reaches the build context.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
