### PR TITLE
test(ci): Serialize real browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,11 @@ jobs:
           cat /tmp/xvfb.log >&2
           exit 1
 
-      # `--dist loadgroup` keeps the identity tests on one worker. They share
-      # two cached browser launches, and under plain `load` every worker that
-      # received one of them would pay for its own pair. Tests carrying no
-      # group mark are distributed exactly as before.
+      # `--dist loadgroup` keeps every test that launches Chromium on one
+      # worker. The identity cases share two cached launches; the DOM and auth
+      # contracts launch per case, and the DOM timers use wall-clock deadlines
+      # that concurrent browser startups made flaky. Tests without the group
+      # mark are distributed exactly as before.
       - name: Run tests
         env:
           DISPLAY: ":99"

--- a/tests/test_action_signals_dom.py
+++ b/tests/test_action_signals_dom.py
@@ -27,8 +27,9 @@ from linkedin_mcp_server.scraping.extractor import (
     _CLICK_INCOMING_ACCEPT_JS,
 )
 
-#: CI uses ``--dist loadgroup``. Keep every real Chromium test on one worker
-#: so browser startups cannot compete with the DOM cases' wall-clock timers.
+#: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
+#: worker so browser startups cannot compete with the DOM cases' wall-clock
+#: timers.
 #: Without that distribution mode the group mark is inert.
 pytestmark = [
     pytest.mark.browser_dom,

--- a/tests/test_action_signals_dom.py
+++ b/tests/test_action_signals_dom.py
@@ -27,7 +27,13 @@ from linkedin_mcp_server.scraping.extractor import (
     _CLICK_INCOMING_ACCEPT_JS,
 )
 
-pytestmark = pytest.mark.browser_dom
+#: CI uses ``--dist loadgroup``. Keep every real Chromium test on one worker
+#: so browser startups cannot compete with the DOM cases' wall-clock timers.
+#: Without that distribution mode the group mark is inert.
+pytestmark = [
+    pytest.mark.browser_dom,
+    pytest.mark.xdist_group("browser_runtime"),
+]
 
 
 # Each constant is a full <section>. The top card is always the first

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -51,13 +51,13 @@ from linkedin_mcp_server.config.schema import BrowserConfig
 from linkedin_mcp_server.core.browser import BrowserManager
 from browser_identity_harness import IdentityServer, describe_browser
 
-#: The group keeps every case in this file on one xdist worker, so the two
-#: cached launches are two launches rather than two per worker. It only has an
-#: effect under ``--dist loadgroup``, which the CI job passes; without it the
-#: mark is inert and the tests still pass, only slower.
+#: The group keeps every real Chromium test on one xdist worker. The identity
+#: cases reuse two cached launches, while the DOM and auth-contract fixtures
+#: launch per case. CI passes ``--dist loadgroup``; without it the mark is inert
+#: and the tests still pass, only with parallel browser startups.
 pytestmark = [
     pytest.mark.browser_identity,
-    pytest.mark.xdist_group("browser_identity"),
+    pytest.mark.xdist_group("browser_runtime"),
 ]
 
 #: GREASE brands exist to stop anyone parsing the list positionally. They carry

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -51,10 +51,10 @@ from linkedin_mcp_server.config.schema import BrowserConfig
 from linkedin_mcp_server.core.browser import BrowserManager
 from browser_identity_harness import IdentityServer, describe_browser
 
-#: The group keeps every real Chromium test on one xdist worker. The identity
-#: cases reuse two cached launches, while the DOM and auth-contract fixtures
-#: launch per case. CI passes ``--dist loadgroup``; without it the mark is inert
-#: and the tests still pass, only with parallel browser startups.
+#: The group keeps every test that launches Chromium on one xdist worker. The
+#: identity cases reuse two cached launches, while the DOM and auth-contract
+#: fixtures launch per case. CI passes ``--dist loadgroup``; without it the mark
+#: is inert and the tests still pass, only with parallel browser startups.
 pytestmark = [
     pytest.mark.browser_identity,
     pytest.mark.xdist_group("browser_runtime"),

--- a/tests/test_core_auth_browser_contract.py
+++ b/tests/test_core_auth_browser_contract.py
@@ -5,8 +5,9 @@ from patchright.async_api import async_playwright
 
 from linkedin_mcp_server.core.auth import _has_auth_cookie, wait_for_manual_login
 
-#: CI uses ``--dist loadgroup``. Keep every real Chromium test on one worker
-#: so browser startups cannot compete with the DOM cases' wall-clock timers.
+#: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
+#: worker so browser startups cannot compete with the DOM cases' wall-clock
+#: timers.
 #: Without that distribution mode the group mark is inert.
 pytestmark = [
     pytest.mark.browser_contract,

--- a/tests/test_core_auth_browser_contract.py
+++ b/tests/test_core_auth_browser_contract.py
@@ -5,7 +5,13 @@ from patchright.async_api import async_playwright
 
 from linkedin_mcp_server.core.auth import _has_auth_cookie, wait_for_manual_login
 
-pytestmark = pytest.mark.browser_contract
+#: CI uses ``--dist loadgroup``. Keep every real Chromium test on one worker
+#: so browser startups cannot compete with the DOM cases' wall-clock timers.
+#: Without that distribution mode the group mark is inert.
+pytestmark = [
+    pytest.mark.browser_contract,
+    pytest.mark.xdist_group("browser_runtime"),
+]
 
 
 @pytest.fixture

--- a/tests/test_job_sidebar_scroll_dom.py
+++ b/tests/test_job_sidebar_scroll_dom.py
@@ -29,8 +29,9 @@ async def job_ids(page, *, scoped: bool = False) -> list[str]:
     return result["ids"]
 
 
-#: CI uses ``--dist loadgroup``. Keep every real Chromium test on one worker
-#: so browser startups cannot compete with the DOM cases' wall-clock timers.
+#: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
+#: worker so browser startups cannot compete with the DOM cases' wall-clock
+#: timers.
 #: Without that distribution mode the group mark is inert.
 pytestmark = [
     pytest.mark.browser_dom,

--- a/tests/test_job_sidebar_scroll_dom.py
+++ b/tests/test_job_sidebar_scroll_dom.py
@@ -29,7 +29,13 @@ async def job_ids(page, *, scoped: bool = False) -> list[str]:
     return result["ids"]
 
 
-pytestmark = pytest.mark.browser_dom
+#: CI uses ``--dist loadgroup``. Keep every real Chromium test on one worker
+#: so browser startups cannot compete with the DOM cases' wall-clock timers.
+#: Without that distribution mode the group mark is inert.
+pytestmark = [
+    pytest.mark.browser_dom,
+    pytest.mark.xdist_group("browser_runtime"),
+]
 
 
 def sidebar(


### PR DESCRIPTION
Closes #812

The CI job could run real Chromium launches on several xdist workers while the sidebar tests measured browser page timers against wall-clock deadlines. The fast and slow sidebar cases then lost their first batch together under runner load, even after the slow fixture's individual margin was widened.

Assign every real-browser test module to one `browser_runtime` xdist group. Browserless tests remain parallel, while Chromium startup, identity, auth-contract and DOM cases run serially on one worker.

Verified with the CI test command: 2,367 passed and 20 skipped. The 78 real-browser cases all ran on one worker. Ruff, formatting, ty and all pre-commit hooks pass.

## Synthetic prompt

> Investigate the recurring job-sidebar browser-DOM CI flake, fix its root cause without weakening the timing assertions, and get the blocked documentation PR through CI.

Generated with Claude Opus 5 high + Sol 5.6 xhigh
