### PR TITLE
fix(tools): Validate references before startup

### DIFF
--- a/linkedin_mcp_server/dependencies.py
+++ b/linkedin_mcp_server/dependencies.py
@@ -73,8 +73,8 @@ async def handle_auth_error(
 
     *nothing_ran_yet* says whether the tool had done any work before the failure,
     which decides whether a client may safely run the call again after signing in.
-    Only :func:`get_ready_extractor` can answer yes: it is the first statement of
-    every tool body, so a failure there means nothing has been scraped. The 18
+    Only :func:`get_ready_extractor` can answer yes: boundary validation may run
+    first, but no tool work has started when it fails. The 18
     catch sites in the tool bodies leave it at the default, because by then the
     scrape may be part done, and some of these tools send messages and connection
     requests. A 19th added later is non-replayable until someone says otherwise,
@@ -171,9 +171,8 @@ async def get_ready_extractor(
         await ensure_authenticated()
         return LinkedInExtractor(browser.page)
     except AuthenticationError as e:
-        # The first statement of every tool body, so a failure here means the
-        # scrape has not started and the client may safely run the call again once
-        # it has signed in.
+        # Boundary validation may run first, but no tool work has started here,
+        # so the client may safely run the call again once it has signed in.
         await handle_auth_error(e, ctx, nothing_ran_yet=True)  # always raises
     except Exception as e:
         if isinstance(e, NetworkError) and _is_browser_binary_missing_error(e):

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -26,6 +26,7 @@ from linkedin_mcp_server.core import (
 )
 from linkedin_mcp_server.core.exceptions import (
     AuthenticationError,
+    InvalidReferenceError,
     LinkedInScraperException,
 )
 from linkedin_mcp_server.debug_trace import record_page_trace
@@ -46,8 +47,9 @@ from linkedin_mcp_server.scraping.identifiers import (
     messaging_thread_url,
     normalize_company_identifier,
     normalize_job_id,
-    normalize_thread_id,
     normalize_person_identifier,
+    normalize_profile_urn,
+    normalize_thread_id,
     person_profile_url,
 )
 from linkedin_mcp_server.scraping.link_metadata import (
@@ -813,6 +815,17 @@ class FilterValidationError(ValueError):
     letting the MCP tool wrapper catch this case precisely and surface the
     actionable message past ``mask_error_details``.
     """
+
+
+def validate_current_company_filter(current_company: str | None) -> None:
+    """Require the numeric company URN used by LinkedIn's people-search facet."""
+    if current_company and not re.fullmatch(r"[0-9]+", current_company):
+        raise FilterValidationError(
+            f"current_company must be a numeric LinkedIn company URN id "
+            f"(e.g. '1115' for SAP); got {current_company!r}. Plain-text "
+            f"company names are silently ignored by LinkedIn. Look up the "
+            f'URN via get_company_profile -> references["about"].'
+        )
 
 
 def strip_linkedin_noise(text: str) -> str:
@@ -4376,13 +4389,7 @@ class LinkedInExtractor:
                     f"{invalid!r}; expected any of {list(_NETWORK_TOKENS)!r}"
                 )
 
-        if current_company and not re.fullmatch(r"[0-9]+", current_company):
-            raise FilterValidationError(
-                f"current_company must be a numeric LinkedIn company URN id "
-                f"(e.g. '1115' for SAP); got {current_company!r}. Plain-text "
-                f"company names are silently ignored by LinkedIn. Look up the "
-                f'URN via get_company_profile -> references["about"].'
-            )
+        validate_current_company_filter(current_company)
 
         params = f"keywords={quote_plus(keywords)}"
         if location:
@@ -4736,7 +4743,7 @@ class LinkedInExtractor:
         to skip this enumeration.
         """
         if not linkedin_username and not thread_id:
-            raise LinkedInScraperException(
+            raise InvalidReferenceError(
                 "Provide at least one of linkedin_username or thread_id"
             )
 
@@ -4841,6 +4848,8 @@ class LinkedInExtractor:
                 compose URL directly, bypassing the Message-button lookup.
         """
         linkedin_username = normalize_person_identifier(linkedin_username)
+        if profile_urn is not None:
+            profile_urn = normalize_profile_urn(profile_urn)
         profile_url = person_profile_url(linkedin_username, "/")
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)

--- a/linkedin_mcp_server/scraping/identifiers.py
+++ b/linkedin_mcp_server/scraping/identifiers.py
@@ -467,3 +467,8 @@ def normalize_job_id(value: str) -> str:
 def normalize_thread_id(value: str) -> str:
     """The id for a conversation, from the id or from a reference to it."""
     return normalize_opaque_id(value, field="thread_id", route=_THREAD_ROUTE)
+
+
+def normalize_profile_urn(value: str) -> str:
+    """The opaque profile id LinkedIn uses in a messaging compose URL."""
+    return normalize_opaque_id(value, field="profile_urn")

--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -73,6 +73,7 @@ def register_company_tools(
             that facet.
         """
         try:
+            company_name = normalize_company_identifier(company_name)
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="get_company_profile"
             )
@@ -126,6 +127,7 @@ def register_company_tools(
             The LLM should parse the raw text to extract individual posts.
         """
         try:
+            company_name = normalize_company_identifier(company_name)
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="get_company_posts"
             )
@@ -135,7 +137,6 @@ def register_company_tools(
                 progress=0, total=100, message="Starting company posts scrape"
             )
 
-            company_name = normalize_company_identifier(company_name)
             url = company_page_url(company_name, "/posts/")
             extracted = await extractor.extract_page(url, section_name="posts")
 
@@ -260,6 +261,7 @@ def register_company_tools(
             References include /in/ profile paths for listed employees.
         """
         try:
+            company_name = normalize_company_identifier(company_name)
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="get_company_employees"
             )

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -15,6 +15,7 @@ from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
 from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
+from linkedin_mcp_server.scraping.identifiers import normalize_job_id
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ def register_job_tools(
             The LLM should parse the raw text to extract job details.
         """
         try:
+            job_id = normalize_job_id(job_id)
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="get_job_details"
             )

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -13,10 +13,15 @@ from pydantic import Field
 from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
 from linkedin_mcp_server.core.exceptions import (
     AuthenticationError,
-    LinkedInScraperException,
+    InvalidReferenceError,
 )
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
+from linkedin_mcp_server.scraping.identifiers import (
+    normalize_person_identifier,
+    normalize_profile_urn,
+    normalize_thread_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -116,13 +121,24 @@ def register_messaging_tools(
         """
         if not linkedin_username and not thread_id:
             raise_tool_error(
-                LinkedInScraperException(
+                InvalidReferenceError(
                     "Provide at least one of linkedin_username or thread_id"
+                ),
+                "get_conversation",
+            )
+        if linkedin_username and thread_id:
+            raise_tool_error(
+                InvalidReferenceError(
+                    "Provide either linkedin_username or thread_id, not both"
                 ),
                 "get_conversation",
             )
 
         try:
+            if thread_id:
+                thread_id = normalize_thread_id(thread_id)
+            else:
+                linkedin_username = normalize_person_identifier(linkedin_username or "")
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="get_conversation"
             )
@@ -247,6 +263,9 @@ def register_messaging_tools(
             Dict with url, status, message, recipient_selected, and sent.
         """
         try:
+            linkedin_username = normalize_person_identifier(linkedin_username)
+            if profile_urn is not None:
+                profile_urn = normalize_profile_urn(profile_urn)
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="send_message"
             )

--- a/linkedin_mcp_server/tools/person.py
+++ b/linkedin_mcp_server/tools/person.py
@@ -18,7 +18,11 @@ from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.scraping import parse_person_sections
-from linkedin_mcp_server.scraping.extractor import FilterValidationError
+from linkedin_mcp_server.scraping.extractor import (
+    FilterValidationError,
+    validate_current_company_filter,
+)
+from linkedin_mcp_server.scraping.identifiers import normalize_person_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +73,7 @@ def register_person_tools(
             The LLM should parse the raw text in each section.
         """
         try:
+            linkedin_username = normalize_person_identifier(linkedin_username)
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="get_person_profile"
             )
@@ -139,6 +144,11 @@ def register_person_tools(
             Dict with url, sections (name -> raw text), and optional references.
             The LLM should parse the raw text to extract individual people and their profiles.
         """
+        try:
+            validate_current_company_filter(current_company)
+        except FilterValidationError as e:
+            raise ToolError(str(e)) from e
+
         try:
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="search_people"
@@ -221,6 +231,7 @@ def register_person_tools(
             text read from LinkedIn.
         """
         try:
+            linkedin_username = normalize_person_identifier(linkedin_username)
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="connect_with_person"
             )
@@ -283,6 +294,7 @@ def register_person_tools(
             /in/username/ paths. Only sections present on the page are included.
         """
         try:
+            linkedin_username = normalize_person_identifier(linkedin_username)
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="get_sidebar_profiles"
             )

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -21,6 +21,7 @@ from linkedin_mcp_server.scraping.identifiers import (
     normalize_job_id,
     normalize_opaque_id,
     normalize_person_identifier,
+    normalize_profile_urn,
     normalize_thread_id,
     person_profile_url,
 )
@@ -334,6 +335,13 @@ class TestReferencesThisServerEmits:
 
     def test_thread_id_still_passes_through(self):
         assert normalize_thread_id("2-abc123") == "2-abc123"
+
+    def test_profile_urn_is_trimmed(self):
+        assert normalize_profile_urn(f" {PROFILE_ID} ") == PROFILE_ID
+
+    def test_profile_urn_refuses_a_path(self):
+        with pytest.raises(InvalidReferenceError, match="profile_urn"):
+            normalize_profile_urn("/feed/")
 
     def test_job_reference_yields_the_id(self):
         assert normalize_job_id("/jobs/view/4252026496/") == "4252026496"

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -7214,10 +7214,9 @@ class TestGetConversation:
 
         assert result["sections"]["conversation"] == "Hello!"
 
-    async def test_raises_when_no_identifier(self, mock_page):
-        """get_conversation raises LinkedInScraperException with no args."""
+    async def test_raises_invalid_reference_when_no_identifier(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        with pytest.raises(LinkedInScraperException):
+        with pytest.raises(InvalidReferenceError, match="at least one"):
             await extractor.get_conversation()
 
     async def test_by_username_default_index_picks_first_thread(self, mock_page):
@@ -7789,6 +7788,23 @@ class TestSendMessage:
 
         assert result["status"] == "message_unavailable"
         assert result["sent"] is False
+
+    async def test_invalid_profile_urn_is_rejected_before_navigation(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        navigate = AsyncMock()
+
+        with (
+            patch.object(extractor, "_navigate_to_page", navigate),
+            pytest.raises(InvalidReferenceError, match="profile_urn"),
+        ):
+            await extractor.send_message(
+                "testuser",
+                "Hello!",
+                confirm_send=False,
+                profile_urn="/feed/",
+            )
+
+        navigate.assert_not_awaited()
 
     async def test_uses_profile_urn_when_provided(self, mock_page):
         """send_message builds compose URL from profile_urn without Message-button lookup."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -46,6 +46,119 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     return mock
 
 
+@pytest.mark.parametrize(
+    ("module_name", "tool_name", "arguments", "error_match"),
+    [
+        (
+            "person",
+            "get_person_profile",
+            {"linkedin_username": "/feed/"},
+            "not a personal profile",
+        ),
+        (
+            "person",
+            "connect_with_person",
+            {"linkedin_username": "/feed/"},
+            "not a personal profile",
+        ),
+        (
+            "person",
+            "get_sidebar_profiles",
+            {"linkedin_username": "/feed/"},
+            "not a personal profile",
+        ),
+        (
+            "person",
+            "search_people",
+            {"keywords": "engineer", "current_company": "SAP"},
+            "numeric LinkedIn company URN id",
+        ),
+        (
+            "company",
+            "get_company_profile",
+            {"company_name": "/feed/"},
+            "not a company page",
+        ),
+        (
+            "company",
+            "get_company_posts",
+            {"company_name": "/feed/"},
+            "not a company page",
+        ),
+        (
+            "company",
+            "get_company_employees",
+            {"company_name": "/feed/"},
+            "not a company page",
+        ),
+        (
+            "job",
+            "get_job_details",
+            {"job_id": "/feed/"},
+            "job_id is not a LinkedIn id",
+        ),
+        (
+            "messaging",
+            "get_conversation",
+            {"linkedin_username": "/feed/"},
+            "not a personal profile",
+        ),
+        (
+            "messaging",
+            "get_conversation",
+            {"thread_id": "/feed/"},
+            "thread_id is not a LinkedIn id",
+        ),
+        (
+            "messaging",
+            "send_message",
+            {
+                "linkedin_username": "/feed/",
+                "message": "Hello",
+                "confirm_send": False,
+            },
+            "not a personal profile",
+        ),
+        (
+            "messaging",
+            "send_message",
+            {
+                "linkedin_username": "alice",
+                "profile_urn": "/feed/",
+                "message": "Hello",
+                "confirm_send": False,
+            },
+            "profile_urn is not a LinkedIn id",
+        ),
+    ],
+)
+async def test_invalid_reference_is_rejected_before_extractor(
+    module_name, tool_name, arguments, error_match
+):
+    from fastmcp.exceptions import ToolError
+
+    from linkedin_mcp_server.tools.company import register_company_tools
+    from linkedin_mcp_server.tools.job import register_job_tools
+    from linkedin_mcp_server.tools.messaging import register_messaging_tools
+    from linkedin_mcp_server.tools.person import register_person_tools
+
+    register_by_module = {
+        "company": register_company_tools,
+        "job": register_job_tools,
+        "messaging": register_messaging_tools,
+        "person": register_person_tools,
+    }
+    mcp = FastMCP("test")
+    register_by_module[module_name](mcp)
+    ready = AsyncMock(side_effect=AssertionError("get_ready_extractor was called"))
+
+    with patch(f"linkedin_mcp_server.tools.{module_name}.get_ready_extractor", ready):
+        with pytest.raises(ToolError, match=error_match):
+            await mcp.call_tool(tool_name, arguments)
+
+    ready.assert_not_awaited()
+
+
 class TestPersonTool:
     async def test_get_person_profile_success(self, mock_context):
         expected = {
@@ -60,11 +173,16 @@ class TestPersonTool:
         register_person_tools(mcp)
 
         tool_fn = await get_tool_fn(mcp, "get_person_profile")
-        result = await tool_fn("test-user", mock_context, extractor=mock_extractor)
+        result = await tool_fn(
+            "https://de.linkedin.com/in/test-user/",
+            mock_context,
+            extractor=mock_extractor,
+        )
         assert result["url"] == "https://www.linkedin.com/in/test-user/"
         assert "main_profile" in result["sections"]
         assert "pages_visited" not in result
         assert "sections_requested" not in result
+        assert mock_extractor.scrape_person.await_args.args[0] == "test-user"
 
     async def test_get_person_profile_with_sections(self, mock_context):
         """Verify sections parameter is passed through."""
@@ -328,7 +446,7 @@ class TestPersonTool:
             await tool_fn(
                 "engineer",
                 mock_context,
-                current_company="SAP",
+                current_company="1115",
                 extractor=mock_extractor,
             )
 
@@ -348,7 +466,7 @@ class TestPersonTool:
 
         tool_fn = await get_tool_fn(mcp, "connect_with_person")
         result = await tool_fn(
-            "test-user",
+            "https://www.linkedin.com/in/test-user/",
             mock_context,
             note="Let us connect.",
             extractor=mock_extractor,
@@ -486,9 +604,14 @@ class TestCompanyTools:
         register_company_tools(mcp)
 
         tool_fn = await get_tool_fn(mcp, "get_company_profile")
-        result = await tool_fn("testcorp", mock_context, extractor=mock_extractor)
+        result = await tool_fn(
+            "https://uk.linkedin.com/company/testcorp/",
+            mock_context,
+            extractor=mock_extractor,
+        )
         assert "about" in result["sections"]
         assert "pages_visited" not in result
+        assert mock_extractor.scrape_company.await_args.args[0] == "testcorp"
 
     async def test_get_company_posts_normalizes_a_pasted_link(self, mock_context):
         """get_company_posts builds its URL in the tool, not in the extractor.
@@ -663,9 +786,14 @@ class TestJobTools:
         register_job_tools(mcp)
 
         tool_fn = await get_tool_fn(mcp, "get_job_details")
-        result = await tool_fn("12345", mock_context, extractor=mock_extractor)
+        result = await tool_fn(
+            "https://www.linkedin.com/jobs/view/12345/",
+            mock_context,
+            extractor=mock_extractor,
+        )
         assert "job_posting" in result["sections"]
         assert "pages_visited" not in result
+        mock_extractor.scrape_job.assert_awaited_once_with("12345")
 
     async def test_search_jobs(self, mock_context):
         expected = {
@@ -792,7 +920,11 @@ class TestGetSidebarProfilesTool:
         register_person_tools(mcp)
 
         tool_fn = await get_tool_fn(mcp, "get_sidebar_profiles")
-        result = await tool_fn("test-user", mock_context, extractor=mock_extractor)
+        result = await tool_fn(
+            "https://www.linkedin.com/in/test-user/",
+            mock_context,
+            extractor=mock_extractor,
+        )
 
         assert result["url"] == "https://www.linkedin.com/in/test-user/"
         assert "more_profiles_for_you" in result["sidebar_profiles"]
@@ -868,13 +1000,75 @@ class TestMessagingTools:
 
         tool_fn = await get_tool_fn(mcp, "get_conversation")
         result = await tool_fn(
-            mock_context, linkedin_username="testuser", extractor=mock_extractor
+            mock_context,
+            linkedin_username="https://www.linkedin.com/in/testuser/",
+            extractor=mock_extractor,
         )
 
         assert result["sections"]["conversation"] == "Hello!\nHi there!"
         mock_extractor.get_conversation.assert_awaited_once_with(
             linkedin_username="testuser", thread_id=None, index=0
         )
+
+    async def test_get_conversation_normalizes_a_thread_url(self, mock_context):
+        mock_extractor = _make_mock_extractor(
+            {
+                "url": "https://www.linkedin.com/messaging/thread/abc123/",
+                "sections": {"conversation": "Hello!"},
+            }
+        )
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_conversation")
+        await tool_fn(
+            mock_context,
+            thread_id="https://www.linkedin.com/messaging/thread/abc123/",
+            extractor=mock_extractor,
+        )
+
+        mock_extractor.get_conversation.assert_awaited_once_with(
+            linkedin_username=None, thread_id="abc123", index=0
+        )
+
+    async def test_get_conversation_rejects_both_identifiers_before_extractor(self):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+        ready = AsyncMock(side_effect=AssertionError("get_ready_extractor was called"))
+
+        with patch("linkedin_mcp_server.tools.messaging.get_ready_extractor", ready):
+            with pytest.raises(ToolError, match="not both"):
+                await mcp.call_tool(
+                    "get_conversation",
+                    {"linkedin_username": "alice", "thread_id": "abc123"},
+                )
+
+        ready.assert_not_awaited()
+
+    async def test_get_conversation_rejects_missing_identifier_before_extractor(self):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+        ready = AsyncMock(side_effect=AssertionError("get_ready_extractor was called"))
+
+        with patch("linkedin_mcp_server.tools.messaging.get_ready_extractor", ready):
+            with pytest.raises(ToolError) as raised:
+                await mcp.call_tool("get_conversation", {})
+
+        assert str(raised.value) == (
+            "Provide at least one of linkedin_username or thread_id"
+        )
+        ready.assert_not_awaited()
 
     async def test_search_conversations_success(self, mock_context):
         expected = {
@@ -911,7 +1105,7 @@ class TestMessagingTools:
 
         tool_fn = await get_tool_fn(mcp, "send_message")
         result = await tool_fn(
-            "testuser",
+            "https://www.linkedin.com/in/testuser/",
             "Hello!",
             True,
             mock_context,
@@ -945,7 +1139,7 @@ class TestMessagingTools:
             "Hello!",
             True,
             mock_context,
-            profile_urn="ACoAAB1IelEB",
+            profile_urn=" ACoAAB1IelEB ",
             extractor=mock_extractor,
         )
 
@@ -1123,7 +1317,11 @@ class TestGetCompanyEmployeesTool:
         register_company_tools(mcp)
 
         tool_fn = await get_tool_fn(mcp, "get_company_employees")
-        result = await tool_fn("anthropic", mock_context, extractor=mock_extractor)
+        result = await tool_fn(
+            "https://www.linkedin.com/company/anthropic/",
+            mock_context,
+            extractor=mock_extractor,
+        )
         assert "employees" in result["sections"]
         mock_extractor.get_company_employees.assert_awaited_once_with(
             "anthropic", keywords=None


### PR DESCRIPTION
Closes #752

Malformed person, company, job, and conversation references were validated only after acquiring the authenticated extractor. An invalid input could therefore start Chromium and prompt for login before the tool refused it.

Normalize identifiers, messaging profile URNs, and the people-search company URN at the tool boundary before extractor acquisition. Valid references retain defensive extractor validation; invalid or missing references fail without browser startup or issue diagnostics. Conversation calls must choose exactly one selector.

Verified with 546 tool, identifier, dependency, and scraping tests. Ruff, formatting, ty, and pre-commit pass. Removing boundary validation starts extractor acquisition; discarding normalized values fails the positive wiring cases.

## Synthetic prompt

> Reject malformed person, company, job, and conversation references before starting the browser, preserving existing normalization and adding regression coverage for every affected tool.

Generated with Claude Opus 5 high + Sol 5.6 high + Sol 5.6 xhigh
