### PR TITLE
fix(scraping): Preserve scraper failures

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -2675,6 +2675,8 @@ class LinkedInExtractor:
 
             try:
                 await self._navigate_to_page(show_all_url)
+            except LinkedInScraperException:
+                raise
             except Exception:
                 logger.debug(
                     "Failed to navigate to Show all for section %s: %s",

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -6696,6 +6696,97 @@ class TestGetSidebarProfiles:
         assert result["sidebar_profiles"]["explore_premium_profiles"] == ["/in/carol/"]
         assert result["sidebar_profiles"]["people_you_may_know"] == ["/in/dave/"]
 
+    @pytest.mark.parametrize(
+        ("error_type", "message"),
+        [
+            pytest.param(
+                AuthenticationError,
+                "Run with --login",
+                id="authentication-error",
+            ),
+            pytest.param(
+                ProxyConnectionError,
+                "Proxy unavailable",
+                id="proxy-connection-error",
+            ),
+        ],
+    )
+    async def test_scraper_exception_from_show_all_propagates(
+        self,
+        mock_page,
+        error_type: type[LinkedInScraperException],
+        message: str,
+    ):
+        sidebar_js_result = {
+            "sections": {"more_profiles_for_you": ["/in/alice/"]},
+            "showAllUrls": {
+                "more_profiles_for_you": "https://www.linkedin.com/search/results/people/?keywords=test"
+            },
+        }
+        mock_page.evaluate = AsyncMock(return_value=sidebar_js_result)
+        mock_page.url = "https://www.linkedin.com/in/testuser/"
+
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+                side_effect=[None, error_type(message)],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            pytest.raises(error_type, match=message),
+        ):
+            await extractor.get_sidebar_profiles("testuser")
+
+    async def test_raw_exception_from_show_all_keeps_inline_profiles(self, mock_page):
+        show_all_url = "https://www.linkedin.com/search/results/people/?keywords=test"
+        sidebar_js_result = {
+            "sections": {"more_profiles_for_you": ["/in/alice/"]},
+            "showAllUrls": {"more_profiles_for_you": show_all_url},
+        }
+        mock_page.evaluate = AsyncMock(return_value=sidebar_js_result)
+        mock_page.url = "https://www.linkedin.com/in/testuser/"
+
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+                side_effect=[None, RuntimeError("navigation failed")],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(extractor_module.logger, "debug") as debug_mock,
+        ):
+            result = await extractor.get_sidebar_profiles("testuser")
+
+        assert result == {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "sidebar_profiles": {"more_profiles_for_you": ["/in/alice/"]},
+        }
+        debug_mock.assert_called_once_with(
+            "Failed to navigate to Show all for section %s: %s",
+            "more_profiles_for_you",
+            show_all_url,
+        )
+
     async def test_skips_show_all_when_url_contains_premium(self, mock_page):
         """Show all URL containing /premium is skipped without navigation."""
         sidebar_js_result = {


### PR DESCRIPTION
Closes #787

Sidebar profile extraction treats optional “Show all” navigation as best-effort. Its broad exception handler also swallowed classified scraper failures, so an expired session or proxy failure returned only the inline profiles and appeared to be a valid shorter result.

Propagate every `LinkedInScraperException` from expansion navigation while retaining the fallback for ordinary browser errors. Regression tests cover authentication and proxy failures, plus a raw navigation error that remains swallowed and preserves the inline profiles.

Verified with all 297 scraping tests. Ruff and formatting pass. Narrowing propagation to authentication alone fails the proxy case; removing the raw-error fallback fails the inline-data case.

## Synthetic prompt

> Preserve best-effort sidebar expansion for raw browser failures while propagating classified scraper errors, with tests that pin both sides of the exception boundary.

Generated with Claude Opus 5 high + Sol 5.6 high + Sol 5.6 xhigh
