### PR TITLE
chore: Bump version to 4.23.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-linkedin"
-version = "4.23.2"
+version = "4.23.3"
 description = "MCP server that gives AI assistants like Claude access to LinkedIn profiles, companies, and job postings through the user's own browser session."
 readme = "README.md"
 requires-python = ">=3.12.4,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-linkedin"
-version = "4.23.2"
+version = "4.23.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Closes #851.

Release 4.23.3: ships the FastMCP `<4` cap from #854 so fresh `uvx mcp-server-linkedin@latest` installs resolve FastMCP 3 and start again. Triggers the release workflow.

Verification: `uv lock --check` clean, `uv run pytest tests/test_fastmcp_compatibility.py` green, packaged initialize + tools/list verified locally on the pinned commit.

## Synthetic prompt

> Bump the version to 4.23.3 on a release branch and open the PR that triggers the release workflow, shipping the FastMCP compatibility cap merged in #854.