### PR TITLE
feat(messaging): add archive_conversation, unarchive_conversation, and mark_conversation_read tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_conversation` | Read a specific messaging conversation by username or thread ID |
 | `search_conversations` | Search messages by keyword |
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) |
+| `archive_conversation` | Archive a conversation thread (requires confirmation) |
+| `unarchive_conversation` | Restore an archived conversation to the inbox (requires confirmation) |
+| `mark_conversation_read` | Mark a conversation as read without opening it |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed |
 | `search_companies` | Search for companies on LinkedIn by keywords |

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5027,6 +5027,190 @@ class LinkedInExtractor:
             sent=True,
         )
 
+    async def _voyager_conversation_action(
+        self,
+        thread_id: str,
+        *,
+        action: str,
+        confirm_action: bool = False,
+    ) -> dict[str, Any]:
+        """Perform a Voyager API action on a conversation thread.
+
+        Calls LinkedIn's internal Voyager API from within the authenticated
+        browser session using ``page.evaluate()`` — the same pattern
+        ``send_message`` uses for compose-box interaction. The CSRF token
+        comes from the ``csrf-token`` meta tag, and cookies/TLS fingerprint
+        come from the real browser session.
+
+        Args:
+            thread_id: The conversation thread ID (already normalized).
+            action: One of ``"archive"``, ``"unarchive"``, ``"mark_read"``.
+            confirm_action: When False, reports what would happen without
+                making the API call. Archive/unarchive require this to be
+                True; mark_read always executes (read-only state change).
+
+        Returns:
+            Dict with url, status, message, and action.
+        """
+        # Navigate to the messaging page first so the page origin is
+        # linkedin.com and the Voyager API is reachable with the right
+        # cookies. Using the thread URL ensures the thread exists.
+        thread_url = messaging_thread_url(thread_id, "/")
+        await self._navigate_to_page(thread_url)
+        await detect_rate_limit(self._page)
+
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("Thread page did not fully load for %s", thread_id)
+
+        # DOM dependency: we need to call fetch() from within the page
+        # context to reach the Voyager API with the session's cookies and
+        # CSRF token. This cannot be done via innerText or URL navigation.
+        # The Voyager conversation endpoint accepts PATCH to flip the
+        # archived flag and POST to mark as seen.
+        if action == "mark_read":
+            # Mark-as-read is not a destructive action; always execute.
+            result = await self._page.evaluate(
+                """async ({ threadId }) => {
+                    const csrfToken = document.querySelector(
+                        'meta[name="csrf-token"]'
+                    )?.getAttribute('content') || '';
+                    try {
+                        const resp = await fetch(
+                            '/voyager/api/messaging/conversations/'
+                            + encodeURIComponent(threadId)
+                            + '/events?action=markAsRead',
+                            {
+                                method: 'POST',
+                                headers: {
+                                    'csrf-token': csrfToken,
+                                    'content-type': 'application/json',
+                                    'x-restli-method': 'CREATE',
+                                },
+                                credentials: 'same-origin',
+                            }
+                        );
+                        return { ok: resp.ok, status: resp.status };
+                    } catch (e) {
+                        return { ok: false, status: 0, error: String(e) };
+                    }
+                }""",
+                {"threadId": thread_id},
+            )
+        else:
+            # Archive / unarchive: flip the archived flag via PATCH.
+            if not confirm_action:
+                return self._message_action_result(
+                    thread_url,
+                    "confirmation_required",
+                    f"Set confirm_action=true to {action} this conversation.",
+                )
+
+            archive_value = action == "archive"
+            result = await self._page.evaluate(
+                """async ({ threadId, archiveValue }) => {
+                    const csrfToken = document.querySelector(
+                        'meta[name="csrf-token"]'
+                    )?.getAttribute('content') || '';
+                    try {
+                        const resp = await fetch(
+                            '/voyager/api/messaging/conversations/'
+                            + encodeURIComponent(threadId),
+                            {
+                                method: 'PATCH',
+                                headers: {
+                                    'csrf-token': csrfToken,
+                                    'content-type': 'application/json',
+                                    'x-restli-method': 'PARTIAL_UPDATE',
+                                },
+                                credentials: 'same-origin',
+                                body: JSON.stringify({
+                                    patch: {
+                                        $set: { archived: archiveValue }
+                                    }
+                                }),
+                            }
+                        );
+                        return { ok: resp.ok, status: resp.status };
+                    } catch (e) {
+                        return { ok: false, status: 0, error: String(e) };
+                    }
+                }""",
+                {"threadId": thread_id, "archiveValue": archive_value},
+            )
+
+        if result.get("ok"):
+            return self._message_action_result(
+                thread_url,
+                action,
+                f"Conversation {action.replace('_', ' ')} successful.",
+            )
+        else:
+            status_code = result.get("status", 0)
+            error_detail = result.get("error", "")
+            return self._message_action_result(
+                thread_url,
+                f"{action}_failed",
+                f"LinkedIn returned status {status_code}"
+                + (f": {error_detail}" if error_detail else ""),
+            )
+
+    async def archive_conversation(
+        self,
+        thread_id: str,
+        *,
+        confirm_action: bool = False,
+    ) -> dict[str, Any]:
+        """Archive a conversation thread.
+
+        Moves the conversation to LinkedIn's archived folder. The thread
+        remains accessible and can be unarchived. Requires explicit
+        confirmation via ``confirm_action=True``.
+
+        Args:
+            thread_id: The conversation thread ID.
+            confirm_action: Must be True to archive. False does a dry run.
+        """
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(
+            thread_id, action="archive", confirm_action=confirm_action
+        )
+
+    async def unarchive_conversation(
+        self,
+        thread_id: str,
+        *,
+        confirm_action: bool = False,
+    ) -> dict[str, Any]:
+        """Restore an archived conversation to the inbox.
+
+        Args:
+            thread_id: The conversation thread ID.
+            confirm_action: Must be True to unarchive. False does a dry run.
+        """
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(
+            thread_id, action="unarchive", confirm_action=confirm_action
+        )
+
+    async def mark_conversation_read(
+        self,
+        thread_id: str,
+    ) -> dict[str, Any]:
+        """Mark a conversation as read without opening it.
+
+        Clears the unread badge on the conversation. Unlike
+        ``get_conversation``, this does not navigate to the thread content
+        and does not mark it read as a side effect of viewing — it calls
+        the Voyager mark-as-read endpoint directly.
+
+        Args:
+            thread_id: The conversation thread ID.
+        """
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(thread_id, action="mark_read")
+
     async def _extract_root_content(
         self,
         selectors: list[str],

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -276,3 +276,167 @@ def register_messaging_tools(
                 raise_tool_error(relogin_exc, "send_message")
         except Exception as e:
             raise_tool_error(e, "send_message")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Archive Conversation",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"messaging", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def archive_conversation(
+        thread_id: str,
+        confirm_action: bool,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Archive a LinkedIn conversation thread.
+
+        Moves the conversation to LinkedIn's archived folder. The thread
+        remains accessible and can be unarchived. This is a write operation
+        that requires confirmation.
+
+        Args:
+            thread_id: LinkedIn messaging thread ID (from get_inbox or
+                search_conversations references)
+            confirm_action: Must be True to archive. False does a dry run.
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, status, message, and action result.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="archive_conversation"
+            )
+            logger.info(
+                "Archiving conversation %s (confirm_action=%s)",
+                thread_id,
+                confirm_action,
+            )
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Archiving conversation"
+            )
+
+            result = await extractor.archive_conversation(
+                thread_id, confirm_action=confirm_action
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "archive_conversation")
+        except Exception as e:
+            raise_tool_error(e, "archive_conversation")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Unarchive Conversation",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"messaging", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def unarchive_conversation(
+        thread_id: str,
+        confirm_action: bool,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Restore an archived conversation to the inbox.
+
+        Args:
+            thread_id: LinkedIn messaging thread ID
+            confirm_action: Must be True to unarchive. False does a dry run.
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, status, message, and action result.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="unarchive_conversation"
+            )
+            logger.info(
+                "Unarchiving conversation %s (confirm_action=%s)",
+                thread_id,
+                confirm_action,
+            )
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Unarchiving conversation"
+            )
+
+            result = await extractor.unarchive_conversation(
+                thread_id, confirm_action=confirm_action
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "unarchive_conversation")
+        except Exception as e:
+            raise_tool_error(e, "unarchive_conversation")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Mark Conversation Read",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"messaging", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def mark_conversation_read(
+        thread_id: str,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Mark a conversation as read without opening it.
+
+        Clears the unread badge on the conversation. Unlike
+        get_conversation, this does not navigate to the thread content
+        and does not mark it read as a side effect of viewing — it calls
+        the Voyager mark-as-read endpoint directly.
+
+        Args:
+            thread_id: LinkedIn messaging thread ID
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, status, message, and action result.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="mark_conversation_read"
+            )
+            logger.info("Marking conversation %s as read", thread_id)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Marking conversation read"
+            )
+
+            result = await extractor.mark_conversation_read(thread_id)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "mark_conversation_read")
+        except Exception as e:
+            raise_tool_error(e, "mark_conversation_read")  # NoReturn

--- a/manifest.json
+++ b/manifest.json
@@ -112,6 +112,18 @@
       "description": "Send a message to a LinkedIn user with explicit confirmation and optional profile URN support"
     },
     {
+      "name": "archive_conversation",
+      "description": "Archive a LinkedIn conversation thread, moving it to the archived folder"
+    },
+    {
+      "name": "unarchive_conversation",
+      "description": "Restore an archived conversation back to the inbox"
+    },
+    {
+      "name": "mark_conversation_read",
+      "description": "Mark a conversation as read without opening it, clearing the unread badge"
+    },
+    {
       "name": "get_feed",
       "description": "Get recent posts from the authenticated user's LinkedIn home feed"
     },

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -35,6 +35,9 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.get_conversation = AsyncMock(return_value=scrape_result)
     mock.search_conversations = AsyncMock(return_value=scrape_result)
     mock.send_message = AsyncMock(return_value=scrape_result)
+    mock.archive_conversation = AsyncMock(return_value=scrape_result)
+    mock.unarchive_conversation = AsyncMock(return_value=scrape_result)
+    mock.mark_conversation_read = AsyncMock(return_value=scrape_result)
     mock.get_my_profile = AsyncMock(return_value=scrape_result)
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.search_posts = AsyncMock(return_value=scrape_result)
@@ -977,6 +980,121 @@ class TestMessagingTools:
                 extractor=mock_extractor,
             )
 
+    async def test_archive_conversation_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "archive",
+            "message": "Conversation archive successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "archive_conversation")
+        result = await tool_fn(
+            "2-abc123==", True, mock_context, extractor=mock_extractor
+        )
+
+        assert result["status"] == "archive"
+        mock_extractor.archive_conversation.assert_awaited_once_with(
+            "2-abc123==", confirm_action=True
+        )
+
+    async def test_archive_conversation_not_confirmed(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "confirmation_required",
+            "message": "Set confirm_action=true to archive this conversation.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "archive_conversation")
+        result = await tool_fn(
+            "2-abc123==", False, mock_context, extractor=mock_extractor
+        )
+
+        assert result["status"] == "confirmation_required"
+        mock_extractor.archive_conversation.assert_awaited_once_with(
+            "2-abc123==", confirm_action=False
+        )
+
+    async def test_unarchive_conversation_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "unarchive",
+            "message": "Conversation unarchive successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "unarchive_conversation")
+        result = await tool_fn(
+            "2-abc123==", True, mock_context, extractor=mock_extractor
+        )
+
+        assert result["status"] == "unarchive"
+        mock_extractor.unarchive_conversation.assert_awaited_once_with(
+            "2-abc123==", confirm_action=True
+        )
+
+    async def test_mark_conversation_read_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "mark_read",
+            "message": "Conversation mark read successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "mark_conversation_read")
+        result = await tool_fn("2-abc123==", mock_context, extractor=mock_extractor)
+
+        assert result["status"] == "mark_read"
+        mock_extractor.mark_conversation_read.assert_awaited_once_with("2-abc123==")
+
+    async def test_mark_conversation_read_error(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.exceptions import SessionExpiredError
+
+        mock_extractor = MagicMock()
+        mock_extractor.mark_conversation_read = AsyncMock(
+            side_effect=SessionExpiredError()
+        )
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "mark_conversation_read")
+        with pytest.raises(ToolError, match="Session expired"):
+            await tool_fn("2-abc123==", mock_context, extractor=mock_extractor)
+
 
 class TestGetMyProfileTool:
     async def test_get_my_profile_success(self, mock_context):
@@ -1382,6 +1500,9 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "archive_conversation",
+            "unarchive_conversation",
+            "mark_conversation_read",
             "get_feed",
             "search_posts",
             "close_session",
@@ -1415,6 +1536,9 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "archive_conversation",
+            "unarchive_conversation",
+            "mark_conversation_read",
             "get_feed",
             "search_posts",
             "close_session",


### PR DESCRIPTION
Closes #794

Adds three new MCP tools for conversation state management:

- archive_conversation: Move a thread to the archived folder via Voyager API PATCH (requires confirm_action=True)
- unarchive_conversation: Restore an archived thread to the inbox (requires confirm_action=True)
- mark_conversation_read: Clear the unread badge without opening the thread via Voyager API POST

All three use page.evaluate() to call LinkedIn's Voyager API from within the authenticated browser session — the same pattern already used by send_message. The CSRF token comes from the csrf-token meta tag, and cookies/TLS fingerprint come from the real browser session.

Changes:
- extractor.py: Added _voyager_conversation_action(), archive_conversation(), unarchive_conversation(), mark_conversation_read() methods
- tools/messaging.py: Registered three new MCP tools with confirmation gating
- tests/test_tools.py: 5 new tests + updated mock extractor and tool-count assertions
- manifest.json: Three new tool entries
- README.md: Three new rows in the tool table

Testing: 64 tool tests passed, 6 manifest tests passed, ruff clean.