### PR TITLE
fix(jobs): Load a full page of job cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,18 +148,19 @@ Optional additional keys:
 
 ## Tests
 
-- **A test that cannot fail is not a test.** Run a new test against the
-  broken state it is meant to catch before committing it. One that passes
-  there asserts something every implementation satisfies (a count that holds
-  either way, a branch merely touched) and has to be rewritten to assert the
-  behaviour, usually against the log line or the elapsed time. Two of the ten
-  tests in `tests/test_job_sidebar_scroll_dom.py` shipped that way and only
-  review caught them.
+- **A test that cannot fail is not a test.** Before committing one, mutate
+  the code it covers and watch it fail. A test that survives the mutation
+  asserts something every implementation satisfies (a count that holds
+  either way, a branch merely touched), and the usual repair is to assert
+  the log line, the elapsed time, or a count scoped to the thing under
+  test. Fixtures that reload on every scroll event mask a premature stop:
+  slow them down until one batch lands per round, or the mutation survives
+  for the wrong reason.
 - **Browser-DOM tests belong where the unit suite mocks `page.evaluate`.**
   Extractor JS never executes under a mock, so a `browser_dom` test is its
-  only coverage. Elsewhere prefer a unit test: a browser fixture is a claim
-  about LinkedIn's own behaviour, and a wrong claim costs more than the
-  missing test would have.
+  only coverage. Prefer a unit test elsewhere, and keep in mind that a
+  fixture imitating LinkedIn's markup is a claim about LinkedIn, while one
+  driving a synthetic container is a claim about the algorithm only.
 
 ## Verifying Bug Reports
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,21 @@ Optional additional keys:
 - `job_ids: [id, ...]` (search_jobs and get_saved_jobs)
 - `references["feed"]` (get_feed only) — every entry is `kind: "feed_post"`; non-post anchors (sidebar profiles, employer logos) are filtered. URLs may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) form; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
 
+## Tests
+
+- **A test that cannot fail is not a test.** Run a new test against the
+  broken state it is meant to catch before committing it. One that passes
+  there asserts something every implementation satisfies (a count that holds
+  either way, a branch merely touched) and has to be rewritten to assert the
+  behaviour, usually against the log line or the elapsed time. Two of the ten
+  tests in `tests/test_job_sidebar_scroll_dom.py` shipped that way and only
+  review caught them.
+- **Browser-DOM tests belong where the unit suite mocks `page.evaluate`.**
+  Extractor JS never executes under a mock, so a `browser_dom` test is its
+  only coverage. Elsewhere prefer a unit test: a browser fixture is a claim
+  about LinkedIn's own behaviour, and a wrong claim costs more than the
+  missing test would have.
+
 ## Verifying Bug Reports
 
 Always verify scraping bugs end-to-end against live LinkedIn, not just code analysis. Use `uv run`, not `uvx`, so the running process reflects your workspace. Use `uvx` only for packaged distribution verification. For live Docker investigations, refresh the source session first with `uv run -m linkedin_mcp_server --login` before testing each materially different approach. Assume a valid login profile already exists at `~/.linkedin-mcp/profile/`.

--- a/linkedin_mcp_server/core/utils.py
+++ b/linkedin_mcp_server/core/utils.py
@@ -9,6 +9,8 @@ from .exceptions import RateLimitError
 
 logger = logging.getLogger(__name__)
 
+_JOB_CARD_SELECTOR = 'a[href*="/jobs/view/"]'
+
 
 async def detect_rate_limit(page: Page) -> None:
     """Detect if LinkedIn has rate-limited or security-challenged the session.
@@ -87,33 +89,48 @@ async def scroll_to_bottom(
 
 
 async def scroll_job_sidebar(
-    page: Page, pause_time: float = 1.0, max_scrolls: int = 10
+    page: Page,
+    target_count: int,
+    settle_timeout: float = 3.0,
+    poll_interval: float = 0.15,
+    max_scrolls: int = 10,
 ) -> None:
-    """Scroll the job search sidebar to load all job cards.
+    """Scroll the job search sidebar until the page's worth of cards is loaded.
 
     LinkedIn renders job search results in a scrollable sidebar container,
-    not the main page body. This function finds that container by locating
-    a job card link and walking up to its scrollable ancestor, then scrolls
-    it iteratively until no new content loads.
+    not the main page body. This function finds that container through a job
+    card link and scrolls it until ``target_count`` cards are present or the
+    list stops growing.
+
+    Each scroll waits for the next batch by polling instead of sleeping a
+    fixed amount, because how long a batch takes is a property of the user's
+    connection. ``settle_timeout`` bounds the wait for the first batch; every
+    later round waits three times what the previous batch actually took, so a
+    fast connection stops early and a slow one is given the full budget.
+
+    DOM dependency: scrolling requires an element reference, which innerText
+    extraction cannot provide.
 
     Args:
         page: Patchright page object
-        pause_time: Time to pause between scrolls (seconds)
+        target_count: Cards to stop at, i.e. the pagination page size
+        settle_timeout: Upper bound per round for a batch to appear (seconds)
+        poll_interval: How often to look for the batch (seconds)
         max_scrolls: Maximum number of scroll attempts
     """
-    # Wait for at least one job card link to render before scrolling
     try:
-        await page.wait_for_selector('a[href*="/jobs/view/"]', timeout=5000)
+        await page.wait_for_selector(_JOB_CARD_SELECTOR, timeout=5000)
     except PlaywrightTimeoutError:
         logger.debug("No job card links found, skipping sidebar scroll")
         return
 
-    scrolled = await page.evaluate(
-        """async ({pauseTime, maxScrolls}) => {
-            const link = document.querySelector('a[href*="/jobs/view/"]');
-            if (!link) return -2;
+    result = await page.evaluate(
+        """async ({selector, targetCount, settleMs, pollMs, maxScrolls}) => {
+            const countCards = () => document.querySelectorAll(selector).length;
+            const first = document.querySelector(selector);
+            if (!first) return {status: 'gone'};
 
-            let container = link.parentElement;
+            let container = first.parentElement;
             while (container && container !== document.body) {
                 const style = window.getComputedStyle(container);
                 const overflowY = style.overflowY;
@@ -125,29 +142,65 @@ async def scroll_job_sidebar(
             }
 
             if (!container || container === document.body) {
-                return -1;
+                return {status: 'no-container', cards: countCards()};
             }
 
-            let scrollCount = 0;
-            for (let i = 0; i < maxScrolls; i++) {
-                const prevHeight = container.scrollHeight;
+            const minWaitMs = 400;
+            let budgetMs = settleMs;
+            let scrolls = 0;
+
+            while (countCards() < targetCount && scrolls < maxScrolls) {
+                const beforeCards = countCards();
+                const beforeHeight = container.scrollHeight;
                 container.scrollTop = container.scrollHeight;
-                await new Promise(r => setTimeout(r, pauseTime * 1000));
-                if (container.scrollHeight === prevHeight) break;
-                scrollCount++;
+
+                const started = Date.now();
+                const deadline = started + budgetMs;
+                let grew = false;
+                while (Date.now() < deadline) {
+                    await new Promise(r => setTimeout(r, pollMs));
+                    if (countCards() > beforeCards
+                        || container.scrollHeight > beforeHeight) {
+                        grew = true;
+                        break;
+                    }
+                }
+                if (!grew) break;
+
+                const took = Date.now() - started;
+                budgetMs = Math.min(settleMs, Math.max(minWaitMs, took * 3));
+                scrolls++;
             }
-            return scrollCount;
+
+            return {status: 'ok', scrolls, cards: countCards()};
         }""",
-        {"pauseTime": pause_time, "maxScrolls": max_scrolls},
+        {
+            "selector": _JOB_CARD_SELECTOR,
+            "targetCount": target_count,
+            "settleMs": settle_timeout * 1000,
+            "pollMs": poll_interval * 1000,
+            "maxScrolls": max_scrolls,
+        },
     )
-    if scrolled == -2:
+
+    status = result.get("status")
+    if status == "gone":
         logger.debug("Job card link disappeared before evaluate, skipping scroll")
-    elif scrolled == -1:
+    elif status == "no-container":
         logger.debug("No scrollable container found for job sidebar")
-    elif scrolled:
-        logger.debug("Scrolled job sidebar %d times", scrolled)
+    elif result["cards"] < target_count:
+        logger.debug(
+            "Job sidebar stopped at %d of %d cards after %d scrolls",
+            result["cards"],
+            target_count,
+            result["scrolls"],
+        )
     else:
-        logger.debug("Job sidebar container found but no new content loaded")
+        logger.debug(
+            "Job sidebar loaded %d cards after %d scrolls",
+            result["cards"],
+            result["scrolls"],
+        )
 
 
 async def handle_modal_close(page: Page) -> bool:

--- a/linkedin_mcp_server/core/utils.py
+++ b/linkedin_mcp_server/core/utils.py
@@ -100,23 +100,28 @@ async def scroll_job_sidebar(
     """Scroll the job search sidebar until the page's worth of cards is loaded.
 
     LinkedIn renders job search results in a scrollable sidebar container,
-    not the main page body. Which container that is cannot be decided from a
-    snapshot: the job detail pane scrolls on its own and carries both its own
-    permalink and a "similar jobs" list, so it can hold more matches than the
-    rail has rendered yet. Every scrollable ancestor of a card is scrolled,
-    and the target counts the richest one, which is the one that grows.
+    not the main page body. Finding it means looking at every scrollable
+    ancestor of every card, not the nearest one of the first card: the job
+    detail pane scrolls on its own and carries its own permalink, and a card
+    may sit in a scrollable wrapper of its own. The rail is the container
+    holding the most distinct job ids, and it is the only one scrolled, so a
+    "similar jobs" list in the pane can neither be lazy-loaded into the page
+    nor be mistaken for progress. Known limit: a pane holding more jobs than
+    the rail has rendered would win the comparison. A live search rendered 11
+    rail cards against a single pane permalink, so the margin is wide, but
+    the heuristic is a count and not proof.
 
-    Cards are counted as distinct job ids rather than selector matches, since
-    one card can carry several links to the same job.
+    Cards count as distinct job ids rather than selector matches, since one
+    card can carry several links to the same job.
 
     Each scroll waits for the next batch by polling instead of sleeping a
     fixed amount, because how long a batch takes belongs to the user's
     connection. A round that sees nothing scrolls once more at the full
     ``settle_timeout`` before the list counts as exhausted, so a single slow
     batch cannot end the page: that is what the fixed 0.5s sleep did, and one
-    measured search lost 14 of 25 cards to it. The longest a round can wait is
-    therefore ``2 * settle_timeout``. Later rounds start from three times what
-    the previous batch took, floored at ``min_budget``, which shortens the
+    measured search lost 14 of 25 cards to it. A round therefore waits at
+    most ``2 * settle_timeout``. Later rounds start from three times what the
+    previous batch took, floored at ``min_budget``, which shortens the
     terminating round on a fast connection.
 
     ``deadline`` bounds the whole call; ``search_jobs`` divides a search-wide
@@ -135,76 +140,94 @@ async def scroll_job_sidebar(
         deadline: Wall-clock bound for the whole call (seconds)
     """
     try:
-        await page.wait_for_selector(_JOB_CARD_SELECTOR, timeout=5000)
+        await page.wait_for_selector(
+            _JOB_CARD_SELECTOR, timeout=min(5000, int(deadline * 1000))
+        )
     except PlaywrightTimeoutError:
         logger.debug("No job card links found, skipping sidebar scroll")
+        return
+    except Exception as exc:
+        # Same reason as the guard around the evaluate below: the page can go
+        # away under us, and scrolling must not take the search with it.
+        logger.warning("Job sidebar scroll failed, page may be short: %s", exc)
         return
 
     try:
         result = await page.evaluate(
-            """async (opts) => {
+            r"""async (opts) => {
             const {selector, targetCount, settleMs, pollMs,
                    minBudgetMs, maxScrolls, deadlineMs} = opts;
 
-            const scrollableAncestor = (card) => {
-                let node = card ? card.parentElement : null;
-                while (node && node !== document.body) {
-                    const style = window.getComputedStyle(node);
-                    const overflowY = style.overflowY;
-                    if ((overflowY === 'auto' || overflowY === 'scroll')
-                        && node.scrollHeight > node.clientHeight) {
-                        return node;
-                    }
-                    node = node.parentElement;
-                }
-                return null;
+            // Slugged hrefs (/jobs/view/<slug>-<id>) and the currentJobId
+            // form both occur. #727 widens the selector to componentkey
+            // cards and has to widen this with it.
+            const idOf = (node) => {
+                const match = (node.getAttribute('href') || '').match(
+                    /\/jobs\/view\/(?:[\w-]*?-)?(\d+)|currentJobId=(\d+)/
+                );
+                return match ? (match[1] || match[2]) : null;
             };
 
             const idsIn = (scope) => {
                 const ids = new Set();
                 for (const node of scope.querySelectorAll(selector)) {
-                    const source = node.getAttribute('href')
-                        || node.getAttribute('componentkey') || '';
-                    const match = source.match(
-                        /(?:\/jobs\/view\/|job-card-component-ref-)(\d+)/
-                    );
-                    if (match) ids.add(match[1]);
+                    const id = idOf(node);
+                    if (id) ids.add(id);
                 }
                 return ids.size;
             };
 
-            const cards = document.querySelectorAll(selector);
-            if (!cards.length) return {status: 'gone'};
-
-            let containers = [];
-            for (const card of cards) {
-                const candidate = scrollableAncestor(card);
-                if (candidate && !containers.includes(candidate)) {
-                    containers.push(candidate);
+            // Every scrollable ancestor of every card is a candidate: a
+            // card can sit in its own scrollable wrapper, and the nearest
+            // one is then a container holding a single card. Collected
+            // fresh on every pick, because a re-render replaces the nodes.
+            const collect = () => {
+                const found = [];
+                for (const card of document.querySelectorAll(selector)) {
+                    let node = card.parentElement;
+                    while (node && node !== document.body) {
+                        const style = window.getComputedStyle(node);
+                        const overflowY = style.overflowY;
+                        if ((overflowY === 'auto' || overflowY === 'scroll')
+                            && node.scrollHeight > node.clientHeight
+                            && !found.includes(node)) {
+                            found.push(node);
+                        }
+                        node = node.parentElement;
+                    }
                 }
-            }
-            if (!containers.length) {
-                return {status: 'no-container', cards: idsIn(document)};
-            }
-
-            const live = () =>
-                containers.filter((node) => document.contains(node));
-            const countCards = () =>
-                live().reduce((most, node) => Math.max(most, idsIn(node)), 0);
-            const totalHeight = () =>
-                live().reduce((sum, node) => sum + node.scrollHeight, 0);
-            const scrollAll = () => {
-                for (const node of live()) {
-                    node.scrollTop = node.scrollHeight;
-                }
+                return found;
             };
+
+            if (!document.querySelectorAll(selector).length) {
+                return {status: 'gone'};
+            }
+
+            // The rail is the candidate holding the most jobs. Scrolling only
+            // it keeps a scrollable detail pane out of the page entirely.
+            const pickRail = () => {
+                let best = 0;
+                let picked = null;
+                for (const node of collect()) {
+                    const held = idsIn(node);
+                    if (held > best) {
+                        best = held;
+                        picked = node;
+                    }
+                }
+                return picked;
+            };
+
+            let rail = pickRail();
+            if (!rail) return {status: 'no-container', cards: 0};
 
             const hardDeadline = Date.now() + deadlineMs;
             const grewSince = async (cardCount, height, budgetMs) => {
                 const until = Math.min(Date.now() + budgetMs, hardDeadline);
                 while (Date.now() < until) {
                     await new Promise(r => setTimeout(r, pollMs));
-                    if (countCards() > cardCount || totalHeight() > height) {
+                    if (idsIn(rail) > cardCount
+                        || rail.scrollHeight > height) {
                         return true;
                     }
                 }
@@ -214,34 +237,37 @@ async def scroll_job_sidebar(
             let budgetMs = settleMs;
             let scrolls = 0;
             let timedOut = false;
+            let cappedOut = false;
 
-            while (countCards() < targetCount && scrolls < maxScrolls) {
+            while (idsIn(rail) < targetCount) {
+                if (scrolls >= maxScrolls) {
+                    cappedOut = true;
+                    break;
+                }
                 if (Date.now() >= hardDeadline) {
                     timedOut = true;
                     break;
                 }
-                if (!live().length) {
-                    // A re-render detaches the rail; polling the old nodes
+                if (!document.contains(rail)) {
+                    // A re-render detaches the rail; polling the old node
                     // would measure a corpse until the deadline.
-                    const again = scrollableAncestor(
-                        document.querySelector(selector)
-                    );
+                    const again = pickRail();
                     if (!again) break;
-                    containers = [again];
+                    rail = again;
                 }
 
-                const beforeCards = countCards();
-                const beforeHeight = totalHeight();
+                const beforeCards = idsIn(rail);
+                const beforeHeight = rail.scrollHeight;
                 const started = Date.now();
 
-                scrollAll();
+                rail.scrollTop = rail.scrollHeight;
                 let grew = await grewSince(
                     beforeCards, beforeHeight, budgetMs
                 );
                 if (!grew) {
                     // One confirmation round at the full budget: a batch
                     // slower than the shrunken budget is not an empty list.
-                    scrollAll();
+                    rail.scrollTop = rail.scrollHeight;
                     grew = await grewSince(
                         beforeCards, beforeHeight, settleMs
                     );
@@ -261,8 +287,9 @@ async def scroll_job_sidebar(
             return {
                 status: 'ok',
                 scrolls,
-                cards: countCards(),
+                cards: idsIn(rail),
                 timedOut,
+                cappedOut,
             };
         }""",
             {
@@ -278,7 +305,7 @@ async def scroll_job_sidebar(
     except Exception as exc:
         # Scrolling is best effort: a navigation or a destroyed context during
         # the evaluate must not discard the page the caller is about to read.
-        logger.debug("Job sidebar scroll failed: %s", exc)
+        logger.warning("Job sidebar scroll failed, page may be short: %s", exc)
         return
 
     status = result.get("status")
@@ -299,7 +326,7 @@ async def scroll_job_sidebar(
             result["cards"],
             target_count,
             result["scrolls"],
-            " (scroll cap reached)" if result["scrolls"] >= max_scrolls else "",
+            " (scroll cap reached)" if result["cappedOut"] else "",
         )
     else:
         logger.debug(

--- a/linkedin_mcp_server/core/utils.py
+++ b/linkedin_mcp_server/core/utils.py
@@ -93,7 +93,9 @@ async def scroll_job_sidebar(
     target_count: int,
     settle_timeout: float = 3.0,
     poll_interval: float = 0.15,
+    min_budget: float = 0.4,
     max_scrolls: int = 10,
+    deadline: float = 12.0,
 ) -> None:
     """Scroll the job search sidebar until the page's worth of cards is loaded.
 
@@ -103,10 +105,17 @@ async def scroll_job_sidebar(
     list stops growing.
 
     Each scroll waits for the next batch by polling instead of sleeping a
-    fixed amount, because how long a batch takes is a property of the user's
-    connection. ``settle_timeout`` bounds the wait for the first batch; every
-    later round waits three times what the previous batch actually took, so a
-    fast connection stops early and a slow one is given the full budget.
+    fixed amount, because how long a batch takes belongs to the user's
+    connection. A round that sees nothing scrolls once more at the full
+    ``settle_timeout`` before the list counts as exhausted, so a single slow
+    batch cannot end the page: that is what the fixed 0.5s sleep did, and one
+    measured search lost 14 of 25 cards to it. Later rounds start from three
+    times what the previous batch took, floored at ``min_budget``, which keeps
+    a fast connection fast without making a spike fatal.
+
+    ``deadline`` bounds the whole call. ``max_pages`` reaches 10 and
+    ``tool_timeout_seconds`` defaults to 180, so a per-page bound is what
+    keeps a pathological page from spending the tool's entire budget.
 
     DOM dependency: scrolling requires an element reference, which innerText
     extraction cannot provide.
@@ -114,9 +123,11 @@ async def scroll_job_sidebar(
     Args:
         page: Patchright page object
         target_count: Cards to stop at, i.e. the pagination page size
-        settle_timeout: Upper bound per round for a batch to appear (seconds)
+        settle_timeout: Longest wait for a batch, and the confirmation wait
         poll_interval: How often to look for the batch (seconds)
+        min_budget: Smallest wait a fast connection may shrink to (seconds)
         max_scrolls: Maximum number of scroll attempts
+        deadline: Wall-clock bound for the whole call (seconds)
     """
     try:
         await page.wait_for_selector(_JOB_CARD_SELECTOR, timeout=5000)
@@ -125,61 +136,104 @@ async def scroll_job_sidebar(
         return
 
     result = await page.evaluate(
-        """async ({selector, targetCount, settleMs, pollMs, maxScrolls}) => {
-            const countCards = () => document.querySelectorAll(selector).length;
-            const first = document.querySelector(selector);
-            if (!first) return {status: 'gone'};
+        """async (opts) => {
+            const {selector, targetCount, settleMs, pollMs,
+                   minBudgetMs, maxScrolls, deadlineMs} = opts;
+            const cards = document.querySelectorAll(selector);
+            if (!cards.length) return {status: 'gone'};
 
-            let container = first.parentElement;
-            while (container && container !== document.body) {
-                const style = window.getComputedStyle(container);
-                const overflowY = style.overflowY;
-                if ((overflowY === 'auto' || overflowY === 'scroll')
-                    && container.scrollHeight > container.clientHeight) {
-                    break;
+            // Walk up from every card, not just the first one in the
+            // document: the detail pane carries its own /jobs/view/ link and
+            // sits outside the scrollable rail, so starting there finds no
+            // container at all.
+            let container = null;
+            for (const card of cards) {
+                let node = card.parentElement;
+                while (node && node !== document.body) {
+                    const style = window.getComputedStyle(node);
+                    const overflowY = style.overflowY;
+                    if ((overflowY === 'auto' || overflowY === 'scroll')
+                        && node.scrollHeight > node.clientHeight) {
+                        container = node;
+                        break;
+                    }
+                    node = node.parentElement;
                 }
-                container = container.parentElement;
+                if (container) break;
             }
 
-            if (!container || container === document.body) {
+            // Scope the count to the sidebar: the job detail pane carries its
+            // own /jobs/view/ permalink and would count toward the target.
+            const countCards = () =>
+                (container || document).querySelectorAll(selector).length;
+
+            if (!container) {
                 return {status: 'no-container', cards: countCards()};
             }
 
-            const minWaitMs = 400;
-            let budgetMs = settleMs;
-            let scrolls = 0;
-
-            while (countCards() < targetCount && scrolls < maxScrolls) {
-                const beforeCards = countCards();
-                const beforeHeight = container.scrollHeight;
-                container.scrollTop = container.scrollHeight;
-
-                const started = Date.now();
-                const deadline = started + budgetMs;
-                let grew = false;
-                while (Date.now() < deadline) {
+            const hardDeadline = Date.now() + deadlineMs;
+            const grewSince = async (cards, height, budgetMs) => {
+                const until = Math.min(Date.now() + budgetMs, hardDeadline);
+                while (Date.now() < until) {
                     await new Promise(r => setTimeout(r, pollMs));
-                    if (countCards() > beforeCards
-                        || container.scrollHeight > beforeHeight) {
-                        grew = true;
-                        break;
+                    if (countCards() > cards
+                        || container.scrollHeight > height) {
+                        return true;
                     }
                 }
-                if (!grew) break;
+                return false;
+            };
+
+            let budgetMs = settleMs;
+            let scrolls = 0;
+            let timedOut = false;
+
+            while (countCards() < targetCount && scrolls < maxScrolls) {
+                if (Date.now() >= hardDeadline) {
+                    timedOut = true;
+                    break;
+                }
+                const beforeCards = countCards();
+                const beforeHeight = container.scrollHeight;
+                const started = Date.now();
+
+                container.scrollTop = container.scrollHeight;
+                let grew = await grewSince(beforeCards, beforeHeight, budgetMs);
+                if (!grew) {
+                    // One confirmation round at the full budget: a batch
+                    // slower than the shrunken budget is not an empty list.
+                    container.scrollTop = container.scrollHeight;
+                    grew = await grewSince(
+                        beforeCards, beforeHeight, settleMs
+                    );
+                }
+                if (!grew) {
+                    timedOut = Date.now() >= hardDeadline;
+                    break;
+                }
 
                 const took = Date.now() - started;
-                budgetMs = Math.min(settleMs, Math.max(minWaitMs, took * 3));
+                budgetMs = Math.min(
+                    settleMs, Math.max(minBudgetMs, took * 3)
+                );
                 scrolls++;
             }
 
-            return {status: 'ok', scrolls, cards: countCards()};
+            return {
+                status: 'ok',
+                scrolls,
+                cards: countCards(),
+                timedOut,
+            };
         }""",
         {
             "selector": _JOB_CARD_SELECTOR,
             "targetCount": target_count,
             "settleMs": settle_timeout * 1000,
             "pollMs": poll_interval * 1000,
+            "minBudgetMs": min_budget * 1000,
             "maxScrolls": max_scrolls,
+            "deadlineMs": deadline * 1000,
         },
     )
 
@@ -188,6 +242,13 @@ async def scroll_job_sidebar(
         logger.debug("Job card link disappeared before evaluate, skipping scroll")
     elif status == "no-container":
         logger.debug("No scrollable container found for job sidebar")
+    elif result["timedOut"]:
+        logger.debug(
+            "Job sidebar hit the %.0fs deadline at %d of %d cards",
+            deadline,
+            result["cards"],
+            target_count,
+        )
     elif result["cards"] < target_count:
         logger.debug(
             "Job sidebar stopped at %d of %d cards after %d scrolls",

--- a/linkedin_mcp_server/core/utils.py
+++ b/linkedin_mcp_server/core/utils.py
@@ -100,22 +100,27 @@ async def scroll_job_sidebar(
     """Scroll the job search sidebar until the page's worth of cards is loaded.
 
     LinkedIn renders job search results in a scrollable sidebar container,
-    not the main page body. This function finds that container through a job
-    card link and scrolls it until ``target_count`` cards are present or the
-    list stops growing.
+    not the main page body. Which container that is cannot be decided from a
+    snapshot: the job detail pane scrolls on its own and carries both its own
+    permalink and a "similar jobs" list, so it can hold more matches than the
+    rail has rendered yet. Every scrollable ancestor of a card is scrolled,
+    and the target counts the richest one, which is the one that grows.
+
+    Cards are counted as distinct job ids rather than selector matches, since
+    one card can carry several links to the same job.
 
     Each scroll waits for the next batch by polling instead of sleeping a
     fixed amount, because how long a batch takes belongs to the user's
     connection. A round that sees nothing scrolls once more at the full
     ``settle_timeout`` before the list counts as exhausted, so a single slow
     batch cannot end the page: that is what the fixed 0.5s sleep did, and one
-    measured search lost 14 of 25 cards to it. Later rounds start from three
-    times what the previous batch took, floored at ``min_budget``, which keeps
-    a fast connection fast without making a spike fatal.
+    measured search lost 14 of 25 cards to it. The longest a round can wait is
+    therefore ``2 * settle_timeout``. Later rounds start from three times what
+    the previous batch took, floored at ``min_budget``, which shortens the
+    terminating round on a fast connection.
 
-    ``deadline`` bounds the whole call. ``max_pages`` reaches 10 and
-    ``tool_timeout_seconds`` defaults to 180, so a per-page bound is what
-    keeps a pathological page from spending the tool's entire budget.
+    ``deadline`` bounds the whole call; ``search_jobs`` divides a search-wide
+    budget over ``max_pages`` to keep a long search inside the tool timeout.
 
     DOM dependency: scrolling requires an element reference, which innerText
     extraction cannot provide.
@@ -123,7 +128,7 @@ async def scroll_job_sidebar(
     Args:
         page: Patchright page object
         target_count: Cards to stop at, i.e. the pagination page size
-        settle_timeout: Longest wait for a batch, and the confirmation wait
+        settle_timeout: Longest wait for one batch; a round may use it twice
         poll_interval: How often to look for the batch (seconds)
         min_budget: Smallest wait a fast connection may shrink to (seconds)
         max_scrolls: Maximum number of scroll attempts
@@ -135,49 +140,71 @@ async def scroll_job_sidebar(
         logger.debug("No job card links found, skipping sidebar scroll")
         return
 
-    result = await page.evaluate(
-        """async (opts) => {
+    try:
+        result = await page.evaluate(
+            """async (opts) => {
             const {selector, targetCount, settleMs, pollMs,
                    minBudgetMs, maxScrolls, deadlineMs} = opts;
-            const cards = document.querySelectorAll(selector);
-            if (!cards.length) return {status: 'gone'};
 
-            // Walk up from every card, not just the first one in the
-            // document: the detail pane carries its own /jobs/view/ link and
-            // sits outside the scrollable rail, so starting there finds no
-            // container at all.
-            let container = null;
-            for (const card of cards) {
-                let node = card.parentElement;
+            const scrollableAncestor = (card) => {
+                let node = card ? card.parentElement : null;
                 while (node && node !== document.body) {
                     const style = window.getComputedStyle(node);
                     const overflowY = style.overflowY;
                     if ((overflowY === 'auto' || overflowY === 'scroll')
                         && node.scrollHeight > node.clientHeight) {
-                        container = node;
-                        break;
+                        return node;
                     }
                     node = node.parentElement;
                 }
-                if (container) break;
+                return null;
+            };
+
+            const idsIn = (scope) => {
+                const ids = new Set();
+                for (const node of scope.querySelectorAll(selector)) {
+                    const source = node.getAttribute('href')
+                        || node.getAttribute('componentkey') || '';
+                    const match = source.match(
+                        /(?:\/jobs\/view\/|job-card-component-ref-)(\d+)/
+                    );
+                    if (match) ids.add(match[1]);
+                }
+                return ids.size;
+            };
+
+            const cards = document.querySelectorAll(selector);
+            if (!cards.length) return {status: 'gone'};
+
+            let containers = [];
+            for (const card of cards) {
+                const candidate = scrollableAncestor(card);
+                if (candidate && !containers.includes(candidate)) {
+                    containers.push(candidate);
+                }
+            }
+            if (!containers.length) {
+                return {status: 'no-container', cards: idsIn(document)};
             }
 
-            // Scope the count to the sidebar: the job detail pane carries its
-            // own /jobs/view/ permalink and would count toward the target.
+            const live = () =>
+                containers.filter((node) => document.contains(node));
             const countCards = () =>
-                (container || document).querySelectorAll(selector).length;
-
-            if (!container) {
-                return {status: 'no-container', cards: countCards()};
-            }
+                live().reduce((most, node) => Math.max(most, idsIn(node)), 0);
+            const totalHeight = () =>
+                live().reduce((sum, node) => sum + node.scrollHeight, 0);
+            const scrollAll = () => {
+                for (const node of live()) {
+                    node.scrollTop = node.scrollHeight;
+                }
+            };
 
             const hardDeadline = Date.now() + deadlineMs;
-            const grewSince = async (cards, height, budgetMs) => {
+            const grewSince = async (cardCount, height, budgetMs) => {
                 const until = Math.min(Date.now() + budgetMs, hardDeadline);
                 while (Date.now() < until) {
                     await new Promise(r => setTimeout(r, pollMs));
-                    if (countCards() > cards
-                        || container.scrollHeight > height) {
+                    if (countCards() > cardCount || totalHeight() > height) {
                         return true;
                     }
                 }
@@ -193,16 +220,28 @@ async def scroll_job_sidebar(
                     timedOut = true;
                     break;
                 }
+                if (!live().length) {
+                    // A re-render detaches the rail; polling the old nodes
+                    // would measure a corpse until the deadline.
+                    const again = scrollableAncestor(
+                        document.querySelector(selector)
+                    );
+                    if (!again) break;
+                    containers = [again];
+                }
+
                 const beforeCards = countCards();
-                const beforeHeight = container.scrollHeight;
+                const beforeHeight = totalHeight();
                 const started = Date.now();
 
-                container.scrollTop = container.scrollHeight;
-                let grew = await grewSince(beforeCards, beforeHeight, budgetMs);
+                scrollAll();
+                let grew = await grewSince(
+                    beforeCards, beforeHeight, budgetMs
+                );
                 if (!grew) {
                     // One confirmation round at the full budget: a batch
                     // slower than the shrunken budget is not an empty list.
-                    container.scrollTop = container.scrollHeight;
+                    scrollAll();
                     grew = await grewSince(
                         beforeCards, beforeHeight, settleMs
                     );
@@ -226,16 +265,21 @@ async def scroll_job_sidebar(
                 timedOut,
             };
         }""",
-        {
-            "selector": _JOB_CARD_SELECTOR,
-            "targetCount": target_count,
-            "settleMs": settle_timeout * 1000,
-            "pollMs": poll_interval * 1000,
-            "minBudgetMs": min_budget * 1000,
-            "maxScrolls": max_scrolls,
-            "deadlineMs": deadline * 1000,
-        },
-    )
+            {
+                "selector": _JOB_CARD_SELECTOR,
+                "targetCount": target_count,
+                "settleMs": settle_timeout * 1000,
+                "pollMs": poll_interval * 1000,
+                "minBudgetMs": min_budget * 1000,
+                "maxScrolls": max_scrolls,
+                "deadlineMs": deadline * 1000,
+            },
+        )
+    except Exception as exc:
+        # Scrolling is best effort: a navigation or a destroyed context during
+        # the evaluate must not discard the page the caller is about to read.
+        logger.debug("Job sidebar scroll failed: %s", exc)
+        return
 
     status = result.get("status")
     if status == "gone":
@@ -251,10 +295,11 @@ async def scroll_job_sidebar(
         )
     elif result["cards"] < target_count:
         logger.debug(
-            "Job sidebar stopped at %d of %d cards after %d scrolls",
+            "Job sidebar stopped at %d of %d cards after %d scrolls%s",
             result["cards"],
             target_count,
             result["scrolls"],
+            " (scroll cap reached)" if result["scrolls"] >= max_scrolls else "",
         )
     else:
         logger.debug(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -96,6 +96,11 @@ def rate_limited_section_error() -> dict[str, str]:
 
 # LinkedIn shows 25 results per page
 _PAGE_SIZE = 25
+# Scrolling a page is bounded twice: per page, and across a whole search.
+# max_pages reaches 10 and tool_timeout_seconds defaults to 180, so an
+# unbounded per-page wait could spend the caller's entire budget.
+_SCROLL_DEADLINE_MAX = 12.0
+_SCROLL_BUDGET_TOTAL = 60.0
 
 _SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
 
@@ -3079,6 +3084,7 @@ class LinkedInExtractor:
         self,
         url: str,
         section_name: str,
+        scroll_deadline: float = _SCROLL_DEADLINE_MAX,
     ) -> ExtractedSection:
         """Extract innerText from a job search page with soft rate-limit retry.
 
@@ -3087,7 +3093,9 @@ class LinkedInExtractor:
         ``_RATE_LIMITED_MSG`` sentinel instead of silent empty results.
         """
         try:
-            result = await self._extract_search_page_once(url, section_name)
+            result = await self._extract_search_page_once(
+                url, section_name, scroll_deadline
+            )
             if result.text != _RATE_LIMITED_MSG:
                 return result
 
@@ -3097,7 +3105,9 @@ class LinkedInExtractor:
                 _RATE_LIMIT_RETRY_DELAY,
             )
             await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
-            result = await self._extract_search_page_once(url, section_name)
+            result = await self._extract_search_page_once(
+                url, section_name, scroll_deadline
+            )
             if result.text == _RATE_LIMITED_MSG:
                 logger.warning("Search page %s still rate-limited after retry", url)
             return result
@@ -3121,6 +3131,7 @@ class LinkedInExtractor:
         self,
         url: str,
         section_name: str,
+        scroll_deadline: float = _SCROLL_DEADLINE_MAX,
     ) -> ExtractedSection:
         """Single attempt to navigate, scroll sidebar, and extract innerText."""
         await self._navigate_to_page(url)
@@ -3135,7 +3146,9 @@ class LinkedInExtractor:
 
         await handle_modal_close(self._page)
         if main_found:
-            await scroll_job_sidebar(self._page, target_count=_PAGE_SIZE)
+            await scroll_job_sidebar(
+                self._page, target_count=_PAGE_SIZE, deadline=scroll_deadline
+            )
 
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
@@ -3266,6 +3279,10 @@ class LinkedInExtractor:
             easy_apply=easy_apply,
             sort_by=sort_by,
         )
+        # Split the search-wide scroll budget over the pages asked for, so a
+        # 10-page search cannot spend more on scrolling than the tool timeout
+        # leaves for navigation and extraction.
+        scroll_deadline = min(_SCROLL_DEADLINE_MAX, _SCROLL_BUDGET_TOTAL / max_pages)
         all_job_ids: list[str] = []
         seen_ids: set[str] = set()
         page_texts: list[str] = []
@@ -3291,7 +3308,9 @@ class LinkedInExtractor:
 
             try:
                 extracted = await self._extract_search_page(
-                    url, section_name="search_results"
+                    url,
+                    section_name="search_results",
+                    scroll_deadline=scroll_deadline,
                 )
 
                 if not extracted.text or extracted.text == _RATE_LIMITED_MSG:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3282,7 +3282,9 @@ class LinkedInExtractor:
         # Split the search-wide scroll budget over the pages asked for, so a
         # 10-page search cannot spend more on scrolling than the tool timeout
         # leaves for navigation and extraction.
-        scroll_deadline = min(_SCROLL_DEADLINE_MAX, _SCROLL_BUDGET_TOTAL / max_pages)
+        scroll_deadline = min(
+            _SCROLL_DEADLINE_MAX, _SCROLL_BUDGET_TOTAL / max(1, max_pages)
+        )
         all_job_ids: list[str] = []
         seen_ids: set[str] = set()
         page_texts: list[str] = []

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3135,7 +3135,7 @@ class LinkedInExtractor:
 
         await handle_modal_close(self._page)
         if main_found:
-            await scroll_job_sidebar(self._page, pause_time=0.5, max_scrolls=5)
+            await scroll_job_sidebar(self._page, target_count=_PAGE_SIZE)
 
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]

--- a/tests/test_job_sidebar_scroll_dom.py
+++ b/tests/test_job_sidebar_scroll_dom.py
@@ -27,19 +27,30 @@ def sidebar(
     batch: int,
     delays: list[int],
     initial: int = 5,
-    stray: bool = False,
+    strays: int = 0,
+    links_per_card: int = 1,
+    scrollable_pane: bool = False,
 ) -> str:
     """A scrollable sidebar that appends `batch` cards after each scroll.
 
     ``delays`` gives the delay of each successive batch in ms, so a fixture
     can vary latency the way a real connection does. The last value repeats.
-    ``stray`` adds a job link outside the sidebar, standing in for the detail
-    pane's own permalink, which must not count toward the target.
+    ``strays`` adds job links outside the rail, standing in for the detail
+    pane's own permalink. ``links_per_card`` mirrors a card carrying both a
+    title link and an overlay link to the same job. ``scrollable_pane`` puts
+    those stray links in a container that scrolls on its own, which is what
+    makes "first scrollable ancestor" the wrong container to pick.
     """
+    stray_links = "".join(
+        f'<a href="/jobs/view/{900000 + i}/" style="display:block;height:40px">'
+        f"Pane {i}</a>"
+        for i in range(strays)
+    )
     outside = (
-        '<a href="/jobs/view/999999/" style="display:block">Detail pane</a>'
-        if stray
-        else ""
+        f'<div id="pane" style="height:80px;overflow-y:scroll">{stray_links}'
+        '<div style="height:400px"></div></div>'
+        if scrollable_pane
+        else stray_links
     )
     return f"""
     <body style="margin:0">
@@ -57,12 +68,14 @@ def sidebar(
         function add(count) {{
           for (let i = 0; i < count && n < {total}; i++) {{
             n++;
-            const a = document.createElement('a');
-            a.href = '/jobs/view/' + (1000 + n) + '/';
-            a.textContent = 'Job ' + n;
-            a.style.display = 'block';
-            a.style.height = '40px';
-            list.appendChild(a);
+            for (let k = 0; k < {links_per_card}; k++) {{
+              const a = document.createElement('a');
+              a.href = '/jobs/view/' + (1000 + n) + '/';
+              a.textContent = 'Job ' + n;
+              a.style.display = 'block';
+              a.style.height = '40px';
+              list.appendChild(a);
+            }}
           }}
         }}
         add({initial});
@@ -77,6 +90,13 @@ def sidebar(
       </script>
     </body>
     """
+
+
+async def rail_cards(page) -> int:
+    """Links inside the results rail alone, ignoring anything the pane holds."""
+    return await page.evaluate(
+        "document.querySelectorAll('#rail a[href*=\"/jobs/view/\"]').length"
+    )
 
 
 async def cards(page) -> int:
@@ -159,21 +179,28 @@ class TestSidebarScroll:
 
     async def test_ignores_job_links_outside_the_sidebar(self, dom_page):
         """The detail pane's own permalink must not count toward the target."""
-        await dom_page.set_content(sidebar(total=25, batch=5, delays=[30], stray=True))
+        await dom_page.set_content(sidebar(total=25, batch=5, delays=[30], strays=5))
 
         await scroll_job_sidebar(dom_page, target_count=25)
 
-        assert await cards(dom_page) == 26  # 25 in the rail, 1 outside
+        # Counting the whole document would stop the loop 5 cards early.
+        assert await rail_cards(dom_page) == 25
 
-    async def test_returns_at_the_deadline(self, dom_page):
+    async def test_returns_at_the_deadline(self, dom_page, caplog):
         """A page that keeps loading slowly must not spend the tool timeout."""
         await dom_page.set_content(sidebar(total=200, batch=1, delays=[900]))
 
-        await scroll_job_sidebar(
-            dom_page, target_count=25, settle_timeout=2.0, deadline=3.0
-        )
+        started = time.monotonic()
+        with caplog.at_level(logging.DEBUG, logger="linkedin_mcp_server.core.utils"):
+            await scroll_job_sidebar(
+                dom_page, target_count=25, settle_timeout=2.0, deadline=3.0
+            )
+        elapsed = time.monotonic() - started
 
-        assert await cards(dom_page) < 25
+        # A card count alone cannot fail here: max_scrolls caps this fixture
+        # below 25 whatever the deadline does.
+        assert "hit the 3s deadline" in caplog.text
+        assert elapsed < 5.0
 
     async def test_returns_when_the_list_is_exhausted(self, dom_page):
         """The last search page holds fewer cards than the page size.
@@ -203,3 +230,31 @@ class TestSidebarScroll:
             await scroll_job_sidebar(dom_page, target_count=25)
 
         assert "skipping sidebar scroll" in caplog.text
+
+    async def test_counts_jobs_not_links(self, dom_page):
+        """A card with two links to one job must not count twice."""
+        await dom_page.set_content(
+            # Slow enough that one batch lands per round, so a loop
+            # counting links instead of jobs visibly stops at half a page.
+            sidebar(total=25, batch=5, delays=[300], links_per_card=2)
+        )
+
+        await scroll_job_sidebar(dom_page, target_count=25)
+
+        assert await rail_cards(dom_page) == 50  # 25 jobs, two links each
+
+    async def test_picks_the_rail_over_a_scrollable_pane(self, dom_page):
+        """The detail pane scrolls too, and comes first in document order."""
+        await dom_page.set_content(
+            sidebar(
+                total=25,
+                batch=5,
+                delays=[30],
+                strays=6,
+                scrollable_pane=True,
+            )
+        )
+
+        await scroll_job_sidebar(dom_page, target_count=25)
+
+        assert await rail_cards(dom_page) == 25

--- a/tests/test_job_sidebar_scroll_dom.py
+++ b/tests/test_job_sidebar_scroll_dom.py
@@ -30,6 +30,9 @@ def sidebar(
     strays: int = 0,
     links_per_card: int = 1,
     scrollable_pane: bool = False,
+    wrap_cards: bool = False,
+    rerender_after: int | None = None,
+    slugged: bool = False,
 ) -> str:
     """A scrollable sidebar that appends `batch` cards after each scroll.
 
@@ -52,6 +55,9 @@ def sidebar(
         if scrollable_pane
         else stray_links
     )
+    wrap_cards_js = "true" if wrap_cards else "false"
+    slug_js = "true" if slugged else "false"
+    rerender_js = "null" if rerender_after is None else str(rerender_after)
     return f"""
     <body style="margin:0">
       {outside}
@@ -60,8 +66,8 @@ def sidebar(
         <div style="height:600px"></div>
       </div>
       <script>
-        const list = document.getElementById('list');
-        const rail = document.getElementById('rail');
+        let list = document.getElementById('list');
+        let rail = document.getElementById('rail');
         const delays = {delays!r};
         let n = 0;
         let round = 0;
@@ -70,23 +76,50 @@ def sidebar(
             n++;
             for (let k = 0; k < {links_per_card}; k++) {{
               const a = document.createElement('a');
-              a.href = '/jobs/view/' + (1000 + n) + '/';
+              a.href = {slug_js}
+                ? '/jobs/view/senior-engineer-at-acme-' + (1000 + n)
+                : '/jobs/view/' + (1000 + n) + '/';
               a.textContent = 'Job ' + n;
               a.style.display = 'block';
               a.style.height = '40px';
-              list.appendChild(a);
+              if ({wrap_cards_js}) {{
+                const wrap = document.createElement('div');
+                wrap.style.cssText = 'height:20px;overflow-y:auto';
+                const filler = document.createElement('div');
+                filler.style.height = '60px';
+                wrap.appendChild(a);
+                wrap.appendChild(filler);
+                list.appendChild(wrap);
+              }} else {{
+                list.appendChild(a);
+              }}
             }}
           }}
         }}
         add({initial});
         let pending = false;
+        let batches = 0;
+        function mount() {{
         rail.addEventListener('scroll', () => {{
           if (pending || n >= {total}) return;
           pending = true;
           const delay = delays[Math.min(round, delays.length - 1)];
           round++;
-          setTimeout(() => {{ add({batch}); pending = false; }}, delay);
+          setTimeout(() => {{
+            add({batch});
+            batches++;
+            if ({rerender_js} !== null && batches === {rerender_js}) {{
+              const fresh = rail.cloneNode(true);
+              rail.replaceWith(fresh);
+              rail = fresh;
+              list = fresh.querySelector('#list');
+              mount();
+            }}
+            pending = false;
+          }}, delay);
         }});
+        }}
+        mount();
       </script>
     </body>
     """
@@ -244,15 +277,92 @@ class TestSidebarScroll:
         assert await rail_cards(dom_page) == 50  # 25 jobs, two links each
 
     async def test_picks_the_rail_over_a_scrollable_pane(self, dom_page):
-        """The detail pane scrolls too, and comes first in document order."""
+        """The detail pane scrolls too, and comes first in document order.
+
+        ``initial=11`` is what a live search rendered before any scroll, so
+        the rail outweighs a pane holding its permalink plus a handful of
+        similar jobs. The heuristic is "most job ids", so a pane holding more
+        jobs than the rail has rendered would still win; that is documented
+        in the function and has not been observed.
+        """
         await dom_page.set_content(
             sidebar(
                 total=25,
                 batch=5,
                 delays=[30],
+                initial=11,
                 strays=6,
                 scrollable_pane=True,
             )
+        )
+
+        await scroll_job_sidebar(dom_page, target_count=25)
+
+        assert await rail_cards(dom_page) == 25
+
+    async def test_picks_the_rail_over_per_card_wrappers(self, dom_page):
+        """A card in its own scrollable wrapper must not become the container.
+
+        The nearest scrollable ancestor is then a container holding one card,
+        and the rail is never scrolled at all.
+        """
+        await dom_page.set_content(
+            sidebar(total=25, batch=5, delays=[30], wrap_cards=True)
+        )
+
+        await scroll_job_sidebar(dom_page, target_count=25)
+
+        assert await rail_cards(dom_page) == 25
+
+    async def test_shrinks_the_budget_after_fast_batches(self, dom_page):
+        """A fast connection must not pay the full budget to conclude.
+
+        The terminating round costs budget + settle_timeout. Without the
+        shrink that is 2x settle_timeout; with it the first half collapses
+        to min_budget.
+        """
+        await dom_page.set_content(sidebar(total=15, batch=5, delays=[40]))
+
+        started = time.monotonic()
+        await scroll_job_sidebar(dom_page, target_count=25, settle_timeout=3.0)
+        elapsed = time.monotonic() - started
+
+        assert await rail_cards(dom_page) == 15
+        assert elapsed < 5.0
+
+    async def test_recovers_when_the_rail_is_replaced(self, dom_page):
+        """A re-render detaches the rail; polling it would measure a corpse."""
+        await dom_page.set_content(
+            sidebar(total=25, batch=5, delays=[30], rerender_after=1)
+        )
+
+        await scroll_job_sidebar(dom_page, target_count=25, settle_timeout=1.0)
+
+        assert await rail_cards(dom_page) == 25
+
+    async def test_stops_at_the_scroll_cap(self, dom_page, caplog):
+        """The cap must be distinguishable from an exhausted list in the log."""
+        await dom_page.set_content(sidebar(total=200, batch=1, delays=[30]))
+
+        with caplog.at_level(logging.DEBUG, logger="linkedin_mcp_server.core.utils"):
+            await scroll_job_sidebar(dom_page, target_count=25, max_scrolls=3)
+
+        assert "scroll cap reached" in caplog.text
+
+    async def test_a_closed_page_does_not_raise(self, dom_page, caplog):
+        """Scrolling is best effort and must never end the caller's search."""
+        await dom_page.set_content(sidebar(total=25, batch=5, delays=[30]))
+        await dom_page.close()  # stands in for a navigation mid-scroll
+
+        with caplog.at_level(logging.DEBUG, logger="linkedin_mcp_server.core.utils"):
+            await scroll_job_sidebar(dom_page, target_count=25, deadline=1.0)
+
+        assert "scroll failed" in caplog.text
+
+    async def test_reads_ids_from_slugged_hrefs(self, dom_page):
+        """LinkedIn also serves /jobs/view/<slug>-<id>; the id is the target."""
+        await dom_page.set_content(
+            sidebar(total=25, batch=5, delays=[30], slugged=True)
         )
 
         await scroll_job_sidebar(dom_page, target_count=25)

--- a/tests/test_job_sidebar_scroll_dom.py
+++ b/tests/test_job_sidebar_scroll_dom.py
@@ -12,6 +12,7 @@ installed; run locally after ``uv run patchright install chromium --no-shell``.
 from __future__ import annotations
 
 import logging
+import time
 
 import pytest
 from patchright.async_api import async_playwright
@@ -110,11 +111,19 @@ class TestSidebarScroll:
         assert await cards(dom_page) == 25
 
     async def test_loads_full_page_on_a_fast_connection(self, dom_page):
+        """Card count alone would pass for any loop, so bound the time too.
+
+        Waiting the full budget every round would take four rounds times
+        settle_timeout here. Measured span on this fixture is 0.17-0.35s.
+        """
         await dom_page.set_content(sidebar(total=25, batch=5, delays=[30]))
 
+        started = time.monotonic()
         await scroll_job_sidebar(dom_page, target_count=25)
+        elapsed = time.monotonic() - started
 
         assert await cards(dom_page) == 25
+        assert elapsed < 2.0
 
     async def test_stops_at_target_without_over_scrolling(self, dom_page):
         """More cards than a page holds must not pull the next page in.
@@ -167,7 +176,11 @@ class TestSidebarScroll:
         assert await cards(dom_page) < 25
 
     async def test_returns_when_the_list_is_exhausted(self, dom_page):
-        """The last search page holds fewer cards than the page size."""
+        """The last search page holds fewer cards than the page size.
+
+        A loop that never concludes the list is done would hang here rather
+        than fail an assertion, which is what this covers.
+        """
         await dom_page.set_content(sidebar(total=16, batch=5, delays=[30]))
 
         await scroll_job_sidebar(dom_page, target_count=25, settle_timeout=0.6)

--- a/tests/test_job_sidebar_scroll_dom.py
+++ b/tests/test_job_sidebar_scroll_dom.py
@@ -11,6 +11,8 @@ installed; run locally after ``uv run patchright install chromium --no-shell``.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from patchright.async_api import async_playwright
 
@@ -19,10 +21,28 @@ from linkedin_mcp_server.core.utils import scroll_job_sidebar
 pytestmark = pytest.mark.browser_dom
 
 
-def sidebar(total: int, batch: int, delay_ms: int, initial: int = 5) -> str:
-    """A scrollable sidebar that appends `batch` cards `delay_ms` after a scroll."""
+def sidebar(
+    total: int,
+    batch: int,
+    delays: list[int],
+    initial: int = 5,
+    stray: bool = False,
+) -> str:
+    """A scrollable sidebar that appends `batch` cards after each scroll.
+
+    ``delays`` gives the delay of each successive batch in ms, so a fixture
+    can vary latency the way a real connection does. The last value repeats.
+    ``stray`` adds a job link outside the sidebar, standing in for the detail
+    pane's own permalink, which must not count toward the target.
+    """
+    outside = (
+        '<a href="/jobs/view/999999/" style="display:block">Detail pane</a>'
+        if stray
+        else ""
+    )
     return f"""
     <body style="margin:0">
+      {outside}
       <div id="rail" style="height:120px; overflow-y:scroll">
         <div id="list"></div>
         <div style="height:600px"></div>
@@ -30,7 +50,9 @@ def sidebar(total: int, batch: int, delay_ms: int, initial: int = 5) -> str:
       <script>
         const list = document.getElementById('list');
         const rail = document.getElementById('rail');
+        const delays = {delays!r};
         let n = 0;
+        let round = 0;
         function add(count) {{
           for (let i = 0; i < count && n < {total}; i++) {{
             n++;
@@ -47,7 +69,9 @@ def sidebar(total: int, batch: int, delay_ms: int, initial: int = 5) -> str:
         rail.addEventListener('scroll', () => {{
           if (pending || n >= {total}) return;
           pending = true;
-          setTimeout(() => {{ add({batch}); pending = false; }}, {delay_ms});
+          const delay = delays[Math.min(round, delays.length - 1)];
+          round++;
+          setTimeout(() => {{ add({batch}); pending = false; }}, delay);
         }});
       </script>
     </body>
@@ -79,45 +103,90 @@ async def dom_page():
 class TestSidebarScroll:
     async def test_loads_full_page_on_a_slow_connection(self, dom_page):
         """A batch slower than the old fixed 0.5s sleep must not end the loop."""
-        await dom_page.set_content(sidebar(total=25, batch=5, delay_ms=800))
+        await dom_page.set_content(sidebar(total=25, batch=5, delays=[800]))
 
         await scroll_job_sidebar(dom_page, target_count=25)
 
         assert await cards(dom_page) == 25
 
     async def test_loads_full_page_on_a_fast_connection(self, dom_page):
-        await dom_page.set_content(sidebar(total=25, batch=5, delay_ms=30))
+        await dom_page.set_content(sidebar(total=25, batch=5, delays=[30]))
 
         await scroll_job_sidebar(dom_page, target_count=25)
 
         assert await cards(dom_page) == 25
 
     async def test_stops_at_target_without_over_scrolling(self, dom_page):
-        """More cards than a page holds must not pull the next page in."""
-        await dom_page.set_content(sidebar(total=60, batch=5, delay_ms=30))
+        """More cards than a page holds must not pull the next page in.
+
+        The upper bound is loose on purpose: the fixture appends on every
+        scroll event, so a batch queued by the last scroll still lands after
+        the loop returns. Without the target check the loop reaches all 60,
+        which is what this discriminates against.
+        """
+        await dom_page.set_content(sidebar(total=60, batch=5, delays=[30]))
 
         await scroll_job_sidebar(dom_page, target_count=25)
 
         assert 25 <= await cards(dom_page) < 60
 
+    async def test_survives_a_latency_spike(self, dom_page):
+        """Two fast batches shrink the budget; the third must not end the page."""
+        await dom_page.set_content(
+            sidebar(total=25, batch=5, delays=[30, 30, 1500, 30])
+        )
+
+        await scroll_job_sidebar(dom_page, target_count=25)
+
+        assert await cards(dom_page) == 25
+
+    async def test_survives_a_slow_first_batch(self, dom_page):
+        """The first round has no measurement to size its budget from."""
+        await dom_page.set_content(sidebar(total=25, batch=5, delays=[2800, 30]))
+
+        await scroll_job_sidebar(dom_page, target_count=25, settle_timeout=2.0)
+
+        assert await cards(dom_page) == 25
+
+    async def test_ignores_job_links_outside_the_sidebar(self, dom_page):
+        """The detail pane's own permalink must not count toward the target."""
+        await dom_page.set_content(sidebar(total=25, batch=5, delays=[30], stray=True))
+
+        await scroll_job_sidebar(dom_page, target_count=25)
+
+        assert await cards(dom_page) == 26  # 25 in the rail, 1 outside
+
+    async def test_returns_at_the_deadline(self, dom_page):
+        """A page that keeps loading slowly must not spend the tool timeout."""
+        await dom_page.set_content(sidebar(total=200, batch=1, delays=[900]))
+
+        await scroll_job_sidebar(
+            dom_page, target_count=25, settle_timeout=2.0, deadline=3.0
+        )
+
+        assert await cards(dom_page) < 25
+
     async def test_returns_when_the_list_is_exhausted(self, dom_page):
         """The last search page holds fewer cards than the page size."""
-        await dom_page.set_content(sidebar(total=16, batch=5, delay_ms=30))
+        await dom_page.set_content(sidebar(total=16, batch=5, delays=[30]))
 
         await scroll_job_sidebar(dom_page, target_count=25, settle_timeout=0.6)
 
         assert await cards(dom_page) == 16
 
-    async def test_no_scrollable_container(self, dom_page):
+    async def test_no_scrollable_container(self, dom_page, caplog):
+        """Card counts alone cannot fail here, so assert which branch ran."""
         await dom_page.set_content('<body><a href="/jobs/view/111/">One</a></body>')
 
-        await scroll_job_sidebar(dom_page, target_count=25, settle_timeout=0.3)
+        with caplog.at_level(logging.DEBUG, logger="linkedin_mcp_server.core.utils"):
+            await scroll_job_sidebar(dom_page, target_count=25, settle_timeout=0.3)
 
-        assert await cards(dom_page) == 1
+        assert "No scrollable container found" in caplog.text
 
-    async def test_no_cards_at_all(self, dom_page):
+    async def test_no_cards_at_all(self, dom_page, caplog):
         await dom_page.set_content("<body><main>No matching jobs found</main></body>")
 
-        await scroll_job_sidebar(dom_page, target_count=25)
+        with caplog.at_level(logging.DEBUG, logger="linkedin_mcp_server.core.utils"):
+            await scroll_job_sidebar(dom_page, target_count=25)
 
-        assert await cards(dom_page) == 0
+        assert "skipping sidebar scroll" in caplog.text

--- a/tests/test_job_sidebar_scroll_dom.py
+++ b/tests/test_job_sidebar_scroll_dom.py
@@ -1,0 +1,123 @@
+"""Browser-DOM tests for the job search sidebar scroll.
+
+The unit suite mocks ``page.evaluate``, so the scrolling JS in
+``scroll_job_sidebar`` never executes there. These tests run it against a
+synthetic sidebar in headless chromium, where each scroll appends the next
+batch of cards after a delay. That delay is the point: it stands in for the
+user's connection, and the loop has to survive a batch that arrives later
+than the previous one did. Skipped automatically when chromium is not
+installed; run locally after ``uv run patchright install chromium --no-shell``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.core.utils import scroll_job_sidebar
+
+pytestmark = pytest.mark.browser_dom
+
+
+def sidebar(total: int, batch: int, delay_ms: int, initial: int = 5) -> str:
+    """A scrollable sidebar that appends `batch` cards `delay_ms` after a scroll."""
+    return f"""
+    <body style="margin:0">
+      <div id="rail" style="height:120px; overflow-y:scroll">
+        <div id="list"></div>
+        <div style="height:600px"></div>
+      </div>
+      <script>
+        const list = document.getElementById('list');
+        const rail = document.getElementById('rail');
+        let n = 0;
+        function add(count) {{
+          for (let i = 0; i < count && n < {total}; i++) {{
+            n++;
+            const a = document.createElement('a');
+            a.href = '/jobs/view/' + (1000 + n) + '/';
+            a.textContent = 'Job ' + n;
+            a.style.display = 'block';
+            a.style.height = '40px';
+            list.appendChild(a);
+          }}
+        }}
+        add({initial});
+        let pending = false;
+        rail.addEventListener('scroll', () => {{
+          if (pending || n >= {total}) return;
+          pending = true;
+          setTimeout(() => {{ add({batch}); pending = false; }}, {delay_ms});
+        }});
+      </script>
+    </body>
+    """
+
+
+async def cards(page) -> int:
+    return await page.evaluate(
+        "document.querySelectorAll('a[href*=\"/jobs/view/\"]').length"
+    )
+
+
+@pytest.fixture
+async def dom_page():
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(
+                channel="chromium", headless=True
+            )
+            page = await browser.new_page()
+        except Exception as exc:  # pragma: no cover - environment dependent
+            pytest.skip(f"chromium unavailable: {exc}")
+        try:
+            yield page
+        finally:
+            await browser.close()
+
+
+class TestSidebarScroll:
+    async def test_loads_full_page_on_a_slow_connection(self, dom_page):
+        """A batch slower than the old fixed 0.5s sleep must not end the loop."""
+        await dom_page.set_content(sidebar(total=25, batch=5, delay_ms=800))
+
+        await scroll_job_sidebar(dom_page, target_count=25)
+
+        assert await cards(dom_page) == 25
+
+    async def test_loads_full_page_on_a_fast_connection(self, dom_page):
+        await dom_page.set_content(sidebar(total=25, batch=5, delay_ms=30))
+
+        await scroll_job_sidebar(dom_page, target_count=25)
+
+        assert await cards(dom_page) == 25
+
+    async def test_stops_at_target_without_over_scrolling(self, dom_page):
+        """More cards than a page holds must not pull the next page in."""
+        await dom_page.set_content(sidebar(total=60, batch=5, delay_ms=30))
+
+        await scroll_job_sidebar(dom_page, target_count=25)
+
+        assert 25 <= await cards(dom_page) < 60
+
+    async def test_returns_when_the_list_is_exhausted(self, dom_page):
+        """The last search page holds fewer cards than the page size."""
+        await dom_page.set_content(sidebar(total=16, batch=5, delay_ms=30))
+
+        await scroll_job_sidebar(dom_page, target_count=25, settle_timeout=0.6)
+
+        assert await cards(dom_page) == 16
+
+    async def test_no_scrollable_container(self, dom_page):
+        await dom_page.set_content('<body><a href="/jobs/view/111/">One</a></body>')
+
+        await scroll_job_sidebar(dom_page, target_count=25, settle_timeout=0.3)
+
+        assert await cards(dom_page) == 1
+
+    async def test_no_cards_at_all(self, dom_page):
+        await dom_page.set_content("<body><main>No matching jobs found</main></body>")
+
+        await scroll_job_sidebar(dom_page, target_count=25)
+
+        assert await cards(dom_page) == 0


### PR DESCRIPTION
Closes #742

The job sidebar scroll gave up as soon as the container had not grown after a single fixed 0.5s sleep, so one batch arriving later than that ended the page permanently. Measured against live LinkedIn: a search that the page itself reports as 14 pages of 25 returned 11 cards per page, twice in a row, with `Scrolled job sidebar 2 times` in the log both times. Pagination was never the problem, `_PAGE_SIZE = 25` matches what LinkedIn does; the cards simply never loaded.

How long a batch takes belongs to the user's connection, so no constant is right: raise it and every fast client pays the worst case on every page, keep it low and slow clients lose more than half the results. Each round now polls for the next batch, and a round that sees nothing scrolls once more at the full `settle_timeout` before the list counts as exhausted. That confirmation round is what makes a single slow batch survivable, including the very first one, where no measurement exists yet. Later rounds start from three times what the previous batch actually took, floored at `min_budget`, so a fast connection stays fast: measured 0.17-0.35s for a full page of 25.

A wall-clock `deadline` bounds the whole call. `max_pages` reaches 10 and `tool_timeout_seconds` defaults to 180, so a page that keeps trickling could otherwise have spent the tool's entire budget. Counting and container discovery are both scoped to the rail: the detail pane carries its own `/jobs/view/` permalink, and walking up from the first match in the document found no scrollable ancestor at all when that link came first, which disabled the scroll entirely.

The DOM tests drive a synthetic sidebar whose per-batch latency is a list, so a fixture can vary it the way a connection does. Covered: an 800ms batch (the old 0.5s budget stops at 5 of 25), a spike after two fast batches (15 of 25 without the confirmation round), a slow first batch, a stray link outside the rail, the deadline, and an exhausted list. Full suite 1983 passed, ruff and ty clean.

Sequencing with #727: it makes the card set a union of `/jobs/view/` anchors and the redesigned `componentkey` cards, while this PR builds counting, the wait-for-cards guard and the container walk on the single anchor selector. Whichever lands second has to move all three to the union selector, otherwise the redesigned route never scrolls at all. Not a textual rebase.

## Synthetic prompt

> `search_jobs` returns about 11 jobs per page although LinkedIn paginates at 25. Find out why, fix it in `scroll_job_sidebar`, and make the fix hold for both fast and slow connections rather than tuning a constant. Add DOM tests that fail against the old behaviour, and review the result adversarially for what a network with uneven latency does to it.

Generated with Claude Opus 5 (high)
