### PR TITLE
chore: Bump version to 4.23.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-linkedin"
-version = "4.22.0"
+version = "4.23.0"
 description = "MCP server that gives AI assistants like Claude access to LinkedIn profiles, companies, and job postings through the user's own browser session."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-linkedin"
-version = "4.22.0"
+version = "4.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Routine version bump for the release workflow.

Since v4.22.0: the browser install shows download progress (#565), a profile reference is normalized and escaped before it reaches the URL (#749), the Docker image build backend is pinned (#728), and the README and Docker Hub page lost their viewer internals (#745, #746).