### PR TITLE
fix(docker): Give the server the container's stdin

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -64,19 +64,41 @@ fi
 # out rather than being moved into the foreground.
 #
 # Docker always supplies a readable descriptor 0, but a launcher need not, and
-# what it hands over then travels straight into Python. A closed one arrives as
-# EBADF on every read; an open directory kills the interpreter outright, before
+# what it hands over then travels straight into Python. Three shapes are not
+# input: a closed descriptor and a write-only one both arrive as EBADF on the
+# first read, and an open directory kills the interpreter outright, before
 # argument parsing, so `--transport streamable-http` and the one-shot commands
-# die on an input none of them reads. The bare `&` used to hide both behind its
-# /dev/null, which is the one thing it was good for.
+# die on an input none of them reads. The bare `&` used to hide all three behind
+# its /dev/null, which is the one thing it was good for.
 #
-# Both are cheap to recognise: duplicating the descriptor fails when it is
-# closed, and /dev/fd names what it points at when it is not. Ask in a subshell,
-# where a failed duplication costs nothing, and hand the unusable cases the
-# /dev/null they would have had. Without /proc there is no /dev/fd and the
-# directory test cannot answer, which leaves the descriptor as it was: the same
-# state every Docker container is in anyway.
-( exec 3<&0 && [ ! -d /dev/fd/3 ] ) 2>/dev/null || exec 0</dev/null
+# Each is cheap to recognise. Duplicating the descriptor fails when it is
+# closed, which is the one question /proc cannot answer, since a closed
+# descriptor and an absent /proc look alike from the outside. /dev/fd names what
+# an open one points at. /proc/self/fdinfo gives its open flags, whose low two
+# bits are the access mode: 1 is write-only, and `-r` cannot stand in for that,
+# because it asks about permissions on the target and answers yes for a
+# write-only /dev/null. Where /proc cannot answer, the descriptor is left as it
+# was: the state every Docker container is in anyway.
+#
+# Each test says so on its own rather than leaning on `set -e`. Inside a `&&` or
+# `||` list errexit is suspended, so a failing `exec` there stops aborting and
+# the checks after it read a descriptor that was never opened, which is how an
+# earlier shape of this guard came to pass the closed case straight through.
+stdin_is_unusable() {
+    (exec 3<&0) 2>/dev/null || return 0
+    [ ! -d /dev/fd/0 ] || return 0
+
+    local flags
+    flags=$(sed -n 's/^flags:[[:space:]]*//p' /proc/self/fdinfo/0 2>/dev/null) ||
+        return 1
+    [ -n "$flags" ] || return 1
+    (( (8#$flags & 3) == 1 ))
+}
+
+if stdin_is_unusable; then
+    exec 0</dev/null
+fi
+
 "$@" <&0 &
 server_pid=$!
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -63,12 +63,20 @@ fi
 # to decide which death ends the container, so it gets the redirection spelled
 # out rather than being moved into the foreground.
 #
-# Docker always supplies descriptor 0, but a launcher is free to close it, and
-# then the redirection fails and takes the whole container down with it, HTTP
-# and the one-shot commands included, which never wanted stdin. Probe it in a
-# subshell, where a failure costs nothing, and give the closed case the
-# /dev/null it would have had.
-(exec 3<&0) 2>/dev/null || exec 0</dev/null
+# Docker always supplies a readable descriptor 0, but a launcher need not, and
+# what it hands over then travels straight into Python. A closed one arrives as
+# EBADF on every read; an open directory kills the interpreter outright, before
+# argument parsing, so `--transport streamable-http` and the one-shot commands
+# die on an input none of them reads. The bare `&` used to hide both behind its
+# /dev/null, which is the one thing it was good for.
+#
+# Both are cheap to recognise: duplicating the descriptor fails when it is
+# closed, and /dev/fd names what it points at when it is not. Ask in a subshell,
+# where a failed duplication costs nothing, and hand the unusable cases the
+# /dev/null they would have had. Without /proc there is no /dev/fd and the
+# directory test cannot answer, which leaves the descriptor as it was: the same
+# state every Docker container is in anyway.
+( exec 3<&0 && [ ! -d /dev/fd/3 ] ) 2>/dev/null || exec 0</dev/null
 "$@" <&0 &
 server_pid=$!
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -74,11 +74,17 @@ fi
 # Each is cheap to recognise. Duplicating the descriptor fails when it is
 # closed, which is the one question /proc cannot answer, since a closed
 # descriptor and an absent /proc look alike from the outside. /dev/fd names what
-# an open one points at. /proc/self/fdinfo gives its open flags, whose low two
-# bits are the access mode: 1 is write-only, and `-r` cannot stand in for that,
-# because it asks about permissions on the target and answers yes for a
-# write-only /dev/null. Where /proc cannot answer, the descriptor is left as it
-# was: the state every Docker container is in anyway.
+# an open one points at. /proc/self/fdinfo gives its open flags, and `-r` cannot
+# stand in for those, because it asks about permissions on the target and
+# answers yes for a write-only /dev/null. Where /proc cannot answer, the
+# descriptor is left as it was: the state every Docker container is in anyway.
+#
+# The closed case does not arrive through the image's own ENTRYPOINT. Tini calls
+# `tcsetpgrp(STDIN_FILENO, ...)` before executing anything and treats every
+# errno but ENOTTY and ENXIO as fatal (`src/tini.c`), so a closed descriptor 0
+# ends the container at Tini with `tcsetpgrp failed: Bad file descriptor` and
+# status 1. It reaches this script when the entrypoint is overridden or the
+# script is run directly, which is also how the tests reach it.
 #
 # Each test says so on its own rather than leaning on `set -e`. Inside a `&&` or
 # `||` list errexit is suspended, so a failing `exec` there stops aborting and
@@ -92,7 +98,19 @@ stdin_is_unusable() {
     flags=$(sed -n 's/^flags:[[:space:]]*//p' /proc/self/fdinfo/0 2>/dev/null) ||
         return 1
     [ -n "$flags" ] || return 1
-    (( (8#$flags & 3) == 1 ))
+
+    # O_PATH names a file without opening it. Every read fails, and the access
+    # mode bits still read 0, so the mode alone would call it readable.
+    if (( (8#$flags & 8#10000000) != 0 )); then
+        return 0
+    fi
+
+    # Two of the four access modes cannot be read: 1 is write-only, and 3 is
+    # the value Linux uses for an open that grants neither direction.
+    case $(( 8#$flags & 3 )) in
+    1 | 3) return 0 ;;
+    esac
+    return 1
 }
 
 if stdin_is_unusable; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -54,7 +54,22 @@ if [[ ! -S "$socket_path" ]]; then
     exit 1
 fi
 
-"$@" &
+# A shell gives an asynchronous list /dev/null for stdin, but only in the
+# absence of an explicit redirection. Backgrounding the server as a bare `"$@" &`
+# therefore cut the stdio transport off from the container's stdin: it started,
+# announced the transport, read EOF from /dev/null at once and shut down without
+# ever answering. That shipped in 4.22.0 and made `docker run -i` return nothing.
+# The server has to stay a child, because `wait -n -p` below needs both children
+# to decide which death ends the container, so it gets the redirection spelled
+# out rather than being moved into the foreground.
+#
+# Docker always supplies descriptor 0, but a launcher is free to close it, and
+# then the redirection fails and takes the whole container down with it, HTTP
+# and the one-shot commands included, which never wanted stdin. Probe it in a
+# subshell, where a failure costs nothing, and give the closed case the
+# /dev/null it would have had.
+(exec 3<&0) 2>/dev/null || exec 0</dev/null
+"$@" <&0 &
 server_pid=$!
 
 terminate() {

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -679,10 +679,14 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
             path.parent.mkdir(parents=True, exist_ok=True)
             if path.exists() or lock.exists():
                 raise SystemExit(91)
+            lock.write_text("owned", encoding="utf-8")
+            # The gap real Xvfb leaves between the two names, widened so that a
+            # readiness check accepting the lock would start the server against
+            # a socket that does not exist yet.
+            time.sleep(0.5)
             server = socket.socket(socket.AF_UNIX)
             server.bind(str(path))
             server.listen()
-            lock.write_text("owned", encoding="utf-8")
             pathlib.Path({str(started_marker)!r}).write_text("started")
             time.sleep(0.3)
             server.close()
@@ -799,6 +803,10 @@ def test_the_supervisor_hands_the_server_the_containers_stdin(tmp_path: Path) ->
 
             number = sys.argv[1].removeprefix(":").split(".", 1)[0]
             path = pathlib.Path(f"/tmp/.X11-unix/X{number}")
+            # Real Xvfb 21.1.7 publishes the lock before it creates the socket.
+            # Measured by inotify inside the image; a fake that reverses it
+            # would let a readiness check that accepts the lock pass here.
+            pathlib.Path(f"/tmp/.X{number}-lock").write_text("owned")
             server = socket.socket(socket.AF_UNIX)
             server.bind(str(path))
             server.listen()
@@ -865,20 +873,24 @@ def test_the_supervisor_hands_the_server_the_containers_stdin(tmp_path: Path) ->
 
 
 @pytest.mark.skipif(os.name == "nt", reason="the image entrypoint is Bash on Linux")
-@pytest.mark.parametrize("kind", ["closed", "directory"])
+@pytest.mark.parametrize("kind", ["closed", "directory", "write_only"])
 def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) -> None:
     """Spelling the redirection out is what stops hiding a bad descriptor.
 
     The bare ``&`` this replaces gave every mode ``/dev/null`` whether it wanted
     one or not, so nothing here noticed what a launcher may actually pass.
-    Handing it through unexamined is worse than either: a closed descriptor
-    reaches Python as ``EBADF`` on every read, and an open directory ends the
-    interpreter before argument parsing, taking down HTTP and the one-shot
-    commands over an input none of them reads.
+    Handing it through unexamined is worse than either. A closed descriptor and
+    a write-only one both reach Python as ``EBADF`` on the first read, and an
+    open directory ends the interpreter before argument parsing, taking down
+    HTTP and the one-shot commands over an input none of them reads.
 
     Asserting that the server merely started is not enough and was tried: with
     the descriptor passed through untouched it starts perfectly well, and only
-    the first read says otherwise. So the fake server reports what it was given.
+    the first read says otherwise. Neither is the name it points at enough, and
+    that was tried too: ``/dev/null`` opened for writing reads back as
+    ``/dev/null``, so a fallback of ``0>/dev/null`` satisfied every case here
+    while handing the server the same unreadable descriptor it was rescued
+    from. The access mode is the part that cannot be faked.
     """
     bash = shutil.which("bash")
     if bash is None:
@@ -890,8 +902,8 @@ def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) 
     )
     if major < 5:
         pytest.skip("wait -n -p requires the Bash 5 shipped by the image")
-    if not Path("/proc/self/fd").is_dir():
-        pytest.skip("the directory case is recognised through /dev/fd")
+    if not Path("/proc/self/fdinfo").is_dir():
+        pytest.skip("the guard recognises these through /dev/fd and /proc")
 
     display_number, socket_path, lock_path = _a_free_display(30_000)
 
@@ -907,6 +919,10 @@ def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) 
 
             number = sys.argv[1].removeprefix(":").split(".", 1)[0]
             path = pathlib.Path(f"/tmp/.X11-unix/X{number}")
+            # Real Xvfb 21.1.7 publishes the lock before it creates the socket.
+            # Measured by inotify inside the image; a fake that reverses it
+            # would let a readiness check that accepts the lock pass here.
+            pathlib.Path(f"/tmp/.X{number}-lock").write_text("owned")
             server = socket.socket(socket.AF_UNIX)
             server.bind(str(path))
             server.listen()
@@ -925,15 +941,18 @@ def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) 
         textwrap.dedent(
             f"""\
             #!/usr/bin/env python3
+            import fcntl
             import os
             import pathlib
 
             try:
-                os.fstat(0)
                 target = os.readlink("/proc/self/fd/0")
+                mode = fcntl.fcntl(0, fcntl.F_GETFL) & os.O_ACCMODE
+                readable = mode in (os.O_RDONLY, os.O_RDWR)
+                answer = f"{{target}} readable={{readable}}"
             except OSError as error:
-                target = f"errno={{error.errno}}"
-            pathlib.Path({str(seen)!r}).write_text(target)
+                answer = f"errno={{error.errno}}"
+            pathlib.Path({str(seen)!r}).write_text(answer)
             """
         ),
         encoding="utf-8",
@@ -945,14 +964,13 @@ def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) 
         "DISPLAY": f":{display_number}",
         "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
     }
-    handed: int | None = None
+    preexec = None
     if kind == "directory":
         handed = os.open(str(tmp_path), os.O_RDONLY)
-        stdin: int = handed
-        preexec = None
+    elif kind == "write_only":
+        handed = os.open(os.devnull, os.O_WRONLY)
     else:
         handed = os.open(os.devnull, os.O_RDONLY)
-        stdin = handed
         # Closes descriptor 0 in the child after the fork, which is the state
         # `stdin=subprocess.DEVNULL` cannot produce.
         preexec = lambda: os.close(0)  # noqa: E731
@@ -961,7 +979,7 @@ def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) 
         process = subprocess.Popen(
             [bash, str(_ENTRYPOINT_PATH), str(fake_server)],
             env=env,
-            stdin=stdin,
+            stdin=handed,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
@@ -983,8 +1001,8 @@ def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) 
         "the supervisor never started the server, so an input it does not read "
         f"takes down the container. stdout={stdout!r} stderr={stderr!r}"
     )
-    assert seen.read_text(encoding="utf-8") == os.devnull, (
+    assert seen.read_text(encoding="utf-8") == f"{os.devnull} readable=True", (
         f"the server was handed {seen.read_text(encoding='utf-8')!r} rather "
-        f"than {os.devnull}, which it cannot read. stderr={stderr!r}"
+        f"than a readable {os.devnull}. stderr={stderr!r}"
     )
     assert process.returncode == 0, (stdout, stderr)

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -658,10 +658,15 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
     stale_socket.close()
     lock_path.write_text("stale", encoding="utf-8")
 
+    # Records that it got past the stale names, which is the half of this the
+    # supervisor's exit status cannot show: a stale socket satisfies the
+    # readiness loop on its own, so dropping the cleanup produces the same
+    # non-zero exit and the same TERM as a display that came up and then died.
+    started_marker = tmp_path / "xvfb-started"
     fake_xvfb = tmp_path / "Xvfb"
     fake_xvfb.write_text(
         textwrap.dedent(
-            """\
+            f"""\
             #!/usr/bin/env python3
             import pathlib
             import socket
@@ -669,8 +674,8 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
             import time
 
             number = sys.argv[1].removeprefix(":").split(".", 1)[0]
-            path = pathlib.Path(f"/tmp/.X11-unix/X{number}")
-            lock = pathlib.Path(f"/tmp/.X{number}-lock")
+            path = pathlib.Path(f"/tmp/.X11-unix/X{{number}}")
+            lock = pathlib.Path(f"/tmp/.X{{number}}-lock")
             path.parent.mkdir(parents=True, exist_ok=True)
             if path.exists() or lock.exists():
                 raise SystemExit(91)
@@ -678,6 +683,7 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
             server.bind(str(path))
             server.listen()
             lock.write_text("owned", encoding="utf-8")
+            pathlib.Path({str(started_marker)!r}).write_text("started")
             time.sleep(0.3)
             server.close()
             path.unlink(missing_ok=True)
@@ -742,6 +748,11 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
         socket_path.unlink(missing_ok=True)
         lock_path.unlink(missing_ok=True)
 
+    assert started_marker.exists(), (
+        "the stale socket and lock were not removed, so the display never came "
+        f"up and the container is back in its restart loop. stdout={stdout!r} "
+        f"stderr={stderr!r}"
+    )
     assert process.returncode != 0, (stdout, stderr)
     assert term_marker.read_text(encoding="utf-8") == "term"
 
@@ -854,14 +865,20 @@ def test_the_supervisor_hands_the_server_the_containers_stdin(tmp_path: Path) ->
 
 
 @pytest.mark.skipif(os.name == "nt", reason="the image entrypoint is Bash on Linux")
-def test_a_closed_standard_input_still_starts_the_server(tmp_path: Path) -> None:
-    """Spelling the redirection out must not make descriptor 0 mandatory.
+@pytest.mark.parametrize("kind", ["closed", "directory"])
+def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) -> None:
+    """Spelling the redirection out is what stops hiding a bad descriptor.
 
-    `docker run` always supplies one, so nothing here noticed that a launcher
-    may close it instead. Then the redirection that hands stdin to the server
-    fails, `set -e` ends the supervisor before the server is ever started, and
-    HTTP and the one-shot commands go down with it over an input they never
-    wanted. The first shape of this fix did exactly that.
+    The bare ``&`` this replaces gave every mode ``/dev/null`` whether it wanted
+    one or not, so nothing here noticed what a launcher may actually pass.
+    Handing it through unexamined is worse than either: a closed descriptor
+    reaches Python as ``EBADF`` on every read, and an open directory ends the
+    interpreter before argument parsing, taking down HTTP and the one-shot
+    commands over an input none of them reads.
+
+    Asserting that the server merely started is not enough and was tried: with
+    the descriptor passed through untouched it starts perfectly well, and only
+    the first read says otherwise. So the fake server reports what it was given.
     """
     bash = shutil.which("bash")
     if bash is None:
@@ -873,6 +890,8 @@ def test_a_closed_standard_input_still_starts_the_server(tmp_path: Path) -> None
     )
     if major < 5:
         pytest.skip("wait -n -p requires the Bash 5 shipped by the image")
+    if not Path("/proc/self/fd").is_dir():
+        pytest.skip("the directory case is recognised through /dev/fd")
 
     display_number, socket_path, lock_path = _a_free_display(30_000)
 
@@ -898,17 +917,23 @@ def test_a_closed_standard_input_still_starts_the_server(tmp_path: Path) -> None
     )
     fake_xvfb.chmod(0o755)
 
-    # Records that it ran at all, which is the whole question. A supervisor that
-    # dies on the redirection never reaches this.
-    started = tmp_path / "started"
+    # Reports the descriptor rather than using it. A real server would already
+    # be dead in the directory case, which is the point.
+    seen = tmp_path / "seen"
     fake_server = tmp_path / "server"
     fake_server.write_text(
         textwrap.dedent(
             f"""\
             #!/usr/bin/env python3
+            import os
             import pathlib
 
-            pathlib.Path({str(started)!r}).write_text("started")
+            try:
+                os.fstat(0)
+                target = os.readlink("/proc/self/fd/0")
+            except OSError as error:
+                target = f"errno={{error.errno}}"
+            pathlib.Path({str(seen)!r}).write_text(target)
             """
         ),
         encoding="utf-8",
@@ -920,19 +945,28 @@ def test_a_closed_standard_input_still_starts_the_server(tmp_path: Path) -> None
         "DISPLAY": f":{display_number}",
         "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
     }
-    devnull = os.open(os.devnull, os.O_RDONLY)
+    handed: int | None = None
+    if kind == "directory":
+        handed = os.open(str(tmp_path), os.O_RDONLY)
+        stdin: int = handed
+        preexec = None
+    else:
+        handed = os.open(os.devnull, os.O_RDONLY)
+        stdin = handed
+        # Closes descriptor 0 in the child after the fork, which is the state
+        # `stdin=subprocess.DEVNULL` cannot produce.
+        preexec = lambda: os.close(0)  # noqa: E731
+
     try:
         process = subprocess.Popen(
             [bash, str(_ENTRYPOINT_PATH), str(fake_server)],
             env=env,
-            stdin=devnull,
+            stdin=stdin,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             start_new_session=True,
-            # Closes descriptor 0 in the child after the fork, which is the state
-            # `stdin=subprocess.DEVNULL` cannot produce.
-            preexec_fn=lambda: os.close(0),
+            preexec_fn=preexec,
         )
         try:
             stdout, stderr = process.communicate(timeout=15)
@@ -941,13 +975,16 @@ def test_a_closed_standard_input_still_starts_the_server(tmp_path: Path) -> None
             process.communicate()
             raise
     finally:
-        os.close(devnull)
+        os.close(handed)
         socket_path.unlink(missing_ok=True)
         lock_path.unlink(missing_ok=True)
 
-    assert started.exists(), (
-        "the supervisor never started the server, so a closed descriptor 0 "
-        f"takes down modes that never read stdin. stdout={stdout!r} "
-        f"stderr={stderr!r}"
+    assert seen.exists(), (
+        "the supervisor never started the server, so an input it does not read "
+        f"takes down the container. stdout={stdout!r} stderr={stderr!r}"
+    )
+    assert seen.read_text(encoding="utf-8") == os.devnull, (
+        f"the server was handed {seen.read_text(encoding='utf-8')!r} rather "
+        f"than {os.devnull}, which it cannot read. stderr={stderr!r}"
     )
     assert process.returncode == 0, (stdout, stderr)

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -567,36 +567,66 @@ def test_the_documented_bind_mount_is_created_by_the_host_user() -> None:
         assert 'sudo chown -R "$(id -u):$(id -g)" ~/.linkedin-mcp' in document
 
 
-def test_no_documented_argument_array_needs_a_shell() -> None:
-    """A client executes these, so nothing in them may need expanding.
-
-    The mounts in the surrounding shell commands are written with ``~`` on
-    purpose and a shell expands them. The arrays inside an MCP client's JSON
-    config are handed to ``docker`` directly, and a literal ``~`` is neither an
-    absolute path nor a legal volume name, so Docker exits 125 before Tini, the
-    supervisor or Python ever start. The stdio transport this container exists
-    to serve is then unreachable through the configuration the docs give for it.
-    """
-    blocks = [
-        block
-        for document in (_README, _DOCKER_GUIDE)
-        for block in re.findall(r"```json\n(.*?)```", document, re.DOTALL)
-    ]
-    assert blocks, "no JSON configuration blocks found to check"
-
-    checked = 0
-    for block in blocks:
+def _documented_client_mounts(document: str) -> list[str]:
+    """Every ``-v`` value an MCP client would hand to ``docker`` verbatim."""
+    mounts: list[str] = []
+    for block in re.findall(r"```json\n(.*?)```", document, re.DOTALL):
         for server in json.loads(block).get("mcpServers", {}).values():
-            for argument in server.get("args", []):
-                checked += 1
-                assert not argument.startswith("~"), (
-                    f"{argument!r} is handed to {server.get('command')!r} "
-                    "without a shell, so nothing expands the tilde"
-                )
-                assert "$" not in argument, (
-                    f"{argument!r} is handed to {server.get('command')!r} "
-                    "without a shell, so nothing expands the variable"
-                )
+            arguments = server.get("args", [])
+            mounts += [
+                value for flag, value in zip(arguments, arguments[1:]) if flag == "-v"
+            ]
+    return mounts
+
+
+def test_every_documented_mount_is_a_path_docker_accepts() -> None:
+    """A client executes these arrays, so Docker reads each path verbatim.
+
+    Docker resolves a bind source only when it is already absolute; anything
+    else is read as a volume *name*, whose character class ``~``, ``$HOME``
+    and ``%USERPROFILE%`` all fail. Docker then exits 125 before Tini, the
+    supervisor or Python ever start, and the stdio transport this container
+    exists to serve is unreachable through the configuration the docs give
+    for it. Measured against the daemon: ``%USERPROFILE%/.linkedin-mcp:...``
+    exits 125, while an absolute path is accepted whatever else it holds -- a
+    ``$`` inside one names a directory rather than a variable, because no
+    shell is involved.
+    """
+    for name, document in (
+        ("README.md", _README),
+        ("docs/docker-hub.md", _DOCKER_GUIDE),
+    ):
+        mounts = _documented_client_mounts(document)
+        written = re.findall(r'"-v",\s*"([^"]*)"', document)
+        assert mounts == written, (
+            f"{name} writes {written} but this check parsed {mounts}, so a "
+            "configuration block was never inspected"
+        )
+        assert mounts, f"{name} documents no mount to check"
+
+        for mount in mounts:
+            host, _, container = mount.rpartition(":")
+            assert re.match(r"(?:/|[A-Za-z]:/)", host), (
+                f"{name}: {host!r} is not an absolute path, so Docker reads it "
+                "as a volume name and exits 125"
+            )
+            assert container.startswith("/"), (
+                f"{name}: {container!r} is not an absolute destination"
+            )
+
+
+def test_no_documented_argument_starts_with_a_tilde() -> None:
+    """No client expands one, and every ``args`` array is executed directly."""
+    checked = 0
+    for document in (_README, _DOCKER_GUIDE):
+        for block in re.findall(r"```json\n(.*?)```", document, re.DOTALL):
+            for server in json.loads(block).get("mcpServers", {}).values():
+                for argument in server.get("args", []):
+                    checked += 1
+                    assert not argument.startswith("~"), (
+                        f"{argument!r} is handed to {server.get('command')!r} "
+                        "without a shell, so nothing expands the tilde"
+                    )
     assert checked, "no arguments found to check"
 
 

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -607,6 +607,28 @@ def test_a_host_prefixed_display_is_refused_before_xvfb_starts() -> None:
     assert "Xvfb" not in process.stderr
 
 
+# A display that comes up and stays up, for the tests whose subject is the
+# descriptor rather than the display.
+_FAKE_XVFB = """\
+#!/usr/bin/env python3
+import pathlib
+import socket
+import sys
+import time
+
+number = sys.argv[1].removeprefix(":").split(".", 1)[0]
+path = pathlib.Path(f"/tmp/.X11-unix/X{number}")
+# Real Xvfb 21.1.7 publishes the lock before it creates the socket. Measured
+# by inotify inside the image; a fake that reverses it would let a readiness
+# check that accepts the lock pass here.
+pathlib.Path(f"/tmp/.X{number}-lock").write_text("owned")
+server = socket.socket(socket.AF_UNIX)
+server.bind(str(path))
+server.listen()
+time.sleep(5)
+"""
+
+
 def _a_free_display(base: int) -> tuple[int, Path, Path]:
     """Pick a display number whose socket and lock nobody else owns.
 
@@ -699,6 +721,7 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
     fake_xvfb.chmod(0o755)
 
     term_marker = tmp_path / "server-received-term"
+    display_marker = tmp_path / "server-saw-display"
     fake_server = tmp_path / "server"
     fake_server.write_text(
         textwrap.dedent(
@@ -707,9 +730,27 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
             import os
             import pathlib
             import signal
+            import socket
             import time
 
             marker = pathlib.Path(os.environ["SERVER_TERM_MARKER"])
+
+            # The display is what the supervisor waited for, so a server that
+            # never touches it cannot tell readiness from a guess. Chromium
+            # connects here; this connects and nothing else.
+            display = os.environ["DISPLAY"].removeprefix(":").split(".", 1)[0]
+            probe = socket.socket(socket.AF_UNIX)
+            try:
+                probe.connect(f"/tmp/.X11-unix/X{display}")
+            except OSError as error:
+                pathlib.Path(os.environ["SERVER_DISPLAY_MARKER"]).write_text(
+                    f"unreachable: {error.errno}", encoding="utf-8"
+                )
+                raise SystemExit(90) from error
+            probe.close()
+            pathlib.Path(os.environ["SERVER_DISPLAY_MARKER"]).write_text(
+                "reachable", encoding="utf-8"
+            )
 
             def stop(*_args):
                 marker.write_text("term", encoding="utf-8")
@@ -729,6 +770,7 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
         "DISPLAY": display,
         "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
         "SERVER_TERM_MARKER": str(term_marker),
+        "SERVER_DISPLAY_MARKER": str(display_marker),
     }
     process = subprocess.Popen(
         [bash, str(_ENTRYPOINT_PATH), str(fake_server)],
@@ -752,6 +794,11 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
         socket_path.unlink(missing_ok=True)
         lock_path.unlink(missing_ok=True)
 
+    assert display_marker.read_text(encoding="utf-8") == "reachable", (
+        "the server was started before the display could accept a connection, "
+        "so the readiness check passed on something other than the socket. "
+        f"marker={display_marker.read_text(encoding='utf-8')!r} stdout={stdout!r}"
+    )
     assert started_marker.exists(), (
         "the stale socket and lock were not removed, so the display never came "
         f"up and the container is back in its restart loop. stdout={stdout!r} "
@@ -792,29 +839,7 @@ def test_the_supervisor_hands_the_server_the_containers_stdin(tmp_path: Path) ->
     display_number, socket_path, lock_path = _a_free_display(20_000)
 
     fake_xvfb = tmp_path / "Xvfb"
-    fake_xvfb.write_text(
-        textwrap.dedent(
-            """\
-            #!/usr/bin/env python3
-            import pathlib
-            import socket
-            import sys
-            import time
-
-            number = sys.argv[1].removeprefix(":").split(".", 1)[0]
-            path = pathlib.Path(f"/tmp/.X11-unix/X{number}")
-            # Real Xvfb 21.1.7 publishes the lock before it creates the socket.
-            # Measured by inotify inside the image; a fake that reverses it
-            # would let a readiness check that accepts the lock pass here.
-            pathlib.Path(f"/tmp/.X{number}-lock").write_text("owned")
-            server = socket.socket(socket.AF_UNIX)
-            server.bind(str(path))
-            server.listen()
-            time.sleep(5)
-            """
-        ),
-        encoding="utf-8",
-    )
+    fake_xvfb.write_text(_FAKE_XVFB, encoding="utf-8")
     fake_xvfb.chmod(0o755)
 
     # Echoes one line back and exits, so a server that is handed /dev/null ends
@@ -873,16 +898,142 @@ def test_the_supervisor_hands_the_server_the_containers_stdin(tmp_path: Path) ->
 
 
 @pytest.mark.skipif(os.name == "nt", reason="the image entrypoint is Bash on Linux")
-@pytest.mark.parametrize("kind", ["closed", "directory", "write_only"])
+@pytest.mark.parametrize("kind", ["read_write_file", "socket", "read_write_null"])
+def test_a_readable_descriptor_is_handed_over_untouched(
+    tmp_path: Path, kind: str
+) -> None:
+    """The guard's false-positive direction is the one that costs the product.
+
+    Condemning a descriptor the server could have read replaces it with
+    ``/dev/null``, and the server then reads EOF and answers nothing: the exact
+    bug this change exists to remove, restored silently and with a zero exit
+    status. Every other test here hands the guard something bad and checks that
+    it notices. This hands it something good.
+
+    Access mode 2 is the gap those tests leave. The pipe behind
+    ``subprocess.PIPE`` is mode 0, so a guard rewritten to reject every non-zero
+    mode passed the entire file while turning away terminals, sockets and the
+    read-write ``/dev/null`` that plain ``docker run`` supplies.
+    """
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise the Linux image entrypoint")
+    major = int(
+        subprocess.check_output(
+            [bash, "-c", 'printf "%s" "${BASH_VERSINFO[0]}"'], text=True
+        )
+    )
+    if major < 5:
+        pytest.skip("wait -n -p requires the Bash 5 shipped by the image")
+    if not Path("/proc/self/fdinfo").is_dir():
+        pytest.skip("the guard reads the access mode through /proc")
+
+    display_number, socket_path, lock_path = _a_free_display(40_000)
+    fake_xvfb = tmp_path / "Xvfb"
+    fake_xvfb.write_text(_FAKE_XVFB, encoding="utf-8")
+    fake_xvfb.chmod(0o755)
+
+    seen = tmp_path / "seen"
+    fake_server = tmp_path / "server"
+    fake_server.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env python3
+            import fcntl
+            import os
+            import pathlib
+            import sys
+
+            mode = fcntl.fcntl(0, fcntl.F_GETFL) & os.O_ACCMODE
+            target = os.readlink("/proc/self/fd/0")
+            first = sys.stdin.readline().strip()
+            pathlib.Path({str(seen)!r}).write_text(
+                f"{{target}} mode={{mode}} read={{first}}"
+            )
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_server.chmod(0o755)
+
+    peer: socket.socket | None = None
+    if kind == "read_write_file":
+        source = tmp_path / "request"
+        source.write_text("a-request\n", encoding="utf-8")
+        handed = os.open(str(source), os.O_RDWR)
+        expected_target, expected_read = str(source), "a-request"
+    elif kind == "socket":
+        near, peer = socket.socketpair()
+        peer.sendall(b"a-request\n")
+        handed = os.dup(near.fileno())
+        near.close()
+        expected_target, expected_read = None, "a-request"
+    else:
+        handed = os.open(os.devnull, os.O_RDWR)
+        expected_target, expected_read = os.devnull, ""
+
+    env = {
+        **os.environ,
+        "DISPLAY": f":{display_number}",
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+    }
+    try:
+        process = subprocess.Popen(
+            [bash, str(_ENTRYPOINT_PATH), str(fake_server)],
+            env=env,
+            stdin=handed,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        try:
+            stdout, stderr = process.communicate(timeout=15)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.communicate()
+            raise
+    finally:
+        os.close(handed)
+        if peer is not None:
+            peer.close()
+        socket_path.unlink(missing_ok=True)
+        lock_path.unlink(missing_ok=True)
+
+    assert seen.exists(), (stdout, stderr)
+    answer = seen.read_text(encoding="utf-8")
+    # Mode 2 in the answer is the whole point: a replaced descriptor reads back
+    # as `/dev/null mode=0`, which is indistinguishable from the original by
+    # name alone in the third case.
+    assert f"mode={os.O_RDWR} read={expected_read}" in answer, (
+        f"the server was handed {answer!r} rather than the descriptor it was "
+        f"started with. stderr={stderr!r}"
+    )
+    if expected_target is not None:
+        assert answer.startswith(f"{expected_target} "), answer
+    assert process.returncode == 0, (stdout, stderr)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the image entrypoint is Bash on Linux")
+@pytest.mark.parametrize(
+    "kind", ["closed", "directory", "write_only", "no_access_mode", "path_only"]
+)
 def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) -> None:
     """Spelling the redirection out is what stops hiding a bad descriptor.
 
     The bare ``&`` this replaces gave every mode ``/dev/null`` whether it wanted
     one or not, so nothing here noticed what a launcher may actually pass.
-    Handing it through unexamined is worse than either. A closed descriptor and
-    a write-only one both reach Python as ``EBADF`` on the first read, and an
-    open directory ends the interpreter before argument parsing, taking down
-    HTTP and the one-shot commands over an input none of them reads.
+    Handing it through unexamined is worse than either. A closed descriptor, a
+    write-only one, one opened in Linux's fourth access mode and an ``O_PATH``
+    handle all reach Python as ``EBADF`` on the first read, and an open
+    directory ends the interpreter before argument parsing, taking down HTTP and
+    the one-shot commands over an input none of them reads.
+
+    The closed case does not arrive this way in the shipped image, because Tini
+    refuses it first: it calls ``tcsetpgrp`` on descriptor 0 before executing
+    anything and treats ``EBADF`` as fatal. This runs the script directly, which
+    is how the case reaches the guard at all, and the guard keeps it for the
+    overridden-entrypoint path.
 
     Asserting that the server merely started is not enough and was tried: with
     the descriptor passed through untouched it starts perfectly well, and only
@@ -908,29 +1059,7 @@ def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) 
     display_number, socket_path, lock_path = _a_free_display(30_000)
 
     fake_xvfb = tmp_path / "Xvfb"
-    fake_xvfb.write_text(
-        textwrap.dedent(
-            """\
-            #!/usr/bin/env python3
-            import pathlib
-            import socket
-            import sys
-            import time
-
-            number = sys.argv[1].removeprefix(":").split(".", 1)[0]
-            path = pathlib.Path(f"/tmp/.X11-unix/X{number}")
-            # Real Xvfb 21.1.7 publishes the lock before it creates the socket.
-            # Measured by inotify inside the image; a fake that reverses it
-            # would let a readiness check that accepts the lock pass here.
-            pathlib.Path(f"/tmp/.X{number}-lock").write_text("owned")
-            server = socket.socket(socket.AF_UNIX)
-            server.bind(str(path))
-            server.listen()
-            time.sleep(5)
-            """
-        ),
-        encoding="utf-8",
-    )
+    fake_xvfb.write_text(_FAKE_XVFB, encoding="utf-8")
     fake_xvfb.chmod(0o755)
 
     # Reports the descriptor rather than using it. A real server would already
@@ -969,6 +1098,18 @@ def test_an_unusable_standard_input_becomes_dev_null(tmp_path: Path, kind: str) 
         handed = os.open(str(tmp_path), os.O_RDONLY)
     elif kind == "write_only":
         handed = os.open(os.devnull, os.O_WRONLY)
+    elif kind == "no_access_mode":
+        # Linux's fourth access mode grants neither direction. Nothing in
+        # Python's `os` names it, and rejecting only write-only let it through.
+        handed = os.open(str(tmp_path / "data"), os.O_CREAT | 3)
+    elif kind == "path_only":
+        # O_PATH names the file without opening it. Every read fails while the
+        # access-mode bits still read 0, which is the readable value.
+        (tmp_path / "data").write_text("x", encoding="utf-8")
+        # `os.O_PATH` is Linux-only and absent from the stubs this file is
+        # checked against, so the value is written out. It is the same
+        # `010000000` the entrypoint masks against.
+        handed = os.open(str(tmp_path / "data"), getattr(os, "O_PATH", 0o10000000))
     else:
         handed = os.open(os.devnull, os.O_RDONLY)
         # Closes descriptor 0 in the child after the fork, which is the state

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -696,20 +696,30 @@ time.sleep(5)
 def _a_free_display(base: int) -> tuple[int, Path, Path]:
     """Pick a display number whose socket and lock nobody else owns.
 
-    These tests run the real entrypoint, which begins by removing both names.
-    Deriving the number from the PID alone keeps two tests in one process apart
-    and reserves nothing, so a concurrent run or a real X server inside the
-    range would have its socket deleted out from under it and its clients left
-    with nowhere to connect. Scan instead, and take a number that is free.
+    These tests run the real entrypoint, which begins by removing both names,
+    so a number that something else is using would have its socket deleted out
+    from under it and its clients left with nowhere to connect. Deriving the
+    number from the PID keeps two tests in one process apart and claims
+    nothing. Scan for a free number instead, and claim it by creating its lock
+    exclusively, which no second scanner can then pick.
     """
     start = base + (os.getpid() % 10_000)
     for offset in range(100):
         number = base + ((start - base + offset) % 10_000)
         socket_path = Path(f"/tmp/.X11-unix/X{number}")
         lock_path = Path(f"/tmp/.X{number}-lock")
-        if not socket_path.exists() and not lock_path.exists():
-            socket_path.parent.mkdir(parents=True, exist_ok=True)
-            return number, socket_path, lock_path
+        if socket_path.exists():
+            continue
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            # Claims the number rather than reporting it free, so a second
+            # scanner cannot pick the same one between this check and the
+            # entrypoint's removal. The entrypoint deletes the lock on start,
+            # which is the stale state these tests want anyway.
+            os.close(os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644))
+        except FileExistsError:
+            continue
+        return number, socket_path, lock_path
     pytest.fail(f"no free X display in {base}..{base + 99}")
 
 

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -23,6 +23,7 @@ not switched off, and that the constraint files still agree with each other.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -564,6 +565,39 @@ def test_the_documented_bind_mount_is_created_by_the_host_user() -> None:
     for document in (_README, _DOCKER_GUIDE):
         assert "mkdir -p ~/.linkedin-mcp" in document
         assert 'sudo chown -R "$(id -u):$(id -g)" ~/.linkedin-mcp' in document
+
+
+def test_no_documented_argument_array_needs_a_shell() -> None:
+    """A client executes these, so nothing in them may need expanding.
+
+    The mounts in the surrounding shell commands are written with ``~`` on
+    purpose and a shell expands them. The arrays inside an MCP client's JSON
+    config are handed to ``docker`` directly, and a literal ``~`` is neither an
+    absolute path nor a legal volume name, so Docker exits 125 before Tini, the
+    supervisor or Python ever start. The stdio transport this container exists
+    to serve is then unreachable through the configuration the docs give for it.
+    """
+    blocks = [
+        block
+        for document in (_README, _DOCKER_GUIDE)
+        for block in re.findall(r"```json\n(.*?)```", document, re.DOTALL)
+    ]
+    assert blocks, "no JSON configuration blocks found to check"
+
+    checked = 0
+    for block in blocks:
+        for server in json.loads(block).get("mcpServers", {}).values():
+            for argument in server.get("args", []):
+                checked += 1
+                assert not argument.startswith("~"), (
+                    f"{argument!r} is handed to {server.get('command')!r} "
+                    "without a shell, so nothing expands the tilde"
+                )
+                assert "$" not in argument, (
+                    f"{argument!r} is handed to {server.get('command')!r} "
+                    "without a shell, so nothing expands the variable"
+                )
+    assert checked, "no arguments found to check"
 
 
 def test_the_supervisor_stops_python_before_the_display() -> None:

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -607,6 +607,26 @@ def test_a_host_prefixed_display_is_refused_before_xvfb_starts() -> None:
     assert "Xvfb" not in process.stderr
 
 
+def _a_free_display(base: int) -> tuple[int, Path, Path]:
+    """Pick a display number whose socket and lock nobody else owns.
+
+    These tests run the real entrypoint, which begins by removing both names.
+    Deriving the number from the PID alone keeps two tests in one process apart
+    and reserves nothing, so a concurrent run or a real X server inside the
+    range would have its socket deleted out from under it and its clients left
+    with nowhere to connect. Scan instead, and take a number that is free.
+    """
+    start = base + (os.getpid() % 10_000)
+    for offset in range(100):
+        number = base + ((start - base + offset) % 10_000)
+        socket_path = Path(f"/tmp/.X11-unix/X{number}")
+        lock_path = Path(f"/tmp/.X{number}-lock")
+        if not socket_path.exists() and not lock_path.exists():
+            socket_path.parent.mkdir(parents=True, exist_ok=True)
+            return number, socket_path, lock_path
+    pytest.fail(f"no free X display in {base}..{base + 99}")
+
+
 @pytest.mark.skipif(os.name == "nt", reason="the image entrypoint is Bash on Linux")
 def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
     tmp_path: Path,
@@ -631,13 +651,8 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
     if major < 5:
         pytest.skip("wait -n -p requires the Bash 5 shipped by the image")
 
-    display_number = 10_000 + (os.getpid() % 10_000)
+    display_number, socket_path, lock_path = _a_free_display(10_000)
     display = f":{display_number}.0"
-    socket_path = Path(f"/tmp/.X11-unix/X{display_number}")
-    lock_path = Path(f"/tmp/.X{display_number}-lock")
-    socket_path.parent.mkdir(parents=True, exist_ok=True)
-    socket_path.unlink(missing_ok=True)
-    lock_path.unlink(missing_ok=True)
     stale_socket = socket.socket(socket.AF_UNIX)
     stale_socket.bind(str(socket_path))
     stale_socket.close()
@@ -729,3 +744,210 @@ def test_stale_x11_state_is_removed_and_xvfb_dying_stops_the_server(
 
     assert process.returncode != 0, (stdout, stderr)
     assert term_marker.read_text(encoding="utf-8") == "term"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the image entrypoint is Bash on Linux")
+def test_the_supervisor_hands_the_server_the_containers_stdin(tmp_path: Path) -> None:
+    """The stdio transport is the whole product over ``docker run -i``.
+
+    A shell assigns ``/dev/null`` to the standard input of an asynchronous list
+    in the absence of an explicit redirection, so ``"$@" &`` left the server
+    reading a descriptor the container's stdin never reached. Measured against
+    the published 4.23.0 image, a full MCP handshake produced nothing at all:
+    the server started, announced the transport, read EOF from ``/dev/null`` at
+    once and exited 0. Nothing failed, so nothing said so.
+
+    A string check would not have caught it and did not: the supervisor already
+    had tests for the display, for signal order and for child liveness, and all
+    of them passed for the two releases this shipped in. So this runs the real
+    script with a fake server that reports what it can read, which is the only
+    form of the question that has an answer.
+    """
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise the Linux image entrypoint")
+    major = int(
+        subprocess.check_output(
+            [bash, "-c", 'printf "%s" "${BASH_VERSINFO[0]}"'], text=True
+        )
+    )
+    if major < 5:
+        pytest.skip("wait -n -p requires the Bash 5 shipped by the image")
+
+    display_number, socket_path, lock_path = _a_free_display(20_000)
+
+    fake_xvfb = tmp_path / "Xvfb"
+    fake_xvfb.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import pathlib
+            import socket
+            import sys
+            import time
+
+            number = sys.argv[1].removeprefix(":").split(".", 1)[0]
+            path = pathlib.Path(f"/tmp/.X11-unix/X{number}")
+            server = socket.socket(socket.AF_UNIX)
+            server.bind(str(path))
+            server.listen()
+            time.sleep(5)
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_xvfb.chmod(0o755)
+
+    # Echoes one line back and exits, so a server that is handed /dev/null ends
+    # the run just as fast as one that is handed the pipe. The difference is
+    # what comes out, never how long the test takes.
+    fake_server = tmp_path / "server"
+    fake_server.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import sys
+
+            line = sys.stdin.readline()
+            sys.stdout.write(f"server-read:{line.strip()}\\n")
+            sys.stdout.flush()
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_server.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "DISPLAY": f":{display_number}",
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+    }
+    process = subprocess.Popen(
+        [bash, str(_ENTRYPOINT_PATH), str(fake_server)],
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        try:
+            stdout, stderr = process.communicate("a-request\n", timeout=15)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.communicate()
+            raise
+    finally:
+        socket_path.unlink(missing_ok=True)
+        lock_path.unlink(missing_ok=True)
+
+    assert "server-read:a-request" in stdout, (
+        "the server was started without the container's stdin, so the stdio "
+        f"transport can never receive a request. stdout={stdout!r} "
+        f"stderr={stderr!r}"
+    )
+    # The reachable descriptor is half the contract. Without this the run also
+    # passes when the supervisor dies on `wait -n -p` right after the fake
+    # server has already echoed, leaving fake Xvfb alive behind a green test.
+    assert process.returncode == 0, (stdout, stderr)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the image entrypoint is Bash on Linux")
+def test_a_closed_standard_input_still_starts_the_server(tmp_path: Path) -> None:
+    """Spelling the redirection out must not make descriptor 0 mandatory.
+
+    `docker run` always supplies one, so nothing here noticed that a launcher
+    may close it instead. Then the redirection that hands stdin to the server
+    fails, `set -e` ends the supervisor before the server is ever started, and
+    HTTP and the one-shot commands go down with it over an input they never
+    wanted. The first shape of this fix did exactly that.
+    """
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise the Linux image entrypoint")
+    major = int(
+        subprocess.check_output(
+            [bash, "-c", 'printf "%s" "${BASH_VERSINFO[0]}"'], text=True
+        )
+    )
+    if major < 5:
+        pytest.skip("wait -n -p requires the Bash 5 shipped by the image")
+
+    display_number, socket_path, lock_path = _a_free_display(30_000)
+
+    fake_xvfb = tmp_path / "Xvfb"
+    fake_xvfb.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import pathlib
+            import socket
+            import sys
+            import time
+
+            number = sys.argv[1].removeprefix(":").split(".", 1)[0]
+            path = pathlib.Path(f"/tmp/.X11-unix/X{number}")
+            server = socket.socket(socket.AF_UNIX)
+            server.bind(str(path))
+            server.listen()
+            time.sleep(5)
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_xvfb.chmod(0o755)
+
+    # Records that it ran at all, which is the whole question. A supervisor that
+    # dies on the redirection never reaches this.
+    started = tmp_path / "started"
+    fake_server = tmp_path / "server"
+    fake_server.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env python3
+            import pathlib
+
+            pathlib.Path({str(started)!r}).write_text("started")
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_server.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "DISPLAY": f":{display_number}",
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+    }
+    devnull = os.open(os.devnull, os.O_RDONLY)
+    try:
+        process = subprocess.Popen(
+            [bash, str(_ENTRYPOINT_PATH), str(fake_server)],
+            env=env,
+            stdin=devnull,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+            # Closes descriptor 0 in the child after the fork, which is the state
+            # `stdin=subprocess.DEVNULL` cannot produce.
+            preexec_fn=lambda: os.close(0),
+        )
+        try:
+            stdout, stderr = process.communicate(timeout=15)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.communicate()
+            raise
+    finally:
+        os.close(devnull)
+        socket_path.unlink(missing_ok=True)
+        lock_path.unlink(missing_ok=True)
+
+    assert started.exists(), (
+        "the supervisor never started the server, so a closed descriptor 0 "
+        f"takes down modes that never read stdin. stdout={stdout!r} "
+        f"stderr={stderr!r}"
+    )
+    assert process.returncode == 0, (stdout, stderr)


### PR DESCRIPTION
Closes #771

`docker run -i --rm stickerdaniel/linkedin-mcp-server:latest`, the configuration the README gives for Claude Desktop, has answered nothing since 4.22.0. The entrypoint backgrounds the server with `"$@" &`, and a shell assigns `/dev/null` to an asynchronous list's standard input in the absence of an explicit redirection. The server started, announced the transport, read EOF at once and exited. Nothing failed loudly, which is why two releases went by without a report.

It stays a child, because `wait -n -p` needs both children to decide which death ends the container, so the redirection is spelled out instead. Descriptor 0 is probed first: a launcher may hand over one that is closed, write-only or a directory, and the redirection would otherwise carry all three into Python, which dies on an input the HTTP and one-shot modes never read. A second check guards the mount paths the docs hand to `docker` directly, asking each one to be absolute rather than banning characters a shell would have expanded.

Measured against the published 4.23.0 image: a handshake returned nothing over 120 seconds; the same image with only this change answered `initialize` and listed all 19 tools.

## Synthetic prompt

> `docker run -i` against the published image never answers. Find out why, fix it, and add a test that fails without the fix. Verify against the real published image, not just the script.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
