### PR TITLE
feat: add opt-in Codex plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "linkedin-mcp-server",
+  "interface": {
+    "displayName": "LinkedIn MCP Server"
+  },
+  "plugins": [
+    {
+      "name": "linkedin-mcp-server",
+      "source": {
+        "source": "local",
+        "path": "./plugins/linkedin-mcp-server"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Business & Operations"
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,48 @@ jobs:
           PY
           echo "✅ Updated server.json to version $VERSION"
 
+      - name: Update Codex plugin version
+        run: |
+          set -e
+          python3 - "$VERSION" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          version = sys.argv[1]
+          manifest_path = Path(
+              "plugins/linkedin-mcp-server/.codex-plugin/plugin.json"
+          )
+          mcp_path = Path("plugins/linkedin-mcp-server/.mcp.json")
+
+          plugin = json.loads(manifest_path.read_text(encoding="utf-8"))
+          plugin["version"] = version
+
+          mcp = json.loads(mcp_path.read_text(encoding="utf-8"))
+          args = mcp["mcpServers"]["linkedin"]["args"]
+          package_args = [
+              index
+              for index, value in enumerate(args)
+              if value.startswith("mcp-server-linkedin@")
+          ]
+          if len(package_args) != 1:
+              raise SystemExit(
+                  "Codex plugin must contain exactly one versioned "
+                  "mcp-server-linkedin package argument"
+              )
+          args[package_args[0]] = f"mcp-server-linkedin@{version}"
+
+          manifest_path.write_text(
+              json.dumps(plugin, indent=2, ensure_ascii=False) + "\n",
+              encoding="utf-8",
+          )
+          mcp_path.write_text(
+              json.dumps(mcp, indent=2, ensure_ascii=False) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          echo "✅ Updated Codex plugin to version $VERSION"
+
       # The rewrites above are text edits that report success whatever they
       # matched, so this asks every file that carries the version what it now
       # says. Rendering the compose file is also what proves it still parses;
@@ -215,6 +257,16 @@ jobs:
           version = sys.argv[1]
           server = json.loads(Path("server.json").read_text(encoding="utf-8"))
           manifest = json.loads(Path("manifest.json").read_text(encoding="utf-8"))
+          plugin = json.loads(
+              Path(
+                  "plugins/linkedin-mcp-server/.codex-plugin/plugin.json"
+              ).read_text(encoding="utf-8")
+          )
+          plugin_mcp = json.loads(
+              Path("plugins/linkedin-mcp-server/.mcp.json").read_text(
+                  encoding="utf-8"
+              )
+          )
           project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
           name = project["project"]["name"]
           image = next(
@@ -262,6 +314,12 @@ jobs:
                   if p["registryType"] == "oci"
               ],
               "docker-compose.yml": [tag(image) for image in images],
+              "Codex plugin": [plugin["version"]],
+              "Codex plugin MCP": [
+                  value.removeprefix("mcp-server-linkedin@")
+                  for value in plugin_mcp["mcpServers"]["linkedin"]["args"]
+                  if value.startswith("mcp-server-linkedin@")
+              ],
           }
           for site, values in found.items():
               if not values:
@@ -284,7 +342,9 @@ jobs:
           set -e
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add manifest.json docker-compose.yml server.json
+          git add manifest.json docker-compose.yml server.json \
+            plugins/linkedin-mcp-server/.codex-plugin/plugin.json \
+            plugins/linkedin-mcp-server/.mcp.json
           if git diff --staged --quiet; then
             echo "ℹ️ No changes to commit"
           else

--- a/README.md
+++ b/README.md
@@ -62,6 +62,31 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 <br/>
 <br/>
 
+## Codex plugin
+
+This repository includes an opt-in Codex plugin that bundles the MCP server and
+its LinkedIn workflow guidance. Add the repository marketplace, then install the
+plugin:
+
+```bash
+codex plugin marketplace add stickerdaniel/linkedin-mcp-server
+codex plugin add linkedin-mcp-server@linkedin-mcp-server
+```
+
+The plugin pins the MCP package to the same version as the plugin release. It
+does not install by default or override the user's enabled state. The plugin can
+be disabled in Codex settings, and its bundled MCP server can be disabled
+independently in `~/.codex/config.toml`:
+
+```toml
+[plugins."linkedin-mcp-server".mcp_servers.linkedin]
+enabled = false
+```
+
+Installing or enabling the plugin does not open a browser or sign in. A
+LinkedIn data request may start the managed browser, import an existing local
+session, or require a visible login window.
+
 ## 🚀 uvx Setup (Recommended - Universal)
 
 **Prerequisites:** [Install uv](https://docs.astral.sh/uv/getting-started/installation/).

--- a/plugins/linkedin-mcp-server/.codex-plugin/plugin.json
+++ b/plugins/linkedin-mcp-server/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "linkedin-mcp-server",
+  "version": "4.23.3",
+  "description": "Research LinkedIn through a local, browser-backed MCP server.",
+  "author": {
+    "name": "Daniel Sticker",
+    "email": "daniel@sticker.name",
+    "url": "https://daniel.sticker.name/"
+  },
+  "homepage": "https://github.com/stickerdaniel/linkedin-mcp-server",
+  "repository": "https://github.com/stickerdaniel/linkedin-mcp-server",
+  "license": "Apache-2.0",
+  "keywords": [
+    "linkedin",
+    "mcp",
+    "jobs",
+    "recruiting"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "LinkedIn MCP",
+    "shortDescription": "Research profiles, companies, jobs, posts, and messages.",
+    "longDescription": "Use your own LinkedIn browser session to research profiles, companies, jobs, posts, and messages in Codex. Write actions require an explicit request. This is an independent open-source integration and is not affiliated with LinkedIn.",
+    "developerName": "Daniel Sticker",
+    "category": "Business & Operations",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/stickerdaniel/linkedin-mcp-server",
+    "defaultPrompt": [
+      "Show my LinkedIn profile.",
+      "Research a company on LinkedIn.",
+      "Find LinkedIn jobs that match my criteria."
+    ],
+    "brandColor": "#0A66C2",
+    "composerIcon": "./assets/icon.svg",
+    "logo": "./assets/icon.svg"
+  },
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/linkedin-mcp-server/.mcp.json
+++ b/plugins/linkedin-mcp-server/.mcp.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "linkedin": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-linkedin@4.23.3",
+        "--transport",
+        "stdio",
+        "--timeout",
+        "10000",
+        "--tool-timeout",
+        "180"
+      ],
+      "env": {
+        "UV_HTTP_TIMEOUT": "300"
+      }
+    }
+  }
+}

--- a/plugins/linkedin-mcp-server/assets/icon.svg
+++ b/plugins/linkedin-mcp-server/assets/icon.svg
@@ -1,0 +1,11 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="96" fill="#334155"/>
+  <g stroke="#94A3B8" stroke-width="20" fill="none">
+    <line x1="170" y1="186" x2="342" y2="186"/>
+    <line x1="170" y1="186" x2="256" y2="344"/>
+    <line x1="342" y1="186" x2="256" y2="344"/>
+  </g>
+  <circle cx="170" cy="186" r="46" fill="#E2E8F0"/>
+  <circle cx="342" cy="186" r="46" fill="#E2E8F0"/>
+  <circle cx="256" cy="344" r="46" fill="#E2E8F0"/>
+</svg>

--- a/plugins/linkedin-mcp-server/skills/linkedin-mcp/SKILL.md
+++ b/plugins/linkedin-mcp-server/skills/linkedin-mcp/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: linkedin-mcp
+description: Use LinkedIn data for profile, company, job, post, feed, inbox, recruiting, and outreach work through the bundled LinkedIn MCP server. Use only for an explicit LinkedIn request.
+---
+
+# LinkedIn MCP
+
+Use the bundled `linkedin` MCP server only when the user explicitly asks for
+LinkedIn data or an action on LinkedIn. Do not call LinkedIn tools for unrelated
+work, health checks, or background maintenance.
+
+## Operating rules
+
+- Start with the smallest read operation that can answer the request.
+- Treat profile, company, job, post, feed, and message results as live LinkedIn
+  evidence. Distinguish retrieved facts from inference.
+- Keep searches and result pages modest. Do not bulk scrape or spam.
+- Never enable the plugin or its MCP server, edit Codex configuration, or start
+  a login flow merely because LinkedIn might be useful. If either component is
+  disabled, explain that state and stop.
+- `send_message` and `connect_with_person` are write actions. Use them only when
+  the user explicitly authorizes the exact recipient and action. Confirm the
+  final message or connection note unless the user has already supplied it.
+- Do not retry a failed write action unless the result proves it was not sent.
+
+## Browser and authentication
+
+The server uses a managed Chromium browser and the user's own LinkedIn session.
+Installing or enabling the plugin does not sign in. The first LinkedIn data
+request may prepare the browser, import an existing local session, or require a
+visible login window. If LinkedIn presents a captcha, two-factor prompt, or
+other user-owned authentication step, stop and ask the user to complete it.
+
+If browser setup or authentication is still in progress, report that exact
+state and retry once after it finishes. Do not loop, launch extra browser
+instances, clear profiles, or replace the user's browser session.
+
+## Tool selection
+
+- Profiles: `get_my_profile`, `get_person_profile`, `search_people`, and
+  `get_sidebar_profiles`.
+- Companies: `get_company_profile`, `get_company_posts`, `search_companies`,
+  and `get_company_employees`.
+- Jobs: `search_jobs`, `get_saved_jobs`, and `get_job_details`.
+- Content: `get_feed` and `search_posts`.
+- Messages: `get_inbox`, `get_conversation`, and `search_conversations`.
+- Writes: `send_message` and `connect_with_person`, subject to the explicit
+  authorization rules above.
+- Cleanup: use `close_session` only when the user asks to end the managed
+  browser session or when the current LinkedIn task is finished and no follow-up
+  call is expected.

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -1,0 +1,132 @@
+"""Contract tests for the opt-in Codex plugin package."""
+
+from __future__ import annotations
+
+import copy
+import json
+import tomllib
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+from packaging.version import Version
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PLUGIN_ROOT = _REPO_ROOT / "plugins" / "linkedin-mcp-server"
+_PLUGIN_MANIFEST = _PLUGIN_ROOT / ".codex-plugin" / "plugin.json"
+_PLUGIN_MCP = _PLUGIN_ROOT / ".mcp.json"
+_MARKETPLACE = _REPO_ROOT / ".agents" / "plugins" / "marketplace.json"
+_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _project_version() -> str:
+    project = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    return project["project"]["version"]
+
+
+def _released_version() -> str:
+    return _load_json(_REPO_ROOT / "manifest.json")["version"]
+
+
+def _assert_mcp_contract(mcp: dict[str, Any], version: str) -> None:
+    assert set(mcp) == {"mcpServers"}
+    assert set(mcp["mcpServers"]) == {"linkedin"}
+    server = mcp["mcpServers"]["linkedin"]
+    assert server["command"] == "uvx"
+    assert server["args"] == [
+        f"mcp-server-linkedin@{version}",
+        "--transport",
+        "stdio",
+        "--timeout",
+        "10000",
+        "--tool-timeout",
+        "180",
+    ]
+    assert server["env"] == {"UV_HTTP_TIMEOUT": "300"}
+    assert "@latest" not in json.dumps(mcp)
+    assert "enabled" not in json.dumps(mcp)
+
+
+def test_marketplace_is_opt_in_and_resolves_the_plugin() -> None:
+    marketplace = _load_json(_MARKETPLACE)
+    assert marketplace["name"] == "linkedin-mcp-server"
+    assert len(marketplace["plugins"]) == 1
+    entry = marketplace["plugins"][0]
+    assert entry["name"] == "linkedin-mcp-server"
+    assert entry["source"] == {
+        "source": "local",
+        "path": "./plugins/linkedin-mcp-server",
+    }
+    assert entry["policy"] == {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL",
+    }
+    assert "enabled" not in json.dumps(marketplace)
+
+
+def test_manifest_matches_the_repository_release() -> None:
+    manifest = _load_json(_PLUGIN_MANIFEST)
+    assert manifest["name"] == _PLUGIN_ROOT.name
+    assert manifest["version"] == _released_version()
+    assert Version(manifest["version"]) <= Version(_project_version())
+    assert manifest["mcpServers"] == "./.mcp.json"
+    assert manifest["skills"] == "./skills/"
+    assert "hooks" not in manifest
+    assert "enabled" not in json.dumps(manifest)
+
+
+def test_mcp_command_is_version_pinned() -> None:
+    _assert_mcp_contract(_load_json(_PLUGIN_MCP), _released_version())
+
+
+def test_release_workflow_updates_and_commits_both_plugin_files() -> None:
+    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    for path in (
+        "plugins/linkedin-mcp-server/.codex-plugin/plugin.json",
+        "plugins/linkedin-mcp-server/.mcp.json",
+    ):
+        assert workflow.count(path) >= 3
+    assert 'args[package_args[0]] = f"mcp-server-linkedin@{version}"' in workflow
+    assert '"Codex plugin": [plugin["version"]]' in workflow
+    assert '"Codex plugin MCP": [' in workflow
+
+
+def test_plugin_icon_is_the_release_icon() -> None:
+    assert (_PLUGIN_ROOT / "assets" / "icon.svg").read_bytes() == (
+        _REPO_ROOT / "assets" / "icons" / "icon.svg"
+    ).read_bytes()
+
+
+def test_skill_keeps_unrelated_work_and_writes_out_of_scope() -> None:
+    skill = (_PLUGIN_ROOT / "skills" / "linkedin-mcp" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "Use only for an explicit LinkedIn request" in skill
+    assert "Do not call LinkedIn tools for unrelated" in skill
+    assert "exact recipient and action" in skill
+    assert "Never enable the plugin or its MCP server" in skill
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda doc: doc["mcpServers"]["linkedin"]["args"].__setitem__(
+            0, "mcp-server-linkedin@latest"
+        ),
+        lambda doc: doc["mcpServers"]["linkedin"].__setitem__("enabled", True),
+        lambda doc: doc["mcpServers"]["linkedin"]["args"].__setitem__(
+            0, "mcp-server-linkedin@0.0.0"
+        ),
+    ],
+)
+def test_malformed_or_forced_runtime_is_rejected(
+    mutate: Callable[[dict[str, Any]], None],
+) -> None:
+    candidate = copy.deepcopy(_load_json(_PLUGIN_MCP))
+    mutate(candidate)
+    with pytest.raises(AssertionError):
+        _assert_mcp_contract(candidate, _released_version())


### PR DESCRIPTION
Closes #862

## Summary

Add an opt-in Codex marketplace entry and plugin containing the existing project icon, LinkedIn workflow skill, and MCP command pinned to release 4.23.3. Keep plugin and MCP enablement independent. The release workflow updates and checks both version fields together.

The skill requires explicit authorization for messages and connection requests. Installing the plugin does not sign in; actual LinkedIn reads or login can still start the managed browser.

## Verification

- 9 plugin contract and malformed-candidate tests passed.
- Ruff, formatting, ty, and all pre-commit hooks passed.
- The packaged 4.23.3 command initialized and listed all 19 tools with an unchanged browser-process snapshot.
- The actual release step advanced both plugin fields to 9.8.7 in a temporary fixture.
- Merged current upstream main `13734bab` without rewriting the original contribution. [CI](https://github.com/stickerdaniel/linkedin-mcp-server/actions/runs/33994231394), attribution, Greptile, and Socket checks all pass at `12dda1c`.

The separate host-dependent test failures and their test-only fix remain scoped to #864 and #865; they are not plugin regressions. No live LinkedIn data or write operation was used in this verification.

## Synthetic prompt

> Package the released LinkedIn MCP server as an opt-in Codex plugin with its existing icon, workflow skill, exact MCP version pin, independent enablement, release-version synchronization, and tests for those contracts. Preserve explicit write authorization and document browser startup accurately.

Reviewed and updated with GPT-6 Astra Ultra.

