### PR TITLE
Add mark read/unread and archive conversation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_conversation` | Read a specific messaging conversation by username or thread ID |
 | `search_conversations` | Search messages by keyword |
 | `send_message` | Send a message to a LinkedIn user (requires confirmation) |
+| `archive_conversation` | Archive a conversation thread (requires confirmation) |
+| `unarchive_conversation` | Restore an archived conversation to the inbox (requires confirmation) |
+| `mark_conversation_read` | Mark a conversation as read without opening it |
+| `mark_conversation_unread` | Mark a conversation as unread without opening it |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed |
 | `search_companies` | Search for companies on LinkedIn by keywords |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -10,7 +10,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Own Profile**: Fetch the authenticated user's own profile to give agents self-context
 - **Profile Connections**: Send connection requests or accept incoming ones, with optional notes
 - **Sidebar Profiles**: Extract profile URLs from the sidebar recommendation sections on a profile page ("More profiles for you", "Explore premium profiles", "People you may know")
-- **Messaging**: List the inbox, read a conversation by username or thread ID, search messages by keyword, and send a message with explicit confirmation
+- **Messaging**: List the inbox, read a conversation by username or thread ID, search messages by keyword, send a message with explicit confirmation, and manage conversation state (archive, unarchive, mark read/unread)
 - **Company Profiles**: Extract comprehensive company data, including the LinkedIn company URN id (used by LinkedIn's people-search `currentCompany` URL facet)
 - **Company Employees**: List employees at a company with optional keyword filtering
 - **Company Search**: Search for companies by keyword

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5187,7 +5187,7 @@ class LinkedInExtractor:
                 }""",
                 {"threadId": thread_id},
             )
-        else:
+        elif action in {"archive", "unarchive"}:
             archive_value = action == "archive"
             result = await self._page.evaluate(
                 """async ({ threadId, archiveValue }) => {
@@ -5220,6 +5220,8 @@ class LinkedInExtractor:
                 }""",
                 {"threadId": thread_id, "archiveValue": archive_value},
             )
+        else:
+            raise ValueError(f"Unsupported conversation action: {action}")
 
         if result.get("ok"):
             return self._message_action_result(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5124,6 +5124,9 @@ class LinkedInExtractor:
         except PlaywrightTimeoutError:
             logger.debug("Messaging inbox did not fully load for %s", thread_id)
 
+        # DOM dependency: Voyager calls need fetch() inside the page context so
+        # the session cookies and CSRF token match the browser. URL navigation
+        # alone cannot flip read/archive state.
         if action == "mark_read":
             result = await self._page.evaluate(
                 """async ({ threadId }) => {
@@ -5272,9 +5275,7 @@ class LinkedInExtractor:
     ) -> dict[str, Any]:
         """Mark a conversation as unread without opening it."""
         thread_id = normalize_thread_id(thread_id)
-        return await self._voyager_conversation_action(
-            thread_id, action="mark_unread"
-        )
+        return await self._voyager_conversation_action(thread_id, action="mark_unread")
 
     async def _extract_root_content(
         self,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5088,6 +5088,194 @@ class LinkedInExtractor:
             sent=True,
         )
 
+    _MESSAGING_INBOX_URL = "https://www.linkedin.com/messaging/"
+
+    async def _voyager_conversation_action(
+        self,
+        thread_id: str,
+        *,
+        action: str,
+        confirm_action: bool = False,
+    ) -> dict[str, Any]:
+        """Perform a Voyager API action on a conversation thread.
+
+        Calls LinkedIn's internal Voyager API from within the authenticated
+        browser session using ``page.evaluate()``. The CSRF token comes from
+        the ``csrf-token`` meta tag, and cookies/TLS fingerprint come from the
+        real browser session.
+
+        Navigation stays on the inbox so opening a thread does not clear unread
+        badges as a side effect.
+        """
+        thread_url = messaging_thread_url(thread_id, "/")
+
+        if action in {"archive", "unarchive"} and not confirm_action:
+            return self._message_action_result(
+                thread_url,
+                "confirmation_required",
+                f"Set confirm_action=true to {action} this conversation.",
+            )
+
+        await self._navigate_to_page(self._MESSAGING_INBOX_URL)
+        await detect_rate_limit(self._page)
+
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("Messaging inbox did not fully load for %s", thread_id)
+
+        if action == "mark_read":
+            result = await self._page.evaluate(
+                """async ({ threadId }) => {
+                    const csrfToken = document.querySelector(
+                        'meta[name="csrf-token"]'
+                    )?.getAttribute('content') || '';
+                    try {
+                        const resp = await fetch(
+                            '/voyager/api/messaging/conversations/'
+                            + encodeURIComponent(threadId)
+                            + '/events?action=markAsRead',
+                            {
+                                method: 'POST',
+                                headers: {
+                                    'csrf-token': csrfToken,
+                                    'content-type': 'application/json',
+                                    'x-restli-method': 'CREATE',
+                                },
+                                credentials: 'same-origin',
+                            }
+                        );
+                        return { ok: resp.ok, status: resp.status };
+                    } catch (e) {
+                        return { ok: false, status: 0, error: String(e) };
+                    }
+                }""",
+                {"threadId": thread_id},
+            )
+        elif action == "mark_unread":
+            result = await self._page.evaluate(
+                """async ({ threadId }) => {
+                    const csrfToken = document.querySelector(
+                        'meta[name="csrf-token"]'
+                    )?.getAttribute('content') || '';
+                    try {
+                        const resp = await fetch(
+                            '/voyager/api/messaging/conversations/'
+                            + encodeURIComponent(threadId),
+                            {
+                                method: 'PATCH',
+                                headers: {
+                                    'csrf-token': csrfToken,
+                                    'content-type': 'application/json',
+                                    'x-restli-method': 'PARTIAL_UPDATE',
+                                },
+                                credentials: 'same-origin',
+                                body: JSON.stringify({
+                                    patch: {
+                                        $set: { read: false }
+                                    }
+                                }),
+                            }
+                        );
+                        return { ok: resp.ok, status: resp.status };
+                    } catch (e) {
+                        return { ok: false, status: 0, error: String(e) };
+                    }
+                }""",
+                {"threadId": thread_id},
+            )
+        else:
+            archive_value = action == "archive"
+            result = await self._page.evaluate(
+                """async ({ threadId, archiveValue }) => {
+                    const csrfToken = document.querySelector(
+                        'meta[name="csrf-token"]'
+                    )?.getAttribute('content') || '';
+                    try {
+                        const resp = await fetch(
+                            '/voyager/api/messaging/conversations/'
+                            + encodeURIComponent(threadId),
+                            {
+                                method: 'PATCH',
+                                headers: {
+                                    'csrf-token': csrfToken,
+                                    'content-type': 'application/json',
+                                    'x-restli-method': 'PARTIAL_UPDATE',
+                                },
+                                credentials: 'same-origin',
+                                body: JSON.stringify({
+                                    patch: {
+                                        $set: { archived: archiveValue }
+                                    }
+                                }),
+                            }
+                        );
+                        return { ok: resp.ok, status: resp.status };
+                    } catch (e) {
+                        return { ok: false, status: 0, error: String(e) };
+                    }
+                }""",
+                {"threadId": thread_id, "archiveValue": archive_value},
+            )
+
+        if result.get("ok"):
+            return self._message_action_result(
+                thread_url,
+                action,
+                f"Conversation {action.replace('_', ' ')} successful.",
+            )
+
+        status_code = result.get("status", 0)
+        error_detail = result.get("error", "")
+        return self._message_action_result(
+            thread_url,
+            f"{action}_failed",
+            f"LinkedIn returned status {status_code}"
+            + (f": {error_detail}" if error_detail else ""),
+        )
+
+    async def archive_conversation(
+        self,
+        thread_id: str,
+        *,
+        confirm_action: bool = False,
+    ) -> dict[str, Any]:
+        """Archive a conversation thread."""
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(
+            thread_id, action="archive", confirm_action=confirm_action
+        )
+
+    async def unarchive_conversation(
+        self,
+        thread_id: str,
+        *,
+        confirm_action: bool = False,
+    ) -> dict[str, Any]:
+        """Restore an archived conversation to the inbox."""
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(
+            thread_id, action="unarchive", confirm_action=confirm_action
+        )
+
+    async def mark_conversation_read(
+        self,
+        thread_id: str,
+    ) -> dict[str, Any]:
+        """Mark a conversation as read without opening it."""
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(thread_id, action="mark_read")
+
+    async def mark_conversation_unread(
+        self,
+        thread_id: str,
+    ) -> dict[str, Any]:
+        """Mark a conversation as unread without opening it."""
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(
+            thread_id, action="mark_unread"
+        )
+
     async def _extract_root_content(
         self,
         selectors: list[str],

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5222,7 +5222,7 @@ class LinkedInExtractor:
                 }""",
                 {"threadId": thread_id},
             )
-        else:
+        elif action in {"archive", "unarchive"}:
             archive_value = action == "archive"
             result = await self._page.evaluate(
                 """async ({ threadId, archiveValue }) => {
@@ -5255,6 +5255,8 @@ class LinkedInExtractor:
                 }""",
                 {"threadId": thread_id, "archiveValue": archive_value},
             )
+        else:
+            raise ValueError(f"Unsupported conversation action: {action}")
 
         if result.get("ok"):
             return self._message_action_result(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5123,6 +5123,194 @@ class LinkedInExtractor:
             sent=True,
         )
 
+    _MESSAGING_INBOX_URL = "https://www.linkedin.com/messaging/"
+
+    async def _voyager_conversation_action(
+        self,
+        thread_id: str,
+        *,
+        action: str,
+        confirm_action: bool = False,
+    ) -> dict[str, Any]:
+        """Perform a Voyager API action on a conversation thread.
+
+        Calls LinkedIn's internal Voyager API from within the authenticated
+        browser session using ``page.evaluate()``. The CSRF token comes from
+        the ``csrf-token`` meta tag, and cookies/TLS fingerprint come from the
+        real browser session.
+
+        Navigation stays on the inbox so opening a thread does not clear unread
+        badges as a side effect.
+        """
+        thread_url = messaging_thread_url(thread_id, "/")
+
+        if action in {"archive", "unarchive"} and not confirm_action:
+            return self._message_action_result(
+                thread_url,
+                "confirmation_required",
+                f"Set confirm_action=true to {action} this conversation.",
+            )
+
+        await self._navigate_to_page(self._MESSAGING_INBOX_URL)
+        await detect_rate_limit(self._page)
+
+        try:
+            await self._page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("Messaging inbox did not fully load for %s", thread_id)
+
+        if action == "mark_read":
+            result = await self._page.evaluate(
+                """async ({ threadId }) => {
+                    const csrfToken = document.querySelector(
+                        'meta[name="csrf-token"]'
+                    )?.getAttribute('content') || '';
+                    try {
+                        const resp = await fetch(
+                            '/voyager/api/messaging/conversations/'
+                            + encodeURIComponent(threadId)
+                            + '/events?action=markAsRead',
+                            {
+                                method: 'POST',
+                                headers: {
+                                    'csrf-token': csrfToken,
+                                    'content-type': 'application/json',
+                                    'x-restli-method': 'CREATE',
+                                },
+                                credentials: 'same-origin',
+                            }
+                        );
+                        return { ok: resp.ok, status: resp.status };
+                    } catch (e) {
+                        return { ok: false, status: 0, error: String(e) };
+                    }
+                }""",
+                {"threadId": thread_id},
+            )
+        elif action == "mark_unread":
+            result = await self._page.evaluate(
+                """async ({ threadId }) => {
+                    const csrfToken = document.querySelector(
+                        'meta[name="csrf-token"]'
+                    )?.getAttribute('content') || '';
+                    try {
+                        const resp = await fetch(
+                            '/voyager/api/messaging/conversations/'
+                            + encodeURIComponent(threadId),
+                            {
+                                method: 'PATCH',
+                                headers: {
+                                    'csrf-token': csrfToken,
+                                    'content-type': 'application/json',
+                                    'x-restli-method': 'PARTIAL_UPDATE',
+                                },
+                                credentials: 'same-origin',
+                                body: JSON.stringify({
+                                    patch: {
+                                        $set: { read: false }
+                                    }
+                                }),
+                            }
+                        );
+                        return { ok: resp.ok, status: resp.status };
+                    } catch (e) {
+                        return { ok: false, status: 0, error: String(e) };
+                    }
+                }""",
+                {"threadId": thread_id},
+            )
+        else:
+            archive_value = action == "archive"
+            result = await self._page.evaluate(
+                """async ({ threadId, archiveValue }) => {
+                    const csrfToken = document.querySelector(
+                        'meta[name="csrf-token"]'
+                    )?.getAttribute('content') || '';
+                    try {
+                        const resp = await fetch(
+                            '/voyager/api/messaging/conversations/'
+                            + encodeURIComponent(threadId),
+                            {
+                                method: 'PATCH',
+                                headers: {
+                                    'csrf-token': csrfToken,
+                                    'content-type': 'application/json',
+                                    'x-restli-method': 'PARTIAL_UPDATE',
+                                },
+                                credentials: 'same-origin',
+                                body: JSON.stringify({
+                                    patch: {
+                                        $set: { archived: archiveValue }
+                                    }
+                                }),
+                            }
+                        );
+                        return { ok: resp.ok, status: resp.status };
+                    } catch (e) {
+                        return { ok: false, status: 0, error: String(e) };
+                    }
+                }""",
+                {"threadId": thread_id, "archiveValue": archive_value},
+            )
+
+        if result.get("ok"):
+            return self._message_action_result(
+                thread_url,
+                action,
+                f"Conversation {action.replace('_', ' ')} successful.",
+            )
+
+        status_code = result.get("status", 0)
+        error_detail = result.get("error", "")
+        return self._message_action_result(
+            thread_url,
+            f"{action}_failed",
+            f"LinkedIn returned status {status_code}"
+            + (f": {error_detail}" if error_detail else ""),
+        )
+
+    async def archive_conversation(
+        self,
+        thread_id: str,
+        *,
+        confirm_action: bool = False,
+    ) -> dict[str, Any]:
+        """Archive a conversation thread."""
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(
+            thread_id, action="archive", confirm_action=confirm_action
+        )
+
+    async def unarchive_conversation(
+        self,
+        thread_id: str,
+        *,
+        confirm_action: bool = False,
+    ) -> dict[str, Any]:
+        """Restore an archived conversation to the inbox."""
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(
+            thread_id, action="unarchive", confirm_action=confirm_action
+        )
+
+    async def mark_conversation_read(
+        self,
+        thread_id: str,
+    ) -> dict[str, Any]:
+        """Mark a conversation as read without opening it."""
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(thread_id, action="mark_read")
+
+    async def mark_conversation_unread(
+        self,
+        thread_id: str,
+    ) -> dict[str, Any]:
+        """Mark a conversation as unread without opening it."""
+        thread_id = normalize_thread_id(thread_id)
+        return await self._voyager_conversation_action(
+            thread_id, action="mark_unread"
+        )
+
     async def _extract_root_content(
         self,
         selectors: list[str],

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5159,6 +5159,9 @@ class LinkedInExtractor:
         except PlaywrightTimeoutError:
             logger.debug("Messaging inbox did not fully load for %s", thread_id)
 
+        # DOM dependency: Voyager calls need fetch() inside the page context so
+        # the session cookies and CSRF token match the browser. URL navigation
+        # alone cannot flip read/archive state.
         if action == "mark_read":
             result = await self._page.evaluate(
                 """async ({ threadId }) => {
@@ -5307,9 +5310,7 @@ class LinkedInExtractor:
     ) -> dict[str, Any]:
         """Mark a conversation as unread without opening it."""
         thread_id = normalize_thread_id(thread_id)
-        return await self._voyager_conversation_action(
-            thread_id, action="mark_unread"
-        )
+        return await self._voyager_conversation_action(thread_id, action="mark_unread")
 
     async def _extract_root_content(
         self,

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -276,3 +276,217 @@ def register_messaging_tools(
                 raise_tool_error(relogin_exc, "send_message")
         except Exception as e:
             raise_tool_error(e, "send_message")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Archive Conversation",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"messaging", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def archive_conversation(
+        thread_id: str,
+        confirm_action: bool,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Archive a LinkedIn conversation thread.
+
+        Moves the conversation to LinkedIn's archived folder. The thread
+        remains accessible and can be unarchived. This is a write operation
+        that requires confirmation.
+
+        Args:
+            thread_id: LinkedIn messaging thread ID (from get_inbox or
+                search_conversations references)
+            confirm_action: Must be True to archive. False does a dry run.
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, status, message, and action result.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="archive_conversation"
+            )
+            logger.info(
+                "Archiving conversation %s (confirm_action=%s)",
+                thread_id,
+                confirm_action,
+            )
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Archiving conversation"
+            )
+
+            result = await extractor.archive_conversation(
+                thread_id, confirm_action=confirm_action
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "archive_conversation")
+        except Exception as e:
+            raise_tool_error(e, "archive_conversation")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Unarchive Conversation",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"messaging", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def unarchive_conversation(
+        thread_id: str,
+        confirm_action: bool,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Restore an archived conversation to the inbox.
+
+        Args:
+            thread_id: LinkedIn messaging thread ID
+            confirm_action: Must be True to unarchive. False does a dry run.
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, status, message, and action result.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="unarchive_conversation"
+            )
+            logger.info(
+                "Unarchiving conversation %s (confirm_action=%s)",
+                thread_id,
+                confirm_action,
+            )
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Unarchiving conversation"
+            )
+
+            result = await extractor.unarchive_conversation(
+                thread_id, confirm_action=confirm_action
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "unarchive_conversation")
+        except Exception as e:
+            raise_tool_error(e, "unarchive_conversation")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Mark Conversation Read",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"messaging", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def mark_conversation_read(
+        thread_id: str,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Mark a conversation as read without opening it.
+
+        Clears the unread badge on the conversation. Unlike
+        get_conversation, this does not navigate to the thread content
+        and does not mark it read as a side effect of viewing — it calls
+        the Voyager mark-as-read endpoint directly.
+
+        Args:
+            thread_id: LinkedIn messaging thread ID
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, status, message, and action result.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="mark_conversation_read"
+            )
+            logger.info("Marking conversation %s as read", thread_id)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Marking conversation read"
+            )
+
+            result = await extractor.mark_conversation_read(thread_id)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "mark_conversation_read")
+        except Exception as e:
+            raise_tool_error(e, "mark_conversation_read")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Mark Conversation Unread",
+        annotations={"destructiveHint": True, "openWorldHint": True},
+        tags={"messaging", "actions"},
+        exclude_args=["extractor"],
+    )
+    async def mark_conversation_unread(
+        thread_id: str,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Mark a conversation as unread without opening it.
+
+        Restores the unread badge on a conversation. Useful after
+        get_conversation or search_conversations has marked a thread read as
+        a side effect, or to flag a conversation for follow-up.
+
+        Args:
+            thread_id: LinkedIn messaging thread ID
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, status, message, and action result.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="mark_conversation_unread"
+            )
+            logger.info("Marking conversation %s as unread", thread_id)
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Marking conversation unread"
+            )
+
+            result = await extractor.mark_conversation_unread(thread_id)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "mark_conversation_unread")
+        except Exception as e:
+            raise_tool_error(e, "mark_conversation_unread")  # NoReturn

--- a/manifest.json
+++ b/manifest.json
@@ -112,6 +112,22 @@
       "description": "Send a message to a LinkedIn user with explicit confirmation and optional profile URN support"
     },
     {
+      "name": "archive_conversation",
+      "description": "Archive a LinkedIn conversation thread, moving it to the archived folder"
+    },
+    {
+      "name": "unarchive_conversation",
+      "description": "Restore an archived conversation back to the inbox"
+    },
+    {
+      "name": "mark_conversation_read",
+      "description": "Mark a conversation as read without opening it, clearing the unread badge"
+    },
+    {
+      "name": "mark_conversation_unread",
+      "description": "Mark a conversation as unread without opening it, restoring the unread badge"
+    },
+    {
       "name": "get_feed",
       "description": "Get recent posts from the authenticated user's LinkedIn home feed"
     },

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -4728,7 +4728,7 @@ class TestRealOwner:
             # in a `register_*` call.
             assert "get_person_profile" in names
             assert "close_session" in names
-            assert len(names) == 19, sorted(names)
+            assert len(names) == 23, sorted(names)
         finally:
             _stop(result.get("pid"))
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8918,6 +8918,14 @@ class TestVoyagerConversationAction:
         assert result["status"] == "mark_unread"
         mock_page.evaluate.assert_awaited_once()
 
+    async def test_unsupported_action_raises(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+
+        with pytest.raises(ValueError, match="Unsupported conversation action"):
+            await extractor._voyager_conversation_action(
+                "2-abc123==", action="not-a-real-action"
+            )
+
 
 class TestBuildFeedReferences:
     """Tests for _build_feed_references SDUI-capture / DOM-anchor merging."""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8865,6 +8865,60 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.press.assert_awaited_once_with("Enter")
 
 
+class TestVoyagerConversationAction:
+    async def test_archive_dry_run_skips_navigation(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        navigate = patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock)
+
+        with navigate as mock_navigate:
+            result = await extractor.archive_conversation(
+                "2-abc123==", confirm_action=False
+            )
+
+        assert result["status"] == "confirmation_required"
+        mock_navigate.assert_not_awaited()
+
+    async def test_mark_read_uses_inbox_navigation(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value={"ok": True, "status": 200})
+        mock_page.wait_for_selector = AsyncMock()
+
+        with (
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as mock_navigate,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.mark_conversation_read("2-abc123==")
+
+        mock_navigate.assert_awaited_once_with("https://www.linkedin.com/messaging/")
+        assert result["status"] == "mark_read"
+        mock_page.evaluate.assert_awaited_once()
+
+    async def test_mark_unread_uses_inbox_navigation(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value={"ok": True, "status": 200})
+        mock_page.wait_for_selector = AsyncMock()
+
+        with (
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as mock_navigate,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.mark_conversation_unread("2-abc123==")
+
+        mock_navigate.assert_awaited_once_with("https://www.linkedin.com/messaging/")
+        assert result["status"] == "mark_unread"
+        mock_page.evaluate.assert_awaited_once()
+
+
 class TestBuildFeedReferences:
     """Tests for _build_feed_references SDUI-capture / DOM-anchor merging."""
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8868,6 +8868,60 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.press.assert_awaited_once_with("Enter")
 
 
+class TestVoyagerConversationAction:
+    async def test_archive_dry_run_skips_navigation(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        navigate = patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock)
+
+        with navigate as mock_navigate:
+            result = await extractor.archive_conversation(
+                "2-abc123==", confirm_action=False
+            )
+
+        assert result["status"] == "confirmation_required"
+        mock_navigate.assert_not_awaited()
+
+    async def test_mark_read_uses_inbox_navigation(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value={"ok": True, "status": 200})
+        mock_page.wait_for_selector = AsyncMock()
+
+        with (
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as mock_navigate,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.mark_conversation_read("2-abc123==")
+
+        mock_navigate.assert_awaited_once_with("https://www.linkedin.com/messaging/")
+        assert result["status"] == "mark_read"
+        mock_page.evaluate.assert_awaited_once()
+
+    async def test_mark_unread_uses_inbox_navigation(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value={"ok": True, "status": 200})
+        mock_page.wait_for_selector = AsyncMock()
+
+        with (
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as mock_navigate,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.mark_conversation_unread("2-abc123==")
+
+        mock_navigate.assert_awaited_once_with("https://www.linkedin.com/messaging/")
+        assert result["status"] == "mark_unread"
+        mock_page.evaluate.assert_awaited_once()
+
+
 class TestBuildFeedReferences:
     """Tests for _build_feed_references SDUI-capture / DOM-anchor merging."""
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8921,6 +8921,14 @@ class TestVoyagerConversationAction:
         assert result["status"] == "mark_unread"
         mock_page.evaluate.assert_awaited_once()
 
+    async def test_unsupported_action_raises(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+
+        with pytest.raises(ValueError, match="Unsupported conversation action"):
+            await extractor._voyager_conversation_action(
+                "2-abc123==", action="not-a-real-action"
+            )
+
 
 class TestBuildFeedReferences:
     """Tests for _build_feed_references SDUI-capture / DOM-anchor merging."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -935,3 +935,23 @@ class TestWhatTheToolsPromise:
             "these tools mark conversations as read, so they cannot be replayed "
             f"unattended: {sorted(marks_things_read & claiming)}"
         )
+
+    async def test_state_changing_messaging_tools_do_not_claim_read_only(self):
+        mcp = create_mcp_server()
+        state_changing = {
+            "archive_conversation",
+            "unarchive_conversation",
+            "mark_conversation_read",
+            "mark_conversation_unread",
+        }
+        claiming = set()
+        for name in state_changing:
+            tool = await mcp.get_tool(name)
+            assert tool is not None, f"{name} is not registered any more"
+            if tool.annotations and tool.annotations.readOnlyHint:
+                claiming.add(name)
+
+        assert not claiming, (
+            "these tools change conversation state and cannot be replayed "
+            f"unattended: {sorted(claiming)}"
+        )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -35,6 +35,10 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.get_conversation = AsyncMock(return_value=scrape_result)
     mock.search_conversations = AsyncMock(return_value=scrape_result)
     mock.send_message = AsyncMock(return_value=scrape_result)
+    mock.archive_conversation = AsyncMock(return_value=scrape_result)
+    mock.unarchive_conversation = AsyncMock(return_value=scrape_result)
+    mock.mark_conversation_read = AsyncMock(return_value=scrape_result)
+    mock.mark_conversation_unread = AsyncMock(return_value=scrape_result)
     mock.get_my_profile = AsyncMock(return_value=scrape_result)
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.search_posts = AsyncMock(return_value=scrape_result)
@@ -977,6 +981,142 @@ class TestMessagingTools:
                 extractor=mock_extractor,
             )
 
+    async def test_archive_conversation_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "archive",
+            "message": "Conversation archive successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "archive_conversation")
+        result = await tool_fn(
+            "2-abc123==", True, mock_context, extractor=mock_extractor
+        )
+
+        assert result["status"] == "archive"
+        mock_extractor.archive_conversation.assert_awaited_once_with(
+            "2-abc123==", confirm_action=True
+        )
+
+    async def test_archive_conversation_not_confirmed(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "confirmation_required",
+            "message": "Set confirm_action=true to archive this conversation.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "archive_conversation")
+        result = await tool_fn(
+            "2-abc123==", False, mock_context, extractor=mock_extractor
+        )
+
+        assert result["status"] == "confirmation_required"
+        mock_extractor.archive_conversation.assert_awaited_once_with(
+            "2-abc123==", confirm_action=False
+        )
+
+    async def test_unarchive_conversation_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "unarchive",
+            "message": "Conversation unarchive successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "unarchive_conversation")
+        result = await tool_fn(
+            "2-abc123==", True, mock_context, extractor=mock_extractor
+        )
+
+        assert result["status"] == "unarchive"
+        mock_extractor.unarchive_conversation.assert_awaited_once_with(
+            "2-abc123==", confirm_action=True
+        )
+
+    async def test_mark_conversation_read_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "mark_read",
+            "message": "Conversation mark read successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "mark_conversation_read")
+        result = await tool_fn("2-abc123==", mock_context, extractor=mock_extractor)
+
+        assert result["status"] == "mark_read"
+        mock_extractor.mark_conversation_read.assert_awaited_once_with("2-abc123==")
+
+    async def test_mark_conversation_unread_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "mark_unread",
+            "message": "Conversation mark unread successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "mark_conversation_unread")
+        result = await tool_fn("2-abc123==", mock_context, extractor=mock_extractor)
+
+        assert result["status"] == "mark_unread"
+        mock_extractor.mark_conversation_unread.assert_awaited_once_with("2-abc123==")
+
+    async def test_mark_conversation_read_error(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.exceptions import SessionExpiredError
+
+        mock_extractor = MagicMock()
+        mock_extractor.mark_conversation_read = AsyncMock(
+            side_effect=SessionExpiredError()
+        )
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "mark_conversation_read")
+        with pytest.raises(ToolError, match="Session expired"):
+            await tool_fn("2-abc123==", mock_context, extractor=mock_extractor)
+
 
 class TestGetMyProfileTool:
     async def test_get_my_profile_success(self, mock_context):
@@ -1382,6 +1522,10 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "archive_conversation",
+            "unarchive_conversation",
+            "mark_conversation_read",
+            "mark_conversation_unread",
             "get_feed",
             "search_posts",
             "close_session",
@@ -1415,6 +1559,10 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "archive_conversation",
+            "unarchive_conversation",
+            "mark_conversation_read",
+            "mark_conversation_unread",
             "get_feed",
             "search_posts",
             "close_session",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -36,6 +36,10 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.get_conversation = AsyncMock(return_value=scrape_result)
     mock.search_conversations = AsyncMock(return_value=scrape_result)
     mock.send_message = AsyncMock(return_value=scrape_result)
+    mock.archive_conversation = AsyncMock(return_value=scrape_result)
+    mock.unarchive_conversation = AsyncMock(return_value=scrape_result)
+    mock.mark_conversation_read = AsyncMock(return_value=scrape_result)
+    mock.mark_conversation_unread = AsyncMock(return_value=scrape_result)
     mock.get_my_profile = AsyncMock(return_value=scrape_result)
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.search_posts = AsyncMock(return_value=scrape_result)
@@ -978,6 +982,142 @@ class TestMessagingTools:
                 extractor=mock_extractor,
             )
 
+    async def test_archive_conversation_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "archive",
+            "message": "Conversation archive successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "archive_conversation")
+        result = await tool_fn(
+            "2-abc123==", True, mock_context, extractor=mock_extractor
+        )
+
+        assert result["status"] == "archive"
+        mock_extractor.archive_conversation.assert_awaited_once_with(
+            "2-abc123==", confirm_action=True
+        )
+
+    async def test_archive_conversation_not_confirmed(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "confirmation_required",
+            "message": "Set confirm_action=true to archive this conversation.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "archive_conversation")
+        result = await tool_fn(
+            "2-abc123==", False, mock_context, extractor=mock_extractor
+        )
+
+        assert result["status"] == "confirmation_required"
+        mock_extractor.archive_conversation.assert_awaited_once_with(
+            "2-abc123==", confirm_action=False
+        )
+
+    async def test_unarchive_conversation_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "unarchive",
+            "message": "Conversation unarchive successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "unarchive_conversation")
+        result = await tool_fn(
+            "2-abc123==", True, mock_context, extractor=mock_extractor
+        )
+
+        assert result["status"] == "unarchive"
+        mock_extractor.unarchive_conversation.assert_awaited_once_with(
+            "2-abc123==", confirm_action=True
+        )
+
+    async def test_mark_conversation_read_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "mark_read",
+            "message": "Conversation mark read successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "mark_conversation_read")
+        result = await tool_fn("2-abc123==", mock_context, extractor=mock_extractor)
+
+        assert result["status"] == "mark_read"
+        mock_extractor.mark_conversation_read.assert_awaited_once_with("2-abc123==")
+
+    async def test_mark_conversation_unread_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/messaging/thread/2-abc123==/",
+            "status": "mark_unread",
+            "message": "Conversation mark unread successful.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "mark_conversation_unread")
+        result = await tool_fn("2-abc123==", mock_context, extractor=mock_extractor)
+
+        assert result["status"] == "mark_unread"
+        mock_extractor.mark_conversation_unread.assert_awaited_once_with("2-abc123==")
+
+    async def test_mark_conversation_read_error(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.exceptions import SessionExpiredError
+
+        mock_extractor = MagicMock()
+        mock_extractor.mark_conversation_read = AsyncMock(
+            side_effect=SessionExpiredError()
+        )
+
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "mark_conversation_read")
+        with pytest.raises(ToolError, match="Session expired"):
+            await tool_fn("2-abc123==", mock_context, extractor=mock_extractor)
+
 
 class TestGetMyProfileTool:
     async def test_get_my_profile_success(self, mock_context):
@@ -1463,6 +1603,10 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "archive_conversation",
+            "unarchive_conversation",
+            "mark_conversation_read",
+            "mark_conversation_unread",
             "get_feed",
             "search_posts",
             "close_session",
@@ -1496,6 +1640,10 @@ class TestToolTimeouts:
             "get_conversation",
             "search_conversations",
             "send_message",
+            "archive_conversation",
+            "unarchive_conversation",
+            "mark_conversation_read",
+            "mark_conversation_unread",
             "get_feed",
             "search_posts",
             "close_session",


### PR DESCRIPTION
## Summary
Adds four MCP tools for LinkedIn conversation state management, so agents can triage the inbox without opening every thread (which `get_conversation` and `search_conversations` can mark read as a side effect).
- **`mark_conversation_read`** — clear the unread badge via Voyager `markAsRead`, without navigating to the thread
- **`mark_conversation_unread`** — restore the unread badge via Voyager PATCH (`read: false`); useful after accidental reads or to flag threads for follow-up
- **`archive_conversation`** / **`unarchive_conversation`** — move threads to/from the archived folder (confirmation-gated)
Implementation follows the same authenticated-browser `page.evaluate()` + Voyager API pattern as `send_message`. Navigation stays on `/messaging/` so API calls do not open thread URLs and accidentally clear unread state.
Closes #794
Closes #620
Related to #795 — incorporates that work and addresses Greptile review feedback:
- state-changing tools use `destructiveHint`, not `readOnlyHint`
- archive/unarchive dry runs return before any navigation
- Voyager calls use the inbox page, not the thread URL
## Motivation
Messaging tools today support read and send, but not inbox hygiene. Agents that read threads to extract content cannot reliably distinguish "human read" vs "agent read", and there is no way to archive handled threads or clear unread badges without click-navigation side effects.
## Changes
| Area | What |
|------|------|
| `scraping/extractor.py` | `_voyager_conversation_action()` plus four public extractor methods |
| `tools/messaging.py` | Register four new MCP tools |
| `tests/test_tools.py` | Tool delegation + error handling tests |
| `tests/test_scraping.py` | Extractor tests (dry-run skips nav, read/unread use inbox URL) |
| `tests/test_server.py` | Assert state-changing tools do not claim `readOnlyHint` |
| `README.md`, `docs/docker-hub.md`, `manifest.json` | Document new tools |
## Test plan
- [x] `uv run pytest tests/test_tools.py::TestMessagingTools -q`
- [x] `uv run pytest tests/test_scraping.py::TestVoyagerConversationAction -q`
- [x] `uv run pytest tests/test_server.py::TestWhatTheToolsPromise -q`
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run ty check` (changed modules)
- [ ] `uv run pytest --cov` (full suite — maintainer CI)
- [ ] Manual: `mark_conversation_read` clears badge on an unread thread
- [ ] Manual: `mark_conversation_unread` restores badge after reading a thread
- [ ] Manual: `archive_conversation` with `confirm_action=false` does not open the thread