### PR TITLE
chore: Bump version to 4.23.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-linkedin"
-version = "4.23.0"
+version = "4.23.1"
 description = "MCP server that gives AI assistants like Claude access to LinkedIn profiles, companies, and job postings through the user's own browser session."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-linkedin"
-version = "4.23.0"
+version = "4.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
`docker run -i` has answered nothing since 4.22.0, so every Docker stdio user has been stuck on a container that starts, announces its transport and exits before the client's first request. The fix is on `main` and reaches nobody until it ships (#773, #771).

Riding along: the MCP Registry preparation (#768) and the Windows form of the documented mount path (#784).

Patch only: `pyproject.toml` and `uv.lock`. The release workflow updates `manifest.json`, `docker-compose.yml` and `server.json` itself.

Generated with Claude Opus 5 high