### PR TITLE
fix: cap FastMCP below v4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 ]
 dependencies = [
     "cryptography>=48.0.1",
-    "fastmcp>=3.4.4",
+    "fastmcp>=3.4.4,<4",
     "inquirer>=3.4.0",
     "packaging>=26.2",
     "patchright>=1.55.0",

--- a/tests/test_fastmcp_compatibility.py
+++ b/tests/test_fastmcp_compatibility.py
@@ -1,0 +1,38 @@
+"""Keep published FastMCP metadata compatible with the registered tools."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_fastmcp_v4_is_excluded_while_exclude_args_is_used() -> None:
+    """FastMCP 4 removed the ``exclude_args`` decorator argument."""
+    tool_sources = (_REPO_ROOT / "linkedin_mcp_server" / "tools").glob("*.py")
+    legacy_sources = [
+        path.name
+        for path in tool_sources
+        if "exclude_args=" in path.read_text(encoding="utf-8")
+    ]
+    assert legacy_sources, (
+        "exclude_args has been migrated; remove this compatibility test and "
+        "review the FastMCP upper bound"
+    )
+
+    pyproject = tomllib.loads(
+        (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    fastmcp = next(
+        Requirement(raw)
+        for raw in pyproject["project"]["dependencies"]
+        if canonicalize_name(Requirement(raw).name) == "fastmcp"
+    )
+
+    assert Version("4.0.0") not in fastmcp.specifier
+    assert Version("4.99.0") not in fastmcp.specifier

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "fastmcp", specifier = ">=3.4.4" },
+    { name = "fastmcp", specifier = ">=3.4.4,<4" },
     { name = "inquirer", specifier = ">=3.4.0" },
     { name = "packaging", specifier = ">=26.2" },
     { name = "patchright", specifier = ">=1.55.0" },


### PR DESCRIPTION
Fixes #851.

## What changed

- cap FastMCP below v4 while the server still registers six tools with the removed `exclude_args` argument
- keep the lockfile and published wheel metadata on the same dependency range
- add a regression test that requires the cap to be revisited when those call sites are migrated

## Why

Version 4.23.2 declares `fastmcp>=3.4.4`, so a fresh `uvx mcp-server-linkedin@latest` installation can resolve FastMCP 4 and fail during MCP initialization with `TypeError: FastMCP.tool() got an unexpected keyword argument 'exclude_args'`.

## Validation

- focused dependency/tool suite: 61 passed
- Ruff check and format check: passed
- `ty check`: passed
- pre-commit: all hooks passed
- built wheel metadata contains `Requires-Dist: fastmcp<4,>=3.4.4`
- fresh isolated wheel MCP initialize + tools/list: server 4.23.2, 19 tools
- full suite: 2,958 passed, 148 skipped; the same 12 environment-sensitive failures reproduce on untouched `origin/main`

## Synthetic prompt

> Cap FastMCP below v4 while the server still uses the removed `exclude_args` decorator argument, update the lock metadata, and add a regression test that forces the cap to be reconsidered when those call sites are migrated.

Generated with GPT-5.6 Sol (ultra)
