### PR TITLE
docs(docker): Add PowerShell examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,9 @@ On startup, the MCP Bundle starts preparing the shared Patchright Chromium brows
 
 ### Authentication
 
-Log in once. The container opens a LinkedIn login browser that you drive from your own browser tab:
+Log in once. The container opens a LinkedIn login browser that you drive from your own browser tab.
+
+macOS / Linux:
 
 ```bash
 # Create the directory first so the container can save your session into it
@@ -313,9 +315,21 @@ docker run -it --rm \
   --login --login-viewer
 ```
 
+PowerShell (Windows):
+
+```powershell
+$sessionDir = Join-Path $env:USERPROFILE ".linkedin-mcp"
+New-Item -ItemType Directory -Force -Path $sessionDir | Out-Null
+docker run -it --rm `
+  -v "${sessionDir}:/home/pwuser/.linkedin-mcp" `
+  -p 127.0.0.1:6080:6080 `
+  stickerdaniel/linkedin-mcp-server:latest `
+  --login --login-viewer
+```
+
 Open the full URL the command prints (it carries the access token) and sign in. The viewer closes itself afterwards; let the command exit on its own so the session is stored completely. It gives up after 30 minutes.
 
-Keep the `-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp` mount on every later `docker run`, otherwise the server cannot find the session.
+Keep the same host directory mounted at `/home/pwuser/.linkedin-mcp` on every later `docker run`, otherwise the server cannot find the session.
 
 **Configure Claude Desktop with Docker**
 
@@ -416,8 +430,9 @@ docker run -it --rm \
 PowerShell (Windows):
 
 ```powershell
+$sessionDir = Join-Path $env:USERPROFILE ".linkedin-mcp"
 docker run -it --rm `
-  -v C:/Users/Alice/.linkedin-mcp:/home/pwuser/.linkedin-mcp `
+  -v "${sessionDir}:/home/pwuser/.linkedin-mcp" `
   -p 127.0.0.1:8080:8080 `
   stickerdaniel/linkedin-mcp-server:latest `
   --transport streamable-http --host 0.0.0.0 --port 8080 --path /mcp

--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ Spell that first path out in full. A client runs `docker` directly rather than t
 
 **PowerShell (Windows):** use a forward-slash JSON path. A backslash path like
 `C:\Users\Alice\.linkedin-mcp` fails JSON parsing because `\U` is an invalid
-escape. Replace `Alice` with your username.
+escape. Use `C:/Users/Alice/.linkedin-mcp` instead, replacing `Alice` with your
+username.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ Keep the `-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp` mount on every later `d
 
 **Configure Claude Desktop with Docker**
 
+**macOS / Linux (absolute path in JSON):**
+
 ```json
 {
   "mcpServers": {
@@ -334,7 +336,31 @@ Keep the `-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp` mount on every later `d
 }
 ```
 
-Spell that first path out in full. A client runs `docker` directly rather than through a shell, so a leading `~` reaches Docker unexpanded and it refuses the mount. On Windows write it with forward slashes, `C:/Users/you/.linkedin-mcp`; a backslash opens an escape sequence in JSON and `C:\Users` is not one the client can read.
+Spell that first path out in full. A client runs `docker` directly rather than through a shell, so a leading `~` reaches Docker unexpanded and it refuses the mount.
+
+**PowerShell (Windows):** use a forward-slash JSON path. A backslash path like
+`C:\Users\Alice\.linkedin-mcp` fails JSON parsing because `\U` is an invalid
+escape. Replace `Alice` with your username.
+
+```json
+{
+  "mcpServers": {
+    "mcp-server-linkedin": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-v", "C:/Users/Alice/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
+        "stickerdaniel/linkedin-mcp-server:latest"
+      ]
+    }
+  }
+}
+```
+
+> [!NOTE]
+> In PowerShell, `~` is not expanded inside a composite Docker `-v` argument.
+> Use `C:/Users/<you>/.linkedin-mcp` or build the path with
+> `$env:USERPROFILE\.linkedin-mcp` before passing it to Docker.
 
 > [!NOTE]
 > Sessions expire over time. When tool calls start asking for authentication, repeat the login command above, or run `uvx mcp-server-linkedin@latest --login` on the host.
@@ -376,11 +402,23 @@ Spell that first path out in full. A client runs `docker` directly rather than t
 
 **HTTP Mode Example (for web-based MCP clients):**
 
+Bash / macOS / Linux:
+
 ```bash
 docker run -it --rm \
   -v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp \
   -p 127.0.0.1:8080:8080 \
   stickerdaniel/linkedin-mcp-server:latest \
+  --transport streamable-http --host 0.0.0.0 --port 8080 --path /mcp
+```
+
+PowerShell (Windows):
+
+```powershell
+docker run -it --rm `
+  -v C:/Users/Alice/.linkedin-mcp:/home/pwuser/.linkedin-mcp `
+  -p 127.0.0.1:8080:8080 `
+  stickerdaniel/linkedin-mcp-server:latest `
   --transport streamable-http --host 0.0.0.0 --port 8080 --path /mcp
 ```
 

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -46,6 +46,8 @@ If an older rootful Docker run left that host directory owned by root, repair it
 
 **Configure Claude Desktop with Docker**
 
+**macOS / Linux (absolute path in JSON):**
+
 ```json
 {
   "mcpServers": {
@@ -61,7 +63,28 @@ If an older rootful Docker run left that host directory owned by root, repair it
 }
 ```
 
-Spell that first path out in full. A client runs `docker` directly rather than through a shell, so a leading `~` reaches Docker unexpanded and it refuses the mount. On Windows write it with forward slashes, `C:/Users/you/.linkedin-mcp`; a backslash opens an escape sequence in JSON and `C:\Users` is not one the client can read.
+Spell that first path out in full. A client runs `docker` directly rather than through a shell, so a leading `~` reaches Docker unexpanded and it refuses the mount.
+
+**PowerShell (Windows):** use a forward-slash JSON path. A backslash path like
+`C:\Users\Alice\.linkedin-mcp` fails JSON parsing because `\U` is an invalid
+escape. Replace `Alice` with your username.
+
+```json
+{
+  "mcpServers": {
+    "mcp-server-linkedin": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-v", "C:/Users/Alice/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
+        "stickerdaniel/linkedin-mcp-server:latest"
+      ]
+    }
+  }
+}
+```
+
+Use `$env:USERPROFILE\.linkedin-mcp` when constructing the host path outside JSON.
 
 > **Note:** Plain `--login` does not publish a viewer. Use `--login --login-viewer` only for the one-shot login container, with port 6080 published to loopback.
 >
@@ -111,7 +134,7 @@ Spell that first path out in full. A client runs `docker` directly rather than t
 | `LINKEDIN_EXPERIMENTAL_PERSIST_DERIVED_SESSION` | `false` | Experimental: keep the container's derived profile across restarts instead of rebuilding it on each start |
 | `LINKEDIN_TRACE_MODE` | `on_error` | Trace retention: `on_error` keeps artifacts only from failed runs, `always` keeps every run, `off` keeps none |
 
-**Example with custom timeouts:**
+**Example with custom timeouts (macOS / Linux):**
 
 ```json
 {
@@ -121,6 +144,25 @@ Spell that first path out in full. A client runs `docker` directly rather than t
       "args": [
         "run", "-i", "--rm",
         "-v", "/absolute/path/to/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
+        "-e", "TIMEOUT=10000",
+        "-e", "TOOL_TIMEOUT=300",
+        "stickerdaniel/linkedin-mcp-server"
+      ]
+    }
+  }
+}
+```
+
+**Example with custom timeouts (Windows):**
+
+```json
+{
+  "mcpServers": {
+    "mcp-server-linkedin": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-v", "C:/Users/Alice/.linkedin-mcp:/home/pwuser/.linkedin-mcp",
         "-e", "TIMEOUT=10000",
         "-e", "TOOL_TIMEOUT=300",
         "stickerdaniel/linkedin-mcp-server"

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -26,7 +26,9 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 
 ## Quick Start
 
-The image ships full Chromium. Log in once through a browser the container shows you in your own browser tab:
+The image ships full Chromium. Log in once through a browser the container shows you in your own browser tab.
+
+macOS / Linux:
 
 ```bash
 # Create the directory first so the container can save your session into it
@@ -38,9 +40,21 @@ docker run -it --rm \
   --login --login-viewer
 ```
 
+PowerShell (Windows):
+
+```powershell
+$sessionDir = Join-Path $env:USERPROFILE ".linkedin-mcp"
+New-Item -ItemType Directory -Force -Path $sessionDir | Out-Null
+docker run -it --rm `
+  -v "${sessionDir}:/home/pwuser/.linkedin-mcp" `
+  -p 127.0.0.1:6080:6080 `
+  stickerdaniel/linkedin-mcp-server:latest `
+  --login --login-viewer
+```
+
 Open the full URL the command prints (it carries the access token) and sign in. The viewer closes itself afterwards; let the command exit on its own so the session is stored completely. It gives up after 30 minutes.
 
-Keep the `-v ~/.linkedin-mcp:/home/pwuser/.linkedin-mcp` mount on every later `docker run`. A session created on the host with `uvx mcp-server-linkedin@latest --login` works too, and the container then rebuilds its own profile from those cookies on each start.
+Keep the same host directory mounted at `/home/pwuser/.linkedin-mcp` on every later `docker run`. A session created on the host with `uvx mcp-server-linkedin@latest --login` works too, and the container then rebuilds its own profile from those cookies on each start.
 
 If an older rootful Docker run left that host directory owned by root, repair it with `sudo chown -R "$(id -u):$(id -g)" ~/.linkedin-mcp`.
 


### PR DESCRIPTION
## Summary
- Adds PowerShell `docker run` examples with backtick line continuation
- Documents `C:/Users/Alice/.linkedin-mcp` forward-slash JSON mount paths for Windows
- Notes that `~` is not expanded inside Docker `-v` arguments on PowerShell

## Test plan
- [x] Verified JSON examples use forward slashes (avoids `\\U` invalid escape)
- [ ] Maintainer review of README + docker-hub.md rendering

Closes #783
