### PR TITLE
docs(docker): Name the Windows form of the mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Keep the `-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp` mount on every later `d
 }
 ```
 
-Spell that first path out in full. A client runs `docker` directly rather than through a shell, so a leading `~` reaches Docker unexpanded and it refuses the mount.
+Spell that first path out in full. A client runs `docker` directly rather than through a shell, so a leading `~` reaches Docker unexpanded and it refuses the mount. On Windows write it with forward slashes, `C:/Users/you/.linkedin-mcp`; a backslash opens an escape sequence in JSON and `C:\Users` is not one the client can read.
 
 > [!NOTE]
 > Sessions expire over time. When tool calls start asking for authentication, repeat the login command above, or run `uvx mcp-server-linkedin@latest --login` on the host.

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -59,7 +59,7 @@ If an older rootful Docker run left that host directory owned by root, repair it
 }
 ```
 
-Spell that first path out in full. A client runs `docker` directly rather than through a shell, so a leading `~` reaches Docker unexpanded and it refuses the mount.
+Spell that first path out in full. A client runs `docker` directly rather than through a shell, so a leading `~` reaches Docker unexpanded and it refuses the mount. On Windows write it with forward slashes, `C:/Users/you/.linkedin-mcp`; a backslash opens an escape sequence in JSON and `C:\Users` is not one the client can read.
 
 > **Note:** Plain `--login` does not publish a viewer. Use `--login --login-viewer` only for the one-shot login container, with port 6080 published to loopback.
 >


### PR DESCRIPTION
See also #783

The Docker section gives the client configuration's bind mount as `/absolute/path/to/.linkedin-mcp`, a POSIX placeholder. A Windows user substitutes `C:\Users\Alice\.linkedin-mcp` and their client stops loading its config: `\U` is not a JSON escape, so the failure lands before Docker is ever reached and says nothing about mounts. The forward-slash form parses and Docker Desktop accepts it, and it appeared nowhere.

One sentence in each of the two documents names it. The PowerShell variants of the surrounding shell commands are the larger half of #783 and are not in here.

`tests/test_docker_image.py::test_every_documented_mount_is_a_path_docker_accepts` already accepts a `C:/` host path, so nothing in the checks moves.

## Synthetic prompt

> A Windows user pasting a `C:\...` path into the documented Docker MCP config gets invalid JSON. Add the correct form to the docs.

Generated with Claude Opus 5 high