### PR TITLE
Add create_post tool for immediate feed post publishing

### DIFF
--- a/.agents/skills/4-address-pr-review/SKILL.md
+++ b/.agents/skills/4-address-pr-review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: 4-address-pr-review
+description: Fix a failed CI run and/or Greptile/reviewer comments on an already-open PR against stickerdaniel/linkedin-mcp-server, using the repo's own coding rules (CLAUDE.md) as the checklist, then commit and push the fixes back to the same PR branch. Use when the user says "the build failed on the PR", "check the review comments and update", "address the feedback on #N", or similar. Assumes the PR already exists (see checkpoint/history for how it was opened) and the local clone still has the `fork` remote configured.
+argument-hint: '<pr-number>'
+---
+
+# Address CI Failures and Review Comments on an Open PR
+
+Goal: diagnose why CI is red and/or what reviewers flagged, fix root causes (not just symptoms), verify locally, and push an update to the same PR branch — without scope creep into unrelated files.
+
+## Phase 1 — Pull CI status and review comments
+
+```bash
+PR=$ARGUMENTS
+REPO=stickerdaniel/linkedin-mcp-server
+
+gh pr view $PR --repo $REPO --json statusCheckRollup -q '.statusCheckRollup[] | {name,status,conclusion}'
+gh api repos/$REPO/pulls/$PR/comments --paginate > /tmp/pr$PR-comments.json   # inline review comments
+gh api repos/$REPO/issues/$PR/comments --paginate > /tmp/pr$PR-issue-comments.json  # PR-level comments (e.g. Greptile summary)
+```
+
+For a FAILURE conclusion, get the failing job's log:
+
+```bash
+RUN_ID=$(gh run list --repo $REPO --branch <head-branch> --json databaseId,conclusion -q '.[] | select(.conclusion=="failure") | .databaseId' | head -1)
+gh run view $RUN_ID --repo $REPO --log-failed > /tmp/pr$PR-fail.log   # can be large; grep it, don't dump it
+```
+
+Parse both comment JSON files (Python one-liner is fine) to extract `{path, line, body}` for each inline comment — that's the actual review surface to address, not just the summary text.
+
+## Phase 2 — Known recurring CI trap: hardcoded tool counts
+
+`tests/test_daemon_election.py::TestRealOwner::test_a_proxy_serves_the_real_owners_tools_over_loopback` asserts an exact `len(names) == N` for the total MCP tools exposed via the daemon-proxy. **Any PR that adds a new top-level `@mcp.tool` registration will fail this test** until the number is bumped. Grep for it first before deep-diving a mysterious CI failure:
+
+```bash
+grep -n "len(names) ==" tests/test_daemon_election.py
+```
+
+If failing for this reason, bump the count by the number of new tools added and move on — this isn't a real regression, just a magic number that has to track the tool count.
+
+## Phase 3 — Fix DOM-selector review flags against CLAUDE.md
+
+Greptile (and human reviewers) will flag any new scraping code that violates the repo's own rules in `CLAUDE.md → Scraping Rules`:
+
+- **Never select by LinkedIn's own CSS class names** (e.g. `button.share-actions__primary-action`). These are auto-generated/unstable and explicitly forbidden.
+- **Never gate detection logic on locale-dependent text** (`"Post to Anyone"`, `"Connect"`, etc.) — prefer URL patterns, attribute *presence* (not value), or structural position/counts.
+- Preferred replacement pattern discovered while building `create_post`: scope a selector to the enclosing dialog/section, then pick out the *one or two* buttons that lack an attribute every other button in that scope carries (e.g. `button:not([aria-label])` isolated the composer's author-switch and Post-submit buttons because every other composer button has an `aria-label`). Verify this kind of selector **live** before trusting it — write a small throwaway probe script (Playwright/Patchright, using the existing authenticated persistent profile at `~/.linkedin-mcp/profile`), dump `element.attributes` for the candidates, confirm uniqueness, then delete the probe script. Do not guess at selectors from memory of a prior session — the DOM may have changed.
+
+## Phase 4 — Fix substring/ambiguous-matching flags
+
+Any code matching a caller-supplied name against on-page text (e.g. "post as this Page") must use **exact equality** (after casefold + strip), never `in`/substring containment. Substring matching lets a short/generic name silently match the wrong option (e.g. `"Labs"` matching "Peacock Labs"), or falsely early-exit thinking the current state already matches. When multiple options can exactly match, **fail loudly and refuse** rather than picking the first one — silent wrong-identity actions (e.g. posting under the wrong company Page) are worse than a refusal.
+
+If the on-page label carries extra lines/text beyond the actual name (e.g. `"<Name>\nPost to Anyone"`), match only the relevant line/segment, not the full string — verify the exact shape live via the same probe-script approach as Phase 3.
+
+## Phase 5 — Add missing test coverage
+
+Reviewers will flag any new write/destructive tool with zero test coverage. Follow existing conventions in `tests/test_tools.py` (`TestPostTools`, `_make_mock_extractor`, `get_tool_fn` helper) and `tests/test_scraping.py` for extractor-level unit tests. Minimum coverage for a new write tool:
+
+- Tool registration + dry-run gating (confirm flag False vs True forwarded correctly)
+- Refusal path (e.g. ambiguous/absent match) passes through untouched
+- The tool's name added to `TestToolTimeouts`' enumerated tuples (both custom-timeout and default-timeout tests) — easy to miss, causes silent gaps in timeout coverage.
+- Any new pure-function helper (e.g. an exact-match comparator) gets its own small `TestXxx` class with a regression test for the specific bug it fixes.
+
+## Phase 6 — Verify before pushing
+
+```bash
+uv run ruff check <changed files>
+uv run ruff format <changed files>       # then re-run tests if this changed anything
+uv run ty check <changed files>
+uv run pytest tests/test_scraping.py tests/test_tools.py -q     # fast, targeted
+uv run pytest tests/test_daemon_election.py -q                  # if you touched the tool-count assertion
+```
+
+Note: on Windows, `tests/test_daemon_election.py::TestRealOwner::*` (subprocess-based real-daemon tests) fail locally with `AttributeError: module 'signal' has no attribute 'SIGKILL'` — this is a pre-existing POSIX-only limitation, not something your change broke. Confirm by checking the same failures occur on a clean `git stash` before your changes. Don't try to fix it; it doesn't run in this form on Windows and CI runs it on Linux/macOS anyway.
+
+Also guard against `uv sync`/`uv run` silently rewriting `uv.lock` with unrelated platform-diff churn — `git checkout -- uv.lock` before committing if it shows as modified and you didn't intend to touch dependencies.
+
+## Phase 7 — Commit and push
+
+```bash
+git add <only the files that changed for this fix>
+git commit -m "Address review feedback on <feature> PR
+
+- <bullet per fix, referencing the specific review comment/CI failure addressed>"
+git push fork <head-branch>
+```
+
+Then optionally re-check `gh pr checks $PR --repo $REPO` to confirm CI goes green.
+
+## Non-negotiables
+
+- Fix root causes flagged by reviewers, not just whatever makes the diff smaller. A P1 (misrouting/wrong-identity risk) always gets fixed even if it requires restructuring the matching logic, not just tightening a regex.
+- Verify any new DOM selector live against the real site before trusting it — this repo's browser-automation code has no room for "looks right" without confirmation, per its own contribution rules.
+- Never widen scope beyond what reviewers/CI flagged — no drive-by refactors of unrelated code in the same PR.

--- a/.agents/skills/5-run-local-mcp-tool-call/SKILL.md
+++ b/.agents/skills/5-run-local-mcp-tool-call/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: 5-run-local-mcp-tool-call
+description: Start this repo's MCP server locally (streamable-http transport) and drive a real tool call (e.g. send_message, create_post, search_people) via curl against the running instance, using the existing persistent LinkedIn browser profile. Use when the user asks to "try/test" a tool live, "send a message to X", "post something as a test", or otherwise wants an actual LinkedIn action executed rather than just code changes. Not for verifying a candidate PR fix (use /3-verify-pr-fix for that) and not for opening/updating a PR (use /4-address-pr-review for that).
+argument-hint: '<tool-name> <json-arguments>'
+---
+
+# Run a Live MCP Tool Call Against the Local Server
+
+Goal: get from "try calling tool X with these args" to an actual executed LinkedIn action (or a clear, actionable error) with minimal back-and-forth, reusing the existing authenticated persistent profile at `~/.linkedin-mcp/profile` rather than re-logging in every time.
+
+## Phase 0 — Identify the target unambiguously before any write/destructive tool
+
+For any tool with `destructiveHint: true` (`send_message`, `create_post`, `connect_with_person`, etc.), **never** guess at a recipient/target from a name alone. Run a read-only lookup first (`search_people`, `get_person_profile`, `get_company_profile`) and require an *unambiguous* match — a name, headline, mutual-connections count, or vanity URL that clearly identifies one person/page — before proceeding to the write call. If the search returns multiple plausible matches (e.g. two people with the same or similar names) and nothing else disambiguates them, stop and ask the user for the exact profile URL/username rather than picking one.
+
+## Phase 1 — Start the server
+
+```bash
+cd <repo>
+.venv\Scripts\python.exe -m linkedin_mcp_server --transport streamable-http --port 8765 --log-level INFO --browser-idle-timeout 0
+```
+
+Run this **detached** (`mode: async, detach: true` in this environment) since it's a long-lived process the user will want to keep across multiple tool calls in the same session, not a one-shot command.
+
+Pick a free port; 8000 is commonly already in use. Wait ~10s for "StreamableHTTP session manager started" before calling the endpoint.
+
+### Known trap: browser profile version mismatch → "Target page, context or browser has been closed"
+
+If the persistent profile (`~/.linkedin-mcp/profile`) was last opened by a **different/newer Chrome build** than the server's bundled Patchright Chromium, Chrome's own downgrade-protection logic tries to migrate/quarantine cache directories and the launch fails with errors like:
+
+```
+ERROR:chrome\browser\downgrade\downgrade_utils.cc:36] ...\GPUPersistentCache -> ...CHROME_DELETE\GPUPersistentCache: Access is denied.
+Failed to start browser: BrowserType.launch_persistent_context: Target page, context or browser has been closed
+```
+
+This is **not** a locked-profile issue (check with `Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*<profile-path>*' }` to confirm nothing is actually holding it open before assuming otherwise). The fix is to restart the server pointing `--chrome-path` at the actual installed Chrome binary that created/last touched the profile (commonly `C:\Program Files\Google\Chrome\Application\chrome.exe` on Windows), rather than letting it fall back to the bundled Chromium:
+
+```bash
+.venv\Scripts\python.exe -m linkedin_mcp_server --transport streamable-http --port 8765 --log-level INFO --browser-idle-timeout 0 --chrome-path "C:\Program Files\Google\Chrome\Application\chrome.exe"
+```
+
+## Phase 2 — Initialize an MCP session
+
+```bash
+curl -sS -D headers.txt -o init.txt -X POST http://127.0.0.1:8765/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"copilot-cli","version":"1.0"}}}'
+# Extract Mcp-Session-Id from headers.txt, then:
+curl -sS -o NUL -X POST http://127.0.0.1:8765/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
+```
+
+`notifications/initialized` commonly returns a harmless pydantic validation error in the response body — ignore it, the session ID still works for subsequent `tools/call` requests.
+
+## Phase 3 — Call the tool
+
+```bash
+curl -sS -X POST http://127.0.0.1:8765/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $SID" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"$TOOL\",\"arguments\":$ARGS_JSON}}"
+```
+
+Check exact keyword-argument names against the tool's Python signature before calling — FastMCP surfaces a pydantic `unexpected_keyword_argument` error immediately for anything not accepted (e.g. `search_people` takes no `max_pages`, only `search_posts` does).
+
+### Known trap: session expiry mid-flow needs a real wait, not just a retry
+
+If a call returns `"Session expired. A login browser window has been opened. Sign in..."`, a headed browser window opened for manual login. Two things must both be true before retrying:
+
+1. The user has actually completed sign-in in that window (ask them to confirm — do not assume).
+2. Enough wall-clock time has passed for the server's login-detection loop to notice. It polls roughly every 30s (`"Still waiting for manual login..."` in the server log) and only writes `"Manual login completed successfully"` + re-exports cookies once it detects the change — retrying the tool call within a few seconds of the user confirming can still race ahead of that detection and return `"login is still in progress"`. Tail the server's log file (`--log-level INFO` output, or the `.log` file if run detached) for the `"Manual login completed successfully"` line before retrying, rather than guessing based on elapsed time alone.
+
+## Phase 4 — Report and clean up
+
+Report the tool's raw JSON result (status, message, whatever identifying info like `url`/`recipient_selected`/`posted` it returns) — don't just say "done". For any destructive action, explicitly confirm which target it hit (profile URL, page name) so the user can verify it went to the right place.
+
+Stop the detached server process (`stop_powershell` on its shellId) once the user is done testing, unless they indicate they want it left running for further calls.
+
+## Non-negotiables
+
+- Never call a destructive tool against a name-only, unverified target — resolve to an unambiguous profile/page first (Phase 0).
+- Don't guess-fix profile/browser errors — read the actual error text and server log; "Access is denied" + downgrade_utils.cc means a Chrome-version mismatch, not a permissions bug to route around with elevated privileges.
+- Don't add new messaging/posting code paths without first checking whether the existing tool (`send_message`, `create_post`, etc.) already covers the request — this repo already has full messaging and posting tools; confirm via `grep -n "async def send_message\|async def create_post"` in `linkedin_mcp_server/tools/` before assuming something needs to be built.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -387,6 +387,23 @@ _DIALOG_PREMIUM_LINK_SELECTOR = (
 )
 _DIALOG_TEXTAREA_SELECTOR = '[role="dialog"] textarea, dialog textarea'
 
+# --- Share composer (immediate feed post creation) --------------------------
+#
+# The composer renders inside an open shadow root (LinkedIn's SDUI interop
+# surface). Patchright locators pierce shadow roots, so plain CSS works here;
+# `page.evaluate` + `querySelectorAll` does not. Opened by URL
+# (`/feed/?shareActive=true`) rather than by clicking the "Start a post"
+# trigger, whose only stable identity is its label text.
+_COMPOSER_EDITOR_SELECTOR = 'div[role="textbox"][contenteditable="true"]'
+# LinkedIn's modal close button carries this test hook in the composer.
+_COMPOSER_DISMISS_SELECTOR = "button[data-test-modal-close-btn]"
+# The composer's own "Post" submit button carries this stable class.
+_COMPOSER_PRIMARY_ACTION_SELECTOR = "button.share-actions__primary-action"
+# The "Post as" author-switch control, when the account admins one or more
+# organization pages. It renders as a button showing the current author's
+# name/avatar near the top of the composer dialog.
+_COMPOSER_AUTHOR_SWITCH_SELECTOR = "button.share-unified-settings-entry-button"
+
 _MESSAGING_COMPOSE_LINK_SELECTOR = 'main a[href*="/messaging/compose/"]'
 _MESSAGING_COMPOSE_SELECTOR = (
     'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"]'
@@ -4819,6 +4836,228 @@ class LinkedInExtractor:
             "search_results",
             cleaned,
             references=references,
+        )
+
+    @staticmethod
+    def _post_result(
+        url: str,
+        status: str,
+        message: str,
+        *,
+        posted: bool = False,
+        author: str | None = None,
+        composer_text: str | None = None,
+    ) -> dict[str, Any]:
+        """Build a structured response for the create_post tool."""
+        result: dict[str, Any] = {
+            "url": url,
+            "status": status,
+            "message": message,
+            "posted": posted,
+        }
+        if author is not None:
+            result["author"] = author
+        if composer_text is not None:
+            result["composer_text"] = composer_text
+        return result
+
+    def _composer_dialog(self) -> Any:
+        """The dialog that holds the share composer's editor."""
+        return self._page.locator(_DIALOG_SELECTOR).filter(
+            has=self._page.locator(_COMPOSER_EDITOR_SELECTOR)
+        )
+
+    async def _clear_and_dismiss_composer(self) -> None:
+        """Empty the editor, then close the composer without a draft prompt.
+
+        Escape does not close this composer, and the discard-prompt buttons
+        have no locale-independent identity — but an *empty* composer closes
+        from its Dismiss button without any prompt, so emptiness is the
+        dismissal strategy rather than prompt-button classification.
+        """
+        try:
+            editor = self._page.locator(_COMPOSER_EDITOR_SELECTOR).first
+            if await editor.is_visible():
+                await editor.click(timeout=2000)
+                await self._page.keyboard.press("ControlOrMeta+a")
+                await self._page.keyboard.press("Delete")
+            dismiss = self._page.locator(_COMPOSER_DISMISS_SELECTOR).first
+            await dismiss.click(timeout=3000)
+            await editor.wait_for(state="hidden", timeout=5000)
+        except Exception:
+            logger.debug("Composer dismissal failed", exc_info=True)
+
+    async def _switch_composer_author(self, post_as: str) -> tuple[bool, str | None]:
+        """Try to switch the composer's author to a page/profile matching ``post_as``.
+
+        Returns ``(switched, current_author)``. LinkedIn's composer defaults
+        to the signed-in profile; accounts that admin one or more
+        organization pages get an author-switch control near the top of the
+        dialog. ``post_as`` is matched case-insensitively against the visible
+        option text (e.g. a company page name). If the switcher cannot be
+        found or no option matches, ``switched`` is False and the composer is
+        left on whatever author it already had — callers must not publish in
+        that case, since publishing would go out under the wrong identity.
+        """
+        dialog = self._composer_dialog()
+        switch_button = dialog.locator(_COMPOSER_AUTHOR_SWITCH_SELECTOR).first
+        try:
+            await switch_button.wait_for(state="visible", timeout=3000)
+        except Exception:
+            return False, None
+
+        try:
+            current_label = (await switch_button.inner_text()).strip()
+        except Exception:
+            current_label = None
+        if current_label and post_as.lower() in current_label.lower():
+            return True, current_label
+
+        try:
+            # Opens the "Post settings" dialog, which carries the #ACTOR
+            # toggle (LinkedIn's own semantic id for the author row).
+            await switch_button.click(timeout=5000)
+            settings_dialog = self._page.locator(_DIALOG_SELECTOR).filter(
+                has=self._page.locator("#share-to-linkedin-modal__header")
+            )
+            actor_toggle = settings_dialog.locator("#ACTOR").first
+            await actor_toggle.wait_for(state="visible", timeout=5000)
+            await actor_toggle.click(timeout=5000)
+
+            # The toggle swaps this same dialog's content in place to a
+            # "Posting as" radio list (measured: same dialog element, not a
+            # new one) -- matched on the requested author's visible text,
+            # since post_as is an arbitrary page/profile name with no other
+            # stable identity here.
+            option = settings_dialog.locator(
+                '[role="radiogroup"] button[role="radio"]', has_text=post_as
+            ).first
+            await option.wait_for(state="visible", timeout=5000)
+            await option.click(timeout=5000)
+            await asyncio.sleep(0.3)
+
+            # Save (posting-as picker) then Done (post-settings screen) are
+            # each the last visible button in this same dialog once enabled
+            # by the preceding click -- the last-button convention used
+            # elsewhere in this file, scoped to this dialog so hidden
+            # video-player dialogs cannot shift the count.
+            save_button = settings_dialog.locator("button").filter(visible=True).last
+            await save_button.click(timeout=5000)
+            await asyncio.sleep(0.3)
+
+            done_button = settings_dialog.locator("button").filter(visible=True).last
+            await done_button.click(timeout=5000)
+
+            await switch_button.wait_for(state="visible", timeout=5000)
+            new_label = (await switch_button.inner_text()).strip()
+        except Exception:
+            logger.debug("Author switch to %r failed", post_as, exc_info=True)
+            return False, current_label
+
+        return post_as.lower() in new_label.lower(), new_label
+
+    async def create_post(
+        self,
+        text: str,
+        *,
+        confirm_post: bool,
+        post_as: str | None = None,
+    ) -> dict[str, Any]:
+        """Publish a feed post immediately via LinkedIn's share composer.
+
+        Args:
+            text: The post body.
+            confirm_post: Must be True to actually publish (False does a dry
+                run that opens the composer, optionally switches the author,
+                types the text, and then discards without posting).
+            post_as: Optional author to post as, matched against the
+                composer's author-switch control (e.g. a company page name
+                this account administers). When omitted, the post is
+                published under whichever identity the composer defaults to
+                (normally the signed-in profile). If ``post_as`` is given but
+                the switcher cannot be found or no option matches, the post
+                is refused rather than publishing under the wrong identity.
+        """
+        await self._navigate_to_page("https://www.linkedin.com/feed/?shareActive=true")
+        await detect_rate_limit(self._page)
+
+        editor = self._page.locator(_COMPOSER_EDITOR_SELECTOR).first
+        try:
+            await editor.wait_for(state="visible", timeout=15000)
+        except PlaywrightTimeoutError:
+            return self._post_result(
+                self._page.url,
+                "composer_unavailable",
+                "LinkedIn did not open the share composer.",
+            )
+
+        current_author: str | None = None
+        if post_as:
+            switched, current_author = await self._switch_composer_author(post_as)
+            if not switched:
+                await self._clear_and_dismiss_composer()
+                return self._post_result(
+                    self._page.url,
+                    "author_switch_failed",
+                    f"Could not switch the composer's author to {post_as!r}"
+                    f" (composer showed {current_author!r}); refusing to post"
+                    " under the wrong identity.",
+                    author=current_author,
+                )
+
+        await editor.click(timeout=5000)
+        await self._page.keyboard.press("ControlOrMeta+a")
+        await self._page.keyboard.press("Delete")
+        await self._page.keyboard.type(text, delay=10)
+        await asyncio.sleep(1.0)  # let the composer enable its primary action
+
+        composer_dialog = self._composer_dialog()
+        composer_text = ""
+        try:
+            composer_text = await composer_dialog.first.inner_text()
+        except Exception:
+            logger.debug("Could not read composer text", exc_info=True)
+
+        if not confirm_post:
+            await self._clear_and_dismiss_composer()
+            return self._post_result(
+                self._page.url,
+                "confirmation_required",
+                "Dry run complete. Set confirm_post=true to publish the post.",
+                author=current_author,
+                composer_text=composer_text,
+            )
+
+        primary = composer_dialog.locator(_COMPOSER_PRIMARY_ACTION_SELECTOR).first
+        try:
+            if await primary.is_disabled():
+                await self._clear_and_dismiss_composer()
+                return self._post_result(
+                    self._page.url,
+                    "post_unavailable",
+                    "The composer's Post action stayed disabled after typing.",
+                    author=current_author,
+                    composer_text=composer_text,
+                )
+            await primary.click(timeout=8000)
+            await editor.wait_for(state="hidden", timeout=10000)
+        except Exception:
+            await self._clear_and_dismiss_composer()
+            return self._post_result(
+                self._page.url,
+                "post_unconfirmed",
+                "LinkedIn did not confirm that the post was published.",
+                author=current_author,
+                composer_text=composer_text,
+            )
+
+        return self._post_result(
+            self._page.url,
+            "posted",
+            "Post published.",
+            posted=True,
+            author=current_author,
+            composer_text=composer_text,
         )
 
     async def send_message(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -397,12 +397,32 @@ _DIALOG_TEXTAREA_SELECTOR = '[role="dialog"] textarea, dialog textarea'
 _COMPOSER_EDITOR_SELECTOR = 'div[role="textbox"][contenteditable="true"]'
 # LinkedIn's modal close button carries this test hook in the composer.
 _COMPOSER_DISMISS_SELECTOR = "button[data-test-modal-close-btn]"
-# The composer's own "Post" submit button carries this stable class.
-_COMPOSER_PRIMARY_ACTION_SELECTOR = "button.share-actions__primary-action"
-# The "Post as" author-switch control, when the account admins one or more
-# organization pages. It renders as a button showing the current author's
-# name/avatar near the top of the composer dialog.
-_COMPOSER_AUTHOR_SWITCH_SELECTOR = "button.share-unified-settings-entry-button"
+# Every other actionable button in the composer (emoji, add-media, event,
+# celebrate, more, schedule) carries an `aria-label`; only two do not: the
+# "Post as" author-switch control near the top, and the primary "Post"
+# submit button in the footer. Attribute *presence* (not a class name tied
+# to LinkedIn's layout, and not locale-dependent label text) is what
+# distinguishes both from the rest of the dialog's buttons -- position then
+# tells them apart from each other, since the switch control is the first
+# such button and the submit button is the last.
+_COMPOSER_UNLABELLED_BUTTON_SELECTOR = "button:not([aria-label])"
+
+
+def _labels_match(candidate: str, target: str) -> bool:
+    """Case-insensitive *exact* match of ``target`` against a label's name line.
+
+    Composer author labels carry a trailing audience/action line (observed:
+    ``"Manik Khandelwal\\nPost to Anyone"`` for a profile, and an analogous
+    ``"<Page name>\\nPost to <audience>"`` shape for an organization page),
+    so only the first line is the author's actual name. That first line is
+    compared to ``target`` with exact (not substring) equality: a Page named
+    "Peacock Labs" must not match a request for "Labs", and a request for
+    "Peacock Labs" must not silently match some other label that merely
+    contains it.
+    """
+    name_line = candidate.splitlines()[0] if candidate else ""
+    return name_line.strip().casefold() == target.strip().casefold()
+
 
 _MESSAGING_COMPOSE_LINK_SELECTOR = 'main a[href*="/messaging/compose/"]'
 _MESSAGING_COMPOSE_SELECTOR = (
@@ -4893,14 +4913,18 @@ class LinkedInExtractor:
         Returns ``(switched, current_author)``. LinkedIn's composer defaults
         to the signed-in profile; accounts that admin one or more
         organization pages get an author-switch control near the top of the
-        dialog. ``post_as`` is matched case-insensitively against the visible
-        option text (e.g. a company page name). If the switcher cannot be
-        found or no option matches, ``switched`` is False and the composer is
-        left on whatever author it already had — callers must not publish in
-        that case, since publishing would go out under the wrong identity.
+        dialog. ``post_as`` is matched via an *exact* (case-insensitive,
+        whitespace-normalized) comparison against the full visible option
+        text, never substring containment — a substring match could pick the
+        wrong Page whenever one administered Page's name contains another's,
+        or falsely treat a not-yet-switched composer as already matching. If
+        the switcher cannot be found, or exactly one option does not match
+        ``post_as``, ``switched`` is False and the composer is left on
+        whatever author it already had — callers must not publish in that
+        case, since publishing would go out under the wrong identity.
         """
         dialog = self._composer_dialog()
-        switch_button = dialog.locator(_COMPOSER_AUTHOR_SWITCH_SELECTOR).first
+        switch_button = dialog.locator(_COMPOSER_UNLABELLED_BUTTON_SELECTOR).first
         try:
             await switch_button.wait_for(state="visible", timeout=3000)
         except Exception:
@@ -4910,7 +4934,7 @@ class LinkedInExtractor:
             current_label = (await switch_button.inner_text()).strip()
         except Exception:
             current_label = None
-        if current_label and post_as.lower() in current_label.lower():
+        if current_label and _labels_match(current_label, post_as):
             return True, current_label
 
         try:
@@ -4926,12 +4950,32 @@ class LinkedInExtractor:
 
             # The toggle swaps this same dialog's content in place to a
             # "Posting as" radio list (measured: same dialog element, not a
-            # new one) -- matched on the requested author's visible text,
-            # since post_as is an arbitrary page/profile name with no other
-            # stable identity here.
-            option = settings_dialog.locator(
-                '[role="radiogroup"] button[role="radio"]', has_text=post_as
-            ).first
+            # new one). Every option's full visible text is read and matched
+            # exactly (not via Playwright's substring `has_text`) against
+            # ``post_as``, since post_as is an arbitrary page/profile name
+            # with no other stable identity here; an ambiguous (more than
+            # one exact match) or absent (zero matches) result refuses the
+            # switch rather than guessing.
+            radio_options = settings_dialog.locator(
+                '[role="radiogroup"] button[role="radio"]'
+            )
+            option_count = await radio_options.count()
+            matched_index: int | None = None
+            for i in range(option_count):
+                option_label = (await radio_options.nth(i).inner_text()).strip()
+                if _labels_match(option_label, post_as):
+                    if matched_index is not None:
+                        logger.debug(
+                            "Author switch to %r is ambiguous: multiple options match",
+                            post_as,
+                        )
+                        return False, current_label
+                    matched_index = i
+            if matched_index is None:
+                logger.debug("Author switch to %r found no matching option", post_as)
+                return False, current_label
+
+            option = radio_options.nth(matched_index)
             await option.wait_for(state="visible", timeout=5000)
             await option.click(timeout=5000)
             await asyncio.sleep(0.3)
@@ -4954,7 +4998,7 @@ class LinkedInExtractor:
             logger.debug("Author switch to %r failed", post_as, exc_info=True)
             return False, current_label
 
-        return post_as.lower() in new_label.lower(), new_label
+        return _labels_match(new_label, post_as), new_label
 
     async def create_post(
         self,
@@ -5028,7 +5072,11 @@ class LinkedInExtractor:
                 composer_text=composer_text,
             )
 
-        primary = composer_dialog.locator(_COMPOSER_PRIMARY_ACTION_SELECTOR).first
+        # Same attribute-presence selector used for the author switch, scoped
+        # to *this* dialog and taking the last match: the switch control is
+        # the first unlabelled button in the dialog, the "Post" submit
+        # button is the last (see _COMPOSER_UNLABELLED_BUTTON_SELECTOR).
+        primary = composer_dialog.locator(_COMPOSER_UNLABELLED_BUTTON_SELECTOR).last
         try:
             if await primary.is_disabled():
                 await self._clear_and_dismiss_composer()

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -1,11 +1,15 @@
 """
-LinkedIn post/content search tool.
+LinkedIn post/content tools: global post search and immediate post creation.
 
-Performs LinkedIn's global content search (the "Posts" results tab) using
-innerText extraction, so informal "we're hiring" / "Buscamos ..." posts can
-be found before a formal job listing is published. Mirrors search_people:
-build a /search/results/content/ URL, scroll to load results, and return the
-raw innerText for the LLM to parse, plus post-permalink references.
+search_posts performs LinkedIn's global content search (the "Posts" results
+tab) using innerText extraction, so informal "we're hiring" / "Buscamos ..."
+posts can be found before a formal job listing is published. Mirrors
+search_people: build a /search/results/content/ URL, scroll to load results,
+and return the raw innerText for the LLM to parse, plus post-permalink
+references.
+
+create_post drives LinkedIn's native share composer to publish a feed post
+immediately (optionally as an organization page this account administers).
 """
 
 import logging
@@ -114,3 +118,76 @@ def register_post_tools(
                 raise_tool_error(relogin_exc, "search_posts")
         except Exception as e:
             raise_tool_error(e, "search_posts")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Create Post",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"post", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def create_post(
+        text: str,
+        confirm_post: bool,
+        ctx: Context,
+        post_as: str | None = None,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Publish a LinkedIn feed post immediately via the native share composer.
+
+        This is a write operation when confirm_post is True; with False it
+        performs the full flow as a dry run — opening the composer, optionally
+        switching the author, and typing the text — then discards the draft
+        without publishing.
+
+        Args:
+            text: The post body text.
+            confirm_post: Must be True to actually publish the post.
+            ctx: FastMCP context for progress reporting
+            post_as: Optional author to post as (e.g. "Peacock Labs"), matched
+                against the composer's author-switch control for organization
+                pages this account administers. Omit to post as the
+                signed-in profile. If given but no matching option is found,
+                the post is refused rather than publishing under the wrong
+                identity.
+
+        Returns:
+            Dict with url, status, message, posted (bool), and — once the
+            flow reaches the composer — author plus composer_text, the
+            composer dialog's raw text, for verification.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="create_post"
+            )
+            logger.info(
+                "Creating post: post_as=%s, confirm_post=%s, text_len=%d",
+                post_as,
+                confirm_post,
+                len(text),
+            )
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Opening share composer"
+            )
+
+            result = await extractor.create_post(
+                text,
+                confirm_post=confirm_post,
+                post_as=post_as,
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except ToolError:
+            raise
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "create_post")
+        except Exception as e:
+            raise_tool_error(e, "create_post")  # NoReturn

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1623,7 +1623,7 @@ class TestRealOwner:
             # in a `register_*` call.
             assert "get_person_profile" in names
             assert "close_session" in names
-            assert len(names) == 19, sorted(names)
+            assert len(names) == 20, sorted(names)
         finally:
             _stop(result.get("pid"))
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -5561,7 +5561,150 @@ class TestSearchPosts:
         }
 
 
-class TestStripLinkedInNoise:
+class TestLabelsMatch:
+    """Exact (not substring) label matching used by the author-switch flow.
+
+    Regression coverage for a previously reported bug: substring matching
+    let ``post_as="Labs"`` match "Peacock Labs", and let a not-yet-switched
+    composer be misreported as already matching a short/generic name.
+    """
+
+    def test_exact_match_is_case_insensitive(self):
+        assert extractor_module._labels_match("Peacock Labs", "peacock labs")
+
+    def test_substring_is_not_a_match(self):
+        # A candidate containing the target must not match: this is the
+        # exact bug being regression-tested.
+        assert not extractor_module._labels_match("Peacock Labs", "Labs")
+        assert not extractor_module._labels_match("Labs", "Peacock Labs")
+
+    def test_only_the_first_line_of_a_multiline_label_is_compared(self):
+        # The author-switch button's own text carries a trailing
+        # audience/action line the target should never need to match.
+        assert extractor_module._labels_match(
+            "Peacock Labs\nPost to Anyone", "Peacock Labs"
+        )
+        assert not extractor_module._labels_match(
+            "Manik Khandelwal\nPost to Anyone", "Peacock Labs"
+        )
+
+    def test_empty_candidate_does_not_match(self):
+        assert not extractor_module._labels_match("", "Peacock Labs")
+
+
+class TestSwitchComposerAuthor:
+    async def test_ambiguous_match_refuses_the_switch(self, mock_page):
+        """Two radio options with the same exact label must refuse rather
+        than silently picking one -- an ambiguous match is exactly the
+        situation the exact-match fix must not paper over."""
+        extractor = LinkedInExtractor(mock_page)
+
+        switch_button = MagicMock()
+        switch_button.first = switch_button
+        switch_button.wait_for = AsyncMock()
+        switch_button.inner_text = AsyncMock(
+            return_value="Someone Else\nPost to Anyone"
+        )
+        switch_button.click = AsyncMock()
+
+        composer_dialog = MagicMock()
+        composer_dialog.locator = MagicMock(return_value=switch_button)
+
+        actor_toggle = MagicMock()
+        actor_toggle.first = actor_toggle
+        actor_toggle.wait_for = AsyncMock()
+        actor_toggle.click = AsyncMock()
+
+        radio_1 = MagicMock()
+        radio_1.inner_text = AsyncMock(return_value="Peacock Labs")
+        radio_2 = MagicMock()
+        radio_2.inner_text = AsyncMock(return_value="Peacock Labs")
+        radios = MagicMock()
+        radios.count = AsyncMock(return_value=2)
+        radios.nth = MagicMock(side_effect=[radio_1, radio_2])
+
+        def settings_dialog_locator(selector, **kwargs):
+            if selector == "#ACTOR":
+                return actor_toggle
+            if "radiogroup" in selector:
+                return radios
+            return MagicMock()
+
+        settings_dialog = MagicMock()
+        settings_dialog.locator = MagicMock(side_effect=settings_dialog_locator)
+
+        def page_locator(selector, **kwargs):
+            return settings_dialog
+
+        mock_page.locator = MagicMock(side_effect=page_locator)
+
+        with patch.object(extractor, "_composer_dialog", return_value=composer_dialog):
+            switched, current = await extractor._switch_composer_author("Peacock Labs")
+
+        assert switched is False
+        assert current == "Someone Else\nPost to Anyone"
+
+    async def test_exact_unique_match_switches_and_reports_success(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+
+        switch_button = MagicMock()
+        switch_button.first = switch_button
+        switch_button.wait_for = AsyncMock()
+        switch_button.inner_text = AsyncMock(
+            side_effect=[
+                "Manik Khandelwal\nPost to Anyone",
+                "Peacock Labs\nPost to Anyone",
+            ]
+        )
+        switch_button.click = AsyncMock()
+
+        composer_dialog = MagicMock()
+        composer_dialog.locator = MagicMock(return_value=switch_button)
+
+        actor_toggle = MagicMock()
+        actor_toggle.first = actor_toggle
+        actor_toggle.wait_for = AsyncMock()
+        actor_toggle.click = AsyncMock()
+
+        radio_1 = MagicMock()
+        radio_1.inner_text = AsyncMock(return_value="Manik Khandelwal")
+        radio_2 = MagicMock()
+        radio_2.inner_text = AsyncMock(return_value="Peacock Labs")
+        radio_2.wait_for = AsyncMock()
+        radio_2.click = AsyncMock()
+        radios = MagicMock()
+        radios.count = AsyncMock(return_value=2)
+        radios.nth = MagicMock(side_effect=lambda i: [radio_1, radio_2][i])
+
+        save_button = MagicMock()
+        save_button.click = AsyncMock()
+        done_button = MagicMock()
+        done_button.click = AsyncMock()
+        buttons = MagicMock()
+        buttons.filter = MagicMock(return_value=buttons)
+        buttons.last = save_button
+
+        def settings_dialog_locator(selector, **kwargs):
+            if selector == "#ACTOR":
+                return actor_toggle
+            if "radiogroup" in selector:
+                return radios
+            if selector == "button":
+                return buttons
+            return MagicMock()
+
+        settings_dialog = MagicMock()
+        settings_dialog.locator = MagicMock(side_effect=settings_dialog_locator)
+        settings_dialog.filter = MagicMock(return_value=settings_dialog)
+
+        mock_page.locator = MagicMock(return_value=settings_dialog)
+
+        with patch.object(extractor, "_composer_dialog", return_value=composer_dialog):
+            switched, current = await extractor._switch_composer_author("Peacock Labs")
+
+        assert switched is True
+        assert current == "Peacock Labs\nPost to Anyone"
+
     def test_strips_footer(self):
         text = "Bill Gates\nChair, Gates Foundation\n\nAbout\nAccessibility\nTalent Solutions\nCareers"
         assert strip_linkedin_noise(text) == "Bill Gates\nChair, Gates Foundation"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -39,6 +39,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.search_posts = AsyncMock(return_value=scrape_result)
     mock.get_company_employees = AsyncMock(return_value=scrape_result)
+    mock.create_post = AsyncMock(return_value=scrape_result)
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
     )
@@ -1360,6 +1361,130 @@ class TestPostTools:
         with pytest.raises(ValidationError, match="max_pages"):
             await mcp.call_tool("search_posts", {"keywords": "python", "max_pages": 0})
 
+    async def test_create_post_dry_run_success(self, mock_context):
+        """confirm_post=False forwards through to the extractor as a dry run."""
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "confirmation_required",
+            "message": "Dry run complete. Set confirm_post=true to publish the post.",
+            "posted": False,
+            "author": "Peacock Labs",
+            "composer_text": "Peacock Labs\nHello world",
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "create_post")
+        result = await tool_fn(
+            "Hello world",
+            False,
+            mock_context,
+            post_as="Peacock Labs",
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "confirmation_required"
+        assert result["posted"] is False
+        mock_extractor.create_post.assert_awaited_once_with(
+            "Hello world",
+            confirm_post=False,
+            post_as="Peacock Labs",
+        )
+
+    async def test_create_post_confirmed_publish(self, mock_context):
+        """confirm_post=True is forwarded unchanged, and a "posted" result passes through."""
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "posted",
+            "message": "Post published.",
+            "posted": True,
+            "author": "Peacock Labs",
+            "composer_text": "Peacock Labs\nHello world",
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "create_post")
+        result = await tool_fn(
+            "Hello world",
+            True,
+            mock_context,
+            post_as="Peacock Labs",
+            extractor=mock_extractor,
+        )
+
+        assert result == expected
+        mock_extractor.create_post.assert_awaited_once_with(
+            "Hello world",
+            confirm_post=True,
+            post_as="Peacock Labs",
+        )
+
+    async def test_create_post_without_post_as(self, mock_context):
+        """post_as is optional; omitting it still reaches the extractor as None."""
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "posted",
+            "message": "Post published.",
+            "posted": True,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "create_post")
+        await tool_fn("Hello world", True, mock_context, extractor=mock_extractor)
+
+        mock_extractor.create_post.assert_awaited_once_with(
+            "Hello world",
+            confirm_post=True,
+            post_as=None,
+        )
+
+    async def test_create_post_refuses_on_author_switch_failure(self, mock_context):
+        """An author-switch refusal from the extractor passes through untouched,
+        rather than being coerced into a publish."""
+        expected = {
+            "url": "https://www.linkedin.com/feed/?shareActive=true",
+            "status": "author_switch_failed",
+            "message": (
+                "Could not switch the composer's author to 'Peacock Labs'"
+                " (composer showed 'Manik Khandelwal'); refusing to post"
+                " under the wrong identity."
+            ),
+            "posted": False,
+            "author": "Manik Khandelwal",
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "create_post")
+        result = await tool_fn(
+            "Hello world",
+            True,
+            mock_context,
+            post_as="Peacock Labs",
+            extractor=mock_extractor,
+        )
+
+        assert result["status"] == "author_switch_failed"
+        assert result["posted"] is False
+
 
 class TestToolTimeouts:
     async def test_all_tools_have_global_timeout(self):
@@ -1384,6 +1509,7 @@ class TestToolTimeouts:
             "send_message",
             "get_feed",
             "search_posts",
+            "create_post",
             "close_session",
         )
 
@@ -1417,6 +1543,7 @@ class TestToolTimeouts:
             "send_message",
             "get_feed",
             "search_posts",
+            "create_post",
             "close_session",
         )
 


### PR DESCRIPTION
## What
Adds a new create_post MCP tool that publishes a LinkedIn feed post **immediately** via the native share composer, as a lightweight companion to the schedule_post design from #690 (not a replacement — both can coexist).

## Why
The server currently has no way to publish a post right now; the only write-capable post tool in flight (#690) is schedule-only. Many use cases (e.g. company Page admins posting on behalf of an org) want immediate publish, plus the ability to explicitly choose *who* the post goes out as.

## How
- linkedin_mcp_server/scraping/extractor.py
  - LinkedInExtractor.create_post(text, *, confirm_post, post_as=None) — opens the composer via /feed/?shareActive=true, types into the shadow-DOM editor, and clicks the primary "Post" action (utton.share-actions__primary-action). Reuses the composer conventions established for schedule_post: shadow-root-piercing CSS locators, confirm_* dry-run gating, and safe dismissal of an emptied composer.
  - _switch_composer_author(post_as) — optionally switches the post's author to an organization Page the account administers, by driving LinkedIn's own "Posting as" picker: click the composer's share-unified-settings-entry-button → click the #ACTOR toggle inside the "Post settings" dialog → pick the radio option matching post_as by visible text → Save → Done. The whole flow is tracked through one dialog locator scoped by the stable #share-to-linkedin-modal__header id (the picker reuses the same dialog element across each step, so filtering by transient content like #ACTOR breaks once the view changes). If the switcher can't be found or no option matches post_as, the tool refuses to post rather than risk publishing under the wrong identity.
- linkedin_mcp_server/tools/post.py
  - Registers create_post with the same confirm_post/dry-run gating pattern as schedule_post (destructiveHint annotation; confirm_post=False fills the composer, optionally switches author, types text, reports composer_text/uthor for verification, then discards without publishing).

## Testing
Tested manually end-to-end against a real LinkedIn account with an administered company Page:
- Dry run (confirm_post=false, post_as="<Page name>"): composer opens, author switch to the Page succeeds, text is typed, composer_text shows the Page as author with the typed text and an enabled Post button, then the draft is discarded.
- Live run (confirm_post=true): post published successfully; verified via get_company_posts that it appeared on the Page's feed, then removed manually afterward.

No automated tests included yet — happy to add coverage following the pattern in 	ests/test_tools.py / 	ests/test_scraping.py if that's useful before merge; wanted to get feedback on the approach (especially the author-switch flow) first.