### PR TITLE
test(scroll): Widen the slow-connection margin

### DIFF
--- a/tests/test_job_sidebar_scroll_dom.py
+++ b/tests/test_job_sidebar_scroll_dom.py
@@ -196,12 +196,23 @@ async def dom_page():
 
 class TestSidebarScroll:
     async def test_loads_full_page_on_a_slow_connection(self, dom_page):
-        """A batch slower than the old fixed 0.5s sleep must not end the loop."""
-        await dom_page.set_content(sidebar(total=25, batch=5, delays=[800]))
+        """A batch slower than the old fixed 0.5s sleep must not end the loop.
 
-        await scroll_job_sidebar(dom_page, settle_timeout=0.6)
+        Every batch is slower than ``settle_timeout``, so the first wait of
+        each round has to miss and the confirmation round at the full timeout
+        is what buys the batch. The margin that leaves is what the numbers are
+        chosen for: the budget is wall-clock while the batch is a page timer,
+        so a runner that starves the page's event loop slips the timer without
+        slowing the budget. At 800ms against ``settle_timeout=0.6``, each
+        of four growth batches had 400ms of configured slack, which failed
+        once in CI. At 1200ms against 1.0, two growth batches still require
+        the confirmation round while doubling that slack.
+        """
+        await dom_page.set_content(sidebar(total=15, batch=5, delays=[1200]))
 
-        assert await cards(dom_page) == 25
+        await scroll_job_sidebar(dom_page, settle_timeout=1.0)
+
+        assert await cards(dom_page) == 15
 
     async def test_loads_full_page_on_a_fast_connection(self, dom_page):
         """Without scrolling the rail stays at its initial five cards."""


### PR DESCRIPTION
Closes #812

`test_loads_full_page_on_a_slow_connection` failed once in CI with `assert 5 == 25` and passed on a rerun of the same commit. The fixture delayed every batch by 800ms against `settle_timeout=0.6`, so the confirmation round had `2 * 600 - 800 = 400ms` of configured slack across four slow growth batches. That margin is lost asymmetrically: the budget is wall-clock while the batch is a page `setTimeout`, so a runner starving the page's event loop slips the timer and leaves the budget running. Its sibling `test_survives_a_slow_first_batch` has 1200ms of configured slack and one slow batch; this test had the thinnest margin and the most chances to lose it.

Two slow batches at 1200ms against a 1.0s timeout keep what the test is for, that the first wait must miss and the confirmation round buys the batch, with twice the configured slack and no extra runtime.

Deleting that confirmation round still fails the test, and the file's 30 tests pass.

## Synthetic prompt

> `test_loads_full_page_on_a_slow_connection` in `tests/test_job_sidebar_scroll_dom.py` flakes in CI. Work out why from the fixture's batch delay and the scroll loop's budget, then retime it so the margin is wider without weakening what it asserts. Verify the fix still fails when the confirmation round is removed.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
