### PR TITLE
docs(docker-hub): List messaging and sidebar tools

### DIFF
--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -9,6 +9,8 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Profile Access**: Get detailed LinkedIn profile information including experience, education, skills, projects, certifications, and more
 - **Own Profile**: Fetch the authenticated user's own profile to give agents self-context
 - **Profile Connections**: Send connection requests or accept incoming ones, with optional notes
+- **Sidebar Profiles**: Extract profile URLs from the sidebar recommendation sections on a profile page ("More profiles for you", "Explore premium profiles", "People you may know")
+- **Messaging**: List the inbox, read a conversation by username or thread ID, search messages by keyword, and send a message with explicit confirmation
 - **Company Profiles**: Extract comprehensive company data, including the LinkedIn company URN id (used by LinkedIn's people-search `currentCompany` URL facet)
 - **Company Employees**: List employees at a company with optional keyword filtering
 - **Company Search**: Search for companies by keyword


### PR DESCRIPTION
Closes #829

`docs/docker-hub.md` was the only one of the three tool surfaces describing a smaller server than the image ships. `get_sidebar_profiles`, `get_inbox`, `get_conversation`, `search_conversations` and `send_message` are all registered and all listed in `README.md` and `manifest.json`.

Adds two bullets between the connection and company entries, in README order and reusing the README and manifest wording. Two bullets rather than five because the page lists capabilities rather than individual tools, and #746 recently trimmed it in that direction.

Docs only. `ruff`, `ruff format`, `ty` and `pre-commit` clean.

## Synthetic prompt

> `docs/docker-hub.md` is missing the messaging tools and `get_sidebar_profiles` that `README.md` and `manifest.json` both list. Add them to the Features list, matching the README's order and wording, as capability bullets rather than one bullet per tool.

Generated with Claude Opus 5
