### PR TITLE
fix(jobs): Preserve search references

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -53,6 +53,7 @@ from linkedin_mcp_server.scraping.identifiers import (
 from linkedin_mcp_server.scraping.link_metadata import (
     JOB_PATH_RE,
     Reference,
+    _SEARCH_RESULTS_REFERENCE_CAP,
     build_references,
     dedupe_references,
 )
@@ -91,30 +92,42 @@ _RATE_LIMIT_RETRY_DELAY = 5.0
 _RATE_LIMITED_MSG = "[Rate limited] LinkedIn blocked this section. Try again later or request fewer sections."
 
 
-def _references_within(references: list[Reference], ids: list[str]) -> list[Reference]:
-    """Drop job references the rail did not render.
+def _reconcile_search_references(
+    references: list[Reference], ids: list[str]
+) -> list[Reference]:
+    """Align one page's references with the job ids read from its rail.
 
-    The ids are read from the selected rail; the references come from the
-    whole `<main>`, which also holds the detail pane. So a job the pane had
-    loaded was emitted as a search result while `job_ids` correctly left it
-    out, and a caller following the references acts on a job the search never
-    returned. Filtering rather than re-extracting, because the rail is a pick
-    made in the page and not a selector the reference reader could be given.
-
-    Only job references are judged. Everything else on the page is unrelated
-    to which rail was picked.
+    References come from the whole `<main>`, which also holds the detail pane;
+    ids come from the selected results rail. The rail therefore decides which
+    jobs exist, while the DOM references supply richer labels when available.
+    Non-job references share the search-results cap's remaining allowance.
     """
-    kept = set(ids)
+    ordered_ids = list(dict.fromkeys(ids))
+    kept_ids = set(ordered_ids)
+    emitted_ids: set[str] = set()
+    ancillary_left = max(0, _SEARCH_RESULTS_REFERENCE_CAP - len(ordered_ids))
     out: list[Reference] = []
+
     for ref in references:
-        if ref.get("kind") != "job":
+        if ref.get("kind") == "job":
+            match = JOB_PATH_RE.match(str(ref.get("url", "")))
+            if match is None:
+                continue
+            job_id = match.group(1)
+            if job_id not in kept_ids or job_id in emitted_ids:
+                continue
             out.append(ref)
+            emitted_ids.add(job_id)
             continue
-        # The same pattern that produced the reference, so a form one accepts
-        # and the other does not cannot arise.
-        match = JOB_PATH_RE.match(str(ref.get("url", "")))
-        if match is None or match.group(1) in kept:
+
+        if ancillary_left:
             out.append(ref)
+            ancillary_left -= 1
+
+    for job_id in ordered_ids:
+        if job_id not in emitted_ids:
+            out.append({"kind": "job", "url": f"/jobs/view/{job_id}/"})
+
     return out
 
 
@@ -3636,7 +3649,9 @@ class LinkedInExtractor:
         cleaned = _filter_linkedin_noise_lines(truncated)
         return ExtractedSection(
             text=cleaned,
-            references=build_references(raw_result["references"], section_name),
+            references=build_references(
+                raw_result["references"], section_name, apply_cap=False
+            ),
         )
 
     async def _get_total_search_pages(self) -> int | None:
@@ -3973,9 +3988,9 @@ class LinkedInExtractor:
                         if total_pages is not None:
                             logger.debug("LinkedIn reports %d total pages", total_pages)
 
-                page_ids = await self._extract_job_ids(scoped=True)
-                # Advance by what this navigation rendered, duplicates
-                # included: the next unseen result sits right behind them.
+                page_ids = list(dict.fromkeys(await self._extract_job_ids(scoped=True)))
+                # Advance by what this navigation rendered, including ids seen
+                # on earlier pages: the next unseen result sits right behind them.
                 #
                 # This counts the whole document because everything the page
                 # holds also sits in the rail. That is only true while the
@@ -3987,7 +4002,7 @@ class LinkedInExtractor:
                 offset += len(page_ids)
                 new_ids = [jid for jid in page_ids if jid not in seen_ids]
 
-                page_refs = _references_within(extracted.references, page_ids)
+                page_refs = _reconcile_search_references(extracted.references, page_ids)
 
                 if not new_ids:
                     page_texts.append(extracted.text)
@@ -4025,7 +4040,7 @@ class LinkedInExtractor:
         }
         if page_references:
             result["references"] = {
-                "search_results": dedupe_references(page_references, cap=15)
+                "search_results": dedupe_references(page_references)
             }
         if filters_warning is not None:
             existing = section_errors.get("search_results")

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -90,6 +90,7 @@ _SECTION_CONTEXTS = {
 }
 
 _DEFAULT_REFERENCE_CAP = 12
+_SEARCH_RESULTS_REFERENCE_CAP = 15
 _REFERENCE_CAPS = {
     "main_profile": 12,
     "about": 12,
@@ -104,7 +105,7 @@ _REFERENCE_CAPS = {
     "posts": 12,
     "jobs": 8,
     "employees": 12,
-    "search_results": 15,
+    "search_results": _SEARCH_RESULTS_REFERENCE_CAP,
     "job_posting": 8,
     "contact_info": 8,
     "inbox": 30,
@@ -173,9 +174,13 @@ def _first_company_urn_from_query(query: str) -> str | None:
 def build_references(
     raw_references: list[RawReference],
     section_name: str,
+    *,
+    apply_cap: bool = True,
 ) -> list[Reference]:
     """Filter and normalize raw DOM anchors into compact references."""
-    cap = _REFERENCE_CAPS.get(section_name, _DEFAULT_REFERENCE_CAP)
+    cap = (
+        _REFERENCE_CAPS.get(section_name, _DEFAULT_REFERENCE_CAP) if apply_cap else None
+    )
     normalized_references: list[Reference] = []
 
     for raw in raw_references:

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -428,6 +428,23 @@ class TestBuildReferences:
         assert references[0]["url"] == "/company/test-0/"
         assert references[-1]["url"] == "/company/test-11/"
 
+    def test_search_results_cap_can_be_disabled(self):
+        raw: list[RawReference] = [
+            {
+                "href": f"https://www.linkedin.com/jobs/view/{idx}/",
+                "text": f"Job {idx}",
+            }
+            for idx in range(20)
+        ]
+
+        capped = build_references(raw, "search_results")
+        uncapped = build_references(raw, "search_results", apply_cap=False)
+
+        assert len(capped) == 15
+        assert capped[-1]["url"] == "/jobs/view/14/"
+        assert len(uncapped) == 20
+        assert uncapped[-1]["url"] == "/jobs/view/19/"
+
     def test_caps_jobs_section_more_tightly(self):
         raw: list[RawReference] = [
             {

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3357,6 +3357,187 @@ class TestSearchJobs:
             ]
         }
 
+    async def test_componentkey_jobs_without_anchors_get_fallback_references(
+        self, mock_page
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        page = extracted(
+            "Redesigned job cards",
+            [
+                {
+                    "kind": "company",
+                    "url": "/company/acme/",
+                    "text": "Acme",
+                    "context": "search result",
+                }
+            ],
+        )
+
+        with (
+            patch.object(
+                extractor,
+                "_extract_search_page",
+                side_effect=self._navigating(mock_page, [page]),
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["222", "111"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_jobs("python", max_pages=1)
+
+        assert result["job_ids"] == ["222", "111"]
+        assert result["references"]["search_results"] == [
+            {
+                "kind": "company",
+                "url": "/company/acme/",
+                "text": "Acme",
+                "context": "search result",
+            },
+            {"kind": "job", "url": "/jobs/view/222/"},
+            {"kind": "job", "url": "/jobs/view/111/"},
+        ]
+
+    async def test_reconciles_uncapped_raw_references_in_dom_order(self, mock_page):
+        """Rail jobs survive the page cap without losing DOM interleaving."""
+        extractor = LinkedInExtractor(mock_page)
+        ancillary = [
+            {
+                "href": f"https://www.linkedin.com/company/company-{index}/",
+                "text": f"Company {index}",
+            }
+            for index in range(13)
+        ]
+        raw_references = [
+            {
+                "href": "https://www.linkedin.com/jobs/view/999/",
+                "text": "Detail pane job",
+            },
+            ancillary[0],
+            {
+                "href": "https://www.linkedin.com/jobs/view/111/",
+                "text": "Rail job 111",
+            },
+            ancillary[1],
+            ancillary[2],
+            {
+                "href": "https://www.linkedin.com/jobs/view/222/",
+                "text": "Rail job 222",
+            },
+            *ancillary[3:12],
+            {
+                "href": "https://www.linkedin.com/jobs/view/333/",
+                "text": "Rail job 333 after the old cap",
+            },
+            ancillary[12],
+        ]
+        raw_page = {
+            "source": "root",
+            "text": "Job results",
+            "references": raw_references,
+        }
+
+        async def navigate_page(url, *args, **kwargs):
+            navigate(mock_page, url)
+
+        with (
+            patch.object(extractor, "_navigate_to_page", side_effect=navigate_page),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                return_value=raw_page,
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["111", "222", "111", "333"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await extractor.search_jobs("python", max_pages=1)
+
+        assert result["job_ids"] == ["111", "222", "333"]
+        assert result["references"]["search_results"] == [
+            {
+                "kind": "company",
+                "url": "/company/company-0/",
+                "text": "Company 0",
+                "context": "search result",
+            },
+            {
+                "kind": "job",
+                "url": "/jobs/view/111/",
+                "text": "Rail job 111",
+                "context": "job result",
+            },
+            {
+                "kind": "company",
+                "url": "/company/company-1/",
+                "text": "Company 1",
+                "context": "search result",
+            },
+            {
+                "kind": "company",
+                "url": "/company/company-2/",
+                "text": "Company 2",
+                "context": "search result",
+            },
+            {
+                "kind": "job",
+                "url": "/jobs/view/222/",
+                "text": "Rail job 222",
+                "context": "job result",
+            },
+            *[
+                {
+                    "kind": "company",
+                    "url": f"/company/company-{index}/",
+                    "text": f"Company {index}",
+                    "context": "search result",
+                }
+                for index in range(3, 12)
+            ],
+            {
+                "kind": "job",
+                "url": "/jobs/view/333/",
+                "text": "Rail job 333 after the old cap",
+                "context": "job result",
+            },
+        ]
+
     async def test_a_slashless_search_url_still_yields_job_ids(self, mock_page):
         """`/jobs/search?keywords=x` is the same route as `/jobs/search/`.
 
@@ -3489,6 +3670,94 @@ class TestSearchJobs:
         # start=30, which is exactly what a stride regression would produce.
         page2 = parse_qs(urlparse(urls_visited[1]).query)
         assert page2["start"] == ["3"]  # page 1 rendered three cards
+
+    async def test_references_keep_all_jobs_beyond_the_per_section_cap(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        id_pages = [
+            [str(1000 + index) for index in range(11)],
+            [str(2000 + index) for index in range(11)],
+        ]
+        raw_pages = [
+            {
+                "source": "root",
+                "text": f"Page {page_number}",
+                "references": [
+                    {
+                        "href": f"https://www.linkedin.com/jobs/view/{job_id}/",
+                        "text": f"Job {job_id}",
+                    }
+                    for job_id in page_ids
+                ]
+                + [
+                    {
+                        "href": (
+                            "https://www.linkedin.com/company/"
+                            f"page-{page_number}-{index}/"
+                        ),
+                        "text": f"Company {page_number}-{index}",
+                    }
+                    for index in range(6)
+                ],
+            }
+            for page_number, page_ids in enumerate(id_pages, start=1)
+        ]
+
+        async def navigate_page(url, *args, **kwargs):
+            navigate(mock_page, url)
+
+        with (
+            patch.object(extractor, "_navigate_to_page", side_effect=navigate_page),
+            patch.object(
+                extractor,
+                "_extract_root_content",
+                new_callable=AsyncMock,
+                side_effect=raw_pages,
+            ),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                side_effect=id_pages,
+            ),
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.search_jobs("python", max_pages=2)
+
+        expected_ids = [job_id for page_ids in id_pages for job_id in page_ids]
+        references = result["references"]["search_results"]
+        job_references = [ref for ref in references if ref["kind"] == "job"]
+        ancillary = [ref for ref in references if ref["kind"] != "job"]
+
+        assert result["job_ids"] == expected_ids
+        assert [ref["url"] for ref in job_references] == [
+            f"/jobs/view/{job_id}/" for job_id in expected_ids
+        ]
+        assert len(job_references) == 22
+        assert len(ancillary) == 8
+        assert len(references) == 30
 
     async def test_deduplication_across_pages(self, mock_page):
         """Duplicate job IDs across pages should be deduplicated."""
@@ -3881,10 +4150,9 @@ class TestSearchJobs:
             == "pagination_stopped"
         )
 
-    async def test_early_stop_no_new_ids(self, mock_page):
-        """Should stop early when a page yields no new job IDs."""
+    async def test_no_new_id_page_can_upgrade_duplicate_metadata(self, mock_page):
+        """The stopping page still contributes richer duplicate metadata."""
         extractor = LinkedInExtractor(mock_page)
-        # Page 2 returns same IDs as page 1
         id_pages = iter([["100", "200"], ["100", "200"]])
         extract_call_count = 0
 
@@ -3897,11 +4165,29 @@ class TestSearchJobs:
             if extract_call_count == 1:
                 return extracted(
                     "text",
-                    [{"kind": "job", "url": "/jobs/view/100/", "text": "Job 100"}],
+                    [
+                        {
+                            "kind": "job",
+                            "url": "/jobs/view/100/",
+                            "text": "Job 100",
+                        },
+                        {
+                            "kind": "job",
+                            "url": "/jobs/view/200/",
+                            "text": "Job",
+                        },
+                    ],
                 )
             return extracted(
                 "text",
-                [{"kind": "job", "url": "/jobs/view/200/", "text": "Job 200"}],
+                [
+                    {
+                        "kind": "job",
+                        "url": "/jobs/view/200/",
+                        "text": "Senior Software Engineer",
+                        "context": "job result",
+                    }
+                ],
             )
 
         with (
@@ -3930,7 +4216,12 @@ class TestSearchJobs:
         assert result["references"] == {
             "search_results": [
                 {"kind": "job", "url": "/jobs/view/100/", "text": "Job 100"},
-                {"kind": "job", "url": "/jobs/view/200/", "text": "Job 200"},
+                {
+                    "kind": "job",
+                    "url": "/jobs/view/200/",
+                    "text": "Senior Software Engineer",
+                    "context": "job result",
+                },
             ]
         }
 


### PR DESCRIPTION
Closes #744

`search_jobs` capped references across all pages and capped each page before reconciling the whole-page DOM with the selected results rail. Detail panes and anchorless result cards could therefore leave returned job IDs without references.

Reconcile uncapped raw references against each page’s rail IDs, preserve richer metadata, add canonical fallbacks for anchorless cards, and reserve the search cap for ancillary references. Cross-page deduplication no longer drops jobs, and a stopping page can still upgrade earlier metadata.

All 390 relevant tests pass, along with Ruff, formatting, ty, and pre-commit. A live three-page search returned 28 unique job IDs with exactly one canonical reference each and no references outside that set.

## Synthetic prompt

> Ensure every job ID returned by multi-page job search has exactly one canonical reference, without detail-pane contamination or global truncation, while preserving rich metadata and ancillary caps.

Generated with Sol 5.6 high + Sol 5.6 xhigh
