### PR TITLE
docs(agents): Note how Greptile decides to review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,12 +290,36 @@ one pointing at it.
 
 ## PR Reviews
 
+Greptile reviews no draft on its own, so converting the PR out of draft is
+what starts the first pass. A session that opens a draft and then waits for
+the bot waits forever.
+
+A later push to a non-draft PR is reviewed again, but Greptile edits its
+existing comment instead of posting a new one. A check that looks for a new
+comment therefore finds nothing and reads exactly like a pass that never
+ran. Verify that its `Last reviewed commit` SHA equals the PR's current head;
+a timestamp cannot associate an edit with a pushed revision.
+
 Greptile posts initial reviews as PR review comments, but follow-ups as **issue comments**. Always check both.
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/{pr}/reviews    # initial reviews
 gh api repos/{owner}/{repo}/pulls/{pr}/comments   # inline comments
 gh api repos/{owner}/{repo}/issues/{pr}/comments   # follow-up reviews
+
+# A re-review after a push edits the existing comment. Prove which head it saw.
+sha='^[0-9a-f]{40}$'
+head=$(gh pr view {pr} --json headRefOid --jq .headRefOid) &&
+reviewed=$(gh api repos/{owner}/{repo}/issues/{pr}/comments \
+  --jq '[.[]
+         | select(.user.login == "greptile-apps[bot]")
+         | select(.body | contains("Last reviewed commit:"))
+         | .body
+         | capture("Last reviewed commit:.*?/commit/(?<sha>[0-9a-f]{40})").sha]
+        | last') &&
+printf '%s\n' "$head" | grep -Eq "$sha" &&
+printf '%s\n' "$reviewed" | grep -Eq "$sha" &&
+test "$reviewed" = "$head"
 ```
 
 ## btca


### PR DESCRIPTION
A session that opens a draft PR and waits for the bot review waits forever, and one that checks for a new comment after a push reads a re-review as absent. Both cost time on the daemon stack this week.

Record both behaviors in the PR Reviews section of `AGENTS.md`: leaving draft starts the first automatic pass, and a later push is reviewed again by editing the existing comment. The command block extracts Greptile's machine-readable `Last reviewed commit` SHA and compares it with the PR head, avoiding timestamps that cannot associate an edit with a pushed revision.

Measured on #825, which received several draft pushes without a pass and got its first three minutes after leaving draft. Re-reviews on #825, #826, #827, and #836 updated the existing comment, whose reviewed-commit link named the exact head.

## Synthetic prompt

> Document when Greptile automatically reviews a PR and how to prove its latest review covers the current head.

Generated with Claude Opus 5 high + Sol 5.6 xhigh