### PR TITLE
test(process): Publish PID markers atomically

### DIFF
--- a/tests/test_process_tree.py
+++ b/tests/test_process_tree.py
@@ -69,7 +69,8 @@ leader = subprocess.Popen(
         "import os,subprocess,sys,time;"
         "c=subprocess.Popen([sys.executable,'-c','import time; time.sleep(600)']);"
         "Path=__import__('pathlib').Path;"
-        "Path(sys.argv[1]).write_text(f'{{os.getpid()}} {{c.pid}}');"
+        "p=Path(sys.argv[1]);q=p.with_name(p.name+'.partial');"
+        "q.write_text(f'{{os.getpid()}} {{c.pid}}');q.replace(p);"
         "time.sleep(600)",
         str(marker),
     ],
@@ -2280,7 +2281,10 @@ browser = subprocess.Popen(
     start_new_session=True,
     env=dict(os.environ),
 )
-Path(sys.argv[1]).write_text(str(browser.pid))
+marker = Path(sys.argv[1])
+partial = marker.with_name(marker.name + ".partial")
+partial.write_text(str(browser.pid))
+partial.replace(marker)
 time.sleep(600)
 """
     owner_code = r"""
@@ -2428,7 +2432,10 @@ browser = subprocess.Popen(
     stderr=subprocess.DEVNULL,
     start_new_session=True,
 )
-Path(sys.argv[1]).write_text(str(browser.pid))
+marker = Path(sys.argv[1])
+partial = marker.with_name(marker.name + ".partial")
+partial.write_text(str(browser.pid))
+partial.replace(marker)
 while not Path(sys.argv[2]).exists():
     time.sleep(0.01)
 '''


### PR DESCRIPTION
Closes #839

Three child-process fixtures exposed their PID marker before `write_text()` finished, so existence did not imply complete contents. The same race returned an empty marker on Windows CI; a numeric prefix would remain a valid PID and could make cleanup inspect or signal an unrelated process.

Each child now writes beside its marker and atomically replaces it after close. The process-tree module passes with 91 tests and 12 platform skips; Ruff, formatting, ty, and pre-commit pass. A 4 MiB publication probe read the plain write short in 288 of 300 rounds and the replace form in none.

## Synthetic prompt

> Make every process-tree PID fixture publish its marker atomically so readers cannot parse empty or truncated process identifiers.

Generated with Claude Opus 5 high + Sol 5.6 xhigh