### PR TITLE
feat(job): add job-alert tooling (list alerts, check notifications, fetch results)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Optional additional keys:
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs, get_saved_jobs, and get_job_alert_results)
+- `alerts: [{name, url}, ...]` (get_job_alerts only) — pass an alert's `url` to `get_job_alert_results`
 - `references["feed"]` (get_feed only) — every entry is `kind: "feed_post"`; non-post anchors (sidebar profiles, employer logos) are filtered. URLs may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) form; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
 
 ## Verifying Bug Reports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Optional additional keys:
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs, get_saved_jobs, and get_job_alert_results)
 - `alerts: [{name, url}, ...]` (get_job_alerts only) — pass an alert's `url` to `get_job_alert_results`
+- `alerts: [{alert_name, url, unread, posted_at}, ...]` (get_job_alert_notifications only) — `url` is delta-filtered (new results since that alert last fired); pass it to `get_job_alert_results`
 - `references["feed"]` (get_feed only) — every entry is `kind: "feed_post"`; non-post anchors (sidebar profiles, employer logos) are filtered. URLs may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) form; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
 
 ## Verifying Bug Reports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Optional additional keys:
 - `references: {section_name: [{kind, url, text?, context?, value?}]}` — LinkedIn URLs are relative paths; `value` carries non-URL identifiers (e.g. company URN id for `kind: "company_urn"`)
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
-- `job_ids: [id, ...]` (search_jobs and get_saved_jobs)
+- `job_ids: [id, ...]` (search_jobs, get_saved_jobs, and get_job_alert_results)
 - `references["feed"]` (get_feed only) — every entry is `kind: "feed_post"`; non-post anchors (sidebar profiles, employer logos) are filtered. URLs may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) form; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
 
 ## Verifying Bug Reports

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter | working |
 | `search_jobs` | Search for jobs with keywords and location filters | working |
 | `get_saved_jobs` | List job postings saved by the authenticated user | working |
+| `get_job_alerts` | List the authenticated user's configured job alerts (name + search-results URL for each) | working |
 | `get_job_alert_results` | Fetch job results from a specific job-alert or saved-search URL (LinkedIn's personalized/AI-ranked feed, which `search_jobs` cannot reproduce) | working |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | [#526](https://github.com/stickerdaniel/linkedin-mcp-server/issues/526) |
 | `get_job_details` | Get detailed information about a specific job posting | working |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `search_jobs` | Search for jobs with keywords and location filters | working |
 | `get_saved_jobs` | List job postings saved by the authenticated user | working |
 | `get_job_alerts` | List the authenticated user's configured job alerts (name + search-results URL for each) | working |
+| `get_job_alert_notifications` | List job-alert notifications from the notifications feed (name, delta-filtered URL, unread state, timestamp), filterable to unread-only | working |
 | `get_job_alert_results` | Fetch job results from a specific job-alert or saved-search URL (LinkedIn's personalized/AI-ranked feed, which `search_jobs` cannot reproduce) | working |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | [#526](https://github.com/stickerdaniel/linkedin-mcp-server/issues/526) |
 | `get_job_details` | Get detailed information about a specific job posting | working |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter | working |
 | `search_jobs` | Search for jobs with keywords and location filters | working |
 | `get_saved_jobs` | List job postings saved by the authenticated user | working |
+| `get_job_alert_results` | Fetch job results from a specific job-alert or saved-search URL (LinkedIn's personalized/AI-ranked feed, which `search_jobs` cannot reproduce) | working |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company | [#526](https://github.com/stickerdaniel/linkedin-mcp-server/issues/526) |
 | `get_job_details` | Get detailed information about a specific job posting | working |
 | `get_feed` | Get recent posts from the authenticated user's home feed | working |

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -60,6 +60,8 @@ _PAGE_SIZE = 25
 
 _SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
 
+_JOB_ALERTS_URL = "https://www.linkedin.com/jobs/jam/"
+
 # The my-items lists page in 10s, unlike job search. Verified live: ?start=10
 # returns the 11th saved job, while ?start=25 lands past the end of a two-page
 # list and yields nothing.
@@ -3414,6 +3416,173 @@ class LinkedInExtractor:
             result["references"] = {
                 "alert_results": dedupe_references(page_references, cap=15)
             }
+        if section_errors:
+            result["section_errors"] = section_errors
+        return result
+
+    async def _expand_job_alerts_list(self) -> None:
+        """Click the "Show N more" toggle in the job-alerts dialog, if present.
+
+        NOTE: This is a deliberate DOM exception, like ``_get_total_search_pages``.
+        The button's exact wording is locale-dependent, so this matches a numeric
+        pattern rather than a fixed string. If LinkedIn changes the copy or
+        removes the control, this is a no-op and ``get_job_alerts`` just returns
+        whatever was already rendered.
+        """
+        try:
+            clicked = await self._page.evaluate(
+                """(dialogSelector) => {
+                    const dialog = document.querySelector(dialogSelector);
+                    if (!dialog) return false;
+                    const button = Array.from(dialog.querySelectorAll('button')).find(
+                        (b) => /show\\s+\\d+\\s+more/i.test(b.textContent || '')
+                    );
+                    if (!button) return false;
+                    button.click();
+                    return true;
+                }""",
+                _DIALOG_SELECTOR,
+            )
+            if clicked:
+                await asyncio.sleep(0.5)
+        except Exception as e:
+            logger.debug("Could not expand job alerts list: %s", e)
+
+    async def _extract_job_alert_links(self) -> list[dict[str, str]]:
+        """Extract ``{name, url}`` for each alert in the job-alerts dialog.
+
+        NOTE: Deliberate DOM exception. Alert entries are plain
+        ``<a href="/jobs/search-results/?...">`` inside the dialog, a path
+        ``classify_link`` doesn't recognize (it only maps ``/jobs/view/<id>``
+        to a "job" reference), so this reads them directly rather than going
+        through the generic reference pipeline.
+        """
+        return await self._page.evaluate(
+            """(dialogSelector) => {
+                const dialog = document.querySelector(dialogSelector);
+                if (!dialog) return [];
+                const anchors = Array.from(
+                    dialog.querySelectorAll('a[href*="/jobs/search-results/"]')
+                );
+                const seen = new Set();
+                const alerts = [];
+                for (const a of anchors) {
+                    const url = a.href;
+                    const name = (a.textContent || '').replace(/\\s+/g, ' ').trim();
+                    if (!name || seen.has(url)) continue;
+                    seen.add(url);
+                    alerts.push({ name, url });
+                }
+                return alerts;
+            }""",
+            _DIALOG_SELECTOR,
+        )
+
+    async def _extract_job_alerts_page_once(self) -> ExtractedSection:
+        """Single attempt: navigate to the job-alerts dialog and extract innerText."""
+        await self._navigate_to_page(_JOB_ALERTS_URL)
+        await detect_rate_limit(self._page)
+
+        dialog_found = True
+        try:
+            await self._page.wait_for_selector(_DIALOG_SELECTOR)
+        except PlaywrightTimeoutError:
+            logger.debug("No job-alerts dialog found on %s", _JOB_ALERTS_URL)
+            dialog_found = False
+
+        await self._expand_job_alerts_list()
+
+        raw_result = await self._extract_root_content([_DIALOG_SELECTOR, "main"])
+        raw = raw_result["text"]
+        if raw_result["source"] == "body":
+            logger.debug(
+                "No job-alerts dialog at evaluation time on %s, using body fallback",
+                _JOB_ALERTS_URL,
+            )
+        elif not dialog_found:
+            logger.debug(
+                "Job-alerts dialog appeared after wait timeout on %s", _JOB_ALERTS_URL
+            )
+
+        if not raw:
+            return ExtractedSection(text="", references=[])
+        truncated = _truncate_linkedin_noise(raw)
+        if not truncated and raw.strip():
+            logger.warning(
+                "Job alerts page %s returned only LinkedIn chrome (likely rate-limited)",
+                _JOB_ALERTS_URL,
+            )
+            return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+        cleaned = _filter_linkedin_noise_lines(truncated)
+        return ExtractedSection(
+            text=cleaned,
+            references=build_references(raw_result["references"], "job_alerts"),
+        )
+
+    async def _extract_job_alerts_page(self) -> ExtractedSection:
+        """Extract job-alerts dialog text with soft rate-limit retry."""
+        try:
+            result = await self._extract_job_alerts_page_once()
+            if result.text != _RATE_LIMITED_MSG:
+                return result
+
+            logger.info(
+                "Retrying job alerts page after %.0fs backoff", _RATE_LIMIT_RETRY_DELAY
+            )
+            await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
+            result = await self._extract_job_alerts_page_once()
+            if result.text == _RATE_LIMITED_MSG:
+                logger.warning("Job alerts page still rate-limited after retry")
+            return result
+
+        except LinkedInScraperException:
+            raise
+        except Exception as e:
+            logger.warning("Failed to extract job alerts page: %s", e)
+            return ExtractedSection(
+                text="",
+                references=[],
+                error=build_issue_diagnostics(
+                    e,
+                    context="extract_job_alerts_page",
+                    target_url=_JOB_ALERTS_URL,
+                    section_name="job_alerts",
+                ),
+            )
+
+    async def get_job_alerts(self) -> dict[str, Any]:
+        """List the authenticated user's configured job alerts.
+
+        Navigates to LinkedIn's job-alerts management dialog
+        (``linkedin.com/jobs/jam/``) and returns each alert's name and its
+        canonical ``jobs/search-results/`` URL. Pass that URL to
+        ``get_job_alert_results`` to fetch the alert's current results.
+
+        Returns:
+            {url, sections: {job_alerts: text}, alerts: [{name, url}, ...]}
+        """
+        extracted = await self._extract_job_alerts_page()
+
+        sections: dict[str, str] = {}
+        references: dict[str, list[Reference]] = {}
+        section_errors: dict[str, dict[str, Any]] = {}
+        alerts: list[dict[str, str]] = []
+
+        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+            sections["job_alerts"] = extracted.text
+            if extracted.references:
+                references["job_alerts"] = extracted.references
+            alerts = await self._extract_job_alert_links()
+        elif extracted.error:
+            section_errors["job_alerts"] = extracted.error
+
+        result: dict[str, Any] = {
+            "url": _JOB_ALERTS_URL,
+            "sections": sections,
+            "alerts": alerts,
+        }
+        if references:
+            result["references"] = references
         if section_errors:
             result["section_errors"] = section_errors
         return result

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -69,7 +69,7 @@ _SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
 
 _JOB_ALERTS_URL = "https://www.linkedin.com/jobs/jam/"
 
-_NOTIFICATIONS_URL = "https://www.linkedin.com/notifications/"
+_JOB_ALERT_NOTIFICATIONS_URL = "https://www.linkedin.com/notifications/?filter=jobs_all"
 
 # The my-items lists page in 10s, unlike job search. Verified live: ?start=10
 # returns the 11th saved job, while ?start=25 lands past the end of a two-page
@@ -3732,14 +3732,14 @@ class LinkedInExtractor:
         self, limit: int
     ) -> ExtractedSection:
         """Single attempt: navigate to notifications and extract innerText."""
-        await self._navigate_to_page(_NOTIFICATIONS_URL)
+        await self._navigate_to_page(_JOB_ALERT_NOTIFICATIONS_URL)
         await detect_rate_limit(self._page)
 
         main_found = True
         try:
             await self._page.wait_for_selector("main")
         except PlaywrightTimeoutError:
-            logger.debug("No <main> element found on %s", _NOTIFICATIONS_URL)
+            logger.debug("No <main> element found on %s", _JOB_ALERT_NOTIFICATIONS_URL)
             main_found = False
 
         await handle_modal_close(self._page)
@@ -3751,12 +3751,12 @@ class LinkedInExtractor:
         if raw_result["source"] == "body":
             logger.debug(
                 "No <main> at evaluation time on %s, using body fallback",
-                _NOTIFICATIONS_URL,
+                _JOB_ALERT_NOTIFICATIONS_URL,
             )
         elif not main_found:
             logger.debug(
                 "<main> appeared after wait timeout on %s, expand was skipped",
-                _NOTIFICATIONS_URL,
+                _JOB_ALERT_NOTIFICATIONS_URL,
             )
 
         if not raw:
@@ -3766,7 +3766,7 @@ class LinkedInExtractor:
             logger.warning(
                 "Notifications page %s returned only LinkedIn chrome "
                 "(likely rate-limited)",
-                _NOTIFICATIONS_URL,
+                _JOB_ALERT_NOTIFICATIONS_URL,
             )
             return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
         cleaned = _filter_linkedin_noise_lines(truncated)
@@ -3804,7 +3804,7 @@ class LinkedInExtractor:
                 error=build_issue_diagnostics(
                     e,
                     context="extract_job_alert_notifications_page",
-                    target_url=_NOTIFICATIONS_URL,
+                    target_url=_JOB_ALERT_NOTIFICATIONS_URL,
                     section_name="notifications",
                 ),
             )
@@ -3814,13 +3814,17 @@ class LinkedInExtractor:
     ) -> dict[str, Any]:
         """List job-alert notifications from LinkedIn's notifications feed.
 
-        Filters to notifications LinkedIn generated because one of your job
-        alerts has new results, excluding other notification types
-        (connection requests, post reactions, similar-jobs recommendations,
-        etc). Each item's ``url`` is the alert's delta-filtered
-        search-results link (``f_TPR=a<timestamp>-``, marking new results
-        since that alert last fired) — pass it to ``get_job_alert_results``
-        to fetch those jobs.
+        Loads the notifications page's "Jobs" tab (``?filter=jobs_all``)
+        rather than "All", so every loaded item is job-related before any
+        client-side filtering — cheaper than scrolling through unrelated
+        connection/post/mention notifications to find the job ones. Within
+        that, further filters to notifications LinkedIn generated because
+        one of your job alerts specifically has new results, excluding
+        other job-notification types the Jobs tab still mixes in (similar-jobs
+        recommendations, network-hiring posts, qualification-board emails).
+        Each item's ``url`` is the alert's delta-filtered search-results link
+        (``f_TPR=a<timestamp>-``, marking new results since that alert last
+        fired) — pass it to ``get_job_alert_results`` to fetch those jobs.
 
         Args:
             unread_only: Only return notifications not yet marked read.
@@ -3850,7 +3854,7 @@ class LinkedInExtractor:
             section_errors["notifications"] = extracted.error
 
         result: dict[str, Any] = {
-            "url": _NOTIFICATIONS_URL,
+            "url": _JOB_ALERT_NOTIFICATIONS_URL,
             "sections": sections,
             "alerts": items,
         }

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -69,6 +69,8 @@ _SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
 
 _JOB_ALERTS_URL = "https://www.linkedin.com/jobs/jam/"
 
+_NOTIFICATIONS_URL = "https://www.linkedin.com/notifications/"
+
 # The my-items lists page in 10s, unlike job search. Verified live: ?start=10
 # returns the 11th saved job, while ?start=25 lands past the end of a two-page
 # list and yields nothing.
@@ -3635,6 +3637,222 @@ class LinkedInExtractor:
             "url": _JOB_ALERTS_URL,
             "sections": sections,
             "alerts": alerts,
+        }
+        if references:
+            result["references"] = references
+        if section_errors:
+            result["section_errors"] = section_errors
+        return result
+
+    async def _expand_notifications_feed(self, target_count: int) -> None:
+        """Click "Show more results" until ``target_count`` articles are loaded.
+
+        NOTE: Deliberate DOM exception, like ``_expand_job_alerts_list``. Unlike
+        the job-alerts dialog's "Show N more" (a numeric, locale-neutral
+        count), this button's label carries no count to match generically, so
+        this matches the fixed English string "Show more results". If
+        LinkedIn changes the copy or removes the control, this stops early
+        and callers just get whatever was already loaded.
+        """
+        for _ in range(10):
+            count = await self._page.evaluate(
+                "() => document.querySelectorAll('main article').length"
+            )
+            if count >= target_count:
+                break
+            clicked = await self._page.evaluate(
+                """() => {
+                    const button = Array.from(document.querySelectorAll('button')).find(
+                        (b) => /show more results/i.test(b.textContent || '')
+                    );
+                    if (!button) return false;
+                    button.click();
+                    return true;
+                }"""
+            )
+            if not clicked:
+                break
+            await asyncio.sleep(1.0)
+
+    async def _extract_job_alert_notification_items(self) -> list[dict[str, Any]]:
+        """Extract job-alert notifications from the notifications feed.
+
+        NOTE: Deliberate DOM exception. Job-alert notification links are
+        identified by the ``alertAction=viewjobs`` query param, which
+        (verified live) appears only on genuine "your alert has new
+        results" links, not on LinkedIn's other job-notification types
+        (similar-jobs recommendations, network-hiring posts, qualification-
+        board emails). Read/unread state comes from each card's
+        ``aria-label`` ("Unread notification." vs "Notification"), an
+        English string and therefore locale-dependent — it is the only
+        signal LinkedIn exposes for this, with no attribute-presence
+        alternative available.
+        """
+        return await self._page.evaluate(
+            """() => {
+                const main = document.querySelector('main') || document.body;
+                const articles = Array.from(main.querySelectorAll('article'));
+                const seen = new Set();
+                const results = [];
+                for (const article of articles) {
+                    const link = Array.from(
+                        article.querySelectorAll('a[href*="alertAction=viewjobs"]')
+                    ).find((a) => a.querySelector('strong'));
+                    if (!link) continue;
+                    const href = link.href;
+                    if (seen.has(href)) continue;
+                    seen.add(href);
+
+                    const strong = link.querySelector('strong');
+                    const alertName = strong ? strong.textContent.trim() : '';
+
+                    const unread = /^unread/i.test(
+                        article.getAttribute('aria-label') || ''
+                    );
+
+                    const timeNode = Array.from(
+                        article.querySelectorAll('p, span, time')
+                    ).find((el) =>
+                        /^\\d+\\s*[hdwmy]$/i.test((el.textContent || '').trim())
+                    );
+                    const postedAt = timeNode ? timeNode.textContent.trim() : null;
+
+                    results.push({
+                        alert_name: alertName,
+                        url: href,
+                        unread,
+                        posted_at: postedAt,
+                    });
+                }
+                return results;
+            }"""
+        )
+
+    async def _extract_job_alert_notifications_page_once(
+        self, limit: int
+    ) -> ExtractedSection:
+        """Single attempt: navigate to notifications and extract innerText."""
+        await self._navigate_to_page(_NOTIFICATIONS_URL)
+        await detect_rate_limit(self._page)
+
+        main_found = True
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("No <main> element found on %s", _NOTIFICATIONS_URL)
+            main_found = False
+
+        await handle_modal_close(self._page)
+        if main_found:
+            await self._expand_notifications_feed(limit)
+
+        raw_result = await self._extract_root_content(["main"])
+        raw = raw_result["text"]
+        if raw_result["source"] == "body":
+            logger.debug(
+                "No <main> at evaluation time on %s, using body fallback",
+                _NOTIFICATIONS_URL,
+            )
+        elif not main_found:
+            logger.debug(
+                "<main> appeared after wait timeout on %s, expand was skipped",
+                _NOTIFICATIONS_URL,
+            )
+
+        if not raw:
+            return ExtractedSection(text="", references=[])
+        truncated = _truncate_linkedin_noise(raw)
+        if not truncated and raw.strip():
+            logger.warning(
+                "Notifications page %s returned only LinkedIn chrome "
+                "(likely rate-limited)",
+                _NOTIFICATIONS_URL,
+            )
+            return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+        cleaned = _filter_linkedin_noise_lines(truncated)
+        return ExtractedSection(
+            text=cleaned,
+            references=build_references(raw_result["references"], "notifications"),
+        )
+
+    async def _extract_job_alert_notifications_page(
+        self, limit: int
+    ) -> ExtractedSection:
+        """Extract notifications page text with soft rate-limit retry."""
+        try:
+            result = await self._extract_job_alert_notifications_page_once(limit)
+            if result.text != _RATE_LIMITED_MSG:
+                return result
+
+            logger.info(
+                "Retrying notifications page after %.0fs backoff",
+                _RATE_LIMIT_RETRY_DELAY,
+            )
+            await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
+            result = await self._extract_job_alert_notifications_page_once(limit)
+            if result.text == _RATE_LIMITED_MSG:
+                logger.warning("Notifications page still rate-limited after retry")
+            return result
+
+        except LinkedInScraperException:
+            raise
+        except Exception as e:
+            logger.warning("Failed to extract notifications page: %s", e)
+            return ExtractedSection(
+                text="",
+                references=[],
+                error=build_issue_diagnostics(
+                    e,
+                    context="extract_job_alert_notifications_page",
+                    target_url=_NOTIFICATIONS_URL,
+                    section_name="notifications",
+                ),
+            )
+
+    async def get_job_alert_notifications(
+        self, unread_only: bool = False, limit: int = 20
+    ) -> dict[str, Any]:
+        """List job-alert notifications from LinkedIn's notifications feed.
+
+        Filters to notifications LinkedIn generated because one of your job
+        alerts has new results, excluding other notification types
+        (connection requests, post reactions, similar-jobs recommendations,
+        etc). Each item's ``url`` is the alert's delta-filtered
+        search-results link (``f_TPR=a<timestamp>-``, marking new results
+        since that alert last fired) — pass it to ``get_job_alert_results``
+        to fetch those jobs.
+
+        Args:
+            unread_only: Only return notifications not yet marked read.
+            limit: Maximum number of job-alert notifications to return
+                (1-50, default 20).
+
+        Returns:
+            {url, sections: {notifications: text},
+             alerts: [{alert_name, url, unread, posted_at}, ...]}
+        """
+        extracted = await self._extract_job_alert_notifications_page(limit)
+
+        sections: dict[str, str] = {}
+        references: dict[str, list[Reference]] = {}
+        section_errors: dict[str, dict[str, Any]] = {}
+        items: list[dict[str, Any]] = []
+
+        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+            sections["notifications"] = extracted.text
+            if extracted.references:
+                references["notifications"] = extracted.references
+            items = await self._extract_job_alert_notification_items()
+            if unread_only:
+                items = [item for item in items if item["unread"]]
+            items = items[:limit]
+        elif extracted.error:
+            section_errors["notifications"] = extracted.error
+
+        result: dict[str, Any] = {
+            "url": _NOTIFICATIONS_URL,
+            "sections": sections,
+            "alerts": items,
         }
         if references:
             result["references"] = references

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -86,21 +86,32 @@ _DATE_POSTED_MAP = {
 def _with_date_posted(url: str, date_posted: str) -> str:
     """Return ``url`` with its ``f_TPR`` date filter set, replacing any existing one.
 
-    ``date_posted`` is normalized through ``_DATE_POSTED_MAP`` (same presets as
-    ``search_jobs``); unrecognized values pass through unchanged, matching
-    ``_build_job_search_url``. A job-alert URL's own ``f_TPR`` (an absolute
-    timestamp marking when that alert last fired, e.g. ``a1788038570-``) is
-    replaced outright rather than combined, since LinkedIn's date filter is
-    single-valued.
+    ``date_posted`` must be one of ``_DATE_POSTED_MAP``'s keys (the same
+    presets ``search_jobs`` exposes). Unlike ``_build_job_search_url``, this
+    does NOT pass unrecognized values through as raw ``f_TPR`` values:
+    verified live, LinkedIn silently ignores an arbitrary ``r<seconds>`` that
+    doesn't match one of its own UI presets rather than applying it, so a
+    passthrough here would produce a URL that looks filtered but isn't. A job
+    alert's own ``f_TPR`` (an absolute timestamp marking when that alert last
+    fired, e.g. ``a1788038570-``) is replaced outright rather than combined,
+    since LinkedIn's date filter is single-valued.
+
+    Raises:
+        ValueError: If ``date_posted`` is not a recognized preset.
     """
-    mapped = _DATE_POSTED_MAP.get(date_posted.strip(), date_posted)
+    key = date_posted.strip()
+    if key not in _DATE_POSTED_MAP:
+        raise ValueError(
+            "date_posted must be one of "
+            f"{sorted(_DATE_POSTED_MAP)}, got: {date_posted!r}"
+        )
     parsed = urlparse(url)
     pairs = [
         (k, v)
         for k, v in parse_qsl(parsed.query, keep_blank_values=True)
         if k != "f_TPR"
     ]
-    pairs.append(("f_TPR", mapped))
+    pairs.append(("f_TPR", _DATE_POSTED_MAP[key]))
     return parsed._replace(query=urlencode(pairs)).geturl()
 
 
@@ -3344,13 +3355,17 @@ class LinkedInExtractor:
                 past_week, past_month), replacing any date filter already
                 present in ``url`` — including a job-alert URL's own
                 timestamp, which reflects when that alert last fired, not a
-                selectable range. Unrecognized values pass through as-is.
+                selectable range. Must be one of these four presets; verified
+                live, LinkedIn silently ignores other ``f_TPR`` values rather
+                than applying them, so other values are rejected up front
+                instead of producing a URL that looks filtered but isn't.
 
         Returns:
             {url, sections: {alert_results: text}, job_ids: [str]}
 
         Raises:
-            ValueError: If ``url`` is not a linkedin.com ``/jobs/...`` URL.
+            ValueError: If ``url`` is not a linkedin.com ``/jobs/...`` URL, or
+                ``date_posted`` is not a recognized preset.
         """
         parsed = urlparse(url)
         if (

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -8,7 +8,14 @@ import json
 import logging
 import re
 from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import parse_qs, quote_plus, urljoin, urlparse
+from urllib.parse import (
+    parse_qs,
+    parse_qsl,
+    quote_plus,
+    urlencode,
+    urljoin,
+    urlparse,
+)
 
 from patchright.async_api import Page, TimeoutError as PlaywrightTimeoutError
 
@@ -74,6 +81,28 @@ _DATE_POSTED_MAP = {
     "past_week": "r604800",
     "past_month": "r2592000",
 }
+
+
+def _with_date_posted(url: str, date_posted: str) -> str:
+    """Return ``url`` with its ``f_TPR`` date filter set, replacing any existing one.
+
+    ``date_posted`` is normalized through ``_DATE_POSTED_MAP`` (same presets as
+    ``search_jobs``); unrecognized values pass through unchanged, matching
+    ``_build_job_search_url``. A job-alert URL's own ``f_TPR`` (an absolute
+    timestamp marking when that alert last fired, e.g. ``a1788038570-``) is
+    replaced outright rather than combined, since LinkedIn's date filter is
+    single-valued.
+    """
+    mapped = _DATE_POSTED_MAP.get(date_posted.strip(), date_posted)
+    parsed = urlparse(url)
+    pairs = [
+        (k, v)
+        for k, v in parse_qsl(parsed.query, keep_blank_values=True)
+        if k != "f_TPR"
+    ]
+    pairs.append(("f_TPR", mapped))
+    return parsed._replace(query=urlencode(pairs)).geturl()
+
 
 _EXPERIENCE_LEVEL_MAP = {
     "internship": "1",
@@ -3293,7 +3322,10 @@ class LinkedInExtractor:
         )
 
     async def get_job_alert_results(
-        self, url: str, max_pages: int = 3
+        self,
+        url: str,
+        max_pages: int = 3,
+        date_posted: str | None = None,
     ) -> dict[str, Any]:
         """Fetch job results from a LinkedIn job-alert or saved-search URL.
 
@@ -3308,6 +3340,11 @@ class LinkedInExtractor:
         Args:
             url: A ``linkedin.com/jobs/search/`` or ``jobs/search-results/`` URL
             max_pages: Maximum pages to load (1-10, default 3)
+            date_posted: Optional date filter (past_hour, past_24_hours,
+                past_week, past_month), replacing any date filter already
+                present in ``url`` — including a job-alert URL's own
+                timestamp, which reflects when that alert last fired, not a
+                selectable range. Unrecognized values pass through as-is.
 
         Returns:
             {url, sections: {alert_results: text}, job_ids: [str]}
@@ -3325,6 +3362,9 @@ class LinkedInExtractor:
                 "get_job_alert_results requires a linkedin.com/jobs/... URL, "
                 f"got: {url}"
             )
+
+        if date_posted:
+            url = _with_date_posted(url, date_posted)
 
         base_url = url
         all_job_ids: list[str] = []

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3246,6 +3246,178 @@ class LinkedInExtractor:
             result["section_errors"] = section_errors
         return result
 
+    async def _extract_alert_job_ids(self) -> list[str]:
+        """Extract job IDs from LinkedIn's AI-ranked job-alert sidebar.
+
+        Unlike classic search results, cards on the semantic/AI search feed
+        (``origin=SEMANTIC_SEARCH_JOB_ALERT_IN_APP_NOTIFICATION`` and similar
+        ``jobs/search-results/`` pages) have no per-card
+        ``<a href="/jobs/view/...">`` — only the currently open job's detail
+        pane does. Each card's job ID instead lives on an ancestor's
+        ``componentkey="job-card-component-ref-<id>"`` attribute, reached by
+        climbing up from that card's "Dismiss <title> job" button.
+
+        NOTE: This is a deliberate DOM exception, like ``_get_total_search_pages``.
+        If LinkedIn renames ``componentkey`` or the dismiss button's aria-label
+        pattern, this returns an empty list and ``get_job_alert_results`` falls
+        back to ``_extract_job_ids`` (which still finds the one open job's ID).
+        """
+        return await self._page.evaluate(
+            """() => {
+                const buttons = document.querySelectorAll(
+                    'button[aria-label^="Dismiss "][aria-label$=" job"]'
+                );
+                const seen = new Set();
+                const ids = [];
+                for (const btn of buttons) {
+                    let el = btn;
+                    let jobId = null;
+                    for (let i = 0; i < 8 && el; i++) {
+                        el = el.parentElement;
+                        if (!el) break;
+                        const ck = el.getAttribute && el.getAttribute('componentkey');
+                        if (ck && ck.startsWith('job-card-component-ref-')) {
+                            jobId = ck.slice('job-card-component-ref-'.length);
+                            break;
+                        }
+                    }
+                    if (jobId && !seen.has(jobId)) {
+                        seen.add(jobId);
+                        ids.push(jobId);
+                    }
+                }
+                return ids;
+            }"""
+        )
+
+    async def get_job_alert_results(
+        self, url: str, max_pages: int = 3
+    ) -> dict[str, Any]:
+        """Fetch job results from a LinkedIn job-alert or saved-search URL.
+
+        Unlike ``search_jobs``, which builds its own classic search URL, this
+        navigates directly to a URL the caller already has — typically copied
+        from a job-alert notification link (``jobs/search-results/?...
+        origin=SEMANTIC_SEARCH_JOB_ALERT...``). ``search_jobs`` cannot
+        reproduce LinkedIn's personalized/AI-ranked alert feed because it
+        always builds a fresh classic search; this is the only way to reach
+        the exact feed the user sees.
+
+        Args:
+            url: A ``linkedin.com/jobs/search/`` or ``jobs/search-results/`` URL
+            max_pages: Maximum pages to load (1-10, default 3)
+
+        Returns:
+            {url, sections: {alert_results: text}, job_ids: [str]}
+
+        Raises:
+            ValueError: If ``url`` is not a linkedin.com ``/jobs/...`` URL.
+        """
+        parsed = urlparse(url)
+        if (
+            parsed.scheme != "https"
+            or not parsed.netloc.endswith("linkedin.com")
+            or not parsed.path.startswith("/jobs/")
+        ):
+            raise ValueError(
+                "get_job_alert_results requires a linkedin.com/jobs/... URL, "
+                f"got: {url}"
+            )
+
+        base_url = url
+        all_job_ids: list[str] = []
+        seen_ids: set[str] = set()
+        page_texts: list[str] = []
+        page_references: list[Reference] = []
+        section_errors: dict[str, dict[str, Any]] = {}
+        total_pages: int | None = None
+        total_pages_queried = False
+
+        for page_num in range(max_pages):
+            if total_pages is not None and page_num >= total_pages:
+                logger.debug("All %d alert pages fetched, stopping", total_pages)
+                break
+
+            if page_num > 0:
+                await asyncio.sleep(_NAV_DELAY)
+
+            page_url = (
+                base_url
+                if page_num == 0
+                else f"{base_url}&start={page_num * _PAGE_SIZE}"
+            )
+
+            try:
+                extracted = await self._extract_search_page(
+                    page_url, section_name="alert_results"
+                )
+
+                if not extracted.text or extracted.text == _RATE_LIMITED_MSG:
+                    if extracted.error:
+                        section_errors["alert_results"] = extracted.error
+                    break
+
+                if not total_pages_queried:
+                    total_pages_queried = True
+                    try:
+                        total_pages = await self._get_total_search_pages()
+                    except Exception as e:
+                        logger.debug("Could not read total alert pages: %s", e)
+                    else:
+                        if total_pages is not None:
+                            logger.debug(
+                                "LinkedIn reports %d total alert pages", total_pages
+                            )
+
+                page_ids = await self._extract_alert_job_ids()
+                if not page_ids:
+                    page_ids = await self._extract_job_ids()
+                new_ids = [jid for jid in page_ids if jid not in seen_ids]
+
+                if not new_ids:
+                    page_texts.append(extracted.text)
+                    if extracted.references:
+                        page_references.extend(extracted.references)
+                    logger.debug(
+                        "No new job IDs on alert page %d, stopping", page_num + 1
+                    )
+                    break
+
+                for jid in new_ids:
+                    seen_ids.add(jid)
+                    all_job_ids.append(jid)
+
+                page_texts.append(extracted.text)
+                if extracted.references:
+                    page_references.extend(extracted.references)
+
+            except LinkedInScraperException:
+                raise
+            except Exception as e:
+                logger.warning("Error on alert page %d: %s", page_num + 1, e)
+                section_errors["alert_results"] = build_issue_diagnostics(
+                    e,
+                    context="get_job_alert_results",
+                    target_url=page_url,
+                    section_name="alert_results",
+                )
+                break
+
+        result: dict[str, Any] = {
+            "url": base_url,
+            "sections": {"alert_results": "\n---\n".join(page_texts)}
+            if page_texts
+            else {},
+            "job_ids": all_job_ids,
+        }
+        if page_references:
+            result["references"] = {
+                "alert_results": dedupe_references(page_references, cap=15)
+            }
+        if section_errors:
+            result["section_errors"] = section_errors
+        return result
+
     async def _extract_saved_jobs_page(
         self,
         url: str,

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -161,6 +161,7 @@ def register_job_tools(
         url: str,
         ctx: Context,
         max_pages: Annotated[int, Field(ge=1, le=10)] = 3,
+        date_posted: str | None = None,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -177,6 +178,11 @@ def register_job_tools(
             url: A linkedin.com/jobs/search/ or jobs/search-results/ URL
             ctx: FastMCP context for progress reporting
             max_pages: Maximum number of result pages to load (1-10, default 3)
+            date_posted: Filter by posting date (past_hour, past_24_hours,
+                past_week, past_month), replacing any date filter already in
+                the URL. A job-alert URL's own filter marks when that alert
+                last fired, not a chosen range, so pass this to actually
+                narrow results (e.g. "just show me the last week").
 
         Returns:
             Dict with url, sections (alert_results: raw text), job_ids (list of
@@ -194,7 +200,9 @@ def register_job_tools(
                 progress=0, total=100, message="Starting alert fetch"
             )
 
-            result = await extractor.get_job_alert_results(url, max_pages=max_pages)
+            result = await extractor.get_job_alert_results(
+                url, max_pages=max_pages, date_posted=date_posted
+            )
 
             await ctx.report_progress(progress=100, total=100, message="Complete")
 

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -269,6 +269,69 @@ def register_job_tools(
 
     @mcp.tool(
         timeout=tool_timeout,
+        title="Get Job Alert Notifications",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"job", "search"},
+        exclude_args=["extractor"],
+    )
+    async def get_job_alert_notifications(
+        ctx: Context,
+        unread_only: bool = False,
+        limit: Annotated[int, Field(ge=1, le=50)] = 20,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        List job-alert notifications from LinkedIn's notifications feed.
+
+        Filters to notifications LinkedIn generated because one of your job
+        alerts has new results, excluding other notification types
+        (connection requests, post reactions, similar-jobs recommendations,
+        etc). Each item's url is the alert's delta-filtered search-results
+        link (new results since that alert last fired) — pass it to
+        get_job_alert_results to fetch those jobs.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+            unread_only: Only return notifications not yet marked read
+            limit: Maximum number of job-alert notifications to return
+                (1-50, default 20)
+
+        Returns:
+            Dict with url, sections (notifications: raw text), alerts (list of
+            {alert_name, url, unread, posted_at}), and optional references.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_job_alert_notifications"
+            )
+            logger.info(
+                "Fetching job alert notifications: unread_only=%s, limit=%d",
+                unread_only,
+                limit,
+            )
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Loading notifications"
+            )
+
+            result = await extractor.get_job_alert_notifications(
+                unread_only=unread_only, limit=limit
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_job_alert_notifications")
+        except Exception as e:
+            raise_tool_error(e, "get_job_alert_notifications")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
         title="Get Saved Jobs",
         annotations={"readOnlyHint": True, "openWorldHint": True},
         tags={"job", "scraping"},

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -281,13 +281,15 @@ def register_job_tools(
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
-        List job-alert notifications from LinkedIn's notifications feed.
+        List job-alert notifications from the notifications page's Jobs tab.
 
-        Filters to notifications LinkedIn generated because one of your job
-        alerts has new results, excluding other notification types
-        (connection requests, post reactions, similar-jobs recommendations,
-        etc). Each item's url is the alert's delta-filtered search-results
-        link (new results since that alert last fired) — pass it to
+        Loads the notifications page filtered to Jobs (not All), then
+        further filters to notifications LinkedIn generated because one of
+        your job alerts specifically has new results, excluding other
+        job-notification types the Jobs tab still mixes in (similar-jobs
+        recommendations, network-hiring posts, qualification-board emails).
+        Each item's url is the alert's delta-filtered search-results link
+        (new results since that alert last fired) — pass it to
         get_job_alert_results to fetch those jobs.
 
         Args:

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -152,6 +152,64 @@ def register_job_tools(
 
     @mcp.tool(
         timeout=tool_timeout,
+        title="Get Job Alert Results",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"job", "search"},
+        exclude_args=["extractor"],
+    )
+    async def get_job_alert_results(
+        url: str,
+        ctx: Context,
+        max_pages: Annotated[int, Field(ge=1, le=10)] = 3,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Fetch job results from a LinkedIn job-alert or saved-search URL.
+
+        Use this instead of search_jobs when you have a specific URL copied
+        from a LinkedIn job-alert notification, e.g. a
+        "jobs/search-results/?...origin=SEMANTIC_SEARCH_JOB_ALERT..." link.
+        search_jobs always builds its own classic search and cannot
+        reproduce LinkedIn's personalized/AI-ranked alert feed; this
+        navigates to the exact URL you provide instead.
+
+        Args:
+            url: A linkedin.com/jobs/search/ or jobs/search-results/ URL
+            ctx: FastMCP context for progress reporting
+            max_pages: Maximum number of result pages to load (1-10, default 3)
+
+        Returns:
+            Dict with url, sections (alert_results: raw text), job_ids (list of
+            numeric job ID strings usable with get_job_details), and optional references.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_job_alert_results"
+            )
+            logger.info(
+                "Fetching job alert results: url='%s', max_pages=%d", url, max_pages
+            )
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Starting alert fetch"
+            )
+
+            result = await extractor.get_job_alert_results(url, max_pages=max_pages)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_job_alert_results")
+        except Exception as e:
+            raise_tool_error(e, "get_job_alert_results")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
         title="Get Saved Jobs",
         annotations={"readOnlyHint": True, "openWorldHint": True},
         tags={"job", "scraping"},

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -178,11 +178,13 @@ def register_job_tools(
             url: A linkedin.com/jobs/search/ or jobs/search-results/ URL
             ctx: FastMCP context for progress reporting
             max_pages: Maximum number of result pages to load (1-10, default 3)
-            date_posted: Filter by posting date (past_hour, past_24_hours,
-                past_week, past_month), replacing any date filter already in
-                the URL. A job-alert URL's own filter marks when that alert
-                last fired, not a chosen range, so pass this to actually
-                narrow results (e.g. "just show me the last week").
+            date_posted: Filter by posting date. Must be one of past_hour,
+                past_24_hours, past_week, past_month (LinkedIn silently
+                ignores other values rather than applying them), replacing
+                any date filter already in the URL. A job-alert URL's own
+                filter marks when that alert last fired, not a chosen range,
+                so pass this to actually narrow results (e.g. "just show me
+                the last week").
 
         Returns:
             Dict with url, sections (alert_results: raw text), job_ids (list of

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -210,6 +210,55 @@ def register_job_tools(
 
     @mcp.tool(
         timeout=tool_timeout,
+        title="Get Job Alerts",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"job", "search"},
+        exclude_args=["extractor"],
+    )
+    async def get_job_alerts(
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        List the authenticated user's configured job alerts.
+
+        Returns each alert's name and its canonical search-results URL.
+        Pass that URL to get_job_alert_results to fetch the alert's
+        current results.
+
+        Args:
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, sections (job_alerts: raw text), alerts (list of
+            {name, url}), and optional references.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_job_alerts"
+            )
+            logger.info("Fetching job alerts")
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Loading job alerts"
+            )
+
+            result = await extractor.get_job_alerts()
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_job_alerts")
+        except Exception as e:
+            raise_tool_error(e, "get_job_alerts")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
         title="Get Saved Jobs",
         annotations={"readOnlyHint": True, "openWorldHint": True},
         tags={"job", "scraping"},

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -19,6 +19,7 @@ from linkedin_mcp_server.scraping.extractor import (
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
+    _with_date_posted,
     strip_conversation_chrome,
     strip_linkedin_noise,
 )
@@ -119,6 +120,45 @@ class TestBuildJobSearchUrl:
         assert "f_WT=2" in url
         assert "f_EA=true" in url
         assert "sortBy=DD" in url
+
+
+class TestWithDatePosted:
+    """Tests for _with_date_posted URL rewriting."""
+
+    def test_adds_preset_filter(self):
+        url = _with_date_posted(
+            "https://www.linkedin.com/jobs/search-results/?keywords=python",
+            "past_week",
+        )
+        assert "f_TPR=r604800" in url
+        assert "keywords=python" in url
+
+    def test_passthrough_for_unrecognized_value(self):
+        url = _with_date_posted(
+            "https://www.linkedin.com/jobs/search-results/?keywords=python",
+            "r172800",
+        )
+        assert "f_TPR=r172800" in url
+
+    def test_replaces_existing_absolute_timestamp(self):
+        """A job-alert URL's own f_TPR (when it last fired) must be replaced, not combined."""
+        url = _with_date_posted(
+            "https://www.linkedin.com/jobs/search-results/?keywords=python&f_TPR=a1788038570-",
+            "past_24_hours",
+        )
+        assert url.count("f_TPR=") == 1
+        assert "f_TPR=r86400" in url
+        assert "a1788038570" not in url
+
+    def test_preserves_other_query_params(self):
+        url = _with_date_posted(
+            "https://www.linkedin.com/jobs/search-results/?keywords=python&geoId=102890719&origin=SEMANTIC_SEARCH_JOB_ALERT_IN_APP_NOTIFICATION",
+            "past_month",
+        )
+        assert "keywords=python" in url
+        assert "geoId=102890719" in url
+        assert "origin=SEMANTIC_SEARCH_JOB_ALERT_IN_APP_NOTIFICATION" in url
+        assert "f_TPR=r2592000" in url
 
 
 @pytest.fixture
@@ -2677,6 +2717,37 @@ class TestGetJobAlertResults:
         extractor = LinkedInExtractor(mock_page)
         with pytest.raises(ValueError, match="linkedin.com"):
             await extractor.get_job_alert_results("https://www.linkedin.com/feed/?x=1")
+
+    async def test_date_posted_rewrites_url_before_navigation(self, mock_page):
+        """date_posted should replace the alert's own f_TPR before the first page load."""
+        extractor = LinkedInExtractor(mock_page)
+        urls_visited: list[str] = []
+
+        async def mock_extract(url, *args, **kwargs):
+            urls_visited.append(url)
+            return extracted("text")
+
+        with (
+            patch.object(extractor, "_extract_search_page", side_effect=mock_extract),
+            patch.object(
+                extractor,
+                "_extract_alert_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await extractor.get_job_alert_results(
+                self.ALERT_URL, max_pages=1, date_posted="past_week"
+            )
+
+        assert "f_TPR=r604800" in urls_visited[0]
+        assert result["url"] == urls_visited[0]
 
     async def test_returns_job_ids_via_alert_extraction(self, mock_page):
         """Should use the componentkey-based alert extraction when it finds cards."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -133,12 +133,20 @@ class TestWithDatePosted:
         assert "f_TPR=r604800" in url
         assert "keywords=python" in url
 
-    def test_passthrough_for_unrecognized_value(self):
-        url = _with_date_posted(
-            "https://www.linkedin.com/jobs/search-results/?keywords=python",
-            "r172800",
-        )
-        assert "f_TPR=r172800" in url
+    def test_rejects_unrecognized_value(self):
+        """Verified live: LinkedIn silently ignores an f_TPR it doesn't recognize
+        rather than applying it, so passthrough would be misleading."""
+        with pytest.raises(ValueError, match="past_hour"):
+            _with_date_posted(
+                "https://www.linkedin.com/jobs/search-results/?keywords=python",
+                "r172800",
+            )
+
+    def test_rejects_empty_value(self):
+        with pytest.raises(ValueError):
+            _with_date_posted(
+                "https://www.linkedin.com/jobs/search-results/?keywords=python", ""
+            )
 
     def test_replaces_existing_absolute_timestamp(self):
         """A job-alert URL's own f_TPR (when it last fired) must be replaced, not combined."""
@@ -2748,6 +2756,19 @@ class TestGetJobAlertResults:
 
         assert "f_TPR=r604800" in urls_visited[0]
         assert result["url"] == urls_visited[0]
+
+    async def test_rejects_unrecognized_date_posted_before_navigating(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor, "_extract_search_page", new_callable=AsyncMock
+            ) as mock_extract,
+            pytest.raises(ValueError, match="past_hour"),
+        ):
+            await extractor.get_job_alert_results(
+                self.ALERT_URL, max_pages=1, date_posted="last 2 days"
+            )
+        mock_extract.assert_not_awaited()
 
     async def test_returns_job_ids_via_alert_extraction(self, mock_page):
         """Should use the componentkey-based alert extraction when it finds cards."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2600,6 +2600,170 @@ class TestSearchJobs:
         mock_ids.assert_not_awaited()
 
 
+class TestGetJobAlertResults:
+    """Tests for get_job_alert_results with alert-card ID extraction and pagination."""
+
+    ALERT_URL = (
+        "https://www.linkedin.com/jobs/search-results/?currentJobId=111"
+        "&keywords=python&origin=SEMANTIC_SEARCH_JOB_ALERT_IN_APP_NOTIFICATION"
+    )
+
+    async def test_rejects_non_linkedin_url(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with pytest.raises(ValueError, match="linkedin.com"):
+            await extractor.get_job_alert_results("https://evil.example.com/jobs/x")
+
+    async def test_rejects_non_jobs_path(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with pytest.raises(ValueError, match="linkedin.com"):
+            await extractor.get_job_alert_results("https://www.linkedin.com/feed/?x=1")
+
+    async def test_returns_job_ids_via_alert_extraction(self, mock_page):
+        """Should use the componentkey-based alert extraction when it finds cards."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Job 1\nJob 2\nJob 3"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_alert_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111", "222", "333"],
+            ) as mock_alert_ids,
+            patch.object(
+                extractor, "_extract_job_ids", new_callable=AsyncMock
+            ) as mock_fallback_ids,
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_job_alert_results(self.ALERT_URL, max_pages=1)
+
+        assert result["job_ids"] == ["111", "222", "333"]
+        assert "alert_results" in result["sections"]
+        mock_alert_ids.assert_awaited_once()
+        mock_fallback_ids.assert_not_awaited()
+
+    async def test_falls_back_to_extract_job_ids_when_alert_extraction_empty(
+        self, mock_page
+    ):
+        """If componentkey-based extraction finds nothing, fall back to anchors."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Job 1"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_alert_job_ids",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["999"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_job_alert_results(self.ALERT_URL, max_pages=1)
+
+        assert result["job_ids"] == ["999"]
+
+    async def test_pagination_uses_fixed_page_size_and_preserves_query(self, mock_page):
+        """Pages use &start= appended to the original alert URL, filters intact."""
+        extractor = LinkedInExtractor(mock_page)
+        id_pages = iter([["100", "200", "300"], ["400", "500"]])
+        urls_visited: list[str] = []
+
+        async def mock_extract(url, *args, **kwargs):
+            urls_visited.append(url)
+            return extracted("text")
+
+        with (
+            patch.object(extractor, "_extract_search_page", side_effect=mock_extract),
+            patch.object(
+                extractor,
+                "_extract_alert_job_ids",
+                new_callable=AsyncMock,
+                side_effect=lambda: next(id_pages),
+            ),
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_job_alert_results(self.ALERT_URL, max_pages=2)
+
+        assert result["job_ids"] == ["100", "200", "300", "400", "500"]
+        assert len(urls_visited) == 2
+        assert urls_visited[0] == self.ALERT_URL
+        assert urls_visited[1] == f"{self.ALERT_URL}&start=25"
+
+    async def test_early_stop_no_new_ids(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        id_pages = iter([["100"], ["100"]])
+
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_extract,
+            patch.object(
+                extractor,
+                "_extract_alert_job_ids",
+                new_callable=AsyncMock,
+                side_effect=lambda: next(id_pages),
+            ),
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.get_job_alert_results(self.ALERT_URL, max_pages=5)
+
+        assert result["job_ids"] == ["100"]
+        assert mock_extract.await_count == 2
+
+
 class TestGetSavedJobs:
     """Tests for get_saved_jobs with job ID extraction and pagination."""
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2263,7 +2263,9 @@ class TestGetJobAlertNotifications:
         ):
             result = await extractor.get_job_alert_notifications()
 
-        assert result["url"] == "https://www.linkedin.com/notifications/"
+        assert (
+            result["url"] == "https://www.linkedin.com/notifications/?filter=jobs_all"
+        )
         assert result["alerts"] == self.ITEMS
         assert "notifications" in result["sections"]
         mock_items.assert_awaited_once()

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2221,6 +2221,119 @@ class TestGetJobAlerts:
         mock_links.assert_not_awaited()
 
 
+class TestGetJobAlertNotifications:
+    """Tests for get_job_alert_notifications listing and filtering notifications."""
+
+    ITEMS = [
+        {
+            "alert_name": "software engineer",
+            "url": (
+                "https://www.linkedin.com/jobs/search-results/?keywords=software"
+                "+engineer&f_TPR=a1788119314-&alertAction=viewjobs"
+            ),
+            "unread": True,
+            "posted_at": "5h",
+        },
+        {
+            "alert_name": "Junior AI Engineer",
+            "url": (
+                "https://www.linkedin.com/jobs/search-results/?keywords=Junior"
+                "+AI+Engineer&f_TPR=a1788074921-&alertAction=viewjobs"
+            ),
+            "unread": False,
+            "posted_at": "18h",
+        },
+    ]
+
+    async def test_returns_all_by_default(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_job_alert_notifications_page",
+                new_callable=AsyncMock,
+                return_value=extracted("software engineer: new opportunities"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_alert_notification_items",
+                new_callable=AsyncMock,
+                return_value=self.ITEMS,
+            ) as mock_items,
+        ):
+            result = await extractor.get_job_alert_notifications()
+
+        assert result["url"] == "https://www.linkedin.com/notifications/"
+        assert result["alerts"] == self.ITEMS
+        assert "notifications" in result["sections"]
+        mock_items.assert_awaited_once()
+
+    async def test_unread_only_filters(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_job_alert_notifications_page",
+                new_callable=AsyncMock,
+                return_value=extracted("software engineer: new opportunities"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_alert_notification_items",
+                new_callable=AsyncMock,
+                return_value=self.ITEMS,
+            ),
+        ):
+            result = await extractor.get_job_alert_notifications(unread_only=True)
+
+        assert result["alerts"] == [self.ITEMS[0]]
+
+    async def test_limit_caps_results(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_job_alert_notifications_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_alert_notification_items",
+                new_callable=AsyncMock,
+                return_value=self.ITEMS,
+            ),
+        ):
+            result = await extractor.get_job_alert_notifications(limit=1)
+
+        assert result["alerts"] == [self.ITEMS[0]]
+
+    async def test_empty_when_rate_limited(self, mock_page):
+        """Should not attempt item extraction when the page text is empty/rate-limited."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_job_alert_notifications_page",
+                new_callable=AsyncMock,
+                return_value=extracted(
+                    "", error={"error_type": "RateLimit", "error_message": "x"}
+                ),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_alert_notification_items",
+                new_callable=AsyncMock,
+            ) as mock_items,
+        ):
+            result = await extractor.get_job_alert_notifications()
+
+        assert result["alerts"] == []
+        assert result["sections"] == {}
+        assert "notifications" in result["section_errors"]
+        mock_items.assert_not_awaited()
+
+
 class TestSearchJobs:
     """Tests for search_jobs with job ID extraction and pagination."""
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -2113,6 +2113,66 @@ class TestScrapeJob:
         assert "references" not in result
 
 
+class TestGetJobAlerts:
+    """Tests for get_job_alerts listing configured alerts."""
+
+    async def test_returns_alerts_and_text(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        alert_links = [
+            {
+                "name": "python developer",
+                "url": "https://www.linkedin.com/jobs/search-results/?keywords=python",
+            },
+            {
+                "name": "AI Engineer",
+                "url": "https://www.linkedin.com/jobs/search-results/?keywords=AI+Engineer",
+            },
+        ]
+        with (
+            patch.object(
+                extractor,
+                "_extract_job_alerts_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Manage job alerts\npython developer"),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_alert_links",
+                new_callable=AsyncMock,
+                return_value=alert_links,
+            ) as mock_links,
+        ):
+            result = await extractor.get_job_alerts()
+
+        assert result["url"] == "https://www.linkedin.com/jobs/jam/"
+        assert result["alerts"] == alert_links
+        assert "job_alerts" in result["sections"]
+        mock_links.assert_awaited_once()
+
+    async def test_empty_alerts_when_rate_limited(self, mock_page):
+        """Should not attempt link extraction when the page text is empty/rate-limited."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_job_alerts_page",
+                new_callable=AsyncMock,
+                return_value=extracted(
+                    "", error={"error_type": "RateLimit", "error_message": "x"}
+                ),
+            ),
+            patch.object(
+                extractor, "_extract_job_alert_links", new_callable=AsyncMock
+            ) as mock_links,
+        ):
+            result = await extractor.get_job_alerts()
+
+        assert result["alerts"] == []
+        assert result["sections"] == {}
+        assert "job_alerts" in result["section_errors"]
+        mock_links.assert_not_awaited()
+
+
 class TestSearchJobs:
     """Tests for search_jobs with job ID extraction and pagination."""
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -687,7 +687,33 @@ class TestJobTools:
         assert "alert_results" in result["sections"]
         assert result["job_ids"] == ["111", "222"]
         mock_extractor.get_job_alert_results.assert_awaited_once_with(
-            alert_url, max_pages=2
+            alert_url, max_pages=2, date_posted=None
+        )
+
+    async def test_get_job_alert_results_with_date_posted(self, mock_context):
+        alert_url = "https://www.linkedin.com/jobs/search-results/?keywords=python"
+        expected = {
+            "url": alert_url,
+            "sections": {"alert_results": "Job 1"},
+            "job_ids": ["111"],
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_job_alert_results")
+        await tool_fn(
+            alert_url,
+            mock_context,
+            max_pages=1,
+            date_posted="past_week",
+            extractor=mock_extractor,
+        )
+        mock_extractor.get_job_alert_results.assert_awaited_once_with(
+            alert_url, max_pages=1, date_posted="past_week"
         )
 
     async def test_get_job_alerts(self, mock_context):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -30,6 +30,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.get_saved_jobs = AsyncMock(return_value=scrape_result)
     mock.get_job_alert_results = AsyncMock(return_value=scrape_result)
     mock.get_job_alerts = AsyncMock(return_value=scrape_result)
+    mock.get_job_alert_notifications = AsyncMock(return_value=scrape_result)
     mock.search_people = AsyncMock(return_value=scrape_result)
     mock.get_sidebar_profiles = AsyncMock(return_value=scrape_result)
     mock.get_inbox = AsyncMock(return_value=scrape_result)
@@ -740,6 +741,36 @@ class TestJobTools:
         assert result["alerts"] == expected["alerts"]
         mock_extractor.get_job_alerts.assert_awaited_once_with()
 
+    async def test_get_job_alert_notifications(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/notifications/",
+            "sections": {"notifications": "software engineer: new opportunities"},
+            "alerts": [
+                {
+                    "alert_name": "software engineer",
+                    "url": "https://www.linkedin.com/jobs/search-results/?keywords=software+engineer&alertAction=viewjobs",
+                    "unread": True,
+                    "posted_at": "5h",
+                },
+            ],
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_job_alert_notifications")
+        result = await tool_fn(
+            mock_context, unread_only=True, limit=10, extractor=mock_extractor
+        )
+        assert "notifications" in result["sections"]
+        assert result["alerts"] == expected["alerts"]
+        mock_extractor.get_job_alert_notifications.assert_awaited_once_with(
+            unread_only=True, limit=10
+        )
+
 
 class TestGetSidebarProfilesTool:
     async def test_get_sidebar_profiles_success(self, mock_context):
@@ -1269,6 +1300,7 @@ class TestToolTimeouts:
             "get_saved_jobs",
             "get_job_alert_results",
             "get_job_alerts",
+            "get_job_alert_notifications",
             "get_inbox",
             "get_conversation",
             "search_conversations",
@@ -1303,6 +1335,7 @@ class TestToolTimeouts:
             "get_saved_jobs",
             "get_job_alert_results",
             "get_job_alerts",
+            "get_job_alert_notifications",
             "get_inbox",
             "get_conversation",
             "search_conversations",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -28,6 +28,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.scrape_job = AsyncMock(return_value=scrape_result)
     mock.search_jobs = AsyncMock(return_value=scrape_result)
     mock.get_saved_jobs = AsyncMock(return_value=scrape_result)
+    mock.get_job_alert_results = AsyncMock(return_value=scrape_result)
     mock.search_people = AsyncMock(return_value=scrape_result)
     mock.get_sidebar_profiles = AsyncMock(return_value=scrape_result)
     mock.get_inbox = AsyncMock(return_value=scrape_result)
@@ -661,6 +662,33 @@ class TestJobTools:
         assert result["job_ids"] == ["111", "222"]
         mock_extractor.get_saved_jobs.assert_awaited_once_with(max_pages=2)
 
+    async def test_get_job_alert_results(self, mock_context):
+        alert_url = (
+            "https://www.linkedin.com/jobs/search-results/?currentJobId=111"
+            "&keywords=python&origin=SEMANTIC_SEARCH_JOB_ALERT_IN_APP_NOTIFICATION"
+        )
+        expected = {
+            "url": alert_url,
+            "sections": {"alert_results": "Job 1\nJob 2"},
+            "job_ids": ["111", "222"],
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_job_alert_results")
+        result = await tool_fn(
+            alert_url, mock_context, max_pages=2, extractor=mock_extractor
+        )
+        assert "alert_results" in result["sections"]
+        assert result["job_ids"] == ["111", "222"]
+        mock_extractor.get_job_alert_results.assert_awaited_once_with(
+            alert_url, max_pages=2
+        )
+
 
 class TestGetSidebarProfilesTool:
     async def test_get_sidebar_profiles_success(self, mock_context):
@@ -1188,6 +1216,7 @@ class TestToolTimeouts:
             "get_job_details",
             "search_jobs",
             "get_saved_jobs",
+            "get_job_alert_results",
             "get_inbox",
             "get_conversation",
             "search_conversations",
@@ -1220,6 +1249,7 @@ class TestToolTimeouts:
             "get_job_details",
             "search_jobs",
             "get_saved_jobs",
+            "get_job_alert_results",
             "get_inbox",
             "get_conversation",
             "search_conversations",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -743,7 +743,7 @@ class TestJobTools:
 
     async def test_get_job_alert_notifications(self, mock_context):
         expected = {
-            "url": "https://www.linkedin.com/notifications/",
+            "url": "https://www.linkedin.com/notifications/?filter=jobs_all",
             "sections": {"notifications": "software engineer: new opportunities"},
             "alerts": [
                 {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -29,6 +29,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.search_jobs = AsyncMock(return_value=scrape_result)
     mock.get_saved_jobs = AsyncMock(return_value=scrape_result)
     mock.get_job_alert_results = AsyncMock(return_value=scrape_result)
+    mock.get_job_alerts = AsyncMock(return_value=scrape_result)
     mock.search_people = AsyncMock(return_value=scrape_result)
     mock.get_sidebar_profiles = AsyncMock(return_value=scrape_result)
     mock.get_inbox = AsyncMock(return_value=scrape_result)
@@ -689,6 +690,30 @@ class TestJobTools:
             alert_url, max_pages=2
         )
 
+    async def test_get_job_alerts(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/jobs/jam/",
+            "sections": {"job_alerts": "python developer\nAI Engineer"},
+            "alerts": [
+                {
+                    "name": "python developer",
+                    "url": "https://www.linkedin.com/jobs/search-results/?keywords=python",
+                },
+            ],
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_job_alerts")
+        result = await tool_fn(mock_context, extractor=mock_extractor)
+        assert "job_alerts" in result["sections"]
+        assert result["alerts"] == expected["alerts"]
+        mock_extractor.get_job_alerts.assert_awaited_once_with()
+
 
 class TestGetSidebarProfilesTool:
     async def test_get_sidebar_profiles_success(self, mock_context):
@@ -1217,6 +1242,7 @@ class TestToolTimeouts:
             "search_jobs",
             "get_saved_jobs",
             "get_job_alert_results",
+            "get_job_alerts",
             "get_inbox",
             "get_conversation",
             "search_conversations",
@@ -1250,6 +1276,7 @@ class TestToolTimeouts:
             "search_jobs",
             "get_saved_jobs",
             "get_job_alert_results",
+            "get_job_alerts",
             "get_inbox",
             "get_conversation",
             "search_conversations",


### PR DESCRIPTION
## Summary

- Adds `get_job_alerts()`: lists the authenticated user's configured job alerts by navigating to LinkedIn's alert-management dialog (`jobs/jam/`), returning each alert's name and its canonical `jobs/search-results/` URL. Previously that URL had to be copied by hand from a notification.
- Adds `get_job_alert_results(url, max_pages, date_posted)`: navigates directly to a given LinkedIn job-alert/saved-search URL and extracts its job cards, since `search_jobs` always builds its own classic-search URL and cannot reach the personalized/AI-ranked alert feed (`jobs/search-results/?...origin=SEMANTIC_SEARCH_JOB_ALERT...`).
- The two compose: call `get_job_alerts` once to discover all alert URLs, then `get_job_alert_results` per alert to fetch its current listings.
- `date_posted` (`past_hour`/`past_24_hours`/`past_week`/`past_month`, same presets as `search_jobs`) replaces any date filter already in the URL via a new `_with_date_posted` helper. This matters specifically for alert URLs: their own `f_TPR` is an absolute timestamp marking when the alert last fired — confirmed live, LinkedIn's own filter UI renders it as a synthetic "Past N days" label, not a selectable preset — so it can't be used to deliberately narrow results without this.
- `date_posted` only accepts the four presets, and rejects anything else with a `ValueError` rather than passing it through. Verified live: an `f_TPR` value LinkedIn doesn't recognize (e.g. `r10800` for a raw 3-hour window) is silently ignored, returning the same results as no filter at all — not an error, not a narrower result set — so passthrough would produce a URL that looks filtered but isn't.
- Job IDs on the alert feed have no per-card `<a href="/jobs/view/...">` (only the currently-open job's detail pane does) — `_extract_alert_job_ids()` reads the card's `componentkey="job-card-component-ref-<id>"` ancestor attribute instead, falling back to the existing anchor-based `_extract_job_ids` if that attribute is ever renamed. Documented as a deliberate DOM exception, matching the existing `_get_total_search_pages` precedent.
- The alert-management dialog paginates its own list behind a "Show N more" toggle rather than results pagination; `_expand_job_alerts_list()` clicks it via a locale-independent numeric text pattern (`/show \d+ more/i`) rather than a fixed string, also documented as a deliberate DOM exception.
- Same `{url, sections, ...}` return contract as the rest of the job tools: `get_job_alert_results` returns `job_ids: [str]` (matching `search_jobs`/`get_saved_jobs`); `get_job_alerts` returns `alerts: [{name, url}]`.
- Adds `get_job_alert_notifications(unread_only, limit)`: lists job-alert notifications from LinkedIn's notifications feed (`linkedin.com/notifications/`), each with `alert_name`, a delta-filtered `url` (new results since that alert last fired), `unread` state, and `posted_at`. This completes the checking flow: `get_job_alerts` -> which alerts exist, `get_job_alert_notifications` -> which ones actually have new results right now, `get_job_alert_results` -> fetch those jobs.
  - Deliberately narrower in scope than #682 (open, unmerged, generic `get_notifications` for #211): this only surfaces notifications carrying the `alertAction=viewjobs` link param, which verified live appears only on genuine job-alert-fired notifications — not similar-jobs recommendations, network-hiring posts, or qualification-board emails, all of which also live in the same feed. Different tool, different purpose (job-domain-specific vs. generic), no overlap with #682's `tools/feed.py` addition.
  - Read/unread state comes from each notification card's `aria-label` (`"Unread notification."` vs `"Notification"`), documented as an English-only, therefore locale-dependent, signal — it's the only one LinkedIn exposes for this.
  - Loads the notifications page's **Jobs tab** (`?filter=jobs_all`), not the default **All** tab — verified live that this pre-filters server-side to job-related notifications only, so an account with lots of unrelated activity (comments, connections, post reactions) doesn't waste `limit`/pagination budget loading and discarding non-job notifications before the `alertAction=viewjobs` filter even runs.
- Tests in `test_scraping.py` (`TestGetJobAlertResults`, `TestGetJobAlerts`, `TestGetJobAlertNotifications`, `TestWithDatePosted`) and `test_tools.py`, README + AGENTS.md updates.

Closes #846.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check`
- [x] `uv run pytest` (833 passed, 11 skipped — skips are pre-existing, unrelated to this change, due to no local chromium binary)
- [x] Verified all pieces live against my own LinkedIn account through the local MCP server: `get_job_alerts` correctly listed all 5 configured alerts (including the 2 behind "Show more"), `get_job_alert_results` correctly returned job cards across multiple pages matching the real browser page, the "Past 2 days" `f_TPR` behavior was confirmed directly in the LinkedIn UI before implementing `date_posted`, and `get_job_alert_notifications` correctly distinguished read vs. unread job-alert notifications and excluded non-alert job notifications from the same feed.

## Synthetic prompt

> Add composable job-alert tooling (extractor methods + MCP tools + tests) spanning three tools: `get_job_alerts()` to list the user's configured LinkedIn job alerts (name + canonical search-results URL each, expanding the "Show N more" toggle); `get_job_alert_notifications(unread_only, limit)` to list which alerts actually have new results right now, scraped from the notifications feed and filtered to genuine alert-fired notifications (via the `alertAction=viewjobs` link param) with read/unread state per item; and `get_job_alert_results(url, max_pages, date_posted)` to fetch results from a specific alert/saved-search or notification URL directly since `search_jobs` can't reach LinkedIn's personalized AI-ranked alert feed, with a `date_posted` filter that replaces an alert URL's own absolute-timestamp `f_TPR` (verified live to be a non-selectable "last fired" marker, not a real range) with the same presets `search_jobs` uses, rejecting non-preset values since LinkedIn silently ignores them rather than applying them. Handle the alert feed's lack of per-card anchor links by extracting job IDs from the card's `componentkey` attribute, with a documented fallback. Scope `get_job_alert_notifications` narrower than the open, unmerged `get_notifications` PR (#682, for #211) to avoid overlap. Match existing conventions for pagination, return shape, and locale-independent DOM handling; update docs; verify with lint/type-check/tests plus live end-to-end calls for every tool.

Generated with Claude Sonnet 5
