### PR TITLE
fix(daemon): Stop failed owner children

### DIFF
--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -228,11 +228,11 @@ def obtain_owner(
             return ElectionOutcome(lookup, started_owner=started)
 
         if attempt is _Attempt.FAILED:
-            # This process held the lock, started a child, and the child said it
-            # could not serve. Nobody else is coming: the lock is free again and
-            # a fresh attempt would fail the same way. Waiting out the deadline
-            # here is what turned a broken owner into a client that hangs for
-            # the better part of a minute before reporting nothing at all.
+            # This process held the lock and its child did not become an owner.
+            # `_spawn` has issued a hard stop and a bounded wait, so no descriptor
+            # will come from this attempt. If the kernel could not finish the
+            # stop, that condition was logged there; waiting here still cannot
+            # turn this failed child into an owner.
             logger.warning("The daemon could not start; see %s", _log_hint(auth_root))
             return ElectionOutcome(look(), started_owner=started)
         started = started or attempt is _Attempt.STARTED
@@ -523,8 +523,10 @@ class _Attempt(enum.Enum):
     #: process started has not answered yet and is still holding one. Wait.
     CONTENDED = "contended"
 
-    #: The child this process started said it could not serve. Nothing is
-    #: holding the lock on its behalf, so waiting on it specifically is delay.
+    #: The child this process started did not become an owner. Before this
+    #: reaches the caller, ``_spawn`` has issued a hard stop and waited for the
+    #: child. If the kernel cannot finish that stop within the bounded wait,
+    #: ``_stop_child`` logs that the profile may remain locked.
     FAILED = "failed"
 
 
@@ -700,16 +702,22 @@ def _spawn(
             # *write* blocked, which needs a configuration large enough to fill
             # a pipe; this is the same wedge reached by the ordinary route.
             #
-            # Safe for the same reason: an owner opens no browser before it
-            # answers, so nothing is interrupted mid-flight. And on POSIX the
-            # frontend still holds its own lock until this returns, so the
-            # position cannot be taken by anyone else in between.
+            # This existing timeout chooses the observed lock wedge over an
+            # unbounded wait. Publication precedes the private ready verdict, so
+            # it can race a newly attachable owner; #790 tracks the commit
+            # protocol needed to distinguish those states atomically.
             logger.warning(
                 "The daemon did not finish starting; stopping it so the lock is "
                 "not held by a process that never served"
             )
             _stop_child(child)
             return _Started.NO
+        if verdict is _Started.NO:
+            # A failure verdict is terminal. The real owner has already run its
+            # bounded shutdown before sending it; EOF means the child exited.
+            # Stop a nonconforming child that reports failure and stays alive,
+            # or its inherited descriptor keeps the profile locked forever.
+            _stop_child(child)
         return verdict
     finally:
         _release_handshake(child)
@@ -717,28 +725,30 @@ def _spawn(
 
 
 #: How long to wait for a killed child to be collected. Short by design: this
-#: follows ``SIGKILL``, which the process cannot decline, so anything but a
-#: prompt exit means the process is stuck in the kernel and no amount of waiting
-#: here will change that.
+#: follows a hard kill (``SIGKILL`` on POSIX and ``TerminateProcess`` on
+#: Windows), which the process cannot decline, so anything but a prompt exit
+#: means the process is stuck in the kernel and no amount of waiting here will
+#: change that.
 _STOP_CHILD_SECONDS = 2.0
 
 
 def _stop_child(child: subprocess.Popen[bytes]) -> None:
-    """End a child that never took its configuration, and collect it.
+    """End a child whose startup cannot produce a usable owner, and collect it.
 
-    Killed outright rather than asked politely first. The usual courtesy buys a
-    process time to clean up, and this one has nothing to clean up: it never
-    read its configuration, so it has opened no browser and holds no state
-    beyond the lock descriptor it inherited and must give back.
+    Called after a configuration timeout, an exhausted startup budget, or a
+    terminal non-ready verdict. A reported failure has already run ``_serve``'s
+    bounded endpoint shutdown, and EOF means the child already exited. The
+    timeout cases cannot be left holding the inherited lock indefinitely.
 
-    The courtesy is not free either. A ``SIGTERM`` grace period is time added
-    *after* the caller's budget is already spent, so a child that ignores the
-    signal turns a half-second election into five and a half, and the documented
-    ceiling stops being a ceiling.
+    Killed outright rather than asked politely first. A ``SIGTERM`` grace period
+    is time added *after* the caller's budget is already spent, so a child that
+    ignores the signal turns a half-second election into five and a half, and the
+    documented ceiling stops being a ceiling.
 
-    The wait is what makes "the lock is free" true before this returns: a
-    signalled process has not necessarily been reaped, and until it is, the
-    descriptor may still be open.
+    The wait normally proves process death before this returns: a signalled
+    process may still have its descriptors open until the kernel finishes the
+    exit. The bounded-wait warning is the explicit exception, and the caller must
+    not claim the lock is certainly free after it.
     """
     with contextlib.suppress(OSError):
         child.kill()
@@ -1006,14 +1016,9 @@ def _await_ready(child: subprocess.Popen[bytes], *, timeout: float) -> _Started:
     try:
         verdict = verdicts.get(timeout=max(timeout, 0.0))
     except queue.Empty:
-        # Not a failure, and the difference matters. The child said nothing and
-        # did not exit, so it is still starting and still holds the lock it
-        # adopted. Reporting this as "the child could not serve" would send the
-        # caller off to drive its own browser against the profile the child is
-        # about to open — two browsers, from a slow machine rather than a bug.
-        logger.warning(
-            "The daemon has not finished starting; leaving it to come up on its own"
-        )
+        # Kept distinct from ``NO`` so ``_spawn`` can diagnose silence at the
+        # point where it enforces the startup budget. The child has not proved it
+        # can serve, so that function still owns and stops it.
         return _Started.STILL_TRYING
 
     if verdict is None:

--- a/linkedin_mcp_server/daemon_owner.py
+++ b/linkedin_mcp_server/daemon_owner.py
@@ -761,6 +761,11 @@ def main(argv: list[str] | None = None) -> int:
         # how this process logs.
         config = _read_config()
     except BaseException:
+        # A failed verdict is terminal to the frontend, which may hard-stop this
+        # process as soon as it reads one. Put the diagnosis in the daemon log
+        # before making that verdict visible rather than relying on the
+        # interpreter to print an unhandled traceback afterwards.
+        logger.exception("The daemon could not read its configuration")
         handshake.fail()
         raise
 

--- a/tests/test_daemon_config.py
+++ b/tests/test_daemon_config.py
@@ -248,6 +248,40 @@ class TestRefusing:
             sys.stdin = stdin
             browser_module.set_headless(original)
 
+    def test_a_configuration_failure_is_logged_before_its_verdict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A frontend that receives ``failed`` owns the child only long enough to
+        # stop it. Anything logged after that verdict races the hard stop, so the
+        # order here is part of preserving the actual startup diagnosis.
+        from linkedin_mcp_server import daemon_owner
+
+        events: list[str] = []
+
+        class RecordingHandshake:
+            def __init__(self, _stream: object) -> None:
+                pass
+
+            def fail(self) -> None:
+                events.append("failed")
+
+        def reject() -> AppConfig:
+            raise ValueError("invalid handed-over configuration")
+
+        monkeypatch.setattr(daemon_owner, "_Handshake", RecordingHandshake)
+        monkeypatch.setattr(daemon_owner, "_claim_handshake_stream", lambda: None)
+        monkeypatch.setattr(daemon_owner, "_read_config", reject)
+        monkeypatch.setattr(
+            daemon_owner.logger,
+            "exception",
+            lambda *_args, **_kwargs: events.append("logged"),
+        )
+
+        with pytest.raises(ValueError, match="invalid handed-over configuration"):
+            daemon_owner.main([])
+
+        assert events == ["logged", "failed"]
+
     def test_the_owner_refuses_to_start_without_a_configuration(self):
         # The owner reads its settings from standard input and must not fall
         # back to parsing its own command line: `load_config` would then see the

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -6,10 +6,11 @@ stayed inside one interpreter could show the code takes the branches it means to
 and would not show the thing that matters: that exactly one browser-owning
 process exists, and that the lock dies with it.
 
-Three of these pin defects that were live in this code and found by running it:
-a failed child read as "somebody is starting" and cost a full deadline, a
-crashed owner's descriptor was handed back as attachable, and the parent's copy
-of the lock outliving the owner would have wedged every recovery.
+Four of these pin defects that were live in this code and found by running it:
+a failed child read as "somebody is starting" and cost a full deadline, a child
+that reported failure kept the inherited lock, a crashed owner's descriptor was
+handed back as attachable, and the parent's copy of the lock outliving the owner
+would have wedged every recovery.
 """
 
 from __future__ import annotations
@@ -751,6 +752,61 @@ class TestFailingFast:
                     sleeper.wait(timeout=30)
 
     @_POSIX_ONLY
+    def test_a_child_that_reports_failure_does_not_keep_the_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # This is the missing third startup failure. The child has consumed its
+        # configuration and reported that it cannot serve, but it stays alive.
+        # Removing the stop attached to the terminal ``NO`` verdict leaves its
+        # returncode unset and the lock probe below contended.
+        profile = _profile(tmp_path)
+        config = _config(profile)
+        auth_root = profile.parent
+
+        children: list[subprocess.Popen[Any]] = []
+        real = subprocess.Popen
+
+        def reports_failure(command: list[str], **kwargs: Any) -> subprocess.Popen[Any]:
+            if command[1:4] != ["-I", "-m", "linkedin_mcp_server.daemon_owner"]:
+                return real(command, **kwargs)
+            child = real(
+                [
+                    command[0],
+                    "-c",
+                    "import sys, time\n"
+                    "sys.stdin.read()\n"
+                    "sys.stdout.write('failed\\n')\n"
+                    "sys.stdout.flush()\n"
+                    "time.sleep(600)\n",
+                ],
+                **kwargs,
+            )
+            children.append(child)
+            return child
+
+        monkeypatch.setattr(election_module.subprocess, "Popen", reports_failure)
+
+        try:
+            attempt = election_module._start_owner(
+                auth_root, profile, config, timeout=5.0
+            )
+            assert attempt is _Attempt.FAILED
+            assert [child.returncode for child in children] == [-signal.SIGKILL], (
+                "the child was left alive after reporting startup failure"
+            )
+
+            probe = DaemonLock(auth_root)
+            assert probe.try_acquire(), (
+                "the failed child kept the daemon lock for this profile"
+            )
+            probe.release()
+        finally:
+            for child in children:
+                if child.poll() is None:  # pragma: no cover - the stop worked
+                    child.kill()
+                    child.wait(timeout=30)
+
+    @_POSIX_ONLY
     def test_a_child_that_says_nothing_does_not_keep_the_lock(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -758,13 +814,11 @@ class TestFailingFast:
         # is stopped, and the reasoning took two passes to get right.
         #
         # The first version called this "still trying" and left the child alone,
-        # on the grounds that it might yet come up and that killing it could
-        # leave the caller driving a second browser. The first half is true and
-        # the second is not: an owner opens no browser before it answers, and on
-        # POSIX the frontend holds its own lock until the spawn returns. What
-        # the leniency actually bought was a child holding the inherited lock
-        # while never serving — measured, the lock was still held afterwards,
-        # and every later election would contend against it forever.
+        # on the grounds that it might yet come up. What the leniency actually
+        # bought was a child holding the inherited lock while never serving —
+        # measured, the lock was still held afterwards, and every later election
+        # would contend against it forever. Publication is not atomic with the
+        # private verdict; #790 tracks the opposite timeout race.
         #
         # This test asserted the lenient behaviour and then killed the child in
         # its own teardown, with a comment saying the lock would otherwise be


### PR DESCRIPTION
Closes #781

A child that reported `failed` could remain alive and retain the inherited POSIX daemon lock, wedging every later election while the frontend claimed the lock was free.

`_spawn` now hard-stops and waits on that terminal non-ready verdict. Existing timeout and interruption behavior stays unchanged; the missing atomic boundary between publication and the private verdict is tracked in #790. Configuration failures are logged before `failed` becomes visible, so the stop cannot erase their diagnosis. The regression asserts the signal and probes the lock. The installer process-tree limitation is #789.

Verified with `uv run pytest` (2,352 passed, 20 skipped) and `uv run pre-commit run --all-files`.

## Synthetic prompt

> Ensure a daemon child that reports startup failure cannot retain the profile lock, without broadening cleanup for unknown startup outcomes.

Generated with Claude Opus 5 high + GPT-5.6 Pro + Sol 5.6 xhigh
