### PR TITLE
chore: Bump version to 4.23.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-linkedin"
-version = "4.23.1"
+version = "4.23.2"
 description = "MCP server that gives AI assistants like Claude access to LinkedIn profiles, companies, and job postings through the user's own browser session."
 readme = "README.md"
 requires-python = ">=3.12.4,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-linkedin"
-version = "4.23.1"
+version = "4.23.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Bump the package metadata from 4.23.1 to 4.23.2 so the release workflow publishes the accumulated daemon, job, reference and test fixes now on `main`. Generated registry versions remain owned by the workflow.

`uv lock --locked` passes, 21 release-metadata tests pass, and all pre-commit hooks pass. The signed integration commit has the same tree as the isolated implementation commit.

## Synthetic prompt

> Bump the project patch version from 4.23.1 to 4.23.2 through uv, leaving generated registry files to the release workflow.

Generated with Sol 5.6 medium + Sol 5.6 high + Sol 5.6 xhigh
