### PR TITLE
feat(job): add save_job tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter |
 | `search_jobs` | Search for jobs with keywords and location filters |
 | `get_saved_jobs` | List job postings saved by the authenticated user |
+| `save_job` | Save a LinkedIn job posting to the authenticated user's saved jobs list |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company |
 | `get_job_details` | Get detailed information about a specific job posting |
 | `get_feed` | Get recent posts from the authenticated user's home feed |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -17,6 +17,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Job Details**: Retrieve job posting information
 - **Job Search**: Search for jobs with keywords and location filters
 - **Saved Jobs**: List job postings saved by the authenticated user
+- **Save Job**: Save a LinkedIn job posting to the authenticated user's saved jobs list
 - **People Search**: Search for people by keywords and location
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -363,6 +363,15 @@ _SAVED_JOBS_PATHS = frozenset({"/my-items/saved-jobs", "/jobs-tracker"})
 # list and yields nothing.
 _SAVED_JOBS_PAGE_SIZE = 10
 
+# Save-state labels for the job Save control, keyed by browser locale.
+# The control's text is the only state signal LinkedIn exposes (no
+# distinguishing URL or attribute), so detection is guarded by this explicit
+# per-locale table and fails closed on unknown locales.
+_JOB_SAVE_LABELS_BY_LOCALE = {
+    "en": {"saved": "Saved", "unsaved": "Save"},
+    "en-US": {"saved": "Saved", "unsaved": "Save"},
+}
+
 # Normalization maps for job search filters. Job search encodes recency as
 # ``f_TPR=r<seconds>``; content search uses named tokens, hence the separate
 # ``_CONTENT_DATE_POSTED_MAP`` below.
@@ -4221,6 +4230,100 @@ class LinkedInExtractor:
             }"""
         )
         return int(value) if value is not None else None
+
+    async def save_job(self, job_id: str) -> dict[str, Any]:
+        """Save a single job posting to the authenticated LinkedIn account."""
+        url = f"https://www.linkedin.com/jobs/view/{job_id}/"
+        await self._navigate_to_page(url)
+        await detect_rate_limit(self._page)
+        await handle_modal_close(self._page)
+
+        state = await self._job_save_button_state()
+        if state == "saved":
+            return {"url": url, "job_id": job_id, "saved": True, "already_saved": True}
+
+        clicked = await self._click_job_save_button("unsaved")
+        if not clicked:
+            raise LinkedInScraperException(
+                "Could not find or click the LinkedIn Save button for this job."
+            )
+
+        await asyncio.sleep(1)
+        return {"url": url, "job_id": job_id, "saved": True, "already_saved": False}
+
+    async def _job_save_labels(self) -> dict[str, str]:
+        """Return labels for the active browser locale, or fail closed."""
+        locale = await self._page.evaluate("() => navigator.language || ''")
+        labels = (
+            _JOB_SAVE_LABELS_BY_LOCALE.get(locale) if isinstance(locale, str) else None
+        )
+        if labels is None:
+            raise LinkedInScraperException(
+                "Job save-state detection is not supported for browser locale "
+                f"{locale!r}."
+            )
+        return labels
+
+    async def _job_save_button_state(self) -> Literal["saved", "unsaved"]:
+        """Read the job Save control's state using the per-locale label table."""
+        labels = await self._job_save_labels()
+        state = await self._page.evaluate(
+            """({ labels }) => {
+                const root = document.querySelector('main') || document.body;
+                const normalize = value =>
+                    (value || '').replace(/\\s+/g, ' ').trim();
+                const controls = Array.from(
+                    root.querySelectorAll('button, [role="button"]')
+                ).filter(element => {
+                    if (element.hasAttribute('aria-expanded')) return false;
+                    if (element.hasAttribute('disabled')) return false;
+                    const text = normalize(element.innerText || element.textContent);
+                    return text === labels.saved || text === labels.unsaved;
+                });
+                if (controls.length !== 1) return null;
+                const text = normalize(
+                    controls[0].innerText || controls[0].textContent
+                );
+                return text === labels.saved ? 'saved' : 'unsaved';
+            }""",
+            {"labels": labels},
+        )
+        if state not in {"saved", "unsaved"}:
+            raise LinkedInScraperException(
+                "Could not uniquely identify the LinkedIn job Save control."
+            )
+        return state
+
+    async def _click_job_save_button(
+        self, expected_state: Literal["saved", "unsaved"] = "unsaved"
+    ) -> bool:
+        """Click the unique job Save control when it has *expected_state*."""
+        labels = await self._job_save_labels()
+        try:
+            return bool(
+                await self._page.evaluate(
+                    """({ expectedLabel }) => {
+                        const root = document.querySelector('main') || document.body;
+                        const normalize = value =>
+                            (value || '').replace(/\\s+/g, ' ').trim();
+                        const controls = Array.from(
+                            root.querySelectorAll('button, [role="button"]')
+                        ).filter(element =>
+                            !element.hasAttribute('aria-expanded') &&
+                            !element.hasAttribute('disabled') &&
+                            normalize(element.innerText || element.textContent) ===
+                                expectedLabel
+                        );
+                        if (controls.length !== 1) return false;
+                        controls[0].click();
+                        return true;
+                    }""",
+                    {"expectedLabel": labels[expected_state]},
+                )
+            )
+        except Exception:
+            logger.debug("Job Save button click failed", exc_info=True)
+            return False
 
     async def get_saved_jobs(self, max_pages: int = 3) -> dict[str, Any]:
         """List the authenticated user's saved job postings.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4268,7 +4268,8 @@ class LinkedInExtractor:
 
     async def save_job(self, job_id: str) -> dict[str, Any]:
         """Save a single job posting to the authenticated LinkedIn account."""
-        url = f"https://www.linkedin.com/jobs/view/{job_id}/"
+        job_id = normalize_job_id(job_id)
+        url = job_view_url(job_id, "/")
         await self._navigate_to_page(url)
         await detect_rate_limit(self._page)
         await handle_modal_close(self._page)
@@ -4283,7 +4284,16 @@ class LinkedInExtractor:
                 "Could not find or click the LinkedIn Save button for this job."
             )
 
+        # The click helper only proves the DOM click dispatched. LinkedIn can
+        # swallow it (overlay, transient disable) without changing state, so
+        # report the observed state rather than the attempt. The tool is
+        # idempotent: a caller retry lands in the already-saved branch.
         await asyncio.sleep(1)
+        if await self._job_save_button_state() != "saved":
+            raise LinkedInScraperException(
+                "Clicked the LinkedIn Save button, but the control did not "
+                "switch to its saved state."
+            )
         return {"url": url, "job_id": job_id, "saved": True, "already_saved": False}
 
     async def _job_save_labels(self) -> dict[str, str]:

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -161,6 +161,50 @@ def register_job_tools(
 
     @mcp.tool(
         timeout=tool_timeout,
+        title="Save Job",
+        annotations={"readOnlyHint": False, "openWorldHint": True},
+        tags={"job", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def save_job(
+        job_id: str,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Save a LinkedIn job posting to the authenticated account's saved jobs list.
+
+        Args:
+            job_id: LinkedIn job ID (e.g., "4252026496", "3856789012")
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, job_id, saved, and already_saved status.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="save_job"
+            )
+            logger.info("Saving job: %s", job_id)
+
+            await ctx.report_progress(progress=0, total=100, message="Opening job")
+
+            result = await extractor.save_job(job_id)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "save_job")
+        except Exception as e:
+            raise_tool_error(e, "save_job")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
         title="Get Saved Jobs",
         annotations={"readOnlyHint": True, "openWorldHint": True},
         tags={"job", "scraping"},

--- a/manifest.json
+++ b/manifest.json
@@ -92,6 +92,10 @@
       "description": "List job postings saved by the authenticated LinkedIn user"
     },
     {
+      "name": "save_job",
+      "description": "Save a LinkedIn job posting to the authenticated user's saved jobs list"
+    },
+    {
       "name": "search_people",
       "description": "Search for people on LinkedIn by keywords, location, connection degree (1st/2nd/3rd), and current company"
     },

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -4728,7 +4728,8 @@ class TestRealOwner:
             # in a `register_*` call.
             assert "get_person_profile" in names
             assert "close_session" in names
-            assert len(names) == 19, sorted(names)
+            assert "save_job" in names
+            assert len(names) == 20, sorted(names)
         finally:
             _stop(result.get("pid"))
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3261,6 +3261,123 @@ class TestScrapeJob:
         assert "references" not in result
 
 
+class TestSaveJob:
+    async def test_job_save_button_state_uses_active_locale(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(side_effect=["en-US", "saved"])
+
+        result = await extractor._job_save_button_state()
+
+        assert result == "saved"
+        assert mock_page.evaluate.await_args_list[1].args[1] == {
+            "labels": {"saved": "Saved", "unsaved": "Save"}
+        }
+
+    async def test_job_save_button_state_rejects_unknown_locale(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value="de-DE")
+
+        with pytest.raises(
+            LinkedInScraperException, match="not supported for browser locale"
+        ):
+            await extractor._job_save_button_state()
+
+    async def test_save_job_already_saved(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="saved",
+            ),
+            patch.object(
+                extractor, "_click_job_save_button", new_callable=AsyncMock
+            ) as click_save,
+        ):
+            result = await extractor.save_job("12345")
+
+        assert result == {
+            "url": "https://www.linkedin.com/jobs/view/12345/",
+            "job_id": "12345",
+            "saved": True,
+            "already_saved": True,
+        }
+        click_save.assert_not_awaited()
+
+    async def test_save_job_clicks_save(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="unsaved",
+            ),
+            patch.object(
+                extractor,
+                "_click_job_save_button",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as click_save,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.save_job("12345")
+
+        assert result["saved"] is True
+        assert result["already_saved"] is False
+        click_save.assert_awaited_once_with("unsaved")
+
+    async def test_save_job_raises_when_save_button_missing(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="unsaved",
+            ),
+            patch.object(
+                extractor,
+                "_click_job_save_button",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(LinkedInScraperException):
+                await extractor.save_job("12345")
+
+
 class TestSearchJobs:
     """Tests for search_jobs with job ID extraction and pagination."""
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3333,8 +3333,8 @@ class TestSaveJob:
                 extractor,
                 "_job_save_button_state",
                 new_callable=AsyncMock,
-                return_value="unsaved",
-            ),
+                side_effect=["unsaved", "saved"],
+            ) as save_state,
             patch.object(
                 extractor,
                 "_click_job_save_button",
@@ -3348,9 +3348,83 @@ class TestSaveJob:
         ):
             result = await extractor.save_job("12345")
 
-        assert result["saved"] is True
-        assert result["already_saved"] is False
+        assert result == {
+            "url": "https://www.linkedin.com/jobs/view/12345/",
+            "job_id": "12345",
+            "saved": True,
+            "already_saved": False,
+        }
         click_save.assert_awaited_once_with("unsaved")
+        assert save_state.await_count == 2
+
+    async def test_save_job_raises_when_click_does_not_stick(self, mock_page):
+        """A dispatched click that leaves the control unsaved is a failure.
+
+        The click helper returns True the moment .click() goes out; LinkedIn
+        can swallow it. Reporting saved here would make callers treat the job
+        as persisted when it is not.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                side_effect=["unsaved", "unsaved"],
+            ),
+            patch.object(
+                extractor,
+                "_click_job_save_button",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            with pytest.raises(
+                LinkedInScraperException, match="did not switch to its saved state"
+            ):
+                await extractor.save_job("12345")
+
+    async def test_save_job_normalizes_a_job_reference(self, mock_page):
+        """A full job URL is accepted and reduced to the numeric id."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="saved",
+            ),
+        ):
+            result = await extractor.save_job("/jobs/view/4252026496/")
+
+        assert result == {
+            "url": "https://www.linkedin.com/jobs/view/4252026496/",
+            "job_id": "4252026496",
+            "saved": True,
+            "already_saved": True,
+        }
 
     async def test_save_job_raises_when_save_button_missing(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
@@ -9678,6 +9752,7 @@ class TestEveryNormalizedEntryPoint:
             ("scrape_company", ("../../feed", {"about"}), {}),
             ("get_company_employees", ("../../feed",), {}),
             ("scrape_job", ("../../feed",), {}),
+            ("save_job", ("../../feed",), {}),
             ("get_conversation", (), {"thread_id": "../../feed"}),
         ],
     )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -28,6 +28,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.scrape_company = AsyncMock(return_value=scrape_result)
     mock.scrape_job = AsyncMock(return_value=scrape_result)
     mock.search_jobs = AsyncMock(return_value=scrape_result)
+    mock.save_job = AsyncMock(return_value=scrape_result)
     mock.get_saved_jobs = AsyncMock(return_value=scrape_result)
     mock.search_people = AsyncMock(return_value=scrape_result)
     mock.get_sidebar_profiles = AsyncMock(return_value=scrape_result)
@@ -755,6 +756,25 @@ class TestJobTools:
 
         passed = mock_extractor.search_jobs.await_args.kwargs["tool_timeout"]
         assert passed < 59.9
+
+    async def test_save_job(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/jobs/view/12345/",
+            "job_id": "12345",
+            "saved": True,
+            "already_saved": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "save_job")
+        result = await tool_fn("12345", mock_context, extractor=mock_extractor)
+        assert result["saved"] is True
+        mock_extractor.save_job.assert_awaited_once_with("12345")
 
     async def test_get_saved_jobs(self, mock_context):
         expected = {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -836,7 +836,7 @@ class TestJobTools:
 
         tool_fn = await get_tool_fn(mcp, "save_job")
         result = await tool_fn("12345", mock_context, extractor=mock_extractor)
-        assert result["saved"] is True
+        assert result == expected
         mock_extractor.save_job.assert_awaited_once_with("12345")
 
     async def test_get_saved_jobs(self, mock_context):


### PR DESCRIPTION
Closes #869. Follow-up to #724 (unsave assumes a save path exists).

Adds a `save_job` MCP tool: navigates to `/jobs/view/{job_id}/`, reads the Save control state via a per-locale label table that fails closed on unknown locales (AGENTS.md scraping rules: text is the only signal here), clicks only when unsaved, returns idempotent `{url, job_id, saved, already_saved}`.

Unblocks the `linkedin-daily-jobs` sweep, which classifies qualifiers then persists them with `save_job(job_id)` expecting `saved`/`already_saved`.

Checklist: extractor method + tool registration, mock + tool-level + extractor-level tests (`TestSaveJob`, 5 new), README + docker-hub + manifest. `ruff check`, `ruff format --check`, `ty check` clean; `test_tools.py` (60), `test_scraping.py` (315), `test_manifest/test_server` (50) all pass.

## Synthetic prompt

> Add a `save_job` MCP tool mirroring the WIP save flow: extractor method on `/jobs/view/{job_id}/` with locale-tabled Save-state detection, tool registration, tests, and docs.

Generated with Muse Spark (muse-spark-1.3)