### PR TITLE
ci(release): Advance Docker catalog branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,11 +326,18 @@ jobs:
           git config --local user.name "github-actions[bot]"
 
           if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
-            echo "⚠️ Tag v$VERSION already exists, skipping tag creation"
+            echo "⚠️ Tag v$VERSION already exists, checking its target"
           else
             git tag "v$VERSION"
             git push origin "v$VERSION"
             echo "✅ Created and pushed tag v$VERSION"
+          fi
+
+          tag_sha=$(git rev-parse "v$VERSION^{commit}")
+          release_sha=$(git rev-parse HEAD)
+          if [ "$tag_sha" != "$release_sha" ]; then
+            echo "::error::v$VERSION points to $tag_sha, expected released commit $release_sha"
+            exit 1
           fi
 
       # The Docker image and the MCP bundle are built from the commit that
@@ -460,3 +467,33 @@ jobs:
           echo "Docker: stickerdaniel/linkedin-mcp-server:$VERSION"
           echo "PyPI: https://pypi.org/project/mcp-server-linkedin/$VERSION/"
           echo "GitHub: https://github.com/${{ github.repository }}/releases/tag/v$VERSION"
+
+  # Docker's managed `mcp/*` image follows this branch instead of `main`, so
+  # catalog users receive released commits rather than every merge. Keep this
+  # after the public release: advancing it earlier lets Docker publish a source
+  # revision whose own image or GitHub release may still fail.
+  advance-docker-catalog:
+    needs: [prepare-release, create-github-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout released commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6 # zizmor: ignore[artipacked]
+        with:
+          ref: ${{ needs.prepare-release.outputs.release-sha }}
+          fetch-depth: 0
+
+      - name: Advance Docker catalog release branch
+        run: |
+          set -euo pipefail
+          branch=docker-release
+          remote_sha=$(git ls-remote --heads origin "refs/heads/$branch" | awk '{print $1}')
+          if [ -n "$remote_sha" ]; then
+            git fetch origin "$branch"
+            if ! git merge-base --is-ancestor "$remote_sha" HEAD; then
+              echo "::error::$branch points outside the released history; refusing to rewrite it"
+              exit 1
+            fi
+          fi
+          git push origin "HEAD:refs/heads/$branch"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,20 +198,14 @@ gt submit                        # merge PR to trigger release workflow
 
 The CI release workflow automatically updates `manifest.json`, `docker-compose.yml` and `server.json` with the new version. Do not update them manually.
 
-After the workflow completes, file a PR against
-[`docker/mcp-registry`](https://github.com/docker/mcp-registry) updating
-`servers/linkedin-mcp-server/server.yaml`. Docker's own sweep refreshes
-`source.commit` only, and only for images in its `mcp/` namespace
-(`cmd/ci/update_pins.go`); this entry names `stickerdaniel/linkedin-mcp-server`,
-so neither its tag nor its pin ever moves on its own. Skipping it is why that
-entry sat on 1.4.0 for a year.
-
-The first such PR is more than a tag: that entry still advertises a
-`LINKEDIN_COOKIE` secret and a `USER_AGENT` field for an authentication path
-this server no longer has, and `USER_AGENT` now refuses to start
-(`config/loaders.py`). It needs the session directory as a mount instead. Docker
-validates a changed entry by pulling the image and listing its tools over stdio,
-so the tag it moves to has to be a release where that works.
+Once the Docker MCP Catalog entry uses Docker's managed
+`mcp/linkedin-mcp-server` image, the release handoff is automatic. After the
+GitHub release succeeds, `advance-docker-catalog` fast-forwards
+`docker-release` to the released commit. Docker's daily pin sweep opens a
+`source.commit` update, builds the image, runs its security review and merges a
+green bot PR. Follow that PR through the published image and tool listing. A
+manual `docker/mcp-registry` PR is needed only when the catalog metadata,
+authentication setup or documentation changes.
 
 `server.json` is a different registry: the official one at
 `registry.modelcontextprotocol.io`, which is a service reached through

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,175 @@
+"""Release workflow invariants outside the versioned registry files."""
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOW = (_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="requires Bash")
+
+
+def _job(name: str) -> str:
+    marker = f"  {name}:\n"
+    start = _WORKFLOW.index(marker)
+    rest = _WORKFLOW[start + len(marker) :]
+    following = re.search(r"(?m)^  [a-zA-Z0-9_-]+:\n", rest)
+    end = (
+        len(_WORKFLOW) if following is None else start + len(marker) + following.start()
+    )
+    return _WORKFLOW[start:end]
+
+
+def _script(job: str, name: str) -> str:
+    rest = job.split(f"      - name: {name}\n", 1)[1]
+    block = rest.split("        run: |\n", 1)[1]
+    lines = []
+    for line in block.splitlines():
+        if line.startswith("          "):
+            lines.append(line[10:])
+        elif line:
+            break
+        else:
+            lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, text=True, capture_output=True
+    ).stdout.strip()
+
+
+def _repository(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    remote, source = tmp_path / "remote.git", tmp_path / "source"
+    _git(tmp_path, "init", "--bare", str(remote))
+    _git(tmp_path, "init", "-b", "main", str(source))
+    for key, value in {
+        "user.name": "Release Test",
+        "user.email": "release@example.invalid",
+        "commit.gpgsign": "false",
+    }.items():
+        _git(source, "config", key, value)
+    _git(source, "remote", "add", "origin", str(remote))
+
+    def commit(name: str) -> str:
+        (source / "version.txt").write_text(name, encoding="utf-8")
+        _git(source, "add", "version.txt")
+        _git(source, "commit", "-m", name)
+        return _git(source, "rev-parse", "HEAD")
+
+    one = commit("released-one")
+    _git(source, "tag", "v1.0.0")
+    two = commit("released-two")
+    _git(source, "tag", "v2.0.0")
+    unreleased = commit("unreleased")
+    _git(source, "switch", "-c", "diverged", one)
+    divergent = commit("divergent")
+    _git(source, "switch", "main")
+    _git(source, "push", "origin", "--all")
+    _git(source, "push", "origin", "--tags")
+    return remote, {
+        "one": one,
+        "two": two,
+        "unreleased": unreleased,
+        "divergent": divergent,
+    }
+
+
+def _run(
+    tmp_path: Path,
+    remote: Path,
+    head: str,
+    branch: str | None,
+    script: str,
+    **env: str,
+):
+    if branch is not None:
+        _git(remote, "update-ref", "refs/heads/docker-release", branch)
+    checkout = tmp_path / "checkout"
+    _git(tmp_path, "clone", str(remote), str(checkout))
+    _git(checkout, "checkout", "--detach", head)
+    result = subprocess.run(
+        ["bash", "-c", script],
+        cwd=checkout,
+        text=True,
+        capture_output=True,
+        env={**os.environ, **env},
+    )
+    tip = _git(remote, "rev-parse", "refs/heads/docker-release")
+    return result, tip, checkout
+
+
+def test_release_order_permissions_and_checkout_are_pinned() -> None:
+    job = _job("advance-docker-catalog")
+    assert "needs: [prepare-release, create-github-release]" in job
+    assert _WORKFLOW.index("  create-github-release:\n") < _WORKFLOW.index(
+        "  advance-docker-catalog:\n"
+    )
+    assert "ref: ${{ needs.prepare-release.outputs.release-sha }}" in job
+    assert "fetch-depth: 0" in job
+    assert "\n    if:" not in job
+    assert "permissions:\n      contents: write" in job
+    assert "id-token:" not in job
+
+
+def test_existing_tag_must_name_the_release_commit(tmp_path: Path) -> None:
+    remote, revisions = _repository(tmp_path)
+    script = _script(_job("prepare-release"), "Create release tag")
+    result, _, _ = _run(
+        tmp_path, remote, revisions["two"], revisions["one"], script, VERSION="1.0.0"
+    )
+    assert result.returncode != 0
+    assert "expected released commit" in result.stdout
+
+
+def test_non_commit_tag_is_refused(tmp_path: Path) -> None:
+    remote, revisions = _repository(tmp_path)
+    tree = _git(remote, "rev-parse", f"{revisions['one']}^{{tree}}")
+    _git(remote, "update-ref", "refs/tags/v1.0.0", tree)
+    script = _script(_job("prepare-release"), "Create release tag")
+    result, _, _ = _run(
+        tmp_path, remote, revisions["two"], revisions["one"], script, VERSION="1.0.0"
+    )
+    assert result.returncode != 0
+
+
+@pytest.mark.parametrize(
+    ("head", "branch", "succeeds", "expected"),
+    [
+        ("one", None, True, "one"),
+        ("two", "one", True, "two"),
+        ("one", "two", False, "two"),
+        ("two", "unreleased", False, "unreleased"),
+        ("two", "divergent", False, "divergent"),
+    ],
+)
+def test_release_branch_moves_only_forward(
+    tmp_path: Path, head: str, branch: str | None, succeeds: bool, expected: str
+) -> None:
+    remote, revisions = _repository(tmp_path)
+    script = _script(
+        _job("advance-docker-catalog"), "Advance Docker catalog release branch"
+    )
+    remote_branch = None if branch is None else revisions[branch]
+    result, tip, _ = _run(tmp_path, remote, revisions[head], remote_branch, script)
+    assert (result.returncode == 0) is succeeds
+    assert tip == revisions[expected]
+
+
+def test_rejected_push_fails_the_job(tmp_path: Path) -> None:
+    remote, revisions = _repository(tmp_path)
+    script = _script(
+        _job("advance-docker-catalog"), "Advance Docker catalog release branch"
+    )
+    _, _, checkout = _run(tmp_path, remote, revisions["two"], revisions["one"], "true")
+    hook = remote / "hooks" / "pre-receive"
+    hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    hook.chmod(0o755)
+    result = subprocess.run(["bash", "-c", script], cwd=checkout)
+    assert result.returncode != 0
+    assert _git(remote, "rev-parse", "refs/heads/docker-release") == revisions["one"]


### PR DESCRIPTION
Closes #803
See also #804

Docker's updater follows only managed `mcp/*` images. Our community image required a registry PR after each release and left the listing stale for a year.

The workflow advances `docker-release` only after the GitHub release succeeds, giving Docker the exact release commit without unreleased `main`. The tag must name that commit before Docker or GitHub publishing; atomic pre-PyPI reservation is #804. Divergent history is rejected, and tests execute the handoff against real Git repositories.

Depends on docker/mcp-registry#960 and should merge after that migration.

Verified with the full pytest suite and pre-commit.

## Synthetic prompt

> Move Docker MCP Catalog distribution to Docker's managed image pipeline without exposing unreleased `main` commits. Advance a dedicated branch only after a successful public release, document the handoff, and test its ordering, permissions and history safety.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
