### PR TITLE
fix(scraping): Normalize and escape the profile reference

### DIFF
--- a/linkedin_mcp_server/core/exceptions.py
+++ b/linkedin_mcp_server/core/exceptions.py
@@ -7,6 +7,17 @@ class LinkedInScraperException(Exception):
     pass
 
 
+class InvalidReferenceError(LinkedInScraperException):
+    """A caller-supplied profile, company, job or thread reference is unusable.
+
+    Separate from the other scraper errors because nothing is broken: the
+    argument is wrong and the message says how to correct it. `raise_tool_error`
+    keeps it free of issue-report diagnostics for that reason.
+    """
+
+    pass
+
+
 class AuthenticationError(LinkedInScraperException):
     """Raised when authentication fails."""
 

--- a/linkedin_mcp_server/error_handler.py
+++ b/linkedin_mcp_server/error_handler.py
@@ -13,6 +13,7 @@ from fastmcp.exceptions import ToolError
 
 from linkedin_mcp_server.core.proxy_errors import redacted_copy
 from linkedin_mcp_server.core.exceptions import (
+    InvalidReferenceError,
     AuthenticationError,
     ElementNotFoundError,
     LinkedInScraperException,
@@ -252,6 +253,13 @@ def raise_tool_error(exception: Exception, context: str = "") -> NoReturn:
             "Scraping failed. LinkedIn page structure may have changed.",
             context=context,
         )
+
+    # Ahead of the catch-all, which it subclasses. No issue diagnostics: a
+    # reference the caller can correct is not a bug worth reporting, and an
+    # issue template appended to it buries the correction it already names.
+    elif isinstance(exception, InvalidReferenceError):
+        logger.info("Invalid reference%s: %s", ctx, exception)
+        raise ToolError(str(exception)) from exception
 
     elif isinstance(exception, (LinkedInScraperException, LinkedInMCPError)):
         # Catch-all for base exception types and any future subclasses

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -34,6 +34,12 @@ from linkedin_mcp_server.core.utils import (
     scroll_to_bottom,
 )
 from linkedin_mcp_server.scraping.connection import ActionSignals
+from linkedin_mcp_server.scraping.identifiers import (
+    company_page_url,
+    normalize_company_identifier,
+    normalize_person_identifier,
+    person_profile_url,
+)
 from linkedin_mcp_server.scraping.link_metadata import (
     Reference,
     build_references,
@@ -1751,7 +1757,8 @@ class LinkedInExtractor:
             {url, sections: {name: text}, profile_urn?: str}
         """
         requested = requested | {"main_profile"}
-        base_url = f"https://www.linkedin.com/in/{username}"
+        username = normalize_person_identifier(username)
+        base_url = person_profile_url(username)
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
         section_errors: dict[str, dict[str, Any]] = {}
@@ -1779,7 +1786,7 @@ class LinkedInExtractor:
                         section_name == "main_profile"
                         and main_profile_already_loaded
                         and urlparse(self._page.url).path.rstrip("/")
-                        == f"/in/{username}"
+                        == urlparse(base_url).path.rstrip("/")
                     )
                     if can_reuse_main:
                         extracted = await self._extract_loaded_section(
@@ -2134,7 +2141,8 @@ class LinkedInExtractor:
         """
         from linkedin_mcp_server.scraping.connection import detect_connection_state
 
-        url = f"https://www.linkedin.com/in/{username}/"
+        username = normalize_person_identifier(username)
+        url = person_profile_url(username, "/")
 
         profile = await self.scrape_person(username, {"main_profile"})
         page_text = profile.get("sections", {}).get("main_profile", "")
@@ -2348,7 +2356,8 @@ class LinkedInExtractor:
             Dict with url and sidebar_profiles mapping section key to list of
             /in/username/ paths. Sections absent from the page are omitted.
         """
-        url = f"https://www.linkedin.com/in/{username}/"
+        username = normalize_person_identifier(username)
+        url = person_profile_url(username, "/")
         await self._navigate_to_page(url)
         await detect_rate_limit(self._page)
 
@@ -2858,7 +2867,8 @@ class LinkedInExtractor:
         if index < 0:
             raise LinkedInScraperException(f"index must be non-negative (got {index}).")
 
-        profile_url = f"https://www.linkedin.com/in/{linkedin_username}/"
+        linkedin_username = normalize_person_identifier(linkedin_username)
+        profile_url = person_profile_url(linkedin_username, "/")
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
 
@@ -2904,7 +2914,8 @@ class LinkedInExtractor:
             {url, sections: {name: text}}
         """
         requested = requested | {"about"}
-        base_url = f"https://www.linkedin.com/company/{company_name}"
+        company_name = normalize_company_identifier(company_name)
+        base_url = company_page_url(company_name)
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
         section_errors: dict[str, dict[str, Any]] = {}
@@ -2995,7 +3006,8 @@ class LinkedInExtractor:
         Returns:
             {url, sections: {employees: text}, references: {employees: [...]}}
         """
-        url = f"https://www.linkedin.com/company/{company_name}/people/"
+        company_name = normalize_company_identifier(company_name)
+        url = company_page_url(company_name, "/people/")
         if keywords:
             url += f"?keywords={quote_plus(keywords)}"
         extracted = await self.extract_page(url, section_name="employees")
@@ -4102,7 +4114,8 @@ class LinkedInExtractor:
             profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
                 compose URL directly, bypassing the Message-button lookup.
         """
-        profile_url = f"https://www.linkedin.com/in/{linkedin_username}/"
+        linkedin_username = normalize_person_identifier(linkedin_username)
+        profile_url = person_profile_url(linkedin_username, "/")
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1746,6 +1746,7 @@ class LinkedInExtractor:
         max_scrolls: int | None = None,
         *,
         main_profile_already_loaded: bool = False,
+        allow_self_alias: bool = False,
     ) -> dict[str, Any]:
         """Scrape a person profile with configurable sections.
 
@@ -1760,7 +1761,9 @@ class LinkedInExtractor:
             {url, sections: {name: text}, profile_urn?: str}
         """
         requested = requested | {"main_profile"}
-        username = normalize_person_identifier(username)
+        username = normalize_person_identifier(
+            username, allow_self_alias=allow_self_alias
+        )
         base_url = person_profile_url(username)
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
@@ -1912,6 +1915,10 @@ class LinkedInExtractor:
             callbacks=callbacks,
             max_scrolls=max_scrolls,
             main_profile_already_loaded=True,
+            # The redirect is what resolves the alias. When it has not, this is
+            # still the tool the user asked for, so "me" stays usable here and
+            # nowhere else.
+            allow_self_alias=True,
         )
 
     async def _read_action_signals(self, username: str) -> ActionSignals:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -39,7 +39,8 @@ from linkedin_mcp_server.scraping.identifiers import (
     job_view_url,
     messaging_thread_url,
     normalize_company_identifier,
-    normalize_opaque_id,
+    normalize_job_id,
+    normalize_thread_id,
     normalize_person_identifier,
     person_profile_url,
 )
@@ -3050,7 +3051,7 @@ class LinkedInExtractor:
         Returns:
             {url, sections: {name: text}}
         """
-        job_id = normalize_opaque_id(job_id, field="job_id")
+        job_id = normalize_job_id(job_id)
         url = job_view_url(job_id, "/")
         extracted = await self.extract_page(url, section_name="job_posting")
 
@@ -4025,7 +4026,7 @@ class LinkedInExtractor:
             )
 
         if thread_id:
-            thread_id = normalize_opaque_id(thread_id, field="thread_id")
+            thread_id = normalize_thread_id(thread_id)
             await self._navigate_to_page(messaging_thread_url(thread_id, "/"))
         else:
             await self._open_conversation_by_username(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -36,7 +36,10 @@ from linkedin_mcp_server.core.utils import (
 from linkedin_mcp_server.scraping.connection import ActionSignals
 from linkedin_mcp_server.scraping.identifiers import (
     company_page_url,
+    job_view_url,
+    messaging_thread_url,
     normalize_company_identifier,
+    normalize_opaque_id,
     normalize_person_identifier,
     person_profile_url,
 )
@@ -3040,7 +3043,8 @@ class LinkedInExtractor:
         Returns:
             {url, sections: {name: text}}
         """
-        url = f"https://www.linkedin.com/jobs/view/{job_id}/"
+        job_id = normalize_opaque_id(job_id, field="job_id")
+        url = job_view_url(job_id, "/")
         extracted = await self.extract_page(url, section_name="job_posting")
 
         sections: dict[str, str] = {}
@@ -4014,9 +4018,8 @@ class LinkedInExtractor:
             )
 
         if thread_id:
-            await self._navigate_to_page(
-                f"https://www.linkedin.com/messaging/thread/{thread_id}/"
-            )
+            thread_id = normalize_opaque_id(thread_id, field="thread_id")
+            await self._navigate_to_page(messaging_thread_url(thread_id, "/"))
         else:
             await self._open_conversation_by_username(
                 linkedin_username or "", index=index
@@ -4136,7 +4139,7 @@ class LinkedInExtractor:
             compose_url: str | None = (
                 f"https://www.linkedin.com/messaging/compose/"
                 f"?profileUrn={_encoded}"
-                f"&recipient={profile_urn}"
+                f"&recipient={quote_plus(profile_urn)}"
                 f"&screenContext=NON_SELF_PROFILE_VIEW"
                 f"&interop=msgOverlay"
             )

--- a/linkedin_mcp_server/scraping/identifiers.py
+++ b/linkedin_mcp_server/scraping/identifiers.py
@@ -163,10 +163,17 @@ def _parse_linkedin_url(value: str, *, want: str) -> tuple[str, str | None] | No
     return route, _usable(segments[1]) if len(segments) > 1 else None
 
 
-def normalize_person_identifier(value: str) -> str:
+def normalize_person_identifier(value: str, *, allow_self_alias: bool = False) -> str:
     """The public identifier for a person, from a link or from the identifier.
 
     Idempotent, so applying it twice along a call chain is harmless.
+
+    Args:
+        allow_self_alias: let ``me`` through. Only ``get_my_profile`` sets this,
+            and only for its own fallback: it navigates to ``/in/me/`` and reads
+            the identifier back out of the redirect, so an unresolved redirect
+            leaves it holding the alias. Refusing there would answer the tool
+            that owns the alias with an instruction to call itself.
 
     Raises:
         InvalidReferenceError: when the value cannot name a person, with the
@@ -195,7 +202,7 @@ def normalize_person_identifier(value: str) -> str:
                 '/in/ in a profile URL, for example "williamhgates".'
             )
 
-    if reference.lower() in _RESERVED:
+    if not allow_self_alias and reference.lower() in _RESERVED:
         raise InvalidReferenceError(
             f'"{reference}" is LinkedIn\'s alias for the signed-in member, not a '
             "person you can look up. Call get_my_profile for the authenticated "

--- a/linkedin_mcp_server/scraping/identifiers.py
+++ b/linkedin_mcp_server/scraping/identifiers.py
@@ -1,0 +1,201 @@
+"""Repair the profile reference a caller passes in, before it becomes a URL.
+
+Every tool argument named ``linkedin_username`` or ``company_name`` ends up as a
+path segment of a LinkedIn URL the browser then navigates to. Interpolating it
+raw costs two things.
+
+A pasted profile link never resolves. Handing a model a URL is the most natural
+thing a user does, and ``https://www.linkedin.com/in/`` plus that URL is not a
+page LinkedIn serves. The link arrives in more shapes than the canonical one:
+a member's public profile URL carries the two-letter code of the country on
+their profile (``de.``, ``ca.``, ``uk.``, ``fr.``, …) and those hosts answer
+directly rather than redirecting to ``www.``, mobile adds ``m.``, ``touch.`` and
+the ``/mwlite/in/`` and ``/mwlite/profile/in/`` path wrappers, and a share sheet
+appends ``?originalSubdomain=`` or ``?trk=``.
+
+A value containing ``../`` navigates somewhere else entirely. Browsers apply
+RFC 3986 dot-segment removal before the request, so ``felix/../../feed``
+resolves to ``/feed/`` and the profile tool returns the feed as if it were a
+profile. Measured against live LinkedIn: that URL redirects to
+``session_redirect=https%3A%2F%2Fwww.linkedin.com%2Ffeed%2F``. Query parameters
+in this package already go through ``quote_plus``; the path segment is the one
+place that did not.
+
+Both are fixed here rather than at each call site, so a new URL builder cannot
+miss one. :func:`normalize_person_identifier` is idempotent, which is what makes
+it safe to apply at the extractor boundary even though tools and other extractor
+methods both call in.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import quote, unquote, urlparse
+
+from linkedin_mcp_server.core.exceptions import LinkedInScraperException
+
+__all__ = [
+    "company_page_url",
+    "normalize_company_identifier",
+    "normalize_person_identifier",
+    "person_profile_url",
+]
+
+# linkedin.com and every host under it. There is no canonical host to normalize
+# toward, because the locale subdomain serves the profile itself.
+_LINKEDIN_HOST = re.compile(r"^(?:[a-z0-9-]+\.)*linkedin\.com$")
+
+# LinkedIn's own shortener. Only a redirect resolves one, which nothing here can
+# follow, so it gets its own message instead of a repair attempt.
+_SHORTENER_HOST = re.compile(r"^(?:[a-z0-9-]+\.)*lnkd\.in$")
+
+_HAS_SCHEME = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
+
+# Path, query and whitespace syntax that no identifier carries. The dot segments
+# are what a browser would resolve away, taking the navigation with them.
+_UNUSABLE = re.compile(r"[\s/\\?#]|[\x00-\x1f\x7f]")
+
+# `me` is LinkedIn's alias for the signed-in member. A link that spells it must
+# never collapse into that alias: reading the operator's own profile while
+# reporting someone else's is a silently wrong answer, not a visible failure.
+_RESERVED = {"me"}
+
+# Routes that name a person and routes that name an organization. A school slug
+# is accepted on the company side because /company/<school-slug> 301-redirects to
+# /school/<slug>, so reusing it on the company route resolves (measured).
+_PERSON_ROUTE = "in"
+_ORGANIZATION_ROUTES = {"company", "school", "showcase"}
+
+_ECHO_LIMIT = 96
+
+
+def _echo(value: str) -> str:
+    """The caller's own argument, shortened, for an error a model has to act on."""
+    inline = re.sub(r"[\s\x00-\x1f\x7f]+", " ", value).strip()
+    if len(inline) > _ECHO_LIMIT:
+        inline = inline[: _ECHO_LIMIT - 1] + "…"
+    return f'"{inline}"'
+
+
+def _parse_linkedin_url(value: str) -> tuple[str, str] | None:
+    """``(route, slug)`` for a LinkedIn web URL, or ``None`` when it is not one.
+
+    Lenient on purpose: the input is whatever someone copied out of a browser, so
+    a missing scheme, ``http``, any subdomain, tracking query, hash, trailing
+    slash and profile sub-pages (``/in/x/recent-activity/all/``) all parse. The
+    mobile-web-lite wrappers are unwrapped first. Case is preserved, because a
+    share link from the app can carry a case-sensitive profile id where the
+    public identifier normally sits.
+
+    Raises:
+        LinkedInScraperException: for an ``lnkd.in`` short link, which is a
+            LinkedIn URL that only a redirect resolves.
+    """
+    candidate = value if _HAS_SCHEME.match(value) else f"https://{value}"
+    try:
+        url = urlparse(candidate)
+    except ValueError:
+        return None
+    if url.scheme not in {"http", "https"}:
+        return None
+    host = (url.hostname or "").lower()
+    if _SHORTENER_HOST.match(host):
+        raise LinkedInScraperException(
+            f"{_echo(value)} is a shortened LinkedIn link, and only a redirect "
+            "resolves it. Open it and pass the linkedin.com/in/ address it lands on."
+        )
+    if not _LINKEDIN_HOST.match(host):
+        return None
+
+    segments = [segment for segment in url.path.split("/") if segment]
+    if segments and segments[0].lower() == "mwlite":
+        segments.pop(0)
+        if segments and segments[0].lower() == "profile":
+            segments.pop(0)
+
+    route = segments[0].lower() if segments else ""
+    slug = unquote(segments[1]).strip() if len(segments) > 1 else ""
+    return route, slug
+
+
+def _usable(slug: str) -> bool:
+    return bool(slug) and not _UNUSABLE.search(slug)
+
+
+def normalize_person_identifier(value: str) -> str:
+    """The public identifier for a person, from a link or from the identifier.
+
+    Idempotent: a bare identifier is returned unchanged, so applying this twice
+    along a call chain is harmless.
+
+    Raises:
+        LinkedInScraperException: when the value cannot name a person, with the
+            correction to make. Refusing here costs nothing; letting it through
+            spends a navigation and returns another page's text as a profile.
+    """
+    value = value.strip()
+    if not value:
+        raise LinkedInScraperException(
+            "Missing linkedin_username (the /in/ public identifier of the person)."
+        )
+
+    parsed = _parse_linkedin_url(value)
+    if parsed is not None:
+        route, slug = parsed
+        if route != _PERSON_ROUTE or not _usable(slug) or slug.lower() in _RESERVED:
+            raise LinkedInScraperException(
+                f"{_echo(value)} is a LinkedIn link but not a personal profile. "
+                "Pass the /in/ public identifier of a person, for example "
+                '"williamhgates".'
+            )
+        return slug
+
+    if not _usable(value):
+        raise LinkedInScraperException(
+            f"{_echo(value)} is not a LinkedIn public identifier. Pass the part "
+            'after /in/ in a profile URL, for example "williamhgates".'
+        )
+    return value
+
+
+def normalize_company_identifier(value: str) -> str:
+    """The page slug for an organization, from a link or from the slug itself.
+
+    Idempotent, and raises the same way :func:`normalize_person_identifier` does.
+    """
+    value = value.strip()
+    if not value:
+        raise LinkedInScraperException(
+            "Missing company_name (the /company/ slug of the organization)."
+        )
+
+    parsed = _parse_linkedin_url(value)
+    if parsed is not None:
+        route, slug = parsed
+        if route not in _ORGANIZATION_ROUTES or not _usable(slug):
+            raise LinkedInScraperException(
+                f"{_echo(value)} is a LinkedIn link but not a company page. "
+                'Pass the /company/ slug, for example "microsoft".'
+            )
+        return slug
+
+    if not _usable(value):
+        raise LinkedInScraperException(
+            f"{_echo(value)} is not a LinkedIn company slug. Pass the part after "
+            '/company/ in a company URL, for example "microsoft".'
+        )
+    return value
+
+
+def person_profile_url(identifier: str, suffix: str = "") -> str:
+    """Profile URL for an already-normalized identifier, escaped as one segment.
+
+    ``safe=""`` is the point: an identifier may not contribute path syntax, and a
+    non-ASCII public identifier has to be percent-encoded to survive navigation.
+    """
+    return f"https://www.linkedin.com/in/{quote(identifier, safe='')}{suffix}"
+
+
+def company_page_url(identifier: str, suffix: str = "") -> str:
+    """Company page URL for an already-normalized slug, escaped as one segment."""
+    return f"https://www.linkedin.com/company/{quote(identifier, safe='')}{suffix}"

--- a/linkedin_mcp_server/scraping/identifiers.py
+++ b/linkedin_mcp_server/scraping/identifiers.py
@@ -98,6 +98,10 @@ _RAW_REFUSED = re.compile(r"[\x00-\x1f\x7f\\]")
 # so this is always a malformed escape rather than content.
 _STRAY_PERCENT = re.compile(r"%(?![0-9A-Fa-f]{2})")
 
+# The port each scheme reaches without being told, so an explicitly written one
+# can be told apart from one that redirects the request somewhere else.
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
 # The two segments a browser resolves away. `quote` cannot help here: a period is
 # unreserved, so it survives escaping and `/in/../` still walks up a level.
 _DOT_SEGMENTS = {".", ".."}
@@ -234,7 +238,10 @@ def _linkedin_segments(value: str, *, want: str) -> list[str] | None:
         return None
     if url.scheme not in {"http", "https"}:
         return None
-    host = (url.hostname or "").lower()
+    # A single trailing dot is the fully qualified spelling of the same host, and
+    # LinkedIn answers on it, so it is dropped rather than refused. A second dot
+    # is not a spelling of anything and falls through to the host match below.
+    host = (url.hostname or "").lower().removesuffix(".")
     if _SHORTENER_HOST.match(host):
         raise InvalidReferenceError(
             "That is a shortened LinkedIn link, and only a redirect resolves it. "
@@ -246,11 +253,16 @@ def _linkedin_segments(value: str, *, want: str) -> list[str] | None:
     # path and dropping the port turns an address a browser cannot load into a
     # working call the caller never asked for: `linkedin.com:444/in/x` times out
     # in a browser and would have been rebuilt here as the live profile.
+    #
+    # Judged against the scheme's own default, not against 443 alone.
+    # `http://www.linkedin.com:443/in/x` is a browser request to port 443 spoken
+    # in cleartext, which answers 400, and taking it for the default would have
+    # rebuilt it as the live HTTPS profile.
     try:
         port = url.port
     except ValueError:
         return None
-    if port not in (None, 443):
+    if port is not None and port != _DEFAULT_PORTS[url.scheme]:
         return None
 
     raw_segments = url.path.split("/")

--- a/linkedin_mcp_server/scraping/identifiers.py
+++ b/linkedin_mcp_server/scraping/identifiers.py
@@ -52,8 +52,10 @@ __all__ = [
     "job_view_url",
     "messaging_thread_url",
     "normalize_company_identifier",
+    "normalize_job_id",
     "normalize_opaque_id",
     "normalize_person_identifier",
+    "normalize_thread_id",
     "person_profile_url",
 ]
 
@@ -93,6 +95,19 @@ _RESERVED = {"me"}
 _PERSON_ROUTE = "in"
 _ORGANIZATION_ROUTES = {"company", "school", "showcase"}
 
+# The routes this repository emits for the ids these tools take. link_metadata
+# renders every reference as a site-relative path (``/in/alice/``,
+# ``/messaging/thread/2-abc/``) and the tool descriptions send callers back
+# through them, so a reference handed straight back is a caller following the
+# instructions. Refusing it would refuse this server's own output.
+_JOB_ROUTE = ("jobs", "view")
+_THREAD_ROUTE = ("messaging", "thread")
+
+# A LinkedIn job id is the number in /jobs/view/<id>. Everything that produces
+# one here extracts ``\d+``, and anything else navigates to a 404 that costs a
+# page load to discover.
+_NUMERIC_ID = re.compile(r"^[0-9]+$")
+
 
 def _usable(value: str) -> str | None:
     """The reference in the form the URL builders expect, or ``None``.
@@ -116,15 +131,24 @@ def _usable(value: str) -> str | None:
     value = value.strip()
     if not value or value in _DOT_SEGMENTS:
         return None
+    # A lone surrogate survives JSON parsing and every check above, and then
+    # raises inside `quote` while the URL is being built. The caller would see an
+    # unexpected tool failure with issue-report diagnostics instead of the
+    # correction this module exists to give.
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return None
     return None if _UNUSABLE.search(value) else value
 
 
-def _parse_linkedin_url(value: str, *, want: str) -> tuple[str, str | None] | None:
-    """``(route, reference)`` for a LinkedIn web URL, or ``None`` if it is not one.
+def _linkedin_segments(value: str, *, want: str) -> list[str] | None:
+    """Path segments of a LinkedIn address, or ``None`` if it is not one.
 
-    Lenient on purpose: the input is whatever someone copied out of a browser, so
-    a missing scheme (``linkedin.com/in/x``), ``http``, any subdomain, tracking
-    query, hash, trailing slash and profile sub-pages
+    Lenient on purpose: the input is whatever someone copied out of a browser or
+    read back out of this server's own output, so a missing scheme
+    (``linkedin.com/in/x``), a site-relative path (``/in/x/``), ``http``, any
+    subdomain, tracking query, hash, trailing slash and profile sub-pages
     (``/in/x/recent-activity/all/``) all parse. The mobile-web-lite wrappers are
     unwrapped first. Case is preserved, because a share link from the app can
     carry a case-sensitive profile id where the public identifier normally sits.
@@ -137,7 +161,12 @@ def _parse_linkedin_url(value: str, *, want: str) -> tuple[str, str | None] | No
         InvalidReferenceError: for an ``lnkd.in`` short link, which is a LinkedIn
             URL that only a redirect resolves.
     """
-    candidate = value if _HAS_SCHEME.match(value) else f"https://{value}"
+    if _HAS_SCHEME.match(value):
+        candidate = value
+    elif value.startswith("/"):
+        candidate = f"https://www.linkedin.com{value}"
+    else:
+        candidate = f"https://{value}"
     try:
         url = urlparse(candidate)
     except ValueError:
@@ -158,9 +187,26 @@ def _parse_linkedin_url(value: str, *, want: str) -> tuple[str, str | None] | No
         segments.pop(0)
         if segments and segments[0].lower() == "profile":
             segments.pop(0)
+    return segments
 
+
+def _parse_linkedin_url(value: str, *, want: str) -> tuple[str, str | None] | None:
+    """``(route, reference)`` for a LinkedIn address, or ``None`` if it is not one."""
+    segments = _linkedin_segments(value, want=want)
+    if segments is None:
+        return None
     route = segments[0].lower() if segments else ""
     return route, _usable(segments[1]) if len(segments) > 1 else None
+
+
+def _id_after_route(value: str, route: tuple[str, ...], *, want: str) -> str | None:
+    """The id following ``route`` in a LinkedIn address, or ``None``."""
+    segments = _linkedin_segments(value, want=want)
+    if segments is None or len(segments) <= len(route):
+        return None
+    if [segment.lower() for segment in segments[: len(route)]] != list(route):
+        return None
+    return _usable(segments[len(route)])
 
 
 def normalize_person_identifier(value: str, *, allow_self_alias: bool = False) -> str:
@@ -241,16 +287,31 @@ def normalize_company_identifier(value: str) -> str:
     return reference
 
 
-def normalize_opaque_id(value: str, *, field: str) -> str:
+def normalize_opaque_id(
+    value: str,
+    *,
+    field: str,
+    route: tuple[str, ...] = (),
+    numeric: bool = False,
+) -> str:
     """An id LinkedIn issued (a job id, a conversation thread id), checked as one.
 
-    These are never links and never carry a reserved meaning, so only the syntax
-    rules apply. They earn the same treatment as a username because they reach
-    the same place: ``job_id="../../feed"`` builds ``/jobs/view/../../feed/``,
-    which a browser resolves to ``/feed/`` before it asks for anything.
+    Ids carry no reserved meaning, so mostly the syntax rules apply. They earn
+    the same treatment as a username because they reach the same place:
+    ``job_id="../../feed"`` builds ``/jobs/view/../../feed/``, which a browser
+    resolves to ``/feed/`` before it asks for anything.
+
+    Args:
+        route: the path this kind of id sits under, so the reference this server
+            prints (``/messaging/thread/2-abc/``) can be handed straight back.
+        numeric: reject anything but digits, for the ids LinkedIn issues as a
+            number. A word there is a 404 that costs a page load to learn.
     """
-    reference = _usable(value.strip())
+    value = value.strip()
+    reference = _id_after_route(value, route, want=field) if route else None
     if reference is None:
+        reference = _usable(value)
+    if reference is None or (numeric and not _NUMERIC_ID.match(reference)):
         raise InvalidReferenceError(
             f"{field} is not a LinkedIn id. Pass the id exactly as a previous "
             "result returned it, with no URL, path or query around it."
@@ -282,3 +343,13 @@ def messaging_thread_url(thread_id: str, suffix: str = "") -> str:
     return (
         f"https://www.linkedin.com/messaging/thread/{quote(thread_id, safe='')}{suffix}"
     )
+
+
+def normalize_job_id(value: str) -> str:
+    """The numeric id for a job posting, from the id or from a reference to it."""
+    return normalize_opaque_id(value, field="job_id", route=_JOB_ROUTE, numeric=True)
+
+
+def normalize_thread_id(value: str) -> str:
+    """The id for a conversation, from the id or from a reference to it."""
+    return normalize_opaque_id(value, field="thread_id", route=_THREAD_ROUTE)

--- a/linkedin_mcp_server/scraping/identifiers.py
+++ b/linkedin_mcp_server/scraping/identifiers.py
@@ -78,11 +78,21 @@ _UNUSABLE = re.compile(r"[\s/\\?#]|[\x00-\x1f\x7f]")
 # spent a page load on a 404 that this module exists to avoid.
 _IDENTIFIER = re.compile(r"^[\w-]+$")
 
-# Control characters in the argument itself, checked before it becomes a URL.
+# Characters that have to be judged in the argument itself, before it becomes a
+# URL, because the parse below does not see them the way a browser does.
+#
 # Parsing strips tab, newline and carriage return out of a URL silently, so
 # `/in/foo\nbar/` would arrive as `foobar` and be accepted as a different person
 # than the caller named.
-_RAW_CONTROL = re.compile(r"[\x00-\x1f\x7f]")
+#
+# A backslash is a path separator in the URL Standard for http(s), and
+# `urlparse` is not: it leaves the backslash inside one segment, so splitting on
+# `/` alone reads a path the browser never navigates. Measured,
+# `/in/alice/x\..\..\..\in\bob` reads as `alice` here while a conforming
+# parser resolves it to `/in/bob`, which is the retargeting the dot-segment rule
+# below exists to stop. No supported identifier contains one, so it is refused
+# outright rather than translated.
+_RAW_REFUSED = re.compile(r"[\x00-\x1f\x7f\\]")
 
 # A `%` that begins no valid escape. LinkedIn references contain no literal one,
 # so this is always a malformed escape rather than content.
@@ -196,10 +206,10 @@ def _linkedin_segments(value: str, *, want: str) -> list[str] | None:
         InvalidReferenceError: for an ``lnkd.in`` short link, which is a LinkedIn
             URL that only a redirect resolves.
     """
-    # Checked before the parse, which silently removes tab, newline and carriage
-    # return from a path and would hand back a different reference than the one
-    # the caller wrote.
-    if _RAW_CONTROL.search(value):
+    # Checked before the parse, which reads these differently than a browser
+    # does and would hand back a different reference than the one the caller
+    # wrote. See _RAW_REFUSED.
+    if _RAW_REFUSED.search(value):
         return None
     if _HAS_SCHEME.match(value):
         candidate = value

--- a/linkedin_mcp_server/scraping/identifiers.py
+++ b/linkedin_mcp_server/scraping/identifiers.py
@@ -69,8 +69,20 @@ _SHORTENER_HOST = re.compile(r"^(?:[a-z0-9-]+\.)*lnkd\.in$")
 
 _HAS_SCHEME = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
 
-# Path, query and whitespace syntax that no identifier carries.
+# Path, query and whitespace syntax that no reference carries.
 _UNUSABLE = re.compile(r"[\s/\\?#]|[\x00-\x1f\x7f]")
+
+# Everything a public identifier or a page slug may consist of, as an allowlist
+# rather than a list of forbidden characters. A blacklist keeps losing to inputs
+# nobody enumerated: `foo@example.com` carries no path syntax, so it passed and
+# spent a page load on a 404 that this module exists to avoid.
+_IDENTIFIER = re.compile(r"^[\w-]+$")
+
+# Control characters in the argument itself, checked before it becomes a URL.
+# Parsing strips tab, newline and carriage return out of a URL silently, so
+# `/in/foo\nbar/` would arrive as `foobar` and be accepted as a different person
+# than the caller named.
+_RAW_CONTROL = re.compile(r"[\x00-\x1f\x7f]")
 
 # A `%` that begins no valid escape. LinkedIn references contain no literal one,
 # so this is always a malformed escape rather than content.
@@ -84,16 +96,18 @@ _DOT_SEGMENTS = {".", ".."}
 # tool for that; reaching it through a person lookup answers about the wrong one.
 _RESERVED = {"me"}
 
-# Routes that name a person and routes that name an organization. A school slug
-# is accepted on the company side because /company/<school-slug> 301-redirects to
-# /school/<slug>, measured at the root. The section routes the company scrape
-# appends (/posts/, /people/) answer 302-to-login for a school slug rather than
-# 404, so they are recognised, but what they render needs a signed-in session to
-# establish and has not been. Accepting the slug is still better than refusing
-# it: the caller gets LinkedIn's own answer instead of a refusal Cadenza cannot
-# justify.
+# Routes that name a person and routes that name an organization.
+#
+# `/school/` and `/showcase/` were accepted here and are not any more. Nothing in
+# this module can build an address under either one, so their slug was rebuilt
+# under `/company/`, which 301-redirects to the organization root. That is right
+# for the root and wrong for everything the company scrape appends: measured,
+# `/company/<school-slug>/jobs/` redirects to the school root too, and the
+# extractor does not check where it landed, so root content was recorded under
+# the section the caller asked for. A bare slug still works, because that is the
+# caller asserting which route it belongs to.
 _PERSON_ROUTE = "in"
-_ORGANIZATION_ROUTES = {"company", "school", "showcase"}
+_ORGANIZATION_ROUTES = {"company"}
 
 # The routes this repository emits for the ids these tools take. link_metadata
 # renders every reference as a site-relative path (``/in/alice/``,
@@ -109,26 +123,41 @@ _THREAD_ROUTE = ("messaging", "thread")
 _NUMERIC_ID = re.compile(r"^[0-9]+$")
 
 
+def _decoded(value: str) -> str | None:
+    """The value with at most one layer of percent-encoding removed."""
+    if "%" not in value:
+        return value
+    if _STRAY_PERCENT.search(value):
+        return None
+    try:
+        value = unquote(value, errors="strict")
+    except UnicodeDecodeError:
+        return None
+    # A decoded reference never contains a percent. One that still does carries
+    # another encoding layer, which is how `%252e%252e` would reach `..` on a
+    # later pass through this same function.
+    return None if "%" in value else value
+
+
+def _is_dot_segment(segment: str) -> bool:
+    """Whether a path segment resolves away, in either spelling."""
+    return segment in _DOT_SEGMENTS or _decoded(segment) in _DOT_SEGMENTS
+
+
 def _usable(value: str) -> str | None:
     """The reference in the form the URL builders expect, or ``None``.
 
     Shared by the URL branch and the bare branch on purpose. A segment lifted out
     of a link gets exactly the judgement a bare argument gets, so a second
     encoding layer inside a real profile URL cannot slip past on the way through.
+
+    Nothing trims after decoding. `%20alice` has to reach the checks below as a
+    leading space and be refused, not be tidied into the real `alice`.
     """
-    if "%" in value:
-        if _STRAY_PERCENT.search(value):
-            return None
-        try:
-            value = unquote(value, errors="strict")
-        except UnicodeDecodeError:
-            return None
-        # A decoded reference never contains a percent. One that still does
-        # carries another encoding layer, which is how `%252e%252e` would reach
-        # `..` on a later pass through this same function.
-        if "%" in value:
-            return None
-    value = value.strip()
+    decoded = _decoded(value)
+    if decoded is None:
+        return None
+    value = decoded
     if not value or value in _DOT_SEGMENTS:
         return None
     # A lone surrogate survives JSON parsing and every check above, and then
@@ -140,6 +169,12 @@ def _usable(value: str) -> str | None:
     except UnicodeEncodeError:
         return None
     return None if _UNUSABLE.search(value) else value
+
+
+def _identifier(value: str) -> str | None:
+    """A public identifier or page slug, which is narrower than a usable id."""
+    usable = _usable(value)
+    return usable if usable is not None and _IDENTIFIER.match(usable) else None
 
 
 def _linkedin_segments(value: str, *, want: str) -> list[str] | None:
@@ -161,6 +196,11 @@ def _linkedin_segments(value: str, *, want: str) -> list[str] | None:
         InvalidReferenceError: for an ``lnkd.in`` short link, which is a LinkedIn
             URL that only a redirect resolves.
     """
+    # Checked before the parse, which silently removes tab, newline and carriage
+    # return from a path and would hand back a different reference than the one
+    # the caller wrote.
+    if _RAW_CONTROL.search(value):
+        return None
     if _HAS_SCHEME.match(value):
         candidate = value
     elif value.startswith("/"):
@@ -182,7 +222,19 @@ def _linkedin_segments(value: str, *, want: str) -> list[str] | None:
     if not _LINKEDIN_HOST.match(host):
         return None
 
-    segments = [segment for segment in url.path.split("/") if segment]
+    raw_segments = url.path.split("/")
+    # An interior empty segment is not a formatting quirk: LinkedIn answers 404
+    # for `/company//microsoft/`, so dropping it would turn a path that names
+    # nothing into one that names the real page.
+    if any(segment == "" for segment in raw_segments[1:-1]):
+        return None
+    segments = [segment for segment in raw_segments if segment]
+    # A dot segment anywhere retargets the whole path. A browser resolves
+    # `/in/alice/../../in/bob` to `/in/bob`, while reading the route and the
+    # segment after it answers `alice`, so the tool would act on the person the
+    # reference does not name.
+    if any(_is_dot_segment(segment) for segment in segments):
+        return None
     if segments and segments[0].lower() == "mwlite":
         segments.pop(0)
         if segments and segments[0].lower() == "profile":
@@ -196,7 +248,7 @@ def _parse_linkedin_url(value: str, *, want: str) -> tuple[str, str | None] | No
     if segments is None:
         return None
     route = segments[0].lower() if segments else ""
-    return route, _usable(segments[1]) if len(segments) > 1 else None
+    return route, _identifier(segments[1]) if len(segments) > 1 else None
 
 
 def _id_after_route(value: str, route: tuple[str, ...], *, want: str) -> str | None:
@@ -241,7 +293,7 @@ def normalize_person_identifier(value: str, *, allow_self_alias: bool = False) -
                 '/in/ public identifier of a person, for example "williamhgates".'
             )
     else:
-        reference = _usable(value)
+        reference = _identifier(value)
         if reference is None:
             raise InvalidReferenceError(
                 "That is not a LinkedIn public identifier. Pass the part after "
@@ -278,7 +330,7 @@ def normalize_company_identifier(value: str) -> str:
             )
         return reference
 
-    reference = _usable(value)
+    reference = _identifier(value)
     if reference is None:
         raise InvalidReferenceError(
             "That is not a LinkedIn company slug. Pass the part after /company/ "

--- a/linkedin_mcp_server/scraping/identifiers.py
+++ b/linkedin_mcp_server/scraping/identifiers.py
@@ -209,10 +209,21 @@ def _linkedin_segments(value: str, *, want: str) -> list[str] | None:
     # Checked before the parse, which reads these differently than a browser
     # does and would hand back a different reference than the one the caller
     # wrote. See _RAW_REFUSED.
-    if _RAW_REFUSED.search(value):
+    #
+    # Only up to the first `?` or `#`: a backslash separates paths and nothing
+    # else, so a tracking parameter like `?trk=foo\\bar` leaves the path alone
+    # and refusing it would reject an address that works. Everything before that
+    # cut is in scope, the authority included, because
+    # `https://www.linkedin.com\\evil.example/in/alice` is a path on LinkedIn to
+    # a browser and a host swap to anything that splits on `/`.
+    if _RAW_REFUSED.search(re.split(r"[?#]", value, maxsplit=1)[0]):
         return None
     if _HAS_SCHEME.match(value):
         candidate = value
+    elif value.startswith("//"):
+        # A network-path reference. A browser takes the scheme from the page it
+        # is on, which for a LinkedIn address is always https.
+        candidate = f"https:{value}"
     elif value.startswith("/"):
         candidate = f"https://www.linkedin.com{value}"
     else:
@@ -230,6 +241,16 @@ def _linkedin_segments(value: str, *, want: str) -> list[str] | None:
             f"Open it and pass the {want} the address it lands on contains."
         )
     if not _LINKEDIN_HOST.match(host):
+        return None
+    # A port LinkedIn does not answer on is not a formatting quirk. Reading the
+    # path and dropping the port turns an address a browser cannot load into a
+    # working call the caller never asked for: `linkedin.com:444/in/x` times out
+    # in a browser and would have been rebuilt here as the live profile.
+    try:
+        port = url.port
+    except ValueError:
+        return None
+    if port not in (None, 443):
         return None
 
     raw_segments = url.path.split("/")
@@ -349,6 +370,23 @@ def normalize_company_identifier(value: str) -> str:
     return reference
 
 
+def _numeric_tail(segment: str) -> str:
+    """The id at the end of a slugged path segment, or the segment unchanged.
+
+    LinkedIn serves a job under both `/jobs/view/1967281839/` and
+    `/jobs/view/<title>-at-<company>-1967281839/`, and the slugged form is the
+    one a browser address bar holds. Measured, both 301 to the same destination,
+    so the trailing run of digits is the id and the words in front of it are
+    decoration.
+
+    Only reached for a segment taken out of a URL under the id's own route. A
+    bare argument stays strictly numeric, because there the words are not a slug
+    LinkedIn wrote, they are a wrong value.
+    """
+    match = re.fullmatch(r"[\w-]*?-(\d+)", segment)
+    return match.group(1) if match else segment
+
+
 def normalize_opaque_id(
     value: str,
     *,
@@ -371,6 +409,8 @@ def normalize_opaque_id(
     """
     value = value.strip()
     reference = _id_after_route(value, route, want=field) if route else None
+    if reference is not None and numeric:
+        reference = _numeric_tail(reference)
     if reference is None:
         reference = _usable(value)
     if reference is None or (numeric and not _NUMERIC_ID.match(reference)):

--- a/linkedin_mcp_server/scraping/identifiers.py
+++ b/linkedin_mcp_server/scraping/identifiers.py
@@ -1,30 +1,43 @@
-"""Repair the profile reference a caller passes in, before it becomes a URL.
+"""Repair the reference a caller passes in, before it becomes a URL.
 
-Every tool argument named ``linkedin_username`` or ``company_name`` ends up as a
-path segment of a LinkedIn URL the browser then navigates to. Interpolating it
+Every tool argument that names a person, company, job or conversation ends up as
+a path segment of a LinkedIn URL the browser then navigates to. Interpolating one
 raw costs two things.
 
 A pasted profile link never resolves. Handing a model a URL is the most natural
 thing a user does, and ``https://www.linkedin.com/in/`` plus that URL is not a
-page LinkedIn serves. The link arrives in more shapes than the canonical one:
-a member's public profile URL carries the two-letter code of the country on
-their profile (``de.``, ``ca.``, ``uk.``, ``fr.``, …) and those hosts answer
-directly rather than redirecting to ``www.``, mobile adds ``m.``, ``touch.`` and
-the ``/mwlite/in/`` and ``/mwlite/profile/in/`` path wrappers, and a share sheet
+page LinkedIn serves. The link arrives in more shapes than the canonical one: a
+member's public profile URL carries the two-letter code of the country on their
+profile (``de.``, ``ca.``, ``uk.``, ``fr.``, …) and those hosts answer directly
+rather than redirecting to ``www.``, mobile adds ``m.``, ``touch.`` and the
+``/mwlite/in/`` and ``/mwlite/profile/in/`` path wrappers, and a share sheet
 appends ``?originalSubdomain=`` or ``?trk=``.
 
-A value containing ``../`` navigates somewhere else entirely. Browsers apply
-RFC 3986 dot-segment removal before the request, so ``felix/../../feed``
-resolves to ``/feed/`` and the profile tool returns the feed as if it were a
-profile. Measured against live LinkedIn: that URL redirects to
-``session_redirect=https%3A%2F%2Fwww.linkedin.com%2Ffeed%2F``. Query parameters
-in this package already go through ``quote_plus``; the path segment is the one
-place that did not.
+A value that resolves to a different path navigates somewhere else entirely.
+Browsers apply RFC 3986 dot-segment removal before the request, so
+``felix/../../feed`` reaches ``/feed/`` and the profile tool returns the feed as
+if it were a profile. Percent-escaping the segment closes most of that, but not
+all of it: ``quote`` leaves ``.`` untouched because a period is always URL-safe,
+so a bare ``..`` still walks up a level. Both are refused here rather than
+escaped, since neither can name anything.
 
-Both are fixed here rather than at each call site, so a new URL builder cannot
-miss one. :func:`normalize_person_identifier` is idempotent, which is what makes
-it safe to apply at the extractor boundary even though tools and other extractor
-methods both call in.
+Three rules earn their place by being easy to get wrong:
+
+- **One decode, and no second layer.** A caller can hand over an already-escaped
+  segment: ``get_my_profile`` reads the username straight out of ``page.url``
+  after the ``/in/me/`` redirect, and a browser reports that path encoded.
+  Passing it on unchanged would let the URL builder escape it again (``%D0``
+  becomes ``%25D0``) and navigate to a path that is not the profile. So a value
+  is decoded once. A result that still contains ``%`` is refused, because no
+  identifier carries one and a second layer is how ``%252e%252e`` would survive
+  into ``..`` on a later pass through this same function.
+- **Malformed escapes are refused, never repaired.** ``unquote`` leaves ``%ZZ``
+  untouched and turns ``%FF`` into a replacement character, so tolerating either
+  silently changes the destination rather than rejecting the reference.
+- **The reserved alias is refused in every form.** ``me`` is what LinkedIn
+  resolves to the signed-in member, so accepting it from a caller that meant
+  somebody else answers about the operator's own profile while reporting another
+  person's.
 """
 
 from __future__ import annotations
@@ -32,11 +45,14 @@ from __future__ import annotations
 import re
 from urllib.parse import quote, unquote, urlparse
 
-from linkedin_mcp_server.core.exceptions import LinkedInScraperException
+from linkedin_mcp_server.core.exceptions import InvalidReferenceError
 
 __all__ = [
     "company_page_url",
+    "job_view_url",
+    "messaging_thread_url",
     "normalize_company_identifier",
+    "normalize_opaque_id",
     "normalize_person_identifier",
     "person_profile_url",
 ]
@@ -51,49 +67,75 @@ _SHORTENER_HOST = re.compile(r"^(?:[a-z0-9-]+\.)*lnkd\.in$")
 
 _HAS_SCHEME = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
 
-# Path, query and whitespace syntax that no identifier carries. The dot segments
-# are what a browser would resolve away, taking the navigation with them.
+# Path, query and whitespace syntax that no identifier carries.
 _UNUSABLE = re.compile(r"[\s/\\?#]|[\x00-\x1f\x7f]")
 
-# A `%` that begins no valid escape. LinkedIn identifiers contain no literal one,
+# A `%` that begins no valid escape. LinkedIn references contain no literal one,
 # so this is always a malformed escape rather than content.
 _STRAY_PERCENT = re.compile(r"%(?![0-9A-Fa-f]{2})")
 
-# `me` is LinkedIn's alias for the signed-in member. A link that spells it must
-# never collapse into that alias: reading the operator's own profile while
-# reporting someone else's is a silently wrong answer, not a visible failure.
+# The two segments a browser resolves away. `quote` cannot help here: a period is
+# unreserved, so it survives escaping and `/in/../` still walks up a level.
+_DOT_SEGMENTS = {".", ".."}
+
+# `me` is what LinkedIn resolves to the signed-in member. get_my_profile is the
+# tool for that; reaching it through a person lookup answers about the wrong one.
 _RESERVED = {"me"}
 
 # Routes that name a person and routes that name an organization. A school slug
 # is accepted on the company side because /company/<school-slug> 301-redirects to
-# /school/<slug>, so reusing it on the company route resolves (measured).
+# /school/<slug>, measured at the root. The section routes the company scrape
+# appends (/posts/, /people/) answer 302-to-login for a school slug rather than
+# 404, so they are recognised, but what they render needs a signed-in session to
+# establish and has not been. Accepting the slug is still better than refusing
+# it: the caller gets LinkedIn's own answer instead of a refusal Cadenza cannot
+# justify.
 _PERSON_ROUTE = "in"
 _ORGANIZATION_ROUTES = {"company", "school", "showcase"}
 
-_ECHO_LIMIT = 96
+
+def _usable(value: str) -> str | None:
+    """The reference in the form the URL builders expect, or ``None``.
+
+    Shared by the URL branch and the bare branch on purpose. A segment lifted out
+    of a link gets exactly the judgement a bare argument gets, so a second
+    encoding layer inside a real profile URL cannot slip past on the way through.
+    """
+    if "%" in value:
+        if _STRAY_PERCENT.search(value):
+            return None
+        try:
+            value = unquote(value, errors="strict")
+        except UnicodeDecodeError:
+            return None
+        # A decoded reference never contains a percent. One that still does
+        # carries another encoding layer, which is how `%252e%252e` would reach
+        # `..` on a later pass through this same function.
+        if "%" in value:
+            return None
+    value = value.strip()
+    if not value or value in _DOT_SEGMENTS:
+        return None
+    return None if _UNUSABLE.search(value) else value
 
 
-def _echo(value: str) -> str:
-    """The caller's own argument, shortened, for an error a model has to act on."""
-    inline = re.sub(r"[\s\x00-\x1f\x7f]+", " ", value).strip()
-    if len(inline) > _ECHO_LIMIT:
-        inline = inline[: _ECHO_LIMIT - 1] + "…"
-    return f'"{inline}"'
-
-
-def _parse_linkedin_url(value: str) -> tuple[str, str] | None:
-    """``(route, slug)`` for a LinkedIn web URL, or ``None`` when it is not one.
+def _parse_linkedin_url(value: str, *, want: str) -> tuple[str, str | None] | None:
+    """``(route, reference)`` for a LinkedIn web URL, or ``None`` if it is not one.
 
     Lenient on purpose: the input is whatever someone copied out of a browser, so
-    a missing scheme, ``http``, any subdomain, tracking query, hash, trailing
-    slash and profile sub-pages (``/in/x/recent-activity/all/``) all parse. The
-    mobile-web-lite wrappers are unwrapped first. Case is preserved, because a
-    share link from the app can carry a case-sensitive profile id where the
-    public identifier normally sits.
+    a missing scheme (``linkedin.com/in/x``), ``http``, any subdomain, tracking
+    query, hash, trailing slash and profile sub-pages
+    (``/in/x/recent-activity/all/``) all parse. The mobile-web-lite wrappers are
+    unwrapped first. Case is preserved, because a share link from the app can
+    carry a case-sensitive profile id where the public identifier normally sits.
+
+    Args:
+        want: what the caller is looking for, named in the short-link message so
+            a company tool does not send the model after a personal profile.
 
     Raises:
-        LinkedInScraperException: for an ``lnkd.in`` short link, which is a
-            LinkedIn URL that only a redirect resolves.
+        InvalidReferenceError: for an ``lnkd.in`` short link, which is a LinkedIn
+            URL that only a redirect resolves.
     """
     candidate = value if _HAS_SCHEME.match(value) else f"https://{value}"
     try:
@@ -104,9 +146,9 @@ def _parse_linkedin_url(value: str) -> tuple[str, str] | None:
         return None
     host = (url.hostname or "").lower()
     if _SHORTENER_HOST.match(host):
-        raise LinkedInScraperException(
-            f"{_echo(value)} is a shortened LinkedIn link, and only a redirect "
-            "resolves it. Open it and pass the linkedin.com/in/ address it lands on."
+        raise InvalidReferenceError(
+            "That is a shortened LinkedIn link, and only a redirect resolves it. "
+            f"Open it and pass the {want} the address it lands on contains."
         )
     if not _LINKEDIN_HOST.match(host):
         return None
@@ -118,70 +160,48 @@ def _parse_linkedin_url(value: str) -> tuple[str, str] | None:
             segments.pop(0)
 
     route = segments[0].lower() if segments else ""
-    slug = unquote(segments[1]).strip() if len(segments) > 1 else ""
-    return route, slug
-
-
-def _usable(slug: str) -> bool:
-    return bool(slug) and not _UNUSABLE.search(slug)
-
-
-def _decoded_bare(value: str) -> str | None:
-    """A bare identifier in the form the URL builder expects, or ``None``.
-
-    A caller can hand over an already-escaped segment: ``get_my_profile`` reads
-    the username straight out of ``page.url`` after the ``/in/me/`` redirect, and
-    a browser reports that path percent-encoded. Passing it on unchanged would
-    let :func:`person_profile_url` escape it a second time (``%D0`` becomes
-    ``%25D0``) and navigate to a path that is not the profile. Decoding once here
-    also catches syntax the escapes were hiding, which is the other half of why
-    the raw interpolation was unsafe.
-    """
-    if "%" not in value:
-        return value if _usable(value) else None
-    # `unquote` leaves a malformed escape untouched rather than raising, so a
-    # broken one has to be found before it silently survives into the URL.
-    if _STRAY_PERCENT.search(value):
-        return None
-    decoded = unquote(value)
-    return decoded if _usable(decoded) else None
+    return route, _usable(segments[1]) if len(segments) > 1 else None
 
 
 def normalize_person_identifier(value: str) -> str:
     """The public identifier for a person, from a link or from the identifier.
 
-    Idempotent: a bare identifier is returned unchanged, so applying this twice
-    along a call chain is harmless.
+    Idempotent, so applying it twice along a call chain is harmless.
 
     Raises:
-        LinkedInScraperException: when the value cannot name a person, with the
-            correction to make. Refusing here costs nothing; letting it through
-            spends a navigation and returns another page's text as a profile.
+        InvalidReferenceError: when the value cannot name a person, with the
+            correction to make. Refusing costs nothing; letting it through spends
+            a navigation and returns another page's text as a profile.
     """
     value = value.strip()
     if not value:
-        raise LinkedInScraperException(
+        raise InvalidReferenceError(
             "Missing linkedin_username (the /in/ public identifier of the person)."
         )
 
-    parsed = _parse_linkedin_url(value)
+    parsed = _parse_linkedin_url(value, want="/in/ public identifier")
     if parsed is not None:
-        route, slug = parsed
-        if route != _PERSON_ROUTE or not _usable(slug) or slug.lower() in _RESERVED:
-            raise LinkedInScraperException(
-                f"{_echo(value)} is a LinkedIn link but not a personal profile. "
-                "Pass the /in/ public identifier of a person, for example "
-                '"williamhgates".'
+        route, reference = parsed
+        if route != _PERSON_ROUTE or reference is None:
+            raise InvalidReferenceError(
+                "That is a LinkedIn link but not a personal profile. Pass the "
+                '/in/ public identifier of a person, for example "williamhgates".'
             )
-        return slug
+    else:
+        reference = _usable(value)
+        if reference is None:
+            raise InvalidReferenceError(
+                "That is not a LinkedIn public identifier. Pass the part after "
+                '/in/ in a profile URL, for example "williamhgates".'
+            )
 
-    bare = _decoded_bare(value)
-    if bare is None:
-        raise LinkedInScraperException(
-            f"{_echo(value)} is not a LinkedIn public identifier. Pass the part "
-            'after /in/ in a profile URL, for example "williamhgates".'
+    if reference.lower() in _RESERVED:
+        raise InvalidReferenceError(
+            f'"{reference}" is LinkedIn\'s alias for the signed-in member, not a '
+            "person you can look up. Call get_my_profile for the authenticated "
+            "user, or pass someone's own /in/ public identifier."
         )
-    return bare
+    return reference
 
 
 def normalize_company_identifier(value: str) -> str:
@@ -191,27 +211,44 @@ def normalize_company_identifier(value: str) -> str:
     """
     value = value.strip()
     if not value:
-        raise LinkedInScraperException(
+        raise InvalidReferenceError(
             "Missing company_name (the /company/ slug of the organization)."
         )
 
-    parsed = _parse_linkedin_url(value)
+    parsed = _parse_linkedin_url(value, want="/company/ slug")
     if parsed is not None:
-        route, slug = parsed
-        if route not in _ORGANIZATION_ROUTES or not _usable(slug):
-            raise LinkedInScraperException(
-                f"{_echo(value)} is a LinkedIn link but not a company page. "
-                'Pass the /company/ slug, for example "microsoft".'
+        route, reference = parsed
+        if route not in _ORGANIZATION_ROUTES or reference is None:
+            raise InvalidReferenceError(
+                "That is a LinkedIn link but not a company page. Pass the "
+                '/company/ slug, for example "microsoft".'
             )
-        return slug
+        return reference
 
-    bare = _decoded_bare(value)
-    if bare is None:
-        raise LinkedInScraperException(
-            f"{_echo(value)} is not a LinkedIn company slug. Pass the part after "
-            '/company/ in a company URL, for example "microsoft".'
+    reference = _usable(value)
+    if reference is None:
+        raise InvalidReferenceError(
+            "That is not a LinkedIn company slug. Pass the part after /company/ "
+            'in a company URL, for example "microsoft".'
         )
-    return bare
+    return reference
+
+
+def normalize_opaque_id(value: str, *, field: str) -> str:
+    """An id LinkedIn issued (a job id, a conversation thread id), checked as one.
+
+    These are never links and never carry a reserved meaning, so only the syntax
+    rules apply. They earn the same treatment as a username because they reach
+    the same place: ``job_id="../../feed"`` builds ``/jobs/view/../../feed/``,
+    which a browser resolves to ``/feed/`` before it asks for anything.
+    """
+    reference = _usable(value.strip())
+    if reference is None:
+        raise InvalidReferenceError(
+            f"{field} is not a LinkedIn id. Pass the id exactly as a previous "
+            "result returned it, with no URL, path or query around it."
+        )
+    return reference
 
 
 def person_profile_url(identifier: str, suffix: str = "") -> str:
@@ -226,3 +263,15 @@ def person_profile_url(identifier: str, suffix: str = "") -> str:
 def company_page_url(identifier: str, suffix: str = "") -> str:
     """Company page URL for an already-normalized slug, escaped as one segment."""
     return f"https://www.linkedin.com/company/{quote(identifier, safe='')}{suffix}"
+
+
+def job_view_url(job_id: str, suffix: str = "") -> str:
+    """Job posting URL for an already-normalized id, escaped as one segment."""
+    return f"https://www.linkedin.com/jobs/view/{quote(job_id, safe='')}{suffix}"
+
+
+def messaging_thread_url(thread_id: str, suffix: str = "") -> str:
+    """Conversation URL for an already-normalized thread id, escaped as one segment."""
+    return (
+        f"https://www.linkedin.com/messaging/thread/{quote(thread_id, safe='')}{suffix}"
+    )

--- a/linkedin_mcp_server/scraping/identifiers.py
+++ b/linkedin_mcp_server/scraping/identifiers.py
@@ -55,6 +55,10 @@ _HAS_SCHEME = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
 # are what a browser would resolve away, taking the navigation with them.
 _UNUSABLE = re.compile(r"[\s/\\?#]|[\x00-\x1f\x7f]")
 
+# A `%` that begins no valid escape. LinkedIn identifiers contain no literal one,
+# so this is always a malformed escape rather than content.
+_STRAY_PERCENT = re.compile(r"%(?![0-9A-Fa-f]{2})")
+
 # `me` is LinkedIn's alias for the signed-in member. A link that spells it must
 # never collapse into that alias: reading the operator's own profile while
 # reporting someone else's is a silently wrong answer, not a visible failure.
@@ -122,6 +126,27 @@ def _usable(slug: str) -> bool:
     return bool(slug) and not _UNUSABLE.search(slug)
 
 
+def _decoded_bare(value: str) -> str | None:
+    """A bare identifier in the form the URL builder expects, or ``None``.
+
+    A caller can hand over an already-escaped segment: ``get_my_profile`` reads
+    the username straight out of ``page.url`` after the ``/in/me/`` redirect, and
+    a browser reports that path percent-encoded. Passing it on unchanged would
+    let :func:`person_profile_url` escape it a second time (``%D0`` becomes
+    ``%25D0``) and navigate to a path that is not the profile. Decoding once here
+    also catches syntax the escapes were hiding, which is the other half of why
+    the raw interpolation was unsafe.
+    """
+    if "%" not in value:
+        return value if _usable(value) else None
+    # `unquote` leaves a malformed escape untouched rather than raising, so a
+    # broken one has to be found before it silently survives into the URL.
+    if _STRAY_PERCENT.search(value):
+        return None
+    decoded = unquote(value)
+    return decoded if _usable(decoded) else None
+
+
 def normalize_person_identifier(value: str) -> str:
     """The public identifier for a person, from a link or from the identifier.
 
@@ -150,12 +175,13 @@ def normalize_person_identifier(value: str) -> str:
             )
         return slug
 
-    if not _usable(value):
+    bare = _decoded_bare(value)
+    if bare is None:
         raise LinkedInScraperException(
             f"{_echo(value)} is not a LinkedIn public identifier. Pass the part "
             'after /in/ in a profile URL, for example "williamhgates".'
         )
-    return value
+    return bare
 
 
 def normalize_company_identifier(value: str) -> str:
@@ -179,12 +205,13 @@ def normalize_company_identifier(value: str) -> str:
             )
         return slug
 
-    if not _usable(value):
+    bare = _decoded_bare(value)
+    if bare is None:
         raise LinkedInScraperException(
             f"{_echo(value)} is not a LinkedIn company slug. Pass the part after "
             '/company/ in a company URL, for example "microsoft".'
         )
-    return value
+    return bare
 
 
 def person_profile_url(identifier: str, suffix: str = "") -> str:

--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -20,6 +20,10 @@ from linkedin_mcp_server.scraping.extractor import (
     _RATE_LIMITED_MSG,
     rate_limited_section_error,
 )
+from linkedin_mcp_server.scraping.identifiers import (
+    company_page_url,
+    normalize_company_identifier,
+)
 from linkedin_mcp_server.scraping.link_metadata import Reference
 
 logger = logging.getLogger(__name__)
@@ -47,7 +51,7 @@ def register_company_tools(
         Get a specific company's LinkedIn profile.
 
         Args:
-            company_name: LinkedIn company name (e.g., "docker", "anthropic", "microsoft")
+            company_name: LinkedIn company name (e.g., "docker", "anthropic", "microsoft"). A full company URL is accepted too and is reduced to the slug.
             ctx: FastMCP context for progress reporting
             sections: Comma-separated list of extra sections to scrape.
                 The about page is always included.
@@ -114,7 +118,7 @@ def register_company_tools(
         Get recent posts from a company's LinkedIn feed.
 
         Args:
-            company_name: LinkedIn company name (e.g., "docker", "anthropic", "microsoft")
+            company_name: LinkedIn company name (e.g., "docker", "anthropic", "microsoft"). A full company URL is accepted too and is reduced to the slug.
             ctx: FastMCP context for progress reporting
 
         Returns:
@@ -131,7 +135,8 @@ def register_company_tools(
                 progress=0, total=100, message="Starting company posts scrape"
             )
 
-            url = f"https://www.linkedin.com/company/{company_name}/posts/"
+            company_name = normalize_company_identifier(company_name)
+            url = company_page_url(company_name, "/posts/")
             extracted = await extractor.extract_page(url, section_name="posts")
 
             sections: dict[str, str] = {}
@@ -246,7 +251,7 @@ def register_company_tools(
         from the returned references.
 
         Args:
-            company_name: LinkedIn company URL slug (e.g., "docker", "anthropicresearch", "microsoft")
+            company_name: LinkedIn company URL slug (e.g., "docker", "anthropicresearch", "microsoft"). A full company URL is accepted too and is reduced to the slug.
             ctx: FastMCP context for progress reporting
             keywords: Optional filter by name, job title, or skill (e.g., "engineer", "sales")
 

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -104,7 +104,7 @@ def register_messaging_tools(
 
         Args:
             ctx: FastMCP context for progress reporting
-            linkedin_username: LinkedIn username of the conversation participant
+            linkedin_username: LinkedIn username of the conversation participant; a full profile URL is accepted too
             thread_id: LinkedIn messaging thread ID
             index: 0-based selector for which thread to open when the
                 participant has multiple threads (e.g. an organic 1-on-1 plus
@@ -233,7 +233,7 @@ def register_messaging_tools(
         write operation when confirm_send is True.
 
         Args:
-            linkedin_username: LinkedIn username of the recipient
+            linkedin_username: LinkedIn username of the recipient; a full profile URL is accepted too
             message: The message text to send
             confirm_send: Must be True to send the message
             ctx: FastMCP context for progress reporting

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -46,7 +46,7 @@ def register_person_tools(
         Get a specific person's LinkedIn profile.
 
         Args:
-            linkedin_username: LinkedIn username (e.g., "stickerdaniel", "williamhgates")
+            linkedin_username: LinkedIn username (e.g., "stickerdaniel", "williamhgates"). A full profile URL is accepted too and is reduced to the username.
             ctx: FastMCP context for progress reporting
             sections: Comma-separated list of extra sections to scrape.
                 The main profile page is always included.
@@ -204,7 +204,7 @@ def register_person_tools(
         prompt for user confirmation before execution.
 
         Args:
-            linkedin_username: LinkedIn username (e.g., "stickerdaniel", "williamhgates")
+            linkedin_username: LinkedIn username (e.g., "stickerdaniel", "williamhgates"). A full profile URL is accepted too and is reduced to the username.
             ctx: FastMCP context for progress reporting
             note: Optional note to include with the invitation
 
@@ -274,7 +274,7 @@ def register_person_tools(
         linkedin.com/premium are skipped.
 
         Args:
-            linkedin_username: LinkedIn username of the profile page to scrape
+            linkedin_username: LinkedIn username of the profile page to scrape; a full profile URL is accepted too
                 (e.g., "stickerdaniel", "williamhgates")
             ctx: FastMCP context for progress reporting
 

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -6,6 +6,7 @@ from fastmcp.exceptions import ToolError
 from linkedin_mcp_server.core.exceptions import (
     NetworkError,
     ProfileNotFoundError,
+    InvalidReferenceError,
     ProxyConnectionError,
     RateLimitError,
     ScrapingError,
@@ -221,6 +222,42 @@ def test_proxy_error_skips_issue_diagnostics(monkeypatch):
 
     with pytest.raises(ToolError):
         raise_tool_error(ProxyConnectionError("proxy gate:7000 is unreachable"))
+
+
+def test_invalid_reference_surfaces_the_correction_verbatim():
+    # It subclasses LinkedInScraperException, so the specific branch has to come
+    # first; otherwise the catch-all handles it and the correction arrives buried.
+    with pytest.raises(ToolError, match="williamhgates"):
+        raise_tool_error(
+            InvalidReferenceError(
+                "That is not a LinkedIn public identifier. Pass the part after "
+                '/in/ in a profile URL, for example "williamhgates".'
+            )
+        )
+
+
+def test_invalid_reference_skips_issue_diagnostics(monkeypatch):
+    # A reference the caller can correct is not a bug worth filing, and an issue
+    # template appended to it buries the correction the message already carries.
+    #
+    # Asserted on the surfaced message, not by raising from the patched builder:
+    # _raise_tool_error_with_diagnostics catches every Exception around that call
+    # and falls back to no diagnostics, so a raising double reports success
+    # whether the branch exists or not.
+    marker = "ISSUE-TEMPLATE-MARKER"
+    monkeypatch.setattr(
+        "linkedin_mcp_server.error_handler.build_issue_diagnostics",
+        lambda *args, **kwargs: marker,
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.error_handler.format_tool_error_with_diagnostics",
+        lambda message, diagnostics: f"{message}\n{diagnostics}",
+    )
+
+    with pytest.raises(ToolError) as raised:
+        raise_tool_error(InvalidReferenceError("Pass the /company/ slug."))
+    assert marker not in str(raised.value)
+    assert "Pass the /company/ slug." in str(raised.value)
 
 
 def test_unknown_exception_log_is_redacted(monkeypatch, caplog):

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -227,13 +227,17 @@ def test_proxy_error_skips_issue_diagnostics(monkeypatch):
 def test_invalid_reference_surfaces_the_correction_verbatim():
     # It subclasses LinkedInScraperException, so the specific branch has to come
     # first; otherwise the catch-all handles it and the correction arrives buried.
-    with pytest.raises(ToolError, match="williamhgates"):
-        raise_tool_error(
-            InvalidReferenceError(
-                "That is not a LinkedIn public identifier. Pass the part after "
-                '/in/ in a profile URL, for example "williamhgates".'
-            )
-        )
+    #
+    # Compared whole rather than searched for a substring: the catch-all keeps
+    # the message and appends to it, so `match=` passes either way and the word
+    # "verbatim" in this name would guard nothing.
+    correction = (
+        "That is not a LinkedIn public identifier. Pass the part after "
+        '/in/ in a profile URL, for example "williamhgates".'
+    )
+    with pytest.raises(ToolError) as raised:
+        raise_tool_error(InvalidReferenceError(correction))
+    assert str(raised.value) == correction
 
 
 def test_invalid_reference_skips_issue_diagnostics(monkeypatch):

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -79,6 +79,14 @@ class TestNormalizePersonIdentifier:
             == "андрей"
         )
 
+    def test_raises_the_dedicated_invalid_reference_type(self):
+        # The type is what keeps error_handler from attaching an issue-report
+        # template to a caller mistake, so the base class is not enough here.
+        with pytest.raises(InvalidReferenceError):
+            normalize_person_identifier("https://www.linkedin.com/feed/")
+        with pytest.raises(InvalidReferenceError):
+            normalize_company_identifier("https://www.linkedin.com/in/williamhgates")
+
     @pytest.mark.parametrize("value", ["%ZZ", "felix%", "felix%2", "%"])
     def test_refuses_a_malformed_escape(self, value: str):
         # unquote leaves a broken escape untouched instead of raising, so it

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -428,6 +428,65 @@ class TestDotSegmentsAnywhere:
         assert normalize_person_identifier("/in/alice/recent-activity/all/") == "alice"
 
 
+class TestTheParserAgreesWithABrowser:
+    """Each case was compared against a conforming URL parser before it was
+    written down. The rule is one-directional: this may refuse an address a
+    browser loads, and it may never resolve to a different page than one."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            # A backslash separates paths and nothing else, so the guard that
+            # refuses one must stop at the first `?` or `#` or it rejects the
+            # tracking parameters every shared LinkedIn link carries.
+            ("https://www.linkedin.com/in/alice?trk=foo\\bar", "alice"),
+            ("https://www.linkedin.com/in/alice#foo\\bar", "alice"),
+            # A network-path reference takes its scheme from the page it sits
+            # on, which for a LinkedIn address is always https.
+            ("//de.linkedin.com/in/alice", "alice"),
+            ("//www.linkedin.com/in/alice/recent-activity/all/", "alice"),
+            # An explicitly written default port is the same address.
+            ("https://www.linkedin.com:443/in/alice", "alice"),
+        ],
+    )
+    def test_a_form_a_browser_loads_still_resolves(self, value: str, expected: str):
+        assert normalize_person_identifier(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            # LinkedIn answers on 443. Reading the path and dropping the port
+            # would rebuild an address the caller never named as the live page.
+            "https://www.linkedin.com:444/in/williamhgates",
+            "https://www.linkedin.com:99999/in/williamhgates",
+            "https://www.linkedin.com:foo/in/williamhgates",
+            # A browser reads this as a path on linkedin.com; anything splitting
+            # on "/" reads it as a different host entirely.
+            "https://www.linkedin.com\\evil.example/in/alice",
+        ],
+    )
+    def test_an_address_a_browser_does_not_load_is_refused(self, value: str):
+        with pytest.raises(InvalidReferenceError):
+            normalize_person_identifier(value)
+
+
+class TestSluggedJobUrls:
+    """LinkedIn serves a job under both `/jobs/view/<id>/` and
+    `/jobs/view/<title>-at-<company>-<id>/`, and the slugged one is what an
+    address bar holds. Measured live, both 301 to the same destination."""
+
+    def test_the_slug_resolves_to_the_id_the_numeric_form_carries(self):
+        slugged = "https://www.linkedin.com/jobs/view/software-engineer-new-grad-at-ixl-learning-1967281839/"
+        assert normalize_job_id(slugged) == normalize_job_id("/jobs/view/1967281839/")
+        assert normalize_job_id(slugged) == "1967281839"
+
+    def test_a_bare_argument_stays_strictly_numeric(self):
+        # Outside a URL the words are not a slug LinkedIn wrote, they are a
+        # wrong value, and a page load is what it costs to learn that.
+        with pytest.raises(InvalidReferenceError):
+            normalize_job_id("software-engineer-1967281839")
+
+
 class TestNothingTidiesTheReference:
     """Each of these used to be cleaned up into a real target: the decode was
     followed by a strip, the URL parse drops control characters, and empty segments

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -400,6 +400,28 @@ class TestDotSegmentsAnywhere:
         with pytest.raises(InvalidReferenceError):
             normalize(value)
 
+    @pytest.mark.parametrize(
+        ("normalize", "value"),
+        [
+            (normalize_person_identifier, "/in/alice/x\\..\\..\\..\\in\\bob"),
+            (normalize_company_identifier, "/company/a/x\\..\\..\\..\\company\\b"),
+            (normalize_job_id, "/jobs/view/123/x\\..\\..\\..\\..\\jobs\\view\\456"),
+            (
+                normalize_thread_id,
+                "/messaging/thread/2-a/x\\..\\..\\..\\..\\messaging\\thread\\2-b",
+            ),
+        ],
+    )
+    def test_a_backslash_cannot_smuggle_the_dot_segments_past(
+        self, normalize, value: str
+    ):
+        # The URL Standard makes a backslash a path separator for http(s), and
+        # `urlparse` does not, so splitting on "/" alone reads a path no browser
+        # navigates. Measured with a conforming parser, the first value resolves
+        # to /in/bob while this read Alice.
+        with pytest.raises(InvalidReferenceError):
+            normalize(value)
+
     def test_a_real_sub_page_still_resolves(self):
         # Only dot segments are refused; the sub-pages a profile URL carries are
         # what made reading past the identifier necessary in the first place.

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -445,8 +445,13 @@ class TestTheParserAgreesWithABrowser:
             # on, which for a LinkedIn address is always https.
             ("//de.linkedin.com/in/alice", "alice"),
             ("//www.linkedin.com/in/alice/recent-activity/all/", "alice"),
-            # An explicitly written default port is the same address.
+            # An explicitly written default port is the same address, judged
+            # against the scheme's own default rather than against 443 alone.
             ("https://www.linkedin.com:443/in/alice", "alice"),
+            ("http://www.linkedin.com:80/in/alice", "alice"),
+            # A single trailing dot is the fully qualified spelling of the host,
+            # and LinkedIn answers on it.
+            ("https://www.linkedin.com./in/alice", "alice"),
         ],
     )
     def test_a_form_a_browser_loads_still_resolves(self, value: str, expected: str):
@@ -458,6 +463,12 @@ class TestTheParserAgreesWithABrowser:
             # LinkedIn answers on 443. Reading the path and dropping the port
             # would rebuild an address the caller never named as the live page.
             "https://www.linkedin.com:444/in/williamhgates",
+            # Port 443 spoken in cleartext is a request LinkedIn answers 400 for.
+            # Taking it for a default would rebuild it as the live HTTPS profile.
+            "http://www.linkedin.com:443/in/williamhgates",
+            "https://www.linkedin.com:80/in/williamhgates",
+            # One trailing dot is a spelling; two are not a host.
+            "https://www.linkedin.com../in/williamhgates",
             "https://www.linkedin.com:99999/in/williamhgates",
             "https://www.linkedin.com:foo/in/williamhgates",
             # A browser reads this as a path on linkedin.com; anything splitting

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -18,8 +18,10 @@ from linkedin_mcp_server.scraping.identifiers import (
     job_view_url,
     messaging_thread_url,
     normalize_company_identifier,
+    normalize_job_id,
     normalize_opaque_id,
     normalize_person_identifier,
+    normalize_thread_id,
     person_profile_url,
 )
 
@@ -292,3 +294,75 @@ class TestUrlBuilders:
             company_page_url("microsoft", "/people/")
             == "https://www.linkedin.com/company/microsoft/people/"
         )
+
+
+class TestReferencesThisServerEmits:
+    """link_metadata renders every reference as a site-relative path, and the
+    tool descriptions send callers back through them. A reference handed
+    straight back is a caller following the instructions, so refusing one would
+    refuse this server's own output."""
+
+    @pytest.mark.parametrize(
+        ("reference", "expected"),
+        [
+            ("/in/williamhgates/", "williamhgates"),
+            ("/in/williamhgates", "williamhgates"),
+            ("/mwlite/in/williamhgates/", "williamhgates"),
+        ],
+    )
+    def test_person_reference_yields_the_identifier(self, reference, expected):
+        assert normalize_person_identifier(reference) == expected
+
+    @pytest.mark.parametrize(
+        ("reference", "expected"),
+        [("/company/microsoft/", "microsoft"), ("/school/rwth-aachen/", "rwth-aachen")],
+    )
+    def test_company_reference_yields_the_slug(self, reference, expected):
+        assert normalize_company_identifier(reference) == expected
+
+    def test_thread_reference_yields_the_id(self):
+        assert normalize_thread_id("/messaging/thread/2-abc123/") == "2-abc123"
+
+    def test_thread_id_still_passes_through(self):
+        assert normalize_thread_id("2-abc123") == "2-abc123"
+
+    def test_job_reference_yields_the_id(self):
+        assert normalize_job_id("/jobs/view/4252026496/") == "4252026496"
+
+    def test_a_relative_path_of_the_wrong_kind_is_still_refused(self):
+        with pytest.raises(InvalidReferenceError):
+            normalize_person_identifier("/company/microsoft/")
+
+    def test_dot_segments_survive_neither_form(self):
+        # The relative form is a second way into the same builder, so it has to
+        # refuse what the bare form refuses.
+        for value in ("/in/../../feed/", "/messaging/thread/../../feed/"):
+            with pytest.raises(InvalidReferenceError):
+                normalize_person_identifier(value)
+
+
+class TestJobIdIsANumber:
+    """Everything here that produces a job id extracts \\d+, and the tool
+    documents one. A word navigates to a 404 that costs a page load to learn."""
+
+    def test_a_word_is_refused(self):
+        with pytest.raises(InvalidReferenceError):
+            normalize_job_id("abc")
+
+    def test_the_number_passes(self):
+        assert normalize_job_id("4252026496") == "4252026496"
+
+
+class TestLoneSurrogate:
+    """A lone surrogate survives JSON parsing and every syntax check, then
+    raises inside `quote` while the URL is built. The caller would see an
+    unexpected tool failure carrying issue-report diagnostics instead of the
+    correction this module exists to give."""
+
+    @pytest.mark.parametrize(
+        "normalize",
+        [normalize_person_identifier, normalize_company_identifier, normalize_job_id],
+    )
+    def test_it_is_refused_rather_than_crashing_the_url_builder(self, normalize):
+        with pytest.raises(InvalidReferenceError):
+            normalize("\ud800")

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -214,17 +214,26 @@ class TestNormalizeCompanyIdentifier:
             "https://www.linkedin.com/company/microsoft",
             "https://de.linkedin.com/company/microsoft/",
             "https://www.linkedin.com/company/microsoft/posts/",
-            "https://www.linkedin.com/showcase/microsoft",
         ],
     )
     def test_reduces_a_company_link_to_the_slug(self, value: str):
         assert normalize_company_identifier(value) == "microsoft"
 
-    def test_accepts_a_school_link(self):
-        # /company/<school-slug> 301-redirects to /school/<slug>, so reusing the
-        # slug on the company route resolves.
-        value = "https://www.linkedin.com/school/rwth-aachen-university/"
-        assert normalize_company_identifier(value) == "rwth-aachen-university"
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://www.linkedin.com/school/rwth-aachen-university/",
+            "https://www.linkedin.com/showcase/microsoft",
+        ],
+    )
+    def test_refuses_a_route_it_cannot_build(self, value: str):
+        # The slug used to be rebuilt under /company/, which 301-redirects to the
+        # organization root. Right for the root, wrong for every section the
+        # company scrape appends: /company/<school-slug>/jobs/ redirects to the
+        # school root too, and nothing checks where it landed, so root content
+        # was recorded under the requested section.
+        with pytest.raises(InvalidReferenceError):
+            normalize_company_identifier(value)
 
     @pytest.mark.parametrize(
         "value",
@@ -315,7 +324,7 @@ class TestReferencesThisServerEmits:
 
     @pytest.mark.parametrize(
         ("reference", "expected"),
-        [("/company/microsoft/", "microsoft"), ("/school/rwth-aachen/", "rwth-aachen")],
+        [("/company/microsoft/", "microsoft")],
     )
     def test_company_reference_yields_the_slug(self, reference, expected):
         assert normalize_company_identifier(reference) == expected
@@ -366,3 +375,73 @@ class TestLoneSurrogate:
     def test_it_is_refused_rather_than_crashing_the_url_builder(self, normalize):
         with pytest.raises(InvalidReferenceError):
             normalize("\ud800")
+
+
+class TestDotSegmentsAnywhere:
+    """A browser resolves dot segments across the whole path before it asks for
+    anything, so reading the route and the segment after it answers about a
+    different page than the reference names. `/in/alice/../../in/bob` is Bob to
+    a browser and was Alice here."""
+
+    @pytest.mark.parametrize(
+        ("normalize", "value"),
+        [
+            (normalize_person_identifier, "/in/alice/../../in/bob"),
+            (normalize_person_identifier, "/in/alice/%2e%2e/%2e%2e/in/bob"),
+            (normalize_company_identifier, "/company/a/../../company/b"),
+            (normalize_job_id, "/jobs/view/123/../../../jobs/view/456"),
+            (
+                normalize_thread_id,
+                "/messaging/thread/2-a/../../../messaging/thread/2-b",
+            ),
+        ],
+    )
+    def test_the_whole_path_is_judged(self, normalize, value: str):
+        with pytest.raises(InvalidReferenceError):
+            normalize(value)
+
+    def test_a_real_sub_page_still_resolves(self):
+        # Only dot segments are refused; the sub-pages a profile URL carries are
+        # what made reading past the identifier necessary in the first place.
+        assert normalize_person_identifier("/in/alice/recent-activity/all/") == "alice"
+
+
+class TestNothingTidiesTheReference:
+    """Each of these used to be cleaned up into a real target: the decode was
+    followed by a strip, the URL parse drops control characters, and empty segments
+    were filtered away. LinkedIn answers 404 for the duplicate-segment path, so
+    accepting it names a page the reference does not."""
+
+    @pytest.mark.parametrize(
+        ("normalize", "value"),
+        [
+            (normalize_person_identifier, "/in/%20alice/"),
+            (normalize_person_identifier, "/in/foo\nbar/"),
+            (normalize_person_identifier, "/in/foo\tbar/"),
+            (normalize_company_identifier, "/company//microsoft/"),
+            (normalize_thread_id, "/messaging/thread/%202-abc/"),
+            (normalize_thread_id, "/messaging//thread//2-abc/"),
+        ],
+    )
+    def test_it_is_refused(self, normalize, value: str):
+        with pytest.raises(InvalidReferenceError):
+            normalize(value)
+
+
+class TestIdentifierAllowlist:
+    """A public identifier is letters, digits, hyphen and underscore. The old
+    rule listed forbidden syntax instead, so a value carrying none of it passed
+    and spent a page load on a 404."""
+
+    @pytest.mark.parametrize(
+        "value", ["foo@example.com", "foo:bar", "foo!bar", "foo.bar"]
+    )
+    def test_a_value_that_cannot_be_one_is_refused(self, value: str):
+        with pytest.raises(InvalidReferenceError):
+            normalize_company_identifier(value)
+
+    @pytest.mark.parametrize(
+        "value", ["williamhgates", "felix-krueckel", "андрей", "a_b"]
+    )
+    def test_a_real_one_passes(self, value: str):
+        assert normalize_person_identifier(value) == value

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -9,10 +9,16 @@ from urllib.parse import urlparse
 
 import pytest
 
-from linkedin_mcp_server.core.exceptions import LinkedInScraperException
+from linkedin_mcp_server.core.exceptions import (
+    InvalidReferenceError,
+    LinkedInScraperException,
+)
 from linkedin_mcp_server.scraping.identifiers import (
     company_page_url,
+    job_view_url,
+    messaging_thread_url,
     normalize_company_identifier,
+    normalize_opaque_id,
     normalize_person_identifier,
     person_profile_url,
 )
@@ -101,6 +107,47 @@ class TestNormalizePersonIdentifier:
         with pytest.raises(LinkedInScraperException):
             normalize_person_identifier("williamhgates/../../feed")
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            # Escaping cannot save these: a period is unreserved, so quote leaves
+            # it alone and /in/../ still walks up a level.
+            "..",
+            ".",
+            "https://www.linkedin.com/in/..",
+            "https://www.linkedin.com/in/%2e%2e",
+            # A second encoding layer would reach `..` on the next pass through
+            # the normalizer, which connect_with_person performs.
+            "%252e%252e",
+            "https://www.linkedin.com/in/%252e%252e",
+        ],
+    )
+    def test_refuses_an_exact_dot_segment(self, value: str):
+        with pytest.raises(InvalidReferenceError):
+            normalize_person_identifier(value)
+
+    @pytest.mark.parametrize("value", ["me", "ME", "%6d%65"])
+    def test_refuses_the_signed_in_alias_in_every_form(self, value: str):
+        # LinkedIn resolves /in/me/ to the authenticated member, so a lookup that
+        # meant somebody else answers about the operator instead.
+        with pytest.raises(InvalidReferenceError, match="get_my_profile"):
+            normalize_person_identifier(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            # unquote leaves %ZZ intact and turns %FF into a replacement
+            # character, so tolerating either rewrites the destination rather
+            # than refusing the reference.
+            "https://www.linkedin.com/in/%ZZ",
+            "https://www.linkedin.com/in/%FF",
+            "https://www.linkedin.com/in/a%2Fb",
+        ],
+    )
+    def test_refuses_a_malformed_escape_inside_a_full_url(self, value: str):
+        with pytest.raises(InvalidReferenceError):
+            normalize_person_identifier(value)
+
     def test_never_collapses_a_link_into_the_signed_in_alias(self):
         # /in/me is LinkedIn's alias for the operator's own profile. Resolving a
         # link into it answers confidently about the wrong person.
@@ -183,6 +230,34 @@ class TestNormalizeCompanyIdentifier:
             normalize_company_identifier(value)
 
 
+class TestNormalizeOpaqueId:
+    def test_passes_an_ordinary_id_through(self):
+        assert normalize_opaque_id("4021126051", field="job_id") == "4021126051"
+
+    @pytest.mark.parametrize("value", ["../../feed", "..", "a/b", "a b", "%ZZ", ""])
+    def test_refuses_anything_that_could_redirect_the_path(self, value: str):
+        # job_id="../../feed" builds /jobs/view/../../feed/, which a browser
+        # resolves to /feed/ before it asks for anything.
+        with pytest.raises(InvalidReferenceError):
+            normalize_opaque_id(value, field="job_id")
+
+    def test_names_the_field_it_was_given(self):
+        with pytest.raises(InvalidReferenceError, match="thread_id"):
+            normalize_opaque_id("../x", field="thread_id")
+
+
+class TestShortLinkMessage:
+    def test_asks_a_company_tool_for_a_company_slug(self):
+        # A shared message told every caller to supply a personal profile URL,
+        # which fails a second time in the company normalizer.
+        with pytest.raises(InvalidReferenceError, match="/company/ slug"):
+            normalize_company_identifier("https://lnkd.in/eXaMpLe1")
+
+    def test_asks_a_person_tool_for_a_public_identifier(self):
+        with pytest.raises(InvalidReferenceError, match="/in/ public identifier"):
+            normalize_person_identifier("https://lnkd.in/eXaMpLe1")
+
+
 class TestUrlBuilders:
     def test_escapes_the_identifier_as_a_single_path_segment(self):
         url = person_profile_url("андрей", "/")
@@ -192,6 +267,13 @@ class TestUrlBuilders:
         # safe="" is the point: nothing the identifier carries may become path.
         assert person_profile_url("a/b") == "https://www.linkedin.com/in/a%2Fb"
         assert company_page_url("a/b") == "https://www.linkedin.com/company/a%2Fb"
+
+    def test_escapes_a_job_and_thread_id_as_one_segment(self):
+        assert job_view_url("a b", "/") == "https://www.linkedin.com/jobs/view/a%20b/"
+        assert (
+            messaging_thread_url("a/b")
+            == "https://www.linkedin.com/messaging/thread/a%2Fb"
+        )
 
     def test_builds_the_documented_profile_and_company_urls(self):
         assert (

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,0 +1,180 @@
+"""Tests for the profile/company reference repair applied before URL building.
+
+The shapes below are the ones a caller actually passes. A regression is invisible
+in production: a wrong identifier does not raise, it navigates somewhere and the
+tool returns that page's text as if it were the requested profile.
+"""
+
+from urllib.parse import urlparse
+
+import pytest
+
+from linkedin_mcp_server.core.exceptions import LinkedInScraperException
+from linkedin_mcp_server.scraping.identifiers import (
+    company_page_url,
+    normalize_company_identifier,
+    normalize_person_identifier,
+    person_profile_url,
+)
+
+PROFILE_ID = "ACoAADdZSNYBiaacxEw6je-wVIKjGkKp-it0gD8"
+
+
+class TestNormalizePersonIdentifier:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "williamhgates",
+            "https://www.linkedin.com/in/williamhgates",
+            "https://linkedin.com/in/williamhgates",
+            "http://www.linkedin.com/in/williamhgates",
+            # No scheme, as a browser address bar shows it.
+            "www.linkedin.com/in/williamhgates",
+            "linkedin.com/in/williamhgates",
+            # The locale subdomain follows the country on the member's profile
+            # and serves the profile itself rather than redirecting to www.
+            "https://de.linkedin.com/in/williamhgates",
+            "https://ca.linkedin.com/in/williamhgates",
+            "https://uk.linkedin.com/in/williamhgates",
+            "https://fr.linkedin.com/in/williamhgates",
+            "https://br.linkedin.com/in/williamhgates",
+            "https://jp.linkedin.com/in/williamhgates",
+            # Mobile entry points and the mobile-web-lite path wrappers.
+            "https://m.linkedin.com/in/williamhgates",
+            "https://touch.linkedin.com/in/williamhgates",
+            "https://www.linkedin.com/mwlite/in/williamhgates",
+            "https://www.linkedin.com/mwlite/profile/in/williamhgates",
+            # Trailing slash, share-sheet parameters, hash and sub-pages.
+            "https://www.linkedin.com/in/williamhgates/",
+            "https://www.linkedin.com/in/williamhgates?originalSubdomain=de",
+            "https://www.linkedin.com/in/williamhgates?trk=public_profile",
+            "https://www.linkedin.com/in/williamhgates#experience",
+            "https://www.linkedin.com/in/williamhgates/recent-activity/all/",
+        ],
+    )
+    def test_reduces_every_served_form_to_the_username(self, value: str):
+        assert normalize_person_identifier(value) == "williamhgates"
+
+    def test_is_idempotent(self):
+        once = normalize_person_identifier("https://de.linkedin.com/in/williamhgates")
+        assert normalize_person_identifier(once) == once
+
+    def test_decodes_a_percent_encoded_non_ascii_username(self):
+        value = "https://ru.linkedin.com/in/%D0%B0%D0%BD%D0%B4%D1%80%D0%B5%D0%B9"
+        assert normalize_person_identifier(value) == "андрей"
+
+    def test_preserves_case(self):
+        # A share link from the app can carry a case-sensitive profile id where
+        # the public identifier normally sits.
+        assert (
+            normalize_person_identifier(f"linkedin.com/in/{PROFILE_ID}") == PROFILE_ID
+        )
+        assert normalize_person_identifier("WilliamHGates") == "WilliamHGates"
+
+    def test_refuses_a_value_that_would_escape_the_profile_path(self):
+        # A browser resolves the dot segments away before the request, so this
+        # navigates to /feed/ and returns the feed as if it were a profile.
+        with pytest.raises(LinkedInScraperException):
+            normalize_person_identifier("williamhgates/../../feed")
+
+    def test_never_collapses_a_link_into_the_signed_in_alias(self):
+        # /in/me is LinkedIn's alias for the operator's own profile. Resolving a
+        # link into it answers confidently about the wrong person.
+        with pytest.raises(LinkedInScraperException):
+            normalize_person_identifier("https://www.linkedin.com/in/me")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://www.linkedin.com/company/microsoft",
+            "https://www.linkedin.com/school/rwth-aachen-university",
+            "https://www.linkedin.com/feed/",
+            "https://www.linkedin.com/sales/lead/ACwAA,NAME_SEARCH,abcd",
+            # The legacy form carries name parts and id fragments, never the
+            # public identifier, so no segment of it may be handed over.
+            "https://www.linkedin.com/pub/bill-gates/1/2a/3b",
+        ],
+    )
+    def test_refuses_a_linkedin_link_that_is_not_a_personal_profile(self, value: str):
+        with pytest.raises(LinkedInScraperException):
+            normalize_person_identifier(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["https://lnkd.in/eXaMpLe1", "lnkd.in/eXaMpLe1", "http://www.lnkd.in/eXaMpLe1"],
+    )
+    def test_refuses_a_short_link_that_only_a_redirect_resolves(self, value: str):
+        with pytest.raises(LinkedInScraperException, match="shortened"):
+            normalize_person_identifier(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            # Host-suffix lookalikes must not be read as LinkedIn.
+            "https://evil-linkedin.com/in/williamhgates",
+            "https://linkedin.com.example.test/in/williamhgates",
+            "https://example.com/in/williamhgates",
+            "bill gates",
+            "in/williamhgates",
+            "",
+            "   ",
+        ],
+    )
+    def test_refuses_a_value_that_cannot_name_a_person(self, value: str):
+        with pytest.raises(LinkedInScraperException):
+            normalize_person_identifier(value)
+
+
+class TestNormalizeCompanyIdentifier:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "microsoft",
+            "https://www.linkedin.com/company/microsoft",
+            "https://de.linkedin.com/company/microsoft/",
+            "https://www.linkedin.com/company/microsoft/posts/",
+            "https://www.linkedin.com/showcase/microsoft",
+        ],
+    )
+    def test_reduces_a_company_link_to_the_slug(self, value: str):
+        assert normalize_company_identifier(value) == "microsoft"
+
+    def test_accepts_a_school_link(self):
+        # /company/<school-slug> 301-redirects to /school/<slug>, so reusing the
+        # slug on the company route resolves.
+        value = "https://www.linkedin.com/school/rwth-aachen-university/"
+        assert normalize_company_identifier(value) == "rwth-aachen-university"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://www.linkedin.com/in/williamhgates",
+            "https://www.linkedin.com/feed/",
+            "microsoft/../../feed",
+            "",
+        ],
+    )
+    def test_refuses_a_value_that_cannot_name_a_company(self, value: str):
+        with pytest.raises(LinkedInScraperException):
+            normalize_company_identifier(value)
+
+
+class TestUrlBuilders:
+    def test_escapes_the_identifier_as_a_single_path_segment(self):
+        url = person_profile_url("андрей", "/")
+        assert urlparse(url).path == "/in/%D0%B0%D0%BD%D0%B4%D1%80%D0%B5%D0%B9/"
+
+    def test_a_suffix_is_the_only_way_to_add_path(self):
+        # safe="" is the point: nothing the identifier carries may become path.
+        assert person_profile_url("a/b") == "https://www.linkedin.com/in/a%2Fb"
+        assert company_page_url("a/b") == "https://www.linkedin.com/company/a%2Fb"
+
+    def test_builds_the_documented_profile_and_company_urls(self):
+        assert (
+            person_profile_url("williamhgates")
+            == "https://www.linkedin.com/in/williamhgates"
+        )
+        assert (
+            company_page_url("microsoft", "/people/")
+            == "https://www.linkedin.com/company/microsoft/people/"
+        )

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -63,6 +63,30 @@ class TestNormalizePersonIdentifier:
         value = "https://ru.linkedin.com/in/%D0%B0%D0%BD%D0%B4%D1%80%D0%B5%D0%B9"
         assert normalize_person_identifier(value) == "андрей"
 
+    def test_decodes_a_bare_percent_encoded_username(self):
+        # get_my_profile reads the username out of page.url after the /in/me/
+        # redirect, and a browser reports that path encoded. Returning it as-is
+        # would let the URL builder escape it again into %25D0, a path that is
+        # not the profile.
+        assert (
+            normalize_person_identifier("%D0%B0%D0%BD%D0%B4%D1%80%D0%B5%D0%B9")
+            == "андрей"
+        )
+
+    @pytest.mark.parametrize("value", ["%ZZ", "felix%", "felix%2", "%"])
+    def test_refuses_a_malformed_escape(self, value: str):
+        # unquote leaves a broken escape untouched instead of raising, so it
+        # would otherwise survive into the URL.
+        with pytest.raises(LinkedInScraperException):
+            normalize_person_identifier(value)
+
+    @pytest.mark.parametrize(
+        "value", ["felix%2Ffoo", "felix%20foo", "felix%2E%2E%2Ffeed"]
+    )
+    def test_refuses_syntax_the_escapes_were_hiding(self, value: str):
+        with pytest.raises(LinkedInScraperException):
+            normalize_person_identifier(value)
+
     def test_preserves_case(self):
         # A share link from the app can carry a case-sensitive profile id where
         # the public identifier normally sits.

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -602,6 +602,79 @@ class TestScrapePersonUrls:
         assert urls[0].endswith("/in/testuser/")
         assert set(result["sections"]) == {"main_profile"}
 
+    async def test_a_pasted_profile_link_reaches_the_canonical_profile_url(
+        self, mock_page
+    ):
+        """A URL argument must be reduced before it becomes a path segment.
+
+        Without this the navigation target is
+        https://www.linkedin.com/in/https://de.linkedin.com/in/testuser, which
+        LinkedIn does not serve, and the tool reports that page as a profile.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("profile text"),
+            ) as mock_extract,
+            patch.object(
+                extractor,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_person(
+                "https://de.linkedin.com/in/testuser", {"main_profile"}
+            )
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert urls == ["https://www.linkedin.com/in/testuser/"]
+        assert result["url"] == "https://www.linkedin.com/in/testuser/"
+
+    async def test_a_dot_segment_value_never_reaches_a_navigation(self, mock_page):
+        # A browser resolves ../ away before the request, so this would open the
+        # feed and return it as a profile.
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor, "extract_page", new_callable=AsyncMock
+        ) as mock_extract:
+            with pytest.raises(LinkedInScraperException):
+                await extractor.scrape_person("testuser/../../feed", {"main_profile"})
+        mock_extract.assert_not_called()
+
+    async def test_a_pasted_company_link_reaches_the_canonical_company_url(
+        self, mock_page
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("company text"),
+            ) as mock_extract,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_company(
+                "https://de.linkedin.com/company/testco/posts/", {"about"}
+            )
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert all(
+            u.startswith("https://www.linkedin.com/company/testco") for u in urls
+        )
+        assert result["url"] == "https://www.linkedin.com/company/testco/"
+
     async def test_scrape_person_returns_section_errors(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         with (

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -7,6 +7,7 @@ import pytest
 from linkedin_mcp_server.callbacks import ProgressCallback
 from linkedin_mcp_server.core.exceptions import (
     AuthenticationError,
+    InvalidReferenceError,
     LinkedInScraperException,
     ProxyConnectionError,
 )
@@ -706,6 +707,7 @@ class TestScrapePersonUrls:
             )
 
         urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert urls
         assert all(
             u.startswith("https://www.linkedin.com/company/testco") for u in urls
         )
@@ -6099,3 +6101,45 @@ class TestNavigationFailureCrossesTheToolBoundaryClean:
         # The raw error must not survive as a cause either: the handlers
         # downstream print the whole chain.
         assert excinfo.value.__cause__ is None
+
+
+class TestEveryNormalizedEntryPoint:
+    """Each method that was rewired, refusing a value that redirects the path.
+
+    Without this, removing normalization from one method leaves every other test
+    untouched: the bare-identifier assertions build the same URL either way. The
+    traversal value is the one input whose result differs, and it has to fail
+    before any navigation rather than after one.
+    """
+
+    @staticmethod
+    def _calls(extractor: LinkedInExtractor):
+        return (
+            patch.object(extractor, "extract_page", new_callable=AsyncMock),
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+        )
+
+    @pytest.mark.parametrize(
+        "method,args,kwargs",
+        [
+            ("scrape_person", ("../../feed", {"main_profile"}), {}),
+            ("connect_with_person", ("../../feed",), {}),
+            ("get_sidebar_profiles", ("../../feed",), {}),
+            ("_open_conversation_by_username", ("../../feed",), {}),
+            ("send_message", ("../../feed", "hi"), {"confirm_send": False}),
+            ("scrape_company", ("../../feed", {"about"}), {}),
+            ("get_company_employees", ("../../feed",), {}),
+            ("scrape_job", ("../../feed",), {}),
+            ("get_conversation", (), {"thread_id": "../../feed"}),
+        ],
+    )
+    async def test_refuses_a_traversal_value_before_navigating(
+        self, mock_page, method: str, args: tuple, kwargs: dict
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        extract_patch, navigate_patch = self._calls(extractor)
+        with extract_patch as mock_extract, navigate_patch as mock_navigate:
+            with pytest.raises(InvalidReferenceError):
+                await getattr(extractor, method)(*args, **kwargs)
+        mock_extract.assert_not_called()
+        mock_navigate.assert_not_called()

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -649,6 +649,42 @@ class TestScrapePersonUrls:
                 await extractor.scrape_person("testuser/../../feed", {"main_profile"})
         mock_extract.assert_not_called()
 
+    async def test_an_already_encoded_username_is_not_encoded_twice(self, mock_page):
+        """get_my_profile hands over the username exactly this way.
+
+        It reads the segment out of page.url after the /in/me/ redirect, and a
+        browser reports that path percent-encoded. Escaping it again turns %D0
+        into %25D0, which is a different profile path, so the own-profile scrape
+        of any member with a non-ASCII vanity would navigate somewhere else.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("profile text"),
+            ) as mock_extract,
+            patch.object(
+                extractor,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await extractor.scrape_person(
+                "%D0%B0%D0%BD%D0%B4%D1%80%D0%B5%D0%B9", {"main_profile"}
+            )
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert urls == [
+            "https://www.linkedin.com/in/%D0%B0%D0%BD%D0%B4%D1%80%D0%B5%D0%B9/"
+        ]
+
     async def test_a_pasted_company_link_reaches_the_canonical_company_url(
         self, mock_page
     ):

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -6103,6 +6103,60 @@ class TestNavigationFailureCrossesTheToolBoundaryClean:
         assert excinfo.value.__cause__ is None
 
 
+def _no_signals() -> ActionSignals:
+    """Every structural signal absent, which is all these tests need."""
+    return ActionSignals(
+        has_invite_anchor=False,
+        has_compose_anchor_in_action_root=False,
+        has_edit_intro_anchor=False,
+        has_labeled_action_button=False,
+        has_labeled_action_anchor=False,
+        has_incoming_action_row=False,
+    )
+
+
+class TestGetMyProfileAlias:
+    async def test_survives_a_redirect_that_never_resolves_the_alias(self, mock_page):
+        """The one caller allowed to hold "me".
+
+        get_my_profile navigates to /in/me/ and reads the identifier back out of
+        the redirect. When the redirect has not happened it still holds the
+        alias, and refusing there would answer the tool that owns the alias with
+        an instruction to call itself.
+        """
+        mock_page.url = "https://www.linkedin.com/in/me/"
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("profile text"),
+            ) as mock_extract,
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_my_profile()
+
+        # The alias survives normalization, and because the page is already on
+        # it, the scrape reuses the loaded document instead of navigating again.
+        assert result["url"] == "https://www.linkedin.com/in/me/"
+        assert "main_profile" in result["sections"]
+        mock_extract.assert_not_called()
+
+    async def test_refuses_the_alias_from_an_ordinary_caller(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor, "extract_page", new_callable=AsyncMock
+        ) as mock_extract:
+            with pytest.raises(InvalidReferenceError):
+                await extractor.scrape_person("me", {"main_profile"})
+        mock_extract.assert_not_called()
+
+
 class TestEveryNormalizedEntryPoint:
     """Each method that was rewired, refusing a value that redirects the path.
 
@@ -6118,6 +6172,39 @@ class TestEveryNormalizedEntryPoint:
             patch.object(extractor, "extract_page", new_callable=AsyncMock),
             patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
         )
+
+    async def test_connect_with_person_normalizes_before_its_own_downstream_use(
+        self, mock_page
+    ):
+        """The traversal case cannot see this one.
+
+        scrape_person normalizes too, so removing connect_with_person's own call
+        still raises on "../../feed". A full URL is what separates them: the
+        scrape would succeed while the invite deeplink and the action-signal
+        selectors kept receiving the URL where they expect the vanity.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        seen: list[str] = []
+        with (
+            patch.object(
+                extractor,
+                "scrape_person",
+                new_callable=AsyncMock,
+                return_value={"sections": {"main_profile": "text"}},
+            ),
+            patch.object(
+                extractor,
+                "_read_action_signals",
+                new_callable=AsyncMock,
+                side_effect=lambda username: seen.append(username) or _no_signals(),
+            ),
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+        ):
+            await extractor.connect_with_person(
+                "https://de.linkedin.com/in/williamhgates"
+            )
+
+        assert seen == ["williamhgates"]
 
     @pytest.mark.parametrize(
         "method,args,kwargs",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -489,6 +489,45 @@ class TestCompanyTools:
         assert "about" in result["sections"]
         assert "pages_visited" not in result
 
+    async def test_get_company_posts_normalizes_a_pasted_link(self, mock_context):
+        """get_company_posts builds its URL in the tool, not in the extractor.
+
+        That makes it the one wiring point the extractor tests cannot reach, and
+        the only place a pasted company link would still become
+        /company/https://de.linkedin.com/company/testcorp/posts/.
+        """
+        mock_extractor = _make_mock_extractor({})
+
+        from linkedin_mcp_server.tools.company import register_company_tools
+
+        mcp = FastMCP("test")
+        register_company_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_company_posts")
+        result = await tool_fn(
+            "https://de.linkedin.com/company/testcorp/",
+            mock_context,
+            extractor=mock_extractor,
+        )
+        assert result["url"] == "https://www.linkedin.com/company/testcorp/posts/"
+        assert (
+            mock_extractor.extract_page.call_args.args[0]
+            == "https://www.linkedin.com/company/testcorp/posts/"
+        )
+
+    async def test_get_company_posts_refuses_a_traversal_value(self, mock_context):
+        mock_extractor = _make_mock_extractor({})
+
+        from linkedin_mcp_server.tools.company import register_company_tools
+
+        mcp = FastMCP("test")
+        register_company_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_company_posts")
+        with pytest.raises(Exception):
+            await tool_fn("../../feed", mock_context, extractor=mock_extractor)
+        mock_extractor.extract_page.assert_not_called()
+
     async def test_get_company_profile_passes_callbacks(self, mock_context):
         """Verify tool wires MCPContextProgressCallback to the extractor."""
         expected = {


### PR DESCRIPTION
Closes #748

`linkedin_username` and `company_name` went into the LinkedIn URL as a raw path segment, which broke two things.

A pasted profile link never resolved. Handing a model a URL is what users do, and `https://www.linkedin.com/in/` followed by that URL is not a page LinkedIn serves, so the tool reported whatever came back instead of saying the argument was wrong. The `../` case is worse. Browsers apply RFC 3986 dot-segment removal before the request, so `.../in/x/../../feed` resolves to `/feed/` and `get_person_profile` returned the feed as a profile. Verified live: that URL redirects to `session_redirect=https%3A%2F%2Fwww.linkedin.com%2Ffeed%2F`.

`scraping/identifiers.py` now reduces a reference to its public identifier or company slug, refuses a value that can be neither, and escapes what is left as a single path segment with `safe=""`. It runs where the URLs are built rather than at the tool boundary, so internal extractor callers are covered too, and it is idempotent, so applying it twice along a chain is harmless.

Escaping alone turned out not to be enough, which the review rounds established. `quote` leaves a period untouched because it is unreserved, so a bare `..` still built `/in/../`; exact dot segments are refused rather than escaped, wherever in the path they sit. Judging only the first two segments was its own hole: `/in/alice/../../in/bob` reduced to `alice` while a browser resolves it to Bob's profile, so the whole path is judged now, and an empty interior segment is refused with it. A value that still contains `%` after one decode is refused too, since a second layer reaches `..` on the next pass, and `connect_with_person` performs exactly that second pass when it hands its normalized value to `scrape_person`. Malformed escapes are refused instead of repaired, because `unquote` leaves `%ZZ` intact and turns `%FF` into a replacement character, either of which changes the destination silently. `job_id` and `thread_id` carried the same defect in `get_job_details` and `get_conversation` and go through the same guard now, and the compose `recipient=` parameter is escaped like the `profileUrn` beside it always was.

The link forms it accepts are the ones LinkedIn actually serves. A member's public profile URL carries the two-letter code of the country on their profile, and those hosts answer directly rather than redirecting to `www.`, so every host under `linkedin.com` has to be accepted. Mobile adds `m.`, `touch.` and the `/mwlite/in/` and `/mwlite/profile/in/` wrappers. A share sheet appends `?originalSubdomain=` or `?trk=`. Case is never folded, because a share link from the app can carry a case-sensitive profile id where the public identifier normally sits. An `lnkd.in` short link gets its own message naming what the calling tool needs, since only a redirect resolves one. A school link is accepted on the company side, because `/company/<school-slug>` 301-redirects to `/school/<slug>`.

Two behaviour changes worth naming. `me` is now refused as a person reference in every form, not only as a URL: LinkedIn resolves `/in/me/` to the signed-in member, so a lookup that meant somebody else answered about the operator while reporting another person. The message points at `get_my_profile`. And validation failures raise a new `InvalidReferenceError` that `error_handler.py` answers without the issue-report template, because a wrong argument is not a bug to file and the template buried the correction the message already carried.

The tool argument descriptions now say a full URL is accepted, so the model stops paying for a failed navigation first.

The parser is judged against a conforming one rather than against intuition, because two review rounds in a row found it reading a different page than a browser would. A backslash is a path separator for http(s) and `urlparse` is not, so `/in/alice/x\..\..\..\in\bob` read as Alice while a conforming parser resolves it to Bob; that guard stops at the first `?` or `#`, since a backslash in a tracking parameter changes nothing. An explicit port was read and dropped, turning `linkedin.com:444/in/x`, which times out, into the live profile; a port is now judged against the default its own scheme reaches. A job URL carries its id after a title slug, which is the form an address bar holds, and only the bare numeric one was accepted. A differential sweep of 6.7 million generated addresses against that parser closed with 93,704 of 93,708 accepted inputs agreeing on route and segment, and the four that did not are fixed above.

Two forms stay refused rather than canonicalized: a host carrying percent-encoded characters, and a scheme written with the wrong number of slashes. Both are safe to refuse, since the caller gets a correction instead of a wrong page.

Verified with `uv run pytest` (2134 passed), `uv run ruff check`, `uv run ty check`, and by deleting the wiring from individual methods to confirm the new tests fail without it.

## Synthetic prompt

> `linkedin_username` and `company_name` are interpolated into the LinkedIn URL raw, so a pasted profile URL never resolves and a value containing `../` navigates somewhere else. Add a shared normalizer in `scraping/` that reduces a LinkedIn reference to its public identifier or company slug, refuses anything that can be neither, and percent-escapes the result as a single path segment. Escaping is not sufficient on its own: refuse exact dot segments, malformed escapes, a second encoding layer, and the `me` alias in every form. Cover every link form LinkedIn actually serves (locale and mobile subdomains, missing scheme, mwlite wrappers, tracking params, sub-pages, lnkd.in short links). Apply it at every URL-building call site in `scraping/extractor.py` and `tools/company.py`, including `job_id` and `thread_id`, give validation failures their own exception so `error_handler.py` stops attaching an issue-report template, update the affected tool argument descriptions, and add tests that fail when the wiring is removed from any single method.

Generated with Claude Opus 5, reviewed with GPT-5.6 Sol (xhigh reasoning) and Greptile


