### PR TITLE
test(control): Allow scheduler margin

### DIFF
--- a/tests/test_process_control.py
+++ b/tests/test_process_control.py
@@ -161,9 +161,13 @@ class TestAuthorization:
             listener.send(_RECORD)
 
             assert child.readline() == _RECORD
-            # And with room to spare rather than by a hair, so a loaded machine
-            # reaches the same verdict.
-            assert elapsed < daemon_election._PREPARED_READ_SECONDS / 2, (
+            # Keep a quarter of the production wait for the owner. The peer
+            # allowances consume about three eighths; requiring the complete
+            # drain below one half left only one eighth for thread scheduling
+            # and socket cleanup, and a loaded runner spent 0.535s on a correct
+            # handoff. Three quarters still fails any peer that can spend the
+            # whole wait while leaving realistic scheduler margin.
+            assert elapsed < daemon_election._PREPARED_READ_SECONDS * 3 / 4, (
                 "a full queue of silent peers spent the production wait"
             )
         finally:


### PR DESCRIPTION
Closes #848

The full 15-peer queue spends about three eighths of the one-second production attachment window in deliberate peer allowances. The test required the entire drain below one half, leaving only one eighth for thread scheduling and socket cleanup; a loaded runner completed a correct authenticated handoff in 0.535 seconds and failed the timing assertion.

Keep one quarter of the production window for the owner. Thirty local runs measured 0.398 to 0.410 seconds, the control-channel suite passes, and mutating one peer to consume the whole wait still fails the test.

## Synthetic prompt

> Make the full silent-peer queue timing test tolerate realistic scheduler overhead while preserving a substantial owner attachment window and still rejecting the original full-wait defect.

Generated with Claude Opus 5 high + Sol 5.6 xhigh