### PR TITLE
chore(glama): Declare the repository maintainer

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "stickerdaniel"
+  ]
+}


### PR DESCRIPTION
Closes #769

The Glama listing was indexed automatically and describes this server in words nobody here wrote, including a tool it no longer has. That description is currently the only public account of the project that the project cannot edit.

Editing it requires claiming the listing, and claiming requires this file: Glama reads `glama.json` from the repository root and compares the maintainers to the GitHub account that signs in. The file grants nothing else and is inert for everyone not using Glama.

Validated against `https://glama.ai/mcp/schemas/server.json`. The remaining half of the claim happens on their site and cannot be done from here.