### PR TITLE
docs: Correct stale docs and license metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,8 @@ When adding an entirely new MCP tool (e.g., `search_companies`):
 2. Create a branch: `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`
 3. Implement, test, and update docs (see checklists above)
 4. Open a PR — AI agents review first, then manual review
-5. Don't squash commits on merge
+5. PRs are squash-merged into `main`, so the PR title becomes the commit
+   subject; commits inside a PR are for review only
 
 ## Scraping Philosophy: Minimize DOM Dependence
 

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ belongs behind something that provides it.
 
 ## 🐍 Local Setup (Develop & Contribute)
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for architecture guidelines and checklists. Please [open an issue](https://github.com/stickerdaniel/linkedin-mcp-server/issues) first to discuss the feature or bug fix before submitting a PR.
+Contributions are welcome! See [CONTRIBUTING.md](https://github.com/stickerdaniel/linkedin-mcp-server/blob/main/CONTRIBUTING.md) for architecture guidelines and checklists. Please [open an issue](https://github.com/stickerdaniel/linkedin-mcp-server/issues) first to discuss the feature or bug fix before submitting a PR.
 
 **Prerequisites:** [Git](https://git-scm.com/downloads) and [uv](https://docs.astral.sh/uv/) installed
 
@@ -657,6 +657,6 @@ Use in accordance with [LinkedIn's User Agreement](https://www.linkedin.com/lega
 
 This project is licensed under the Apache 2.0 license.
 
-Building on it is welcome, including under a different license. Apache-2.0 attaches conditions to that, set out in section 4 of the [license](LICENSE). The one most often missed is that the attribution in [`NOTICE`](NOTICE) has to travel with what you ship.
+Building on it is welcome, including under a different license. Apache-2.0 attaches conditions to that, set out in section 4 of the [license](https://github.com/stickerdaniel/linkedin-mcp-server/blob/main/LICENSE). The one most often missed is that the attribution in [`NOTICE`](https://github.com/stickerdaniel/linkedin-mcp-server/blob/main/NOTICE) has to travel with what you ship.
 
 <br>

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/stickerdaniel/linkedin-mcp-server",
   "documentation": "https://github.com/stickerdaniel/linkedin-mcp-server#readme",
   "support": "https://github.com/stickerdaniel/linkedin-mcp-server/issues",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "mcp",
     "mcpb",


### PR DESCRIPTION
Three statements in the repository that were not true.

`manifest.json` declared `"license": "MIT"` while the project is Apache-2.0, so the Claude Desktop bundle has been shipping the wrong licence. That is the one real defect here; the other two are wording. The README is the PyPI package description, and PyPI does not rewrite relative links the way GitHub does, so `LICENSE`, `NOTICE` and `CONTRIBUTING.md` resolved beneath the PyPI project URL and 404'd there. Two of those three were the licence links added last week, which put the compliance guidance out of reach from a primary distribution page. And `CONTRIBUTING.md` told contributors not to squash on merge while every PR is squash-merged, which is the one step they do not control and the file they are most likely to read.

Verified: `tests/test_manifest.py` passes and `mcpb validate` accepts the manifest.
