### PR TITLE
fix(references): Read the job id from a slugged URL

### DIFF
--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -123,7 +123,13 @@ _CONNECTIONS_FOLLOW_RE = re.compile(r"\bconnections follow this page\b", re.IGNO
 _COMPANY_PATH_RE = re.compile(r"^/company/([^/?#]+)")
 _PERSON_PATH_RE = re.compile(r"^/in/([^/?#]+)")
 _SCHOOL_PATH_RE = re.compile(r"^/school/([^/?#]+)")
-JOB_PATH_RE = re.compile(r"^/jobs/view/(\d+)")
+# LinkedIn serves a job under both /jobs/view/<id>/ and
+# /jobs/view/<title>-at-<company>-<id>/, and both 301 to the same page, so the
+# id is the trailing number of the segment rather than its start. Anchoring to
+# the start dropped the slugged form, and matched the wrong number whenever a
+# title opened with one: "2026-software-engineer-at-acme-4252026496" read as
+# job 2026. Same shape as the pattern the job-id extraction uses.
+JOB_PATH_RE = re.compile(r"^/jobs/view/(?:[^/?#]*-)?(\d+)(?=[/?#]|$)")
 _NEWSLETTER_PATH_RE = re.compile(r"^/newsletters/([^/?#]+)")
 _PULSE_PATH_RE = re.compile(r"^/pulse/([^/?#]+)")
 _FEED_PATH_RE = re.compile(r"^/feed/update/([^/?#]+)")

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -128,8 +128,12 @@ _SCHOOL_PATH_RE = re.compile(r"^/school/([^/?#]+)")
 # id is the trailing number of the segment rather than its start. Anchoring to
 # the start dropped the slugged form, and matched the wrong number whenever a
 # title opened with one: "2026-software-engineer-at-acme-4252026496" read as
-# job 2026. Same shape as the pattern the job-id extraction uses.
-JOB_PATH_RE = re.compile(r"^/jobs/view/(?:[^/?#]*-)?(\d+)(?=[/?#]|$)")
+# job 2026. Same shape as the pattern the job-id extraction uses, with one
+# difference that has to stay: `[0-9]` and not `\d`, because Python's `\d`
+# also matches Arabic-Indic and other Unicode decimal digits while
+# JavaScript's does not, and `normalize_job_id` refuses anything outside
+# `[0-9]`. Matching them here only produces a reference the next call rejects.
+JOB_PATH_RE = re.compile(r"^/jobs/view/(?:[^/?#]*-)?([0-9]+)(?=[/?#]|$)")
 _NEWSLETTER_PATH_RE = re.compile(r"^/newsletters/([^/?#]+)")
 _PULSE_PATH_RE = re.compile(r"^/pulse/([^/?#]+)")
 _FEED_PATH_RE = re.compile(r"^/feed/update/([^/?#]+)")

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -714,6 +714,34 @@ class TestBuildReferences:
 
 
 class TestClassifyLink:
+    def test_a_slugged_job_url_keeps_its_id(self):
+        """LinkedIn serves a job under a bare id and under a slugged path.
+
+        Both 301 to the same page, so the slugged form is just as real, and
+        anchoring the id to the front of the segment dropped it: the link
+        vanished from ``references`` entirely.
+        """
+        assert classify_link(
+            "https://www.linkedin.com/jobs/view/senior-ai-engineer-at-acme-1967281839/"
+        ) == ("job", "/jobs/view/1967281839/")
+
+    def test_a_title_opening_with_a_number_is_not_the_job_id(self):
+        """The quiet half of the same bug, and the worse one.
+
+        A title starting with a year matched the front anchor, so the link
+        was kept and pointed at a different job. A dropped reference is
+        visibly missing; this one looks like a result.
+        """
+        assert classify_link(
+            "https://www.linkedin.com/jobs/view/2026-software-engineer-at-acme-4252026496/"
+        ) == ("job", "/jobs/view/4252026496/")
+
+    def test_a_bare_job_url_is_unchanged(self):
+        assert classify_link("https://www.linkedin.com/jobs/view/1967281839/") == (
+            "job",
+            "/jobs/view/1967281839/",
+        )
+
     def test_messaging_thread_url(self):
         result = classify_link(
             "https://www.linkedin.com/messaging/thread/2-NjAwMDAyMDEtZWVh/"

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -736,6 +736,22 @@ class TestClassifyLink:
             "https://www.linkedin.com/jobs/view/2026-software-engineer-at-acme-4252026496/"
         ) == ("job", "/jobs/view/4252026496/")
 
+    def test_unicode_digits_are_not_a_job_id(self):
+        """Python's ``\\d`` matches more than JavaScript's does.
+
+        Arabic-Indic digits pass ``\\d`` here and fail it in the two
+        JavaScript copies of this pattern, and ``normalize_job_id`` accepts
+        only ``[0-9]``. Classifying such a link produces a reference whose
+        very next use raises, so the digits are ASCII on purpose.
+        """
+        assert (
+            classify_link(
+                "https://www.linkedin.com/jobs/view/\u0645\u0647\u0646\u062f\u0633-"
+                "\u0664\u0662\u0665\u0662\u0660\u0662\u0666\u0664\u0669\u0666/"
+            )
+            is None
+        )
+
     def test_a_bare_job_url_is_unchanged(self):
         assert classify_link("https://www.linkedin.com/jobs/view/1967281839/") == (
             "job",


### PR DESCRIPTION
Closes #753

LinkedIn serves the same job under `/jobs/view/1967281839/` and under `/jobs/view/senior-ai-engineer-at-acme-1967281839/`, and both 301 to the same destination, so the slugged form is just as real. `classify_link` anchored the id to the front of the path segment, which loses it.

Two failure modes, and the second is the one worth the fix: a slugged link produced no reference at all, and a title opening with a year produced a *wrong* one, because `2026-software-engineer-at-acme-4252026496` matched as job `2026`. A missing reference is visibly missing; a wrong one looks like a result and points a follow-up call at a different job. The pattern now matches the trailing number of the segment, the same shape job-id extraction already uses.

Verified by mutation: restoring the front anchor fails both new cases and leaves the bare-id case green.

## Synthetic prompt

> `classify_link` drops job references for slugged `/jobs/view/<title>-<id>/` URLs and returns a wrong id when the title starts with a number. Fix the pattern to match what the job-id extraction already does, and pin both failure modes.

Generated with Claude Opus 5 (high) + Sol 5.6 (xhigh)
