### PR TITLE
fix(messaging): Track send outcome safely

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4959,6 +4959,13 @@ class LinkedInExtractor:
         """
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
+        if not message.strip():
+            return self._message_action_result(
+                profile_url,
+                "message_unavailable",
+                "Message must contain non-whitespace characters.",
+            )
+
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -455,6 +455,55 @@ _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Close"]'
 )
 
+# Counts visible occurrences of a message *outside* every open composer.
+# The composer holds the message before it is sent, so plain body text is no
+# evidence of delivery: a Send button whose handler does nothing leaves the
+# text standing in the editor and the page still "contains" it. Occurrences
+# inside visible contenteditable editors are therefore subtracted, and the
+# send path compares a baseline taken before the click with the count after
+# it. Visibility is pure geometry and the match is on normalized text, so no
+# LinkedIn class name or localized label enters the decision.
+_MESSAGE_OCCURRENCES_JS = r"""
+({ expected }) => {
+    const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
+    const needle = normalize(expected);
+    if (!needle) return 0;
+
+    const countIn = value => {
+        const haystack = normalize(value);
+        let count = 0;
+        let index = haystack.indexOf(needle);
+        while (index !== -1) {
+            count += 1;
+            index = haystack.indexOf(needle, index + needle.length);
+        }
+        return count;
+    };
+
+    const isVisible = element =>
+        !!(
+            element &&
+            (element.offsetWidth ||
+                element.offsetHeight ||
+                element.getClientRects().length)
+        );
+
+    let total = countIn(document.body?.innerText || '');
+    for (const editor of document.querySelectorAll('[contenteditable="true"]')) {
+        if (isVisible(editor)) {
+            total -= countIn(editor.innerText);
+        }
+    }
+    return total > 0 ? total : 0;
+}
+"""
+
+# The post-send predicate is the same counting routine, so the baseline and
+# the confirmation can never disagree about what counts as an occurrence.
+_MESSAGE_OCCURRENCES_INCREASED_JS = (
+    f"(arg) => ({_MESSAGE_OCCURRENCES_JS})(arg) > arg.previous"
+)
+
 # Shared JS function that walks up from any /messaging/compose/ anchor
 # inside <main> to find the smallest ancestor that satisfies the
 # action-root predicate (>=2 interactive children, >=1 button). This is
@@ -3013,20 +3062,29 @@ class LinkedInExtractor:
         )
         return bool(matched)
 
-    async def _message_text_visible(self, message: str) -> bool:
-        """Wait until the compose page visibly contains the just-sent message text.
+    async def _message_text_occurrences(self, message: str) -> int:
+        """Count visible occurrences of the message outside any open composer."""
+        occurrences = await self._page.evaluate(
+            _MESSAGE_OCCURRENCES_JS, {"expected": message}
+        )
+        return int(occurrences or 0)
+
+    async def _message_text_visible(
+        self, message: str, *, previous_occurrences: int
+    ) -> bool:
+        """Wait until a *new* copy of the message appears outside the composer.
+
+        ``previous_occurrences`` is the baseline taken after typing and before
+        the send attempt, so the requirement is strictly more occurrences than
+        before: the typed text sitting in the composer cannot confirm itself,
+        and neither can an identical message already in the thread.
 
         Uses the page-level default timeout (``BrowserConfig.default_timeout``).
         """
         try:
             await self._page.wait_for_function(
-                """({ expected }) => {
-                    const normalize = value =>
-                        (value || '').replace(/\\s+/g, ' ').trim();
-                    const bodyText = normalize(document.body?.innerText || '');
-                    return bodyText.includes(normalize(expected));
-                }""",
-                arg={"expected": message},
+                _MESSAGE_OCCURRENCES_INCREASED_JS,
+                arg={"expected": message, "previous": previous_occurrences},
             )
             return True
         except PlaywrightTimeoutError:
@@ -5048,6 +5106,13 @@ class LinkedInExtractor:
         await asyncio.sleep(0.1)
         await self._page.keyboard.type(message, delay=15)
         await asyncio.sleep(0.3)
+        await asyncio.sleep(1.0)  # allow React to process keyboard input
+
+        # Baseline immediately before the send attempt: how often the message
+        # is already visible outside the composer. The click below only tries
+        # to send; delivery is proven by this count growing, never by the text
+        # the composer still holds.
+        previous_occurrences = await self._message_text_occurrences(message)
 
         # patchright actionability also blocks send_button.click(). Use JS click
         # on any visible, enabled send button; fall back to Enter key which
@@ -5056,7 +5121,6 @@ class LinkedInExtractor:
         # DOM dependency: we need btn.click() on the element reference — not
         # achievable via innerText or URL navigation. Selectors use only type,
         # aria-label, and data attributes (no layout class names).
-        await asyncio.sleep(1.0)  # allow React to process keyboard input
         sent_via_js = await self._page.evaluate(
             """() => {
                 const btn = Array.from(document.querySelectorAll(
@@ -5071,7 +5135,9 @@ class LinkedInExtractor:
         if not sent_via_js:
             await self._page.keyboard.press("Enter")
 
-        if not await self._message_text_visible(message):
+        if not await self._message_text_visible(
+            message, previous_occurrences=previous_occurrences
+        ):
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -514,15 +514,15 @@ _MESSAGE_OCCURRENCES_JS = r"""
 """
 
 # A submission is in flight from the moment the send is dispatched until the
-# confirmation answers, and a cancellation in that window cannot be reported:
-# FastMCP runs every tool inside `anyio.fail_after()`, so the deadline raises
-# `CancelledError` past `except Exception` and discards any result returned
-# from the cancelled scope. The caller gets a timeout that carries no
-# `retry_safe`, and this line is then the only record that a message may
-# already have left. Answering the caller instead needs the tool to know its
-# own deadline, which is issue #889.
-_SEND_CANCELLED_WARNING = (
-    "Message submission was cancelled while in flight. Delivery is unknown; "
+# whole path has produced a result, cleanup included, and an interruption in
+# that window cannot be reported. FastMCP runs every tool inside
+# `anyio.fail_after()`, so the deadline raises `CancelledError` past
+# `except Exception` and discards any result returned from the cancelled
+# scope. The caller gets a timeout that carries no `retry_safe`, and this line
+# is then the only record that a message may already have left. Answering the
+# caller instead needs the tool to know its own deadline, which is issue #889.
+_SEND_INTERRUPTED_WARNING = (
+    "Message submission was interrupted while in flight. Delivery is unknown; "
     "check the conversation before retrying, as a retry may deliver the "
     "message twice."
 )
@@ -5219,16 +5219,23 @@ class LinkedInExtractor:
         # the composer still holds.
         previous_occurrences = await self._message_text_occurrences(message)
 
-        # patchright actionability also blocks send_button.click(). Use JS click
-        # on any visible, enabled send button; fall back to Enter key which
-        # LinkedIn's composer also accepts for submission.
-        #
-        # DOM dependency: we need btn.click() on the element reference — not
-        # achievable via innerText or URL navigation. Selectors use only type,
-        # aria-label, and data attributes (no layout class names).
+        # Everything from here on runs with a submission dispatched or about to
+        # be, so any exit that carries no result leaves the caller unable to
+        # tell whether a message went out. The cleanup awaits between the
+        # branches below are inside this window for that reason: an
+        # interruption during `_dismiss_message_ui` is as unreportable as one
+        # during the send itself.
         try:
-            sent_via_js = await self._page.evaluate(
-                """() => {
+            # patchright actionability also blocks send_button.click(). Use JS
+            # click on any visible, enabled send button; fall back to Enter key
+            # which LinkedIn's composer also accepts for submission.
+            #
+            # DOM dependency: we need btn.click() on the element reference — not
+            # achievable via innerText or URL navigation. Selectors use only
+            # type, aria-label, and data attributes (no layout class names).
+            try:
+                sent_via_js = await self._page.evaluate(
+                    """() => {
                     const btn = Array.from(document.querySelectorAll(
                         'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
                         + 'button[data-control-name="send"]'
@@ -5237,71 +5244,69 @@ class LinkedInExtractor:
                     btn.click();
                     return true;
                 }"""
-            )
-            if not sent_via_js:
-                await self._page.keyboard.press("Enter")
-        except Exception:
-            # Both submissions dispatch their input event inside the very call
-            # that then fails, so a context that dies here says nothing about
-            # whether the message left: a send that navigates the page away
-            # looks exactly like one that never started. Letting the error out
-            # would reach the caller as a plain tool failure and invite the
-            # retry that delivers a second message to a real person.
-            logger.debug("Message submission did not complete", exc_info=True)
-            await self._dismiss_message_ui()
-            return self._message_action_result(
-                self._page.url,
-                "send_unconfirmed",
-                "The message submission was interrupted and LinkedIn did not "
-                "confirm delivery. Check the conversation before retrying; "
-                "retrying may deliver the message twice.",
-                recipient_selected=recipient_selected,
-                retry_safe=False,
-            )
-        except BaseException:
-            # Ordered after `except Exception`, so this is cancellation and
-            # not an ordinary failure. Re-raised rather than reported,
-            # because the cancelled scope discards a return value.
-            logger.warning(_SEND_CANCELLED_WARNING)
-            raise
+                )
+                if not sent_via_js:
+                    await self._page.keyboard.press("Enter")
+            except Exception:
+                # Both submissions dispatch their input event inside the very
+                # call that then fails, so a context that dies here says
+                # nothing about whether the message left: a send that navigates
+                # the page away looks exactly like one that never started.
+                # Letting the error out would reach the caller as a plain tool
+                # failure and invite the retry that delivers a second message
+                # to a real person.
+                logger.debug("Message submission did not complete", exc_info=True)
+                await self._dismiss_message_ui()
+                return self._message_action_result(
+                    self._page.url,
+                    "send_unconfirmed",
+                    "The message submission was interrupted and LinkedIn did "
+                    "not confirm delivery. Check the conversation before "
+                    "retrying; retrying may deliver the message twice.",
+                    recipient_selected=recipient_selected,
+                    retry_safe=False,
+                )
 
-        try:
             confirmed = await self._message_text_visible(
                 message, previous_occurrences=previous_occurrences
             )
-        except BaseException:
-            # `_message_text_visible` answers False for every failure it can
-            # observe, so only cancellation arrives here, and it arrives
-            # after a message may already have been delivered.
-            logger.warning(_SEND_CANCELLED_WARNING)
-            raise
 
-        if not confirmed:
-            await self._dismiss_message_ui()
-            # Submission already happened, so this is not evidence that
-            # nothing was sent: a thread that renders the delivered bubble
-            # slower than the page timeout arrives here having delivered.
-            # Reporting a plain failure invites a retry, and a retry sends a
-            # second real message to a real person, so the status says
-            # unknown rather than no.
+            if not confirmed:
+                await self._dismiss_message_ui()
+                # Submission already happened, so this is not evidence that
+                # nothing was sent: a thread that renders the delivered bubble
+                # slower than the page timeout arrives here having delivered.
+                # Reporting a plain failure invites a retry, and a retry sends a
+                # second real message to a real person, so the status says
+                # unknown rather than no.
+                return self._message_action_result(
+                    self._page.url,
+                    "send_unconfirmed",
+                    "The message was submitted but LinkedIn did not confirm "
+                    "delivery in time. Check the conversation before retrying; "
+                    "retrying may deliver the message twice.",
+                    recipient_selected=recipient_selected,
+                    retry_safe=False,
+                )
+
             return self._message_action_result(
                 self._page.url,
-                "send_unconfirmed",
-                "The message was submitted but LinkedIn did not confirm "
-                "delivery in time. Check the conversation before retrying; "
-                "retrying may deliver the message twice.",
+                "sent",
+                "Message sent.",
                 recipient_selected=recipient_selected,
+                sent=True,
                 retry_safe=False,
             )
-
-        return self._message_action_result(
-            self._page.url,
-            "sent",
-            "Message sent.",
-            recipient_selected=recipient_selected,
-            sent=True,
-            retry_safe=False,
-        )
+        except BaseException:
+            # Reached only where the window produced no result at all. An
+            # ordinary submission failure returns from the inner handler, and
+            # `_message_text_visible` answers False for every failure it can
+            # observe, so what arrives here is cancellation or the rare error
+            # escaping cleanup. Both leave the same question behind, and both
+            # are re-raised rather than reported, because a cancelled scope
+            # discards a return value.
+            logger.warning(_SEND_INTERRUPTED_WARNING)
+            raise
 
     async def _extract_root_content(
         self,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -465,6 +465,14 @@ _MESSAGING_CLOSE_SELECTOR = (
 # send path compares a baseline taken before the click with the count after
 # it. Visibility is pure geometry and the match is on normalized text, so no
 # LinkedIn class name or localized label enters the decision.
+#
+# Known limit, and it scales with how short the message is: the count is taken
+# over the whole body, so any unrelated text arriving between the two reads can
+# raise it if the message occurs inside it. A messaging page updates presence
+# and timestamps on its own, so a one-character message can be confirmed by
+# something that has nothing to do with it. A sentence cannot. Scoping the
+# count to the thread would need a container selector, and every candidate
+# LinkedIn offers is a layout class name.
 _MESSAGE_OCCURRENCES_JS = r"""
 ({ expected }) => {
     const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
@@ -491,7 +499,12 @@ _MESSAGE_OCCURRENCES_JS = r"""
         );
 
     let total = countIn(document.body?.innerText || '');
-    for (const editor of document.querySelectorAll('[contenteditable="true"]')) {
+    // Any element that declares contenteditable at all, not only the ones
+    // currently set to "true": a composer commonly goes read-only for the
+    // duration of an in-flight send while keeping its text on screen, and
+    // an occurrence subtracted at baseline must stay subtracted afterwards
+    // or the same unsent draft confirms itself.
+    for (const editor of document.querySelectorAll('[contenteditable]')) {
         if (isVisible(editor)) {
             total -= countIn(editor.innerText);
         }
@@ -5130,18 +5143,35 @@ class LinkedInExtractor:
         # to call .focus() on the element reference, which requires querySelector.
         # Selectors use only role + contenteditable + aria-label (ARIA attributes,
         # not layout class names) so they are stable across LinkedIn UI changes.
-        focused = await self._page.evaluate(
+        composer = await self._page.evaluate(
             """() => {
                 const el = document.querySelector(
                     'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
                     + 'div[role="textbox"][contenteditable="true"]'
                 );
-                if (!el) return false;
+                if (!el) return 'missing';
+                // Text already in the editor belongs to whoever typed it.
+                // Chromium leaves the caret at the start of a contenteditable
+                // after focus(), so typing here puts the message in front of
+                // that draft and LinkedIn delivers the two as one. Clearing
+                // it would destroy it, so refuse and leave it standing.
+                if ((el.innerText || '').replace(/\\s+/g, ' ').trim()) {
+                    return 'occupied';
+                }
                 el.focus();
-                return true;
+                return 'focused';
             }"""
         )
-        if not focused:
+        if composer == "occupied":
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "composer_occupied",
+                "The composer already holds a draft that would be sent along "
+                "with the message. The draft was left untouched.",
+                recipient_selected=recipient_selected,
+            )
+        if composer != "focused":
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
@@ -5185,10 +5215,18 @@ class LinkedInExtractor:
             message, previous_occurrences=previous_occurrences
         ):
             await self._dismiss_message_ui()
+            # Submission already happened, so this is not evidence that
+            # nothing was sent: a thread that renders the delivered bubble
+            # slower than the page timeout arrives here having delivered.
+            # Reporting a plain failure invites a retry, and a retry sends a
+            # second real message to a real person, so the status says
+            # unknown rather than no.
             return self._message_action_result(
                 self._page.url,
-                "send_unavailable",
-                "LinkedIn did not confirm that the message was sent.",
+                "send_unconfirmed",
+                "The message was submitted but LinkedIn did not confirm "
+                "delivery in time. Check the conversation before retrying; "
+                "retrying may deliver the message twice.",
                 recipient_selected=recipient_selected,
             )
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5041,17 +5041,11 @@ class LinkedInExtractor:
             profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
                 compose URL directly, bypassing the Message-button lookup.
         """
+        refusal = refuse_a_blank_message(linkedin_username, message)
+        if refusal is not None:
+            return refusal
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
-        if not message.strip():
-            # Not `message_unavailable`, which says the *recipient* exposes no
-            # Message action and tells a caller to give up on this person. A
-            # blank message is the caller's own input and the repair is theirs.
-            return self._message_action_result(
-                profile_url,
-                "invalid_message",
-                "Message must contain non-whitespace characters.",
-            )
 
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
@@ -5417,3 +5411,26 @@ class LinkedInExtractor:
             {"selectors": selectors},
         )
         return result
+
+
+def refuse_a_blank_message(
+    linkedin_username: str, message: str
+) -> dict[str, Any] | None:
+    """The refusal for a whitespace-only message, or None if there is none.
+
+    Shared between the MCP tool and `LinkedInExtractor.send_message` so the
+    two cannot answer the same input differently. The tool calls it before
+    acquiring a session: the input is the caller's own and needs no browser
+    to judge, while acquiring one can spend a login attempt and answer with
+    an authentication error the caller then has to interpret instead.
+    """
+    if message.strip():
+        return None
+    # Not `message_unavailable`, which says the *recipient* exposes no
+    # Message action and tells a caller to give up on this person. A blank
+    # message is the caller's own input and the repair is theirs.
+    return LinkedInExtractor._message_action_result(
+        person_profile_url(normalize_person_identifier(linkedin_username), "/"),
+        "invalid_message",
+        "Message must contain non-whitespace characters.",
+    )

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1134,14 +1134,25 @@ class LinkedInExtractor:
         *,
         recipient_selected: bool = False,
         sent: bool = False,
+        retry_safe: bool = True,
     ) -> dict[str, Any]:
-        """Build a structured response for the send_message tool."""
+        """Build a structured response for the send_message tool.
+
+        ``sent`` answers whether delivery was proven, so it is false both
+        where nothing was submitted and where submission happened but
+        delivery could not be observed. A caller keying a retry on it alone
+        therefore re-sends a message that may already have arrived, which is
+        what ``retry_safe`` exists to say: it is false from the moment a
+        submission is attempted, and true only while nothing can have left
+        the composer.
+        """
         return {
             "url": url,
             "status": status,
             "message": message,
             "recipient_selected": recipient_selected,
             "sent": sent,
+            "retry_safe": retry_safe,
         }
 
     async def _log_navigation_failure(
@@ -3128,6 +3139,12 @@ class LinkedInExtractor:
         and neither can an identical message already in the thread.
 
         Uses the page-level default timeout (``BrowserConfig.default_timeout``).
+
+        Every failure answers "not observed" rather than raising, because this
+        runs only after a submission was attempted. An execution context that
+        dies mid-wait, which is what an SPA remount looks like from here, would
+        otherwise reach the caller as a plain tool error and invite the one
+        retry that delivers the message twice.
         """
         try:
             await self._page.wait_for_function(
@@ -3135,7 +3152,8 @@ class LinkedInExtractor:
                 arg={"expected": message, "previous": previous_occurrences},
             )
             return True
-        except PlaywrightTimeoutError:
+        except Exception:
+            logger.debug("Message delivery could not be confirmed", exc_info=True)
             return False
 
     async def _dismiss_message_ui(self) -> None:
@@ -5012,9 +5030,12 @@ class LinkedInExtractor:
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
         if not message.strip():
+            # Not `message_unavailable`, which says the *recipient* exposes no
+            # Message action and tells a caller to give up on this person. A
+            # blank message is the caller's own input and the repair is theirs.
             return self._message_action_result(
                 profile_url,
-                "message_unavailable",
+                "invalid_message",
                 "Message must contain non-whitespace characters.",
             )
 
@@ -5228,6 +5249,7 @@ class LinkedInExtractor:
                 "delivery in time. Check the conversation before retrying; "
                 "retrying may deliver the message twice.",
                 recipient_selected=recipient_selected,
+                retry_safe=False,
             )
 
         return self._message_action_result(
@@ -5236,6 +5258,7 @@ class LinkedInExtractor:
             "Message sent.",
             recipient_selected=recipient_selected,
             sent=True,
+            retry_safe=False,
         )
 
     async def _extract_root_content(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -457,6 +457,55 @@ _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Close"]'
 )
 
+# Counts visible occurrences of a message *outside* every open composer.
+# The composer holds the message before it is sent, so plain body text is no
+# evidence of delivery: a Send button whose handler does nothing leaves the
+# text standing in the editor and the page still "contains" it. Occurrences
+# inside visible contenteditable editors are therefore subtracted, and the
+# send path compares a baseline taken before the click with the count after
+# it. Visibility is pure geometry and the match is on normalized text, so no
+# LinkedIn class name or localized label enters the decision.
+_MESSAGE_OCCURRENCES_JS = r"""
+({ expected }) => {
+    const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
+    const needle = normalize(expected);
+    if (!needle) return 0;
+
+    const countIn = value => {
+        const haystack = normalize(value);
+        let count = 0;
+        let index = haystack.indexOf(needle);
+        while (index !== -1) {
+            count += 1;
+            index = haystack.indexOf(needle, index + needle.length);
+        }
+        return count;
+    };
+
+    const isVisible = element =>
+        !!(
+            element &&
+            (element.offsetWidth ||
+                element.offsetHeight ||
+                element.getClientRects().length)
+        );
+
+    let total = countIn(document.body?.innerText || '');
+    for (const editor of document.querySelectorAll('[contenteditable="true"]')) {
+        if (isVisible(editor)) {
+            total -= countIn(editor.innerText);
+        }
+    }
+    return total > 0 ? total : 0;
+}
+"""
+
+# The post-send predicate is the same counting routine, so the baseline and
+# the confirmation can never disagree about what counts as an occurrence.
+_MESSAGE_OCCURRENCES_INCREASED_JS = (
+    f"(arg) => ({_MESSAGE_OCCURRENCES_JS})(arg) > arg.previous"
+)
+
 # Shared JS function that walks up from any /messaging/compose/ anchor
 # inside <main> to find the smallest ancestor that satisfies the
 # action-root predicate (>=2 interactive children, >=1 button). This is
@@ -3048,20 +3097,29 @@ class LinkedInExtractor:
         )
         return bool(matched)
 
-    async def _message_text_visible(self, message: str) -> bool:
-        """Wait until the compose page visibly contains the just-sent message text.
+    async def _message_text_occurrences(self, message: str) -> int:
+        """Count visible occurrences of the message outside any open composer."""
+        occurrences = await self._page.evaluate(
+            _MESSAGE_OCCURRENCES_JS, {"expected": message}
+        )
+        return int(occurrences or 0)
+
+    async def _message_text_visible(
+        self, message: str, *, previous_occurrences: int
+    ) -> bool:
+        """Wait until a *new* copy of the message appears outside the composer.
+
+        ``previous_occurrences`` is the baseline taken after typing and before
+        the send attempt, so the requirement is strictly more occurrences than
+        before: the typed text sitting in the composer cannot confirm itself,
+        and neither can an identical message already in the thread.
 
         Uses the page-level default timeout (``BrowserConfig.default_timeout``).
         """
         try:
             await self._page.wait_for_function(
-                """({ expected }) => {
-                    const normalize = value =>
-                        (value || '').replace(/\\s+/g, ' ').trim();
-                    const bodyText = normalize(document.body?.innerText || '');
-                    return bodyText.includes(normalize(expected));
-                }""",
-                arg={"expected": message},
+                _MESSAGE_OCCURRENCES_INCREASED_JS,
+                arg={"expected": message, "previous": previous_occurrences},
             )
             return True
         except PlaywrightTimeoutError:
@@ -5087,6 +5145,13 @@ class LinkedInExtractor:
         await asyncio.sleep(0.1)
         await self._page.keyboard.type(message, delay=15)
         await asyncio.sleep(0.3)
+        await asyncio.sleep(1.0)  # allow React to process keyboard input
+
+        # Baseline immediately before the send attempt: how often the message
+        # is already visible outside the composer. The click below only tries
+        # to send; delivery is proven by this count growing, never by the text
+        # the composer still holds.
+        previous_occurrences = await self._message_text_occurrences(message)
 
         # patchright actionability also blocks send_button.click(). Use JS click
         # on any visible, enabled send button; fall back to Enter key which
@@ -5095,7 +5160,6 @@ class LinkedInExtractor:
         # DOM dependency: we need btn.click() on the element reference — not
         # achievable via innerText or URL navigation. Selectors use only type,
         # aria-label, and data attributes (no layout class names).
-        await asyncio.sleep(1.0)  # allow React to process keyboard input
         sent_via_js = await self._page.evaluate(
             """() => {
                 const btn = Array.from(document.querySelectorAll(
@@ -5110,7 +5174,9 @@ class LinkedInExtractor:
         if not sent_via_js:
             await self._page.keyboard.press("Enter")
 
-        if not await self._message_text_visible(message):
+        if not await self._message_text_visible(
+            message, previous_occurrences=previous_occurrences
+        ):
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4998,6 +4998,13 @@ class LinkedInExtractor:
         """
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
+        if not message.strip():
+            return self._message_action_result(
+                profile_url,
+                "message_unavailable",
+                "Message must contain non-whitespace characters.",
+            )
+
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -466,7 +466,7 @@ _MESSAGING_CLOSE_SELECTOR = (
 # it. Visibility is pure geometry and the match is on normalized text, so no
 # LinkedIn class name or localized label enters the decision.
 #
-# Known limit, and it scales with how short the message is: the count is taken
+# Known limit (issue #888), and it scales with how short the message is: the count is taken
 # over the whole body, so any unrelated text arriving between the two reads can
 # raise it if the message occurs inside it. A messaging page updates presence
 # and timestamps on its own, so a one-character message can be confirmed by
@@ -512,6 +512,20 @@ _MESSAGE_OCCURRENCES_JS = r"""
     return total > 0 ? total : 0;
 }
 """
+
+# A submission is in flight from the moment the send is dispatched until the
+# confirmation answers, and a cancellation in that window cannot be reported:
+# FastMCP runs every tool inside `anyio.fail_after()`, so the deadline raises
+# `CancelledError` past `except Exception` and discards any result returned
+# from the cancelled scope. The caller gets a timeout that carries no
+# `retry_safe`, and this line is then the only record that a message may
+# already have left. Answering the caller instead needs the tool to know its
+# own deadline, which is issue #889.
+_SEND_CANCELLED_WARNING = (
+    "Message submission was cancelled while in flight. Delivery is unknown; "
+    "check the conversation before retrying, as a retry may deliver the "
+    "message twice."
+)
 
 # The post-send predicate is the same counting routine, so the baseline and
 # the confirmation can never disagree about what counts as an occurrence.
@@ -5250,10 +5264,25 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
                 retry_safe=False,
             )
+        except BaseException:
+            # Ordered after `except Exception`, so this is cancellation and
+            # not an ordinary failure. Re-raised rather than reported,
+            # because the cancelled scope discards a return value.
+            logger.warning(_SEND_CANCELLED_WARNING)
+            raise
 
-        if not await self._message_text_visible(
-            message, previous_occurrences=previous_occurrences
-        ):
+        try:
+            confirmed = await self._message_text_visible(
+                message, previous_occurrences=previous_occurrences
+            )
+        except BaseException:
+            # `_message_text_visible` answers False for every failure it can
+            # observe, so only cancellation arrives here, and it arrives
+            # after a message may already have been delivered.
+            logger.warning(_SEND_CANCELLED_WARNING)
+            raise
+
+        if not confirmed:
             await self._dismiss_message_ui()
             # Submission already happened, so this is not evidence that
             # nothing was sent: a thread that renders the delivered bubble

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5312,14 +5312,43 @@ class LinkedInExtractor:
                 sent=True,
                 retry_safe=False,
             )
+        except Exception:
+            # Reached where a message may already be gone and no result says
+            # so: an error while typing, which a newline has by then turned
+            # into a submission; one from the baseline read; or one from the
+            # cleanup call in a branch above, whose own guard does not cover
+            # the visibility probe it opens with. The inner handler covers the
+            # send call alone, and `_message_text_visible` answers False for
+            # every failure it can observe, so none of these three has an
+            # answer of its own. Letting the error out would reach the caller
+            # as a plain tool failure and invite the retry that delivers a
+            # second message to a real person.
+            #
+            # Cleanup is not attempted here. Its own failure is one of the
+            # ways into this handler, and a second attempt would replace the
+            # answer with the error it was raised for.
+            if not may_have_submitted:
+                # Nothing can have been submitted yet, so the error itself is
+                # the useful answer and the caller can retry on it.
+                raise
+            logger.debug(
+                "Message send failed after a possible submission", exc_info=True
+            )
+            return self._message_action_result(
+                self._page.url,
+                "send_unconfirmed",
+                "The message may already have been submitted when the send "
+                "failed, and LinkedIn did not confirm delivery. Check the "
+                "conversation before retrying; retrying may deliver the "
+                "message twice.",
+                recipient_selected=recipient_selected,
+                retry_safe=False,
+            )
         except BaseException:
-            # Reached only where the window produced no result at all. An
-            # ordinary submission failure returns from the inner handler, and
-            # `_message_text_visible` answers False for every failure it can
-            # observe, so what arrives here is cancellation or the rare error
-            # escaping cleanup. Both leave the same question behind, and both
-            # are re-raised rather than reported, because a cancelled scope
-            # discards a return value.
+            # Cancellation only. FastMCP runs the tool inside
+            # `anyio.fail_after()` and a cancelled scope discards whatever it
+            # returns, so the answer the branch above gives cannot be given
+            # here and the log line is all that is left.
             #
             # Silent for an interruption while typing a message without a
             # newline: nothing can have submitted yet, and a warning that

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -521,7 +521,7 @@ _MESSAGE_OCCURRENCES_JS = r"""
 # scope. The caller gets a timeout that carries no `retry_safe`, and this line
 # is then the only record that a message may already have left. Answering the
 # caller instead needs the tool to know its own deadline, which is issue #889.
-_SEND_INTERRUPTED_WARNING = (
+SEND_INTERRUPTED_WARNING = (
     "Message submission was interrupted while in flight. Delivery is unknown; "
     "check the conversation before retrying, as a retry may deliver the "
     "message twice."
@@ -5209,23 +5209,35 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
         await asyncio.sleep(0.1)
-        await self._page.keyboard.type(message, delay=15)
-        await asyncio.sleep(0.3)
-        await asyncio.sleep(1.0)  # allow React to process keyboard input
 
-        # Baseline immediately before the send attempt: how often the message
-        # is already visible outside the composer. The click below only tries
-        # to send; delivery is proven by this count growing, never by the text
-        # the composer still holds.
-        previous_occurrences = await self._message_text_occurrences(message)
+        # Typing is inside the window, and not as a precaution.
+        # `keyboard.type()` presses one key per character, and patchright maps
+        # "\n" and "\r" onto Enter through its alias table, which this
+        # composer submits on: the send below relies on that very behaviour.
+        # A message carrying a newline therefore delivers its first paragraph
+        # *during* typing, and typing is slow enough for that to matter — at
+        # 15ms per character a 20k-character message runs past the 180s tool
+        # deadline long before the send call is reached. Splitting the text so
+        # a newline cannot submit is issue #441 and a change of its own; until
+        # then the flag below is what keeps the interruption reportable.
+        may_have_submitted = "\n" in message or "\r" in message
 
-        # Everything from here on runs with a submission dispatched or about to
-        # be, so any exit that carries no result leaves the caller unable to
-        # tell whether a message went out. The cleanup awaits between the
-        # branches below are inside this window for that reason: an
-        # interruption during `_dismiss_message_ui` is as unreportable as one
-        # during the send itself.
+        # Everything from here on can leave a message delivered, so any exit
+        # that carries no result leaves the caller unable to tell whether one
+        # went out. The cleanup awaits between the branches below are inside
+        # this window for that reason: an interruption during
+        # `_dismiss_message_ui` is as unreportable as one during the send.
         try:
+            await self._page.keyboard.type(message, delay=15)
+            await asyncio.sleep(0.3)
+            await asyncio.sleep(1.0)  # allow React to process keyboard input
+
+            # Baseline immediately before the send attempt: how often the
+            # message is already visible outside the composer. The click below
+            # only tries to send; delivery is proven by this count growing,
+            # never by the text the composer still holds.
+            previous_occurrences = await self._message_text_occurrences(message)
+
             # patchright actionability also blocks send_button.click(). Use JS
             # click on any visible, enabled send button; fall back to Enter key
             # which LinkedIn's composer also accepts for submission.
@@ -5234,6 +5246,9 @@ class LinkedInExtractor:
             # achievable via innerText or URL navigation. Selectors use only
             # type, aria-label, and data attributes (no layout class names).
             try:
+                # The click is dispatched inside the call that may then fail,
+                # so the flag is set before it rather than after.
+                may_have_submitted = True
                 sent_via_js = await self._page.evaluate(
                     """() => {
                     const btn = Array.from(document.querySelectorAll(
@@ -5305,7 +5320,13 @@ class LinkedInExtractor:
             # escaping cleanup. Both leave the same question behind, and both
             # are re-raised rather than reported, because a cancelled scope
             # discards a return value.
-            logger.warning(_SEND_INTERRUPTED_WARNING)
+            #
+            # Silent for an interruption while typing a message without a
+            # newline: nothing can have submitted yet, and a warning that
+            # cries duplicate delivery where none is possible is the kind
+            # that gets ignored when it is right.
+            if may_have_submitted:
+                logger.warning(SEND_INTERRUPTED_WARNING)
             raise
 
     async def _extract_root_content(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5218,19 +5218,38 @@ class LinkedInExtractor:
         # DOM dependency: we need btn.click() on the element reference — not
         # achievable via innerText or URL navigation. Selectors use only type,
         # aria-label, and data attributes (no layout class names).
-        sent_via_js = await self._page.evaluate(
-            """() => {
-                const btn = Array.from(document.querySelectorAll(
-                    'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
-                    + 'button[data-control-name="send"]'
-                )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
-                if (!btn) return false;
-                btn.click();
-                return true;
-            }"""
-        )
-        if not sent_via_js:
-            await self._page.keyboard.press("Enter")
+        try:
+            sent_via_js = await self._page.evaluate(
+                """() => {
+                    const btn = Array.from(document.querySelectorAll(
+                        'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
+                        + 'button[data-control-name="send"]'
+                    )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
+                    if (!btn) return false;
+                    btn.click();
+                    return true;
+                }"""
+            )
+            if not sent_via_js:
+                await self._page.keyboard.press("Enter")
+        except Exception:
+            # Both submissions dispatch their input event inside the very call
+            # that then fails, so a context that dies here says nothing about
+            # whether the message left: a send that navigates the page away
+            # looks exactly like one that never started. Letting the error out
+            # would reach the caller as a plain tool failure and invite the
+            # retry that delivers a second message to a real person.
+            logger.debug("Message submission did not complete", exc_info=True)
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "send_unconfirmed",
+                "The message submission was interrupted and LinkedIn did not "
+                "confirm delivery. Check the conversation before retrying; "
+                "retrying may deliver the message twice.",
+                recipient_selected=recipient_selected,
+                retry_safe=False,
+            )
 
         if not await self._message_text_visible(
             message, previous_occurrences=previous_occurrences

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -251,7 +251,12 @@ def register_messaging_tools(
                 messages; use search_conversations as a fallback.
 
         Returns:
-            Dict with url, status, message, recipient_selected, and sent.
+            Dict with url, status, message, recipient_selected, sent, and
+            retry_safe. ``sent`` is true only where delivery was observed, so
+            it is false both where nothing was submitted and where the outcome
+            is unknown. ``retry_safe`` separates the two: it is false from the
+            moment a submission is attempted, and calling again while it is
+            false can deliver the message twice.
         """
         try:
             extractor = extractor or await get_ready_extractor(

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -259,15 +259,18 @@ def register_messaging_tools(
             moment a submission is attempted, and calling again while it is
             false can deliver the message twice.
         """
-        # Answered before a session is acquired. Nothing about a blank message
-        # needs a browser, and acquiring one can spend a login attempt and
-        # come back as an authentication error instead of the refusal the
-        # caller can act on.
-        refusal = refuse_a_blank_message(linkedin_username, message)
-        if refusal is not None:
-            return refusal
-
         try:
+            # Answered before a session is acquired. Nothing about a blank
+            # message needs a browser, and acquiring one can spend a login
+            # attempt and come back as an authentication error instead of the
+            # refusal the caller can act on. Inside the `try` because building
+            # the refusal normalizes the recipient, and an unusable one raises
+            # `InvalidReferenceError`; outside, that error would skip
+            # `raise_tool_error` and reach the caller masked by
+            # `mask_error_details` instead of naming the correction.
+            refusal = refuse_a_blank_message(linkedin_username, message)
+            if refusal is not None:
+                return refusal
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="send_message"
             )

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -17,6 +17,7 @@ from linkedin_mcp_server.core.exceptions import (
 )
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
+from linkedin_mcp_server.scraping.extractor import refuse_a_blank_message
 
 logger = logging.getLogger(__name__)
 
@@ -258,6 +259,14 @@ def register_messaging_tools(
             moment a submission is attempted, and calling again while it is
             false can deliver the message twice.
         """
+        # Answered before a session is acquired. Nothing about a blank message
+        # needs a browser, and acquiring one can spend a login attempt and
+        # come back as an authentication error instead of the refusal the
+        # caller can act on.
+        refusal = refuse_a_blank_message(linkedin_username, message)
+        if refusal is not None:
+            return refusal
+
         try:
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="send_message"

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -17,7 +17,10 @@ from linkedin_mcp_server.core.exceptions import (
 )
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
-from linkedin_mcp_server.scraping.extractor import refuse_a_blank_message
+from linkedin_mcp_server.scraping.extractor import (
+    SEND_INTERRUPTED_WARNING,
+    refuse_a_blank_message,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -289,7 +292,18 @@ def register_messaging_tools(
                 profile_urn=profile_urn,
             )
 
-            await ctx.report_progress(progress=100, total=100, message="Complete")
+            try:
+                await ctx.report_progress(progress=100, total=100, message="Complete")
+            except BaseException:
+                # The send has already answered, and this notification is the
+                # last await inside FastMCP's `anyio.fail_after()`. A deadline
+                # landing here discards a result that may say a message was
+                # delivered, and nothing can hand it back afterwards, so the
+                # log line is all that is left. Quiet where the result says a
+                # retry is safe, because then there is nothing to warn about.
+                if result.get("retry_safe") is False:
+                    logger.warning(SEND_INTERRUPTED_WARNING)
+                raise
 
             return result
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -27,6 +27,8 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _CONTENT_DATE_POSTED_MAP,
+    _MESSAGE_OCCURRENCES_INCREASED_JS,
+    _MESSAGE_OCCURRENCES_JS,
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
@@ -8784,6 +8786,12 @@ class TestSendMessageComposerInteraction:
             patches[9],
             patch.object(
                 extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
                 "_message_text_visible",
                 new_callable=AsyncMock,
                 return_value=True,
@@ -8851,6 +8859,12 @@ class TestSendMessageComposerInteraction:
             patches[9],
             patch.object(
                 extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
                 "_message_text_visible",
                 new_callable=AsyncMock,
                 return_value=True,
@@ -8863,6 +8877,170 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "sent"
         # Enter was pressed as fallback
         mock_keyboard.press.assert_awaited_once_with("Enter")
+
+    async def test_baseline_is_taken_after_typing_and_before_send(self, mock_page):
+        """The occurrence baseline is captured between typing and the click.
+
+        Taken any earlier it would miss what the composer already holds; taken
+        after the click it could already include the delivered message, and
+        the confirmation would compare that copy against itself.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        steps: list[str] = []
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock(
+            side_effect=lambda *args, **kwargs: steps.append("type")
+        )
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+
+        async def evaluate(*args, **kwargs):
+            steps.append("click" if steps else "focus")
+            return True
+
+        async def occurrences(message):
+            steps.append("baseline")
+            return 2
+
+        async def visible(message, *, previous_occurrences):
+            steps.append(f"confirm:{previous_occurrences}")
+            return True
+
+        mock_page.evaluate = AsyncMock(side_effect=evaluate)
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                side_effect=occurrences,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                side_effect=visible,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "sent"
+        # The confirmation receives exactly the baseline taken before the click.
+        assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
+
+    async def test_send_unavailable_when_click_adds_nothing(self, mock_page):
+        """A clicked Send button that changes nothing is not a sent message."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        # evaluate returns: True (focus), True (send button found and clicked)
+        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as visible,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert result["sent"] is False
+        visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
+
+
+class TestMessageTextOccurrences:
+    """Tests for the occurrence-based send confirmation (issue #866)."""
+
+    async def test_occurrences_run_the_shared_counting_routine(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=3)
+
+        assert await extractor._message_text_occurrences("Hello!") == 3
+
+        mock_page.evaluate.assert_awaited_once_with(
+            _MESSAGE_OCCURRENCES_JS, {"expected": "Hello!"}
+        )
+
+    async def test_missing_count_reads_as_zero(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=None)
+
+        assert await extractor._message_text_occurrences("Hello!") == 0
+
+    async def test_confirmation_waits_for_more_than_the_baseline(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(return_value=None)
+
+        assert (
+            await extractor._message_text_visible("Hello!", previous_occurrences=2)
+            is True
+        )
+
+        mock_page.wait_for_function.assert_awaited_once_with(
+            _MESSAGE_OCCURRENCES_INCREASED_JS,
+            arg={"expected": "Hello!", "previous": 2},
+        )
+        # Baseline and confirmation run one routine, so they cannot disagree
+        # about what counts as an occurrence.
+        assert _MESSAGE_OCCURRENCES_JS in _MESSAGE_OCCURRENCES_INCREASED_JS
+
+    async def test_confirmation_timeout_is_not_a_send(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("timeout")
+        )
+
+        assert (
+            await extractor._message_text_visible("Hello!", previous_occurrences=0)
+            is False
+        )
+
+    async def test_other_confirmation_errors_do_not_confirm(self, mock_page):
+        """A broken confirmation surfaces as an error, never as a send."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PatchrightError("execution context destroyed")
+        )
+
+        with pytest.raises(PatchrightError):
+            await extractor._message_text_visible("Hello!", previous_occurrences=0)
 
 
 class TestBuildFeedReferences:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8434,6 +8434,33 @@ class TestSearchConversations:
 
 
 class TestSendMessage:
+    @pytest.mark.parametrize("message", ["", " \t\n"], ids=["empty", "whitespace"])
+    async def test_blank_message_is_rejected_before_browser_interaction(
+        self, mock_page, message
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        keyboard = MagicMock()
+        mock_page.keyboard = keyboard
+
+        with patch.object(
+            extractor, "_navigate_to_page", new_callable=AsyncMock
+        ) as navigate:
+            result = await extractor.send_message(
+                "testuser", message, confirm_send=True
+            )
+
+        assert result == {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "status": "message_unavailable",
+            "message": "Message must contain non-whitespace characters.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        navigate.assert_not_awaited()
+        mock_page.evaluate.assert_not_awaited()
+        keyboard.type.assert_not_called()
+        keyboard.press.assert_not_called()
+
     async def test_dry_run_returns_confirmation_required(self, mock_page):
         """send_message with confirm_send=False returns confirmation_required status."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8452,12 +8452,15 @@ class TestSendMessage:
                 "testuser", message, confirm_send=True
             )
 
+        # Not `message_unavailable`: that status is about the recipient and
+        # tells a caller to move on, while this one is about their own input.
         assert result == {
             "url": "https://www.linkedin.com/in/testuser/",
-            "status": "message_unavailable",
+            "status": "invalid_message",
             "message": "Message must contain non-whitespace characters.",
             "recipient_selected": False,
             "sent": False,
+            "retry_safe": True,
         }
         navigate.assert_not_awaited()
         mock_page.evaluate.assert_not_awaited()
@@ -9015,9 +9018,11 @@ class TestSendMessageComposerInteraction:
             )
 
         # The click happened, so nothing here proves the message did not go
-        # out. Answering "not sent" would invite a retry that delivers twice.
+        # out. Answering "not sent" would invite a retry that delivers twice,
+        # which is what `retry_safe` says and `sent` cannot.
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
+        assert result["retry_safe"] is False
         visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
 
 
@@ -9069,14 +9074,21 @@ class TestMessageTextOccurrences:
         )
 
     async def test_other_confirmation_errors_do_not_confirm(self, mock_page):
-        """A broken confirmation surfaces as an error, never as a send."""
+        """A broken confirmation is an unknown, never a send and never an error.
+
+        This runs only after a submission was attempted, so letting the error
+        out would reach the caller as a plain tool failure and invite the one
+        retry that delivers the message a second time.
+        """
         extractor = LinkedInExtractor(mock_page)
         mock_page.wait_for_function = AsyncMock(
             side_effect=PatchrightError("execution context destroyed")
         )
 
-        with pytest.raises(PatchrightError):
+        assert (
             await extractor._message_text_visible("Hello!", previous_occurrences=0)
+            is False
+        )
 
 
 class TestBuildFeedReferences:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8799,8 +8799,9 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), True (send button click)
-        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        # evaluate returns: 'focused' (empty composer, focused), then
+        # True (send button click)
+        mock_page.evaluate = AsyncMock(side_effect=["focused", True])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -8842,8 +8843,8 @@ class TestSendMessageComposerInteraction:
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns False (focus failed)
-        mock_page.evaluate = AsyncMock(return_value=False)
+        # evaluate returns 'missing' (no composer to focus)
+        mock_page.evaluate = AsyncMock(return_value="missing")
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -8872,8 +8873,8 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), False (no send button found)
-        mock_page.evaluate = AsyncMock(side_effect=[True, False])
+        # evaluate returns: 'focused', then False (no send button found)
+        mock_page.evaluate = AsyncMock(side_effect=["focused", False])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -8925,8 +8926,11 @@ class TestSendMessageComposerInteraction:
         mock_page.keyboard = mock_keyboard
 
         async def evaluate(*args, **kwargs):
-            steps.append("click" if steps else "focus")
-            return True
+            focusing = not steps
+            steps.append("focus" if focusing else "click")
+            # The focus call reports the composer state; the click reports
+            # whether a send button was found.
+            return "focused" if focusing else True
 
         async def occurrences(message):
             steps.append("baseline")
@@ -8971,15 +8975,15 @@ class TestSendMessageComposerInteraction:
         # The confirmation receives exactly the baseline taken before the click.
         assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
 
-    async def test_send_unavailable_when_click_adds_nothing(self, mock_page):
+    async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), True (send button found and clicked)
-        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        # evaluate returns: 'focused', then True (send button found and clicked)
+        mock_page.evaluate = AsyncMock(side_effect=["focused", True])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -9010,7 +9014,9 @@ class TestSendMessageComposerInteraction:
                 "testuser", "Hello!", confirm_send=True
             )
 
-        assert result["status"] == "send_unavailable"
+        # The click happened, so nothing here proves the message did not go
+        # out. Answering "not sent" would invite a retry that delivers twice.
+        assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -9169,6 +9169,87 @@ class TestSendMessageComposerInteraction:
         hit = any("retry may deliver the message twice" in w for w in warnings)
         assert hit is warns, warnings
 
+    @pytest.mark.parametrize(
+        "stage",
+        ["typing", "baseline", "cleanup"],
+        ids=["typing", "baseline", "cleanup"],
+    )
+    async def test_ordinary_error_after_a_possible_submission_still_answers(
+        self, mock_page, stage
+    ):
+        """An error a caller could retry on gets an answer, not a raise.
+
+        Three awaits inside the destructive window have no guard of their own.
+        Typing raises before the send call is reached, and a newline has by
+        then submitted a paragraph. The baseline read sits between the two.
+        And `_dismiss_message_ui` guards its click but not the visibility
+        probe it opens with, so a page that dies during cleanup escapes it.
+
+        All three reach the caller as a plain tool failure unless the window
+        answers, and a plain failure invites the retry that delivers a second
+        message to a real person.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(return_value="focused")
+        occurrences = AsyncMock(return_value=1)
+        visible = AsyncMock(return_value=False)
+        dismiss = AsyncMock()
+        if stage == "typing":
+            mock_keyboard.type = AsyncMock(side_effect=RuntimeError("page closed"))
+        elif stage == "baseline":
+            occurrences = AsyncMock(side_effect=RuntimeError("context destroyed"))
+        else:
+            # The send went out unconfirmed and cleanup then failed, which is
+            # the branch that was about to return `retry_safe=False`.
+            mock_page.evaluate = AsyncMock(side_effect=["focused", True])
+            dismiss = AsyncMock(side_effect=RuntimeError("page closed"))
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with ExitStack() as stack:
+            for entered in patches:
+                stack.enter_context(entered)
+            stack.enter_context(
+                patch.object(extractor, "_message_text_occurrences", occurrences)
+            )
+            stack.enter_context(
+                patch.object(extractor, "_message_text_visible", visible)
+            )
+            stack.enter_context(patch.object(extractor, "_dismiss_message_ui", dismiss))
+            result = await extractor.send_message(
+                "testuser", "First\nSecond", confirm_send=True
+            )
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+
+    async def test_an_error_before_anything_can_submit_is_raised(self, mock_page):
+        """Without a newline nothing has submitted yet, so the error is the answer.
+
+        The pair to the case above. Reporting `send_unconfirmed` here would
+        claim a duplicate-delivery risk that cannot exist and take the real
+        error away from a caller who can simply retry.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock(side_effect=RuntimeError("page closed"))
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(return_value="focused")
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            ExitStack() as stack,
+            pytest.raises(RuntimeError, match="page closed"),
+        ):
+            for entered in patches:
+                stack.enter_context(entered)
+            await extractor.send_message("testuser", "Single line", confirm_send=True)
+
     async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -9123,6 +9123,52 @@ class TestSendMessageComposerInteraction:
             warnings
         )
 
+    @pytest.mark.parametrize(
+        ("message", "warns"),
+        [("Hello\nthere!", True), ("Hello there!", False)],
+        ids=["newline", "single-line"],
+    )
+    async def test_cancellation_while_typing_warns_only_for_a_newline(
+        self, mock_page, caplog, message, warns
+    ):
+        """Typing can submit, so the window has to start before it.
+
+        ``keyboard.type()`` presses one key per character and patchright maps
+        ``"\n"`` onto Enter, which this composer submits on: the send path
+        relies on that very behaviour. A message carrying a newline therefore
+        delivers its first paragraph *while* it is being typed, long before
+        the send call, and typing is slow enough for the tool deadline to land
+        in there — at 15ms per character a 20k-character message runs past
+        180s on its own.
+
+        The single-line case is what makes this a test rather than a blanket
+        warning: nothing can have submitted yet, and a warning that cries
+        duplicate delivery where none is possible is the kind that gets
+        ignored when it is right.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(return_value="focused")
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            ExitStack() as stack,
+            caplog.at_level(
+                logging.WARNING, logger="linkedin_mcp_server.scraping.extractor"
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            for entered in patches:
+                stack.enter_context(entered)
+            await extractor.send_message("testuser", message, confirm_send=True)
+
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        hit = any("retry may deliver the message twice" in w for w in warnings)
+        assert hit is warns, warnings
+
     async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -30,6 +30,8 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _CONTENT_DATE_POSTED_MAP,
+    _MESSAGE_OCCURRENCES_INCREASED_JS,
+    _MESSAGE_OCCURRENCES_JS,
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
@@ -8787,6 +8789,12 @@ class TestSendMessageComposerInteraction:
             patches[9],
             patch.object(
                 extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
                 "_message_text_visible",
                 new_callable=AsyncMock,
                 return_value=True,
@@ -8854,6 +8862,12 @@ class TestSendMessageComposerInteraction:
             patches[9],
             patch.object(
                 extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
                 "_message_text_visible",
                 new_callable=AsyncMock,
                 return_value=True,
@@ -8866,6 +8880,170 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "sent"
         # Enter was pressed as fallback
         mock_keyboard.press.assert_awaited_once_with("Enter")
+
+    async def test_baseline_is_taken_after_typing_and_before_send(self, mock_page):
+        """The occurrence baseline is captured between typing and the click.
+
+        Taken any earlier it would miss what the composer already holds; taken
+        after the click it could already include the delivered message, and
+        the confirmation would compare that copy against itself.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        steps: list[str] = []
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock(
+            side_effect=lambda *args, **kwargs: steps.append("type")
+        )
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+
+        async def evaluate(*args, **kwargs):
+            steps.append("click" if steps else "focus")
+            return True
+
+        async def occurrences(message):
+            steps.append("baseline")
+            return 2
+
+        async def visible(message, *, previous_occurrences):
+            steps.append(f"confirm:{previous_occurrences}")
+            return True
+
+        mock_page.evaluate = AsyncMock(side_effect=evaluate)
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                side_effect=occurrences,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                side_effect=visible,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "sent"
+        # The confirmation receives exactly the baseline taken before the click.
+        assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
+
+    async def test_send_unavailable_when_click_adds_nothing(self, mock_page):
+        """A clicked Send button that changes nothing is not a sent message."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        # evaluate returns: True (focus), True (send button found and clicked)
+        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as visible,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert result["sent"] is False
+        visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
+
+
+class TestMessageTextOccurrences:
+    """Tests for the occurrence-based send confirmation (issue #866)."""
+
+    async def test_occurrences_run_the_shared_counting_routine(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=3)
+
+        assert await extractor._message_text_occurrences("Hello!") == 3
+
+        mock_page.evaluate.assert_awaited_once_with(
+            _MESSAGE_OCCURRENCES_JS, {"expected": "Hello!"}
+        )
+
+    async def test_missing_count_reads_as_zero(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=None)
+
+        assert await extractor._message_text_occurrences("Hello!") == 0
+
+    async def test_confirmation_waits_for_more_than_the_baseline(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(return_value=None)
+
+        assert (
+            await extractor._message_text_visible("Hello!", previous_occurrences=2)
+            is True
+        )
+
+        mock_page.wait_for_function.assert_awaited_once_with(
+            _MESSAGE_OCCURRENCES_INCREASED_JS,
+            arg={"expected": "Hello!", "previous": 2},
+        )
+        # Baseline and confirmation run one routine, so they cannot disagree
+        # about what counts as an occurrence.
+        assert _MESSAGE_OCCURRENCES_JS in _MESSAGE_OCCURRENCES_INCREASED_JS
+
+    async def test_confirmation_timeout_is_not_a_send(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("timeout")
+        )
+
+        assert (
+            await extractor._message_text_visible("Hello!", previous_occurrences=0)
+            is False
+        )
+
+    async def test_other_confirmation_errors_do_not_confirm(self, mock_page):
+        """A broken confirmation surfaces as an error, never as a send."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PatchrightError("execution context destroyed")
+        )
+
+        with pytest.raises(PatchrightError):
+            await extractor._message_text_visible("Hello!", previous_occurrences=0)
 
 
 class TestBuildFeedReferences:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,5 +1,6 @@
 """Tests for the LinkedInExtractor scraping engine."""
 
+from contextlib import ExitStack
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -9040,7 +9041,9 @@ class TestSendMessageComposerInteraction:
         # attempted; the answer comes from the interruption itself.
         visible.assert_not_awaited()
 
-    @pytest.mark.parametrize("stage", ["dispatch", "confirmation"])
+    @pytest.mark.parametrize(
+        "stage", ["dispatch", "confirmation", "failed-cleanup", "unconfirmed-cleanup"]
+    )
     async def test_cancellation_after_dispatch_is_logged(
         self, mock_page, caplog, stage
     ):
@@ -9051,33 +9054,51 @@ class TestSendMessageComposerInteraction:
         anything the cancelled scope returns. The caller therefore sees a
         timeout carrying no ``retry_safe``, and this log line is the only
         record that a message may already have left.
+
+        The window ends where a result exists, not where the send returns.
+        Both cleanup calls run after a submission was dispatched, and both
+        await: the one in the submission-failure handler and the one on the
+        unconfirmed path. Cancelled there, the message is exactly as
+        possibly-delivered as during the send itself.
         """
         extractor = LinkedInExtractor(mock_page)
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
+        dismiss_effect = None
         if stage == "dispatch":
             mock_page.evaluate = AsyncMock(
                 side_effect=["focused", asyncio.CancelledError()]
             )
             visible_effect = AsyncMock()
-        else:
+        elif stage == "confirmation":
             mock_page.evaluate = AsyncMock(side_effect=["focused", True])
             visible_effect = AsyncMock(side_effect=asyncio.CancelledError())
+        elif stage == "failed-cleanup":
+            # The submission raised an ordinary error after dispatching its
+            # input event, so the handler runs and is cancelled inside it.
+            mock_page.evaluate = AsyncMock(
+                side_effect=["focused", RuntimeError("context destroyed")]
+            )
+            visible_effect = AsyncMock()
+            dismiss_effect = AsyncMock(side_effect=asyncio.CancelledError())
+        else:
+            # The send went out and delivery was not observed, which is the
+            # path that most needs the warning: the result it was about to
+            # return is the one carrying `retry_safe=False`.
+            mock_page.evaluate = AsyncMock(side_effect=["focused", True])
+            visible_effect = AsyncMock(return_value=False)
+            dismiss_effect = AsyncMock(side_effect=asyncio.CancelledError())
         patches = self._patch_send_message_to_compose(extractor, mock_page)
+        if dismiss_effect is not None:
+            patches = [
+                *patches,
+                patch.object(extractor, "_dismiss_message_ui", dismiss_effect),
+            ]
 
         with (
-            patches[0],
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-            patches[5],
-            patches[6],
-            patches[7],
-            patches[8],
-            patches[9],
+            ExitStack() as stack,
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -9090,6 +9111,8 @@ class TestSendMessageComposerInteraction:
             ),
             pytest.raises(asyncio.CancelledError),
         ):
+            for entered in patches:
+                stack.enter_context(entered)
             await extractor.send_message("testuser", "Hello!", confirm_send=True)
 
         # Cancellation has to keep propagating, or the surrounding scope

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8437,6 +8437,33 @@ class TestSearchConversations:
 
 
 class TestSendMessage:
+    @pytest.mark.parametrize("message", ["", " \t\n"], ids=["empty", "whitespace"])
+    async def test_blank_message_is_rejected_before_browser_interaction(
+        self, mock_page, message
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        keyboard = MagicMock()
+        mock_page.keyboard = keyboard
+
+        with patch.object(
+            extractor, "_navigate_to_page", new_callable=AsyncMock
+        ) as navigate:
+            result = await extractor.send_message(
+                "testuser", message, confirm_send=True
+            )
+
+        assert result == {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "status": "message_unavailable",
+            "message": "Message must contain non-whitespace characters.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        navigate.assert_not_awaited()
+        mock_page.evaluate.assert_not_awaited()
+        keyboard.type.assert_not_called()
+        keyboard.press.assert_not_called()
+
     async def test_dry_run_returns_confirmation_required(self, mock_page):
         """send_message with confirm_send=False returns confirmation_required status."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8978,6 +8978,68 @@ class TestSendMessageComposerInteraction:
         # The confirmation receives exactly the baseline taken before the click.
         assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
 
+    @pytest.mark.parametrize(
+        "side_effect",
+        [
+            ["focused", PatchrightError("execution context was destroyed")],
+            ["focused", False],
+        ],
+        ids=["click", "enter"],
+    )
+    async def test_interrupted_submission_is_not_a_failure(
+        self, mock_page, side_effect
+    ):
+        """A submission that dies mid-call is an unknown, never a tool error.
+
+        Both paths dispatch their input event inside the call that then
+        fails, so the exception says nothing about whether the message left.
+        Letting it out would reach the caller as a plain failure and invite
+        the retry that delivers a second message to a real person.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock(
+            side_effect=PatchrightError("execution context was destroyed")
+        )
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(side_effect=side_effect)
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+            ) as visible,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        # There is no page left to read, so the confirmation is never even
+        # attempted; the answer comes from the interruption itself.
+        visible.assert_not_awaited()
+
     async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -9040,6 +9040,66 @@ class TestSendMessageComposerInteraction:
         # attempted; the answer comes from the interruption itself.
         visible.assert_not_awaited()
 
+    @pytest.mark.parametrize("stage", ["dispatch", "confirmation"])
+    async def test_cancellation_after_dispatch_is_logged(
+        self, mock_page, caplog, stage
+    ):
+        """Cancellation in the destructive window leaves a warning behind.
+
+        FastMCP runs the tool inside ``anyio.fail_after()``, so the deadline
+        raises ``CancelledError`` past ``except Exception`` and discards
+        anything the cancelled scope returns. The caller therefore sees a
+        timeout carrying no ``retry_safe``, and this log line is the only
+        record that a message may already have left.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        if stage == "dispatch":
+            mock_page.evaluate = AsyncMock(
+                side_effect=["focused", asyncio.CancelledError()]
+            )
+            visible_effect = AsyncMock()
+        else:
+            mock_page.evaluate = AsyncMock(side_effect=["focused", True])
+            visible_effect = AsyncMock(side_effect=asyncio.CancelledError())
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch.object(extractor, "_message_text_visible", visible_effect),
+            caplog.at_level(
+                logging.WARNING, logger="linkedin_mcp_server.scraping.extractor"
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await extractor.send_message("testuser", "Hello!", confirm_send=True)
+
+        # Cancellation has to keep propagating, or the surrounding scope
+        # never unwinds. The warning names the duplicate-delivery risk that
+        # the discarded result can no longer report.
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("retry may deliver the message twice" in w for w in warnings), (
+            warnings
+        )
+
     async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -115,7 +115,7 @@ async def dom_page():
             await browser.close()
 
 
-async def send(page, html: str) -> dict:
+async def send(page, html: str, *, message: str = MESSAGE) -> dict:
     """Run the real send path against `html`, mocking discovery only."""
     await page.set_content(html)
     extractor = LinkedInExtractor(page)
@@ -134,7 +134,7 @@ async def send(page, html: str) -> dict:
             return_value=COMPOSE_URL,
         ),
     ):
-        return await extractor.send_message("fadi-eliwi", MESSAGE, confirm_send=True)
+        return await extractor.send_message("fadi-eliwi", message, confirm_send=True)
 
 
 async def text_of(page, selector: str) -> str:
@@ -142,6 +142,23 @@ async def text_of(page, selector: str) -> str:
 
 
 class TestSendConfirmationAgainstRealDom:
+    @pytest.mark.parametrize("message", ["", " \t\n"], ids=["empty", "whitespace"])
+    async def test_blank_message_leaves_existing_draft_untouched(
+        self, dom_page, message
+    ):
+        draft = "Confidential draft"
+        result = await send(
+            dom_page,
+            compose_page(DELIVERING_SEND_JS, draft=draft),
+            message=message,
+        )
+
+        assert result["status"] == "message_unavailable"
+        assert result["sent"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await text_of(dom_page, "#composer") == draft
+        assert await dom_page.locator("#thread .msg").count() == 1
+
     async def test_ineffective_send_is_not_confirmed(self, dom_page):
         # The reported failure: Send is clicked, the handler does nothing,
         # and the message stays in the composer next to an identical earlier

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -48,6 +48,17 @@ NOOP_SEND_JS = """
   });
 """
 
+# Goes read-only for the duration of an in-flight send and delivers nothing,
+# which is what a React composer commonly does while it waits. The text stays
+# on screen the whole time, so an occurrence subtracted at baseline has to
+# stay subtracted or this no-op confirms itself.
+READONLY_NOOP_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    document.getElementById('composer').setAttribute('contenteditable', 'false');
+  });
+"""
+
 # Moves the composer's text into the thread as a plain, non-editable entry,
 # which is what a delivered message looks like to the page.
 DELIVERING_SEND_JS = """
@@ -159,14 +170,44 @@ class TestSendConfirmationAgainstRealDom:
         assert await text_of(dom_page, "#composer") == draft
         assert await dom_page.locator("#thread .msg").count() == 1
 
+    async def test_existing_draft_is_never_sent_along(self, dom_page):
+        # Measured, and the reason this fixture carries a draft at all:
+        # `element.focus()` leaves the caret at the *start* of a
+        # contenteditable in Chromium, so a typed message lands in front of
+        # whatever the composer already held and LinkedIn delivers the two as
+        # one. The draft is the user's text and nobody asked for it to be
+        # sent, so the send refuses here. Clearing it instead would trade the
+        # leak for destroying it.
+        result = await send(dom_page, compose_page(DELIVERING_SEND_JS, draft=DRAFT))
+
+        assert result["status"] == "composer_occupied"
+        assert result["sent"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await text_of(dom_page, "#composer") == DRAFT.strip()
+        assert await dom_page.locator("#thread .msg").count() == 1
+
     async def test_ineffective_send_is_not_confirmed(self, dom_page):
         # The reported failure: Send is clicked, the handler does nothing,
         # and the message stays in the composer next to an identical earlier
-        # copy in the thread. Neither is evidence of delivery.
+        # copy in the thread. Neither is evidence of delivery. The click did
+        # happen, though, so the answer is "unknown" rather than "not sent".
         result = await send(dom_page, compose_page(NOOP_SEND_JS))
 
         assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
-        assert result["status"] == "send_unavailable"
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert await text_of(dom_page, "#composer") == MESSAGE
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_composer_going_read_only_does_not_confirm(self, dom_page):
+        # The same no-op, except the composer stops being editable while it
+        # waits. Counting only `[contenteditable="true"]` would stop
+        # subtracting the unsent text at exactly that moment and read its
+        # own draft as a delivery.
+        result = await send(dom_page, compose_page(READONLY_NOOP_SEND_JS))
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         assert await text_of(dom_page, "#composer") == MESSAGE
         assert await dom_page.locator("#thread .msg").count() == 1
@@ -175,18 +216,11 @@ class TestSendConfirmationAgainstRealDom:
         # Same page, same earlier copy, but the Send handler moves the text
         # into the thread. The count outside the composer grows, so this one
         # confirms where the ineffective click above did not.
-        result = await send(dom_page, compose_page(DELIVERING_SEND_JS, draft=DRAFT))
+        result = await send(dom_page, compose_page(DELIVERING_SEND_JS))
 
         assert result["status"] == "sent"
         assert result["sent"] is True
         assert await text_of(dom_page, "#composer") == ""
         entries = dom_page.locator("#thread .msg")
         assert await entries.count() == 2
-        # Measured, and the reason this fixture carries a draft at all:
-        # `element.focus()` leaves the caret at the *start* of a
-        # contenteditable in Chromium, so the typed message lands in front of
-        # whatever the composer already held. The delivered entry therefore
-        # reads message-then-draft. The confirmation is unaffected — it counts
-        # the message as a substring — but a composer with an unsent draft
-        # sends the two in that order.
-        assert (await entries.last.inner_text()).strip() == f"{MESSAGE}{DRAFT}".strip()
+        assert (await entries.last.inner_text()).strip() == MESSAGE

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -18,6 +18,7 @@ whether or not the send succeeds.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -56,6 +57,18 @@ READONLY_NOOP_SEND_JS = """
   document.getElementById('send').addEventListener('click', () => {
     document.body.setAttribute('data-clicked', 'true');
     document.getElementById('composer').setAttribute('contenteditable', 'false');
+  });
+"""
+
+# Clears the composer and delivers nothing, which is what an optimistic
+# reset followed by a failed submission leaves behind. This is the case that
+# separates "a new occurrence appeared" from "the editor went empty": a
+# confirmation that subtracted the draft only while the editor held text
+# would read the clearance itself as the delivery.
+CLEARING_NOOP_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    document.getElementById('composer').textContent = '';
   });
 """
 
@@ -116,6 +129,12 @@ async def dom_page():
             browser = await p.chromium.launch(channel="chromium", headless=True)
             page = await browser.new_page()
         except Exception as exc:  # browser binary missing
+            if os.environ.get("CI"):
+                # CI installs chromium before this suite runs, so a launch
+                # that fails there is a broken environment rather than an
+                # absent browser. Skipping would take every case in this file
+                # out of CI while the run stayed green.
+                raise
             pytest.skip(f"chromium unavailable: {exc}")
         # The confirmation waits on the page-level default, so a failed send
         # has to give up quickly here.
@@ -217,6 +236,22 @@ class TestSendConfirmationAgainstRealDom:
         # The click happened, so a retry can deliver the message twice.
         assert result["retry_safe"] is False
         assert await text_of(dom_page, "#composer") == MESSAGE
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_a_cleared_composer_alone_does_not_confirm(self, dom_page):
+        # The composer empties and nothing arrives in the thread. The count
+        # outside every editor is the same before and after, so this stays
+        # unconfirmed. Reading the clearance as delivery is the mistake this
+        # case exists to catch: an implementation that stopped subtracting
+        # the draft once the editor went empty would pass every other case
+        # in this file and confirm here.
+        result = await send(dom_page, compose_page(CLEARING_NOOP_SEND_JS))
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert await text_of(dom_page, "#composer") == ""
         assert await dom_page.locator("#thread .msg").count() == 1
 
     async def test_delivered_message_is_confirmed(self, dom_page):

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -1,0 +1,175 @@
+# tests/test_send_message_confirmation_dom.py
+"""Browser-DOM tests for the send_message post-send confirmation (issue #866).
+
+The unit suite mocks ``page.evaluate``, so none of what decides "sent" ever
+runs there: the JS focus, the keyboard typing into a contenteditable, the
+Send click and the occurrence count taken across the resulting DOM. These
+cases drive the production ``send_message`` path in headless chromium and
+replace navigation and recipient discovery only, so every step the
+confirmation depends on executes unchanged. Skipped automatically when
+chromium is not installed; run locally after
+``uv run patchright install chromium --no-shell``.
+
+Both fixtures place an identical earlier message in the thread, which is
+what made "the text is somewhere on the page" worthless as evidence: the
+composer holds the message before it is sent, and the earlier copy holds it
+whether or not the send succeeds.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+
+#: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
+#: worker so browser startups cannot compete with the DOM cases' wall-clock
+#: timers.
+#: Without that distribution mode the group mark is inert.
+pytestmark = [
+    pytest.mark.browser_dom,
+    pytest.mark.xdist_group("browser_runtime"),
+]
+
+DISPLAY_NAME = "Fadi Al Eliwi"
+MESSAGE = "UNDELIVERED SENTINEL"
+DRAFT = "Draft: "
+COMPOSE_URL = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
+
+# Records the click as a body attribute and does nothing else: the button is
+# visible and enabled, so the production JS click path succeeds while the
+# message never leaves the composer.
+NOOP_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+  });
+"""
+
+# Moves the composer's text into the thread as a plain, non-editable entry,
+# which is what a delivered message looks like to the page.
+DELIVERING_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    const composer = document.getElementById('composer');
+    const text = composer.innerText;
+    if (!text.trim()) return;
+    const entry = document.createElement('div');
+    entry.className = 'msg';
+    entry.textContent = text;
+    document.getElementById('thread').appendChild(entry);
+    composer.textContent = '';
+  });
+"""
+
+
+def compose_page(send_js: str, *, draft: str = "") -> str:
+    """A compose surface holding one earlier copy of the same message."""
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Messaging</title></head>
+  <body>
+    <main>
+      <h2 id="recipient">{DISPLAY_NAME}</h2>
+      <div id="thread">
+        <div class="msg">{MESSAGE}</div>
+      </div>
+      <div id="composer" role="textbox" contenteditable="true"
+        aria-label="Write a message…">{draft}</div>
+      <button id="send" type="submit">Send</button>
+    </main>
+    <script>{send_js}</script>
+  </body>
+</html>
+"""
+
+
+@pytest.fixture
+async def dom_page():
+    """Real chromium page, or skip when no browser is installed.
+
+    Only launch/setup is guarded by the skip — the ``yield`` is outside it
+    so an assertion failure or JS error in a test body is never swallowed
+    into a skip.
+
+    ``channel="chromium"`` names the browser this project installs. Without
+    it Playwright picks the *binary* from the ``headless`` flag alone and
+    asks for ``chromium-headless-shell``, which nothing here installs since
+    the setup moved to ``--no-shell``: the launch would fail and every case
+    in this file would skip itself, silently, wherever the real browser is.
+    """
+    async with async_playwright() as p:
+        try:
+            browser = await p.chromium.launch(channel="chromium", headless=True)
+            page = await browser.new_page()
+        except Exception as exc:  # browser binary missing
+            pytest.skip(f"chromium unavailable: {exc}")
+        # The confirmation waits on the page-level default, so a failed send
+        # has to give up quickly here.
+        page.set_default_timeout(1500)
+        try:
+            yield page
+        finally:
+            await browser.close()
+
+
+async def send(page, html: str) -> dict:
+    """Run the real send path against `html`, mocking discovery only."""
+    await page.set_content(html)
+    extractor = LinkedInExtractor(page)
+    with (
+        patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+        patch.object(
+            extractor,
+            "_read_profile_display_name",
+            new_callable=AsyncMock,
+            return_value=DISPLAY_NAME,
+        ),
+        patch.object(
+            extractor,
+            "_resolve_message_compose_href",
+            new_callable=AsyncMock,
+            return_value=COMPOSE_URL,
+        ),
+    ):
+        return await extractor.send_message("fadi-eliwi", MESSAGE, confirm_send=True)
+
+
+async def text_of(page, selector: str) -> str:
+    return (await page.locator(selector).inner_text()).strip()
+
+
+class TestSendConfirmationAgainstRealDom:
+    async def test_ineffective_send_is_not_confirmed(self, dom_page):
+        # The reported failure: Send is clicked, the handler does nothing,
+        # and the message stays in the composer next to an identical earlier
+        # copy in the thread. Neither is evidence of delivery.
+        result = await send(dom_page, compose_page(NOOP_SEND_JS))
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unavailable"
+        assert result["sent"] is False
+        assert await text_of(dom_page, "#composer") == MESSAGE
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_delivered_message_is_confirmed(self, dom_page):
+        # Same page, same earlier copy, but the Send handler moves the text
+        # into the thread. The count outside the composer grows, so this one
+        # confirms where the ineffective click above did not.
+        result = await send(dom_page, compose_page(DELIVERING_SEND_JS, draft=DRAFT))
+
+        assert result["status"] == "sent"
+        assert result["sent"] is True
+        assert await text_of(dom_page, "#composer") == ""
+        entries = dom_page.locator("#thread .msg")
+        assert await entries.count() == 2
+        # Measured, and the reason this fixture carries a draft at all:
+        # `element.focus()` leaves the caret at the *start* of a
+        # contenteditable in Chromium, so the typed message lands in front of
+        # whatever the composer already held. The delivered entry therefore
+        # reads message-then-draft. The confirmation is unaffected — it counts
+        # the message as a substring — but a composer with an unsent draft
+        # sends the two in that order.
+        assert (await entries.last.inner_text()).strip() == f"{MESSAGE}{DRAFT}".strip()

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -164,8 +164,9 @@ class TestSendConfirmationAgainstRealDom:
             message=message,
         )
 
-        assert result["status"] == "message_unavailable"
+        assert result["status"] == "invalid_message"
         assert result["sent"] is False
+        assert result["retry_safe"] is True
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
         assert await text_of(dom_page, "#composer") == draft
         assert await dom_page.locator("#thread .msg").count() == 1
@@ -182,6 +183,8 @@ class TestSendConfirmationAgainstRealDom:
 
         assert result["status"] == "composer_occupied"
         assert result["sent"] is False
+        # Nothing was submitted, so calling again cannot deliver twice.
+        assert result["retry_safe"] is True
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
         assert await text_of(dom_page, "#composer") == DRAFT.strip()
         assert await dom_page.locator("#thread .msg").count() == 1
@@ -196,6 +199,8 @@ class TestSendConfirmationAgainstRealDom:
         assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
+        # The click happened, so a retry can deliver the message twice.
+        assert result["retry_safe"] is False
         assert await text_of(dom_page, "#composer") == MESSAGE
         assert await dom_page.locator("#thread .msg").count() == 1
 
@@ -209,6 +214,8 @@ class TestSendConfirmationAgainstRealDom:
         assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
+        # The click happened, so a retry can deliver the message twice.
+        assert result["retry_safe"] is False
         assert await text_of(dom_page, "#composer") == MESSAGE
         assert await dom_page.locator("#thread .msg").count() == 1
 
@@ -220,6 +227,7 @@ class TestSendConfirmationAgainstRealDom:
 
         assert result["status"] == "sent"
         assert result["sent"] is True
+        assert result["retry_safe"] is False
         assert await text_of(dom_page, "#composer") == ""
         entries = dom_page.locator("#thread .msg")
         assert await entries.count() == 2

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1060,12 +1060,16 @@ class TestMessagingTools:
         assert str(excinfo.value) == str(cause) != ""
 
     @pytest.mark.parametrize(
-        ("retry_safe", "warns"),
-        [(False, True), (True, False)],
-        ids=["submitted", "retry-safe"],
+        ("result", "warns"),
+        [
+            ({"status": "sent", "sent": True, "retry_safe": False}, True),
+            ({"status": "send_unconfirmed", "sent": False, "retry_safe": False}, True),
+            ({"status": "composer_occupied", "sent": False, "retry_safe": True}, False),
+        ],
+        ids=["sent", "unconfirmed", "refused"],
     )
     async def test_cancelled_completion_notification_warns(
-        self, mock_context, caplog, retry_safe, warns
+        self, mock_context, caplog, result, warns
     ):
         """The last await can discard an answer that says a message went out.
 
@@ -1076,18 +1080,21 @@ class TestMessagingTools:
         the log line is then the only record.
 
         Silent where the result says a retry is safe: nothing was submitted,
-        so there is no duplicate delivery to warn about.
+        so there is no duplicate delivery to warn about. That is `retry_safe`
+        and not the status, which is why a confirmed send is parametrized
+        here alongside an unconfirmed one.
         """
         from linkedin_mcp_server.scraping.extractor import SEND_INTERRUPTED_WARNING
         from linkedin_mcp_server.tools.messaging import register_messaging_tools
 
         mock_extractor = _make_mock_extractor({})
+        # Only shapes the extractor can actually return. A confirmed send is
+        # the one that most needs the warning and the one an implementation
+        # keyed on `status == "send_unconfirmed"` would silently drop.
         mock_extractor.send_message = AsyncMock(
             return_value={
                 "url": "https://www.linkedin.com/messaging/compose/",
-                "status": "send_unconfirmed" if retry_safe is False else "sent",
-                "sent": False,
-                "retry_safe": retry_safe,
+                **result,
             }
         )
         # Only the completion notification is cancelled; the one before the

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1017,6 +1017,47 @@ class TestMessagingTools:
         assert result["retry_safe"] is True
         assert result["url"] == "https://www.linkedin.com/in/testuser/"
 
+    @pytest.mark.parametrize(
+        "username",
+        ["", "me", "https://www.linkedin.com/company/microsoft/"],
+        ids=["empty", "self-alias", "not-a-person"],
+    )
+    async def test_blank_message_with_an_unusable_recipient_is_mapped(
+        self, mock_context, username
+    ):
+        """A recipient the refusal cannot name still reaches the error mapping.
+
+        Building the refusal normalizes the recipient, so a username that
+        cannot become a profile URL raises `InvalidReferenceError` from inside
+        the guard. Raised past `raise_tool_error` it would arrive at the caller
+        as a generic masked error (`mask_error_details=True` in `server.py`),
+        which drops the one sentence that says what to correct.
+        """
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.core.exceptions import InvalidReferenceError
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "send_message")
+        with (
+            patch(
+                "linkedin_mcp_server.tools.messaging.get_ready_extractor",
+                new_callable=AsyncMock,
+            ) as ready,
+            pytest.raises(ToolError) as excinfo,
+        ):
+            await tool_fn(username, "", True, mock_context)
+
+        ready.assert_not_awaited()
+        # A ToolError is what `mask_error_details` lets through, so the
+        # correction the message names reaches the caller intact.
+        cause = excinfo.value.__cause__
+        assert isinstance(cause, InvalidReferenceError)
+        assert str(excinfo.value) == str(cause) != ""
+
     async def test_send_message_with_profile_urn(self, mock_context):
         expected = {
             "url": "https://www.linkedin.com/messaging/thread/abc123/",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -987,6 +987,36 @@ class TestMessagingTools:
             "testuser", "Hello!", confirm_send=True, profile_urn=None
         )
 
+    @pytest.mark.parametrize("message", ["", "   \t\n"], ids=["empty", "whitespace"])
+    async def test_send_message_refuses_blank_before_a_session(
+        self, mock_context, message
+    ):
+        """A blank message is answered without acquiring a browser session.
+
+        The extractor keeps the same guard, but it only runs once a session
+        exists. Reaching it means `get_ready_extractor` has already had the
+        chance to spend a login attempt and answer with an authentication
+        error, which is not the refusal the caller can act on.
+        """
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "send_message")
+        with patch(
+            "linkedin_mcp_server.tools.messaging.get_ready_extractor",
+            new_callable=AsyncMock,
+        ) as ready:
+            result = await tool_fn("testuser", message, True, mock_context)
+
+        ready.assert_not_awaited()
+        assert result["status"] == "invalid_message"
+        assert result["sent"] is False
+        # Nothing was submitted, so calling again cannot deliver twice.
+        assert result["retry_safe"] is True
+        assert result["url"] == "https://www.linkedin.com/in/testuser/"
+
     async def test_send_message_with_profile_urn(self, mock_context):
         expected = {
             "url": "https://www.linkedin.com/messaging/thread/abc123/",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from types import SimpleNamespace
 from typing import Any, Callable, Coroutine, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1057,6 +1058,64 @@ class TestMessagingTools:
         cause = excinfo.value.__cause__
         assert isinstance(cause, InvalidReferenceError)
         assert str(excinfo.value) == str(cause) != ""
+
+    @pytest.mark.parametrize(
+        ("retry_safe", "warns"),
+        [(False, True), (True, False)],
+        ids=["submitted", "retry-safe"],
+    )
+    async def test_cancelled_completion_notification_warns(
+        self, mock_context, caplog, retry_safe, warns
+    ):
+        """The last await can discard an answer that says a message went out.
+
+        `ctx.report_progress` is the final await inside FastMCP's
+        `anyio.fail_after()`, so a deadline landing there raises
+        `CancelledError` past `except Exception` and throws away the result
+        the send already produced. Nothing can hand it back afterwards, and
+        the log line is then the only record.
+
+        Silent where the result says a retry is safe: nothing was submitted,
+        so there is no duplicate delivery to warn about.
+        """
+        from linkedin_mcp_server.scraping.extractor import SEND_INTERRUPTED_WARNING
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mock_extractor = _make_mock_extractor({})
+        mock_extractor.send_message = AsyncMock(
+            return_value={
+                "url": "https://www.linkedin.com/messaging/compose/",
+                "status": "send_unconfirmed" if retry_safe is False else "sent",
+                "sent": False,
+                "retry_safe": retry_safe,
+            }
+        )
+        # Only the completion notification is cancelled; the one before the
+        # send has to pass or the send never runs.
+        mock_context.report_progress = AsyncMock(
+            side_effect=[None, asyncio.CancelledError()]
+        )
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+        tool_fn = await get_tool_fn(mcp, "send_message")
+
+        with (
+            patch(
+                "linkedin_mcp_server.tools.messaging.get_ready_extractor",
+                new_callable=AsyncMock,
+                return_value=mock_extractor,
+            ),
+            caplog.at_level(
+                logging.WARNING, logger="linkedin_mcp_server.tools.messaging"
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await tool_fn("testuser", "Hello!", True, mock_context)
+
+        mock_extractor.send_message.assert_awaited_once()
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert (SEND_INTERRUPTED_WARNING in warnings) is warns, warnings
 
     async def test_send_message_with_profile_urn(self, mock_context):
         expected = {


### PR DESCRIPTION
Closes #866.

`send_message` could treat composer text or an older matching message as success. A blank send could also submit an existing draft.

This stage excludes visible editor text from send evidence, baselines matching message text immediately before submission, refuses occupied composers, rejects blank input before browser acquisition, and adds `retry_safe` so callers can distinguish a safe refusal from an ambiguous attempt. Cancellation preserves that ambiguity and emits a warning when FastMCP can no longer return the result. This PR must merge with its safety follow-up, #896.

Verification: 3,255 tests passed locally in sequential and CI-style xdist runs. Ruff, ty, pre-commit, and Chromium DOM regressions passed.

## Synthetic prompt

> Make message submission evidence exclude composer text and old matching messages. Refuse blank input and occupied drafts, preserve cancellation ambiguity, and expose whether retrying can duplicate a send.

Generated with GPT-5.6 Sol
