### PR TITLE
test: isolate host terminal and startup hooks

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -6632,6 +6632,12 @@ class TestRendererSurvivesOddOutput:
 class TestCliProgress:
     """The terminal bar, and the plain lines everywhere else."""
 
+    @staticmethod
+    def _enable_rich_terminal(monkeypatch) -> None:
+        """Remove host settings that deliberately select plain output."""
+        monkeypatch.setenv("TERM", "xterm-256color")
+        monkeypatch.delenv("NO_COLOR", raising=False)
+
     def _terminal(self, monkeypatch) -> list:
         """Make the CLI path believe it is on a terminal, and capture it.
 
@@ -6643,6 +6649,7 @@ class TestCliProgress:
 
         from linkedin_mcp_server import bootstrap
 
+        self._enable_rich_terminal(monkeypatch)
         buffer = io.StringIO()
         built: list = [buffer]
         monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
@@ -6699,6 +6706,8 @@ class TestCliProgress:
         the plain-line path already gives a stream that will not take a line.
         """
         from linkedin_mcp_server import bootstrap
+
+        self._enable_rich_terminal(monkeypatch)
 
         class _Pipe(io.StringIO):
             def isatty(self) -> bool:

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -5128,8 +5128,12 @@ class TestVersionSkew:
         assert user_site_result.returncode == 0, user_site_result.stderr
         user_site = Path(user_site_result.stdout.strip())
         user_site.mkdir(parents=True)
-        (user_site / "sitecustomize.py").write_text(
+        hook_module = "_linkedin_mcp_test_user_site_hook"
+        (user_site / f"{hook_module}.py").write_text(
             "import builtins\nbuiltins.OWNER_USER_SITE_STARTED = True\n"
+        )
+        (user_site / "linkedin-mcp-test-user-site.pth").write_text(
+            f"import {hook_module}\n"
         )
 
         startup_probe = (

--- a/tests/test_installer_supervisor.py
+++ b/tests/test_installer_supervisor.py
@@ -229,8 +229,19 @@ def test_worker_status_accepts_a_frame_after_large_startup_noise():
     assert frame == [authentic]
 
 
+_STARTUP_HOOK_MODULE = "_linkedin_mcp_test_startup_hook"
+
+
+def _install_startup_hook(site_dir: Path, hook: str) -> None:
+    """Install a startup hook without colliding with vendor ``sitecustomize``."""
+    (site_dir / f"{_STARTUP_HOOK_MODULE}.py").write_text(hook)
+    (site_dir / "linkedin-mcp-startup-hook.pth").write_text(
+        f"import {_STARTUP_HOOK_MODULE}\n"
+    )
+
+
 def _user_site_with_hook(tmp_path: Path, hook: str) -> tuple[str, dict[str, str], Path]:
-    """Install *hook* as a real ``sitecustomize`` an interpreter would execute.
+    """Install *hook* as executable user-site startup code.
 
     Returns the interpreter that honours it, the environment that points at it,
     and the user-site directory. The base interpreter is needed because a
@@ -257,19 +268,19 @@ def _user_site_with_hook(tmp_path: Path, hook: str) -> tuple[str, dict[str, str]
     # The worker resolves the package through ordinary startup, so it needs a
     # path entry. The supervisor does not: it runs the file by absolute path.
     (user_site / "linkedin-mcp-source.pth").write_text(f"{_REPO_ROOT}\n")
-    (user_site / "sitecustomize.py").write_text(hook)
+    _install_startup_hook(user_site, hook)
     return base_executable, environment, user_site
 
 
 def _venv_with_site_hook(tmp_path: Path, hook: str) -> tuple[str, dict[str, str]]:
     """Install *hook* where only ``-S`` can stop it: a real environment's site.
 
-    A ``sitecustomize`` in the interpreter's own ``site-packages`` is what a
-    virtual environment or a system install ships, and it survives ``-P``,
-    ``PYTHONNOUSERSITE``, a popped ``PYTHONPATH`` and ``-I`` alike, because all
-    of those act on the user-site copy or on path entries. The environment
-    keeps the source root on a ``.pth`` for the worker, which runs with
-    ordinary startup.
+    Executable ``.pth`` startup code in the interpreter's own
+    ``site-packages`` survives ``-P``, ``PYTHONNOUSERSITE``, a popped
+    ``PYTHONPATH`` and ``-I`` alike. Unlike a test-owned ``sitecustomize.py``,
+    it cannot be shadowed by a vendor module of the same name. The environment
+    keeps the source root on a separate ``.pth`` for the worker, which runs
+    with ordinary startup.
     """
     venv = tmp_path / "hooked-venv"
     subprocess.run(
@@ -294,7 +305,7 @@ def _venv_with_site_hook(tmp_path: Path, hook: str) -> tuple[str, dict[str, str]
     )
     site_packages = Path(located.stdout.strip())
     (site_packages / "linkedin-mcp-source.pth").write_text(f"{_REPO_ROOT}\n")
-    (site_packages / "sitecustomize.py").write_text(hook)
+    _install_startup_hook(site_packages, hook)
 
     environment = os.environ.copy()
     environment.pop("PYTHONPATH", None)
@@ -351,7 +362,11 @@ def test_real_user_site_hook_cannot_join_the_completion_frame(tmp_path: Path):
     )
 
     enabled = subprocess.run(
-        [base_executable, "-c", "import sys; print('sitecustomize' in sys.modules)"],
+        [
+            base_executable,
+            "-c",
+            f"import sys; print({_STARTUP_HOOK_MODULE!r} in sys.modules)",
+        ],
         cwd=tmp_path,
         env=environment,
         capture_output=True,
@@ -441,7 +456,7 @@ def test_a_startup_hook_cannot_spawn_a_pipe_holder_in_the_supervisor(tmp_path: P
                 interpreter,
                 "-I",
                 "-c",
-                "import sys; print('sitecustomize' in sys.modules)",
+                f"import sys; print({_STARTUP_HOOK_MODULE!r} in sys.modules)",
             ],
             env=environment,
             stdout=sink,

--- a/tests/test_process_tree.py
+++ b/tests/test_process_tree.py
@@ -201,8 +201,12 @@ def test_gate_preserves_payload_streams_and_target_site_startup(tmp_path: Path):
     user_site = Path(probe.stdout.strip())
     user_site.mkdir(parents=True)
     sentinel = tmp_path / "site-started.txt"
-    (user_site / "sitecustomize.py").write_text(
+    hook_module = "_linkedin_mcp_test_gate_startup"
+    (user_site / f"{hook_module}.py").write_text(
         f"import os\nopen({str(sentinel)!r}, 'a').write(str(os.getpid()) + '\\n')\n"
+    )
+    (user_site / "linkedin-mcp-test-gate-startup.pth").write_text(
+        f"import {hook_module}\n"
     )
     target = [
         base_executable,


### PR DESCRIPTION
Closes #864

## Summary

Make rich-progress tests explicitly select a capable terminal, and replace shadowable `sitecustomize.py` fixtures with uniquely named modules loaded through `.pth` hooks. Preserve the startup-hook sentinels and isolated-process assertions. Production code is unchanged by this PR.

Homebrew's own `sitecustomize.py`, `TERM=dumb`, and `NO_COLOR=1` caused the original 12 local failures while clean CI runners passed.

## Verification

- Full local suite on current upstream: 2,982 passed, 148 skipped, zero failures under Homebrew Python 3.13.15 with `TERM=dumb NO_COLOR=1`.
- Native skips cover unavailable Chromium and platform-specific tests; no browser was installed and no live LinkedIn operation was run.
- Ruff, formatting, ty, and all nine pre-commit hooks passed.
- Merged upstream main `13734bab` without rewriting the original contribution; the PR diff remains four test files. [CI](https://github.com/stickerdaniel/linkedin-mcp-server/actions/runs/33994345988), attribution, Greptile, and Socket checks all pass at `62940dc`.

## Synthetic prompt

> Isolate rich-progress and Python startup-hook tests from host terminal settings and Homebrew's sitecustomize module. Use explicit terminal inputs and uniquely named .pth hooks while preserving startup sentinels, isolation checks, and production behavior.

Reviewed and updated with GPT-6 Astra Ultra.

