### PR TITLE
fix(auth): Detect login across browser tabs

### DIFF
--- a/linkedin_mcp_server/core/auth.py
+++ b/linkedin_mcp_server/core/auth.py
@@ -5,7 +5,11 @@ import logging
 import re
 from urllib.parse import urlparse
 
-from patchright.async_api import Page, TimeoutError as PlaywrightTimeoutError
+from patchright.async_api import (
+    Error as PlaywrightError,
+    Page,
+    TimeoutError as PlaywrightTimeoutError,
+)
 
 from .exceptions import AuthenticationError
 
@@ -35,6 +39,8 @@ _AUTH_BARRIER_TEXT_MARKERS = (
 )
 _REMEMBER_ME_CONTAINER_SELECTOR = "#rememberme-div"
 _REMEMBER_ME_BUTTON_SELECTOR = "#rememberme-div button"
+_MANUAL_LOGIN_STATUS_INTERVAL_SECONDS = 30
+_AUTH_COOKIE_URL = "https://www.linkedin.com/feed/"
 
 
 async def is_logged_in(page: Page) -> bool:
@@ -172,39 +178,46 @@ async def detect_auth_barrier_quick(page: Page) -> str | None:
     return await _detect_auth_barrier(page, include_body_text=False)
 
 
-async def resolve_remember_me_prompt(page: Page) -> bool:
-    """Click through LinkedIn's saved-account chooser when it appears."""
+async def resolve_remember_me_prompt(page: Page, *, timeout: int | None = None) -> bool:
+    """Click through LinkedIn's saved-account chooser when it appears.
+
+    ``timeout`` bounds the whole attempt in milliseconds. ``None`` retains the
+    normal per-operation limits.
+    """
+    deadline = None
+    loop = None
+    if timeout is not None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout / 1000
+
+    def _operation_timeout(default: int) -> int | None:
+        if deadline is None or loop is None:
+            return default
+        remaining = int((deadline - loop.time()) * 1000)
+        if remaining <= 0:
+            return None
+        return min(default, remaining)
+
     try:
         logger.debug("Checking remember-me prompt on %s", page.url)
         try:
-            await page.wait_for_selector(_REMEMBER_ME_CONTAINER_SELECTOR, timeout=3000)
+            operation_timeout = _operation_timeout(3000)
+            if operation_timeout is None:
+                return False
+            await page.wait_for_selector(
+                _REMEMBER_ME_CONTAINER_SELECTOR, timeout=operation_timeout
+            )
             logger.debug("Remember-me container appeared")
         except PlaywrightTimeoutError:
             logger.debug("Remember-me container did not appear in time")
             return False
 
-        target_locator = page.locator(_REMEMBER_ME_BUTTON_SELECTOR)
-        target = target_locator.first
+        target = page.locator(_REMEMBER_ME_BUTTON_SELECTOR).first
         try:
-            target_count = await target_locator.count()
-        except Exception:
-            logger.debug(
-                "Could not count remember-me buttons; continuing with first match",
-                exc_info=True,
-            )
-            target_count = -1
-        logger.debug(
-            "Remember-me target count for %s: %d",
-            _REMEMBER_ME_BUTTON_SELECTOR,
-            target_count,
-        )
-        if target_count == 0:
-            logger.debug(
-                "Remember-me container appeared without any matching button selector"
-            )
-            return False
-        try:
-            await target.wait_for(state="visible", timeout=3000)
+            operation_timeout = _operation_timeout(3000)
+            if operation_timeout is None:
+                return False
+            await target.wait_for(state="visible", timeout=operation_timeout)
             logger.debug("Remember-me button became visible")
         except PlaywrightTimeoutError:
             logger.debug(
@@ -214,22 +227,42 @@ async def resolve_remember_me_prompt(page: Page) -> bool:
 
         logger.info("Clicking LinkedIn saved-account chooser to resume session")
         try:
-            await target.scroll_into_view_if_needed(timeout=3000)
+            operation_timeout = _operation_timeout(3000)
+            if operation_timeout is None:
+                return False
+            await target.scroll_into_view_if_needed(timeout=operation_timeout)
         except PlaywrightTimeoutError:
             logger.debug("Remember-me button did not scroll into view in time")
 
         try:
-            await target.click(timeout=5000)
+            operation_timeout = _operation_timeout(5000)
+            if operation_timeout is None:
+                return False
+            await target.click(timeout=operation_timeout)
             logger.debug("Remember-me button click succeeded")
         except PlaywrightTimeoutError:
             logger.debug("Retrying remember-me prompt click with force=True")
-            await target.click(timeout=5000, force=True)
+            operation_timeout = _operation_timeout(5000)
+            if operation_timeout is None:
+                return False
+            await target.click(timeout=operation_timeout, force=True)
             logger.debug("Remember-me button force-click succeeded")
         try:
-            await page.wait_for_load_state("domcontentloaded", timeout=10000)
+            operation_timeout = _operation_timeout(10000)
+            if operation_timeout is None:
+                return False
+            await page.wait_for_load_state(
+                "domcontentloaded", timeout=operation_timeout
+            )
         except PlaywrightTimeoutError:
             logger.debug("Remember-me prompt click did not finish loading in time")
-        await asyncio.sleep(1)
+
+        if deadline is None or loop is None:
+            await asyncio.sleep(1)
+        else:
+            remaining = deadline - loop.time()
+            if remaining > 0:
+                await asyncio.sleep(min(1, remaining))
         return True
     except PlaywrightTimeoutError:
         logger.debug("Remember-me prompt was present but not clickable in time")
@@ -249,6 +282,14 @@ def _is_auth_blocker_url(url: str) -> bool:
     return any(
         path == f"{pattern}/" or path.startswith(f"{pattern}/")
         for pattern in _AUTH_BLOCKER_URL_PATTERNS
+    )
+
+
+async def _has_auth_cookie(page: Page) -> bool:
+    """Return whether this context can send ``li_at`` to LinkedIn's feed."""
+    cookies = await page.context.cookies(_AUTH_COOKIE_URL)
+    return any(
+        cookie.get("name") == "li_at" and cookie.get("value") for cookie in cookies
     )
 
 
@@ -284,21 +325,76 @@ async def wait_for_manual_login(page: Page, timeout: int = 300000) -> None:
 
     loop = asyncio.get_running_loop()
     start_time = loop.time()
+    deadline = start_time + timeout / 1000 if timeout else None
+    next_status_time = start_time + _MANUAL_LOGIN_STATUS_INTERVAL_SECONDS
+
+    def _check_wait_budget(*, log_status: bool = True) -> None:
+        nonlocal next_status_time
+        now = loop.time()
+        if deadline is not None and now > deadline:
+            raise _timeout_error()
+        if log_status and now >= next_status_time:
+            logger.info(
+                "Still waiting for manual login. Complete sign-in in any "
+                "LinkedIn tab in this browser."
+            )
+            next_status_time = now + _MANUAL_LOGIN_STATUS_INTERVAL_SECONDS
+
+    def _remaining_wait_seconds() -> float | None:
+        if deadline is None:
+            return None
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise _timeout_error()
+        return remaining
 
     while True:
-        if await resolve_remember_me_prompt(page):
-            logger.info("Resolved saved-account chooser during manual login flow")
-            elapsed = (loop.time() - start_time) * 1000
-            if timeout and elapsed > timeout:
-                raise _timeout_error()
-            continue
+        _check_wait_budget(log_status=False)
+        # interactive_login rotates the old profile before opening this context,
+        # so any li_at here was issued after the current login's challenges
+        # cleared. The cookie belongs to the context rather than a tab and survives
+        # the tab
+        # that completed sign-in being closed.
+        try:
+            remaining = _remaining_wait_seconds()
+            if remaining is None:
+                has_auth_cookie = await _has_auth_cookie(page)
+            else:
+                has_auth_cookie = await asyncio.wait_for(
+                    _has_auth_cookie(page), timeout=remaining
+                )
+        except TimeoutError:
+            raise _timeout_error() from None
+        except PlaywrightError as exc:
+            raise AuthenticationError(
+                "Manual login cancelled because the browser was closed."
+            ) from exc
 
-        if await is_logged_in(page):
+        if has_auth_cookie:
+            _check_wait_budget(log_status=False)
             logger.info("Manual login completed successfully")
             return
 
-        elapsed = (loop.time() - start_time) * 1000
-        if timeout and elapsed > timeout:
-            raise _timeout_error()
+        _check_wait_budget()
 
-        await asyncio.sleep(1)
+        if page.is_closed() and not page.context.pages:
+            raise AuthenticationError(
+                "Manual login cancelled because the browser was closed."
+            )
+
+        resolved_prompt = False
+        if not page.is_closed():
+            remaining = _remaining_wait_seconds()
+            if remaining is None:
+                resolved_prompt = await resolve_remember_me_prompt(page)
+            else:
+                resolved_prompt = await resolve_remember_me_prompt(
+                    page, timeout=max(1, int(remaining * 1000))
+                )
+
+        if resolved_prompt:
+            logger.info("Resolved saved-account chooser during manual login flow")
+            continue
+
+        remaining = _remaining_wait_seconds()
+        await asyncio.sleep(1 if remaining is None else min(1, remaining))

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ asyncio_default_fixture_loop_scope = function
 addopts = -v --strict-markers -ra
 markers =
     browser_dom: evaluates extractor JS against a real chromium DOM; skipped when no browser is installed
+    browser_contract: measures browser API behavior against real Chromium; skipped when no browser is installed
     slow: spawns real server processes; each case starts the full server graph
     image_build: shells out to a docker daemon; skipped where there is none
     browser_identity: the identity gate; fails rather than skips in CI

--- a/tests/test_core_auth.py
+++ b/tests/test_core_auth.py
@@ -1,8 +1,13 @@
 """Tests for auth barrier detection helpers."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from patchright.async_api import (
+    Error as PlaywrightError,
+    TimeoutError as PlaywrightTimeoutError,
+)
 
 from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.core.auth import (
@@ -293,12 +298,11 @@ async def test_resolve_remember_me_prompt_returns_false_when_absent():
 
 
 @pytest.mark.asyncio
-async def test_resolve_remember_me_prompt_returns_false_when_container_has_no_button():
+async def test_resolve_remember_me_prompt_returns_false_when_button_is_not_visible():
     page = MagicMock()
     target = MagicMock()
-    target.wait_for = AsyncMock()
+    target.wait_for = AsyncMock(side_effect=PlaywrightTimeoutError("not visible"))
     locator = MagicMock()
-    locator.count = AsyncMock(return_value=0)
     locator.first = target
     page.locator.return_value = locator
     page.wait_for_selector = AsyncMock()
@@ -306,27 +310,43 @@ async def test_resolve_remember_me_prompt_returns_false_when_container_has_no_bu
     result = await resolve_remember_me_prompt(page)
 
     assert result is False
-    target.wait_for.assert_not_awaited()
+    target.wait_for.assert_awaited_once()
+
+
+def _linkedin_cookie() -> dict[str, str]:
+    return {
+        "name": "li_at",
+        "value": "session",
+        "domain": ".linkedin.com",
+    }
+
+
+def _manual_login_page() -> MagicMock:
+    page = MagicMock()
+    page.url = "https://www.linkedin.com/login"
+    page.is_closed.return_value = False
+    page.context.cookies = AsyncMock(return_value=[])
+    return page
 
 
 @pytest.mark.asyncio
 async def test_wait_for_manual_login_clicks_saved_account(monkeypatch):
-    page = MagicMock()
+    page = _manual_login_page()
     clicked = {"value": False}
 
-    async def fake_resolve(_page):
+    async def fake_cookies(_url):
+        return [_linkedin_cookie()] if clicked["value"] else []
+
+    async def fake_resolve(_page, **_kwargs):
         if not clicked["value"]:
             clicked["value"] = True
             return True
         return False
 
-    async def fake_is_logged_in(_page):
-        return clicked["value"]
-
+    page.context.cookies = AsyncMock(side_effect=fake_cookies)
     monkeypatch.setattr(
         "linkedin_mcp_server.core.auth.resolve_remember_me_prompt", fake_resolve
     )
-    monkeypatch.setattr("linkedin_mcp_server.core.auth.is_logged_in", fake_is_logged_in)
 
     await wait_for_manual_login(page, timeout=1000)
 
@@ -335,19 +355,19 @@ async def test_wait_for_manual_login_clicks_saved_account(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_wait_for_manual_login_times_out_when_remember_me_repeats(monkeypatch):
-    page = MagicMock()
+    page = _manual_login_page()
 
     # 120000ms = 2 minutes so the rendered "N minutes" is a clean integer.
     class _FakeLoop:
         def __init__(self):
-            self._times = iter([0.0, 130.0])
+            self._times = iter([0.0, 0.0, 0.0, 0.0, 0.0, 130.0])
 
         def time(self):
             return next(self._times)
 
+    resolve_prompt = AsyncMock(return_value=True)
     monkeypatch.setattr(
-        "linkedin_mcp_server.core.auth.resolve_remember_me_prompt",
-        AsyncMock(return_value=True),
+        "linkedin_mcp_server.core.auth.resolve_remember_me_prompt", resolve_prompt
     )
     monkeypatch.setattr(
         "linkedin_mcp_server.core.auth.asyncio.get_running_loop",
@@ -360,35 +380,284 @@ async def test_wait_for_manual_login_times_out_when_remember_me_repeats(monkeypa
     message = str(exc_info.value)
     assert "LOGIN_TIMEOUT" in message
     assert "2 minutes" in message
+    resolve_prompt.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_wait_for_manual_login_unlimited_when_timeout_zero(monkeypatch):
-    page = MagicMock()
-    calls = {"value": 0}
-
-    async def fake_is_logged_in(_page):
-        calls["value"] += 1
-        return calls["value"] >= 2
+    page = _manual_login_page()
+    page.context.cookies = AsyncMock(side_effect=[[], [_linkedin_cookie()]])
 
     class _FakeLoop:
-        """Time jumps far beyond any positive bound to prove 0 disables it."""
+        """Elapsed time jumps far beyond any positive timeout."""
+
+        def __init__(self):
+            self._times = iter([0.0, 10**12])
 
         def time(self):
-            return 10**12
+            return next(self._times, 10**12)
 
     monkeypatch.setattr(
         "linkedin_mcp_server.core.auth.resolve_remember_me_prompt",
         AsyncMock(return_value=False),
     )
-    monkeypatch.setattr("linkedin_mcp_server.core.auth.is_logged_in", fake_is_logged_in)
     monkeypatch.setattr(
         "linkedin_mcp_server.core.auth.asyncio.get_running_loop",
         lambda: _FakeLoop(),
     )
     monkeypatch.setattr("linkedin_mcp_server.core.auth.asyncio.sleep", AsyncMock())
 
-    # timeout=0 means unlimited: the elapsed check never fires even though the
-    # fake clock is enormous, so it returns once is_logged_in becomes True.
     await wait_for_manual_login(page, timeout=0)
-    assert calls["value"] == 2
+
+    assert page.context.cookies.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_accepts_context_cookie():
+    page = _manual_login_page()
+    page.context.cookies = AsyncMock(return_value=[_linkedin_cookie()])
+
+    await wait_for_manual_login(page, timeout=1000)
+
+    page.context.cookies.assert_awaited_once_with("https://www.linkedin.com/feed/")
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_waits_for_applicable_cookie(monkeypatch):
+    page = _manual_login_page()
+    page.context.cookies = AsyncMock(side_effect=[[], [_linkedin_cookie()]])
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.resolve_remember_me_prompt",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr("linkedin_mcp_server.core.auth.asyncio.sleep", AsyncMock())
+
+    await wait_for_manual_login(page, timeout=1000)
+
+    assert page.context.cookies.await_count == 2
+    assert all(
+        call.args == ("https://www.linkedin.com/feed/",)
+        for call in page.context.cookies.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_survives_tracked_tab_closing(monkeypatch):
+    page = _manual_login_page()
+    page.is_closed.return_value = True
+    page.context.pages = [MagicMock()]
+    page.context.cookies = AsyncMock(side_effect=[[], [_linkedin_cookie()]])
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.resolve_remember_me_prompt",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr("linkedin_mcp_server.core.auth.asyncio.sleep", AsyncMock())
+
+    await wait_for_manual_login(page, timeout=0)
+
+    assert page.context.cookies.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_stops_when_last_page_closes():
+    page = _manual_login_page()
+    page.is_closed.return_value = True
+    page.context.pages = []
+
+    with pytest.raises(AuthenticationError, match="browser was closed"):
+        await wait_for_manual_login(page, timeout=0)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_stops_when_browser_closes():
+    page = _manual_login_page()
+    page.context.cookies = AsyncMock(
+        side_effect=PlaywrightError("Target page, context or browser has been closed")
+    )
+
+    with pytest.raises(AuthenticationError, match="browser was closed"):
+        await wait_for_manual_login(page, timeout=0)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_logs_while_waiting(monkeypatch, caplog):
+    page = _manual_login_page()
+    page.context.cookies = AsyncMock(side_effect=[[], [_linkedin_cookie()]])
+
+    class _FakeLoop:
+        def __init__(self):
+            self._times = iter([0.0, 31.0])
+
+        def time(self):
+            return next(self._times, 31.0)
+
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.resolve_remember_me_prompt",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.asyncio.get_running_loop",
+        lambda: _FakeLoop(),
+    )
+    monkeypatch.setattr("linkedin_mcp_server.core.auth.asyncio.sleep", AsyncMock())
+
+    with caplog.at_level("INFO"):
+        await wait_for_manual_login(page, timeout=0)
+
+    assert "Complete sign-in in any LinkedIn tab" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_checks_cookie_before_repeated_prompt(monkeypatch):
+    page = _manual_login_page()
+    page.context.cookies = AsyncMock(side_effect=[[], [_linkedin_cookie()]])
+    resolve_prompt = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.resolve_remember_me_prompt", resolve_prompt
+    )
+
+    await wait_for_manual_login(page, timeout=1000)
+
+    assert resolve_prompt.await_count == 1
+    await_args = resolve_prompt.await_args
+    assert await_args is not None
+    assert await_args.args == (page,)
+    assert 0 < await_args.kwargs["timeout"] <= 1000
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_does_not_poll_other_tabs(monkeypatch):
+    page = _manual_login_page()
+    page.context.pages = [page, MagicMock(), MagicMock()]
+    resolve_prompt = AsyncMock(return_value=True)
+
+    class _FakeLoop:
+        def __init__(self):
+            self._times = iter([0.0, 0.0, 0.0, 0.0, 0.0, 2.0])
+
+        def time(self):
+            return next(self._times)
+
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.resolve_remember_me_prompt", resolve_prompt
+    )
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.asyncio.get_running_loop",
+        lambda: _FakeLoop(),
+    )
+
+    with pytest.raises(AuthenticationError, match="Manual login timeout"):
+        await wait_for_manual_login(page, timeout=1000)
+
+    assert resolve_prompt.await_count == 1
+    await_args = resolve_prompt.await_args
+    assert await_args is not None
+    assert await_args.args == (page,)
+    assert 0 < await_args.kwargs["timeout"] <= 1000
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_rejects_cookie_after_deadline(monkeypatch):
+    page = _manual_login_page()
+    page.context.cookies = AsyncMock(return_value=[_linkedin_cookie()])
+
+    class _FakeLoop:
+        def __init__(self):
+            self._times = iter([0.0, 0.0, 0.0, 4.0])
+
+        def time(self):
+            return next(self._times)
+
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.asyncio.get_running_loop",
+        lambda: _FakeLoop(),
+    )
+
+    with pytest.raises(AuthenticationError, match="Manual login timeout"):
+        await wait_for_manual_login(page, timeout=3500)
+
+    page.context.cookies.assert_awaited_once_with("https://www.linkedin.com/feed/")
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_bounds_prompt_by_deadline():
+    page = _manual_login_page()
+
+    async def slow_selector(_selector, *, timeout):
+        await asyncio.sleep(timeout / 1000)
+        raise PlaywrightTimeoutError("selector timed out")
+
+    page.wait_for_selector = AsyncMock(side_effect=slow_selector)
+
+    started = asyncio.get_running_loop().time()
+    with pytest.raises(AuthenticationError, match="Manual login timeout"):
+        await wait_for_manual_login(page, timeout=50)
+
+    assert asyncio.get_running_loop().time() - started < 0.5
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_bounds_cookie_query():
+    page = _manual_login_page()
+
+    async def slow_cookies(_url):
+        await asyncio.sleep(0.2)
+        return []
+
+    page.context.cookies = AsyncMock(side_effect=slow_cookies)
+
+    started = asyncio.get_running_loop().time()
+    with pytest.raises(AuthenticationError, match="Manual login timeout"):
+        await wait_for_manual_login(page, timeout=10)
+
+    assert asyncio.get_running_loop().time() - started < 0.1
+
+
+@pytest.mark.asyncio
+async def test_resolve_remember_me_prompt_does_not_count_buttons():
+    page = MagicMock()
+    page.url = "https://www.linkedin.com/feed/"
+    page.wait_for_selector = AsyncMock()
+    target = MagicMock()
+    target.wait_for = AsyncMock(side_effect=PlaywrightTimeoutError("not visible"))
+    locator = MagicMock()
+
+    async def slow_count():
+        await asyncio.sleep(0.2)
+        return 1
+
+    locator.count = AsyncMock(side_effect=slow_count)
+    locator.first = target
+    page.locator.return_value = locator
+
+    started = asyncio.get_running_loop().time()
+    result = await resolve_remember_me_prompt(page, timeout=10)
+
+    assert result is False
+    assert asyncio.get_running_loop().time() - started < 0.1
+    locator.count.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_manual_login_does_not_log_waiting_after_cookie(
+    monkeypatch, caplog
+):
+    page = _manual_login_page()
+    page.context.cookies = AsyncMock(return_value=[_linkedin_cookie()])
+
+    class _FakeLoop:
+        def __init__(self):
+            self._times = iter([0.0, 31.0, 31.0])
+
+        def time(self):
+            return next(self._times)
+
+    monkeypatch.setattr(
+        "linkedin_mcp_server.core.auth.asyncio.get_running_loop",
+        lambda: _FakeLoop(),
+    )
+
+    with caplog.at_level("INFO"):
+        await wait_for_manual_login(page, timeout=0)
+
+    assert "Still waiting for manual login" not in caplog.text

--- a/tests/test_core_auth_browser_contract.py
+++ b/tests/test_core_auth_browser_contract.py
@@ -1,0 +1,69 @@
+"""Patchright contracts used by the manual-login wait."""
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.core.auth import _has_auth_cookie, wait_for_manual_login
+
+pytestmark = pytest.mark.browser_contract
+
+
+@pytest.fixture
+async def persistent_context(tmp_path):
+    """Real persistent Chromium context, or skip when unavailable."""
+    async with async_playwright() as playwright:
+        try:
+            context = await playwright.chromium.launch_persistent_context(
+                tmp_path / "profile", channel="chromium", headless=True
+            )
+        except Exception as exc:  # browser binary missing
+            pytest.skip(f"chromium unavailable: {exc}")
+        try:
+            yield context
+        finally:
+            await context.close()
+
+
+async def test_cookie_from_closed_tab_completes_wait(persistent_context):
+    """A cookie issued in tab B remains visible through tab A after B closes."""
+    context = persistent_context
+    tracked = context.pages[0]
+    authenticated = await context.new_page()
+    await context.route(
+        "https://www.linkedin.com/**",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="text/html",
+            body="<!doctype html><meta charset=utf-8><title>LinkedIn</title>",
+        ),
+    )
+    await authenticated.goto("https://www.linkedin.com/contract-test")
+    await authenticated.evaluate(
+        "document.cookie = "
+        "'li_at=contract-session; Domain=.www.linkedin.com; Path=/; Secure'"
+    )
+    await authenticated.close()
+
+    assert context.pages == [tracked]
+    await wait_for_manual_login(tracked, timeout=1000)
+
+
+async def test_auth_cookie_must_apply_to_feed(persistent_context):
+    """Chromium, rather than a domain suffix check, decides applicability."""
+    context = persistent_context
+    page = context.pages[0]
+    base = {
+        "name": "li_at",
+        "value": "session",
+        "secure": True,
+        "httpOnly": True,
+    }
+    unusable = [
+        {**base, "domain": ".learning.linkedin.com", "path": "/"},
+        {**base, "domain": ".www.linkedin.com", "path": "/learning"},
+    ]
+
+    for cookie in unusable:
+        await context.clear_cookies()
+        await context.add_cookies([cookie])
+        assert await _has_auth_cookie(page) is False


### PR DESCRIPTION
Closes #740

The manual-login loop watched only the startup page. Sign-in in another tab could issue a valid `li_at` while `--login` waited indefinitely and never exported the session.

Manual login starts from a freshly rotated profile, so a non-empty LinkedIn `li_at` in the shared browser context now completes the wait, even after that tab closes. Browser closure and timeout deadlines now terminate cleanly. A status message appears every 30 seconds.

Verified with an isolated real session: a second tab loaded `/feed/` with HTTP 200, was closed, and the wait completed from the context cookie. `uv run pytest`: 2,367 passed, 20 skipped. All pre-commit checks passed.

## Synthetic prompt

> Reproduce #740 against real LinkedIn, then detect login completed in another tab, including after it closes. Preserve account-picker handling, handle browser closure, log periodically, and add regression tests.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
