### PR TITLE
fix(jobs): Follow the saved-jobs redirect, drop a stray page

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4036,8 +4036,17 @@ class LinkedInExtractor:
                 # LinkedIn makes on purpose, so comparing against the URL that
                 # was asked for finds a difference on every ordinary failure
                 # and waits out a chain that is not running.
+                #
+                # No document baseline, so every hop counts. One is taken
+                # before the search scroll, where the page is already loaded
+                # and the only navigation to expect is one going wrong. Here
+                # the block opens before this page's own navigation, so a
+                # reading from the top belongs to the document that was left
+                # and would call every ordinary failure a replacement. `None`
+                # says so, and settling costs a moment on a path that has
+                # already failed.
                 try:
-                    await self._settle_navigation(hops)
+                    await self._settle_navigation(hops, None)
                 except Exception:
                     logger.debug(
                         "Could not settle the route after a saved-jobs failure",

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4200,9 +4200,10 @@ class LinkedInExtractor:
                     or parsed_url.path.rstrip("/") not in _SAVED_JOBS_PATHS
                 ):
                     logger.debug(
-                        "Unexpected page URL after saved-jobs extraction: %s — "
-                        "skipping job ID extraction",
+                        "Unexpected page URL after saved-jobs extraction: %s "
+                        "(requested %s) — skipping job ID extraction",
                         self._page.url,
+                        url,
                     )
                     # The page is dropped whole. Keeping its text and
                     # references put a stranger's page under `saved_jobs`
@@ -4211,11 +4212,35 @@ class LinkedInExtractor:
                     # of, because an empty result with nothing beside it is
                     # what an account with nothing saved looks like.
                     # Classified first, so an expired session reaches the
-                    # relogin path instead of a diagnostic.
-                    await self._raise_if_auth_barrier(url)
+                    # relogin path instead of a diagnostic. Against the page
+                    # that answered, because that is where the barrier is; the
+                    # address that was asked for is on the line above.
+                    await self._raise_if_auth_barrier(self._page.url)
                     raise RuntimeError(
                         f"Saved jobs navigation ended on {self._page.url}"
                     )
+
+                # An offset that did not survive the navigation means this
+                # is the first page again, and reading it a second time
+                # appends the whole list to itself under `saved_jobs` before
+                # the no-new-ids branch stops the loop. Measured on
+                # 2026-08-21: `/jobs-tracker/?start=10` lands on
+                # `/jobs-tracker/`, and so does the old route, so the offset
+                # is gone from the list rather than from one address for it.
+                # Judged from where the page landed and not from that
+                # measurement, so an account still served the old route keeps
+                # paginating.
+                landed_start = parse_qs(urlparse(self._page.url).query).get(
+                    "start", ["0"]
+                )[0]
+                if landed_start != str(page_num * _SAVED_JOBS_PAGE_SIZE):
+                    logger.debug(
+                        "Saved-jobs offset %d did not survive navigation "
+                        "(landed on %s), stopping",
+                        page_num * _SAVED_JOBS_PAGE_SIZE,
+                        self._page.url,
+                    )
+                    break
 
                 page_ids = await self._extract_job_ids()
                 new_ids = [jid for jid in page_ids if jid not in seen_ids]

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4287,6 +4287,9 @@ class LinkedInExtractor:
                         page_num * _SAVED_JOBS_PAGE_SIZE,
                         self._page.url,
                     )
+                    section_errors["saved_jobs"] = dropped_offset_section_error(
+                        page_num * _SAVED_JOBS_PAGE_SIZE, self._page.url
+                    )
                     break
 
                 page_ids = await self._extract_job_ids()

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4002,42 +4002,58 @@ class LinkedInExtractor:
         section_name: str,
     ) -> ExtractedSection:
         """Extract innerText from a saved-jobs page with soft rate-limit retry."""
-        try:
-            result = await self._extract_saved_jobs_page_once(url, section_name)
-            if result.text != _RATE_LIMITED_MSG:
+        with self._watching_navigations() as hops:
+            try:
+                result = await self._extract_saved_jobs_page_once(url, section_name)
+                if result.text != _RATE_LIMITED_MSG:
+                    return result
+
+                logger.info(
+                    "Retrying saved jobs page %s after %.0fs backoff",
+                    url,
+                    _RATE_LIMIT_RETRY_DELAY,
+                )
+                await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
+                result = await self._extract_saved_jobs_page_once(url, section_name)
+                if result.text == _RATE_LIMITED_MSG:
+                    logger.warning(
+                        "Saved jobs page %s still rate-limited after retry", url
+                    )
                 return result
 
-            logger.info(
-                "Retrying saved jobs page %s after %.0fs backoff",
-                url,
-                _RATE_LIMIT_RETRY_DELAY,
-            )
-            await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
-            result = await self._extract_saved_jobs_page_once(url, section_name)
-            if result.text == _RATE_LIMITED_MSG:
-                logger.warning("Saved jobs page %s still rate-limited after retry", url)
-            return result
-
-        except LinkedInScraperException:
-            raise
-        except Exception as e:
-            logger.warning("Failed to extract saved jobs page %s: %s", url, e)
-            # A navigation destroys the scroll's execution context, and what
-            # waits behind it is a checkpoint as often as a layout change.
-            # Turning that into a section diagnostic hands the caller an empty
-            # list, leaves the browser registered and offers no relogin, so
-            # the next call meets the same barrier.
-            await self._raise_if_auth_barrier(self._page.url, navigation_error=e)
-            return ExtractedSection(
-                text="",
-                references=[],
-                error=build_issue_diagnostics(
-                    e,
-                    context="extract_saved_jobs_page",
-                    target_url=url,
-                    section_name=section_name,
-                ),
-            )
+            except LinkedInScraperException:
+                raise
+            except Exception as e:
+                logger.warning("Failed to extract saved jobs page %s: %s", url, e)
+                # A navigation destroys the scroll's execution context, and
+                # what waits behind it is a checkpoint as often as a layout
+                # change. Turning that into a section diagnostic hands the
+                # caller an empty list, leaves the browser registered and
+                # offers no relogin, so the next call meets the same barrier.
+                #
+                # Whether one happened is the listener's answer and not the
+                # address's: this list reaches `/jobs-tracker/` by a redirect
+                # LinkedIn makes on purpose, so comparing against the URL that
+                # was asked for finds a difference on every ordinary failure
+                # and waits out a chain that is not running.
+                try:
+                    await self._settle_navigation(hops)
+                except Exception:
+                    logger.debug(
+                        "Could not settle the route after a saved-jobs failure",
+                        exc_info=True,
+                    )
+                await self._raise_if_auth_barrier(self._page.url, navigation_error=e)
+                return ExtractedSection(
+                    text="",
+                    references=[],
+                    error=build_issue_diagnostics(
+                        e,
+                        context="extract_saved_jobs_page",
+                        target_url=url,
+                        section_name=section_name,
+                    ),
+                )
 
     async def _extract_saved_jobs_page_once(
         self,
@@ -4176,24 +4192,16 @@ class LinkedInExtractor:
                     url, section_name="saved_jobs"
                 )
 
-                if not extracted.text or extracted.text == _RATE_LIMITED_MSG:
-                    if extracted.text == _RATE_LIMITED_MSG:
-                        section_errors["saved_jobs"] = rate_limited_section_error()
-                    elif extracted.error:
-                        section_errors["saved_jobs"] = extracted.error
+                # Rate limit first: it is the more specific diagnosis, and a
+                # page that was throttled may carry a generic error too. Then
+                # the extraction error, which names what actually failed and
+                # would be masked by the route guard below.
+                if extracted.text == _RATE_LIMITED_MSG:
+                    section_errors["saved_jobs"] = rate_limited_section_error()
                     break
-
-                if not total_pages_queried:
-                    total_pages_queried = True
-                    try:
-                        total_pages = await self._get_total_list_pages()
-                    except Exception as e:
-                        logger.debug("Could not read saved-jobs page count: %s", e)
-                    else:
-                        if total_pages is not None:
-                            logger.debug(
-                                "LinkedIn reports %d saved-jobs pages", total_pages
-                            )
+                if extracted.error:
+                    section_errors["saved_jobs"] = extracted.error
+                    break
 
                 # Host and parsed path, like the job-search guard: a
                 # substring test accepts any origin that happens to serve
@@ -4232,6 +4240,23 @@ class LinkedInExtractor:
                     raise RuntimeError(
                         f"Saved jobs navigation ended on {self._page.url}"
                     )
+
+                if not extracted.text:
+                    # Nothing to read, and the page is the one that was asked
+                    # for: an account with nothing saved.
+                    break
+
+                if not total_pages_queried:
+                    total_pages_queried = True
+                    try:
+                        total_pages = await self._get_total_list_pages()
+                    except Exception as e:
+                        logger.debug("Could not read saved-jobs page count: %s", e)
+                    else:
+                        if total_pages is not None:
+                            logger.debug(
+                                "LinkedIn reports %d saved-jobs pages", total_pages
+                            )
 
                 # An offset that did not survive the navigation means this
                 # is the first page again, and reading it a second time

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4178,7 +4178,16 @@ class LinkedInExtractor:
                                 "LinkedIn reports %d saved-jobs pages", total_pages
                             )
 
-                if "/my-items/saved-jobs" not in self._page.url:
+                # Host and parsed path, like the job-search guard: a
+                # substring test accepts any origin that happens to serve
+                # this path, and an interstitial carrying a single
+                # /jobs/view/ anchor would come back as the account's saved
+                # jobs with no diagnostic beside it.
+                parsed_url = urlparse(self._page.url)
+                if (
+                    parsed_url.netloc != "www.linkedin.com"
+                    or parsed_url.path.rstrip("/") != "/my-items/saved-jobs"
+                ):
                     logger.debug(
                         "Unexpected page URL after saved-jobs extraction: %s — "
                         "skipping job ID extraction",

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4022,6 +4022,12 @@ class LinkedInExtractor:
             raise
         except Exception as e:
             logger.warning("Failed to extract saved jobs page %s: %s", url, e)
+            # A navigation destroys the scroll's execution context, and what
+            # waits behind it is a checkpoint as often as a layout change.
+            # Turning that into a section diagnostic hands the caller an empty
+            # list, leaves the browser registered and offers no relogin, so
+            # the next call meets the same barrier.
+            await self._raise_if_auth_barrier(self._page.url, navigation_error=e)
             return ExtractedSection(
                 text="",
                 references=[],
@@ -4055,6 +4061,13 @@ class LinkedInExtractor:
         await handle_modal_close(self._page)
         if main_found:
             await scroll_to_bottom(self._page, pause_time=0.5, max_scrolls=5)
+        else:
+            # A picker served in place of the list keeps the list's address
+            # and its title, so the route guard below sees an allowed page and
+            # the body fallback returns the picker under `saved_jobs`. Missing
+            # `<main>` is what is left, and an emptied list has none either,
+            # which is why the check decides it rather than the absence.
+            await self._raise_if_auth_barrier(self._page.url)
 
         # A picker served by a reload keeps this page's address and this
         # page's title, so the route guard reads it as the list. Nothing else

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -311,6 +311,10 @@ _SCROLL_BUDGET_TOTAL = 60.0
 _SEARCH_TIMEOUT_FRACTION = 0.8
 
 _SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
+# Where a saved-jobs navigation may legitimately end. LinkedIn redirects the
+# first to the second and drops the query doing so, so the tool navigates to
+# one and arrives at the other.
+_SAVED_JOBS_PATHS = frozenset({"/my-items/saved-jobs", "/jobs-tracker"})
 
 # The my-items lists page in 10s, unlike job search. Verified live: ?start=10
 # returns the 11th saved job, while ?start=25 lands past the end of a two-page
@@ -4182,21 +4186,36 @@ class LinkedInExtractor:
                 # substring test accepts any origin that happens to serve
                 # this path, and an interstitial carrying a single
                 # /jobs/view/ anchor would come back as the account's saved
-                # jobs with no diagnostic beside it.
+                # jobs.
+                #
+                # Both destinations, because LinkedIn now answers
+                # /my-items/saved-jobs/ with a redirect to /jobs-tracker/ and
+                # drops the query on the way. Measured on 2026-08-21 against
+                # an authenticated profile, for the bare URL and for
+                # ?start=10 alike. The old route is kept because the redirect
+                # is a rollout and the server still navigates to it.
                 parsed_url = urlparse(self._page.url)
                 if (
                     parsed_url.netloc != "www.linkedin.com"
-                    or parsed_url.path.rstrip("/") != "/my-items/saved-jobs"
+                    or parsed_url.path.rstrip("/") not in _SAVED_JOBS_PATHS
                 ):
                     logger.debug(
                         "Unexpected page URL after saved-jobs extraction: %s — "
                         "skipping job ID extraction",
                         self._page.url,
                     )
-                    page_texts.append(extracted.text)
-                    if extracted.references:
-                        page_references.extend(extracted.references)
-                    break
+                    # The page is dropped whole. Keeping its text and
+                    # references put a stranger's page under `saved_jobs`
+                    # with the job links it happened to carry, which reads
+                    # as the account's own list. Raised and not broken out
+                    # of, because an empty result with nothing beside it is
+                    # what an account with nothing saved looks like.
+                    # Classified first, so an expired session reaches the
+                    # relogin path instead of a diagnostic.
+                    await self._raise_if_auth_barrier(url)
+                    raise RuntimeError(
+                        f"Saved jobs navigation ended on {self._page.url}"
+                    )
 
                 page_ids = await self._extract_job_ids()
                 new_ids = [jid for jid in page_ids if jid not in seen_ids]

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4873,6 +4873,74 @@ class TestGetSavedJobs:
         # Stops on the repeat page rather than exhausting max_pages
         assert mock_extract.await_count == 2
 
+    async def test_a_picker_without_main_is_an_auth_error(self, mock_page):
+        """The picker keeps the list's address, so the route guard clears it.
+
+        Served in place of the list it carries that page's URL and its title,
+        and the guard below compares exactly those. Missing `<main>` is what
+        is left, and an emptied list has none either, so the barrier check has
+        to decide it.
+        """
+        mock_page.url = "https://www.linkedin.com/jobs-tracker/"
+        mock_page.wait_for_selector = AsyncMock(
+            side_effect=PlaywrightTimeoutError("no main")
+        )
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                new_callable=AsyncMock,
+                return_value="account picker: #rememberme-div",
+            ),
+            pytest.raises(AuthenticationError, match="--login"),
+        ):
+            await extractor.get_saved_jobs(max_pages=1)
+
+    async def test_a_redirect_while_scrolling_the_list_is_an_auth_error(
+        self, mock_page
+    ):
+        """A navigation destroys the scroll's context, and that error is generic.
+
+        Turned straight into a section diagnostic it hands the caller an empty
+        list, leaves the browser registered and offers no relogin, so the next
+        call meets the same checkpoint.
+        """
+        mock_page.url = "https://www.linkedin.com/jobs-tracker/"
+
+        async def redirect(page, **kwargs):
+            mock_page.url = "https://www.linkedin.com/checkpoint/challenge/"
+            raise RuntimeError("Execution context was destroyed")
+
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                side_effect=redirect,
+            ),
+            pytest.raises(AuthenticationError, match="--login"),
+        ):
+            await extractor.get_saved_jobs(max_pages=1)
+
     async def test_a_dropped_offset_stops_the_list(self, mock_page):
         """The redirect keeps the path and loses the query.
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4672,6 +4672,45 @@ class TestGetSavedJobs:
         assert "saved_jobs" in result["sections"]
         assert result["url"] == "https://www.linkedin.com/my-items/saved-jobs/"
 
+    async def test_a_foreign_host_is_not_the_saved_jobs_list(self, mock_page):
+        """A substring test accepts any origin serving this path.
+
+        An interstitial or captive portal carrying a single `/jobs/view/`
+        anchor would then come back as the account's saved jobs, with no
+        `section_errors` to say otherwise, which is a stranger's page
+        presented as the user's own list.
+        """
+        mock_page.url = "https://interstitial.example/my-items/saved-jobs/"
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Captive portal"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["999"],
+            ) as ids,
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=1)
+
+        assert result["job_ids"] == []
+        ids.assert_not_called()
+
     async def test_returns_references(self, mock_page):
         """References are keyed by the section name, per the return contract."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 
 import asyncio
 
+from patchright.async_api import Error as PatchrightError
 from patchright.async_api import TimeoutError as PlaywrightTimeoutError
 
 import pytest
@@ -4400,6 +4401,24 @@ class TestSettleNavigation:
 
         return sleep
 
+    async def test_a_destroyed_context_reads_as_no_document(self, mock_page):
+        """A navigation in flight takes the context the reading needs with it.
+
+        The class patchright raises for that is `Error`, measured, and not a
+        `RuntimeError`. A handler narrowed to the latter would turn the
+        ordinary case this reading exists for into an unhandled exception,
+        so the double is held to the real class.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(
+            side_effect=PatchrightError(
+                "Page.evaluate: Execution context was destroyed, "
+                "most likely because of a navigation."
+            )
+        )
+
+        assert await extractor._document_origin() is None
+
     async def test_a_page_going_nowhere_costs_the_lag_and_not_the_quiet(
         self, mock_page
     ):
@@ -4926,7 +4945,13 @@ class TestGetSavedJobs:
                 navigate(mock_page, "https://www.linkedin.com/checkpoint/challenge/")
 
             asyncio.get_running_loop().create_task(land())
-            raise RuntimeError("Execution context was destroyed")
+            # The class patchright raises for this, measured: an `Error`,
+            # not a `RuntimeError`. Keeping the double on the real one stops
+            # a handler from being narrowed to a class that never arrives.
+            raise PatchrightError(
+                "Page.evaluate: Execution context was destroyed, "
+                "most likely because of a navigation."
+            )
 
         extractor = LinkedInExtractor(mock_page)
         with (

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4918,7 +4918,14 @@ class TestGetSavedJobs:
         mock_page.url = "https://www.linkedin.com/jobs-tracker/"
 
         async def redirect(page, **kwargs):
-            mock_page.url = "https://www.linkedin.com/checkpoint/challenge/"
+            # The address lands after the raise, which is what `page.url` does:
+            # measured 20 times out of 20, the URL sampled the moment an
+            # evaluate is destroyed is still the page that was left.
+            async def land() -> None:
+                await asyncio.sleep(0.05)
+                navigate(mock_page, "https://www.linkedin.com/checkpoint/challenge/")
+
+            asyncio.get_running_loop().create_task(land())
             raise RuntimeError("Execution context was destroyed")
 
         extractor = LinkedInExtractor(mock_page)
@@ -4940,6 +4947,66 @@ class TestGetSavedJobs:
             pytest.raises(AuthenticationError, match="--login"),
         ):
             await extractor.get_saved_jobs(max_pages=1)
+
+    async def test_a_blank_foreign_page_is_not_an_empty_list(self, mock_page):
+        """An empty page returned before the route is judged says nothing.
+
+        A captive portal or interstitial that renders no text broke the loop
+        ahead of the guard, so the call came back with no sections, no ids and
+        no `section_errors`, which is exactly what an account with nothing
+        saved looks like.
+        """
+        mock_page.url = "https://interstitial.example/blank"
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=1)
+
+        assert result["job_ids"] == []
+        assert "saved_jobs" in result["section_errors"]
+
+    async def test_an_empty_list_is_still_an_empty_list(self, mock_page):
+        """An account with nothing saved renders nothing, and that is not an error."""
+        mock_page.url = "https://www.linkedin.com/jobs-tracker/"
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=1)
+
+        assert result["job_ids"] == []
+        assert "section_errors" not in result
 
     async def test_a_dropped_offset_stops_the_list(self, mock_page):
         """The redirect keeps the path and loses the query.

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5050,6 +5050,11 @@ class TestGetSavedJobs:
         assert result["job_ids"] == ["100", "200"]
         assert result["sections"]["saved_jobs"] == "the list"
         assert mock_extract.await_count == 2
+        # An account with eleven saved jobs gets ten and no sign of the rest,
+        # which is exactly what an account with ten saved jobs gets.
+        assert (
+            result["section_errors"]["saved_jobs"]["error_type"] == "pagination_stopped"
+        )
 
     async def test_stops_at_total_pages(self, mock_page):
         """The pager's page count caps pagination below max_pages."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4709,6 +4709,9 @@ class TestGetSavedJobs:
             result = await extractor.get_saved_jobs(max_pages=1)
 
         assert result["job_ids"] == []
+        assert "saved_jobs" not in result["sections"]
+        assert "references" not in result
+        assert "saved_jobs" in result["section_errors"]
         ids.assert_not_called()
 
     async def test_returns_references(self, mock_page):
@@ -4929,11 +4932,52 @@ class TestGetSavedJobs:
         assert result["sections"]["saved_jobs"] == "first page"
         assert result["section_errors"]["saved_jobs"]["error_type"] == "rate_limit"
 
-    async def test_url_redirect_skips_id_extraction(self, mock_page):
-        """A redirect away from the list captures the landing page, no IDs.
+    async def test_the_jobs_tracker_redirect_is_the_list(self, mock_page):
+        """LinkedIn answers the saved-jobs URL with a redirect now.
 
-        Mirrors ``search_jobs``: the text is kept deliberately so the caller
-        can see what LinkedIn served instead (e.g. a login wall).
+        Measured on 2026-08-21 against an authenticated profile:
+        ``/my-items/saved-jobs/`` lands on ``/jobs-tracker/``, and the query
+        is dropped on the way, for ``?start=10`` as well. Refusing that
+        destination makes every call return an empty list for every account,
+        which is indistinguishable from having nothing saved.
+        """
+        mock_page.url = "https://www.linkedin.com/jobs-tracker/"
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Saved Job 1"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=1)
+
+        assert result["job_ids"] == ["111"]
+        assert result["sections"]["saved_jobs"] == "Saved Job 1"
+
+    async def test_a_login_redirect_raises_an_auth_error(self, mock_page):
+        """A redirect to the login wall is an expired session, not a result.
+
+        Mirrors ``search_jobs``. Returning the login page's text under
+        `saved_jobs` left the dead browser registered and offered no
+        relogin, so the next call walked into the same wall.
         """
         extractor = LinkedInExtractor(mock_page)
         mock_page.url = "https://www.linkedin.com/uas/login"
@@ -4961,12 +5005,54 @@ class TestGetSavedJobs:
                 new_callable=AsyncMock,
             ),
         ):
-            result = await extractor.get_saved_jobs(max_pages=2)
+            with pytest.raises(AuthenticationError, match="--login"):
+                await extractor.get_saved_jobs(max_pages=2)
 
         # Never mine IDs off a page that is not the saved-jobs list.
         mock_ids.assert_not_awaited()
+
+    async def test_a_plain_redirect_is_reported_not_returned(self, mock_page):
+        """Anything else that is not the list is dropped and diagnosed.
+
+        Keeping the landing page's text and its references handed a
+        stranger's page back under `saved_jobs`, carrying whatever job links
+        it happened to hold. An empty result with nothing beside it is not
+        an option either: that is what an account with nothing saved looks
+        like.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.url = "https://www.linkedin.com/feed/"
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Some other page"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["999"],
+            ) as mock_ids,
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=2)
+
+        mock_ids.assert_not_awaited()
         assert result["job_ids"] == []
-        assert result["sections"]["saved_jobs"] == "Login page content"
+        assert "saved_jobs" not in result["sections"]
+        assert "references" not in result
+        assert "saved_jobs" in result["section_errors"]
 
 
 class TestSingleSectionRateLimits:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4640,6 +4640,22 @@ class TestGetSavedJobs:
     def _set_saved_jobs_url(self, mock_page):
         mock_page.url = "https://www.linkedin.com/my-items/saved-jobs/"
 
+    @staticmethod
+    def _navigating(mock_page, texts, *, lands_on=None):
+        """A page double that moves `page.url` the way a navigation does.
+
+        Leaving it fixed makes every page look like the first one, which is
+        the very thing the offset check reads. `lands_on` is the address
+        LinkedIn answers with, for a redirect that does not keep the offset.
+        """
+        supply = iter(texts)
+
+        async def navigate(url, *args, **kwargs):
+            mock_page.url = lands_on or url
+            return next(supply)
+
+        return navigate
+
     async def test_returns_job_ids(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         with (
@@ -4753,14 +4769,14 @@ class TestGetSavedJobs:
     async def test_page_texts_joined_with_separator(self, mock_page):
         """Multi-page text is joined so the caller can tell pages apart."""
         extractor = LinkedInExtractor(mock_page)
-        texts = iter([extracted("page one"), extracted("page two")])
         id_pages = iter([["100"], ["200"]])
         with (
             patch.object(
                 extractor,
                 "_extract_saved_jobs_page",
-                new_callable=AsyncMock,
-                side_effect=lambda *a, **kw: next(texts),
+                side_effect=self._navigating(
+                    mock_page, [extracted("page one"), extracted("page two")]
+                ),
             ),
             patch.object(
                 extractor,
@@ -4789,9 +4805,11 @@ class TestGetSavedJobs:
         id_pages = iter([["100", "200"], ["300"], ["400"]])
         urls_visited: list[str] = []
 
+        navigate = self._navigating(mock_page, [extracted("page text")] * 3)
+
         async def mock_extract(url, *args, **kwargs):
             urls_visited.append(url)
-            return extracted("page text")
+            return await navigate(url)
 
         with (
             patch.object(
@@ -4830,8 +4848,7 @@ class TestGetSavedJobs:
             patch.object(
                 extractor,
                 "_extract_saved_jobs_page",
-                new_callable=AsyncMock,
-                return_value=extracted("text"),
+                side_effect=self._navigating(mock_page, [extracted("text")] * 2),
             ) as mock_extract,
             patch.object(
                 extractor,
@@ -4856,6 +4873,49 @@ class TestGetSavedJobs:
         # Stops on the repeat page rather than exhausting max_pages
         assert mock_extract.await_count == 2
 
+    async def test_a_dropped_offset_stops_the_list(self, mock_page):
+        """The redirect keeps the path and loses the query.
+
+        Measured on 2026-08-21: `/jobs-tracker/?start=10` lands on
+        `/jobs-tracker/`, so the second request is served the first page.
+        Reading it appends the whole list to itself under `saved_jobs` before
+        the no-new-ids branch stops the loop, and every further offset costs
+        another navigation for the same page.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_saved_jobs_page",
+                side_effect=self._navigating(
+                    mock_page,
+                    [extracted("the list")] * 3,
+                    lands_on="https://www.linkedin.com/jobs-tracker/",
+                ),
+            ) as mock_extract,
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["100", "200"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_list_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_saved_jobs(max_pages=3)
+
+        assert result["job_ids"] == ["100", "200"]
+        assert result["sections"]["saved_jobs"] == "the list"
+        assert mock_extract.await_count == 2
+
     async def test_stops_at_total_pages(self, mock_page):
         """The pager's page count caps pagination below max_pages."""
         extractor = LinkedInExtractor(mock_page)
@@ -4864,8 +4924,7 @@ class TestGetSavedJobs:
             patch.object(
                 extractor,
                 "_extract_saved_jobs_page",
-                new_callable=AsyncMock,
-                return_value=extracted("text"),
+                side_effect=self._navigating(mock_page, [extracted("text")] * 3),
             ) as mock_extract,
             patch.object(
                 extractor,


### PR DESCRIPTION
The guard deciding whether a page is still the saved-jobs list was `"/my-items/saved-jobs" not in self._page.url`, a substring test on the whole URL, and it carried two defects.

Any origin serving that path passed it, so a captive portal or proxy interstitial holding a single `/jobs/view/` anchor came back as the account's own saved jobs. On a mismatch the landing page's text and references were appended anyway, so even the rejected page reached the caller under `saved_jobs`. It also pinned a route LinkedIn no longer serves: measured on 2026-08-21 against an authenticated profile, `/my-items/saved-jobs/` redirects to `/jobs-tracker/` and drops the query doing so, for `?start=10` as well, so the guard refused the destination for every account on every call and `get_saved_jobs` returned an empty list with no diagnostic.

Host and parsed path are compared now, against both destinations. A page that is neither is dropped whole and raised rather than returned, because an empty result with nothing beside it is exactly what an account with nothing saved looks like; a login redirect is classified first so an expired session reaches the relogin path instead of a section error. Each of the four properties is pinned by a test that fails when it is mutated out.

Measured end to end against a live account with one saved job, on the branch and on its base:

| | `job_ids` | `section_errors` | returned text |
| --- | --- | --- | --- |
| base | `[]` | none | `Saved · 1` |
| branch | `['4440190409']` | none | `Saved · 1` |

The base returns an empty list with nothing beside it while the page it just read says one job is saved, which a caller cannot tell from an account that has saved nothing. It also returned that job as a `references` entry with no matching id, because the rejected page's references were appended anyway.

The dropped query has a second consequence. `?start=10` reaches the same first page, so the loop read it again, appended its text to itself under `saved_jobs`, and only then stopped on the repeated ids. `/jobs-tracker/?start=10` lands on `/jobs-tracker/` too, so this is not a redirect losing the offset on the way to a route that still honours it: offset pagination of the saved list is gone. The offset is read back from where the page landed, so an account still served the old route pages as before and one whose offset did not survive stops at the page it has. Reaching page two needs the list scrolled, which is #764.

Three existing tests failed on this and none of them failed on the code: their page doubles left `page.url` fixed, so every page looked like the first one, which is what the check reads. The doubles navigate now.

A picker served in place of the list clears the guard, because it carries that page's address and that page's title and the guard compares exactly those. Missing `<main>` is what is left of it, so the barrier check decides that shape rather than the absence, an emptied list having none either. A navigation during the list scroll destroys the evaluation context, and that error is generic: turned straight into a section diagnostic it handed the caller an empty list, left the browser registered and offered no relogin, so the next call met the same checkpoint. That check waits for the browser's own navigation signal first, because the address cannot answer: this list reaches `/jobs-tracker/` by a redirect LinkedIn makes on purpose, so comparing against the URL that was asked for finds a difference on every ordinary failure and waits out a chain that is not running. And the guard runs before the empty-text branch, or a blank interstitial comes back as no sections, no ids and no errors, which is what an account with nothing saved looks like.

## Synthetic prompt

> The `get_saved_jobs` route guard is a substring test on the URL, it keeps the rejected page's text and references, and the route it pins now redirects elsewhere. Measure where the saved-jobs URL actually lands, compare host and parsed path against both destinations, drop and report a page that is neither, and pin each property with a test.

Generated with Claude Opus 5 (high) + Sol 5.6 (xhigh)





