### PR TITLE
fix(messaging): Verify recipient before sending

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -532,12 +532,17 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
                 url.username ||
                 url.password ||
                 (url.port && url.port !== '443') ||
-                url.hash ||
-                !/^\/in\/[^/?#]+\/$/.test(url.pathname)
+                url.hash
             ) {
                 return null;
             }
-            return url.pathname;
+            // Everything under /in/<slug>/ belongs to that member, so the
+            // canonical path is the identity. Measured on a live profile:
+            // four of its own anchors point at /overlay/... and
+            // /recent-activity/, and reading those as an unknown member let
+            // the recipient contradict themselves.
+            const match = /^\/in\/([^/?#]+)(?:\/.*)?$/.exec(url.pathname);
+            return match ? `/in/${match[1]}/` : null;
         } catch {
             return null;
         }
@@ -673,7 +678,13 @@ _MESSAGE_COMPOSER_SUBMIT_JS = (
 
 _LINKEDIN_MESSAGE_HOST_RE = re.compile(r"^(?:[a-z0-9-]+\.)*linkedin\.com$")
 _PROFILE_PATH_RE = re.compile(r"^/in/[^/?#]+/$")
-_MESSAGE_THREAD_PATH_RE = re.compile(r"^/messaging/thread/[A-Za-z0-9_-]+/$")
+# A thread id is base64url and keeps its padding literally. Measured live:
+# /messaging/thread/2-ZDBkMjZiY2Ut...XzEwMA==/ is what LinkedIn redirects an
+# existing conversation to, and rejecting it stopped every send to a member
+# the account had already written to. Only '=' is added: '%' would readmit an
+# encoded slash and let one path pose as another. The id identifies nobody on
+# its own, and the recipient is proven by the composer rather than this path.
+_MESSAGE_THREAD_PATH_RE = re.compile(r"^/messaging/thread/[A-Za-z0-9_=-]+/$")
 _PROFILE_URN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _PROFILE_URN_PREFIX = "urn:li:fsd_profile:"
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -11,7 +11,7 @@ import logging
 import re
 import time
 from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import parse_qs, quote_plus, urljoin, urlparse
+from urllib.parse import ParseResult, parse_qs, quote_plus, urljoin, urlparse
 
 from patchright.async_api import Page, TimeoutError as PlaywrightTimeoutError
 
@@ -429,25 +429,7 @@ _DIALOG_PREMIUM_LINK_SELECTOR = (
 )
 _DIALOG_TEXTAREA_SELECTOR = '[role="dialog"] textarea, dialog textarea'
 
-_MESSAGING_COMPOSE_LINK_SELECTOR = 'main a[href*="/messaging/compose/"]'
-_MESSAGING_COMPOSE_SELECTOR = (
-    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"]'
-)
-_MESSAGING_COMPOSE_FALLBACK_SELECTORS = (
-    _MESSAGING_COMPOSE_SELECTOR,
-    'main div[role="textbox"][contenteditable="true"]',
-    'main [contenteditable="true"][aria-label*="message"]',
-)
-_MESSAGING_ENABLED_SEND_SELECTOR = (
-    'button[type="submit"]:not([disabled]), '
-    'button[aria-label*="Send"]:not([disabled]), '
-    'button[aria-label*="send"]:not([disabled])'
-)
-_MESSAGING_RECIPIENT_PICKER_SELECTOR = (
-    'input[placeholder*="Type a name"], '
-    'input[aria-label*="Type a name"], '
-    'input[placeholder*="multiple names"]'
-)
+_MESSAGING_COMPOSE_SELECTOR = '[role="textbox"][contenteditable="true"]'
 _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Close your draft conversation"], '
     'button[aria-label="Dismiss"], '
@@ -503,6 +485,289 @@ _MESSAGE_OCCURRENCES_JS = r"""
 _MESSAGE_OCCURRENCES_INCREASED_JS = (
     f"(arg) => ({_MESSAGE_OCCURRENCES_JS})(arg) > arg.previous"
 )
+
+_PROFILE_MESSAGE_TARGET_JS = r"""() => {
+    const visible = element => !!(
+        element &&
+        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+    );
+    const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
+    const main = document.querySelector('main');
+    if (!main) return null;
+    const scope = main.querySelector('section') || main.firstElementChild || main;
+    const composeHrefs = Array.from(
+        scope.querySelectorAll('a[href*="/messaging/compose/"]')
+    )
+        .filter(visible)
+        .map(anchor => anchor.getAttribute('href') || anchor.href || '');
+    const heading = scope.querySelector('h1');
+    return {
+        pageUrl: window.location.href,
+        displayName: normalize(heading?.innerText || heading?.textContent || ''),
+        composeHrefs,
+    };
+}"""
+
+_MESSAGE_COMPOSER_INSPECT_JS = r"""
+    const visible = element => !!(
+        element &&
+        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+    );
+    const normalizeUrn = value => {
+        const text = (value || '').trim();
+        const prefix = 'urn:li:fsd_profile:';
+        const identifier = text.startsWith(prefix) ? text.slice(prefix.length) : text;
+        return /^[A-Za-z0-9_-]+$/.test(identifier) ? identifier : null;
+    };
+    const profilePath = value => {
+        if (typeof value !== 'string' || /[\\\x00-\x1f\x7f]/.test(value)) {
+            return null;
+        }
+        try {
+            const url = new URL(value, window.location.href);
+            const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
+            if (
+                url.protocol !== 'https:' ||
+                !/(^|\.)linkedin\.com$/.test(hostname) ||
+                url.username ||
+                url.password ||
+                (url.port && url.port !== '443') ||
+                url.hash ||
+                !/^\/in\/[^/?#]+\/$/.test(url.pathname)
+            ) {
+                return null;
+            }
+            return url.pathname;
+        } catch {
+            return null;
+        }
+    };
+    const inspect = target => {
+        const editors = Array.from(
+            document.querySelectorAll('[role="textbox"][contenteditable="true"]')
+        ).filter(visible);
+        if (editors.length !== 1) return {status: 'ambiguous_editor'};
+        const editor = editors[0];
+        const outsideEditor = element =>
+            element !== editor && !editor.contains(element);
+        const readIdentity = owner => ({
+            // Draft content is untrusted. Neither the editor nor anything
+            // inside it may authorize or contradict the outer recipient.
+            paths: Array.from(owner.querySelectorAll('a[href*="/in/"]'))
+                .filter(element => visible(element) && outsideEditor(element))
+                .map(anchor => profilePath(anchor.getAttribute('href') || anchor.href || '')),
+            // Every identity attribute an element carries is read, never only
+            // the first one present: a matching data-profile-urn must not hide
+            // a contradicting data-recipient-urn on the same element. An
+            // absent attribute is skipped, while a present one that is empty
+            // or malformed normalizes to null and so fails closed.
+            urns: [
+                ...(owner.matches('[data-profile-urn], [data-recipient-urn]')
+                    ? [owner]
+                    : []),
+                ...owner.querySelectorAll(
+                    '[data-profile-urn], [data-recipient-urn]'
+                ),
+            ].filter(element => visible(element) && outsideEditor(element)).flatMap(
+                element => ['data-profile-urn', 'data-recipient-urn']
+                    .filter(name => element.hasAttribute(name))
+                    .map(name => normalizeUrn(element.getAttribute(name)))
+            ),
+        });
+        const identities = [];
+        let ancestor = editor.parentElement;
+        while (ancestor) {
+            if (ancestor.matches('dialog, [role="dialog"], form, section, article')) {
+                const identity = readIdentity(ancestor);
+                if (identity.paths.length + identity.urns.length > 0) {
+                    identities.push({owner: ancestor, ...identity});
+                }
+                if (ancestor.matches('dialog, [role="dialog"]')) break;
+            }
+            ancestor = ancestor.parentElement;
+        }
+        if (identities.length === 0) return {status: 'missing_recipient'};
+        const owner = identities[0].owner;
+        const paths = identities.flatMap(identity => identity.paths);
+        const urns = identities.flatMap(identity => identity.urns);
+        if (
+            paths.some(path => path !== target.profilePath) ||
+            urns.some(urn => urn !== target.profileUrn)
+        ) {
+            return {status: 'recipient_mismatch'};
+        }
+
+        const buttons = Array.from(
+            owner.querySelectorAll('button[type="submit"], button[data-control-name="send"]')
+        ).filter(visible);
+        return {
+            status: 'valid',
+            editor,
+            owner,
+            buttons,
+            active: document.activeElement === editor,
+        };
+    };
+"""
+
+_MESSAGE_COMPOSER_STATE_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        const state = inspect(target);
+        return {
+            status: state.status,
+            active: state.active === true,
+            submitCount: state.buttons ? state.buttons.length : 0,
+        };
+    }"""
+)
+
+_MESSAGE_COMPOSER_READY_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        return inspect(target).status === 'valid';
+    }"""
+)
+
+_MESSAGE_COMPOSER_FOCUS_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        const state = inspect(target);
+        if (state.status !== 'valid') return false;
+        state.editor.focus();
+        return state.editor.isConnected && document.activeElement === state.editor;
+    }"""
+)
+
+_MESSAGE_COMPOSER_SUBMIT_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        const state = inspect(target);
+        if (
+            state.status !== 'valid' ||
+            !state.editor.isConnected ||
+            document.activeElement !== state.editor
+        ) {
+            return 'invalid';
+        }
+        if (state.buttons.length === 0) {
+            return target.allowEnter === true ? 'enter' : 'invalid';
+        }
+        if (state.buttons.length !== 1) return 'invalid';
+        const button = state.buttons[0];
+        if (
+            !button.isConnected ||
+            button.disabled ||
+            button.getAttribute('aria-disabled') === 'true'
+        ) {
+            return 'invalid';
+        }
+        button.click();
+        return 'clicked';
+    }"""
+)
+
+_LINKEDIN_MESSAGE_HOST_RE = re.compile(r"^(?:[a-z0-9-]+\.)*linkedin\.com$")
+_PROFILE_PATH_RE = re.compile(r"^/in/[^/?#]+/$")
+_MESSAGE_THREAD_PATH_RE = re.compile(r"^/messaging/thread/[A-Za-z0-9_-]+/$")
+_PROFILE_URN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_PROFILE_URN_PREFIX = "urn:li:fsd_profile:"
+
+
+@dataclass(frozen=True)
+class _ProfileMessageTarget:
+    profile_path: str
+    profile_urn: str
+    compose_url: str
+    display_name: str | None
+
+
+def _safe_linkedin_url(value: str, *, base: str | None = None) -> ParseResult | None:
+    """Parse an HTTPS LinkedIn URL without credentials or an ambiguous origin."""
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or "\\" in value
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        return None
+    candidate = urljoin(base, value.strip()) if base else value.strip()
+    try:
+        parsed = urlparse(candidate)
+        port = parsed.port
+    except ValueError:
+        return None
+    hostname = (parsed.hostname or "").lower().removesuffix(".")
+    if (
+        parsed.scheme != "https"
+        or not _LINKEDIN_MESSAGE_HOST_RE.fullmatch(hostname)
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in (None, 443)
+        or parsed.fragment
+    ):
+        return None
+    return parsed
+
+
+def _normalize_profile_urn(value: str | None) -> str | None:
+    """Return the identifier carried by a profile URN or raw recipient value."""
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if candidate.startswith(_PROFILE_URN_PREFIX):
+        candidate = candidate[len(_PROFILE_URN_PREFIX) :]
+    return candidate if _PROFILE_URN_RE.fullmatch(candidate) else None
+
+
+def _profile_path_from_url(value: str) -> str | None:
+    parsed = _safe_linkedin_url(value)
+    if parsed is None or parsed.query or not _PROFILE_PATH_RE.fullmatch(parsed.path):
+        return None
+    try:
+        username = normalize_person_identifier(value)
+    except LinkedInScraperException:
+        return None
+    canonical_path = urlparse(person_profile_url(username, "/")).path
+    return parsed.path if parsed.path == canonical_path else None
+
+
+def _profile_urn_from_compose_url(value: str, *, base: str | None = None) -> str | None:
+    parsed = _safe_linkedin_url(value, base=base)
+    if parsed is None or parsed.path != "/messaging/compose/":
+        return None
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    identifiers: set[str] = set()
+    for key in ("recipient", "profileUrn"):
+        values = params.get(key, [])
+        normalized = [_normalize_profile_urn(item) for item in values]
+        if any(item is None for item in normalized):
+            return None
+        identifiers.update(item for item in normalized if item is not None)
+    if len(identifiers) != 1:
+        return None
+    return identifiers.pop()
+
+
+def _message_page_url_is_safe(value: str, profile_urn: str) -> bool:
+    parsed = _safe_linkedin_url(value)
+    if parsed is None:
+        return False
+
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    recipient_values = [
+        item for key in ("recipient", "profileUrn") for item in params.get(key, [])
+    ]
+    if parsed.path != "/messaging/compose/" and not _MESSAGE_THREAD_PATH_RE.fullmatch(
+        parsed.path
+    ):
+        return False
+    return all(_normalize_profile_urn(item) == profile_urn for item in recipient_values)
+
 
 # Shared JS function that walks up from any /messaging/compose/ anchor
 # inside <main> to find the smallest ancestor that satisfies the
@@ -2634,27 +2899,9 @@ class LinkedInExtractor:
         )
 
     async def _extract_profile_urn(self) -> str | None:
-        """Extract the recipient profile URN from the messaging compose link.
-
-        The compose button on a person's profile contains a recipient URN in its
-        href query string. This URN is more reliable than username for messaging.
-        Returns None when no compose button is present (e.g. not a 1st-degree
-        connection or viewing own profile).
-        """
-        href: str | None = await self._page.evaluate(
-            """() => {
-                const anchor = document.querySelector(
-                    'main a[href*="/messaging/compose/"]'
-                );
-                if (!anchor) return null;
-                return anchor.getAttribute('href') || anchor.href || null;
-            }"""
-        )
-        if not isinstance(href, str) or not href.strip():
-            return None
-        params = parse_qs(urlparse(href.strip()).query)
-        recipient = params.get("recipient", [None])[0]
-        return recipient if isinstance(recipient, str) and recipient else None
+        """Extract a profile URN only from one unambiguous top-card snapshot."""
+        target = await self._read_profile_message_target()
+        return target.profile_urn if target else None
 
     async def get_sidebar_profiles(self, username: str) -> dict[str, Any]:
         """Extract profile links from sidebar sections on a LinkedIn profile page.
@@ -2833,29 +3080,48 @@ class LinkedInExtractor:
             "sidebar_profiles": sidebar_profiles,
         }
 
-    async def _resolve_message_compose_href(self) -> str | None:
-        """Return the direct recipient-specific compose URL from a profile page."""
-        href = await self._page.evaluate(
-            """(selector) => {
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth ||
-                            element.offsetHeight ||
-                            element.getClientRects().length)
-                    );
-
-                const anchor = Array.from(
-                    document.querySelectorAll(selector)
-                ).find(isVisible);
-                if (!anchor) return null;
-                return anchor.getAttribute('href') || anchor.href || null;
-            }""",
-            _MESSAGING_COMPOSE_LINK_SELECTOR,
-        )
-        if not isinstance(href, str) or not href.strip():
+    async def _read_profile_message_target(
+        self, _expected_username: str | None = None
+    ) -> _ProfileMessageTarget | None:
+        """Read profile identity, name, compose URL and URN in one DOM snapshot."""
+        data = await self._page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
+        if not isinstance(data, dict):
             return None
-        return urljoin("https://www.linkedin.com", href.strip())
+
+        page_url = data.get("pageUrl")
+        compose_hrefs = data.get("composeHrefs")
+        if not isinstance(page_url, str) or not isinstance(compose_hrefs, list):
+            return None
+        profile_path = _profile_path_from_url(page_url)
+        if profile_path is None:
+            return None
+        if len(compose_hrefs) != 1 or not isinstance(compose_hrefs[0], str):
+            return None
+
+        parsed_compose = _safe_linkedin_url(compose_hrefs[0], base=page_url)
+        if parsed_compose is None:
+            return None
+        compose_url = parsed_compose.geturl()
+        profile_urn = _profile_urn_from_compose_url(compose_url)
+        if profile_urn is None:
+            return None
+
+        display_name = data.get("displayName")
+        if not isinstance(display_name, str) or not display_name.strip():
+            display_name = None
+        else:
+            display_name = display_name.strip()
+        return _ProfileMessageTarget(
+            profile_path=profile_path,
+            profile_urn=profile_urn,
+            compose_url=compose_url,
+            display_name=display_name,
+        )
+
+    async def _resolve_message_compose_href(self) -> str | None:
+        """Return an unambiguous recipient-specific top-card compose URL."""
+        target = await self._read_profile_message_target()
+        return target.compose_url if target else None
 
     async def _read_profile_display_name(self) -> str | None:
         """Read the visible profile name from the current person page."""
@@ -2885,182 +3151,75 @@ class LinkedInExtractor:
         return display_name or None
 
     async def _wait_for_message_surface(
-        self,
-    ) -> Literal["composer", "recipient_picker"] | None:
-        """Wait for either the recipient picker or the real composer to appear.
-
-        The recipient-picker probe uses a short 2 s cap so we fall through
-        quickly to the composer check, which uses the page-level default
-        (``BrowserConfig.default_timeout``, configurable via ``--timeout``).
-        """
-        if await self._locator_is_visible(
-            _MESSAGING_RECIPIENT_PICKER_SELECTOR, timeout=2000
-        ):
-            return "recipient_picker"
-        if await self._wait_for_message_composer():
+        self, target: _ProfileMessageTarget
+    ) -> Literal["composer"] | None:
+        """Wait for one editor with a matching local recipient identity."""
+        if await self._wait_for_message_composer(target):
             return "composer"
         return None
 
-    async def _select_message_recipient(self, *candidates: str) -> bool:
-        """Select the intended recipient from LinkedIn's New message picker."""
-        normalized_candidates = [value.strip() for value in candidates if value.strip()]
-        if not normalized_candidates:
+    async def _wait_for_message_composer(self, target: _ProfileMessageTarget) -> bool:
+        """Wait for the complete verified LinkedIn composer state to settle."""
+        try:
+            await self._page.wait_for_function(
+                _MESSAGE_COMPOSER_READY_JS,
+                arg=self._message_target_argument(target),
+            )
+        except PlaywrightTimeoutError:
             return False
-
-        selected = await self._page.evaluate(
-            """({ candidates }) => {
-                const normalize = value =>
-                    (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
-                    );
-                const pickerInput = Array.from(document.querySelectorAll('input')).find(
-                    element =>
-                        isVisible(element) &&
-                        /type a name|multiple names/i.test(
-                            `${element.placeholder || ''} ${
-                                element.getAttribute('aria-label') || ''
-                            }`
-                        )
-                );
-                const pickerRoot =
-                    pickerInput?.closest('section, dialog, [role="dialog"], aside, div') ||
-                    document.body;
-                const rows = Array.from(
-                    pickerRoot.querySelectorAll(
-                        '[role="option"], [role="listitem"], li, button, a, div'
-                    )
-                ).filter(element => {
-                    if (!isVisible(element)) return false;
-                    const text = normalize(element.innerText || element.textContent);
-                    return text.length > 0 && text !== 'new message';
-                });
-
-                for (const candidate of candidates.map(normalize)) {
-                    const exact = rows.find(element =>
-                        normalize(element.innerText || element.textContent) === candidate
-                    );
-                    if (exact) {
-                        exact.click();
-                        return true;
-                    }
-                }
-
-                for (const candidate of candidates.map(normalize)) {
-                    const partial = rows.find(element =>
-                        normalize(element.innerText || element.textContent).includes(candidate)
-                    );
-                    if (partial) {
-                        partial.click();
-                        return true;
-                    }
-                }
-
-                return false;
-            }""",
-            {"candidates": normalized_candidates},
-        )
-        if selected:
-            await asyncio.sleep(0.75)
-        return bool(selected)
-
-    async def _wait_for_message_composer(self) -> bool:
-        """Wait for the usable LinkedIn message composer to appear."""
-        return await self._resolve_message_compose_box() is not None
+        except Exception:
+            logger.debug("Could not wait for the message editor", exc_info=True)
+            return False
+        return True
 
     async def _resolve_message_compose_box(self) -> Any | None:
-        """Resolve the visible compose box used for writing a LinkedIn message.
+        """Resolve the editor only when exactly one visible candidate exists."""
+        locator = self._page.locator(f"{_MESSAGING_COMPOSE_SELECTOR}:visible")
+        try:
+            if await locator.count() != 1:
+                return None
+        except Exception:
+            logger.debug("Could not count message editor candidates", exc_info=True)
+            return None
+        return locator.first
 
-        Uses the page-level default timeout (``BrowserConfig.default_timeout``)
-        so the ``--timeout`` CLI flag is respected.
-        """
-        for selector in _MESSAGING_COMPOSE_FALLBACK_SELECTORS:
-            locator = self._page.locator(selector)
-            candidate_count: int | None = None
-            try:
-                candidate_count = await locator.count()
-            except Exception:
-                logger.debug(
-                    "Could not count compose box candidates for selector %r",
-                    selector,
-                    exc_info=True,
-                )
+    @staticmethod
+    def _message_target_argument(
+        target: _ProfileMessageTarget,
+    ) -> dict[str, str | bool]:
+        return {
+            "profilePath": target.profile_path,
+            "profileUrn": target.profile_urn,
+        }
 
-            logger.debug(
-                "Message compose selector %r matched %s candidate(s)",
-                selector,
-                candidate_count if candidate_count is not None else "unknown",
-            )
-
-            # patchright quirk: locator.wait_for(state="visible") times out on
-            # the contenteditable compose div even though count() > 0 and the
-            # element is fully visible by every CSS/DOM criterion (display:block,
-            # visibility:visible, opacity:1, non-zero bbox, no inert ancestor).
-            # This appears to be a patchright bug with React-hydrated contenteditable
-            # elements in isolated worlds. Skip the actionability wait when count()
-            # already confirmed the element is present — downstream interactions
-            # use page.evaluate() which bypasses the same check.
-            if candidate_count and candidate_count > 0:
-                return locator.last
-
-            # Fallback: when count() raised an exception above (candidate_count
-            # is None), attempt the original wait_for path.  This is unlikely to
-            # succeed given the same patchright quirk, but preserves the prior
-            # behaviour for non-patchright drivers where wait_for works normally.
-            candidate = locator.last
-            try:
-                await candidate.wait_for(state="visible")
-                return candidate
-            except PlaywrightTimeoutError:
-                continue
-
-        return None
-
-    async def _compose_page_matches_recipient(self, *candidates: str) -> bool:
-        """Verify the compose page visibly identifies the intended recipient."""
-        normalized_candidates = [value.strip() for value in candidates if value.strip()]
-        if not normalized_candidates:
-            return False
-
-        matched = await self._page.evaluate(
-            """({ candidates }) => {
-                const normalize = value =>
-                    (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth ||
-                            element.offsetHeight ||
-                            element.getClientRects().length)
-                    );
-
-                const targetValues = candidates.map(normalize).filter(Boolean);
-                const root = document.querySelector('main') || document.body;
-                if (!root) return false;
-
-                const entries = Array.from(
-                    root.querySelectorAll(
-                        'button, [role="button"], a, span, div, li, p, h1, h2, h3'
-                    )
-                )
-                    .filter(isVisible)
-                    .map(element =>
-                        [
-                            normalize(element.innerText || element.textContent || ''),
-                            normalize(element.getAttribute('aria-label') || ''),
-                        ].filter(Boolean)
-                    )
-                    .flat();
-
-                return targetValues.some(candidate =>
-                    entries.some(entry => entry === candidate || entry.includes(candidate))
-                );
-            }""",
-            {"candidates": normalized_candidates},
+    async def _read_message_composer_state(
+        self, target: _ProfileMessageTarget
+    ) -> dict[str, Any]:
+        """Inspect the unique editor and recipient inside its semantic owner."""
+        state = await self._page.evaluate(
+            _MESSAGE_COMPOSER_STATE_JS,
+            self._message_target_argument(target),
         )
-        return bool(matched)
+        return state if isinstance(state, dict) else {"status": "invalid"}
+
+    async def _focus_verified_message_editor(
+        self, target: _ProfileMessageTarget
+    ) -> bool:
+        """Focus the same local editor whose recipient identity was verified."""
+        focused = await self._page.evaluate(
+            _MESSAGE_COMPOSER_FOCUS_JS,
+            self._message_target_argument(target),
+        )
+        return focused is True
+
+    async def _submit_verified_message(
+        self, target: _ProfileMessageTarget, *, allow_enter: bool
+    ) -> str:
+        """Click one local submit button or authorize the strict Enter fallback."""
+        argument = self._message_target_argument(target)
+        argument["allowEnter"] = allow_enter
+        result = await self._page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, argument)
+        return result if result in {"clicked", "enter"} else "invalid"
 
     async def _message_text_occurrences(self, message: str) -> int:
         """Count visible occurrences of the message outside any open composer."""
@@ -4948,15 +5107,7 @@ class LinkedInExtractor:
         confirm_send: bool,
         profile_urn: str | None = None,
     ) -> dict[str, Any]:
-        """Send a message to a LinkedIn user with explicit confirmation gating.
-
-        Args:
-            linkedin_username: LinkedIn username of the recipient.
-            message: The message text to send.
-            confirm_send: Must be True to actually send (False does a dry run).
-            profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
-                compose URL directly, bypassing the Message-button lookup.
-        """
+        """Send only after the loaded profile and local composer identify one user."""
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
         if not message.strip():
@@ -4975,31 +5126,23 @@ class LinkedInExtractor:
             logger.debug("Profile page did not load for %s", linkedin_username)
 
         await handle_modal_close(self._page)
-        display_name = await self._read_profile_display_name()
-        if profile_urn:
-            # Build the full compose URL that LinkedIn's own Message button
-            # generates. The minimal ?recipient=<URN> form works for established
-            # connections but shows a "Say hello" widget (no compose box) for new
-            # connections. Adding profileUrn + screenContext + interop=msgOverlay
-            # consistently opens the real composer regardless of connection age.
-            _encoded = quote_plus(f"urn:li:fsd_profile:{profile_urn}")
-            compose_url: str | None = (
-                f"https://www.linkedin.com/messaging/compose/"
-                f"?profileUrn={_encoded}"
-                f"&recipient={quote_plus(profile_urn)}"
-                f"&screenContext=NON_SELF_PROFILE_VIEW"
-                f"&interop=msgOverlay"
-            )
-        else:
-            compose_url = await self._resolve_message_compose_href()
-        if not compose_url:
+        target = await self._read_profile_message_target(linkedin_username)
+        if target is None:
             return self._message_action_result(
                 profile_url,
                 "message_unavailable",
-                "LinkedIn did not expose a usable Message action for this profile.",
+                "LinkedIn did not expose one usable Message action for this profile.",
             )
 
-        await self._navigate_to_page(compose_url)
+        supplied_urn = _normalize_profile_urn(profile_urn) if profile_urn else None
+        if profile_urn is not None and supplied_urn != target.profile_urn:
+            return self._message_action_result(
+                profile_url,
+                "recipient_resolution_failed",
+                "The supplied profile URN did not match the loaded profile.",
+            )
+
+        await self._navigate_to_page(target.compose_url)
         await detect_rate_limit(self._page)
 
         try:
@@ -5008,67 +5151,38 @@ class LinkedInExtractor:
             logger.debug("Compose page did not fully load for %s", linkedin_username)
 
         await handle_modal_close(self._page)
-        message_surface = await self._wait_for_message_surface()
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "LinkedIn opened an unexpected messaging URL.",
+            )
+
+        message_surface = await self._wait_for_message_surface(target)
         logger.debug(
-            "Message surface for %s before hydration was %s",
-            linkedin_username,
-            message_surface,
+            "Message surface for %s was %s", linkedin_username, message_surface
         )
-
-        recipient_selected = False
-        if message_surface == "recipient_picker":
-            recipient_selected = await self._select_message_recipient(
-                display_name or "",
-                linkedin_username,
-            )
-            logger.debug(
-                "Recipient picker selection for %s returned %s",
-                linkedin_username,
-                recipient_selected,
-            )
-            if not recipient_selected:
-                await self._dismiss_message_ui()
-                return self._message_action_result(
-                    self._page.url,
-                    "recipient_resolution_failed",
-                    "LinkedIn opened a compose page, but the visible recipient did not match the requested profile.",
-                )
-            message_surface = await self._wait_for_message_surface()
-            logger.debug(
-                "Message surface for %s after recipient selection was %s",
-                linkedin_username,
-                message_surface,
-            )
-
-        compose_box = await self._resolve_message_compose_box()
-        if compose_box is None:
+        if message_surface != "composer":
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "composer_unavailable",
-                "LinkedIn did not expose a usable message composer.",
-                recipient_selected=recipient_selected,
+                "LinkedIn did not expose one usable message composer.",
             )
 
-        logger.debug(
-            "Message compose box resolved for %s after hydration",
-            linkedin_username,
-        )
-
-        if not await self._compose_page_matches_recipient(
-            display_name or "",
-            linkedin_username,
-        ):
+        state = await self._read_message_composer_state(target)
+        if state.get("status") != "valid":
             logger.debug(
-                "Recipient match still failed for %s after compose hydration",
+                "Message recipient verification for %s returned %s",
                 linkedin_username,
+                state.get("status"),
             )
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
-                "LinkedIn opened a compose page, but the visible recipient did not match the requested profile.",
-                recipient_selected=recipient_selected,
+                "The local composer did not identify exactly the requested profile.",
             )
         recipient_selected = True
 
@@ -5081,66 +5195,86 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
 
-        # patchright quirk: compose_box.click() and press_sequentially() use
-        # actionability checks internally and hit the same wait_for timeout.
-        # Instead: focus via page.evaluate() (no actionability check) and type
-        # via page.keyboard.type() which operates on the active element directly
-        # and fires the real keydown/input/keyup events React needs to enable Send.
-        #
-        # DOM dependency: innerText extraction is not applicable here — we need
-        # to call .focus() on the element reference, which requires querySelector.
-        # Selectors use only role + contenteditable + aria-label (ARIA attributes,
-        # not layout class names) so they are stable across LinkedIn UI changes.
-        focused = await self._page.evaluate(
-            """() => {
-                const el = document.querySelector(
-                    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
-                    + 'div[role="textbox"][contenteditable="true"]'
-                );
-                if (!el) return false;
-                el.focus();
-                return true;
-            }"""
-        )
-        if not focused:
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed before the editor could be focused.",
+                recipient_selected=recipient_selected,
+            )
+        state = await self._read_message_composer_state(target)
+        if state.get(
+            "status"
+        ) != "valid" or not await self._focus_verified_message_editor(target):
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "compose_interact_failed",
-                "Could not focus compose box via JavaScript.",
+                "The verified message editor could not be focused.",
                 recipient_selected=recipient_selected,
             )
-        await asyncio.sleep(0.1)
-        await self._page.keyboard.type(message, delay=15)
-        await asyncio.sleep(0.3)
-        await asyncio.sleep(1.0)  # allow React to process keyboard input
 
-        # Baseline immediately before the send attempt: how often the message
-        # is already visible outside the composer. The click below only tries
-        # to send; delivery is proven by this count growing, never by the text
-        # the composer still holds.
+        await asyncio.sleep(0.1)
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed before text entry.",
+                recipient_selected=recipient_selected,
+            )
+        state = await self._read_message_composer_state(target)
+        if state.get("status") != "valid" or state.get("active") is not True:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "compose_interact_failed",
+                "The verified message editor changed before text entry.",
+                recipient_selected=recipient_selected,
+            )
+        allow_enter = state.get("submitCount") == 0
+
+        await self._page.keyboard.type(message, delay=15)
+        await asyncio.sleep(1.0)
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed before submission.",
+                recipient_selected=recipient_selected,
+            )
+
+        # Baseline immediately before the submit attempt: how often the message
+        # is already visible outside every composer. Submission only tries to
+        # send; delivery is proven by this count growing, never by the text the
+        # verified editor still holds.
         previous_occurrences = await self._message_text_occurrences(message)
 
-        # patchright actionability also blocks send_button.click(). Use JS click
-        # on any visible, enabled send button; fall back to Enter key which
-        # LinkedIn's composer also accepts for submission.
-        #
-        # DOM dependency: we need btn.click() on the element reference — not
-        # achievable via innerText or URL navigation. Selectors use only type,
-        # aria-label, and data attributes (no layout class names).
-        sent_via_js = await self._page.evaluate(
-            """() => {
-                const btn = Array.from(document.querySelectorAll(
-                    'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
-                    + 'button[data-control-name="send"]'
-                )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
-                if (!btn) return false;
-                btn.click();
-                return true;
-            }"""
+        submission = await self._submit_verified_message(
+            target, allow_enter=allow_enter
         )
-        if not sent_via_js:
-            await self._page.keyboard.press("Enter")
+        if submission == "enter":
+            state = await self._read_message_composer_state(target)
+            if (
+                not allow_enter
+                or not _message_page_url_is_safe(self._page.url, target.profile_urn)
+                or state.get("status") != "valid"
+                or state.get("active") is not True
+                or state.get("submitCount") != 0
+            ):
+                submission = "invalid"
+            else:
+                await self._page.keyboard.press("Enter")
+        if submission not in {"clicked", "enter"}:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "send_unavailable",
+                "The local submit path was missing, disabled, or ambiguous.",
+                recipient_selected=recipient_selected,
+            )
 
         if not await self._message_text_visible(
             message, previous_occurrences=previous_occurrences

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3091,9 +3091,7 @@ class LinkedInExtractor:
             "sidebar_profiles": sidebar_profiles,
         }
 
-    async def _read_profile_message_target(
-        self, _expected_username: str | None = None
-    ) -> _ProfileMessageTarget | None:
+    async def _read_profile_message_target(self) -> _ProfileMessageTarget | None:
         """Read profile identity, name, compose URL and URN in one DOM snapshot."""
         data = await self._page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
         if not isinstance(data, dict):
@@ -5137,7 +5135,7 @@ class LinkedInExtractor:
             logger.debug("Profile page did not load for %s", linkedin_username)
 
         await handle_modal_close(self._page)
-        target = await self._read_profile_message_target(linkedin_username)
+        target = await self._read_profile_message_target()
         if target is None:
             return self._message_action_result(
                 profile_url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -592,6 +592,21 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
                     .map(name => normalizeUrn(element.getAttribute(name)))
             ),
         });
+        // The walk climbs until a dialog closes it, and every identity it
+        // finds on the way has to agree with the target. That scope is
+        // deliberate and it is not free. A thread rendered inside the same
+        // section as the editor puts its message history in the walk, so a
+        // profile mention anyone can drop into a conversation refuses every
+        // later send to that person. The refusal is the safe half of the
+        // trade: adding identities can only ever make this stricter, so the
+        // recipient cannot use it to redirect a message. The unsafe half
+        // needs the real recipient to expose no identity at all in the whole
+        // chain while a mention of the target does, which no measurement has
+        // reached: the live compose surface has not been read yet, so what
+        // LinkedIn actually puts between the editor and its dialog is
+        // unknown. Narrowing the walk to the innermost owner would cut the
+        // false refusals and give up that asymmetry, which is a design
+        // decision and not a repair.
         const identities = [];
         let ancestor = editor.parentElement;
         while (ancestor) {
@@ -5307,6 +5322,11 @@ class LinkedInExtractor:
             ):
                 submission = "invalid"
             else:
+                # The read and the keypress are two round trips, so the editor
+                # could in principle lose focus between them. Nothing a caller
+                # or a recipient controls reaches that window, and closing it
+                # would need the keystroke and the check to be one operation,
+                # which no input API offers.
                 await self._page.keyboard.press("Enter")
         if submission not in {"clicked", "enter"}:
             await self._dismiss_message_ui()

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -11,7 +11,7 @@ import logging
 import re
 import time
 from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import parse_qs, quote_plus, urljoin, urlparse
+from urllib.parse import ParseResult, parse_qs, quote_plus, urljoin, urlparse
 
 from patchright.async_api import Page, TimeoutError as PlaywrightTimeoutError
 
@@ -429,25 +429,7 @@ _DIALOG_PREMIUM_LINK_SELECTOR = (
 )
 _DIALOG_TEXTAREA_SELECTOR = '[role="dialog"] textarea, dialog textarea'
 
-_MESSAGING_COMPOSE_LINK_SELECTOR = 'main a[href*="/messaging/compose/"]'
-_MESSAGING_COMPOSE_SELECTOR = (
-    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"]'
-)
-_MESSAGING_COMPOSE_FALLBACK_SELECTORS = (
-    _MESSAGING_COMPOSE_SELECTOR,
-    'main div[role="textbox"][contenteditable="true"]',
-    'main [contenteditable="true"][aria-label*="message"]',
-)
-_MESSAGING_ENABLED_SEND_SELECTOR = (
-    'button[type="submit"]:not([disabled]), '
-    'button[aria-label*="Send"]:not([disabled]), '
-    'button[aria-label*="send"]:not([disabled])'
-)
-_MESSAGING_RECIPIENT_PICKER_SELECTOR = (
-    'input[placeholder*="Type a name"], '
-    'input[aria-label*="Type a name"], '
-    'input[placeholder*="multiple names"]'
-)
+_MESSAGING_COMPOSE_SELECTOR = '[role="textbox"][contenteditable="true"]'
 _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Close your draft conversation"], '
     'button[aria-label="Dismiss"], '
@@ -516,6 +498,294 @@ _MESSAGE_OCCURRENCES_JS = r"""
 _MESSAGE_OCCURRENCES_INCREASED_JS = (
     f"(arg) => ({_MESSAGE_OCCURRENCES_JS})(arg) > arg.previous"
 )
+
+_PROFILE_MESSAGE_TARGET_JS = r"""() => {
+    const visible = element => !!(
+        element &&
+        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+    );
+    const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
+    const main = document.querySelector('main');
+    if (!main) return null;
+    const scope = main.querySelector('section') || main.firstElementChild || main;
+    const composeHrefs = Array.from(
+        scope.querySelectorAll('a[href*="/messaging/compose/"]')
+    )
+        .filter(visible)
+        .map(anchor => anchor.getAttribute('href') || anchor.href || '');
+    const heading = scope.querySelector('h1');
+    return {
+        pageUrl: window.location.href,
+        displayName: normalize(heading?.innerText || heading?.textContent || ''),
+        composeHrefs,
+    };
+}"""
+
+_MESSAGE_COMPOSER_INSPECT_JS = r"""
+    const visible = element => !!(
+        element &&
+        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+    );
+    const normalizeUrn = value => {
+        const text = (value || '').trim();
+        const prefix = 'urn:li:fsd_profile:';
+        const identifier = text.startsWith(prefix) ? text.slice(prefix.length) : text;
+        return /^[A-Za-z0-9_-]+$/.test(identifier) ? identifier : null;
+    };
+    const profilePath = value => {
+        if (typeof value !== 'string' || /[\\\x00-\x1f\x7f]/.test(value)) {
+            return null;
+        }
+        try {
+            const url = new URL(value, window.location.href);
+            const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
+            if (
+                url.protocol !== 'https:' ||
+                !/(^|\.)linkedin\.com$/.test(hostname) ||
+                url.username ||
+                url.password ||
+                (url.port && url.port !== '443') ||
+                url.hash ||
+                !/^\/in\/[^/?#]+\/$/.test(url.pathname)
+            ) {
+                return null;
+            }
+            return url.pathname;
+        } catch {
+            return null;
+        }
+    };
+    const inspect = target => {
+        const editors = Array.from(
+            document.querySelectorAll('[role="textbox"][contenteditable="true"]')
+        ).filter(visible);
+        if (editors.length !== 1) return {status: 'ambiguous_editor'};
+        const editor = editors[0];
+        const outsideEditor = element =>
+            element !== editor && !editor.contains(element);
+        const readIdentity = owner => ({
+            // Draft content is untrusted. Neither the editor nor anything
+            // inside it may authorize or contradict the outer recipient.
+            paths: Array.from(owner.querySelectorAll('a[href*="/in/"]'))
+                .filter(element => visible(element) && outsideEditor(element))
+                .map(anchor => profilePath(anchor.getAttribute('href') || anchor.href || '')),
+            // Every identity attribute an element carries is read, never only
+            // the first one present: a matching data-profile-urn must not hide
+            // a contradicting data-recipient-urn on the same element. An
+            // absent attribute is skipped, while a present one that is empty
+            // or malformed normalizes to null and so fails closed.
+            urns: [
+                ...(owner.matches('[data-profile-urn], [data-recipient-urn]')
+                    ? [owner]
+                    : []),
+                ...owner.querySelectorAll(
+                    '[data-profile-urn], [data-recipient-urn]'
+                ),
+            ].filter(element => visible(element) && outsideEditor(element)).flatMap(
+                element => ['data-profile-urn', 'data-recipient-urn']
+                    .filter(name => element.hasAttribute(name))
+                    .map(name => normalizeUrn(element.getAttribute(name)))
+            ),
+        });
+        const identities = [];
+        let ancestor = editor.parentElement;
+        while (ancestor) {
+            if (ancestor.matches('dialog, [role="dialog"], form, section, article')) {
+                const identity = readIdentity(ancestor);
+                if (identity.paths.length + identity.urns.length > 0) {
+                    identities.push({owner: ancestor, ...identity});
+                }
+                if (ancestor.matches('dialog, [role="dialog"]')) break;
+            }
+            ancestor = ancestor.parentElement;
+        }
+        if (identities.length === 0) return {status: 'missing_recipient'};
+        const owner = identities[0].owner;
+        const paths = identities.flatMap(identity => identity.paths);
+        const urns = identities.flatMap(identity => identity.urns);
+        if (
+            paths.some(path => path !== target.profilePath) ||
+            urns.some(urn => urn !== target.profileUrn)
+        ) {
+            return {status: 'recipient_mismatch'};
+        }
+
+        const buttons = Array.from(
+            owner.querySelectorAll('button[type="submit"], button[data-control-name="send"]')
+        ).filter(visible);
+        return {
+            status: 'valid',
+            editor,
+            owner,
+            buttons,
+            active: document.activeElement === editor,
+            // Reported, never required: the send path refuses a composer that
+            // already holds a draft, and the same routine runs again after
+            // typing, when the editor is of course no longer empty.
+            empty: !(editor.innerText || '').replace(/\s+/g, ' ').trim(),
+        };
+    };
+"""
+
+_MESSAGE_COMPOSER_STATE_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        const state = inspect(target);
+        return {
+            status: state.status,
+            active: state.active === true,
+            empty: state.empty === true,
+            submitCount: state.buttons ? state.buttons.length : 0,
+        };
+    }"""
+)
+
+_MESSAGE_COMPOSER_READY_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        return inspect(target).status === 'valid';
+    }"""
+)
+
+_MESSAGE_COMPOSER_FOCUS_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        const state = inspect(target);
+        if (state.status !== 'valid') return false;
+        state.editor.focus();
+        return state.editor.isConnected && document.activeElement === state.editor;
+    }"""
+)
+
+_MESSAGE_COMPOSER_SUBMIT_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        const state = inspect(target);
+        if (
+            state.status !== 'valid' ||
+            !state.editor.isConnected ||
+            document.activeElement !== state.editor
+        ) {
+            return 'invalid';
+        }
+        if (state.buttons.length === 0) {
+            return target.allowEnter === true ? 'enter' : 'invalid';
+        }
+        if (state.buttons.length !== 1) return 'invalid';
+        const button = state.buttons[0];
+        if (
+            !button.isConnected ||
+            button.disabled ||
+            button.getAttribute('aria-disabled') === 'true'
+        ) {
+            return 'invalid';
+        }
+        button.click();
+        return 'clicked';
+    }"""
+)
+
+_LINKEDIN_MESSAGE_HOST_RE = re.compile(r"^(?:[a-z0-9-]+\.)*linkedin\.com$")
+_PROFILE_PATH_RE = re.compile(r"^/in/[^/?#]+/$")
+_MESSAGE_THREAD_PATH_RE = re.compile(r"^/messaging/thread/[A-Za-z0-9_-]+/$")
+_PROFILE_URN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_PROFILE_URN_PREFIX = "urn:li:fsd_profile:"
+
+
+@dataclass(frozen=True)
+class _ProfileMessageTarget:
+    profile_path: str
+    profile_urn: str
+    compose_url: str
+    display_name: str | None
+
+
+def _safe_linkedin_url(value: str, *, base: str | None = None) -> ParseResult | None:
+    """Parse an HTTPS LinkedIn URL without credentials or an ambiguous origin."""
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or "\\" in value
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        return None
+    candidate = urljoin(base, value.strip()) if base else value.strip()
+    try:
+        parsed = urlparse(candidate)
+        port = parsed.port
+    except ValueError:
+        return None
+    hostname = (parsed.hostname or "").lower().removesuffix(".")
+    if (
+        parsed.scheme != "https"
+        or not _LINKEDIN_MESSAGE_HOST_RE.fullmatch(hostname)
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in (None, 443)
+        or parsed.fragment
+    ):
+        return None
+    return parsed
+
+
+def _normalize_profile_urn(value: str | None) -> str | None:
+    """Return the identifier carried by a profile URN or raw recipient value."""
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if candidate.startswith(_PROFILE_URN_PREFIX):
+        candidate = candidate[len(_PROFILE_URN_PREFIX) :]
+    return candidate if _PROFILE_URN_RE.fullmatch(candidate) else None
+
+
+def _profile_path_from_url(value: str) -> str | None:
+    parsed = _safe_linkedin_url(value)
+    if parsed is None or parsed.query or not _PROFILE_PATH_RE.fullmatch(parsed.path):
+        return None
+    try:
+        username = normalize_person_identifier(value)
+    except LinkedInScraperException:
+        return None
+    canonical_path = urlparse(person_profile_url(username, "/")).path
+    return parsed.path if parsed.path == canonical_path else None
+
+
+def _profile_urn_from_compose_url(value: str, *, base: str | None = None) -> str | None:
+    parsed = _safe_linkedin_url(value, base=base)
+    if parsed is None or parsed.path != "/messaging/compose/":
+        return None
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    identifiers: set[str] = set()
+    for key in ("recipient", "profileUrn"):
+        values = params.get(key, [])
+        normalized = [_normalize_profile_urn(item) for item in values]
+        if any(item is None for item in normalized):
+            return None
+        identifiers.update(item for item in normalized if item is not None)
+    if len(identifiers) != 1:
+        return None
+    return identifiers.pop()
+
+
+def _message_page_url_is_safe(value: str, profile_urn: str) -> bool:
+    parsed = _safe_linkedin_url(value)
+    if parsed is None:
+        return False
+
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    recipient_values = [
+        item for key in ("recipient", "profileUrn") for item in params.get(key, [])
+    ]
+    if parsed.path != "/messaging/compose/" and not _MESSAGE_THREAD_PATH_RE.fullmatch(
+        parsed.path
+    ):
+        return False
+    return all(_normalize_profile_urn(item) == profile_urn for item in recipient_values)
+
 
 # Shared JS function that walks up from any /messaging/compose/ anchor
 # inside <main> to find the smallest ancestor that satisfies the
@@ -2647,27 +2917,9 @@ class LinkedInExtractor:
         )
 
     async def _extract_profile_urn(self) -> str | None:
-        """Extract the recipient profile URN from the messaging compose link.
-
-        The compose button on a person's profile contains a recipient URN in its
-        href query string. This URN is more reliable than username for messaging.
-        Returns None when no compose button is present (e.g. not a 1st-degree
-        connection or viewing own profile).
-        """
-        href: str | None = await self._page.evaluate(
-            """() => {
-                const anchor = document.querySelector(
-                    'main a[href*="/messaging/compose/"]'
-                );
-                if (!anchor) return null;
-                return anchor.getAttribute('href') || anchor.href || null;
-            }"""
-        )
-        if not isinstance(href, str) or not href.strip():
-            return None
-        params = parse_qs(urlparse(href.strip()).query)
-        recipient = params.get("recipient", [None])[0]
-        return recipient if isinstance(recipient, str) and recipient else None
+        """Extract a profile URN only from one unambiguous top-card snapshot."""
+        target = await self._read_profile_message_target()
+        return target.profile_urn if target else None
 
     async def get_sidebar_profiles(self, username: str) -> dict[str, Any]:
         """Extract profile links from sidebar sections on a LinkedIn profile page.
@@ -2846,29 +3098,48 @@ class LinkedInExtractor:
             "sidebar_profiles": sidebar_profiles,
         }
 
-    async def _resolve_message_compose_href(self) -> str | None:
-        """Return the direct recipient-specific compose URL from a profile page."""
-        href = await self._page.evaluate(
-            """(selector) => {
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth ||
-                            element.offsetHeight ||
-                            element.getClientRects().length)
-                    );
-
-                const anchor = Array.from(
-                    document.querySelectorAll(selector)
-                ).find(isVisible);
-                if (!anchor) return null;
-                return anchor.getAttribute('href') || anchor.href || null;
-            }""",
-            _MESSAGING_COMPOSE_LINK_SELECTOR,
-        )
-        if not isinstance(href, str) or not href.strip():
+    async def _read_profile_message_target(
+        self, _expected_username: str | None = None
+    ) -> _ProfileMessageTarget | None:
+        """Read profile identity, name, compose URL and URN in one DOM snapshot."""
+        data = await self._page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
+        if not isinstance(data, dict):
             return None
-        return urljoin("https://www.linkedin.com", href.strip())
+
+        page_url = data.get("pageUrl")
+        compose_hrefs = data.get("composeHrefs")
+        if not isinstance(page_url, str) or not isinstance(compose_hrefs, list):
+            return None
+        profile_path = _profile_path_from_url(page_url)
+        if profile_path is None:
+            return None
+        if len(compose_hrefs) != 1 or not isinstance(compose_hrefs[0], str):
+            return None
+
+        parsed_compose = _safe_linkedin_url(compose_hrefs[0], base=page_url)
+        if parsed_compose is None:
+            return None
+        compose_url = parsed_compose.geturl()
+        profile_urn = _profile_urn_from_compose_url(compose_url)
+        if profile_urn is None:
+            return None
+
+        display_name = data.get("displayName")
+        if not isinstance(display_name, str) or not display_name.strip():
+            display_name = None
+        else:
+            display_name = display_name.strip()
+        return _ProfileMessageTarget(
+            profile_path=profile_path,
+            profile_urn=profile_urn,
+            compose_url=compose_url,
+            display_name=display_name,
+        )
+
+    async def _resolve_message_compose_href(self) -> str | None:
+        """Return an unambiguous recipient-specific top-card compose URL."""
+        target = await self._read_profile_message_target()
+        return target.compose_url if target else None
 
     async def _read_profile_display_name(self) -> str | None:
         """Read the visible profile name from the current person page."""
@@ -2898,182 +3169,75 @@ class LinkedInExtractor:
         return display_name or None
 
     async def _wait_for_message_surface(
-        self,
-    ) -> Literal["composer", "recipient_picker"] | None:
-        """Wait for either the recipient picker or the real composer to appear.
-
-        The recipient-picker probe uses a short 2 s cap so we fall through
-        quickly to the composer check, which uses the page-level default
-        (``BrowserConfig.default_timeout``, configurable via ``--timeout``).
-        """
-        if await self._locator_is_visible(
-            _MESSAGING_RECIPIENT_PICKER_SELECTOR, timeout=2000
-        ):
-            return "recipient_picker"
-        if await self._wait_for_message_composer():
+        self, target: _ProfileMessageTarget
+    ) -> Literal["composer"] | None:
+        """Wait for one editor with a matching local recipient identity."""
+        if await self._wait_for_message_composer(target):
             return "composer"
         return None
 
-    async def _select_message_recipient(self, *candidates: str) -> bool:
-        """Select the intended recipient from LinkedIn's New message picker."""
-        normalized_candidates = [value.strip() for value in candidates if value.strip()]
-        if not normalized_candidates:
+    async def _wait_for_message_composer(self, target: _ProfileMessageTarget) -> bool:
+        """Wait for the complete verified LinkedIn composer state to settle."""
+        try:
+            await self._page.wait_for_function(
+                _MESSAGE_COMPOSER_READY_JS,
+                arg=self._message_target_argument(target),
+            )
+        except PlaywrightTimeoutError:
             return False
-
-        selected = await self._page.evaluate(
-            """({ candidates }) => {
-                const normalize = value =>
-                    (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
-                    );
-                const pickerInput = Array.from(document.querySelectorAll('input')).find(
-                    element =>
-                        isVisible(element) &&
-                        /type a name|multiple names/i.test(
-                            `${element.placeholder || ''} ${
-                                element.getAttribute('aria-label') || ''
-                            }`
-                        )
-                );
-                const pickerRoot =
-                    pickerInput?.closest('section, dialog, [role="dialog"], aside, div') ||
-                    document.body;
-                const rows = Array.from(
-                    pickerRoot.querySelectorAll(
-                        '[role="option"], [role="listitem"], li, button, a, div'
-                    )
-                ).filter(element => {
-                    if (!isVisible(element)) return false;
-                    const text = normalize(element.innerText || element.textContent);
-                    return text.length > 0 && text !== 'new message';
-                });
-
-                for (const candidate of candidates.map(normalize)) {
-                    const exact = rows.find(element =>
-                        normalize(element.innerText || element.textContent) === candidate
-                    );
-                    if (exact) {
-                        exact.click();
-                        return true;
-                    }
-                }
-
-                for (const candidate of candidates.map(normalize)) {
-                    const partial = rows.find(element =>
-                        normalize(element.innerText || element.textContent).includes(candidate)
-                    );
-                    if (partial) {
-                        partial.click();
-                        return true;
-                    }
-                }
-
-                return false;
-            }""",
-            {"candidates": normalized_candidates},
-        )
-        if selected:
-            await asyncio.sleep(0.75)
-        return bool(selected)
-
-    async def _wait_for_message_composer(self) -> bool:
-        """Wait for the usable LinkedIn message composer to appear."""
-        return await self._resolve_message_compose_box() is not None
+        except Exception:
+            logger.debug("Could not wait for the message editor", exc_info=True)
+            return False
+        return True
 
     async def _resolve_message_compose_box(self) -> Any | None:
-        """Resolve the visible compose box used for writing a LinkedIn message.
+        """Resolve the editor only when exactly one visible candidate exists."""
+        locator = self._page.locator(f"{_MESSAGING_COMPOSE_SELECTOR}:visible")
+        try:
+            if await locator.count() != 1:
+                return None
+        except Exception:
+            logger.debug("Could not count message editor candidates", exc_info=True)
+            return None
+        return locator.first
 
-        Uses the page-level default timeout (``BrowserConfig.default_timeout``)
-        so the ``--timeout`` CLI flag is respected.
-        """
-        for selector in _MESSAGING_COMPOSE_FALLBACK_SELECTORS:
-            locator = self._page.locator(selector)
-            candidate_count: int | None = None
-            try:
-                candidate_count = await locator.count()
-            except Exception:
-                logger.debug(
-                    "Could not count compose box candidates for selector %r",
-                    selector,
-                    exc_info=True,
-                )
+    @staticmethod
+    def _message_target_argument(
+        target: _ProfileMessageTarget,
+    ) -> dict[str, str | bool]:
+        return {
+            "profilePath": target.profile_path,
+            "profileUrn": target.profile_urn,
+        }
 
-            logger.debug(
-                "Message compose selector %r matched %s candidate(s)",
-                selector,
-                candidate_count if candidate_count is not None else "unknown",
-            )
-
-            # patchright quirk: locator.wait_for(state="visible") times out on
-            # the contenteditable compose div even though count() > 0 and the
-            # element is fully visible by every CSS/DOM criterion (display:block,
-            # visibility:visible, opacity:1, non-zero bbox, no inert ancestor).
-            # This appears to be a patchright bug with React-hydrated contenteditable
-            # elements in isolated worlds. Skip the actionability wait when count()
-            # already confirmed the element is present — downstream interactions
-            # use page.evaluate() which bypasses the same check.
-            if candidate_count and candidate_count > 0:
-                return locator.last
-
-            # Fallback: when count() raised an exception above (candidate_count
-            # is None), attempt the original wait_for path.  This is unlikely to
-            # succeed given the same patchright quirk, but preserves the prior
-            # behaviour for non-patchright drivers where wait_for works normally.
-            candidate = locator.last
-            try:
-                await candidate.wait_for(state="visible")
-                return candidate
-            except PlaywrightTimeoutError:
-                continue
-
-        return None
-
-    async def _compose_page_matches_recipient(self, *candidates: str) -> bool:
-        """Verify the compose page visibly identifies the intended recipient."""
-        normalized_candidates = [value.strip() for value in candidates if value.strip()]
-        if not normalized_candidates:
-            return False
-
-        matched = await self._page.evaluate(
-            """({ candidates }) => {
-                const normalize = value =>
-                    (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth ||
-                            element.offsetHeight ||
-                            element.getClientRects().length)
-                    );
-
-                const targetValues = candidates.map(normalize).filter(Boolean);
-                const root = document.querySelector('main') || document.body;
-                if (!root) return false;
-
-                const entries = Array.from(
-                    root.querySelectorAll(
-                        'button, [role="button"], a, span, div, li, p, h1, h2, h3'
-                    )
-                )
-                    .filter(isVisible)
-                    .map(element =>
-                        [
-                            normalize(element.innerText || element.textContent || ''),
-                            normalize(element.getAttribute('aria-label') || ''),
-                        ].filter(Boolean)
-                    )
-                    .flat();
-
-                return targetValues.some(candidate =>
-                    entries.some(entry => entry === candidate || entry.includes(candidate))
-                );
-            }""",
-            {"candidates": normalized_candidates},
+    async def _read_message_composer_state(
+        self, target: _ProfileMessageTarget
+    ) -> dict[str, Any]:
+        """Inspect the unique editor and recipient inside its semantic owner."""
+        state = await self._page.evaluate(
+            _MESSAGE_COMPOSER_STATE_JS,
+            self._message_target_argument(target),
         )
-        return bool(matched)
+        return state if isinstance(state, dict) else {"status": "invalid"}
+
+    async def _focus_verified_message_editor(
+        self, target: _ProfileMessageTarget
+    ) -> bool:
+        """Focus the same local editor whose recipient identity was verified."""
+        focused = await self._page.evaluate(
+            _MESSAGE_COMPOSER_FOCUS_JS,
+            self._message_target_argument(target),
+        )
+        return focused is True
+
+    async def _submit_verified_message(
+        self, target: _ProfileMessageTarget, *, allow_enter: bool
+    ) -> str:
+        """Click one local submit button or authorize the strict Enter fallback."""
+        argument = self._message_target_argument(target)
+        argument["allowEnter"] = allow_enter
+        result = await self._page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, argument)
+        return result if result in {"clicked", "enter"} else "invalid"
 
     async def _message_text_occurrences(self, message: str) -> int:
         """Count visible occurrences of the message outside any open composer."""
@@ -4961,15 +5125,7 @@ class LinkedInExtractor:
         confirm_send: bool,
         profile_urn: str | None = None,
     ) -> dict[str, Any]:
-        """Send a message to a LinkedIn user with explicit confirmation gating.
-
-        Args:
-            linkedin_username: LinkedIn username of the recipient.
-            message: The message text to send.
-            confirm_send: Must be True to actually send (False does a dry run).
-            profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
-                compose URL directly, bypassing the Message-button lookup.
-        """
+        """Send only after the loaded profile and local composer identify one user."""
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
         if not message.strip():
@@ -4988,31 +5144,23 @@ class LinkedInExtractor:
             logger.debug("Profile page did not load for %s", linkedin_username)
 
         await handle_modal_close(self._page)
-        display_name = await self._read_profile_display_name()
-        if profile_urn:
-            # Build the full compose URL that LinkedIn's own Message button
-            # generates. The minimal ?recipient=<URN> form works for established
-            # connections but shows a "Say hello" widget (no compose box) for new
-            # connections. Adding profileUrn + screenContext + interop=msgOverlay
-            # consistently opens the real composer regardless of connection age.
-            _encoded = quote_plus(f"urn:li:fsd_profile:{profile_urn}")
-            compose_url: str | None = (
-                f"https://www.linkedin.com/messaging/compose/"
-                f"?profileUrn={_encoded}"
-                f"&recipient={quote_plus(profile_urn)}"
-                f"&screenContext=NON_SELF_PROFILE_VIEW"
-                f"&interop=msgOverlay"
-            )
-        else:
-            compose_url = await self._resolve_message_compose_href()
-        if not compose_url:
+        target = await self._read_profile_message_target(linkedin_username)
+        if target is None:
             return self._message_action_result(
                 profile_url,
                 "message_unavailable",
-                "LinkedIn did not expose a usable Message action for this profile.",
+                "LinkedIn did not expose one usable Message action for this profile.",
             )
 
-        await self._navigate_to_page(compose_url)
+        supplied_urn = _normalize_profile_urn(profile_urn) if profile_urn else None
+        if profile_urn is not None and supplied_urn != target.profile_urn:
+            return self._message_action_result(
+                profile_url,
+                "recipient_resolution_failed",
+                "The supplied profile URN did not match the loaded profile.",
+            )
+
+        await self._navigate_to_page(target.compose_url)
         await detect_rate_limit(self._page)
 
         try:
@@ -5021,67 +5169,38 @@ class LinkedInExtractor:
             logger.debug("Compose page did not fully load for %s", linkedin_username)
 
         await handle_modal_close(self._page)
-        message_surface = await self._wait_for_message_surface()
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "LinkedIn opened an unexpected messaging URL.",
+            )
+
+        message_surface = await self._wait_for_message_surface(target)
         logger.debug(
-            "Message surface for %s before hydration was %s",
-            linkedin_username,
-            message_surface,
+            "Message surface for %s was %s", linkedin_username, message_surface
         )
-
-        recipient_selected = False
-        if message_surface == "recipient_picker":
-            recipient_selected = await self._select_message_recipient(
-                display_name or "",
-                linkedin_username,
-            )
-            logger.debug(
-                "Recipient picker selection for %s returned %s",
-                linkedin_username,
-                recipient_selected,
-            )
-            if not recipient_selected:
-                await self._dismiss_message_ui()
-                return self._message_action_result(
-                    self._page.url,
-                    "recipient_resolution_failed",
-                    "LinkedIn opened a compose page, but the visible recipient did not match the requested profile.",
-                )
-            message_surface = await self._wait_for_message_surface()
-            logger.debug(
-                "Message surface for %s after recipient selection was %s",
-                linkedin_username,
-                message_surface,
-            )
-
-        compose_box = await self._resolve_message_compose_box()
-        if compose_box is None:
+        if message_surface != "composer":
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "composer_unavailable",
-                "LinkedIn did not expose a usable message composer.",
-                recipient_selected=recipient_selected,
+                "LinkedIn did not expose one usable message composer.",
             )
 
-        logger.debug(
-            "Message compose box resolved for %s after hydration",
-            linkedin_username,
-        )
-
-        if not await self._compose_page_matches_recipient(
-            display_name or "",
-            linkedin_username,
-        ):
+        state = await self._read_message_composer_state(target)
+        if state.get("status") != "valid":
             logger.debug(
-                "Recipient match still failed for %s after compose hydration",
+                "Message recipient verification for %s returned %s",
                 linkedin_username,
+                state.get("status"),
             )
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
-                "LinkedIn opened a compose page, but the visible recipient did not match the requested profile.",
-                recipient_selected=recipient_selected,
+                "The local composer did not identify exactly the requested profile.",
             )
         recipient_selected = True
 
@@ -5094,37 +5213,22 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
 
-        # patchright quirk: compose_box.click() and press_sequentially() use
-        # actionability checks internally and hit the same wait_for timeout.
-        # Instead: focus via page.evaluate() (no actionability check) and type
-        # via page.keyboard.type() which operates on the active element directly
-        # and fires the real keydown/input/keyup events React needs to enable Send.
-        #
-        # DOM dependency: innerText extraction is not applicable here — we need
-        # to call .focus() on the element reference, which requires querySelector.
-        # Selectors use only role + contenteditable + aria-label (ARIA attributes,
-        # not layout class names) so they are stable across LinkedIn UI changes.
-        composer = await self._page.evaluate(
-            """() => {
-                const el = document.querySelector(
-                    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
-                    + 'div[role="textbox"][contenteditable="true"]'
-                );
-                if (!el) return 'missing';
-                // Text already in the editor belongs to whoever typed it.
-                // Chromium leaves the caret at the start of a contenteditable
-                // after focus(), so typing here puts the message in front of
-                // that draft and LinkedIn delivers the two as one. Clearing
-                // it would destroy it, so refuse and leave it standing.
-                if ((el.innerText || '').replace(/\\s+/g, ' ').trim()) {
-                    return 'occupied';
-                }
-                el.focus();
-                return 'focused';
-            }"""
-        )
-        if composer == "occupied":
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
             await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed before the editor could be focused.",
+                recipient_selected=recipient_selected,
+            )
+        state = await self._read_message_composer_state(target)
+        if state.get("status") == "valid" and state.get("empty") is not True:
+            await self._dismiss_message_ui()
+            # Text already in the editor belongs to whoever typed it.
+            # Chromium leaves the caret at the start of a contenteditable
+            # after focus(), so the message would land in front of that draft
+            # and LinkedIn would deliver the two as one. Clearing it would
+            # trade the leak for destroying it, so refuse and leave it.
             return self._message_action_result(
                 self._page.url,
                 "composer_occupied",
@@ -5132,45 +5236,77 @@ class LinkedInExtractor:
                 "with the message. The draft was left untouched.",
                 recipient_selected=recipient_selected,
             )
-        if composer != "focused":
+        if state.get(
+            "status"
+        ) != "valid" or not await self._focus_verified_message_editor(target):
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "compose_interact_failed",
-                "Could not focus compose box via JavaScript.",
+                "The verified message editor could not be focused.",
                 recipient_selected=recipient_selected,
             )
-        await asyncio.sleep(0.1)
-        await self._page.keyboard.type(message, delay=15)
-        await asyncio.sleep(0.3)
-        await asyncio.sleep(1.0)  # allow React to process keyboard input
 
-        # Baseline immediately before the send attempt: how often the message
-        # is already visible outside the composer. The click below only tries
-        # to send; delivery is proven by this count growing, never by the text
-        # the composer still holds.
+        await asyncio.sleep(0.1)
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed before text entry.",
+                recipient_selected=recipient_selected,
+            )
+        state = await self._read_message_composer_state(target)
+        if state.get("status") != "valid" or state.get("active") is not True:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "compose_interact_failed",
+                "The verified message editor changed before text entry.",
+                recipient_selected=recipient_selected,
+            )
+        allow_enter = state.get("submitCount") == 0
+
+        await self._page.keyboard.type(message, delay=15)
+        await asyncio.sleep(1.0)
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed before submission.",
+                recipient_selected=recipient_selected,
+            )
+
+        # Baseline immediately before the submit attempt: how often the message
+        # is already visible outside every composer. Submission only tries to
+        # send; delivery is proven by this count growing, never by the text the
+        # verified editor still holds.
         previous_occurrences = await self._message_text_occurrences(message)
 
-        # patchright actionability also blocks send_button.click(). Use JS click
-        # on any visible, enabled send button; fall back to Enter key which
-        # LinkedIn's composer also accepts for submission.
-        #
-        # DOM dependency: we need btn.click() on the element reference — not
-        # achievable via innerText or URL navigation. Selectors use only type,
-        # aria-label, and data attributes (no layout class names).
-        sent_via_js = await self._page.evaluate(
-            """() => {
-                const btn = Array.from(document.querySelectorAll(
-                    'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
-                    + 'button[data-control-name="send"]'
-                )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
-                if (!btn) return false;
-                btn.click();
-                return true;
-            }"""
+        submission = await self._submit_verified_message(
+            target, allow_enter=allow_enter
         )
-        if not sent_via_js:
-            await self._page.keyboard.press("Enter")
+        if submission == "enter":
+            state = await self._read_message_composer_state(target)
+            if (
+                not allow_enter
+                or not _message_page_url_is_safe(self._page.url, target.profile_urn)
+                or state.get("status") != "valid"
+                or state.get("active") is not True
+                or state.get("submitCount") != 0
+            ):
+                submission = "invalid"
+            else:
+                await self._page.keyboard.press("Enter")
+        if submission not in {"clicked", "enter"}:
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "send_unavailable",
+                "The local submit path was missing, disabled, or ambiguous.",
+                recipient_selected=recipient_selected,
+            )
 
         if not await self._message_text_visible(
             message, previous_occurrences=previous_occurrences

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4959,6 +4959,13 @@ class LinkedInExtractor:
         """
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
+        if not message.strip():
+            return self._message_action_result(
+                profile_url,
+                "message_unavailable",
+                "Message must contain non-whitespace characters.",
+            )
+
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -455,6 +455,55 @@ _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Close"]'
 )
 
+# Counts visible occurrences of a message *outside* every open composer.
+# The composer holds the message before it is sent, so plain body text is no
+# evidence of delivery: a Send button whose handler does nothing leaves the
+# text standing in the editor and the page still "contains" it. Occurrences
+# inside visible contenteditable editors are therefore subtracted, and the
+# send path compares a baseline taken before the click with the count after
+# it. Visibility is pure geometry and the match is on normalized text, so no
+# LinkedIn class name or localized label enters the decision.
+_MESSAGE_OCCURRENCES_JS = r"""
+({ expected }) => {
+    const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
+    const needle = normalize(expected);
+    if (!needle) return 0;
+
+    const countIn = value => {
+        const haystack = normalize(value);
+        let count = 0;
+        let index = haystack.indexOf(needle);
+        while (index !== -1) {
+            count += 1;
+            index = haystack.indexOf(needle, index + needle.length);
+        }
+        return count;
+    };
+
+    const isVisible = element =>
+        !!(
+            element &&
+            (element.offsetWidth ||
+                element.offsetHeight ||
+                element.getClientRects().length)
+        );
+
+    let total = countIn(document.body?.innerText || '');
+    for (const editor of document.querySelectorAll('[contenteditable="true"]')) {
+        if (isVisible(editor)) {
+            total -= countIn(editor.innerText);
+        }
+    }
+    return total > 0 ? total : 0;
+}
+"""
+
+# The post-send predicate is the same counting routine, so the baseline and
+# the confirmation can never disagree about what counts as an occurrence.
+_MESSAGE_OCCURRENCES_INCREASED_JS = (
+    f"(arg) => ({_MESSAGE_OCCURRENCES_JS})(arg) > arg.previous"
+)
+
 # Shared JS function that walks up from any /messaging/compose/ anchor
 # inside <main> to find the smallest ancestor that satisfies the
 # action-root predicate (>=2 interactive children, >=1 button). This is
@@ -3013,20 +3062,29 @@ class LinkedInExtractor:
         )
         return bool(matched)
 
-    async def _message_text_visible(self, message: str) -> bool:
-        """Wait until the compose page visibly contains the just-sent message text.
+    async def _message_text_occurrences(self, message: str) -> int:
+        """Count visible occurrences of the message outside any open composer."""
+        occurrences = await self._page.evaluate(
+            _MESSAGE_OCCURRENCES_JS, {"expected": message}
+        )
+        return int(occurrences or 0)
+
+    async def _message_text_visible(
+        self, message: str, *, previous_occurrences: int
+    ) -> bool:
+        """Wait until a *new* copy of the message appears outside the composer.
+
+        ``previous_occurrences`` is the baseline taken after typing and before
+        the send attempt, so the requirement is strictly more occurrences than
+        before: the typed text sitting in the composer cannot confirm itself,
+        and neither can an identical message already in the thread.
 
         Uses the page-level default timeout (``BrowserConfig.default_timeout``).
         """
         try:
             await self._page.wait_for_function(
-                """({ expected }) => {
-                    const normalize = value =>
-                        (value || '').replace(/\\s+/g, ' ').trim();
-                    const bodyText = normalize(document.body?.innerText || '');
-                    return bodyText.includes(normalize(expected));
-                }""",
-                arg={"expected": message},
+                _MESSAGE_OCCURRENCES_INCREASED_JS,
+                arg={"expected": message, "previous": previous_occurrences},
             )
             return True
         except PlaywrightTimeoutError:
@@ -5048,6 +5106,13 @@ class LinkedInExtractor:
         await asyncio.sleep(0.1)
         await self._page.keyboard.type(message, delay=15)
         await asyncio.sleep(0.3)
+        await asyncio.sleep(1.0)  # allow React to process keyboard input
+
+        # Baseline immediately before the send attempt: how often the message
+        # is already visible outside the composer. The click below only tries
+        # to send; delivery is proven by this count growing, never by the text
+        # the composer still holds.
+        previous_occurrences = await self._message_text_occurrences(message)
 
         # patchright actionability also blocks send_button.click(). Use JS click
         # on any visible, enabled send button; fall back to Enter key which
@@ -5056,7 +5121,6 @@ class LinkedInExtractor:
         # DOM dependency: we need btn.click() on the element reference — not
         # achievable via innerText or URL navigation. Selectors use only type,
         # aria-label, and data attributes (no layout class names).
-        await asyncio.sleep(1.0)  # allow React to process keyboard input
         sent_via_js = await self._page.evaluate(
             """() => {
                 const btn = Array.from(document.querySelectorAll(
@@ -5071,7 +5135,9 @@ class LinkedInExtractor:
         if not sent_via_js:
             await self._page.keyboard.press("Enter")
 
-        if not await self._message_text_visible(message):
+        if not await self._message_text_visible(
+            message, previous_occurrences=previous_occurrences
+        ):
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -545,12 +545,17 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
                 url.username ||
                 url.password ||
                 (url.port && url.port !== '443') ||
-                url.hash ||
-                !/^\/in\/[^/?#]+\/$/.test(url.pathname)
+                url.hash
             ) {
                 return null;
             }
-            return url.pathname;
+            // Everything under /in/<slug>/ belongs to that member, so the
+            // canonical path is the identity. Measured on a live profile:
+            // four of its own anchors point at /overlay/... and
+            // /recent-activity/, and reading those as an unknown member let
+            // the recipient contradict themselves.
+            const match = /^\/in\/([^/?#]+)(?:\/.*)?$/.exec(url.pathname);
+            return match ? `/in/${match[1]}/` : null;
         } catch {
             return null;
         }
@@ -691,7 +696,13 @@ _MESSAGE_COMPOSER_SUBMIT_JS = (
 
 _LINKEDIN_MESSAGE_HOST_RE = re.compile(r"^(?:[a-z0-9-]+\.)*linkedin\.com$")
 _PROFILE_PATH_RE = re.compile(r"^/in/[^/?#]+/$")
-_MESSAGE_THREAD_PATH_RE = re.compile(r"^/messaging/thread/[A-Za-z0-9_-]+/$")
+# A thread id is base64url and keeps its padding literally. Measured live:
+# /messaging/thread/2-ZDBkMjZiY2Ut...XzEwMA==/ is what LinkedIn redirects an
+# existing conversation to, and rejecting it stopped every send to a member
+# the account had already written to. Only '=' is added: '%' would readmit an
+# encoded slash and let one path pose as another. The id identifies nobody on
+# its own, and the recipient is proven by the composer rather than this path.
+_MESSAGE_THREAD_PATH_RE = re.compile(r"^/messaging/thread/[A-Za-z0-9_=-]+/$")
 _PROFILE_URN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _PROFILE_URN_PREFIX = "urn:li:fsd_profile:"
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -463,6 +463,14 @@ _MESSAGING_CLOSE_SELECTOR = (
 # send path compares a baseline taken before the click with the count after
 # it. Visibility is pure geometry and the match is on normalized text, so no
 # LinkedIn class name or localized label enters the decision.
+#
+# Known limit, and it scales with how short the message is: the count is taken
+# over the whole body, so any unrelated text arriving between the two reads can
+# raise it if the message occurs inside it. A messaging page updates presence
+# and timestamps on its own, so a one-character message can be confirmed by
+# something that has nothing to do with it. A sentence cannot. Scoping the
+# count to the thread would need a container selector, and every candidate
+# LinkedIn offers is a layout class name.
 _MESSAGE_OCCURRENCES_JS = r"""
 ({ expected }) => {
     const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
@@ -489,7 +497,12 @@ _MESSAGE_OCCURRENCES_JS = r"""
         );
 
     let total = countIn(document.body?.innerText || '');
-    for (const editor of document.querySelectorAll('[contenteditable="true"]')) {
+    // Any element that declares contenteditable at all, not only the ones
+    // currently set to "true": a composer commonly goes read-only for the
+    // duration of an in-flight send while keeping its text on screen, and
+    // an occurrence subtracted at baseline must stay subtracted afterwards
+    // or the same unsent draft confirms itself.
+    for (const editor of document.querySelectorAll('[contenteditable]')) {
         if (isVisible(editor)) {
             total -= countIn(editor.innerText);
         }
@@ -5091,18 +5104,35 @@ class LinkedInExtractor:
         # to call .focus() on the element reference, which requires querySelector.
         # Selectors use only role + contenteditable + aria-label (ARIA attributes,
         # not layout class names) so they are stable across LinkedIn UI changes.
-        focused = await self._page.evaluate(
+        composer = await self._page.evaluate(
             """() => {
                 const el = document.querySelector(
                     'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
                     + 'div[role="textbox"][contenteditable="true"]'
                 );
-                if (!el) return false;
+                if (!el) return 'missing';
+                // Text already in the editor belongs to whoever typed it.
+                // Chromium leaves the caret at the start of a contenteditable
+                // after focus(), so typing here puts the message in front of
+                // that draft and LinkedIn delivers the two as one. Clearing
+                // it would destroy it, so refuse and leave it standing.
+                if ((el.innerText || '').replace(/\\s+/g, ' ').trim()) {
+                    return 'occupied';
+                }
                 el.focus();
-                return true;
+                return 'focused';
             }"""
         )
-        if not focused:
+        if composer == "occupied":
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "composer_occupied",
+                "The composer already holds a draft that would be sent along "
+                "with the message. The draft was left untouched.",
+                recipient_selected=recipient_selected,
+            )
+        if composer != "focused":
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
@@ -5146,10 +5176,18 @@ class LinkedInExtractor:
             message, previous_occurrences=previous_occurrences
         ):
             await self._dismiss_message_ui()
+            # Submission already happened, so this is not evidence that
+            # nothing was sent: a thread that renders the delivered bubble
+            # slower than the page timeout arrives here having delivered.
+            # Reporting a plain failure invites a retry, and a retry sends a
+            # second real message to a real person, so the status says
+            # unknown rather than no.
             return self._message_action_result(
                 self._page.url,
-                "send_unavailable",
-                "LinkedIn did not confirm that the message was sent.",
+                "send_unconfirmed",
+                "The message was submitted but LinkedIn did not confirm "
+                "delivery in time. Check the conversation before retrying; "
+                "retrying may deliver the message twice.",
                 recipient_selected=recipient_selected,
             )
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3109,9 +3109,7 @@ class LinkedInExtractor:
             "sidebar_profiles": sidebar_profiles,
         }
 
-    async def _read_profile_message_target(
-        self, _expected_username: str | None = None
-    ) -> _ProfileMessageTarget | None:
+    async def _read_profile_message_target(self) -> _ProfileMessageTarget | None:
         """Read profile identity, name, compose URL and URN in one DOM snapshot."""
         data = await self._page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
         if not isinstance(data, dict):
@@ -5155,7 +5153,7 @@ class LinkedInExtractor:
             logger.debug("Profile page did not load for %s", linkedin_username)
 
         await handle_modal_close(self._page)
-        target = await self._read_profile_message_target(linkedin_username)
+        target = await self._read_profile_message_target()
         if target is None:
             return self._message_action_result(
                 profile_url,

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -229,19 +229,21 @@ def register_messaging_tools(
         """
         Send a message to a LinkedIn user.
 
-        The recipient must be directly messageable from the profile page. This is a
-        write operation when confirm_send is True.
+        The recipient must be directly messageable from the profile page. Nothing
+        is typed or submitted until the loaded profile and the open composer
+        identify the same person; on any disagreement the tool returns without
+        touching the editor. This is a write operation when confirm_send is True.
 
         Args:
             linkedin_username: LinkedIn username of the recipient; a full profile URL is accepted too
             message: The message text to send
             confirm_send: Must be True to send the message
             ctx: FastMCP context for progress reporting
-            profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
-                compose URL directly. Providing this bypasses the Message-button
-                lookup and is more reliable when available. Obtain via
-                get_person_profile. Note: inbox may not always show all
-                messages; use search_conversations as a fallback.
+            profile_urn: Optional profile URN (e.g. ACoAAB...) to verify against
+                the URN exposed by the loaded profile before opening its Message
+                action. It never bypasses recipient verification. Obtain via
+                get_person_profile. Note: inbox may not always show all messages;
+                use search_conversations as a fallback.
 
         Returns:
             Dict with url, status, message, recipient_selected, and sent.

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -390,6 +390,36 @@ class TestMessageComposerDom:
         assert foreign["status"] == "recipient_mismatch"
         assert multiple["status"] == "ambiguous_editor"
 
+    @pytest.mark.parametrize(
+        ("href", "expected"),
+        [
+            # Every shape below was read off one live profile page. Four of
+            # its 38 visible anchors point into the member's own subtree, and
+            # reading those as an unknown member made the recipient
+            # contradict themselves and stopped the send.
+            ("https://www.linkedin.com/in/testuser/overlay/contact-info/", "valid"),
+            ("https://www.linkedin.com/in/testuser/recent-activity/all/", "valid"),
+            ("https://www.linkedin.com/in/testuser", "valid"),
+            ("https://www.linkedin.com/in/testuser?miniProfileUrn=urn%3A", "valid"),
+            # A different member stays a different member in every shape.
+            ("https://www.linkedin.com/in/other/en/", "recipient_mismatch"),
+            ("https://www.linkedin.com/in/other", "recipient_mismatch"),
+            # An anchor that names nobody stays a contradiction rather than
+            # silence: a link the check cannot read is not evidence that the
+            # recipient is the requested one.
+            ("https://www.linkedin.com/in/", "recipient_mismatch"),
+            ("https://evil.example/in/testuser/", "recipient_mismatch"),
+        ],
+    )
+    async def test_subpaths_belong_to_the_member_they_sit_under(
+        self, dom_page, href, expected
+    ):
+        state = await _state(
+            dom_page, _composer(identity=f'<a href="{href}">Profile</a>')
+        )
+
+        assert state["status"] == expected
+
     async def test_focus_and_single_submit_stay_local(self, dom_page):
         await dom_page.set_content(
             _composer(

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -1,0 +1,491 @@
+"""Browser-DOM tests for local message-recipient verification.
+
+The unit suite mocks ``page.evaluate``, so these cases execute the extraction,
+focus, and submit JavaScript against synthetic Chromium DOMs. No LinkedIn page
+is loaded and no account action is performed.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.scraping.extractor import (
+    LinkedInExtractor,
+    _MESSAGE_COMPOSER_FOCUS_JS,
+    _MESSAGE_COMPOSER_STATE_JS,
+    _MESSAGE_COMPOSER_SUBMIT_JS,
+    _PROFILE_MESSAGE_TARGET_JS,
+    _ProfileMessageTarget,
+)
+
+pytestmark = [
+    pytest.mark.browser_dom,
+    pytest.mark.xdist_group("browser_runtime"),
+]
+
+TARGET = {"profilePath": "/in/testuser/", "profileUrn": "ACoAAB"}
+ENTER_TARGET = {**TARGET, "allowEnter": True}
+
+
+def _message_target() -> _ProfileMessageTarget:
+    return _ProfileMessageTarget(
+        profile_path=TARGET["profilePath"],
+        profile_urn=TARGET["profileUrn"],
+        compose_url="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+        display_name="Test User",
+    )
+
+
+@pytest.fixture
+async def dom_page():
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(
+                channel="chromium", headless=True
+            )
+            page = await browser.new_page()
+        except Exception as exc:
+            pytest.skip(f"chromium unavailable: {exc}")
+        try:
+            yield page
+        finally:
+            await browser.close()
+
+
+def _composer(*, identity: str, buttons: str = "", extra: str = "") -> str:
+    return f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+      <main>
+        <section role="dialog">
+          {identity}
+          <form>
+            <div role="textbox" contenteditable="true"
+                 style="display:block;width:200px;height:30px"></div>
+            {buttons}
+          </form>
+        </section>
+        {extra}
+      </main>
+    </body></html>
+    """
+
+
+async def _state(page, html: str) -> dict:
+    await page.set_content(html)
+    return await page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET)
+
+
+class TestMessageSurfaceDom:
+    async def test_waits_for_delayed_recipient_identity(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog">
+                <form>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                </form>
+              </section>
+            </body></html>"""
+        )
+        dom_page.set_default_timeout(1_000)
+        await dom_page.evaluate(
+            """() => setTimeout(() => {
+                document.querySelector('form').insertAdjacentHTML(
+                    'afterbegin',
+                    '<a href="https://www.linkedin.com/in/testuser/">Test</a>'
+                );
+            }, 250)"""
+        )
+        started = time.monotonic()
+
+        result = await LinkedInExtractor(dom_page)._wait_for_message_surface(
+            _message_target()
+        )
+
+        assert result == "composer"
+        assert time.monotonic() - started >= 0.2
+
+    async def test_waits_for_multiple_editors_to_settle(self, dom_page):
+        await dom_page.set_content(
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                extra=(
+                    '<div role="textbox" contenteditable="true" data-stale '
+                    'style="display:block;width:200px;height:30px"></div>'
+                ),
+            )
+        )
+        dom_page.set_default_timeout(1_000)
+        await dom_page.evaluate(
+            """() => setTimeout(() => {
+                document.querySelector('[data-stale]').remove();
+            }, 250)"""
+        )
+        started = time.monotonic()
+
+        result = await LinkedInExtractor(dom_page)._wait_for_message_surface(
+            _message_target()
+        )
+
+        assert result == "composer"
+        assert time.monotonic() - started >= 0.2
+
+    async def test_permanent_recipient_conflict_times_out(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog" data-recipient-urn="OTHER">
+                <form>
+                  <a href="https://www.linkedin.com/in/testuser/">Test</a>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                </form>
+              </section>
+            </body></html>"""
+        )
+        dom_page.set_default_timeout(350)
+        started = time.monotonic()
+
+        result = await LinkedInExtractor(dom_page)._wait_for_message_surface(
+            _message_target()
+        )
+
+        assert result is None
+        assert time.monotonic() - started >= 0.25
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET) == {
+            "status": "recipient_mismatch",
+            "active": False,
+            "submitCount": 0,
+        }
+
+
+class TestProfileMessageTargetDom:
+    async def test_snapshot_stays_inside_first_top_card(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body><main>
+              <section>
+                <h1>Test User</h1>
+                <a style="display:block" href="/messaging/compose/?recipient=ACoAAB">
+                  Nachricht
+                </a>
+              </section>
+              <section>
+                <a style="display:block" href="/messaging/compose/?recipient=OTHER">
+                  Sidebar
+                </a>
+              </section>
+            </main></body></html>
+            """
+        )
+
+        result = await dom_page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
+
+        assert result["displayName"] == "Test User"
+        assert result["composeHrefs"] == ["/messaging/compose/?recipient=ACoAAB"]
+
+
+class TestMessageComposerDom:
+    async def test_generic_data_urn_never_authorizes_recipient(self, dom_page):
+        state = await _state(
+            dom_page,
+            _composer(identity='<span data-urn="ACoAAB">unrelated generic data</span>'),
+        )
+
+        assert state["status"] == "missing_recipient"
+
+    async def test_native_dialog_accepts_explicit_recipient_urn(self, dom_page):
+        state = await _state(
+            dom_page,
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <dialog open>
+                <span data-recipient-urn="ACoAAB">Test</span>
+                <div role="textbox" contenteditable="true"
+                     style="display:block;width:200px;height:30px"></div>
+              </dialog>
+            </body></html>""",
+        )
+
+        assert state["status"] == "valid"
+
+    async def test_second_urn_attribute_on_one_element_is_never_skipped(self, dom_page):
+        conflicting = await _state(
+            dom_page,
+            _composer(
+                identity=(
+                    '<span data-profile-urn="ACoAAB" data-recipient-urn="OTHER">'
+                    "Test</span>"
+                )
+            ),
+        )
+        empty = await _state(
+            dom_page,
+            _composer(
+                identity=(
+                    '<span data-profile-urn="ACoAAB" data-recipient-urn="">Test</span>'
+                )
+            ),
+        )
+        consistent = await _state(
+            dom_page,
+            _composer(
+                identity=(
+                    '<span data-profile-urn="ACoAAB" '
+                    'data-recipient-urn="urn:li:fsd_profile:ACoAAB">Test</span>'
+                )
+            ),
+        )
+
+        assert conflicting["status"] == "recipient_mismatch"
+        assert empty["status"] == "recipient_mismatch"
+        assert consistent["status"] == "valid"
+
+    async def test_nested_owner_conflict_fails_closed(self, dom_page):
+        state = await _state(
+            dom_page,
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog" data-recipient-urn="OTHER">
+                <form>
+                  <a href="https://www.linkedin.com/in/testuser/">Test</a>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                  <button type="submit">Local</button>
+                </form>
+                <button type="submit" data-outer>Outer</button>
+              </section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "recipient_mismatch"
+        assert state["submitCount"] == 0
+
+    async def test_nested_consistent_identity_keeps_submit_local(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog" data-recipient-urn="ACoAAB">
+                <form>
+                  <a href="https://www.linkedin.com/in/testuser/">Test</a>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                  <button type="submit" onclick="event.preventDefault();
+                    this.setAttribute('data-clicked','yes')">Local</button>
+                </form>
+                <button type="submit" data-outer>Outer</button>
+              </section>
+            </body></html>"""
+        )
+
+        focused = await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET)
+        submitted = await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET)
+
+        assert focused is True
+        assert submitted == "clicked"
+        assert (
+            await dom_page.locator("form button").get_attribute("data-clicked") == "yes"
+        )
+        assert (
+            await dom_page.locator("[data-outer]").get_attribute("data-clicked") is None
+        )
+
+    async def test_profile_link_inside_editor_never_authorizes(self, dom_page):
+        """Draft content is not a recipient, however well-formed it looks."""
+        state = await _state(
+            dom_page,
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog"><form>
+                <div role="textbox" contenteditable="true"
+                     style="display:block;width:200px;height:30px">
+                  <a href="https://www.linkedin.com/in/testuser/">Draft link</a>
+                </div>
+              </form></section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "missing_recipient"
+
+    @pytest.mark.parametrize("attribute", ["data-profile-urn", "data-recipient-urn"])
+    @pytest.mark.parametrize("location", ["editor", "descendant"])
+    async def test_recipient_urn_inside_editor_never_authorizes(
+        self, dom_page, attribute, location
+    ):
+        editor_attribute = f'{attribute}="ACoAAB"' if location == "editor" else ""
+        draft = (
+            f'<span {attribute}="ACoAAB">Draft identity</span>'
+            if location == "descendant"
+            else "Draft"
+        )
+        state = await _state(
+            dom_page,
+            f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog"><form>
+                <div role="textbox" contenteditable="true" {editor_attribute}
+                     style="display:block;width:200px;height:30px">{draft}</div>
+              </form></section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "missing_recipient"
+
+    @pytest.mark.parametrize(
+        "draft_identity",
+        [
+            '<a href="https://www.linkedin.com/in/testuser/">Matching draft</a>',
+            '<a href="https://www.linkedin.com/in/other/">Foreign draft</a>',
+            '<span data-profile-urn="ACoAAB">Matching draft</span>',
+            '<span data-profile-urn="OTHER">Foreign draft</span>',
+            '<span data-recipient-urn="ACoAAB">Matching draft</span>',
+            '<span data-recipient-urn="OTHER">Foreign draft</span>',
+        ],
+    )
+    async def test_outer_identity_ignores_draft_identity(
+        self, dom_page, draft_identity
+    ):
+        """The verdict comes from the recipient chip, never from the draft."""
+        state = await _state(
+            dom_page,
+            f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog"><form>
+                <a href="https://www.linkedin.com/in/testuser/">Recipient</a>
+                <div role="textbox" contenteditable="true"
+                     style="display:block;width:200px;height:30px">
+                  {draft_identity}
+                </div>
+              </form></section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "valid"
+
+    async def test_name_only_or_global_identity_never_authorizes(self, dom_page):
+        html = _composer(
+            identity=(
+                "<span>Test User</span>"
+                '<span hidden data-profile-urn="ACoAAB">stale identity</span>'
+            ),
+            extra='<a href="https://www.linkedin.com/in/testuser/">Test User</a>',
+        )
+
+        state = await _state(dom_page, html)
+
+        assert state["status"] == "missing_recipient"
+
+    async def test_foreign_or_multiple_editor_fails_closed(self, dom_page):
+        foreign = await _state(
+            dom_page,
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/other/">Other</a>'
+            ),
+        )
+        multiple = await _state(
+            dom_page,
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                extra=(
+                    '<div role="textbox" contenteditable="true" '
+                    'style="display:block;width:200px;height:30px"></div>'
+                ),
+            ),
+        )
+
+        assert foreign["status"] == "recipient_mismatch"
+        assert multiple["status"] == "ambiguous_editor"
+
+    async def test_focus_and_single_submit_stay_local(self, dom_page):
+        await dom_page.set_content(
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                buttons=(
+                    '<button type="submit" onclick="event.preventDefault();'
+                    "this.setAttribute('data-clicked','yes')\">Senden</button>"
+                ),
+                extra=('<button type="submit" data-global="true">Global</button>'),
+            )
+        )
+
+        focused = await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET)
+        submitted = await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET)
+
+        assert focused is True
+        assert submitted == "clicked"
+        assert (
+            await dom_page.locator("form button").get_attribute("data-clicked") == "yes"
+        )
+        assert (
+            await dom_page.locator("[data-global]").get_attribute("data-clicked")
+            is None
+        )
+
+    async def test_ambiguous_disabled_and_changed_recipient_never_submit(
+        self, dom_page
+    ):
+        identity = '<a href="https://www.linkedin.com/in/testuser/">Test</a>'
+        await dom_page.set_content(
+            _composer(
+                identity=identity,
+                buttons='<button type="submit">A</button><button type="submit">B</button>',
+            )
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
+
+        await dom_page.set_content(
+            _composer(
+                identity=identity, buttons='<button type="submit" disabled>A</button>'
+            )
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
+
+        await dom_page.set_content(
+            _composer(
+                identity=identity,
+                buttons='<button type="submit" aria-disabled="true">A</button>',
+            )
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
+
+        await dom_page.set_content(
+            _composer(identity=identity, buttons='<button type="submit">stale</button>')
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        state = await dom_page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET)
+        await dom_page.locator("form button").evaluate("element => element.remove()")
+        submit_target = {**TARGET, "allowEnter": state["submitCount"] == 0}
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, submit_target)
+            == "invalid"
+        )
+
+        await dom_page.set_content(_composer(identity=identity))
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        await dom_page.locator('[role="dialog"] > a').evaluate(
+            "element => element.setAttribute('href', 'https://www.linkedin.com/in/other/')"
+        )
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
+            == "invalid"
+        )
+
+    async def test_enter_only_when_verified_editor_stays_active_without_buttons(
+        self, dom_page
+    ):
+        await dom_page.set_content(
+            _composer(
+                identity=(
+                    '<span data-profile-urn="urn:li:fsd_profile:ACoAAB">Test</span>'
+                )
+            )
+        )
+
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
+            == "enter"
+        )
+
+        await dom_page.evaluate("document.activeElement.blur()")
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
+            == "invalid"
+        )

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -393,6 +393,36 @@ class TestMessageComposerDom:
         assert foreign["status"] == "recipient_mismatch"
         assert multiple["status"] == "ambiguous_editor"
 
+    @pytest.mark.parametrize(
+        ("href", "expected"),
+        [
+            # Every shape below was read off one live profile page. Four of
+            # its 38 visible anchors point into the member's own subtree, and
+            # reading those as an unknown member made the recipient
+            # contradict themselves and stopped the send.
+            ("https://www.linkedin.com/in/testuser/overlay/contact-info/", "valid"),
+            ("https://www.linkedin.com/in/testuser/recent-activity/all/", "valid"),
+            ("https://www.linkedin.com/in/testuser", "valid"),
+            ("https://www.linkedin.com/in/testuser?miniProfileUrn=urn%3A", "valid"),
+            # A different member stays a different member in every shape.
+            ("https://www.linkedin.com/in/other/en/", "recipient_mismatch"),
+            ("https://www.linkedin.com/in/other", "recipient_mismatch"),
+            # An anchor that names nobody stays a contradiction rather than
+            # silence: a link the check cannot read is not evidence that the
+            # recipient is the requested one.
+            ("https://www.linkedin.com/in/", "recipient_mismatch"),
+            ("https://evil.example/in/testuser/", "recipient_mismatch"),
+        ],
+    )
+    async def test_subpaths_belong_to_the_member_they_sit_under(
+        self, dom_page, href, expected
+    ):
+        state = await _state(
+            dom_page, _composer(identity=f'<a href="{href}">Profile</a>')
+        )
+
+        assert state["status"] == expected
+
     async def test_focus_and_single_submit_stay_local(self, dom_page):
         await dom_page.set_content(
             _composer(

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -1,0 +1,494 @@
+"""Browser-DOM tests for local message-recipient verification.
+
+The unit suite mocks ``page.evaluate``, so these cases execute the extraction,
+focus, and submit JavaScript against synthetic Chromium DOMs. No LinkedIn page
+is loaded and no account action is performed.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.scraping.extractor import (
+    LinkedInExtractor,
+    _MESSAGE_COMPOSER_FOCUS_JS,
+    _MESSAGE_COMPOSER_STATE_JS,
+    _MESSAGE_COMPOSER_SUBMIT_JS,
+    _PROFILE_MESSAGE_TARGET_JS,
+    _ProfileMessageTarget,
+)
+
+pytestmark = [
+    pytest.mark.browser_dom,
+    pytest.mark.xdist_group("browser_runtime"),
+]
+
+TARGET = {"profilePath": "/in/testuser/", "profileUrn": "ACoAAB"}
+ENTER_TARGET = {**TARGET, "allowEnter": True}
+
+
+def _message_target() -> _ProfileMessageTarget:
+    return _ProfileMessageTarget(
+        profile_path=TARGET["profilePath"],
+        profile_urn=TARGET["profileUrn"],
+        compose_url="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+        display_name="Test User",
+    )
+
+
+@pytest.fixture
+async def dom_page():
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(
+                channel="chromium", headless=True
+            )
+            page = await browser.new_page()
+        except Exception as exc:
+            pytest.skip(f"chromium unavailable: {exc}")
+        try:
+            yield page
+        finally:
+            await browser.close()
+
+
+def _composer(*, identity: str, buttons: str = "", extra: str = "") -> str:
+    return f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+      <main>
+        <section role="dialog">
+          {identity}
+          <form>
+            <div role="textbox" contenteditable="true"
+                 style="display:block;width:200px;height:30px"></div>
+            {buttons}
+          </form>
+        </section>
+        {extra}
+      </main>
+    </body></html>
+    """
+
+
+async def _state(page, html: str) -> dict:
+    await page.set_content(html)
+    return await page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET)
+
+
+class TestMessageSurfaceDom:
+    async def test_waits_for_delayed_recipient_identity(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog">
+                <form>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                </form>
+              </section>
+            </body></html>"""
+        )
+        dom_page.set_default_timeout(1_000)
+        await dom_page.evaluate(
+            """() => setTimeout(() => {
+                document.querySelector('form').insertAdjacentHTML(
+                    'afterbegin',
+                    '<a href="https://www.linkedin.com/in/testuser/">Test</a>'
+                );
+            }, 250)"""
+        )
+        started = time.monotonic()
+
+        result = await LinkedInExtractor(dom_page)._wait_for_message_surface(
+            _message_target()
+        )
+
+        assert result == "composer"
+        assert time.monotonic() - started >= 0.2
+
+    async def test_waits_for_multiple_editors_to_settle(self, dom_page):
+        await dom_page.set_content(
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                extra=(
+                    '<div role="textbox" contenteditable="true" data-stale '
+                    'style="display:block;width:200px;height:30px"></div>'
+                ),
+            )
+        )
+        dom_page.set_default_timeout(1_000)
+        await dom_page.evaluate(
+            """() => setTimeout(() => {
+                document.querySelector('[data-stale]').remove();
+            }, 250)"""
+        )
+        started = time.monotonic()
+
+        result = await LinkedInExtractor(dom_page)._wait_for_message_surface(
+            _message_target()
+        )
+
+        assert result == "composer"
+        assert time.monotonic() - started >= 0.2
+
+    async def test_permanent_recipient_conflict_times_out(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog" data-recipient-urn="OTHER">
+                <form>
+                  <a href="https://www.linkedin.com/in/testuser/">Test</a>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                </form>
+              </section>
+            </body></html>"""
+        )
+        dom_page.set_default_timeout(350)
+        started = time.monotonic()
+
+        result = await LinkedInExtractor(dom_page)._wait_for_message_surface(
+            _message_target()
+        )
+
+        assert result is None
+        assert time.monotonic() - started >= 0.25
+        # `active` and `empty` both read false wherever the inspect never
+        # settled on an editor: they answer for one, and there is none.
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET) == {
+            "status": "recipient_mismatch",
+            "active": False,
+            "empty": False,
+            "submitCount": 0,
+        }
+
+
+class TestProfileMessageTargetDom:
+    async def test_snapshot_stays_inside_first_top_card(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body><main>
+              <section>
+                <h1>Test User</h1>
+                <a style="display:block" href="/messaging/compose/?recipient=ACoAAB">
+                  Nachricht
+                </a>
+              </section>
+              <section>
+                <a style="display:block" href="/messaging/compose/?recipient=OTHER">
+                  Sidebar
+                </a>
+              </section>
+            </main></body></html>
+            """
+        )
+
+        result = await dom_page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
+
+        assert result["displayName"] == "Test User"
+        assert result["composeHrefs"] == ["/messaging/compose/?recipient=ACoAAB"]
+
+
+class TestMessageComposerDom:
+    async def test_generic_data_urn_never_authorizes_recipient(self, dom_page):
+        state = await _state(
+            dom_page,
+            _composer(identity='<span data-urn="ACoAAB">unrelated generic data</span>'),
+        )
+
+        assert state["status"] == "missing_recipient"
+
+    async def test_native_dialog_accepts_explicit_recipient_urn(self, dom_page):
+        state = await _state(
+            dom_page,
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <dialog open>
+                <span data-recipient-urn="ACoAAB">Test</span>
+                <div role="textbox" contenteditable="true"
+                     style="display:block;width:200px;height:30px"></div>
+              </dialog>
+            </body></html>""",
+        )
+
+        assert state["status"] == "valid"
+
+    async def test_second_urn_attribute_on_one_element_is_never_skipped(self, dom_page):
+        conflicting = await _state(
+            dom_page,
+            _composer(
+                identity=(
+                    '<span data-profile-urn="ACoAAB" data-recipient-urn="OTHER">'
+                    "Test</span>"
+                )
+            ),
+        )
+        empty = await _state(
+            dom_page,
+            _composer(
+                identity=(
+                    '<span data-profile-urn="ACoAAB" data-recipient-urn="">Test</span>'
+                )
+            ),
+        )
+        consistent = await _state(
+            dom_page,
+            _composer(
+                identity=(
+                    '<span data-profile-urn="ACoAAB" '
+                    'data-recipient-urn="urn:li:fsd_profile:ACoAAB">Test</span>'
+                )
+            ),
+        )
+
+        assert conflicting["status"] == "recipient_mismatch"
+        assert empty["status"] == "recipient_mismatch"
+        assert consistent["status"] == "valid"
+
+    async def test_nested_owner_conflict_fails_closed(self, dom_page):
+        state = await _state(
+            dom_page,
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog" data-recipient-urn="OTHER">
+                <form>
+                  <a href="https://www.linkedin.com/in/testuser/">Test</a>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                  <button type="submit">Local</button>
+                </form>
+                <button type="submit" data-outer>Outer</button>
+              </section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "recipient_mismatch"
+        assert state["submitCount"] == 0
+
+    async def test_nested_consistent_identity_keeps_submit_local(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog" data-recipient-urn="ACoAAB">
+                <form>
+                  <a href="https://www.linkedin.com/in/testuser/">Test</a>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                  <button type="submit" onclick="event.preventDefault();
+                    this.setAttribute('data-clicked','yes')">Local</button>
+                </form>
+                <button type="submit" data-outer>Outer</button>
+              </section>
+            </body></html>"""
+        )
+
+        focused = await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET)
+        submitted = await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET)
+
+        assert focused is True
+        assert submitted == "clicked"
+        assert (
+            await dom_page.locator("form button").get_attribute("data-clicked") == "yes"
+        )
+        assert (
+            await dom_page.locator("[data-outer]").get_attribute("data-clicked") is None
+        )
+
+    async def test_profile_link_inside_editor_never_authorizes(self, dom_page):
+        """Draft content is not a recipient, however well-formed it looks."""
+        state = await _state(
+            dom_page,
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog"><form>
+                <div role="textbox" contenteditable="true"
+                     style="display:block;width:200px;height:30px">
+                  <a href="https://www.linkedin.com/in/testuser/">Draft link</a>
+                </div>
+              </form></section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "missing_recipient"
+
+    @pytest.mark.parametrize("attribute", ["data-profile-urn", "data-recipient-urn"])
+    @pytest.mark.parametrize("location", ["editor", "descendant"])
+    async def test_recipient_urn_inside_editor_never_authorizes(
+        self, dom_page, attribute, location
+    ):
+        editor_attribute = f'{attribute}="ACoAAB"' if location == "editor" else ""
+        draft = (
+            f'<span {attribute}="ACoAAB">Draft identity</span>'
+            if location == "descendant"
+            else "Draft"
+        )
+        state = await _state(
+            dom_page,
+            f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog"><form>
+                <div role="textbox" contenteditable="true" {editor_attribute}
+                     style="display:block;width:200px;height:30px">{draft}</div>
+              </form></section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "missing_recipient"
+
+    @pytest.mark.parametrize(
+        "draft_identity",
+        [
+            '<a href="https://www.linkedin.com/in/testuser/">Matching draft</a>',
+            '<a href="https://www.linkedin.com/in/other/">Foreign draft</a>',
+            '<span data-profile-urn="ACoAAB">Matching draft</span>',
+            '<span data-profile-urn="OTHER">Foreign draft</span>',
+            '<span data-recipient-urn="ACoAAB">Matching draft</span>',
+            '<span data-recipient-urn="OTHER">Foreign draft</span>',
+        ],
+    )
+    async def test_outer_identity_ignores_draft_identity(
+        self, dom_page, draft_identity
+    ):
+        """The verdict comes from the recipient chip, never from the draft."""
+        state = await _state(
+            dom_page,
+            f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog"><form>
+                <a href="https://www.linkedin.com/in/testuser/">Recipient</a>
+                <div role="textbox" contenteditable="true"
+                     style="display:block;width:200px;height:30px">
+                  {draft_identity}
+                </div>
+              </form></section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "valid"
+
+    async def test_name_only_or_global_identity_never_authorizes(self, dom_page):
+        html = _composer(
+            identity=(
+                "<span>Test User</span>"
+                '<span hidden data-profile-urn="ACoAAB">stale identity</span>'
+            ),
+            extra='<a href="https://www.linkedin.com/in/testuser/">Test User</a>',
+        )
+
+        state = await _state(dom_page, html)
+
+        assert state["status"] == "missing_recipient"
+
+    async def test_foreign_or_multiple_editor_fails_closed(self, dom_page):
+        foreign = await _state(
+            dom_page,
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/other/">Other</a>'
+            ),
+        )
+        multiple = await _state(
+            dom_page,
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                extra=(
+                    '<div role="textbox" contenteditable="true" '
+                    'style="display:block;width:200px;height:30px"></div>'
+                ),
+            ),
+        )
+
+        assert foreign["status"] == "recipient_mismatch"
+        assert multiple["status"] == "ambiguous_editor"
+
+    async def test_focus_and_single_submit_stay_local(self, dom_page):
+        await dom_page.set_content(
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                buttons=(
+                    '<button type="submit" onclick="event.preventDefault();'
+                    "this.setAttribute('data-clicked','yes')\">Senden</button>"
+                ),
+                extra=('<button type="submit" data-global="true">Global</button>'),
+            )
+        )
+
+        focused = await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET)
+        submitted = await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET)
+
+        assert focused is True
+        assert submitted == "clicked"
+        assert (
+            await dom_page.locator("form button").get_attribute("data-clicked") == "yes"
+        )
+        assert (
+            await dom_page.locator("[data-global]").get_attribute("data-clicked")
+            is None
+        )
+
+    async def test_ambiguous_disabled_and_changed_recipient_never_submit(
+        self, dom_page
+    ):
+        identity = '<a href="https://www.linkedin.com/in/testuser/">Test</a>'
+        await dom_page.set_content(
+            _composer(
+                identity=identity,
+                buttons='<button type="submit">A</button><button type="submit">B</button>',
+            )
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
+
+        await dom_page.set_content(
+            _composer(
+                identity=identity, buttons='<button type="submit" disabled>A</button>'
+            )
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
+
+        await dom_page.set_content(
+            _composer(
+                identity=identity,
+                buttons='<button type="submit" aria-disabled="true">A</button>',
+            )
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
+
+        await dom_page.set_content(
+            _composer(identity=identity, buttons='<button type="submit">stale</button>')
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        state = await dom_page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET)
+        await dom_page.locator("form button").evaluate("element => element.remove()")
+        submit_target = {**TARGET, "allowEnter": state["submitCount"] == 0}
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, submit_target)
+            == "invalid"
+        )
+
+        await dom_page.set_content(_composer(identity=identity))
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        await dom_page.locator('[role="dialog"] > a').evaluate(
+            "element => element.setAttribute('href', 'https://www.linkedin.com/in/other/')"
+        )
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
+            == "invalid"
+        )
+
+    async def test_enter_only_when_verified_editor_stays_active_without_buttons(
+        self, dom_page
+    ):
+        await dom_page.set_content(
+            _composer(
+                identity=(
+                    '<span data-profile-urn="urn:li:fsd_profile:ACoAAB">Test</span>'
+                )
+            )
+        )
+
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
+            == "enter"
+        )
+
+        await dom_page.evaluate("document.activeElement.blur()")
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
+            == "invalid"
+        )

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -7735,6 +7735,13 @@ class TestMessageTargetUrls:
             ("https://www.linkedin.com:444/messaging/compose/", False),
             ("https://www.linkedin.com/messaging/compose/#draft", False),
             ("https://www.linkedin.com/messaging/thread/2-abc%2Fother/", False),
+            # Measured live: LinkedIn redirects an existing conversation to a
+            # padded base64url id, and the padding reaches the path unescaped.
+            (
+                "https://www.linkedin.com/messaging/thread/"
+                "2-ZDBkMjZiY2UtNjQwYi00NzczLWIxYWYtNTczZTZhZDkzMzQ4XzEwMA==/",
+                True,
+            ),
             ("https://www.linkedin.com/feed/", False),
         ],
     )

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -7620,35 +7620,181 @@ class TestGetSidebarProfiles:
         }
 
 
+class TestMessageTargetUrls:
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+                "ACoAAB",
+            ),
+            (
+                "https://de.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB",
+                "ACoAAB",
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=ACoAAB",
+                "ACoAAB",
+            ),
+            ("http://www.linkedin.com/messaging/compose/?recipient=ACoAAB", None),
+            ("https://evil.example/messaging/compose/?recipient=ACoAAB", None),
+            ("//evil.example/messaging/compose/?recipient=ACoAAB", None),
+            ("https://user@www.linkedin.com/messaging/compose/?recipient=ACoAAB", None),
+            ("https://www.linkedin.com:444/messaging/compose/?recipient=ACoAAB", None),
+            ("https://www.linkedin.com/jobs/?recipient=ACoAAB", None),
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB#draft",
+                None,
+            ),
+            ("https://www.linkedin.com/messaging/compose/?recipient=ACoAAB\n", None),
+            ("https://www.linkedin.com/messaging/compose/?recipient=", None),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=OTHER",
+                None,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AOTHER",
+                None,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/?profileUrn=malformed%3Aurn",
+                None,
+            ),
+        ],
+    )
+    def test_compose_url_requires_one_linkedin_recipient(self, url, expected):
+        assert extractor_module._profile_urn_from_compose_url(url) == expected
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://www.linkedin.com/in/testuser/", "/in/testuser/"),
+            ("https://de.linkedin.com/in/testuser/", "/in/testuser/"),
+            ("http://www.linkedin.com/in/testuser/", None),
+            ("https://evil.example/in/testuser/", None),
+            ("https://user@www.linkedin.com/in/testuser/", None),
+            ("https://www.linkedin.com:444/in/testuser/", None),
+            ("https://www.linkedin.com/in/testuser/edit/intro/", None),
+            ("https://www.linkedin.com/in/testuser%2Fedit/", None),
+            ("https://www.linkedin.com/in/testuser/?trk=profile", None),
+            ("https://www.linkedin.com/in/testuser/#details", None),
+        ],
+    )
+    def test_profile_url_requires_exact_linkedin_profile(self, url, expected):
+        assert extractor_module._profile_path_from_url(url) == expected
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://www.linkedin.com/messaging/compose/", True),
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+                True,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=ACoAAB&"
+                "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB",
+                True,
+            ),
+            ("https://de.linkedin.com/messaging/thread/2-abc/", True),
+            (
+                "https://www.linkedin.com/messaging/thread/2-abc/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB",
+                True,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=OTHER",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=OTHER",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/?profileUrn=",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/thread/2-abc/"
+                "?recipient=ACoAAB&recipient=OTHER",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/thread/2-abc/?profileUrn=",
+                False,
+            ),
+            ("http://www.linkedin.com/messaging/compose/", False),
+            ("https://evil.example/messaging/compose/", False),
+            ("https://user@www.linkedin.com/messaging/thread/2-abc/", False),
+            ("https://www.linkedin.com:444/messaging/compose/", False),
+            ("https://www.linkedin.com/messaging/compose/#draft", False),
+            ("https://www.linkedin.com/messaging/thread/2-abc%2Fother/", False),
+            ("https://www.linkedin.com/feed/", False),
+        ],
+    )
+    def test_final_url_requires_safe_messaging_path(self, url, expected):
+        assert extractor_module._message_page_url_is_safe(url, "ACoAAB") is expected
+
+
 class TestExtractProfileUrn:
-    async def test_returns_urn_from_compose_href(self, mock_page):
-        """Extracts the recipient URN from the messaging compose link."""
+    async def test_returns_urn_from_atomic_top_card_snapshot(self, mock_page):
         mock_page.evaluate = AsyncMock(
-            return_value="/messaging/compose/?recipient=ACoAAB1IelEBLEkqTkNbZ-a1D8mq5R-6C1ihSEk&lipi=urn..."
+            return_value={
+                "pageUrl": "https://www.linkedin.com/in/testuser/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB&"
+                    "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+                ],
+            }
         )
 
-        extractor = LinkedInExtractor(mock_page)
-        result = await extractor._extract_profile_urn()
+        result = await LinkedInExtractor(mock_page)._extract_profile_urn()
 
-        assert result == "ACoAAB1IelEBLEkqTkNbZ-a1D8mq5R-6C1ihSEk"
-
-    async def test_returns_none_when_no_compose_button(self, mock_page):
-        """Returns None when no messaging compose link is found."""
-        mock_page.evaluate = AsyncMock(return_value=None)
-
-        extractor = LinkedInExtractor(mock_page)
-        result = await extractor._extract_profile_urn()
-
-        assert result is None
-
-    async def test_returns_none_when_no_recipient_param(self, mock_page):
-        """Returns None when the compose href has no recipient query param."""
-        mock_page.evaluate = AsyncMock(
-            return_value="/messaging/compose/?someOtherParam=value"
+        assert result == "ACoAAB"
+        mock_page.evaluate.assert_awaited_once_with(
+            extractor_module._PROFILE_MESSAGE_TARGET_JS
         )
 
-        extractor = LinkedInExtractor(mock_page)
-        result = await extractor._extract_profile_urn()
+    async def test_accepts_safe_final_vanity_redirect(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "pageUrl": "https://www.linkedin.com/in/canonical-user/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB&"
+                    "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+                ],
+            }
+        )
+
+        target = await LinkedInExtractor(mock_page)._read_profile_message_target(
+            "testuser"
+        )
+
+        assert target is not None
+        assert target.profile_path == "/in/canonical-user/"
+        assert target.profile_urn == "ACoAAB"
+
+    async def test_returns_none_for_ambiguous_top_card_links(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "pageUrl": "https://www.linkedin.com/in/testuser/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB",
+                    "/messaging/compose/?recipient=OTHER",
+                ],
+            }
+        )
+
+        result = await LinkedInExtractor(mock_page)._extract_profile_urn()
 
         assert result is None
 
@@ -8461,10 +8607,25 @@ class TestSendMessage:
         keyboard.type.assert_not_called()
         keyboard.press.assert_not_called()
 
-    async def test_dry_run_returns_confirmation_required(self, mock_page):
-        """send_message with confirm_send=False returns confirmation_required status."""
-        extractor = LinkedInExtractor(mock_page)
-        with (
+    @staticmethod
+    def _target():
+        return extractor_module._ProfileMessageTarget(
+            profile_path="/in/testuser/",
+            profile_urn="ACoAAB",
+            compose_url=(
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+            ),
+            display_name="Test User",
+        )
+
+    @staticmethod
+    def _patch_to_composer(extractor, mock_page, *, states=None, submission="clicked"):
+        target = TestSendMessage._target()
+        mock_page.url = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
+        mock_page.keyboard = MagicMock(type=AsyncMock(), press=AsyncMock())
+        return (
+            target,
             patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
@@ -8476,15 +8637,9 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_read_profile_display_name",
+                "_read_profile_message_target",
                 new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+                return_value=target,
             ),
             patch.object(
                 extractor,
@@ -8494,34 +8649,74 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_resolve_message_compose_box",
+                "_read_message_composer_state",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                side_effect=states or None,
+                return_value={"status": "valid", "active": True, "submitCount": 0},
             ),
             patch.object(
                 extractor,
-                "_compose_page_matches_recipient",
+                "_focus_verified_message_editor",
                 new_callable=AsyncMock,
                 return_value=True,
             ),
             patch.object(
                 extractor,
-                "_dismiss_message_ui",
+                "_submit_verified_message",
+                new_callable=AsyncMock,
+                return_value=submission,
+            ),
+            patch.object(extractor, "_dismiss_message_ui", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        )
+
+    async def test_dry_run_returns_before_focus_or_text_entry(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=False
             )
 
         assert result["status"] == "confirmation_required"
-        assert result["sent"] is False
+        assert result["recipient_selected"] is True
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_message_unavailable_when_no_compose_href(self, mock_page):
-        """send_message returns message_unavailable when no compose URL found."""
+    async def test_rejects_supplied_urn_before_compose_navigation(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
+        target = self._target()
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as navigate,
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8532,276 +8727,143 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_read_profile_display_name",
+                "_read_profile_message_target",
                 new_callable=AsyncMock,
-                return_value="Test User",
+                return_value=target,
             ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
+        ):
+            result = await extractor.send_message(
+                "testuser",
+                "Hello!",
+                confirm_send=True,
+                profile_urn="OTHER",
+            )
+
+        assert result["status"] == "recipient_resolution_failed"
+        navigate.assert_awaited_once_with("https://www.linkedin.com/in/testuser/")
+
+    async def test_rejects_foreign_url_recipient_after_navigation(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        mock_page.url = "https://www.linkedin.com/messaging/compose/?recipient=OTHER"
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5] as surface,
+            patches[6] as state,
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
-        assert result["status"] == "message_unavailable"
-        assert result["sent"] is False
+        assert result["status"] == "recipient_resolution_failed"
+        surface.assert_not_awaited()
+        state.assert_not_awaited()
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_uses_profile_urn_when_provided(self, mock_page):
-        """send_message builds compose URL from profile_urn without Message-button lookup."""
+    async def test_rejects_contradictory_url_before_focus(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
+
+        async def change_url_after_initial_state(_target):
+            mock_page.url = (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=OTHER"
+            )
+            return {"status": "valid", "active": False}
+
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=change_url_after_initial_state,
+        )
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-            ),
-            patch.object(
-                extractor,
-                "_read_profile_display_name",
-                new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value=None,
-            ) as mock_resolve_href,
-            patch.object(
-                extractor,
-                "_wait_for_message_surface",
-                new_callable=AsyncMock,
-                return_value="composer",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_box",
-                new_callable=AsyncMock,
-                return_value=MagicMock(),
-            ),
-            patch.object(
-                extractor,
-                "_compose_page_matches_recipient",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch.object(
-                extractor,
-                "_dismiss_message_ui",
-                new_callable=AsyncMock,
-            ),
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6] as state,
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
-                "testuser",
-                "Hello!",
-                confirm_send=False,
-                profile_urn="ACoAAB1IelEB",
+                "testuser", "Hello!", confirm_send=True
             )
 
-        # _resolve_message_compose_href should NOT be called when profile_urn given
-        mock_resolve_href.assert_not_awaited()
-        assert result["status"] == "confirmation_required"
+        assert result["status"] == "recipient_resolution_failed"
+        state.assert_awaited_once()
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_profile_urn_compose_url_includes_full_params(self, mock_page):
-        """send_message with profile_urn builds URL with profileUrn, screenContext, interop."""
+    async def test_rejects_foreign_url_recipient_before_text_entry(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        navigate_calls = []
+        state_calls = 0
 
-        async def capture_navigate(url):
-            navigate_calls.append(url)
+        async def change_url_during_prefocus_state(_target):
+            nonlocal state_calls
+            state_calls += 1
+            if state_calls == 2:
+                mock_page.url = (
+                    "https://www.linkedin.com/messaging/compose/?recipient=OTHER"
+                )
+            return {"status": "valid", "active": state_calls > 1}
 
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=change_url_during_prefocus_state,
+        )
         with (
-            patch.object(
-                extractor,
-                "_navigate_to_page",
-                new_callable=AsyncMock,
-                side_effect=capture_navigate,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-            ),
-            patch.object(
-                extractor,
-                "_read_profile_display_name",
-                new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_wait_for_message_surface",
-                new_callable=AsyncMock,
-                return_value="composer",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_box",
-                new_callable=AsyncMock,
-                return_value=MagicMock(),
-            ),
-            patch.object(
-                extractor,
-                "_compose_page_matches_recipient",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch.object(
-                extractor,
-                "_dismiss_message_ui",
-                new_callable=AsyncMock,
-            ),
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
-            await extractor.send_message(
-                "testuser",
-                "Hello!",
-                confirm_send=False,
-                profile_urn="ACoAAB1IelEB",
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
             )
 
-        # Second navigate call is the compose URL (first is the profile page)
-        compose_url = navigate_calls[1]
-        assert "profileUrn=" in compose_url
-        assert "urn%3Ali%3Afsd_profile%3AACoAAB1IelEB" in compose_url
-        assert "recipient=ACoAAB1IelEB" in compose_url
-        assert "screenContext=NON_SELF_PROFILE_VIEW" in compose_url
-        assert "interop=msgOverlay" in compose_url
+        assert result["status"] == "recipient_resolution_failed"
+        focus.assert_awaited_once()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-
-class TestResolveMessageComposeBox:
-    async def test_returns_locator_when_count_positive(self, mock_page):
-        """_resolve_message_compose_box returns locator.last when count() > 0."""
+    async def test_rejects_contradictory_url_before_submission(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_locator = MagicMock()
-        mock_locator.count = AsyncMock(return_value=1)
-        sentinel = MagicMock(name="last_locator")
-        sentinel.wait_for = AsyncMock()
-        mock_locator.last = sentinel
-        mock_locator.wait_for = AsyncMock()
-        mock_page.locator = MagicMock(return_value=mock_locator)
+        patches = self._patch_to_composer(extractor, mock_page)
 
-        result = await extractor._resolve_message_compose_box()
+        async def change_url_after_typing(_message, *, delay):
+            assert delay == 15
+            mock_page.url = (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AOTHER"
+            )
 
-        assert result is sentinel
-        # wait_for should NOT be called on the early-return path
-        sentinel.wait_for.assert_not_called()
-        mock_locator.wait_for.assert_not_called()
-
-    async def test_returns_none_when_all_selectors_miss(self, mock_page):
-        """_resolve_message_compose_box returns None when no selector matches."""
-        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
-
-        extractor = LinkedInExtractor(mock_page)
-        mock_locator = MagicMock()
-        mock_locator.count = AsyncMock(return_value=0)
-        mock_locator.last = MagicMock()
-        mock_locator.last.wait_for = AsyncMock(
-            side_effect=PlaywrightTimeoutError("timeout")
-        )
-        mock_page.locator = MagicMock(return_value=mock_locator)
-
-        result = await extractor._resolve_message_compose_box()
-
-        assert result is None
-
-    async def test_falls_through_when_count_raises(self, mock_page):
-        """_resolve_message_compose_box handles count() exceptions gracefully."""
-        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
-
-        extractor = LinkedInExtractor(mock_page)
-        mock_locator = MagicMock()
-        mock_locator.count = AsyncMock(side_effect=Exception("detached"))
-        mock_locator.last = MagicMock()
-        mock_locator.last.wait_for = AsyncMock(
-            side_effect=PlaywrightTimeoutError("timeout")
-        )
-        mock_page.locator = MagicMock(return_value=mock_locator)
-
-        result = await extractor._resolve_message_compose_box()
-
-        assert result is None
-
-
-class TestSendMessageComposerInteraction:
-    """Tests for the page.evaluate + keyboard.type send path (patchright workaround)."""
-
-    def _patch_send_message_to_compose(self, extractor, mock_page):
-        """Return a context manager that patches send_message up to the compose step."""
-        return (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-            ),
-            patch.object(
-                extractor,
-                "_read_profile_display_name",
-                new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
-            ),
-            patch.object(
-                extractor,
-                "_wait_for_message_surface",
-                new_callable=AsyncMock,
-                return_value="composer",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_box",
-                new_callable=AsyncMock,
-                return_value=MagicMock(),
-            ),
-            patch.object(
-                extractor,
-                "_compose_page_matches_recipient",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch.object(
-                extractor,
-                "_dismiss_message_ui",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        )
-
-    async def test_focus_and_type_via_evaluate_and_keyboard(self, mock_page):
-        """send_message uses page.evaluate to focus and page.keyboard.type to type."""
-        extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), True (send button click)
-        mock_page.evaluate = AsyncMock(side_effect=[True, True])
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        mock_page.keyboard.type.side_effect = change_url_after_typing
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8809,72 +8871,65 @@ class TestSendMessageComposerInteraction:
             patches[5],
             patches[6],
             patches[7],
-            patches[8],
+            patches[8] as submit,
             patches[9],
-            patch.object(
-                extractor,
-                "_message_text_occurrences",
-                new_callable=AsyncMock,
-                return_value=0,
-            ),
-            patch.object(
-                extractor,
-                "_message_text_visible",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
-        assert result["status"] == "sent"
-        assert result["sent"] is True
-        # Verify keyboard.type was used (not press_sequentially)
-        mock_keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        assert result["status"] == "recipient_resolution_failed"
+        mock_page.keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        submit.assert_not_awaited()
+        mock_page.keyboard.press.assert_not_awaited()
 
-    async def test_compose_interact_failed_when_focus_fails(self, mock_page):
-        """send_message returns compose_interact_failed when JS focus fails."""
+    async def test_rejects_recipient_change_before_focus(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns False (focus failed)
-        mock_page.evaluate = AsyncMock(return_value=False)
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=[
+                {"status": "valid", "active": False},
+                {"status": "recipient_mismatch", "active": False},
+            ],
+        )
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
+            patches[7] as focus,
             patches[8],
             patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
         assert result["status"] == "compose_interact_failed"
-        assert result["sent"] is False
+        focus.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_enter_fallback_when_send_button_not_found(self, mock_page):
-        """send_message falls back to Enter key when JS cannot find send button."""
+    async def test_rejects_editor_change_before_text_entry(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), False (no send button found)
-        mock_page.evaluate = AsyncMock(side_effect=[True, False])
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=[
+                {"status": "valid", "active": False},
+                {"status": "valid", "active": False},
+                {"status": "ambiguous_editor", "active": False},
+            ],
+        )
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8884,6 +8939,137 @@ class TestSendMessageComposerInteraction:
             patches[7],
             patches[8],
             patches[9],
+            patches[10],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "compose_interact_failed"
+        mock_page.keyboard.type.assert_not_awaited()
+
+    async def test_rejects_ambiguous_submit_after_text_entry(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page, submission="invalid")
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        mock_page.keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_removed_submit_candidate_cannot_switch_to_enter(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        states = [
+            {"status": "valid", "active": False, "submitCount": 1},
+            {"status": "valid", "active": False, "submitCount": 1},
+            {"status": "valid", "active": True, "submitCount": 1},
+            {"status": "valid", "active": True, "submitCount": 0},
+        ]
+        patches = self._patch_to_composer(
+            extractor, mock_page, states=states, submission="enter"
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        submit.assert_awaited_once_with(self._target(), allow_enter=False)
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_enter_revalidates_active_editor_before_press(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        states = [
+            {"status": "valid", "active": False, "submitCount": 0},
+            {"status": "valid", "active": False, "submitCount": 0},
+            {"status": "valid", "active": True, "submitCount": 0},
+            {"status": "valid", "active": False, "submitCount": 0},
+        ]
+        patches = self._patch_to_composer(
+            extractor, mock_page, states=states, submission="enter"
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6] as state,
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert state.await_count == 4
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_enter_requires_verified_zero_button_path(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page, submission="enter")
+        mock_page.url = (
+            "https://www.linkedin.com/messaging/compose/"
+            "?recipient=ACoAAB&recipient=ACoAAB&"
+            "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8] as submit,
+            patches[9],
+            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -8902,42 +9088,38 @@ class TestSendMessageComposerInteraction:
             )
 
         assert result["status"] == "sent"
-        # Enter was pressed as fallback
-        mock_keyboard.press.assert_awaited_once_with("Enter")
+        submit.assert_awaited_once_with(self._target(), allow_enter=True)
+        mock_page.keyboard.press.assert_awaited_once_with("Enter")
 
-    async def test_baseline_is_taken_after_typing_and_before_send(self, mock_page):
-        """The occurrence baseline is captured between typing and the click.
+    async def test_baseline_is_taken_after_typing_and_before_submission(
+        self, mock_page
+    ):
+        """The occurrence baseline is captured between typing and submission.
 
-        Taken any earlier it would miss what the composer already holds; taken
-        after the click it could already include the delivered message, and
-        the confirmation would compare that copy against itself.
+        Taken any earlier it would miss what the verified composer already
+        holds; taken after submission it could already include the delivered
+        message, and the confirmation would compare that copy against itself.
         """
         extractor = LinkedInExtractor(mock_page)
         steps: list[str] = []
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock(
-            side_effect=lambda *args, **kwargs: steps.append("type")
+        patches = self._patch_to_composer(extractor, mock_page)
+        mock_page.keyboard.type.side_effect = lambda *args, **kwargs: steps.append(
+            "type"
         )
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-
-        async def evaluate(*args, **kwargs):
-            steps.append("click" if steps else "focus")
-            return True
 
         async def occurrences(message):
             steps.append("baseline")
             return 2
 
+        async def submit(target, *, allow_enter):
+            steps.append("submit")
+            return "clicked"
+
         async def visible(message, *, previous_occurrences):
             steps.append(f"confirm:{previous_occurrences}")
             return True
 
-        mock_page.evaluate = AsyncMock(side_effect=evaluate)
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8945,8 +9127,14 @@ class TestSendMessageComposerInteraction:
             patches[5],
             patches[6],
             patches[7],
-            patches[8],
+            patch.object(
+                extractor,
+                "_submit_verified_message",
+                new_callable=AsyncMock,
+                side_effect=submit,
+            ),
             patches[9],
+            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -8965,22 +9153,14 @@ class TestSendMessageComposerInteraction:
             )
 
         assert result["status"] == "sent"
-        # The confirmation receives exactly the baseline taken before the click.
-        assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
+        # The confirmation receives exactly the baseline taken before submission.
+        assert steps == ["type", "baseline", "submit", "confirm:2"]
 
-    async def test_send_unavailable_when_click_adds_nothing(self, mock_page):
-        """A clicked Send button that changes nothing is not a sent message."""
+    async def test_submission_that_adds_nothing_is_not_a_sent_message(self, mock_page):
+        """A submit path that leaves the page unchanged has delivered nothing."""
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), True (send button found and clicked)
-        mock_page.evaluate = AsyncMock(side_effect=[True, True])
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        patches = self._patch_to_composer(extractor, mock_page)
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8990,6 +9170,7 @@ class TestSendMessageComposerInteraction:
             patches[7],
             patches[8],
             patches[9],
+            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -9010,6 +9191,20 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "send_unavailable"
         assert result["sent"] is False
         visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
+
+
+class TestResolveMessageComposeBox:
+    async def test_requires_exactly_one_visible_editor(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        locator = MagicMock(count=AsyncMock(return_value=2))
+        locator.first = MagicMock()
+        mock_page.locator.return_value = locator
+
+        assert await extractor._resolve_message_compose_box() is None
+
+        mock_page.locator.assert_called_once_with(
+            f"{extractor_module._MESSAGING_COMPOSE_SELECTOR}:visible"
+        )
 
 
 class TestMessageTextOccurrences:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -7781,9 +7781,7 @@ class TestExtractProfileUrn:
             }
         )
 
-        target = await LinkedInExtractor(mock_page)._read_profile_message_target(
-            "testuser"
-        )
+        target = await LinkedInExtractor(mock_page)._read_profile_message_target()
 
         assert target is not None
         assert target.profile_path == "/in/canonical-user/"

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -27,6 +27,8 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _CONTENT_DATE_POSTED_MAP,
+    _MESSAGE_OCCURRENCES_INCREASED_JS,
+    _MESSAGE_OCCURRENCES_JS,
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
@@ -8784,6 +8786,12 @@ class TestSendMessageComposerInteraction:
             patches[9],
             patch.object(
                 extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
                 "_message_text_visible",
                 new_callable=AsyncMock,
                 return_value=True,
@@ -8851,6 +8859,12 @@ class TestSendMessageComposerInteraction:
             patches[9],
             patch.object(
                 extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
                 "_message_text_visible",
                 new_callable=AsyncMock,
                 return_value=True,
@@ -8863,6 +8877,170 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "sent"
         # Enter was pressed as fallback
         mock_keyboard.press.assert_awaited_once_with("Enter")
+
+    async def test_baseline_is_taken_after_typing_and_before_send(self, mock_page):
+        """The occurrence baseline is captured between typing and the click.
+
+        Taken any earlier it would miss what the composer already holds; taken
+        after the click it could already include the delivered message, and
+        the confirmation would compare that copy against itself.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        steps: list[str] = []
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock(
+            side_effect=lambda *args, **kwargs: steps.append("type")
+        )
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+
+        async def evaluate(*args, **kwargs):
+            steps.append("click" if steps else "focus")
+            return True
+
+        async def occurrences(message):
+            steps.append("baseline")
+            return 2
+
+        async def visible(message, *, previous_occurrences):
+            steps.append(f"confirm:{previous_occurrences}")
+            return True
+
+        mock_page.evaluate = AsyncMock(side_effect=evaluate)
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                side_effect=occurrences,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                side_effect=visible,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "sent"
+        # The confirmation receives exactly the baseline taken before the click.
+        assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
+
+    async def test_send_unavailable_when_click_adds_nothing(self, mock_page):
+        """A clicked Send button that changes nothing is not a sent message."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        # evaluate returns: True (focus), True (send button found and clicked)
+        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as visible,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert result["sent"] is False
+        visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
+
+
+class TestMessageTextOccurrences:
+    """Tests for the occurrence-based send confirmation (issue #866)."""
+
+    async def test_occurrences_run_the_shared_counting_routine(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=3)
+
+        assert await extractor._message_text_occurrences("Hello!") == 3
+
+        mock_page.evaluate.assert_awaited_once_with(
+            _MESSAGE_OCCURRENCES_JS, {"expected": "Hello!"}
+        )
+
+    async def test_missing_count_reads_as_zero(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=None)
+
+        assert await extractor._message_text_occurrences("Hello!") == 0
+
+    async def test_confirmation_waits_for_more_than_the_baseline(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(return_value=None)
+
+        assert (
+            await extractor._message_text_visible("Hello!", previous_occurrences=2)
+            is True
+        )
+
+        mock_page.wait_for_function.assert_awaited_once_with(
+            _MESSAGE_OCCURRENCES_INCREASED_JS,
+            arg={"expected": "Hello!", "previous": 2},
+        )
+        # Baseline and confirmation run one routine, so they cannot disagree
+        # about what counts as an occurrence.
+        assert _MESSAGE_OCCURRENCES_JS in _MESSAGE_OCCURRENCES_INCREASED_JS
+
+    async def test_confirmation_timeout_is_not_a_send(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("timeout")
+        )
+
+        assert (
+            await extractor._message_text_visible("Hello!", previous_occurrences=0)
+            is False
+        )
+
+    async def test_other_confirmation_errors_do_not_confirm(self, mock_page):
+        """A broken confirmation surfaces as an error, never as a send."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PatchrightError("execution context destroyed")
+        )
+
+        with pytest.raises(PatchrightError):
+            await extractor._message_text_visible("Hello!", previous_occurrences=0)
 
 
 class TestBuildFeedReferences:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8434,6 +8434,33 @@ class TestSearchConversations:
 
 
 class TestSendMessage:
+    @pytest.mark.parametrize("message", ["", " \t\n"], ids=["empty", "whitespace"])
+    async def test_blank_message_is_rejected_before_browser_interaction(
+        self, mock_page, message
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        keyboard = MagicMock()
+        mock_page.keyboard = keyboard
+
+        with patch.object(
+            extractor, "_navigate_to_page", new_callable=AsyncMock
+        ) as navigate:
+            result = await extractor.send_message(
+                "testuser", message, confirm_send=True
+            )
+
+        assert result == {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "status": "message_unavailable",
+            "message": "Message must contain non-whitespace characters.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        navigate.assert_not_awaited()
+        mock_page.evaluate.assert_not_awaited()
+        keyboard.type.assert_not_called()
+        keyboard.press.assert_not_called()
+
     async def test_dry_run_returns_confirmation_required(self, mock_page):
         """send_message with confirm_send=False returns confirmation_required status."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8796,8 +8796,9 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), True (send button click)
-        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        # evaluate returns: 'focused' (empty composer, focused), then
+        # True (send button click)
+        mock_page.evaluate = AsyncMock(side_effect=["focused", True])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -8839,8 +8840,8 @@ class TestSendMessageComposerInteraction:
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns False (focus failed)
-        mock_page.evaluate = AsyncMock(return_value=False)
+        # evaluate returns 'missing' (no composer to focus)
+        mock_page.evaluate = AsyncMock(return_value="missing")
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -8869,8 +8870,8 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), False (no send button found)
-        mock_page.evaluate = AsyncMock(side_effect=[True, False])
+        # evaluate returns: 'focused', then False (no send button found)
+        mock_page.evaluate = AsyncMock(side_effect=["focused", False])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -8922,8 +8923,11 @@ class TestSendMessageComposerInteraction:
         mock_page.keyboard = mock_keyboard
 
         async def evaluate(*args, **kwargs):
-            steps.append("click" if steps else "focus")
-            return True
+            focusing = not steps
+            steps.append("focus" if focusing else "click")
+            # The focus call reports the composer state; the click reports
+            # whether a send button was found.
+            return "focused" if focusing else True
 
         async def occurrences(message):
             steps.append("baseline")
@@ -8968,15 +8972,15 @@ class TestSendMessageComposerInteraction:
         # The confirmation receives exactly the baseline taken before the click.
         assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
 
-    async def test_send_unavailable_when_click_adds_nothing(self, mock_page):
+    async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), True (send button found and clicked)
-        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        # evaluate returns: 'focused', then True (send button found and clicked)
+        mock_page.evaluate = AsyncMock(side_effect=["focused", True])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -9007,7 +9011,9 @@ class TestSendMessageComposerInteraction:
                 "testuser", "Hello!", confirm_send=True
             )
 
-        assert result["status"] == "send_unavailable"
+        # The click happened, so nothing here proves the message did not go
+        # out. Answering "not sent" would invite a retry that delivers twice.
+        assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -7620,35 +7620,181 @@ class TestGetSidebarProfiles:
         }
 
 
+class TestMessageTargetUrls:
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+                "ACoAAB",
+            ),
+            (
+                "https://de.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB",
+                "ACoAAB",
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=ACoAAB",
+                "ACoAAB",
+            ),
+            ("http://www.linkedin.com/messaging/compose/?recipient=ACoAAB", None),
+            ("https://evil.example/messaging/compose/?recipient=ACoAAB", None),
+            ("//evil.example/messaging/compose/?recipient=ACoAAB", None),
+            ("https://user@www.linkedin.com/messaging/compose/?recipient=ACoAAB", None),
+            ("https://www.linkedin.com:444/messaging/compose/?recipient=ACoAAB", None),
+            ("https://www.linkedin.com/jobs/?recipient=ACoAAB", None),
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB#draft",
+                None,
+            ),
+            ("https://www.linkedin.com/messaging/compose/?recipient=ACoAAB\n", None),
+            ("https://www.linkedin.com/messaging/compose/?recipient=", None),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=OTHER",
+                None,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AOTHER",
+                None,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/?profileUrn=malformed%3Aurn",
+                None,
+            ),
+        ],
+    )
+    def test_compose_url_requires_one_linkedin_recipient(self, url, expected):
+        assert extractor_module._profile_urn_from_compose_url(url) == expected
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://www.linkedin.com/in/testuser/", "/in/testuser/"),
+            ("https://de.linkedin.com/in/testuser/", "/in/testuser/"),
+            ("http://www.linkedin.com/in/testuser/", None),
+            ("https://evil.example/in/testuser/", None),
+            ("https://user@www.linkedin.com/in/testuser/", None),
+            ("https://www.linkedin.com:444/in/testuser/", None),
+            ("https://www.linkedin.com/in/testuser/edit/intro/", None),
+            ("https://www.linkedin.com/in/testuser%2Fedit/", None),
+            ("https://www.linkedin.com/in/testuser/?trk=profile", None),
+            ("https://www.linkedin.com/in/testuser/#details", None),
+        ],
+    )
+    def test_profile_url_requires_exact_linkedin_profile(self, url, expected):
+        assert extractor_module._profile_path_from_url(url) == expected
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://www.linkedin.com/messaging/compose/", True),
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+                True,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=ACoAAB&"
+                "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB",
+                True,
+            ),
+            ("https://de.linkedin.com/messaging/thread/2-abc/", True),
+            (
+                "https://www.linkedin.com/messaging/thread/2-abc/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB",
+                True,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=OTHER",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=OTHER",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/?profileUrn=",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/thread/2-abc/"
+                "?recipient=ACoAAB&recipient=OTHER",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/thread/2-abc/?profileUrn=",
+                False,
+            ),
+            ("http://www.linkedin.com/messaging/compose/", False),
+            ("https://evil.example/messaging/compose/", False),
+            ("https://user@www.linkedin.com/messaging/thread/2-abc/", False),
+            ("https://www.linkedin.com:444/messaging/compose/", False),
+            ("https://www.linkedin.com/messaging/compose/#draft", False),
+            ("https://www.linkedin.com/messaging/thread/2-abc%2Fother/", False),
+            ("https://www.linkedin.com/feed/", False),
+        ],
+    )
+    def test_final_url_requires_safe_messaging_path(self, url, expected):
+        assert extractor_module._message_page_url_is_safe(url, "ACoAAB") is expected
+
+
 class TestExtractProfileUrn:
-    async def test_returns_urn_from_compose_href(self, mock_page):
-        """Extracts the recipient URN from the messaging compose link."""
+    async def test_returns_urn_from_atomic_top_card_snapshot(self, mock_page):
         mock_page.evaluate = AsyncMock(
-            return_value="/messaging/compose/?recipient=ACoAAB1IelEBLEkqTkNbZ-a1D8mq5R-6C1ihSEk&lipi=urn..."
+            return_value={
+                "pageUrl": "https://www.linkedin.com/in/testuser/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB&"
+                    "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+                ],
+            }
         )
 
-        extractor = LinkedInExtractor(mock_page)
-        result = await extractor._extract_profile_urn()
+        result = await LinkedInExtractor(mock_page)._extract_profile_urn()
 
-        assert result == "ACoAAB1IelEBLEkqTkNbZ-a1D8mq5R-6C1ihSEk"
-
-    async def test_returns_none_when_no_compose_button(self, mock_page):
-        """Returns None when no messaging compose link is found."""
-        mock_page.evaluate = AsyncMock(return_value=None)
-
-        extractor = LinkedInExtractor(mock_page)
-        result = await extractor._extract_profile_urn()
-
-        assert result is None
-
-    async def test_returns_none_when_no_recipient_param(self, mock_page):
-        """Returns None when the compose href has no recipient query param."""
-        mock_page.evaluate = AsyncMock(
-            return_value="/messaging/compose/?someOtherParam=value"
+        assert result == "ACoAAB"
+        mock_page.evaluate.assert_awaited_once_with(
+            extractor_module._PROFILE_MESSAGE_TARGET_JS
         )
 
-        extractor = LinkedInExtractor(mock_page)
-        result = await extractor._extract_profile_urn()
+    async def test_accepts_safe_final_vanity_redirect(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "pageUrl": "https://www.linkedin.com/in/canonical-user/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB&"
+                    "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+                ],
+            }
+        )
+
+        target = await LinkedInExtractor(mock_page)._read_profile_message_target(
+            "testuser"
+        )
+
+        assert target is not None
+        assert target.profile_path == "/in/canonical-user/"
+        assert target.profile_urn == "ACoAAB"
+
+    async def test_returns_none_for_ambiguous_top_card_links(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "pageUrl": "https://www.linkedin.com/in/testuser/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB",
+                    "/messaging/compose/?recipient=OTHER",
+                ],
+            }
+        )
+
+        result = await LinkedInExtractor(mock_page)._extract_profile_urn()
 
         assert result is None
 
@@ -8461,10 +8607,41 @@ class TestSendMessage:
         keyboard.type.assert_not_called()
         keyboard.press.assert_not_called()
 
-    async def test_dry_run_returns_confirmation_required(self, mock_page):
-        """send_message with confirm_send=False returns confirmation_required status."""
-        extractor = LinkedInExtractor(mock_page)
-        with (
+    @staticmethod
+    def _target():
+        return extractor_module._ProfileMessageTarget(
+            profile_path="/in/testuser/",
+            profile_urn="ACoAAB",
+            compose_url=(
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+            ),
+            display_name="Test User",
+        )
+
+    @staticmethod
+    def _patch_to_composer(extractor, mock_page, *, states=None, submission="clicked"):
+        target = TestSendMessage._target()
+        mock_page.url = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
+        mock_page.keyboard = MagicMock(type=AsyncMock(), press=AsyncMock())
+
+        # An empty composer is the ordinary precondition for sending, so a
+        # state that says nothing about it means empty. A case about a draft
+        # still standing in the editor says `"empty": False` and gets it.
+        def with_empty(state):
+            if isinstance(state, dict) and "empty" not in state:
+                return {**state, "empty": True}
+            return state
+
+        if callable(states):
+            inner = states
+
+            async def states(*args, **kwargs):
+                return with_empty(await inner(*args, **kwargs))
+        elif states is not None:
+            states = [with_empty(state) for state in states]
+        return (
+            target,
             patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
@@ -8476,15 +8653,9 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_read_profile_display_name",
+                "_read_profile_message_target",
                 new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+                return_value=target,
             ),
             patch.object(
                 extractor,
@@ -8494,34 +8665,79 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_resolve_message_compose_box",
+                "_read_message_composer_state",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                side_effect=states or None,
+                return_value={
+                    "status": "valid",
+                    "active": True,
+                    "empty": True,
+                    "submitCount": 0,
+                },
             ),
             patch.object(
                 extractor,
-                "_compose_page_matches_recipient",
+                "_focus_verified_message_editor",
                 new_callable=AsyncMock,
                 return_value=True,
             ),
             patch.object(
                 extractor,
-                "_dismiss_message_ui",
+                "_submit_verified_message",
+                new_callable=AsyncMock,
+                return_value=submission,
+            ),
+            patch.object(extractor, "_dismiss_message_ui", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        )
+
+    async def test_dry_run_returns_before_focus_or_text_entry(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=False
             )
 
         assert result["status"] == "confirmation_required"
-        assert result["sent"] is False
+        assert result["recipient_selected"] is True
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_message_unavailable_when_no_compose_href(self, mock_page):
-        """send_message returns message_unavailable when no compose URL found."""
+    async def test_rejects_supplied_urn_before_compose_navigation(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
+        target = self._target()
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as navigate,
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8532,277 +8748,143 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_read_profile_display_name",
+                "_read_profile_message_target",
                 new_callable=AsyncMock,
-                return_value="Test User",
+                return_value=target,
             ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
+        ):
+            result = await extractor.send_message(
+                "testuser",
+                "Hello!",
+                confirm_send=True,
+                profile_urn="OTHER",
+            )
+
+        assert result["status"] == "recipient_resolution_failed"
+        navigate.assert_awaited_once_with("https://www.linkedin.com/in/testuser/")
+
+    async def test_rejects_foreign_url_recipient_after_navigation(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        mock_page.url = "https://www.linkedin.com/messaging/compose/?recipient=OTHER"
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5] as surface,
+            patches[6] as state,
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
-        assert result["status"] == "message_unavailable"
-        assert result["sent"] is False
+        assert result["status"] == "recipient_resolution_failed"
+        surface.assert_not_awaited()
+        state.assert_not_awaited()
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_uses_profile_urn_when_provided(self, mock_page):
-        """send_message builds compose URL from profile_urn without Message-button lookup."""
+    async def test_rejects_contradictory_url_before_focus(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
+
+        async def change_url_after_initial_state(_target):
+            mock_page.url = (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=OTHER"
+            )
+            return {"status": "valid", "active": False}
+
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=change_url_after_initial_state,
+        )
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-            ),
-            patch.object(
-                extractor,
-                "_read_profile_display_name",
-                new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value=None,
-            ) as mock_resolve_href,
-            patch.object(
-                extractor,
-                "_wait_for_message_surface",
-                new_callable=AsyncMock,
-                return_value="composer",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_box",
-                new_callable=AsyncMock,
-                return_value=MagicMock(),
-            ),
-            patch.object(
-                extractor,
-                "_compose_page_matches_recipient",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch.object(
-                extractor,
-                "_dismiss_message_ui",
-                new_callable=AsyncMock,
-            ),
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6] as state,
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
-                "testuser",
-                "Hello!",
-                confirm_send=False,
-                profile_urn="ACoAAB1IelEB",
+                "testuser", "Hello!", confirm_send=True
             )
 
-        # _resolve_message_compose_href should NOT be called when profile_urn given
-        mock_resolve_href.assert_not_awaited()
-        assert result["status"] == "confirmation_required"
+        assert result["status"] == "recipient_resolution_failed"
+        state.assert_awaited_once()
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_profile_urn_compose_url_includes_full_params(self, mock_page):
-        """send_message with profile_urn builds URL with profileUrn, screenContext, interop."""
+    async def test_rejects_foreign_url_recipient_before_text_entry(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        navigate_calls = []
+        state_calls = 0
 
-        async def capture_navigate(url):
-            navigate_calls.append(url)
+        async def change_url_during_prefocus_state(_target):
+            nonlocal state_calls
+            state_calls += 1
+            if state_calls == 2:
+                mock_page.url = (
+                    "https://www.linkedin.com/messaging/compose/?recipient=OTHER"
+                )
+            return {"status": "valid", "active": state_calls > 1}
 
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=change_url_during_prefocus_state,
+        )
         with (
-            patch.object(
-                extractor,
-                "_navigate_to_page",
-                new_callable=AsyncMock,
-                side_effect=capture_navigate,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-            ),
-            patch.object(
-                extractor,
-                "_read_profile_display_name",
-                new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_wait_for_message_surface",
-                new_callable=AsyncMock,
-                return_value="composer",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_box",
-                new_callable=AsyncMock,
-                return_value=MagicMock(),
-            ),
-            patch.object(
-                extractor,
-                "_compose_page_matches_recipient",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch.object(
-                extractor,
-                "_dismiss_message_ui",
-                new_callable=AsyncMock,
-            ),
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
-            await extractor.send_message(
-                "testuser",
-                "Hello!",
-                confirm_send=False,
-                profile_urn="ACoAAB1IelEB",
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
             )
 
-        # Second navigate call is the compose URL (first is the profile page)
-        compose_url = navigate_calls[1]
-        assert "profileUrn=" in compose_url
-        assert "urn%3Ali%3Afsd_profile%3AACoAAB1IelEB" in compose_url
-        assert "recipient=ACoAAB1IelEB" in compose_url
-        assert "screenContext=NON_SELF_PROFILE_VIEW" in compose_url
-        assert "interop=msgOverlay" in compose_url
+        assert result["status"] == "recipient_resolution_failed"
+        focus.assert_awaited_once()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-
-class TestResolveMessageComposeBox:
-    async def test_returns_locator_when_count_positive(self, mock_page):
-        """_resolve_message_compose_box returns locator.last when count() > 0."""
+    async def test_rejects_contradictory_url_before_submission(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_locator = MagicMock()
-        mock_locator.count = AsyncMock(return_value=1)
-        sentinel = MagicMock(name="last_locator")
-        sentinel.wait_for = AsyncMock()
-        mock_locator.last = sentinel
-        mock_locator.wait_for = AsyncMock()
-        mock_page.locator = MagicMock(return_value=mock_locator)
+        patches = self._patch_to_composer(extractor, mock_page)
 
-        result = await extractor._resolve_message_compose_box()
+        async def change_url_after_typing(_message, *, delay):
+            assert delay == 15
+            mock_page.url = (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AOTHER"
+            )
 
-        assert result is sentinel
-        # wait_for should NOT be called on the early-return path
-        sentinel.wait_for.assert_not_called()
-        mock_locator.wait_for.assert_not_called()
-
-    async def test_returns_none_when_all_selectors_miss(self, mock_page):
-        """_resolve_message_compose_box returns None when no selector matches."""
-        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
-
-        extractor = LinkedInExtractor(mock_page)
-        mock_locator = MagicMock()
-        mock_locator.count = AsyncMock(return_value=0)
-        mock_locator.last = MagicMock()
-        mock_locator.last.wait_for = AsyncMock(
-            side_effect=PlaywrightTimeoutError("timeout")
-        )
-        mock_page.locator = MagicMock(return_value=mock_locator)
-
-        result = await extractor._resolve_message_compose_box()
-
-        assert result is None
-
-    async def test_falls_through_when_count_raises(self, mock_page):
-        """_resolve_message_compose_box handles count() exceptions gracefully."""
-        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
-
-        extractor = LinkedInExtractor(mock_page)
-        mock_locator = MagicMock()
-        mock_locator.count = AsyncMock(side_effect=Exception("detached"))
-        mock_locator.last = MagicMock()
-        mock_locator.last.wait_for = AsyncMock(
-            side_effect=PlaywrightTimeoutError("timeout")
-        )
-        mock_page.locator = MagicMock(return_value=mock_locator)
-
-        result = await extractor._resolve_message_compose_box()
-
-        assert result is None
-
-
-class TestSendMessageComposerInteraction:
-    """Tests for the page.evaluate + keyboard.type send path (patchright workaround)."""
-
-    def _patch_send_message_to_compose(self, extractor, mock_page):
-        """Return a context manager that patches send_message up to the compose step."""
-        return (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-            ),
-            patch.object(
-                extractor,
-                "_read_profile_display_name",
-                new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
-            ),
-            patch.object(
-                extractor,
-                "_wait_for_message_surface",
-                new_callable=AsyncMock,
-                return_value="composer",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_box",
-                new_callable=AsyncMock,
-                return_value=MagicMock(),
-            ),
-            patch.object(
-                extractor,
-                "_compose_page_matches_recipient",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch.object(
-                extractor,
-                "_dismiss_message_ui",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        )
-
-    async def test_focus_and_type_via_evaluate_and_keyboard(self, mock_page):
-        """send_message uses page.evaluate to focus and page.keyboard.type to type."""
-        extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns: 'focused' (empty composer, focused), then
-        # True (send button click)
-        mock_page.evaluate = AsyncMock(side_effect=["focused", True])
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        mock_page.keyboard.type.side_effect = change_url_after_typing
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8810,72 +8892,105 @@ class TestSendMessageComposerInteraction:
             patches[5],
             patches[6],
             patches[7],
-            patches[8],
+            patches[8] as submit,
             patches[9],
-            patch.object(
-                extractor,
-                "_message_text_occurrences",
-                new_callable=AsyncMock,
-                return_value=0,
-            ),
-            patch.object(
-                extractor,
-                "_message_text_visible",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
-        assert result["status"] == "sent"
-        assert result["sent"] is True
-        # Verify keyboard.type was used (not press_sequentially)
-        mock_keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        assert result["status"] == "recipient_resolution_failed"
+        mock_page.keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        submit.assert_not_awaited()
+        mock_page.keyboard.press.assert_not_awaited()
 
-    async def test_compose_interact_failed_when_focus_fails(self, mock_page):
-        """send_message returns compose_interact_failed when JS focus fails."""
+    async def test_refuses_a_composer_that_already_holds_a_draft(self, mock_page):
+        """A draft in the editor is not ours to send, and not ours to clear."""
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns 'missing' (no composer to focus)
-        mock_page.evaluate = AsyncMock(return_value="missing")
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            # The recipient check first, then the read taken immediately
+            # before focus: that one still finds the author's draft.
+            states=[
+                {"status": "valid", "active": False},
+                {"status": "valid", "active": False, "empty": False},
+            ],
+        )
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "composer_occupied"
+        assert result["sent"] is False
+        # Nothing is typed, nothing is submitted, and the draft is left where
+        # its author put it.
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_rejects_recipient_change_before_focus(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=[
+                {"status": "valid", "active": False},
+                {"status": "recipient_mismatch", "active": False},
+            ],
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7] as focus,
             patches[8],
             patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
         assert result["status"] == "compose_interact_failed"
-        assert result["sent"] is False
+        focus.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_enter_fallback_when_send_button_not_found(self, mock_page):
-        """send_message falls back to Enter key when JS cannot find send button."""
+    async def test_rejects_editor_change_before_text_entry(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns: 'focused', then False (no send button found)
-        mock_page.evaluate = AsyncMock(side_effect=["focused", False])
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=[
+                {"status": "valid", "active": False},
+                {"status": "valid", "active": False},
+                {"status": "ambiguous_editor", "active": False},
+            ],
+        )
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8885,6 +9000,137 @@ class TestSendMessageComposerInteraction:
             patches[7],
             patches[8],
             patches[9],
+            patches[10],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "compose_interact_failed"
+        mock_page.keyboard.type.assert_not_awaited()
+
+    async def test_rejects_ambiguous_submit_after_text_entry(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page, submission="invalid")
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        mock_page.keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_removed_submit_candidate_cannot_switch_to_enter(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        states = [
+            {"status": "valid", "active": False, "submitCount": 1},
+            {"status": "valid", "active": False, "submitCount": 1},
+            {"status": "valid", "active": True, "submitCount": 1},
+            {"status": "valid", "active": True, "submitCount": 0},
+        ]
+        patches = self._patch_to_composer(
+            extractor, mock_page, states=states, submission="enter"
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        submit.assert_awaited_once_with(self._target(), allow_enter=False)
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_enter_revalidates_active_editor_before_press(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        states = [
+            {"status": "valid", "active": False, "submitCount": 0},
+            {"status": "valid", "active": False, "submitCount": 0},
+            {"status": "valid", "active": True, "submitCount": 0},
+            {"status": "valid", "active": False, "submitCount": 0},
+        ]
+        patches = self._patch_to_composer(
+            extractor, mock_page, states=states, submission="enter"
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6] as state,
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert state.await_count == 4
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_enter_requires_verified_zero_button_path(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page, submission="enter")
+        mock_page.url = (
+            "https://www.linkedin.com/messaging/compose/"
+            "?recipient=ACoAAB&recipient=ACoAAB&"
+            "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8] as submit,
+            patches[9],
+            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -8903,45 +9149,38 @@ class TestSendMessageComposerInteraction:
             )
 
         assert result["status"] == "sent"
-        # Enter was pressed as fallback
-        mock_keyboard.press.assert_awaited_once_with("Enter")
+        submit.assert_awaited_once_with(self._target(), allow_enter=True)
+        mock_page.keyboard.press.assert_awaited_once_with("Enter")
 
-    async def test_baseline_is_taken_after_typing_and_before_send(self, mock_page):
-        """The occurrence baseline is captured between typing and the click.
+    async def test_baseline_is_taken_after_typing_and_before_submission(
+        self, mock_page
+    ):
+        """The occurrence baseline is captured between typing and submission.
 
-        Taken any earlier it would miss what the composer already holds; taken
-        after the click it could already include the delivered message, and
-        the confirmation would compare that copy against itself.
+        Taken any earlier it would miss what the verified composer already
+        holds; taken after submission it could already include the delivered
+        message, and the confirmation would compare that copy against itself.
         """
         extractor = LinkedInExtractor(mock_page)
         steps: list[str] = []
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock(
-            side_effect=lambda *args, **kwargs: steps.append("type")
+        patches = self._patch_to_composer(extractor, mock_page)
+        mock_page.keyboard.type.side_effect = lambda *args, **kwargs: steps.append(
+            "type"
         )
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-
-        async def evaluate(*args, **kwargs):
-            focusing = not steps
-            steps.append("focus" if focusing else "click")
-            # The focus call reports the composer state; the click reports
-            # whether a send button was found.
-            return "focused" if focusing else True
 
         async def occurrences(message):
             steps.append("baseline")
             return 2
 
+        async def submit(target, *, allow_enter):
+            steps.append("submit")
+            return "clicked"
+
         async def visible(message, *, previous_occurrences):
             steps.append(f"confirm:{previous_occurrences}")
             return True
 
-        mock_page.evaluate = AsyncMock(side_effect=evaluate)
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8949,8 +9188,14 @@ class TestSendMessageComposerInteraction:
             patches[5],
             patches[6],
             patches[7],
-            patches[8],
+            patch.object(
+                extractor,
+                "_submit_verified_message",
+                new_callable=AsyncMock,
+                side_effect=submit,
+            ),
             patches[9],
+            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -8969,22 +9214,14 @@ class TestSendMessageComposerInteraction:
             )
 
         assert result["status"] == "sent"
-        # The confirmation receives exactly the baseline taken before the click.
-        assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
+        # The confirmation receives exactly the baseline taken before submission.
+        assert steps == ["type", "baseline", "submit", "confirm:2"]
 
-    async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
-        """A clicked Send button that changes nothing is not a sent message."""
+    async def test_submission_that_adds_nothing_stays_unconfirmed(self, mock_page):
+        """A submit path that leaves the page unchanged has delivered nothing."""
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns: 'focused', then True (send button found and clicked)
-        mock_page.evaluate = AsyncMock(side_effect=["focused", True])
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        patches = self._patch_to_composer(extractor, mock_page)
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8994,6 +9231,7 @@ class TestSendMessageComposerInteraction:
             patches[7],
             patches[8],
             patches[9],
+            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -9011,11 +9249,26 @@ class TestSendMessageComposerInteraction:
                 "testuser", "Hello!", confirm_send=True
             )
 
-        # The click happened, so nothing here proves the message did not go
-        # out. Answering "not sent" would invite a retry that delivers twice.
+        # The submit already happened, so nothing here proves the message did
+        # not go out. Answering "not sent" would invite a retry that delivers
+        # a second real message.
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
+
+
+class TestResolveMessageComposeBox:
+    async def test_requires_exactly_one_visible_editor(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        locator = MagicMock(count=AsyncMock(return_value=2))
+        locator.first = MagicMock()
+        mock_page.locator.return_value = locator
+
+        assert await extractor._resolve_message_compose_box() is None
+
+        mock_page.locator.assert_called_once_with(
+            f"{extractor_module._MESSAGING_COMPOSE_SELECTOR}:visible"
+        )
 
 
 class TestMessageTextOccurrences:

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -6,7 +6,9 @@ runs there: the JS focus, the keyboard typing into a contenteditable, the
 Send click and the occurrence count taken across the resulting DOM. These
 cases drive the production ``send_message`` path in headless chromium and
 replace navigation and recipient discovery only, so every step the
-confirmation depends on executes unchanged. Skipped automatically when
+confirmation depends on executes unchanged: recipient verification reads
+this page's own identity and submission clicks this page's own button.
+Skipped automatically when
 chromium is not installed; run locally after
 ``uv run patchright install chromium --no-shell``.
 
@@ -23,7 +25,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from patchright.async_api import async_playwright
 
-from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+from linkedin_mcp_server.scraping.extractor import (
+    LinkedInExtractor,
+    _ProfileMessageTarget,
+)
 
 #: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
 #: worker so browser startups cannot compete with the DOM cases' wall-clock
@@ -38,6 +43,13 @@ DISPLAY_NAME = "Fadi Al Eliwi"
 MESSAGE = "UNDELIVERED SENTINEL"
 DRAFT = "Draft: "
 COMPOSE_URL = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
+PROFILE_PATH = "/in/fadi-eliwi/"
+TARGET = _ProfileMessageTarget(
+    profile_path=PROFILE_PATH,
+    profile_urn="ACoAAB",
+    compose_url=COMPOSE_URL,
+    display_name=DISPLAY_NAME,
+)
 
 # Records the click as a body attribute and does nothing else: the button is
 # visible and enabled, so the production JS click path succeeds while the
@@ -66,19 +78,27 @@ DELIVERING_SEND_JS = """
 
 
 def compose_page(send_js: str, *, draft: str = "") -> str:
-    """A compose surface holding one earlier copy of the same message."""
+    """A compose surface holding one earlier copy of the same message.
+
+    The recipient link sits beside the editor rather than inside it, which is
+    what lets the production verification resolve an identity at all: draft
+    content never authorizes anyone.
+    """
     return f"""<!DOCTYPE html>
 <html lang="en">
   <head><meta charset="utf-8"><title>Messaging</title></head>
   <body>
     <main>
-      <h2 id="recipient">{DISPLAY_NAME}</h2>
-      <div id="thread">
-        <div class="msg">{MESSAGE}</div>
-      </div>
-      <div id="composer" role="textbox" contenteditable="true"
-        aria-label="Write a message…">{draft}</div>
-      <button id="send" type="submit">Send</button>
+      <section id="conversation">
+        <a id="recipient" href="https://www.linkedin.com{PROFILE_PATH}">
+          {DISPLAY_NAME}</a>
+        <div id="thread">
+          <div class="msg">{MESSAGE}</div>
+        </div>
+        <div id="composer" role="textbox" contenteditable="true"
+          aria-label="Write a message…">{draft}</div>
+        <button id="send" type="submit">Send</button>
+      </section>
     </main>
     <script>{send_js}</script>
   </body>
@@ -116,22 +136,26 @@ async def dom_page():
 
 
 async def send(page, html: str, *, message: str = MESSAGE) -> dict:
-    """Run the real send path against `html`, mocking discovery only."""
+    """Run the real send path against `html`, mocking discovery only.
+
+    Only the two steps that need a live LinkedIn are replaced: reading the
+    target off a profile page, and the messaging-URL guard, which cannot pass
+    for the ``about:blank`` a ``set_content`` page reports. Both have their own
+    unit tests. Everything the confirmation rests on runs here for real.
+    """
     await page.set_content(html)
     extractor = LinkedInExtractor(page)
     with (
         patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
         patch.object(
             extractor,
-            "_read_profile_display_name",
+            "_read_profile_message_target",
             new_callable=AsyncMock,
-            return_value=DISPLAY_NAME,
+            return_value=TARGET,
         ),
-        patch.object(
-            extractor,
-            "_resolve_message_compose_href",
-            new_callable=AsyncMock,
-            return_value=COMPOSE_URL,
+        patch(
+            "linkedin_mcp_server.scraping.extractor._message_page_url_is_safe",
+            return_value=True,
         ),
     ):
         return await extractor.send_message("fadi-eliwi", message, confirm_send=True)
@@ -157,6 +181,22 @@ class TestSendConfirmationAgainstRealDom:
         assert result["sent"] is False
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
         assert await text_of(dom_page, "#composer") == draft
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_foreign_recipient_never_reaches_the_composer(self, dom_page):
+        # Issue #861: the composer belongs to someone else. Nothing may be
+        # typed and nothing may be clicked, so the message the caller wrote
+        # cannot reach a person they never named.
+        page = compose_page(DELIVERING_SEND_JS).replace(
+            f'href="https://www.linkedin.com{PROFILE_PATH}"',
+            'href="https://www.linkedin.com/in/someone-else/"',
+        )
+        result = await send(dom_page, page)
+
+        assert result["sent"] is False
+        assert result["status"] == "composer_unavailable"
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await text_of(dom_page, "#composer") == ""
         assert await dom_page.locator("#thread .msg").count() == 1
 
     async def test_ineffective_send_is_not_confirmed(self, dom_page):

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -115,7 +115,7 @@ async def dom_page():
             await browser.close()
 
 
-async def send(page, html: str) -> dict:
+async def send(page, html: str, *, message: str = MESSAGE) -> dict:
     """Run the real send path against `html`, mocking discovery only."""
     await page.set_content(html)
     extractor = LinkedInExtractor(page)
@@ -134,7 +134,7 @@ async def send(page, html: str) -> dict:
             return_value=COMPOSE_URL,
         ),
     ):
-        return await extractor.send_message("fadi-eliwi", MESSAGE, confirm_send=True)
+        return await extractor.send_message("fadi-eliwi", message, confirm_send=True)
 
 
 async def text_of(page, selector: str) -> str:
@@ -142,6 +142,23 @@ async def text_of(page, selector: str) -> str:
 
 
 class TestSendConfirmationAgainstRealDom:
+    @pytest.mark.parametrize("message", ["", " \t\n"], ids=["empty", "whitespace"])
+    async def test_blank_message_leaves_existing_draft_untouched(
+        self, dom_page, message
+    ):
+        draft = "Confidential draft"
+        result = await send(
+            dom_page,
+            compose_page(DELIVERING_SEND_JS, draft=draft),
+            message=message,
+        )
+
+        assert result["status"] == "message_unavailable"
+        assert result["sent"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await text_of(dom_page, "#composer") == draft
+        assert await dom_page.locator("#thread .msg").count() == 1
+
     async def test_ineffective_send_is_not_confirmed(self, dom_page):
         # The reported failure: Send is clicked, the handler does nothing,
         # and the message stays in the composer next to an identical earlier

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -48,6 +48,17 @@ NOOP_SEND_JS = """
   });
 """
 
+# Goes read-only for the duration of an in-flight send and delivers nothing,
+# which is what a React composer commonly does while it waits. The text stays
+# on screen the whole time, so an occurrence subtracted at baseline has to
+# stay subtracted or this no-op confirms itself.
+READONLY_NOOP_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    document.getElementById('composer').setAttribute('contenteditable', 'false');
+  });
+"""
+
 # Moves the composer's text into the thread as a plain, non-editable entry,
 # which is what a delivered message looks like to the page.
 DELIVERING_SEND_JS = """
@@ -159,14 +170,44 @@ class TestSendConfirmationAgainstRealDom:
         assert await text_of(dom_page, "#composer") == draft
         assert await dom_page.locator("#thread .msg").count() == 1
 
+    async def test_existing_draft_is_never_sent_along(self, dom_page):
+        # Measured, and the reason this fixture carries a draft at all:
+        # `element.focus()` leaves the caret at the *start* of a
+        # contenteditable in Chromium, so a typed message lands in front of
+        # whatever the composer already held and LinkedIn delivers the two as
+        # one. The draft is the user's text and nobody asked for it to be
+        # sent, so the send refuses here. Clearing it instead would trade the
+        # leak for destroying it.
+        result = await send(dom_page, compose_page(DELIVERING_SEND_JS, draft=DRAFT))
+
+        assert result["status"] == "composer_occupied"
+        assert result["sent"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await text_of(dom_page, "#composer") == DRAFT.strip()
+        assert await dom_page.locator("#thread .msg").count() == 1
+
     async def test_ineffective_send_is_not_confirmed(self, dom_page):
         # The reported failure: Send is clicked, the handler does nothing,
         # and the message stays in the composer next to an identical earlier
-        # copy in the thread. Neither is evidence of delivery.
+        # copy in the thread. Neither is evidence of delivery. The click did
+        # happen, though, so the answer is "unknown" rather than "not sent".
         result = await send(dom_page, compose_page(NOOP_SEND_JS))
 
         assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
-        assert result["status"] == "send_unavailable"
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert await text_of(dom_page, "#composer") == MESSAGE
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_composer_going_read_only_does_not_confirm(self, dom_page):
+        # The same no-op, except the composer stops being editable while it
+        # waits. Counting only `[contenteditable="true"]` would stop
+        # subtracting the unsent text at exactly that moment and read its
+        # own draft as a delivery.
+        result = await send(dom_page, compose_page(READONLY_NOOP_SEND_JS))
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         assert await text_of(dom_page, "#composer") == MESSAGE
         assert await dom_page.locator("#thread .msg").count() == 1
@@ -175,18 +216,11 @@ class TestSendConfirmationAgainstRealDom:
         # Same page, same earlier copy, but the Send handler moves the text
         # into the thread. The count outside the composer grows, so this one
         # confirms where the ineffective click above did not.
-        result = await send(dom_page, compose_page(DELIVERING_SEND_JS, draft=DRAFT))
+        result = await send(dom_page, compose_page(DELIVERING_SEND_JS))
 
         assert result["status"] == "sent"
         assert result["sent"] is True
         assert await text_of(dom_page, "#composer") == ""
         entries = dom_page.locator("#thread .msg")
         assert await entries.count() == 2
-        # Measured, and the reason this fixture carries a draft at all:
-        # `element.focus()` leaves the caret at the *start* of a
-        # contenteditable in Chromium, so the typed message lands in front of
-        # whatever the composer already held. The delivered entry therefore
-        # reads message-then-draft. The confirmation is unaffected — it counts
-        # the message as a substring — but a composer with an unsent draft
-        # sends the two in that order.
-        assert (await entries.last.inner_text()).strip() == f"{MESSAGE}{DRAFT}".strip()
+        assert (await entries.last.inner_text()).strip() == MESSAGE

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -1,0 +1,175 @@
+# tests/test_send_message_confirmation_dom.py
+"""Browser-DOM tests for the send_message post-send confirmation (issue #866).
+
+The unit suite mocks ``page.evaluate``, so none of what decides "sent" ever
+runs there: the JS focus, the keyboard typing into a contenteditable, the
+Send click and the occurrence count taken across the resulting DOM. These
+cases drive the production ``send_message`` path in headless chromium and
+replace navigation and recipient discovery only, so every step the
+confirmation depends on executes unchanged. Skipped automatically when
+chromium is not installed; run locally after
+``uv run patchright install chromium --no-shell``.
+
+Both fixtures place an identical earlier message in the thread, which is
+what made "the text is somewhere on the page" worthless as evidence: the
+composer holds the message before it is sent, and the earlier copy holds it
+whether or not the send succeeds.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+
+#: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
+#: worker so browser startups cannot compete with the DOM cases' wall-clock
+#: timers.
+#: Without that distribution mode the group mark is inert.
+pytestmark = [
+    pytest.mark.browser_dom,
+    pytest.mark.xdist_group("browser_runtime"),
+]
+
+DISPLAY_NAME = "Fadi Al Eliwi"
+MESSAGE = "UNDELIVERED SENTINEL"
+DRAFT = "Draft: "
+COMPOSE_URL = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
+
+# Records the click as a body attribute and does nothing else: the button is
+# visible and enabled, so the production JS click path succeeds while the
+# message never leaves the composer.
+NOOP_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+  });
+"""
+
+# Moves the composer's text into the thread as a plain, non-editable entry,
+# which is what a delivered message looks like to the page.
+DELIVERING_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    const composer = document.getElementById('composer');
+    const text = composer.innerText;
+    if (!text.trim()) return;
+    const entry = document.createElement('div');
+    entry.className = 'msg';
+    entry.textContent = text;
+    document.getElementById('thread').appendChild(entry);
+    composer.textContent = '';
+  });
+"""
+
+
+def compose_page(send_js: str, *, draft: str = "") -> str:
+    """A compose surface holding one earlier copy of the same message."""
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Messaging</title></head>
+  <body>
+    <main>
+      <h2 id="recipient">{DISPLAY_NAME}</h2>
+      <div id="thread">
+        <div class="msg">{MESSAGE}</div>
+      </div>
+      <div id="composer" role="textbox" contenteditable="true"
+        aria-label="Write a message…">{draft}</div>
+      <button id="send" type="submit">Send</button>
+    </main>
+    <script>{send_js}</script>
+  </body>
+</html>
+"""
+
+
+@pytest.fixture
+async def dom_page():
+    """Real chromium page, or skip when no browser is installed.
+
+    Only launch/setup is guarded by the skip — the ``yield`` is outside it
+    so an assertion failure or JS error in a test body is never swallowed
+    into a skip.
+
+    ``channel="chromium"`` names the browser this project installs. Without
+    it Playwright picks the *binary* from the ``headless`` flag alone and
+    asks for ``chromium-headless-shell``, which nothing here installs since
+    the setup moved to ``--no-shell``: the launch would fail and every case
+    in this file would skip itself, silently, wherever the real browser is.
+    """
+    async with async_playwright() as p:
+        try:
+            browser = await p.chromium.launch(channel="chromium", headless=True)
+            page = await browser.new_page()
+        except Exception as exc:  # browser binary missing
+            pytest.skip(f"chromium unavailable: {exc}")
+        # The confirmation waits on the page-level default, so a failed send
+        # has to give up quickly here.
+        page.set_default_timeout(1500)
+        try:
+            yield page
+        finally:
+            await browser.close()
+
+
+async def send(page, html: str) -> dict:
+    """Run the real send path against `html`, mocking discovery only."""
+    await page.set_content(html)
+    extractor = LinkedInExtractor(page)
+    with (
+        patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+        patch.object(
+            extractor,
+            "_read_profile_display_name",
+            new_callable=AsyncMock,
+            return_value=DISPLAY_NAME,
+        ),
+        patch.object(
+            extractor,
+            "_resolve_message_compose_href",
+            new_callable=AsyncMock,
+            return_value=COMPOSE_URL,
+        ),
+    ):
+        return await extractor.send_message("fadi-eliwi", MESSAGE, confirm_send=True)
+
+
+async def text_of(page, selector: str) -> str:
+    return (await page.locator(selector).inner_text()).strip()
+
+
+class TestSendConfirmationAgainstRealDom:
+    async def test_ineffective_send_is_not_confirmed(self, dom_page):
+        # The reported failure: Send is clicked, the handler does nothing,
+        # and the message stays in the composer next to an identical earlier
+        # copy in the thread. Neither is evidence of delivery.
+        result = await send(dom_page, compose_page(NOOP_SEND_JS))
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unavailable"
+        assert result["sent"] is False
+        assert await text_of(dom_page, "#composer") == MESSAGE
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_delivered_message_is_confirmed(self, dom_page):
+        # Same page, same earlier copy, but the Send handler moves the text
+        # into the thread. The count outside the composer grows, so this one
+        # confirms where the ineffective click above did not.
+        result = await send(dom_page, compose_page(DELIVERING_SEND_JS, draft=DRAFT))
+
+        assert result["status"] == "sent"
+        assert result["sent"] is True
+        assert await text_of(dom_page, "#composer") == ""
+        entries = dom_page.locator("#thread .msg")
+        assert await entries.count() == 2
+        # Measured, and the reason this fixture carries a draft at all:
+        # `element.focus()` leaves the caret at the *start* of a
+        # contenteditable in Chromium, so the typed message lands in front of
+        # whatever the composer already held. The delivered entry therefore
+        # reads message-then-draft. The confirmation is unaffected — it counts
+        # the message as a substring — but a composer with an unsent draft
+        # sends the two in that order.
+        assert (await entries.last.inner_text()).strip() == f"{MESSAGE}{DRAFT}".strip()

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -6,7 +6,9 @@ runs there: the JS focus, the keyboard typing into a contenteditable, the
 Send click and the occurrence count taken across the resulting DOM. These
 cases drive the production ``send_message`` path in headless chromium and
 replace navigation and recipient discovery only, so every step the
-confirmation depends on executes unchanged. Skipped automatically when
+confirmation depends on executes unchanged: recipient verification reads
+this page's own identity and submission clicks this page's own button.
+Skipped automatically when
 chromium is not installed; run locally after
 ``uv run patchright install chromium --no-shell``.
 
@@ -23,7 +25,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from patchright.async_api import async_playwright
 
-from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+from linkedin_mcp_server.scraping.extractor import (
+    LinkedInExtractor,
+    _ProfileMessageTarget,
+)
 
 #: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
 #: worker so browser startups cannot compete with the DOM cases' wall-clock
@@ -38,6 +43,13 @@ DISPLAY_NAME = "Fadi Al Eliwi"
 MESSAGE = "UNDELIVERED SENTINEL"
 DRAFT = "Draft: "
 COMPOSE_URL = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
+PROFILE_PATH = "/in/fadi-eliwi/"
+TARGET = _ProfileMessageTarget(
+    profile_path=PROFILE_PATH,
+    profile_urn="ACoAAB",
+    compose_url=COMPOSE_URL,
+    display_name=DISPLAY_NAME,
+)
 
 # Records the click as a body attribute and does nothing else: the button is
 # visible and enabled, so the production JS click path succeeds while the
@@ -77,19 +89,27 @@ DELIVERING_SEND_JS = """
 
 
 def compose_page(send_js: str, *, draft: str = "") -> str:
-    """A compose surface holding one earlier copy of the same message."""
+    """A compose surface holding one earlier copy of the same message.
+
+    The recipient link sits beside the editor rather than inside it, which is
+    what lets the production verification resolve an identity at all: draft
+    content never authorizes anyone.
+    """
     return f"""<!DOCTYPE html>
 <html lang="en">
   <head><meta charset="utf-8"><title>Messaging</title></head>
   <body>
     <main>
-      <h2 id="recipient">{DISPLAY_NAME}</h2>
-      <div id="thread">
-        <div class="msg">{MESSAGE}</div>
-      </div>
-      <div id="composer" role="textbox" contenteditable="true"
-        aria-label="Write a message…">{draft}</div>
-      <button id="send" type="submit">Send</button>
+      <section id="conversation">
+        <a id="recipient" href="https://www.linkedin.com{PROFILE_PATH}">
+          {DISPLAY_NAME}</a>
+        <div id="thread">
+          <div class="msg">{MESSAGE}</div>
+        </div>
+        <div id="composer" role="textbox" contenteditable="true"
+          aria-label="Write a message…">{draft}</div>
+        <button id="send" type="submit">Send</button>
+      </section>
     </main>
     <script>{send_js}</script>
   </body>
@@ -127,22 +147,26 @@ async def dom_page():
 
 
 async def send(page, html: str, *, message: str = MESSAGE) -> dict:
-    """Run the real send path against `html`, mocking discovery only."""
+    """Run the real send path against `html`, mocking discovery only.
+
+    Only the two steps that need a live LinkedIn are replaced: reading the
+    target off a profile page, and the messaging-URL guard, which cannot pass
+    for the ``about:blank`` a ``set_content`` page reports. Both have their own
+    unit tests. Everything the confirmation rests on runs here for real.
+    """
     await page.set_content(html)
     extractor = LinkedInExtractor(page)
     with (
         patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
         patch.object(
             extractor,
-            "_read_profile_display_name",
+            "_read_profile_message_target",
             new_callable=AsyncMock,
-            return_value=DISPLAY_NAME,
+            return_value=TARGET,
         ),
-        patch.object(
-            extractor,
-            "_resolve_message_compose_href",
-            new_callable=AsyncMock,
-            return_value=COMPOSE_URL,
+        patch(
+            "linkedin_mcp_server.scraping.extractor._message_page_url_is_safe",
+            return_value=True,
         ),
     ):
         return await extractor.send_message("fadi-eliwi", message, confirm_send=True)
@@ -168,6 +192,22 @@ class TestSendConfirmationAgainstRealDom:
         assert result["sent"] is False
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
         assert await text_of(dom_page, "#composer") == draft
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_foreign_recipient_never_reaches_the_composer(self, dom_page):
+        # Issue #861: the composer belongs to someone else. Nothing may be
+        # typed and nothing may be clicked, so the message the caller wrote
+        # cannot reach a person they never named.
+        page = compose_page(DELIVERING_SEND_JS).replace(
+            f'href="https://www.linkedin.com{PROFILE_PATH}"',
+            'href="https://www.linkedin.com/in/someone-else/"',
+        )
+        result = await send(dom_page, page)
+
+        assert result["sent"] is False
+        assert result["status"] == "composer_unavailable"
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await text_of(dom_page, "#composer") == ""
         assert await dom_page.locator("#thread .msg").count() == 1
 
     async def test_existing_draft_is_never_sent_along(self, dom_page):


### PR DESCRIPTION
Closes #861

`send_message` opened a compose surface and typed the caller's text into whatever editor it found. Nothing tied that editor to the person the caller named, so a stale composer, a redirect, or a recipient chip for another member could deliver the message to someone the caller never addressed, and the result still reported success.

The profile page, its compose link, the messaging URL, and the composer's own recipient identity now have to name one person before anything is focused, typed, or submitted. On any disagreement the tool returns with the editor untouched. Draft content is excluded from that identity read, so text the caller wrote cannot authorize its own delivery. The walk collects every identity up to the enclosing dialog, so a profile merely mentioned in a rendered thread refuses later sends to that person: extra identities can only tighten the check, never redirect a message.

A synthetic Chromium page drives the real production path; with the identity check mutated away, that page delivers the message to a foreign recipient, which is Issue #861 reproduced in a DOM.

## Synthetic prompt

> `send_message` types into whatever composer it finds, so the message can reach the wrong person. Bind the profile page, `profile_urn`, the compose link, the messaging URL, and the composer's own recipient identity to one person, and abort before focus, typing, or submission on any disagreement. Draft content must never authorize a recipient. Cover it with DOM tests on the real path and verify each one by mutation.

Generated with Claude Opus 5 and Claude Fable 5.1
