### PR TITLE
feat(search): Paginate people and company search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,7 @@ Optional additional keys:
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs and get_saved_jobs)
+- `result_counts: {rows_seen, returned, stopped_by}` (search_people and search_companies) — `stopped_by` is the walk's exit condition: `"max_pages"` (the depth budget ran out, so there is more), `"linkedin_end_of_list"` (a page added nothing new), or `"error"` (see `section_errors`). A caller who asked for ten pages and got two must be able to tell those apart; without it a short answer is silent truncation. `returned` counts references *after* the cap, since that is the list the follow-up tools can act on.
 - `references["feed"]` (get_feed only) — every entry is `kind: "feed_post"`; non-post anchors (sidebar profiles, employer logos) are filtered. URLs may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) form; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
 
 ## Verifying Bug Reports

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) | [#433](https://github.com/stickerdaniel/linkedin-mcp-server/issues/433) [#441](https://github.com/stickerdaniel/linkedin-mcp-server/issues/441) [#483](https://github.com/stickerdaniel/linkedin-mcp-server/issues/483) [#560](https://github.com/stickerdaniel/linkedin-mcp-server/issues/560) [#573](https://github.com/stickerdaniel/linkedin-mcp-server/issues/573) |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet | working |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed | working |
-| `search_companies` | Search for companies on LinkedIn by keywords | working |
+| `search_companies` | Search for companies on LinkedIn by keywords, paginated with `max_pages` and resumable with `start_page` | working |
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter | working |
 | `search_jobs` | Search for jobs with keywords and location filters | working |
 | `get_saved_jobs` | List job postings saved by the authenticated user | working |
-| `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | [#526](https://github.com/stickerdaniel/linkedin-mcp-server/issues/526) |
+| `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company, paginated with `max_pages` and resumable with `start_page` | working |
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |
 | `search_posts` | Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter (past-24h/past-week/past-month) | working |

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -104,6 +104,42 @@ _SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
 # list and yields nothing.
 _SAVED_JOBS_PAGE_SIZE = 10
 
+# People and company search page with ``&page=N``, one-based, ten result cards
+# each. Verified live: page 1 and page 2 of one query were disjoint, and the
+# parameter was still in the final URL at page 20 — LinkedIn neither clamps it
+# nor re-serves page one.
+#
+# Scrolling is not an alternative here and never was: the same page-1 URL
+# extracted with a larger scroll budget returned byte-identical text and an
+# identical slug set, because ``document.body.scrollHeight`` equals the
+# viewport height on a fully rendered results page. The scrolls inside
+# ``extract_page`` break after one iteration and can never reach result #11.
+#
+# The constant below is the tool-side ceiling on ``max_pages``, restated here
+# because the reference cap further down is derived from it.
+_ENTITY_SEARCH_MAX_PAGES = 10
+
+# Distinct entity slugs one results page carries, which is not its number of
+# result cards. Measured live: a people page with 10 cards held 26 distinct
+# /in/ slugs, because each card also links the mutual connections it shares
+# with the viewer. Company pages measured at exactly 10; the larger number
+# governs, since one cap serves both.
+_ENTITY_SEARCH_SLUGS_PER_PAGE = 30
+
+# Every reference a full-depth walk can produce, and the reason it is derived
+# from slugs-per-page rather than from results-per-page: sizing this at 100 —
+# the *result* count — truncates a ten-page walk at roughly page four, and what
+# it drops is the tail, so the last pages' result cards are lost behind the
+# first pages' mutual-connection anchors. That is the depth thrown away at the
+# last step, which is the bug this cap exists to avoid. A slug is the only
+# handle get_person_profile and get_company_profile accept, so a capped
+# reference list is a capped result set no matter how much text came back.
+#
+# ``link_metadata._REFERENCE_CAPS["search_results"]`` is the per-navigation cap
+# and has to hold one page's worth (``_ENTITY_SEARCH_SLUGS_PER_PAGE``); this
+# one has to hold the whole walk.
+_ENTITY_SEARCH_REFERENCE_CAP = _ENTITY_SEARCH_SLUGS_PER_PAGE * _ENTITY_SEARCH_MAX_PAGES
+
 # Normalization maps for job search filters. Job search encodes recency as
 # ``f_TPR=r<seconds>``; content search uses named tokens, hence the separate
 # ``_CONTENT_DATE_POSTED_MAP`` below.
@@ -3602,14 +3638,145 @@ class LinkedInExtractor:
             result["section_errors"] = section_errors
         return result
 
+    async def _paginated_entity_search(
+        self,
+        base_url: str,
+        *,
+        entity_kind: str,
+        max_pages: int,
+        context: str,
+        start_page: int = 1,
+    ) -> dict[str, Any]:
+        """Walk ``&page=N`` over a people or company search and merge the pages.
+
+        The same loop ``search_jobs`` runs over ``&start=``, with two
+        differences that follow from the surface rather than from taste. There
+        is no page-count element to read — measured, a fully rendered people
+        results page carries zero ``ul.artdeco-pagination__pages li button``
+        nodes and no element whose class matches /pagination|pager/, so
+        ``_get_total_list_pages`` answers ``None`` here and asking costs a
+        round trip for nothing. And the early stop counts entity slugs rather
+        than job IDs: the slug comes out of the href, so the signal is a URL
+        pattern, never a text value that a locale could change. The results
+        header ("About 5,200 results") would be the obvious source for a total
+        and is deliberately not read, for the same reason.
+
+        A page that adds no slug the walk has not already seen ends it. That is
+        how LinkedIn's end of results shows up from here — a query with one
+        page of matches costs one navigation whether the caller asked for one
+        page or ten. Verified live past the last page: LinkedIn keeps the
+        ``&page=N`` in the URL and renders "No results found" — 78 characters
+        of text and zero entity anchors — so the walk ends on the honest
+        signal rather than on the empty-text branch that means an error.
+
+        ``start_page`` is where the walk begins, and it is the whole of the
+        resumable story: ``&page=N`` is a URL parameter, so a caller resumes
+        by naming a number rather than by handing back a cursor this scraper
+        would have to keep. ``start_page=1, max_pages=3`` walks 1-3 and
+        ``start_page=4, max_pages=3`` walks 4-6, which is why the docstrings
+        can tell an agent to advance by ``max_pages``: the ranges abut.
+
+        The bare URL belongs to page one and to no other, so the parameter is
+        decided by the page number rather than by the loop index. Keying it to
+        the index instead would serve page one for every ``start_page``, and
+        that is the one failure a looping caller cannot detect: the batch comes
+        back full, every slug is new to that call's own seen-set, and the loop
+        walks the same ten people forever.
+        """
+        page_texts: list[str] = []
+        page_references: list[Reference] = []
+        section_errors: dict[str, dict[str, Any]] = {}
+        seen_entities: set[str] = set()
+        stopped_by = "max_pages"
+
+        for offset in range(max_pages):
+            page_num = start_page + offset
+            if offset > 0:
+                await asyncio.sleep(_NAV_DELAY)
+
+            url = base_url if page_num == 1 else f"{base_url}&page={page_num}"
+
+            try:
+                extracted = await self.extract_page(url, section_name="search_results")
+            except LinkedInScraperException:
+                raise
+            except Exception as e:
+                logger.warning("Error on %s page %d: %s", context, page_num, e)
+                section_errors["search_results"] = build_issue_diagnostics(
+                    e,
+                    context=context,
+                    target_url=url,
+                    section_name="search_results",
+                )
+                stopped_by = "error"
+                break
+
+            if not extracted.text or extracted.text == _RATE_LIMITED_MSG:
+                # Rate limit first: it is the more specific diagnosis, and a
+                # page that was throttled may carry a generic error too.
+                if extracted.text == _RATE_LIMITED_MSG:
+                    section_errors["search_results"] = rate_limited_section_error()
+                elif extracted.error:
+                    section_errors["search_results"] = extracted.error
+                stopped_by = "error"
+                break
+
+            new_entities = [
+                ref["url"]
+                for ref in extracted.references
+                if ref["kind"] == entity_kind and ref["url"] not in seen_entities
+            ]
+
+            page_texts.append(extracted.text)
+            if extracted.references:
+                page_references.extend(extracted.references)
+
+            if not new_entities:
+                logger.debug(
+                    "No new %s results on page %d, stopping", entity_kind, page_num
+                )
+                stopped_by = "linkedin_end_of_list"
+                break
+
+            seen_entities.update(new_entities)
+
+        references = (
+            dedupe_references(page_references, cap=_ENTITY_SEARCH_REFERENCE_CAP)
+            if page_texts
+            else []
+        )
+        result: dict[str, Any] = {
+            "url": base_url,
+            "sections": {"search_results": "\n---\n".join(page_texts)}
+            if page_texts
+            else {},
+            # Not decoration: a caller who asked for ten pages and got two has
+            # to be able to tell "LinkedIn had no more" from "the budget ran
+            # out", and the shortfall is otherwise only inferrable by counting
+            # the text. ``returned`` counts references after the cap, which is
+            # the list the follow-up tools can actually act on.
+            "result_counts": {
+                "rows_seen": len(seen_entities),
+                "returned": len(references),
+                "stopped_by": stopped_by,
+            },
+        }
+        if references:
+            result["references"] = {"search_results": references}
+        if section_errors:
+            result["section_errors"] = section_errors
+        return result
+
     async def search_people(
         self,
         keywords: str,
         location: str | None = None,
         network: list[str] | None = None,
         current_company: str | None = None,
+        max_pages: int = 1,
+        start_page: int = 1,
     ) -> dict[str, Any]:
-        """Search for people and extract the results page.
+        """Search for people and extract the results pages.
 
         Args:
             keywords: Free-text query ("software engineer", "recruiter at Google").
@@ -3625,9 +3792,14 @@ class LinkedInExtractor:
                 unfiltered result set. Look up a company's URN via
                 ``get_company_profile`` -- it is exposed under
                 ``references["about"]``.
+            max_pages: How many ``&page=N`` result pages to walk, ten people
+                each (1-10, default 1). Costs one navigation per page.
+            start_page: Which results page the walk begins on (default 1), so
+                a caller can resume where the last call stopped without
+                re-fetching what it already has.
 
         Returns:
-            {url, sections: {name: text}}
+            {url, sections: {name: text}, result_counts: {...}}
         """
         if network is not None:
             invalid = [t for t in network if t not in _NETWORK_TOKENS]
@@ -3654,63 +3826,41 @@ class LinkedInExtractor:
             params += f"&currentCompany={_encode_list_facet([current_company])}"
 
         url = f"https://www.linkedin.com/search/results/people/?{params}"
-        extracted = await self.extract_page(url, section_name="search_results")
-
-        sections: dict[str, str] = {}
-        references: dict[str, list[Reference]] = {}
-        section_errors: dict[str, dict[str, Any]] = {}
-        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
-            sections["search_results"] = extracted.text
-            if extracted.references:
-                references["search_results"] = extracted.references
-        elif extracted.text == _RATE_LIMITED_MSG:
-            section_errors["search_results"] = rate_limited_section_error()
-        elif extracted.error:
-            section_errors["search_results"] = extracted.error
-
-        result: dict[str, Any] = {
-            "url": url,
-            "sections": sections,
-        }
-        if references:
-            result["references"] = references
-        if section_errors:
-            result["section_errors"] = section_errors
-        return result
+        return await self._paginated_entity_search(
+            url,
+            entity_kind="person",
+            max_pages=max_pages,
+            context="search_people",
+            start_page=start_page,
+        )
 
     async def search_companies(
         self,
         keywords: str,
+        max_pages: int = 1,
+        start_page: int = 1,
     ) -> dict[str, Any]:
-        """Search for companies and extract the results page.
+        """Search for companies and extract the results pages.
+
+        Args:
+            keywords: Free-text query ("fintech", "electric vehicles").
+            max_pages: How many ``&page=N`` result pages to walk, ten companies
+                each (1-10, default 1). Costs one navigation per page.
+            start_page: Which results page the walk begins on (default 1), so
+                a caller can resume where the last call stopped without
+                re-fetching what it already has.
 
         Returns:
-            {url, sections: {search_results: text}}
+            {url, sections: {search_results: text}, result_counts: {...}}
         """
         url = f"https://www.linkedin.com/search/results/companies/?keywords={quote_plus(keywords)}"
-        extracted = await self.extract_page(url, section_name="search_results")
-
-        sections: dict[str, str] = {}
-        references: dict[str, list[Reference]] = {}
-        section_errors: dict[str, dict[str, Any]] = {}
-        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
-            sections["search_results"] = extracted.text
-            if extracted.references:
-                references["search_results"] = extracted.references
-        elif extracted.text == _RATE_LIMITED_MSG:
-            section_errors["search_results"] = rate_limited_section_error()
-        elif extracted.error:
-            section_errors["search_results"] = extracted.error
-
-        result: dict[str, Any] = {
-            "url": url,
-            "sections": sections,
-        }
-        if references:
-            result["references"] = references
-        if section_errors:
-            result["section_errors"] = section_errors
-        return result
+        return await self._paginated_entity_search(
+            url,
+            entity_kind="company",
+            max_pages=max_pages,
+            context="search_companies",
+            start_page=start_page,
+        )
 
     @staticmethod
     def _build_content_search_url(

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -96,7 +96,22 @@ _REFERENCE_CAPS = {
     "languages": 12,
     "posts": 12,
     "jobs": 8,
-    "search_results": 15,
+    # This cap applies per navigation, so it has to hold one search results
+    # page: measured live, that is 26 distinct /in/ slugs behind 10 result
+    # cards, the extras being the mutual connections each card links. It sits
+    # above extractor._ENTITY_SEARCH_SLUGS_PER_PAGE (30) with margin; the cap
+    # on the merged multi-page walk is _ENTITY_SEARCH_REFERENCE_CAP, and the
+    # two are checked against each other in tests/test_link_metadata.py.
+    #
+    # This is a floor on usable results, not cosmetics. The slug inside the
+    # reference URL is the only handle get_person_profile, get_company_profile
+    # and get_company_employees accept, so at the previous 15 a single page
+    # already lost more than half of what it found — and a ten-page walk
+    # returned a hundred people in the text and fifteen anyone could act on.
+    #
+    # search_jobs and get_saved_jobs share this section name but re-cap their
+    # merged reference list at 15 of their own accord, so they are unaffected.
+    "search_results": 100,
     "job_posting": 8,
     "contact_info": 8,
     "inbox": 30,

--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -6,9 +6,10 @@ with configurable section selection.
 """
 
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
+from pydantic import Field
 
 from linkedin_mcp_server.callbacks import MCPContextProgressCallback
 from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
@@ -176,30 +177,63 @@ def register_company_tools(
     async def search_companies(
         keywords: str,
         ctx: Context,
+        max_pages: Annotated[int, Field(ge=1, le=10)] = 1,
+        start_page: Annotated[int, Field(ge=1, le=100)] = 1,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
         Search for companies on LinkedIn.
 
+        To collect more companies than one call returns, loop: call with
+        start_page=1; if result_counts.stopped_by == "max_pages" there is more,
+        so call again with the same keywords and start_page increased by
+        max_pages (1 -> 4 -> 7 with max_pages=3); stop when stopped_by ==
+        "linkedin_end_of_list". Each call is independent — nothing is
+        remembered between them — and the page ranges abut exactly, so no
+        company is fetched twice.
+
         Args:
             keywords: Search keywords (e.g., "fintech", "anthropic", "electric vehicles")
             ctx: FastMCP context for progress reporting
+            max_pages: How many result pages to load, 10 companies each
+                (1-10, default 1). Each page is a separate navigation, so depth
+                costs time roughly linearly: about four seconds per page. The
+                walk stops as soon as a page returns no new company, so asking
+                for 10 pages of a narrow query costs only the pages that exist.
+            start_page: Which results page to begin at (1-100, default 1). Use
+                it to continue a previous call instead of re-fetching what you
+                already have: start_page=1 with max_pages=3 covers pages 1-3,
+                start_page=4 covers 4-6. Costs nothing extra — a deep start is
+                one navigation like any other.
 
         Returns:
-            Dict with url, sections (search_results -> raw text), and optional references.
+            Dict with url, sections (search_results -> raw text), optional
+            references, and result_counts {rows_seen, returned, stopped_by} —
+            stopped_by is "max_pages" when the depth budget ran out (there is
+            more; call again with start_page += max_pages, or raise max_pages),
+            "linkedin_end_of_list" when LinkedIn had nothing further (stop
+            looping — a further start_page returns nothing), or "error" when a
+            page failed (see section_errors; retry the same start_page).
             The LLM should parse the raw text to extract individual companies and their pages.
         """
         try:
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="search_companies"
             )
-            logger.info("Searching companies: keywords='%s'", keywords)
+            logger.info(
+                "Searching companies: keywords='%s', max_pages=%d, start_page=%d",
+                keywords,
+                max_pages,
+                start_page,
+            )
 
             await ctx.report_progress(
                 progress=0, total=100, message="Starting company search"
             )
 
-            result = await extractor.search_companies(keywords)
+            result = await extractor.search_companies(
+                keywords, max_pages=max_pages, start_page=start_page
+            )
 
             await ctx.report_progress(progress=100, total=100, message="Complete")
 

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -114,15 +114,35 @@ def register_person_tools(
         location: str | None = None,
         network: list[str] | None = None,
         current_company: str | None = None,
+        max_pages: Annotated[int, Field(ge=1, le=10)] = 1,
+        start_page: Annotated[int, Field(ge=1, le=100)] = 1,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
         Search for people on LinkedIn.
 
+        To collect more people than one call returns, loop: call with
+        start_page=1; if result_counts.stopped_by == "max_pages" there is more,
+        so call again with the same keywords and start_page increased by
+        max_pages (1 -> 4 -> 7 with max_pages=3); stop when stopped_by ==
+        "linkedin_end_of_list". Each call is independent — nothing is
+        remembered between them — and the page ranges abut exactly, so no
+        person is fetched twice.
+
         Args:
             keywords: Search keywords (e.g., "software engineer", "recruiter at Google")
             ctx: FastMCP context for progress reporting
             location: Optional location filter (e.g., "New York", "Remote")
+            max_pages: How many result pages to load, 10 people each
+                (1-10, default 1). Each page is a separate navigation, so depth
+                costs time roughly linearly: about four seconds per page. The
+                walk stops as soon as a page returns nobody new, so asking for
+                10 pages of a query with one page of matches costs one page.
+            start_page: Which results page to begin at (1-100, default 1). Use
+                it to continue a previous call instead of re-fetching what you
+                already have: start_page=1 with max_pages=3 covers pages 1-3,
+                start_page=4 covers 4-6. Costs nothing extra — a deep start is
+                one navigation like any other.
             network: Optional connection-degree filter. Each element is one of
                 "F" (1st-degree), "S" (2nd-degree), "O" (3rd-degree and beyond).
                 Example: ["F"] to only return 1st-degree connections.
@@ -136,7 +156,13 @@ def register_person_tools(
                 slug-based lookup, use get_company_employees instead.
 
         Returns:
-            Dict with url, sections (name -> raw text), and optional references.
+            Dict with url, sections (name -> raw text), optional references, and
+            result_counts {rows_seen, returned, stopped_by} — stopped_by is
+            "max_pages" when the depth budget ran out (there is more; call
+            again with start_page += max_pages, or raise max_pages),
+            "linkedin_end_of_list" when LinkedIn had nothing further (stop
+            looping — a further start_page returns nothing), or "error" when a
+            page failed (see section_errors; retry the same start_page).
             The LLM should parse the raw text to extract individual people and their profiles.
         """
         try:
@@ -144,11 +170,14 @@ def register_person_tools(
                 ctx, tool_name="search_people"
             )
             logger.info(
-                "Searching people: keywords='%s', location='%s', network=%s, current_company='%s'",
+                "Searching people: keywords='%s', location='%s', network=%s, "
+                "current_company='%s', max_pages=%d, start_page=%d",
                 keywords,
                 location,
                 network,
                 current_company,
+                max_pages,
+                start_page,
             )
 
             await ctx.report_progress(
@@ -161,6 +190,8 @@ def register_person_tools(
                     location,
                     network=network,
                     current_company=current_company,
+                    max_pages=max_pages,
+                    start_page=start_page,
                 )
             except FilterValidationError as e:
                 # Validation messages carry actionable detail; surface

--- a/manifest.json
+++ b/manifest.json
@@ -73,7 +73,7 @@
     },
     {
       "name": "search_companies",
-      "description": "Search for companies on LinkedIn by keywords"
+      "description": "Search for companies on LinkedIn by keywords, paginating with max_pages and resuming a previous walk with start_page"
     },
     {
       "name": "get_company_employees",
@@ -93,7 +93,7 @@
     },
     {
       "name": "search_people",
-      "description": "Search for people on LinkedIn by keywords, location, connection degree (1st/2nd/3rd), and current company"
+      "description": "Search for people on LinkedIn by keywords, location, connection degree (1st/2nd/3rd), and current company, paginating with max_pages and resuming a previous walk with start_page"
     },
     {
       "name": "get_inbox",

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -2,7 +2,13 @@
 
 from urllib.parse import quote
 
+from linkedin_mcp_server.scraping.extractor import (
+    _ENTITY_SEARCH_MAX_PAGES,
+    _ENTITY_SEARCH_REFERENCE_CAP,
+    _ENTITY_SEARCH_SLUGS_PER_PAGE,
+)
 from linkedin_mcp_server.scraping.link_metadata import (
+    _REFERENCE_CAPS,
     RawReference,
     build_references,
     classify_link,
@@ -441,6 +447,44 @@ class TestBuildReferences:
         assert len(references) == 8
         assert references[0]["url"] == "/jobs/view/0/"
         assert references[-1]["url"] == "/jobs/view/7/"
+
+    def test_one_search_page_survives_intact(self):
+        """The cap was 15 and a live people page carries 26 distinct slugs.
+
+        So more than half of a single page's usable handles were dropped before
+        pagination was ever in the picture — and the slug is the only handle
+        get_person_profile accepts.
+        """
+        raw: list[RawReference] = [
+            {
+                "href": f"https://www.linkedin.com/in/person-{idx}/",
+                "text": f"Person {idx}",
+            }
+            for idx in range(_ENTITY_SEARCH_SLUGS_PER_PAGE)
+        ]
+
+        references = build_references(raw, "search_results")
+
+        assert len(references) == _ENTITY_SEARCH_SLUGS_PER_PAGE
+
+    def test_the_per_page_cap_holds_a_whole_page(self):
+        """The two caps are stacked, and only the outer one is visible.
+
+        A per-page cap below what a page carries truncates on the way in, and
+        the merged list then sits comfortably under its own cap — so nothing
+        looks wrong while results are being dropped.
+        """
+        assert _REFERENCE_CAPS["search_results"] >= _ENTITY_SEARCH_SLUGS_PER_PAGE
+
+    def test_the_merged_cap_holds_every_page_of_a_full_walk(self):
+        """Sizing the merged cap by results-per-page instead of slugs-per-page
+        truncates a ten-page walk around page four, and it drops the tail — so
+        the last pages' result cards are lost behind the first pages'
+        mutual-connection anchors."""
+        assert (
+            _ENTITY_SEARCH_REFERENCE_CAP
+            >= _ENTITY_SEARCH_SLUGS_PER_PAGE * _ENTITY_SEARCH_MAX_PAGES
+        )
 
     def test_uses_default_cap_for_unknown_section(self):
         raw: list[RawReference] = [

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -18,13 +18,15 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _CONTENT_DATE_POSTED_MAP,
+    _ENTITY_SEARCH_REFERENCE_CAP,
+    _ENTITY_SEARCH_SLUGS_PER_PAGE,
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
     strip_conversation_chrome,
     strip_linkedin_noise,
 )
-from linkedin_mcp_server.scraping.link_metadata import Reference
+from linkedin_mcp_server.scraping.link_metadata import Reference, ReferenceKind
 
 
 def extracted(
@@ -3116,6 +3118,370 @@ class TestSearchPeople:
         assert "location=Seattle" in result["url"]
         assert "network=%5B%22F%22%5D" in result["url"]
         assert "currentCompany=%5B%221115%22%5D" in result["url"]
+
+
+def _entity_page(
+    kind: ReferenceKind, prefix: str, start: int, count: int = 10
+) -> ExtractedSection:
+    """One results page carrying *count* distinct entity anchors."""
+    references: list[Reference] = [
+        {
+            "kind": kind,
+            "url": f"{prefix}{start + i}/",
+            "text": f"Result {start + i}",
+        }
+        for i in range(count)
+    ]
+    return extracted(f"page from {start}", references)
+
+
+class _PagedSearch:
+    """Drive one of the two entity searches over a scripted set of pages."""
+
+    def __init__(self, extractor, pages):
+        self._extractor = extractor
+        self._pages = list(pages)
+        self.urls: list[str] = []
+
+    async def _extract(self, url, *args, **kwargs):
+        self.urls.append(url)
+        if not self._pages:
+            return extracted("")
+        return self._pages.pop(0)
+
+    async def run(self, method: str, *args, **kwargs):
+        with (
+            patch.object(self._extractor, "extract_page", side_effect=self._extract),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            return await getattr(self._extractor, method)(*args, **kwargs)
+
+
+class TestEntitySearchPagination:
+    """``search_people`` / ``search_companies`` had no depth control at all.
+
+    Measured live: the results page has no body scroll (``scrollHeight`` equals
+    the viewport), so the scrolls inside ``extract_page`` could never reach
+    result #11. Depth here is ``&page=N``, one navigation per page, exactly as
+    ``search_jobs`` paginates with ``&start=``.
+    """
+
+    CASES = [
+        ("search_people", "person", "/in/p"),
+        ("search_companies", "company", "/company/c"),
+    ]
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_later_pages_carry_the_page_parameter(
+        self, mock_page, method, kind, prefix
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 0), _entity_page(kind, prefix, 100)],
+        )
+        await driver.run(method, "query", max_pages=2)
+
+        assert "&page=" not in driver.urls[0]
+        assert driver.urls[1] == f"{driver.urls[0]}&page=2"
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_pages_accumulate_into_one_section(
+        self, mock_page, method, kind, prefix
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 0), _entity_page(kind, prefix, 100)],
+        )
+        result = await driver.run(method, "query", max_pages=2)
+
+        assert result["sections"]["search_results"] == "page from 0\n---\npage from 100"
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_references_survive_past_the_first_fifteen(
+        self, mock_page, method, kind, prefix
+    ):
+        """The depth is thrown away at the last step without this.
+
+        ``_REFERENCE_CAPS["search_results"]`` was 15, so ten pages of ten
+        results returned a hundred entities in the text and fifteen usable
+        links — and the slug in the link is the only handle the follow-up
+        tools accept.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 100 * n) for n in range(4)],
+        )
+        result = await driver.run(method, "query", max_pages=4)
+
+        refs = result["references"]["search_results"]
+        assert len(refs) == 40
+        assert refs[-1]["url"] == f"{prefix}309/"
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_the_merged_cap_is_reported_where_it_bites(
+        self, mock_page, method, kind, prefix
+    ):
+        """``returned`` is the list the caller can act on, not what was found.
+
+        Reporting the pre-cap count would say 330 while handing back 300, and
+        the 30 missing are the tail — the last page's results, dropped behind
+        the first page's mutual-connection anchors.
+        """
+        per_page = _ENTITY_SEARCH_SLUGS_PER_PAGE
+        pages = (_ENTITY_SEARCH_REFERENCE_CAP // per_page) + 1
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [
+                _entity_page(kind, prefix, 1000 * n, count=per_page)
+                for n in range(pages)
+            ],
+        )
+        result = await driver.run(method, "query", max_pages=pages)
+
+        assert len(result["references"]["search_results"]) == (
+            _ENTITY_SEARCH_REFERENCE_CAP
+        )
+        assert result["result_counts"]["returned"] == _ENTITY_SEARCH_REFERENCE_CAP
+        assert result["result_counts"]["rows_seen"] == per_page * pages
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_a_page_with_no_new_entities_stops_the_walk(
+        self, mock_page, method, kind, prefix
+    ):
+        """Asking for ten pages of a query with one costs one navigation."""
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 0), _entity_page(kind, prefix, 0)],
+        )
+        result = await driver.run(method, "query", max_pages=10)
+
+        assert len(driver.urls) == 2
+        assert result["result_counts"]["stopped_by"] == "linkedin_end_of_list"
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_exhausting_the_budget_is_reported_as_such(
+        self, mock_page, method, kind, prefix
+    ):
+        """A full batch and an exhausted one must not look alike.
+
+        "20 of 20" and "the first 20 of who knows how many" are the same
+        twenty rows; only ``stopped_by`` separates them.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 100 * n) for n in range(2)],
+        )
+        result = await driver.run(method, "query", max_pages=2)
+
+        assert result["result_counts"] == {
+            "rows_seen": 20,
+            "returned": 20,
+            "stopped_by": "max_pages",
+        }
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_pages_are_spaced_by_the_navigation_gap(
+        self, mock_page, method, kind, prefix
+    ):
+        """Three navigations back to back is not something a person does."""
+        extractor = LinkedInExtractor(mock_page)
+        pages = [_entity_page(kind, prefix, 100 * n) for n in range(3)]
+
+        async def extract(url, *args, **kwargs):
+            return pages.pop(0)
+
+        with (
+            patch.object(extractor, "extract_page", side_effect=extract),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as sleep,
+        ):
+            await getattr(extractor, method)("query", max_pages=3)
+
+        assert [call.args[0] for call in sleep.await_args_list] == [2.0, 2.0]
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_default_depth_is_one_page(self, mock_page, method, kind, prefix):
+        """Pagination is opt-in: the default must cost what it always did."""
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 100 * n) for n in range(5)],
+        )
+        await driver.run(method, "query")
+
+        assert len(driver.urls) == 1
+        assert "&page=" not in driver.urls[0]
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_a_rate_limited_second_page_keeps_the_first(
+        self, mock_page, method, kind, prefix
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 0), extracted(_RATE_LIMITED_MSG)],
+        )
+        result = await driver.run(method, "query", max_pages=3)
+
+        assert result["sections"]["search_results"] == "page from 0"
+        assert result["section_errors"]["search_results"]["error_type"] == "rate_limit"
+        assert result["result_counts"]["stopped_by"] == "error"
+
+
+class TestResumableEntitySearch:
+    """The agent loop: fetch a batch, read it, fetch the next one.
+
+    ``&page=N`` is a URL parameter, so nothing has to be carried between
+    calls. ``start_page`` says where the walk begins and ``max_pages`` how far
+    it goes; together they name a half-open range of pages a caller can
+    advance without ever paying for a page twice.
+
+    Confirmed end to end against LinkedIn: ``start_page`` 1 / 4 / 7 at
+    ``max_pages=3`` returned 30 + 30 + 30 result cards with zero overlap, 90
+    distinct people across 9 pages.
+    """
+
+    CASES = TestEntitySearchPagination.CASES
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_a_resumed_walk_starts_where_the_last_one_stopped(
+        self, mock_page, method, kind, prefix
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 100 * n) for n in range(3)],
+        )
+        await driver.run(method, "query", max_pages=3, start_page=4)
+
+        base = driver.urls[0].split("&page=")[0]
+        assert driver.urls == [f"{base}&page={n}" for n in (4, 5, 6)]
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_page_one_is_still_the_bare_url(
+        self, mock_page, method, kind, prefix
+    ):
+        """Default start_page must not start appending ``&page=1``."""
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(extractor, [_entity_page(kind, prefix, 0)])
+        await driver.run(method, "query", max_pages=1)
+
+        assert "&page=" not in driver.urls[0]
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_a_resumed_walk_never_silently_refetches_page_one(
+        self, mock_page, method, kind, prefix
+    ):
+        """The first page of a walk is not the first page of the results.
+
+        Keying the bare-URL case off the loop index rather than the page
+        number hands back page one for every ``start_page``, which is the one
+        failure a looping caller cannot see: the batch is full, the slugs are
+        all new to that call's own seen-set, and the loop runs forever over
+        the same ten people.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(extractor, [_entity_page(kind, prefix, 0)])
+        await driver.run(method, "query", max_pages=1, start_page=2)
+
+        assert driver.urls[0].endswith("&page=2")
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_the_documented_loop_covers_every_page_exactly_once(
+        self, mock_page, method, kind, prefix
+    ):
+        """Three calls of ``start_page += max_pages`` walk 1..9 with no repeat.
+
+        This is the whole feature in one assertion — the docstrings tell an
+        agent to advance by ``max_pages``, and that advice is only true if the
+        ranges abut exactly.
+        """
+        visited: list[str] = []
+        for start in (1, 4, 7):
+            extractor = LinkedInExtractor(mock_page)
+            driver = _PagedSearch(
+                extractor,
+                [_entity_page(kind, prefix, 100 * n) for n in range(3)],
+            )
+            await driver.run(method, "query", max_pages=3, start_page=start)
+            visited.extend(driver.urls)
+
+        base = visited[0]
+        pages = [1 if url == base else int(url.split("&page=")[1]) for url in visited]
+        assert pages == list(range(1, 10))
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_only_max_pages_bounds_the_walk_not_the_end_page(
+        self, mock_page, method, kind, prefix
+    ):
+        """``max_pages`` stays a count of navigations, not a page number."""
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 100 * n) for n in range(5)],
+        )
+        await driver.run(method, "query", max_pages=2, start_page=5)
+
+        assert len(driver.urls) == 2
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_end_of_list_is_still_reported_from_a_resumed_walk(
+        self, mock_page, method, kind, prefix
+    ):
+        """An agent looping on a wrong signal never stops or stops early."""
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 0), _entity_page(kind, prefix, 0)],
+        )
+        result = await driver.run(method, "query", max_pages=5, start_page=4)
+
+        assert len(driver.urls) == 2
+        assert result["result_counts"]["stopped_by"] == "linkedin_end_of_list"
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_a_walk_that_starts_past_the_end_stops_on_the_first_page(
+        self, mock_page, method, kind, prefix
+    ):
+        """Measured live: past the last page LinkedIn keeps ``&page=N`` in the
+        URL and renders "No results found" — 78 characters of text and zero
+        entity anchors. Non-empty text, so this is not the ``error`` branch;
+        no new slugs, so the walk ends and says ``linkedin_end_of_list``.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(extractor, [extracted("No results found")])
+        result = await driver.run(method, "query", max_pages=3, start_page=9)
+
+        assert len(driver.urls) == 1
+        assert result["result_counts"] == {
+            "rows_seen": 0,
+            "returned": 0,
+            "stopped_by": "linkedin_end_of_list",
+        }
+
+    @pytest.mark.parametrize(("method", "kind", "prefix"), CASES)
+    async def test_a_full_resumed_batch_asks_to_be_resumed_again(
+        self, mock_page, method, kind, prefix
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        driver = _PagedSearch(
+            extractor,
+            [_entity_page(kind, prefix, 100 * n) for n in range(2)],
+        )
+        result = await driver.run(method, "query", max_pages=2, start_page=7)
+
+        assert result["result_counts"]["stopped_by"] == "max_pages"
 
 
 class TestBuildContentSearchUrl:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -267,6 +267,8 @@ class TestPersonTool:
             "New York",
             network=None,
             current_company=None,
+            max_pages=1,
+            start_page=1,
         )
 
     async def test_search_people_with_network_and_company_filters(self, mock_context):
@@ -301,7 +303,94 @@ class TestPersonTool:
             None,
             network=["F"],
             current_company="1115",
+            max_pages=1,
+            start_page=1,
         )
+
+    async def test_search_people_forwards_max_pages(self, mock_context):
+        mock_extractor = _make_mock_extractor(
+            {"url": "https://example.invalid", "sections": {"search_results": "text"}}
+        )
+
+        from linkedin_mcp_server.tools.person import register_person_tools
+
+        mcp = FastMCP("test")
+        register_person_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "search_people")
+        await tool_fn("engineer", mock_context, max_pages=10, extractor=mock_extractor)
+
+        mock_extractor.search_people.assert_awaited_once_with(
+            "engineer",
+            None,
+            network=None,
+            current_company=None,
+            max_pages=10,
+            start_page=1,
+        )
+
+    async def test_search_people_forwards_start_page(self, mock_context):
+        """A parameter that reaches the URL builder but not the extractor is
+        the failure mode this covers: the call succeeds and quietly returns
+        page one."""
+        mock_extractor = _make_mock_extractor(
+            {"url": "https://example.invalid", "sections": {"search_results": "text"}}
+        )
+
+        from linkedin_mcp_server.tools.person import register_person_tools
+
+        mcp = FastMCP("test")
+        register_person_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "search_people")
+        await tool_fn(
+            "engineer",
+            mock_context,
+            max_pages=3,
+            start_page=4,
+            extractor=mock_extractor,
+        )
+
+        mock_extractor.search_people.assert_awaited_once_with(
+            "engineer",
+            None,
+            network=None,
+            current_company=None,
+            max_pages=3,
+            start_page=4,
+        )
+
+    @pytest.mark.parametrize("value", [0, 101])
+    async def test_search_people_rejects_out_of_range_start_page(self, value):
+        # FastMCP wraps the pydantic error raised by Field() constraints in
+        # its own ValidationError, which does not subclass pydantic's.
+        from fastmcp.exceptions import ValidationError
+
+        from linkedin_mcp_server.tools.person import register_person_tools
+
+        mcp = FastMCP("test")
+        register_person_tools(mcp)
+
+        with pytest.raises(ValidationError, match="start_page"):
+            await mcp.call_tool(
+                "search_people", {"keywords": "engineer", "start_page": value}
+            )
+
+    @pytest.mark.parametrize("value", [0, 11])
+    async def test_search_people_rejects_out_of_range_max_pages(self, value):
+        # FastMCP wraps the pydantic error raised by Field() constraints in
+        # its own ValidationError, which does not subclass pydantic's.
+        from fastmcp.exceptions import ValidationError
+
+        from linkedin_mcp_server.tools.person import register_person_tools
+
+        mcp = FastMCP("test")
+        register_person_tools(mcp)
+
+        with pytest.raises(ValidationError, match="max_pages"):
+            await mcp.call_tool(
+                "search_people", {"keywords": "engineer", "max_pages": value}
+            )
 
     async def test_search_people_validation_error_surfaced_as_tool_error(
         self, mock_context
@@ -979,7 +1068,77 @@ class TestSearchCompaniesTool:
         tool_fn = await get_tool_fn(mcp, "search_companies")
         result = await tool_fn("fintech", mock_context, extractor=mock_extractor)
         assert "search_results" in result["sections"]
-        mock_extractor.search_companies.assert_awaited_once_with("fintech")
+        mock_extractor.search_companies.assert_awaited_once_with(
+            "fintech", max_pages=1, start_page=1
+        )
+
+    async def test_search_companies_forwards_max_pages(self, mock_context):
+        mock_extractor = _make_mock_extractor(
+            {"url": "https://example.invalid", "sections": {"search_results": "text"}}
+        )
+
+        from linkedin_mcp_server.tools.company import register_company_tools
+
+        mcp = FastMCP("test")
+        register_company_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "search_companies")
+        await tool_fn("fintech", mock_context, max_pages=10, extractor=mock_extractor)
+
+        mock_extractor.search_companies.assert_awaited_once_with(
+            "fintech", max_pages=10, start_page=1
+        )
+
+    async def test_search_companies_forwards_start_page(self, mock_context):
+        mock_extractor = _make_mock_extractor(
+            {"url": "https://example.invalid", "sections": {"search_results": "text"}}
+        )
+
+        from linkedin_mcp_server.tools.company import register_company_tools
+
+        mcp = FastMCP("test")
+        register_company_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "search_companies")
+        await tool_fn(
+            "fintech", mock_context, max_pages=3, start_page=7, extractor=mock_extractor
+        )
+
+        mock_extractor.search_companies.assert_awaited_once_with(
+            "fintech", max_pages=3, start_page=7
+        )
+
+    @pytest.mark.parametrize("value", [0, 101])
+    async def test_search_companies_rejects_out_of_range_start_page(self, value):
+        # FastMCP wraps the pydantic error raised by Field() constraints in
+        # its own ValidationError, which does not subclass pydantic's.
+        from fastmcp.exceptions import ValidationError
+
+        from linkedin_mcp_server.tools.company import register_company_tools
+
+        mcp = FastMCP("test")
+        register_company_tools(mcp)
+
+        with pytest.raises(ValidationError, match="start_page"):
+            await mcp.call_tool(
+                "search_companies", {"keywords": "fintech", "start_page": value}
+            )
+
+    @pytest.mark.parametrize("value", [0, 11])
+    async def test_search_companies_rejects_out_of_range_max_pages(self, value):
+        # FastMCP wraps the pydantic error raised by Field() constraints in
+        # its own ValidationError, which does not subclass pydantic's.
+        from fastmcp.exceptions import ValidationError
+
+        from linkedin_mcp_server.tools.company import register_company_tools
+
+        mcp = FastMCP("test")
+        register_company_tools(mcp)
+
+        with pytest.raises(ValidationError, match="max_pages"):
+            await mcp.call_tool(
+                "search_companies", {"keywords": "fintech", "max_pages": value}
+            )
 
     async def test_search_companies_error(self, mock_context):
         from fastmcp.exceptions import ToolError
@@ -997,6 +1156,61 @@ class TestSearchCompaniesTool:
         tool_fn = await get_tool_fn(mcp, "search_companies")
         with pytest.raises(ToolError, match="Session expired"):
             await tool_fn("fintech", mock_context, extractor=mock_extractor)
+
+
+class TestEntitySearchDepthBounds:
+    """The declared ceiling and the one the reference cap is derived from.
+
+    ``_ENTITY_SEARCH_REFERENCE_CAP`` is slugs-per-page times
+    ``_ENTITY_SEARCH_MAX_PAGES``. If the tool schema let a caller ask for more
+    pages than that constant names, the merged reference list would be capped
+    below what the walk actually fetched — silently, since the text would
+    still carry every result.
+    """
+
+    ENTITY_SEARCHES = ["search_people", "search_companies"]
+
+    @pytest.mark.parametrize("tool_name", ENTITY_SEARCHES)
+    async def test_max_pages_ceiling_matches_the_reference_cap_derivation(
+        self, tool_name
+    ):
+        from linkedin_mcp_server.scraping.extractor import _ENTITY_SEARCH_MAX_PAGES
+        from linkedin_mcp_server.server import create_mcp_server
+
+        mcp = create_mcp_server()
+        tool = await mcp.get_tool(tool_name)
+        assert tool is not None
+
+        schema = tool.parameters["properties"]["max_pages"]
+        assert schema["minimum"] == 1
+        assert schema["maximum"] == _ENTITY_SEARCH_MAX_PAGES
+
+    @pytest.mark.parametrize("tool_name", ENTITY_SEARCHES)
+    async def test_pagination_is_opt_in(self, tool_name):
+        """Default depth of one page keeps an existing caller's cost unchanged."""
+        from linkedin_mcp_server.server import create_mcp_server
+
+        mcp = create_mcp_server()
+        tool = await mcp.get_tool(tool_name)
+        assert tool is not None
+
+        assert tool.parameters["properties"]["max_pages"]["default"] == 1
+        assert tool.parameters["properties"]["start_page"]["default"] == 1
+
+    @pytest.mark.parametrize("tool_name", ENTITY_SEARCHES)
+    async def test_start_page_is_bounded_but_not_by_max_pages(self, tool_name):
+        """A deep start costs one navigation like any other, so its ceiling is
+        a claim about LinkedIn rather than about the clock — ``max_pages``
+        alone bounds how long a call runs."""
+        from linkedin_mcp_server.server import create_mcp_server
+
+        mcp = create_mcp_server()
+        tool = await mcp.get_tool(tool_name)
+        assert tool is not None
+
+        schema = tool.parameters["properties"]["start_page"]
+        assert schema["minimum"] == 1
+        assert schema["maximum"] == 100
 
 
 class TestGetCompanyEmployeesTool:


### PR DESCRIPTION
Closes #526.

`search_people` and `search_companies` each ran one navigation and returned whatever the first results page held — about ten people. This adds `max_pages` to both, walking LinkedIn's `&page=N` the way `search_jobs` already walks `&start=`, plus a `start_page` so a caller can resume a walk instead of refetching it.

## Why pagination and not a bigger scroll budget

The obvious fix is to let `extract_page` scroll further, and it cannot work. On a fully rendered people-search results page `document.body.scrollHeight` equals `window.innerHeight`, so `scroll_to_bottom` breaks on its first iteration and the whole budget is spent as a single no-op scroll. Extracting the same page-1 URL with a larger scroll budget returned byte-identical text and an identical slug set. Result #11 is not below the fold; it is on the next URL.

`&page=N` is that URL. Verified live: page 1 and page 2 of one query were disjoint (page 1 headed by "Erik Söderpalm", page 2 by "Oskar More Arvidsson"), and the parameter survived into the final URL as far as page 20 ("Susanna W." at page 11, "Isaac Gonzalez" at page 20) — LinkedIn neither clamps it nor silently re-serves page one.

## What changed

**`max_pages` (1-10, default 1)** on both tools. One navigation per page, the same `_NAV_DELAY` between them that `search_jobs` uses, pages joined into the single `search_results` section with `\n---\n`, and references deduped across pages. The walk stops early when a page surfaces no entity slug it has not already seen, so over-requesting is cheap: a query with few matches stopped after 3 of 10 requested pages (~74% faster than a full walk) and a zero-result query cost one navigation.

The default of `1` is deliberate — it preserves today's cost and behaviour exactly, so pagination is opt-in, as #526 proposed. (`search_jobs` defaults to 3; happy to match that instead if you prefer consistency over the no-op default.)

Depth extends rather than resamples: `max_pages=1` returned 26 unique `/in/` slugs and `max_pages=5` returned 123, with the 26 a strict subset of the 123.

**`start_page` (1-100, default 1)**, so an agent can fetch a batch, judge it, and fetch the next. Nothing is stored between calls — `&page=N` is a URL parameter, so resumption is a number the caller passes rather than a cursor the scraper has to keep. `start_page=1, max_pages=3` walks pages 1-3 and `start_page=4, max_pages=3` walks 4-6; because the ranges abut exactly, `start_page += max_pages` is true advice and the tool docstrings give it. Verified live: `start_page` 1 / 4 / 7 at `max_pages=3` returned 30 + 30 + 30 result cards with zero overlap — 90 distinct people across 9 pages.

This is beyond what #526 asked for, but depth without resumability is only usable in one shot, and it is a small addition on the same mechanism. Easy to drop if you would rather keep the PR to the issue's scope.

**`_REFERENCE_CAPS["search_results"]` moves from 15 to 100.** This is the part a reviewer will reasonably wonder about, so: without it the whole feature is thrown away at the last step. That cap applies per navigation, and one live people results page carries **26 distinct `/in/` slugs** behind its 10 result cards — each card also links the mutual connections it shares with the viewer. At 15, a *single* page already lost more than half its usable handles, and a ten-page walk returned a hundred people in the text with fifteen links anyone could act on. The slug inside a reference URL is the only handle `get_person_profile`, `get_company_profile` and `get_company_employees` accept, so a capped reference list is a capped result set no matter how much text came back.

The merged multi-page list gets its own cap, `_ENTITY_SEARCH_REFERENCE_CAP`, derived from slugs-per-page × `max_pages` rather than from results-per-page. Sizing it by the result count (100) would truncate a ten-page walk at roughly page four, and what it drops is the tail — the last pages' result cards, lost behind the first pages' mutual-connection anchors. `tests/test_link_metadata.py` asserts the two caps against each other so the stacking cannot silently invert.

Note the `search_results` section name is shared. `search_jobs` and `get_saved_jobs` re-cap their merged reference list at 15 of their own accord, so they are unaffected; `search_posts` gains the same headroom.

**`result_counts: {rows_seen, returned, stopped_by}`** on both tools. A caller who asks for ten pages and gets two has to be able to tell "LinkedIn had no more" from "the budget ran out" from "a page failed", and otherwise that is only inferrable by counting the text. `stopped_by` is `"max_pages"`, `"linkedin_end_of_list"`, or `"error"`. `returned` counts references *after* the cap, because that is the list the follow-up tools can actually act on. This is what stops the feature reintroducing silent truncation at a new depth.

## Repo rules this had to satisfy

- **One section = one navigation** still holds: each `&page=N` is its own navigation, and they merge into the one `search_results` section rather than one section fanning out to several URLs.
- **Locale independence**: the early stop counts entity slugs taken from `href`s, so the signal is a URL pattern, never a text value. The results header ("About 5,200 results") would be the obvious source for a page total and is deliberately not parsed — it is text. There is also no pagination element to read here: a fully rendered people results page carries zero `ul.artdeco-pagination__pages li button` nodes and no element whose class matches `/pagination|pager/`, so `_get_total_list_pages` answers `None` and asking costs a round trip for nothing. That is why this loop stops on "no new slugs" where `search_jobs` can additionally consult "Page X of Y".
- **Minimal DOM dependence**: no new selectors at all.

Past the last page LinkedIn keeps `&page=N` in the URL and renders "No results found" — non-empty text, so the walk does not take the empty-text branch that means an error, and zero entity anchors, so it ends and reports `linkedin_end_of_list` rather than looping.

## Verification

`uv run pytest` (2029 passed, 11 skipped), `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check` — all clean.

New tests cover both tools through one parametrized suite: the `&page=` parameter shape, page-one staying the bare URL, pages accumulating into one section, references surviving past the old cap, the merged cap being reported where it bites, the early stop, budget exhaustion, the inter-page gap, the opt-in default, a rate-limited later page keeping earlier ones, and — for `start_page` — that a resumed walk never silently refetches page one, that three calls of `start_page += max_pages` cover pages 1-9 exactly once, and that a walk starting past the end stops on its first navigation.

## Synthetic prompt

> Add `max_pages` and `start_page` to `search_people` and `search_companies` so callers can paginate LinkedIn's `&page=N` and resume a walk, following the existing `search_jobs` pagination pattern (same inter-page delay, same early stop when a page yields no new entity — counted on slugs from hrefs so the signal stays locale-independent). Default `max_pages` to 1 so pagination is opt-in. Raise `_REFERENCE_CAPS["search_results"]` so a page's references are not truncated below what one page carries, and cap the merged multi-page list at slugs-per-page × max_pages. Return `result_counts {rows_seen, returned, stopped_by}` from both tools so a short answer is never silent. Update tests, README, AGENTS.md and manifest.json. Closes #526.

Generated with Claude Opus 5
