### PR TITLE
feat(registry): Prepare MCP Registry publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,29 +194,18 @@ jobs:
           PY
           echo "✅ Updated server.json to version $VERSION"
 
-      # A rewrite that leaves a file unparseable is the failure the text checks
-      # below cannot see, so the real parsers go first. `--no-interpolate`
-      # because this asks whether the repository's file is well formed, not
-      # whether the runner happens to hold the operator's environment: a compose
-      # file referring to `${SESSION_DIR}` is valid and would fail without it.
-      - name: Verify the rewritten files still parse
-        run: |
-          set -e
-          python3 -c 'import json; json.load(open("manifest.json"))'
-          python3 -c 'import json; json.load(open("server.json"))'
-          docker compose -f docker-compose.yml config --no-interpolate --quiet
-          docker compose -f docker-compose.yml config --no-interpolate \
-            --format json > /tmp/compose.json
-          echo "✅ manifest.json, server.json and docker-compose.yml still parse"
-
-      # sed matches nothing and still exits 0, so a reformatted manifest.json
-      # would sail through the steps above and ship an MCPB whose own manifest
-      # still advertises the previous release. The tests notice on the next pull
-      # request; the artefacts are published before that. Ask every file that
-      # carries the version, here, once.
+      # The rewrites above are text edits that report success whatever they
+      # matched, so this asks every file that carries the version what it now
+      # says. Rendering the compose file is also what proves it still parses;
+      # a JSON load does the same for the other two, which is why there is one
+      # gate here and not two. `--no-interpolate` because this asks whether the
+      # repository's file is well formed, not whether the runner happens to
+      # hold the operator's environment.
       - name: Verify the versioned files agree
         run: |
           set -e
+          docker compose -f docker-compose.yml config --no-interpolate \
+            --format json > /tmp/compose.json
           python3 - "$VERSION" <<'PY'
           import json
           import sys
@@ -225,44 +214,54 @@ jobs:
 
           version = sys.argv[1]
           server = json.loads(Path("server.json").read_text(encoding="utf-8"))
+          manifest = json.loads(Path("manifest.json").read_text(encoding="utf-8"))
           project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
           name = project["project"]["name"]
+          image = next(
+              p["identifier"] for p in server["packages"]
+              if p["registryType"] == "oci"
+          )
+          repository = image.rpartition(":")[0].removeprefix("docker.io/")
+
+          def tag(reference: str) -> str:
+              return reference.rpartition(":")[2]
 
           # The resolved services rather than the file's text. A commented-out
           # image reference is matched by any regex over the source and blessed
           # a compose file whose live service named something else entirely.
+          # `docker.io/` is the same repository written out, and compose accepts
+          # both spellings.
           compose = json.loads(Path("/tmp/compose.json").read_text(encoding="utf-8"))
           images = [
               service["image"]
               for service in compose.get("services", {}).values()
-              if service.get("image", "").startswith("stickerdaniel/")
+              if service.get("image", "").removeprefix("docker.io/").startswith(
+                  repository
+              )
           ]
 
           # uv.lock carries the project's own version a second time, and `uv
           # lock --check` fails on a release built past a stale one.
           lock = tomllib.loads(Path("uv.lock").read_text(encoding="utf-8"))
-          locked = [
-              package["version"]
-              for package in lock.get("package", [])
-              if package.get("name") == name
-          ]
 
           found = {
               "pyproject.toml": [project["project"]["version"]],
-              "uv.lock": locked,
-              "manifest.json": [
-                  json.loads(Path("manifest.json").read_text(encoding="utf-8"))["version"]
+              "uv.lock": [
+                  package["version"]
+                  for package in lock.get("package", [])
+                  if package.get("name") == name
               ],
+              "manifest.json": [manifest["version"]],
               "server.json": [server["version"]],
               "server.json (pypi)": [
                   p["version"] for p in server["packages"]
                   if p["registryType"] == "pypi"
               ],
               "server.json (oci)": [
-                  p["identifier"].rpartition(":")[2] for p in server["packages"]
+                  tag(p["identifier"]) for p in server["packages"]
                   if p["registryType"] == "oci"
               ],
-              "docker-compose.yml": [i.rpartition(":")[2] for i in images],
+              "docker-compose.yml": [tag(image) for image in images],
           }
           for site, values in found.items():
               if not values:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,10 @@ jobs:
         run: |
           set -e
           sed -i 's/"version": ".*"/"version": "'$VERSION'"/' manifest.json
-          sed -i 's/stickerdaniel\/linkedin-mcp-server:[^ ]*/stickerdaniel\/linkedin-mcp-server:'$VERSION'/' docker-compose.yml
+          # Stop at a quote as well as a space. `[^ ]*` swallowed the closing
+          # quote of a quoted image reference, which YAML then rejects and this
+          # step never notices, because sed reports success either way.
+          sed -i 's|stickerdaniel/linkedin-mcp-server:[^ "'"'"']*|stickerdaniel/linkedin-mcp-server:'$VERSION'|' docker-compose.yml
           echo "✅ Updated manifest.json and docker-compose.yml to version $VERSION"
 
       # server.json carries the version in three places, one of them inside an
@@ -212,8 +215,10 @@ jobs:
 
           # Every occurrence, not the first: a second image reference that the
           # rewrite missed is exactly what this step is here to catch.
+          # The same character class the rewrite above uses. Reading past the
+          # closing quote here would report a tag no file contains.
           tags = re.findall(
-              r"stickerdaniel/linkedin-mcp-server:(\S+)",
+              r"""stickerdaniel/linkedin-mcp-server:([^\s"']+)""",
               Path("docker-compose.yml").read_text(encoding="utf-8"),
           )
           if not tags:
@@ -243,6 +248,16 @@ jobs:
                       raise SystemExit(f"{name}: {value!r}, expected {version!r}")
           PY
           echo "✅ Every versioned file reads $VERSION"
+
+      # The check above reads these files as text, so it cannot see a rewrite
+      # that left one of them structurally broken. Ask the real parsers.
+      - name: Verify the rewritten files still parse
+        run: |
+          set -e
+          python3 -c 'import json; json.load(open("manifest.json"))'
+          python3 -c 'import json; json.load(open("server.json"))'
+          docker compose -f docker-compose.yml config --quiet
+          echo "✅ manifest.json, server.json and docker-compose.yml still parse"
 
       - name: Remove branch protection (temporary)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,41 @@ jobs:
           sed -i 's/stickerdaniel\/linkedin-mcp-server:[^ ]*/stickerdaniel\/linkedin-mcp-server:'$VERSION'/' docker-compose.yml
           echo "✅ Updated manifest.json and docker-compose.yml to version $VERSION"
 
+      # server.json carries the version in three places, one of them inside an
+      # image reference. sed would leave any it failed to match untouched and
+      # exit 0, which ships a registry entry pointing at a release that is not
+      # the one just built. This edits the parsed document and fails loudly
+      # instead. `tests/test_server_json.py` pins the output format, so the
+      # rewrite is a pure version change and never a reformat.
+      - name: Update server.json version
+        run: |
+          set -e
+          python3 - "$VERSION" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          version = sys.argv[1]
+          path = Path("server.json")
+          doc = json.loads(path.read_text(encoding="utf-8"))
+
+          doc["version"] = version
+          for package in doc["packages"]:
+              if package["registryType"] == "pypi":
+                  package["version"] = version
+              elif package["registryType"] == "oci":
+                  repository, _, _tag = package["identifier"].rpartition(":")
+                  package["identifier"] = f"{repository}:{version}"
+              else:
+                  raise SystemExit(
+                      f"unhandled registryType {package['registryType']!r}: "
+                      "teach this step how to version it"
+                  )
+
+          path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+          PY
+          echo "✅ Updated server.json to version $VERSION"
+
       - name: Remove branch protection (temporary)
         run: |
           gh api repos/${{ github.repository }}/branches/main/protection \
@@ -168,11 +203,11 @@ jobs:
           set -e
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add manifest.json docker-compose.yml
+          git add manifest.json docker-compose.yml server.json
           if git diff --staged --quiet; then
             echo "ℹ️ No changes to commit"
           else
-            git commit -m "chore: update manifest.json and docker-compose.yml to v$VERSION [skip ci]"
+            git commit -m "chore: sync versioned files to v$VERSION [skip ci]"
             git push origin main
             echo "✅ Committed version updates"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,17 +194,31 @@ jobs:
           PY
           echo "✅ Updated server.json to version $VERSION"
 
-      # sed matches nothing and still exits 0, so a reformatted manifest.json or
-      # docker-compose.yml would sail through the step above and ship an MCPB
-      # whose own manifest still advertises the previous release. The tests
-      # notice on the next pull request; the artefacts are published before
-      # that. Ask all four files what version they carry, here, once.
+      # A rewrite that leaves a file unparseable is the failure the text checks
+      # below cannot see, so the real parsers go first. `--no-interpolate`
+      # because this asks whether the repository's file is well formed, not
+      # whether the runner happens to hold the operator's environment: a compose
+      # file referring to `${SESSION_DIR}` is valid and would fail without it.
+      - name: Verify the rewritten files still parse
+        run: |
+          set -e
+          python3 -c 'import json; json.load(open("manifest.json"))'
+          python3 -c 'import json; json.load(open("server.json"))'
+          docker compose -f docker-compose.yml config --no-interpolate --quiet
+          docker compose -f docker-compose.yml config --no-interpolate \
+            --format json > /tmp/compose.json
+          echo "✅ manifest.json, server.json and docker-compose.yml still parse"
+
+      # sed matches nothing and still exits 0, so a reformatted manifest.json
+      # would sail through the steps above and ship an MCPB whose own manifest
+      # still advertises the previous release. The tests notice on the next pull
+      # request; the artefacts are published before that. Ask every file that
+      # carries the version, here, once.
       - name: Verify the versioned files agree
         run: |
           set -e
           python3 - "$VERSION" <<'PY'
           import json
-          import re
           import sys
           import tomllib
           from pathlib import Path
@@ -212,20 +226,30 @@ jobs:
           version = sys.argv[1]
           server = json.loads(Path("server.json").read_text(encoding="utf-8"))
           project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          name = project["project"]["name"]
 
-          # Every occurrence, not the first: a second image reference that the
-          # rewrite missed is exactly what this step is here to catch.
-          # The same character class the rewrite above uses. Reading past the
-          # closing quote here would report a tag no file contains.
-          tags = re.findall(
-              r"""stickerdaniel/linkedin-mcp-server:([^\s"']+)""",
-              Path("docker-compose.yml").read_text(encoding="utf-8"),
-          )
-          if not tags:
-              raise SystemExit("docker-compose.yml: no image reference found")
+          # The resolved services rather than the file's text. A commented-out
+          # image reference is matched by any regex over the source and blessed
+          # a compose file whose live service named something else entirely.
+          compose = json.loads(Path("/tmp/compose.json").read_text(encoding="utf-8"))
+          images = [
+              service["image"]
+              for service in compose.get("services", {}).values()
+              if service.get("image", "").startswith("stickerdaniel/")
+          ]
+
+          # uv.lock carries the project's own version a second time, and `uv
+          # lock --check` fails on a release built past a stale one.
+          lock = tomllib.loads(Path("uv.lock").read_text(encoding="utf-8"))
+          locked = [
+              package["version"]
+              for package in lock.get("package", [])
+              if package.get("name") == name
+          ]
 
           found = {
               "pyproject.toml": [project["project"]["version"]],
+              "uv.lock": locked,
               "manifest.json": [
                   json.loads(Path("manifest.json").read_text(encoding="utf-8"))["version"]
               ],
@@ -238,26 +262,16 @@ jobs:
                   p["identifier"].rpartition(":")[2] for p in server["packages"]
                   if p["registryType"] == "oci"
               ],
-              "docker-compose.yml": tags,
+              "docker-compose.yml": [i.rpartition(":")[2] for i in images],
           }
-          for name, values in found.items():
+          for site, values in found.items():
               if not values:
-                  raise SystemExit(f"{name}: no version found; the rewrite missed it")
+                  raise SystemExit(f"{site}: no version found; the rewrite missed it")
               for value in values:
                   if value != version:
-                      raise SystemExit(f"{name}: {value!r}, expected {version!r}")
+                      raise SystemExit(f"{site}: {value!r}, expected {version!r}")
           PY
           echo "✅ Every versioned file reads $VERSION"
-
-      # The check above reads these files as text, so it cannot see a rewrite
-      # that left one of them structurally broken. Ask the real parsers.
-      - name: Verify the rewritten files still parse
-        run: |
-          set -e
-          python3 -c 'import json; json.load(open("manifest.json"))'
-          python3 -c 'import json; json.load(open("server.json"))'
-          docker compose -f docker-compose.yml config --quiet
-          echo "✅ manifest.json, server.json and docker-compose.yml still parse"
 
       - name: Remove branch protection (temporary)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,41 +203,44 @@ jobs:
           import json
           import re
           import sys
+          import tomllib
           from pathlib import Path
 
           version = sys.argv[1]
           server = json.loads(Path("server.json").read_text(encoding="utf-8"))
-          compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+          # Every occurrence, not the first: a second image reference that the
+          # rewrite missed is exactly what this step is here to catch.
+          tags = re.findall(
+              r"stickerdaniel/linkedin-mcp-server:(\S+)",
+              Path("docker-compose.yml").read_text(encoding="utf-8"),
+          )
+          if not tags:
+              raise SystemExit("docker-compose.yml: no image reference found")
 
           found = {
-              "pyproject.toml": re.search(
-                  r'^version = "(.+)"$',
-                  Path("pyproject.toml").read_text(encoding="utf-8"),
-                  re.MULTILINE,
-              ),
-              "manifest.json": json.loads(
-                  Path("manifest.json").read_text(encoding="utf-8")
-              )["version"],
-              "server.json": server["version"],
-              "server.json (pypi)": next(
+              "pyproject.toml": [project["project"]["version"]],
+              "manifest.json": [
+                  json.loads(Path("manifest.json").read_text(encoding="utf-8"))["version"]
+              ],
+              "server.json": [server["version"]],
+              "server.json (pypi)": [
                   p["version"] for p in server["packages"]
                   if p["registryType"] == "pypi"
-              ),
-              "server.json (oci)": next(
-                  p["identifier"] for p in server["packages"]
+              ],
+              "server.json (oci)": [
+                  p["identifier"].rpartition(":")[2] for p in server["packages"]
                   if p["registryType"] == "oci"
-              ).rpartition(":")[2],
-              "docker-compose.yml": re.search(
-                  r"stickerdaniel/linkedin-mcp-server:(\S+)", compose
-              ),
+              ],
+              "docker-compose.yml": tags,
           }
-          for name, value in found.items():
-              if value is None:
+          for name, values in found.items():
+              if not values:
                   raise SystemExit(f"{name}: no version found; the rewrite missed it")
-              if hasattr(value, "group"):
-                  value = value.group(1)
-              if value != version:
-                  raise SystemExit(f"{name}: {value!r}, expected {version!r}")
+              for value in values:
+                  if value != version:
+                      raise SystemExit(f"{name}: {value!r}, expected {version!r}")
           PY
           echo "✅ Every versioned file reads $VERSION"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,56 @@ jobs:
           PY
           echo "✅ Updated server.json to version $VERSION"
 
+      # sed matches nothing and still exits 0, so a reformatted manifest.json or
+      # docker-compose.yml would sail through the step above and ship an MCPB
+      # whose own manifest still advertises the previous release. The tests
+      # notice on the next pull request; the artefacts are published before
+      # that. Ask all four files what version they carry, here, once.
+      - name: Verify the versioned files agree
+        run: |
+          set -e
+          python3 - "$VERSION" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          version = sys.argv[1]
+          server = json.loads(Path("server.json").read_text(encoding="utf-8"))
+          compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+
+          found = {
+              "pyproject.toml": re.search(
+                  r'^version = "(.+)"$',
+                  Path("pyproject.toml").read_text(encoding="utf-8"),
+                  re.MULTILINE,
+              ),
+              "manifest.json": json.loads(
+                  Path("manifest.json").read_text(encoding="utf-8")
+              )["version"],
+              "server.json": server["version"],
+              "server.json (pypi)": next(
+                  p["version"] for p in server["packages"]
+                  if p["registryType"] == "pypi"
+              ),
+              "server.json (oci)": next(
+                  p["identifier"] for p in server["packages"]
+                  if p["registryType"] == "oci"
+              ).rpartition(":")[2],
+              "docker-compose.yml": re.search(
+                  r"stickerdaniel/linkedin-mcp-server:(\S+)", compose
+              ),
+          }
+          for name, value in found.items():
+              if value is None:
+                  raise SystemExit(f"{name}: no version found; the rewrite missed it")
+              if hasattr(value, "group"):
+                  value = value.group(1)
+              if value != version:
+                  raise SystemExit(f"{name}: {value!r}, expected {version!r}")
+          PY
+          echo "✅ Every versioned file reads $VERSION"
+
       - name: Remove branch protection (temporary)
         run: |
           gh api repos/${{ github.repository }}/branches/main/protection \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,14 +180,22 @@ gt create -m "chore: Bump version to X.Y.Z"
 gt submit                        # merge PR to trigger release workflow
 ```
 
-The CI release workflow automatically updates `manifest.json`, `docker-compose.yml` and `server.json` with the new version — do not update them manually.
+The CI release workflow automatically updates `manifest.json`, `docker-compose.yml` and `server.json` with the new version. Do not update them manually.
 
 After the workflow completes, file a PR against
-[`docker/mcp-registry`](https://github.com/docker/mcp-registry) moving
-`servers/linkedin-mcp-server/server.yaml` to the new image tag. Docker advances
-pins only for images in its own `mcp/` namespace (`cmd/ci/update_pins.go`), and
-this entry points at `stickerdaniel/linkedin-mcp-server`, so nothing there
-updates itself. Skipping it is why that entry sat on 1.4.0 for a year.
+[`docker/mcp-registry`](https://github.com/docker/mcp-registry) updating
+`servers/linkedin-mcp-server/server.yaml`. Docker's own sweep refreshes
+`source.commit` only, and only for images in its `mcp/` namespace
+(`cmd/ci/update_pins.go`); this entry names `stickerdaniel/linkedin-mcp-server`,
+so neither its tag nor its pin ever moves on its own. Skipping it is why that
+entry sat on 1.4.0 for a year.
+
+The first such PR is more than a tag: that entry still advertises a
+`LINKEDIN_COOKIE` secret and a `USER_AGENT` field for an authentication path
+this server no longer has, and `USER_AGENT` now refuses to start
+(`config/loaders.py`). It needs the session directory as a mount instead. Docker
+validates a changed entry by pulling the image and listing its tools over stdio,
+so the tag it moves to has to be a release where that works.
 
 `server.json` is a different registry: the official one at
 `registry.modelcontextprotocol.io`, which is a service reached through

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,14 +180,24 @@ gt create -m "chore: Bump version to X.Y.Z"
 gt submit                        # merge PR to trigger release workflow
 ```
 
-The CI release workflow automatically updates `manifest.json` and `docker-compose.yml` with the new version — do not update them manually.
+The CI release workflow automatically updates `manifest.json`, `docker-compose.yml` and `server.json` with the new version — do not update them manually.
 
-The workflow also keeps `server.json` in step with the bump. That file is the
-MCP Registry entry, and nothing in the release publishes it: this server has
-never been listed at `registry.modelcontextprotocol.io`. Publishing there is a
-maintainer decision rather than a release step, and taking it is one
-`mcp-publisher login github && mcp-publisher publish` against the file. There is
-no PR to file: the registry is a service, not a repository.
+After the workflow completes, file a PR against
+[`docker/mcp-registry`](https://github.com/docker/mcp-registry) moving
+`servers/linkedin-mcp-server/server.yaml` to the new image tag. Docker advances
+pins only for images in its own `mcp/` namespace (`cmd/ci/update_pins.go`), and
+this entry points at `stickerdaniel/linkedin-mcp-server`, so nothing there
+updates itself. Skipping it is why that entry sat on 1.4.0 for a year.
+
+`server.json` is a different registry: the official one at
+`registry.modelcontextprotocol.io`, which is a service reached through
+`mcp-publisher` and has no PR flow. This server has never been listed there.
+Publishing is a maintainer decision rather than a release step, and it cannot
+succeed before a release that carries the `mcp-name` token in `README.md` and
+the `io.modelcontextprotocol.server.name` label in the `Dockerfile`: ownership
+is proved against the *published* PyPI description and image config, so the
+markers have to ship first and no local edit can repair an artifact already on
+PyPI.
 
 ## Commit Messages
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,20 +212,18 @@ Docker MCP Gateway, which converts official-registry entries into its catalog.
 Neither is a reason to write the entry differently, and both are reasons not to
 promise that listing alone makes the server work everywhere.
 
-`buildSecrets` in `pkg/catalog/registry_to_catalog.go` keeps only a name and an
-environment variable, so an `isSecret` variable loses its optionality on the way
-in, and `pkg/gateway/mcpadd.go` then treats every converted secret as required.
-The three optional proxy credentials therefore read as missing for anyone who
-does not use a proxy, which is nearly everyone. Dropping `isSecret` would
-satisfy that check by declaring a password not to be one, and it would still not
-produce a working server, because of the next paragraph.
+An `isSecret` variable loses its optionality on the way in, because the catalog
+secret keeps only a name and an environment variable, and the add flow then
+treats every converted secret as required. The three optional proxy credentials
+therefore read as missing for anyone who does not use a proxy, which is nearly
+everyone.
 
-`pkg/gateway/docker_binds.go` allows host binds only under `/tmp`,
-`/private/tmp` and `/var/tmp`, and mounts anything it does allow read-only
-unless the exact source path is named in
-`MCP_GATEWAY_DOCKER_BIND_ALLOW_WRITABLE_PATHS`. The session directory is a
-writable home-directory path, so it needs that variable set by the operator, and
-no field in `server.json` can ask for it.
+A writable host bind needs the operator to name its exact path in
+`MCP_GATEWAY_DOCKER_BIND_ALLOW_WRITABLE_PATHS`. By default the gateway allows
+binds only under the temporary directories and mounts those read-only, and a
+separate variable widens the read-only set without making anything writable. The
+session directory has to be written to, and no field in `server.json` can ask
+for that.
 
 ## Commit Messages
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,26 @@ is proved against the *published* PyPI description and image config, so the
 markers have to ship first and no local edit can repair an artifact already on
 PyPI.
 
+Two things about that entry are outside its own control, both measured against
+Docker MCP Gateway, which converts official-registry entries into its catalog.
+Neither is a reason to write the entry differently, and both are reasons not to
+promise that listing alone makes the server work everywhere.
+
+`buildSecrets` in `pkg/catalog/registry_to_catalog.go` keeps only a name and an
+environment variable, so an `isSecret` variable loses its optionality on the way
+in, and `pkg/gateway/mcpadd.go` then treats every converted secret as required.
+The three optional proxy credentials therefore read as missing for anyone who
+does not use a proxy, which is nearly everyone. Dropping `isSecret` would
+satisfy that check by declaring a password not to be one, and it would still not
+produce a working server, because of the next paragraph.
+
+`pkg/gateway/docker_binds.go` allows host binds only under `/tmp`,
+`/private/tmp` and `/var/tmp`, and mounts anything it does allow read-only
+unless the exact source path is named in
+`MCP_GATEWAY_DOCKER_BIND_ALLOW_WRITABLE_PATHS`. The session directory is a
+writable home-directory path, so it needs that variable set by the operator, and
+no field in `server.json` can ask for it.
+
 ## Commit Messages
 
 - Follow conventional commits: `type(scope): subject`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,12 @@ gt submit                        # merge PR to trigger release workflow
 
 The CI release workflow automatically updates `manifest.json` and `docker-compose.yml` with the new version — do not update them manually.
 
-After the workflow completes, file a PR in the MCP registry to update the version.
+The workflow also keeps `server.json` in step with the bump. That file is the
+MCP Registry entry, and nothing in the release publishes it: this server has
+never been listed at `registry.modelcontextprotocol.io`. Publishing there is a
+maintainer decision rather than a release step, and taking it is one
+`mcp-publisher login github && mcp-publisher publish` against the file. There is
+no PR to file: the registry is a service, not a repository.
 
 ## Commit Messages
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ RUN uv pip install --python /app/.venv/bin/python --no-deps --compile-bytecode \
 # -- Stage 2: Production runtime --
 FROM python:3.13.13-slim-bookworm@sha256:355bfa66770995d7e9a0da4b3473b44d0cb451f6b56f5615ad9c39e3c4eca03f
 
+# The MCP Registry proves ownership of an image by reading this annotation
+# off the published manifest and comparing it to the name in server.json.
+# It has to be on the runtime stage: the builder's labels never ship.
+LABEL io.modelcontextprotocol.server.name="io.github.stickerdaniel/linkedin-mcp-server"
+
 RUN useradd -m -s /bin/bash pwuser
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,11 @@ RUN uv pip install --python /app/.venv/bin/python --no-deps --compile-bytecode \
 # -- Stage 2: Production runtime --
 FROM python:3.13.13-slim-bookworm@sha256:355bfa66770995d7e9a0da4b3473b44d0cb451f6b56f5615ad9c39e3c4eca03f
 
-# The MCP Registry proves ownership of an image by reading this annotation
-# off the published manifest and comparing it to the name in server.json.
-# It has to be on the runtime stage: the builder's labels never ship.
+# The official MCP Registry proves ownership of an image by pulling its config
+# and comparing Config.Labels["io.modelcontextprotocol.server.name"] to the name
+# in server.json. A LABEL instruction is what writes that; a manifest annotation
+# is a different surface it never reads. It has to be on the runtime stage,
+# because the builder's labels never ship.
 LABEL io.modelcontextprotocol.server.name="io.github.stickerdaniel/linkedin-mcp-server"
 
 RUN useradd -m -s /bin/bash pwuser

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Server for LinkedIn
 
+<!-- mcp-name: io.github.stickerdaniel/linkedin-mcp-server -->
+
 <p align="left">
   <a href="https://pypi.org/project/mcp-server-linkedin/" target="_blank"><img src="https://img.shields.io/pypi/v/mcp-server-linkedin?color=blue" alt="PyPI"></a>
   <a href="https://github.com/stickerdaniel/linkedin-mcp-server/actions/workflows/ci.yml" target="_blank"><img src="https://github.com/stickerdaniel/linkedin-mcp-server/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI Status"></a>

--- a/README.md
+++ b/README.md
@@ -326,13 +326,15 @@ Keep the `-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp` mount on every later `d
       "command": "docker",
       "args": [
         "run", "--rm", "-i",
-        "-v", "~/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
+        "-v", "/absolute/path/to/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
         "stickerdaniel/linkedin-mcp-server:latest"
       ]
     }
   }
 }
 ```
+
+Spell that first path out in full. A client runs `docker` directly rather than through a shell, so a leading `~` reaches Docker unexpanded and it refuses the mount.
 
 > [!NOTE]
 > Sessions expire over time. When tool calls start asking for authentication, repeat the login command above, or run `uvx mcp-server-linkedin@latest --login` on the host.

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -51,13 +51,15 @@ If an older rootful Docker run left that host directory owned by root, repair it
       "command": "docker",
       "args": [
         "run", "--rm", "-i",
-        "-v", "~/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
+        "-v", "/absolute/path/to/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
         "stickerdaniel/linkedin-mcp-server:latest"
       ]
     }
   }
 }
 ```
+
+Spell that first path out in full. A client runs `docker` directly rather than through a shell, so a leading `~` reaches Docker unexpanded and it refuses the mount.
 
 > **Note:** Plain `--login` does not publish a viewer. Use `--login --login-viewer` only for the one-shot login container, with port 6080 published to loopback.
 >
@@ -116,7 +118,7 @@ If an older rootful Docker run left that host directory owned by root, repair it
       "command": "docker",
       "args": [
         "run", "-i", "--rm",
-        "-v", "~/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
+        "-v", "/absolute/path/to/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
         "-e", "TIMEOUT=10000",
         "-e", "TOOL_TIMEOUT=300",
         "stickerdaniel/linkedin-mcp-server"

--- a/server.json
+++ b/server.json
@@ -62,9 +62,8 @@
           "isRequired": true,
           "variables": {
             "session_dir": {
-              "description": "Directory on the host holding the session. Create it before the first run; the container writes as its own user.",
+              "description": "Absolute path on the host holding the session, such as /Users/you/.linkedin-mcp. Create it before the first run; the container writes as its own user. A leading ~ is not expanded here and Docker refuses it as a mount source.",
               "format": "filepath",
-              "default": "~/.linkedin-mcp",
               "isRequired": true
             }
           }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.stickerdaniel/linkedin-mcp-server",
+  "title": "MCP Server for LinkedIn",
+  "description": "Access LinkedIn profiles, companies, jobs and messages through your own logged-in browser session.",
+  "version": "4.23.0",
+  "repository": {
+    "url": "https://github.com/stickerdaniel/linkedin-mcp-server",
+    "source": "github"
+  },
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/stickerdaniel/linkedin-mcp-server/main/assets/icons/icon.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "mcp-server-linkedin",
+      "version": "4.23.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "PROXY_SERVER",
+          "description": "Optional. Route the browser through a proxy, as scheme://host:port (http, https, socks4 or socks5). May also include credentials, as http://user:password@host:port. Only browser traffic is routed.",
+          "isSecret": true
+        },
+        {
+          "name": "PROXY_USERNAME",
+          "description": "Optional. Username for the proxy, if it requires one.",
+          "isSecret": true
+        },
+        {
+          "name": "PROXY_PASSWORD",
+          "description": "Optional. Password for the proxy. Chromium cannot authenticate to a SOCKS proxy, so credentials require an http or https endpoint.",
+          "isSecret": true
+        },
+        {
+          "name": "PROXY_BYPASS",
+          "description": "Optional. Comma-separated hosts to reach directly instead of through the proxy."
+        }
+      ]
+    },
+    {
+      "registryType": "oci",
+      "identifier": "docker.io/stickerdaniel/linkedin-mcp-server:4.23.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--volume",
+          "description": "Persist the LinkedIn session outside the container. Without this mount every run starts logged out.",
+          "value": "{session_dir}:/home/pwuser/.linkedin-mcp",
+          "isRequired": true,
+          "variables": {
+            "session_dir": {
+              "description": "Directory on the host holding the session. Create it before the first run; the container writes as its own user.",
+              "format": "filepath",
+              "default": "~/.linkedin-mcp",
+              "isRequired": true
+            }
+          }
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "PROXY_SERVER",
+          "description": "Optional. Route the browser through a proxy, as scheme://host:port (http, https, socks4 or socks5). May also include credentials, as http://user:password@host:port. Only browser traffic is routed.",
+          "isSecret": true
+        },
+        {
+          "name": "PROXY_USERNAME",
+          "description": "Optional. Username for the proxy, if it requires one.",
+          "isSecret": true
+        },
+        {
+          "name": "PROXY_PASSWORD",
+          "description": "Optional. Password for the proxy. Chromium cannot authenticate to a SOCKS proxy, so credentials require an http or https endpoint.",
+          "isSecret": true
+        },
+        {
+          "name": "PROXY_BYPASS",
+          "description": "Optional. Comma-separated hosts to reach directly instead of through the proxy."
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -56,7 +56,7 @@
       "runtimeArguments": [
         {
           "type": "named",
-          "name": "--volume",
+          "name": "-v",
           "description": "Persist the LinkedIn session outside the container. Without this mount every run starts logged out.",
           "value": "{session_dir}:/home/pwuser/.linkedin-mcp",
           "isRequired": true,

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -133,27 +133,30 @@ def test_readme_is_the_published_package_description(pyproject: dict[str, Any]) 
     assert pyproject["project"]["readme"] == "README.md"
 
 
-def test_dockerfile_annotates_the_same_name(server: dict[str, Any]) -> None:
-    """OCI ownership is proved by an annotation on the runtime stage.
+def test_dockerfile_labels_the_same_name(server: dict[str, Any]) -> None:
+    """OCI ownership is proved by a label on the runtime stage.
 
     The builder stage's labels do not ship, so a label placed there passes
     review and fails verification.
     """
     dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
-    label = f'LABEL io.modelcontextprotocol.server.name="{server["name"]}"'
+    key = "io.modelcontextprotocol.server.name"
     runtime_stage = dockerfile.rsplit("\nFROM ", 1)[-1]
 
-    # A substring search is satisfied by `# LABEL ...`, which writes nothing
-    # into the image. Commenting the line out while debugging would leave CI
-    # green and the proof missing, and that only surfaces after the image has
-    # shipped.
-    instructions = [
-        line
+    # Every instruction that sets this key, not merely the presence of a correct
+    # one. Two failures hide behind a substring search, and both leave CI green
+    # while the image ships without the proof: `# LABEL ...` writes nothing at
+    # all, and a second LABEL replaces the first, so the value the registry
+    # reads is whichever came last.
+    setters = [
+        line.strip()
         for line in runtime_stage.splitlines()
-        if line.strip() == label and not line.lstrip().startswith("#")
+        if line.strip().startswith(f"LABEL {key}=")
     ]
-    assert instructions, (
-        f"the final stage must carry {label!r} as an instruction, not as a comment"
+    expected = f'LABEL {key}="{server["name"]}"'
+    assert setters == [expected], (
+        f"the final stage must set {key} exactly once, as {expected!r}, "
+        f"as an instruction rather than a comment. Found: {setters!r}"
     )
 
 
@@ -206,6 +209,27 @@ def test_the_file_moves_with_the_bundle(
     project's life.
     """
     assert server["version"] == manifest["version"]
+
+
+def test_the_mount_uses_a_flag_the_gateway_translates(server: dict[str, Any]) -> None:
+    """Docker MCP Gateway reads this entry, and it knows two spellings.
+
+    ``extractVolumesFromRuntimeArgs`` in ``pkg/catalog/registry_to_catalog.go``
+    switches on the argument name and handles ``-v`` and ``--mount``. Docker
+    itself accepts ``--volume`` as well, so the entry looks right and validates,
+    and the gateway then drops the argument while still collecting the path from
+    the user: a configured server with no mount, which starts, answers, and is
+    logged out on every launch.
+    """
+    translated = {"-v", "--mount"}
+    for package in server["packages"]:
+        for argument in package.get("runtimeArguments", []):
+            if "/home/pwuser/.linkedin-mcp" not in argument.get("value", ""):
+                continue
+            assert argument["name"] in translated, (
+                f"{argument['name']!r} is a valid Docker flag that the gateway "
+                f"does not translate; use one of {sorted(translated)}"
+            )
 
 
 def test_no_variable_defaults_to_a_path_only_a_shell_could_read(

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -183,15 +183,52 @@ def test_the_file_never_runs_ahead_of_the_project(
 
     ``uv version --bump`` changes ``pyproject.toml`` and ``uv.lock`` and nothing
     else, and ``server.json`` catches up in the ``prepare-release`` job after
-    that PR merges. Requiring equality here therefore fails the bump PR, which
-    blocks the merge, which stops the job that would have made it equal:
-    ``manifest.json`` and ``docker-compose.yml`` are synced the same way and
-    carry no such rule for exactly this reason.
+    that PR merges. Requiring equality against ``pyproject.toml`` here therefore
+    fails the bump PR, which blocks the merge, which stops the job that would
+    have made it equal.
 
     Ahead is the state that cannot be reached honestly, because nothing writes
     this file except that job and a person.
     """
     assert Version(server["version"]) <= Version(pyproject["project"]["version"])
+
+
+def test_the_file_moves_with_the_bundle(
+    server: dict[str, Any], manifest: dict[str, Any]
+) -> None:
+    """An upper bound alone lets a missed sync sit here forever.
+
+    Behind ``pyproject.toml`` is legitimate only until the release job runs, and
+    nothing above says when that was. ``manifest.json`` does: the same job, the
+    same commit, and it is equally behind during the bump PR. So the two are
+    equal in every honest state, and a release that skipped this file alone
+    breaks that equality instead of passing quietly for the rest of the
+    project's life.
+    """
+    assert server["version"] == manifest["version"]
+
+
+def test_no_variable_defaults_to_a_path_only_a_shell_could_read(
+    server: dict[str, Any],
+) -> None:
+    """A registry client substitutes and executes; nothing expands a tilde.
+
+    The schema defines ``{variable}`` substitution and no home-directory rule,
+    and clients are told to execute directly rather than through a shell. A
+    default of ``~/.linkedin-mcp`` therefore reaches Docker verbatim, which
+    refuses it: it is neither an absolute path nor a legal volume name, so
+    every user who accepts the offered default cannot start the server at all.
+    A required variable with no default makes the client ask instead.
+    """
+    for package in server["packages"]:
+        for argument in package.get("runtimeArguments", []):
+            for name, variable in argument.get("variables", {}).items():
+                default = variable.get("default")
+                if not isinstance(default, str):
+                    continue
+                assert not default.startswith("~"), (
+                    f"{name} offers {default!r}, which only a shell expands"
+                )
 
 
 def test_oci_identifier_names_the_published_image(server: dict[str, Any]) -> None:

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -1,26 +1,37 @@
 """Rules about ``server.json`` that only a reader of the registry can know.
 
-``server.json`` is the MCP Registry entry for this server. Nothing in the
-release publishes it, so nothing in the release notices when it goes wrong
-either: the file can sit in the repository for months naming a version that was
-never released, and the first sign of it is a rejected publish months later.
+``server.json`` is this server's entry for the *official* MCP Registry at
+``registry.modelcontextprotocol.io``, which is a service published to with the
+``mcp-publisher`` CLI. It is not the Docker MCP Catalog, whose entry for this
+server is a ``server.yaml`` in the ``docker/mcp-registry`` repository and is
+updated by opening a PR there. The two are routinely confused, including once
+on the branch that added this file, so the distinction is written down rather
+than assumed.
+
+Nothing in the release publishes this file, so nothing in the release notices
+when it goes wrong either: it can sit in the repository for months naming
+something that was never released, and the first sign is a rejected publish.
 
 The registry's own checks are the reason most of these rules exist. Publishing
 proves that the publisher owns each package, and it proves it differently per
 registry type. For PyPI it fetches the version's metadata and searches the
 README, which PyPI stores as the package description, for the literal token
-``mcp-name: <server name>``. For an OCI image it reads the
-``io.modelcontextprotocol.server.name`` annotation off the published manifest.
-Both compare against the ``name`` in this file, so three places have to agree
-and only one of them is JSON.
+``mcp-name: <server name>``. For an OCI image it pulls the image *config* and
+reads ``Config.Labels["io.modelcontextprotocol.server.name"]``, which is what a
+Dockerfile ``LABEL`` writes. Manifest annotations are a different surface and
+are not consulted, so a label replaced by an annotation would inspect correctly
+and still fail verification. Both compare against the ``name`` in this file, so
+three places have to agree and only one of them is JSON.
 
 The token check is boundary-anchored, which is the part that surprises people:
-``mcp-name: io.github.acme/widget`` would otherwise satisfy an ownership claim
-for ``io.github.acme/widget-pro``, so the registry requires the matched name to
-be followed by end-of-content, a character that cannot appear in a server name,
-or an HTML comment close. A token written inline and ended with a period fails
-that, and the failure arrives as an ownership error rather than a formatting
-one. Measured against ``internal/validators/registries/mcpname.go``.
+a README declaring ``mcp-name: io.github.acme/widget-pro`` would otherwise
+satisfy an ownership claim for the shorter ``io.github.acme/widget``, because
+the shorter string is a substring of the longer one. The registry therefore
+requires the matched name to be followed by end-of-content, a character that
+cannot appear in a server name, or an HTML comment close. A token written
+inline and ended with a period fails that, and the failure arrives as an
+ownership error rather than a formatting one. Measured against
+``internal/validators/registries/mcpname.go`` and ``oci.go``.
 """
 
 from __future__ import annotations
@@ -32,6 +43,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from packaging.version import Version
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SERVER_JSON = _REPO_ROOT / "server.json"
@@ -129,10 +141,20 @@ def test_dockerfile_annotates_the_same_name(server: dict[str, Any]) -> None:
     """
     dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
     label = f'LABEL io.modelcontextprotocol.server.name="{server["name"]}"'
-    assert label in dockerfile
-
     runtime_stage = dockerfile.rsplit("\nFROM ", 1)[-1]
-    assert label in runtime_stage, "the label must be on the final stage"
+
+    # A substring search is satisfied by `# LABEL ...`, which writes nothing
+    # into the image. Commenting the line out while debugging would leave CI
+    # green and the proof missing, and that only surfaces after the image has
+    # shipped.
+    instructions = [
+        line
+        for line in runtime_stage.splitlines()
+        if line.strip() == label and not line.lstrip().startswith("#")
+    ]
+    assert instructions, (
+        f"the final stage must carry {label!r} as an instruction, not as a comment"
+    )
 
 
 def test_pypi_package_is_the_published_distribution(
@@ -142,19 +164,34 @@ def test_pypi_package_is_the_published_distribution(
     assert package["identifier"] == pyproject["project"]["name"]
 
 
-def test_versions_track_the_project(
-    server: dict[str, Any], pyproject: dict[str, Any]
-) -> None:
-    """All three version sites move together, or the release sync did not run.
+def test_versions_agree_inside_the_file(server: dict[str, Any]) -> None:
+    """The three version sites move together or the sync missed one.
 
-    ``uv version --bump`` touches ``pyproject.toml`` only. Everything else is
-    written by the ``prepare-release`` job, so a mismatch here means that job
-    was skipped or its edit silently missed a field.
+    ``server.json`` spells the version three times, once inside an image
+    reference. The release job rewrites all three; a hand edit reaches whichever
+    one the author was looking at.
     """
-    version = pyproject["project"]["version"]
-    assert server["version"] == version
+    version = server["version"]
     assert _package(server, "pypi")["version"] == version
     assert _package(server, "oci")["identifier"].endswith(f":{version}")
+
+
+def test_the_file_never_runs_ahead_of_the_project(
+    server: dict[str, Any], pyproject: dict[str, Any]
+) -> None:
+    """Behind is the normal state between a bump and its release commit.
+
+    ``uv version --bump`` changes ``pyproject.toml`` and ``uv.lock`` and nothing
+    else, and ``server.json`` catches up in the ``prepare-release`` job after
+    that PR merges. Requiring equality here therefore fails the bump PR, which
+    blocks the merge, which stops the job that would have made it equal:
+    ``manifest.json`` and ``docker-compose.yml`` are synced the same way and
+    carry no such rule for exactly this reason.
+
+    Ahead is the state that cannot be reached honestly, because nothing writes
+    this file except that job and a person.
+    """
+    assert Version(server["version"]) <= Version(pyproject["project"]["version"])
 
 
 def test_oci_identifier_names_the_published_image(server: dict[str, Any]) -> None:

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -1,0 +1,198 @@
+"""Rules about ``server.json`` that only a reader of the registry can know.
+
+``server.json`` is the MCP Registry entry for this server. Nothing in the
+release publishes it, so nothing in the release notices when it goes wrong
+either: the file can sit in the repository for months naming a version that was
+never released, and the first sign of it is a rejected publish months later.
+
+The registry's own checks are the reason most of these rules exist. Publishing
+proves that the publisher owns each package, and it proves it differently per
+registry type. For PyPI it fetches the version's metadata and searches the
+README, which PyPI stores as the package description, for the literal token
+``mcp-name: <server name>``. For an OCI image it reads the
+``io.modelcontextprotocol.server.name`` annotation off the published manifest.
+Both compare against the ``name`` in this file, so three places have to agree
+and only one of them is JSON.
+
+The token check is boundary-anchored, which is the part that surprises people:
+``mcp-name: io.github.acme/widget`` would otherwise satisfy an ownership claim
+for ``io.github.acme/widget-pro``, so the registry requires the matched name to
+be followed by end-of-content, a character that cannot appear in a server name,
+or an HTML comment close. A token written inline and ended with a period fails
+that, and the failure arrives as an ownership error rather than a formatting
+one. Measured against ``internal/validators/registries/mcpname.go``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SERVER_JSON = _REPO_ROOT / "server.json"
+_README = _REPO_ROOT / "README.md"
+_DOCKERFILE = _REPO_ROOT / "Dockerfile"
+
+# The GitHub namespace the registry grants after a GitHub login. It is derived
+# from the account, not chosen, so a name outside it cannot be published at all.
+_NAMESPACE = "io.github.stickerdaniel"
+
+# Characters that may continue a server name, from the schema's own pattern
+# ^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$ plus the separating slash.
+_SERVER_NAME_CHAR = re.compile(r"[A-Za-z0-9._/-]")
+
+
+@pytest.fixture(scope="module")
+def server() -> dict[str, Any]:
+    return json.loads(_SERVER_JSON.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def pyproject() -> dict[str, Any]:
+    return tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict[str, Any]:
+    return json.loads((_REPO_ROOT / "manifest.json").read_text(encoding="utf-8"))
+
+
+def _package(server: dict[str, Any], registry_type: str) -> dict[str, Any]:
+    matches = [p for p in server["packages"] if p["registryType"] == registry_type]
+    assert len(matches) == 1, f"expected exactly one {registry_type} package"
+    return matches[0]
+
+
+def _terminates_token(rest: str) -> bool:
+    """Whether what follows a matched server name ends the token.
+
+    Mirrors ``isMCPNameBoundary``. The comment-close cases are not decoration:
+    ``<!-- mcp-name: NAME-->`` with no space before the close is common enough
+    that the registry special-cases it, and without them the hidden-comment form
+    the PyPI docs recommend would fail its own validator.
+    """
+    if not rest:
+        return True
+    if not _SERVER_NAME_CHAR.match(rest[0]):
+        return True
+    return rest.startswith("-->") or rest.startswith("--!>")
+
+
+def test_name_sits_in_the_authenticated_namespace(server: dict[str, Any]) -> None:
+    assert server["name"].startswith(f"{_NAMESPACE}/")
+
+
+def test_description_fits_the_registry_limit(server: dict[str, Any]) -> None:
+    """The schema caps ``description`` at 100 characters.
+
+    A longer one is refused at publish time, which is the worst moment to find
+    out: the publish is the one step that is taken deliberately and rarely.
+    """
+    assert len(server["description"]) <= 100
+
+
+def test_readme_carries_a_terminated_ownership_token(server: dict[str, Any]) -> None:
+    """PyPI ownership is proved by a token in the README, or not at all."""
+    name = server["name"]
+    token = f"mcp-name: {name}"
+    readme = _README.read_text(encoding="utf-8")
+
+    occurrences = [m.end() for m in re.finditer(re.escape(token), readme)]
+    assert occurrences, f"README.md must contain {token!r}"
+    assert any(_terminates_token(readme[end:]) for end in occurrences), (
+        f"README.md contains {token!r}, but every occurrence is glued to a "
+        "character that continues a server name. Put it on its own line, or "
+        "close the HTML comment right after it."
+    )
+
+
+def test_readme_is_the_published_package_description(pyproject: dict[str, Any]) -> None:
+    """The token only reaches PyPI because README.md *is* the description.
+
+    Point ``readme`` somewhere else and the token stays in the repository while
+    the published package loses it, which reads as an ownership failure with no
+    visible cause.
+    """
+    assert pyproject["project"]["readme"] == "README.md"
+
+
+def test_dockerfile_annotates_the_same_name(server: dict[str, Any]) -> None:
+    """OCI ownership is proved by an annotation on the runtime stage.
+
+    The builder stage's labels do not ship, so a label placed there passes
+    review and fails verification.
+    """
+    dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+    label = f'LABEL io.modelcontextprotocol.server.name="{server["name"]}"'
+    assert label in dockerfile
+
+    runtime_stage = dockerfile.rsplit("\nFROM ", 1)[-1]
+    assert label in runtime_stage, "the label must be on the final stage"
+
+
+def test_pypi_package_is_the_published_distribution(
+    server: dict[str, Any], pyproject: dict[str, Any]
+) -> None:
+    package = _package(server, "pypi")
+    assert package["identifier"] == pyproject["project"]["name"]
+
+
+def test_versions_track_the_project(
+    server: dict[str, Any], pyproject: dict[str, Any]
+) -> None:
+    """All three version sites move together, or the release sync did not run.
+
+    ``uv version --bump`` touches ``pyproject.toml`` only. Everything else is
+    written by the ``prepare-release`` job, so a mismatch here means that job
+    was skipped or its edit silently missed a field.
+    """
+    version = pyproject["project"]["version"]
+    assert server["version"] == version
+    assert _package(server, "pypi")["version"] == version
+    assert _package(server, "oci")["identifier"].endswith(f":{version}")
+
+
+def test_oci_identifier_names_the_published_image(server: dict[str, Any]) -> None:
+    repository, _, _tag = _package(server, "oci")["identifier"].rpartition(":")
+    assert repository == "docker.io/stickerdaniel/linkedin-mcp-server"
+
+
+def test_proxy_settings_match_the_bundle(
+    server: dict[str, Any], manifest: dict[str, Any]
+) -> None:
+    """Every package offers the configuration the MCP bundle already asks for.
+
+    The bundle collects four proxy fields from the user. A registry client has
+    no other way to learn that this server takes any configuration at all, so
+    the two lists have to describe the same server. Dropping one here would not
+    break anything visibly; it would just make the registry entry quietly less
+    capable than the bundle.
+    """
+    expected = {
+        name.upper() for name in manifest["user_config"] if name.startswith("proxy_")
+    }
+    assert expected, "manifest.json no longer declares proxy fields"
+
+    for package in server["packages"]:
+        declared = {v["name"] for v in package.get("environmentVariables", [])}
+        assert declared == expected, (
+            f"{package['registryType']} package declares {sorted(declared)}, "
+            f"manifest.json asks for {sorted(expected)}"
+        )
+
+
+def test_file_is_in_the_form_the_release_job_writes(server: dict[str, Any]) -> None:
+    """Hand edits keep the format the version sync produces.
+
+    That job reparses the file and writes it back with ``json.dumps(indent=2)``.
+    If the checked-in file is formatted any other way, the release commit
+    carries a whole-file reformat on top of the version change, and the diff
+    that should be three lines stops being reviewable.
+    """
+    canonical = json.dumps(server, indent=2, ensure_ascii=False) + "\n"
+    assert _SERVER_JSON.read_text(encoding="utf-8") == canonical

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -167,19 +167,18 @@ def test_dockerfile_labels_the_same_name(server: dict[str, Any]) -> None:
     """
     dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
     key = "io.modelcontextprotocol.server.name"
-    runtime_stage = dockerfile.rsplit("\nFROM ", 1)[-1]
+    # Instruction names are case-insensitive to Docker, so a lowercase final
+    # stage is still the one whose labels ship.
+    stages = re.split(r"(?im)^FROM\s", dockerfile)
+    runtime_stage = stages[-1]
 
-    # Every assignment of this key, wherever it sits. Three failures hide behind
-    # a substring search or a prefix match, and all three leave CI green while
-    # the image ships without the proof: `# LABEL ...` writes nothing at all, a
-    # second LABEL replaces the first, and one LABEL may carry several keys, so
-    # `LABEL maintainer="x" io.modelcontextprotocol.server.name="wrong"` sets it
-    # without starting with it. Docker takes the last write.
+    # Every assignment of this key, wherever it sits: a comment sets nothing, one
+    # LABEL may carry several keys, and Docker takes the last write.
     setters = [
         token.partition("=")[2]
         for line in _joined_instructions(runtime_stage)
-        if line.startswith("LABEL ")
-        for token in shlex.split(line.removeprefix("LABEL "))
+        if line.upper().startswith("LABEL ")
+        for token in shlex.split(line[len("LABEL ") :])
         if token.startswith(f"{key}=")
     ]
     assert setters == [server["name"]], (
@@ -239,24 +238,23 @@ def test_the_file_moves_with_the_bundle(
     assert server["version"] == manifest["version"]
 
 
-def test_every_package_type_is_one_the_release_job_can_version(
+def test_only_package_types_the_release_job_versions_are_declared(
     server: dict[str, Any],
 ) -> None:
-    """The release job refuses a type it does not know, and refuses it late.
+    """A third package type would stop the release after PyPI has published.
 
-    ``prepare-release`` runs after ``publish-pypi``, so a package type the
-    rewrite has no branch for stops the workflow with the distribution already
-    on PyPI, immutably, and with no tag, image, bundle or release to go with it.
-    Adding a package here is the moment to notice, which is this test.
+    ``prepare-release`` runs after ``publish-pypi``, so a type the rewrite has
+    no branch for ends the workflow with the distribution already immutable on
+    PyPI and with no tag, image, bundle or release beside it. Adding a package
+    here is the moment to notice, and the two the job knows are named below
+    rather than grepped out of it: searching the step for the string proves
+    only that the string is there, and a branch emptied to `pass` passed.
     """
-    step = _RELEASE_WORKFLOW.split("- name: Update server.json version", 1)[-1]
-    step = step.split("\n      - name: ", 1)[0]
-    for package in server["packages"]:
-        assert f'"{package["registryType"]}"' in step, (
-            f"{package['registryType']!r} has no branch in the release job's "
-            "server.json rewrite, which would fail the release after PyPI has "
-            "already accepted the distribution"
-        )
+    declared = {package["registryType"] for package in server["packages"]}
+    assert declared == {"pypi", "oci"}, (
+        f"{sorted(declared - {'pypi', 'oci'})} would reach a release job that "
+        "cannot version them; teach the `Update server.json version` step first"
+    )
 
 
 def test_the_mount_uses_a_flag_the_gateway_translates(server: dict[str, Any]) -> None:
@@ -275,9 +273,8 @@ def test_the_mount_uses_a_flag_the_gateway_translates(server: dict[str, Any]) ->
         for argument in _package(server, "oci").get("runtimeArguments", [])
         if "/home/pwuser/.linkedin-mcp" in argument.get("value", "")
     ]
-    # The loop this replaces judged whatever it found and said nothing when it
-    # found nothing, so deleting the mount outright passed. Such an entry starts
-    # logged out on every launch, which is what the mount is for.
+    # Exactly one, because an entry with no mount at all starts logged out on
+    # every launch, which is what the mount is for.
     assert len(mounts) == 1, (
         "the OCI package must mount the session directory exactly once, found "
         f"{len(mounts)}"

--- a/tests/test_server_json.py
+++ b/tests/test_server_json.py
@@ -37,6 +37,7 @@ ownership error rather than a formatting one. Measured against
 from __future__ import annotations
 
 import json
+import shlex
 import re
 import tomllib
 from pathlib import Path
@@ -48,6 +49,9 @@ from packaging.version import Version
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SERVER_JSON = _REPO_ROOT / "server.json"
 _README = _REPO_ROOT / "README.md"
+_RELEASE_WORKFLOW = (_REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(
+    encoding="utf-8"
+)
 _DOCKERFILE = _REPO_ROOT / "Dockerfile"
 
 # The GitHub namespace the registry grants after a GitHub login. It is derived
@@ -133,6 +137,28 @@ def test_readme_is_the_published_package_description(pyproject: dict[str, Any]) 
     assert pyproject["project"]["readme"] == "README.md"
 
 
+def _joined_instructions(stage: str) -> list[str]:
+    """Dockerfile instructions with continuations joined and comments dropped.
+
+    A ``LABEL`` may be wrapped across lines with a trailing backslash, and a
+    comment line may carry the same text without setting anything.
+    """
+    instructions: list[str] = []
+    pending = ""
+    for line in stage.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.endswith("\\"):
+            pending += f"{stripped[:-1].strip()} "
+            continue
+        instructions.append(" ".join(f"{pending}{stripped}".split()))
+        pending = ""
+    if pending:
+        instructions.append(" ".join(pending.split()))
+    return instructions
+
+
 def test_dockerfile_labels_the_same_name(server: dict[str, Any]) -> None:
     """OCI ownership is proved by a label on the runtime stage.
 
@@ -143,19 +169,21 @@ def test_dockerfile_labels_the_same_name(server: dict[str, Any]) -> None:
     key = "io.modelcontextprotocol.server.name"
     runtime_stage = dockerfile.rsplit("\nFROM ", 1)[-1]
 
-    # Every instruction that sets this key, not merely the presence of a correct
-    # one. Two failures hide behind a substring search, and both leave CI green
-    # while the image ships without the proof: `# LABEL ...` writes nothing at
-    # all, and a second LABEL replaces the first, so the value the registry
-    # reads is whichever came last.
+    # Every assignment of this key, wherever it sits. Three failures hide behind
+    # a substring search or a prefix match, and all three leave CI green while
+    # the image ships without the proof: `# LABEL ...` writes nothing at all, a
+    # second LABEL replaces the first, and one LABEL may carry several keys, so
+    # `LABEL maintainer="x" io.modelcontextprotocol.server.name="wrong"` sets it
+    # without starting with it. Docker takes the last write.
     setters = [
-        line.strip()
-        for line in runtime_stage.splitlines()
-        if line.strip().startswith(f"LABEL {key}=")
+        token.partition("=")[2]
+        for line in _joined_instructions(runtime_stage)
+        if line.startswith("LABEL ")
+        for token in shlex.split(line.removeprefix("LABEL "))
+        if token.startswith(f"{key}=")
     ]
-    expected = f'LABEL {key}="{server["name"]}"'
-    assert setters == [expected], (
-        f"the final stage must set {key} exactly once, as {expected!r}, "
+    assert setters == [server["name"]], (
+        f"the final stage must set {key} exactly once, to {server['name']!r}, "
         f"as an instruction rather than a comment. Found: {setters!r}"
     )
 
@@ -211,6 +239,26 @@ def test_the_file_moves_with_the_bundle(
     assert server["version"] == manifest["version"]
 
 
+def test_every_package_type_is_one_the_release_job_can_version(
+    server: dict[str, Any],
+) -> None:
+    """The release job refuses a type it does not know, and refuses it late.
+
+    ``prepare-release`` runs after ``publish-pypi``, so a package type the
+    rewrite has no branch for stops the workflow with the distribution already
+    on PyPI, immutably, and with no tag, image, bundle or release to go with it.
+    Adding a package here is the moment to notice, which is this test.
+    """
+    step = _RELEASE_WORKFLOW.split("- name: Update server.json version", 1)[-1]
+    step = step.split("\n      - name: ", 1)[0]
+    for package in server["packages"]:
+        assert f'"{package["registryType"]}"' in step, (
+            f"{package['registryType']!r} has no branch in the release job's "
+            "server.json rewrite, which would fail the release after PyPI has "
+            "already accepted the distribution"
+        )
+
+
 def test_the_mount_uses_a_flag_the_gateway_translates(server: dict[str, Any]) -> None:
     """Docker MCP Gateway reads this entry, and it knows two spellings.
 
@@ -222,14 +270,22 @@ def test_the_mount_uses_a_flag_the_gateway_translates(server: dict[str, Any]) ->
     logged out on every launch.
     """
     translated = {"-v", "--mount"}
-    for package in server["packages"]:
-        for argument in package.get("runtimeArguments", []):
-            if "/home/pwuser/.linkedin-mcp" not in argument.get("value", ""):
-                continue
-            assert argument["name"] in translated, (
-                f"{argument['name']!r} is a valid Docker flag that the gateway "
-                f"does not translate; use one of {sorted(translated)}"
-            )
+    mounts = [
+        argument
+        for argument in _package(server, "oci").get("runtimeArguments", [])
+        if "/home/pwuser/.linkedin-mcp" in argument.get("value", "")
+    ]
+    # The loop this replaces judged whatever it found and said nothing when it
+    # found nothing, so deleting the mount outright passed. Such an entry starts
+    # logged out on every launch, which is what the mount is for.
+    assert len(mounts) == 1, (
+        "the OCI package must mount the session directory exactly once, found "
+        f"{len(mounts)}"
+    )
+    assert mounts[0]["name"] in translated, (
+        f"{mounts[0]['name']!r} is a valid Docker flag that the gateway "
+        f"does not translate; use one of {sorted(translated)}"
+    )
 
 
 def test_no_variable_defaults_to_a_path_only_a_shell_could_read(
@@ -248,9 +304,19 @@ def test_no_variable_defaults_to_a_path_only_a_shell_could_read(
         for argument in package.get("runtimeArguments", []):
             for name, variable in argument.get("variables", {}).items():
                 default = variable.get("default")
+                if variable.get("format") == "filepath" and variable.get("isRequired"):
+                    # Nothing written here is a path on the machine that will
+                    # run it, so a required one has no honest default and the
+                    # client has to ask. Rejecting only `~` let `$HOME` through,
+                    # which Docker refuses in exactly the same way.
+                    assert default is None, (
+                        f"{name} is a required host path; offering {default!r} "
+                        "puts a value there that cannot be right"
+                    )
+                    continue
                 if not isinstance(default, str):
                     continue
-                assert not default.startswith("~"), (
+                assert not default.startswith("~") and "$" not in default, (
                     f"{name} offers {default!r}, which only a shell expands"
                 )
 


### PR DESCRIPTION
Closes #767

`AGENTS.md` has told the release process to "file a PR in the MCP registry" since 2.2.0. There is no PR flow: the registry is a service reached through `mcp-publisher`. There was also nothing to update, because this server has never been listed there under any name.

This adds the entry and the two things a publish would check but a schema cannot: PyPI proves ownership by finding `mcp-name: <server name>` in the package description, so the token goes in `README.md`; an OCI image proves it from the image config, so a `LABEL` sits on the runtime stage, where a manifest annotation would inspect correctly and still fail. The release job now versions `server.json` by parsing it rather than by `sed`, and refuses to continue when the versioned files disagree. Nothing contacts the registry — publishing stays a deliberate decision.

Full suite green; every new rule was checked against a deliberately broken copy, and the version sync was run against a real bump across five spellings of the compose image.

## Synthetic prompt

> `AGENTS.md` says to file a PR in the MCP registry after a release. That is stale: the registry is a service published to with `mcp-publisher`, and this server was never listed. Add a valid `server.json` under the `io.github.stickerdaniel` namespace covering the PyPI and Docker Hub packages, add the ownership proofs each one needs (README token, Dockerfile label), keep the version in sync from the release workflow, and correct the `AGENTS.md` line. Do not publish.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
