### PR TITLE
refactor(scraping): Extract policy leaves

### DIFF
--- a/linkedin_mcp_server/scraping/contracts.py
+++ b/linkedin_mcp_server/scraping/contracts.py
@@ -1,0 +1,132 @@
+"""Section contracts shared by every scraping workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from linkedin_mcp_server.scraping.identifiers import (
+    normalize_person_identifier,
+    person_profile_url,
+)
+from linkedin_mcp_server.scraping.link_metadata import Reference
+
+# Returned as section text when a page comes back with its content gone and
+# only LinkedIn's own navigation and footer left.
+#
+# Read carefully: that condition is a *guess* that the page was throttled, not
+# an observation of one. It arrived in d8b4c62 with no cited evidence, LinkedIn
+# documents no such behaviour, and nobody here has reproduced it deliberately —
+# doing so would mean provoking a real throttle on a real account. The log line
+# hedges with "likely" for the same reason.
+#
+# The same empty shell could also be a layout change, a resource this account
+# cannot see, or a load that gave up. A session LinkedIn ended is the one
+# alternative already ruled out elsewhere: every navigation checks the URL
+# against the auth-blocker patterns first, and a redirect to /login, /authwall
+# or /checkpoint raises before extraction is reached. That check stays on URLs
+# deliberately — body text would be a per-locale guess, and this project's
+# rule is that classification never depends on text values.
+RATE_LIMITED_SECTION_TEXT = "[Rate limited] LinkedIn blocked this section. Try again later or request fewer sections."
+
+# A submission is in flight from the moment the send is dispatched until the
+# whole path has produced a result, cleanup included, and an interruption in
+# that window cannot be reported. FastMCP runs every tool inside
+# `anyio.fail_after()`, so the deadline raises `CancelledError` past
+# `except Exception` and discards any result returned from the cancelled
+# scope. The caller gets a timeout that carries no `retry_safe`, and this line
+# is then the only record that a message may already have left. Answering the
+# caller instead needs the tool to know its own deadline, which is issue #889.
+SEND_INTERRUPTED_WARNING = (
+    "Message submission was interrupted while in flight. The send outcome is "
+    "unknown; check the conversation before retrying, as a retry may deliver "
+    "the message twice."
+)
+
+
+def rate_limited_section_error() -> dict[str, str]:
+    """The ``section_errors`` entry for a section that came back empty.
+
+    One shape for every caller, because the alternative is what this codebase
+    did until now: most call sites dropped the sentinel and returned the
+    section as simply absent. An agent reading an empty section with no error
+    concludes there was nothing to find and calls again, which is the opposite
+    of what a rate limit asks for. Being told is what lets a client back off.
+
+    Note this reports the *heuristic's* verdict, with the caveats on
+    ``RATE_LIMITED_SECTION_TEXT`` above, and does not make it more accurate.
+    What it changes is that a wrong verdict is now visible and can be argued
+    with, where a silently missing section could not be.
+    """
+    return {
+        "error_type": "rate_limit",
+        "error_message": RATE_LIMITED_SECTION_TEXT,
+    }
+
+
+def message_action_result(
+    url: str,
+    status: str,
+    message: str,
+    *,
+    recipient_selected: bool = False,
+    sent: bool = False,
+    retry_safe: bool = True,
+) -> dict[str, Any]:
+    """Build a structured response for the send_message tool.
+
+    ``sent`` is true only when the narrowly defined message-list UI transition
+    was observed after submission. It does not prove delivery or that the
+    recipient read the message. A caller keying a retry on it alone can re-send
+    a message that may already have arrived, which is what ``retry_safe`` exists
+    to say: it is false from the moment a submission is attempted, and true only
+    while nothing can have left the composer.
+    """
+    return {
+        "url": url,
+        "status": status,
+        "message": message,
+        "recipient_selected": recipient_selected,
+        "sent": sent,
+        "retry_safe": retry_safe,
+    }
+
+
+def refuse_an_invalid_message(
+    linkedin_username: str, message: str
+) -> dict[str, Any] | None:
+    """Return the shared browser-free refusal for an unsafe message."""
+    reason = None
+    if not message.strip():
+        reason = "Message must contain non-whitespace characters."
+    elif any(ord(character) < 32 or ord(character) == 127 for character in message):
+        # Keep the browser-side insertion contract to plain message text.
+        # Reject every C0 control and DEL before a session is acquired so no
+        # control input can reach the contenteditable surface.
+        reason = "Message must not contain control characters or line breaks."
+    if reason is None:
+        return None
+    return message_action_result(
+        person_profile_url(normalize_person_identifier(linkedin_username), "/"),
+        "invalid_message",
+        reason,
+    )
+
+
+@dataclass
+class ExtractedSection:
+    """Text and compact references extracted from a loaded LinkedIn section."""
+
+    text: str
+    references: list[Reference]
+    error: dict[str, Any] | None = None
+
+
+class FilterValidationError(ValueError):
+    """Invalid ``search_people`` filter input (network token / URN shape).
+
+    Subclassing ``ValueError`` keeps backward-compatible behaviour for
+    direct extractor callers (``pytest.raises(ValueError)`` matches), while
+    letting the MCP tool wrapper catch this case precisely and surface the
+    actionable message past ``mask_error_details``.
+    """

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -41,7 +41,19 @@ from linkedin_mcp_server.core.utils import (
     scroll_job_sidebar,
     scroll_to_bottom,
 )
+from linkedin_mcp_server.scraping import contracts
 from linkedin_mcp_server.scraping.connection import ActionSignals
+from linkedin_mcp_server.scraping.contracts import (
+    RATE_LIMITED_SECTION_TEXT,
+    ExtractedSection,
+    FilterValidationError,
+    rate_limited_section_error,
+)
+from linkedin_mcp_server.scraping.feed_payload import (
+    POST_SLUG_URL_RE,
+    build_feed_references,
+    is_feed_payload_response,
+)
 from linkedin_mcp_server.scraping.identifiers import (
     company_page_url,
     job_view_url,
@@ -52,12 +64,32 @@ from linkedin_mcp_server.scraping.identifiers import (
     normalize_person_identifier,
     person_profile_url,
 )
+from linkedin_mcp_server.scraping.job_policy import (
+    JOB_SEARCH_PATHS,
+    RESULTS_PER_LINKEDIN_PAGE,
+    SAVED_JOBS_PAGE_SIZE,
+    SAVED_JOBS_PATHS,
+    SAVED_JOBS_URL,
+    SCROLL_BUDGET_TOTAL,
+    SCROLL_DEADLINE_MAX,
+    SEARCH_TIMEOUT_FRACTION,
+    dropped_filters_section_error,
+    dropped_offset_section_error,
+    lost_keywords_section_error,
+    reconcile_search_references,
+    route,
+    same_job_search,
+)
 from linkedin_mcp_server.scraping.link_metadata import (
-    JOB_PATH_RE,
     Reference,
-    _SEARCH_RESULTS_REFERENCE_CAP,
     build_references,
     dedupe_references,
+)
+from linkedin_mcp_server.scraping.text import (
+    filter_linkedin_noise_lines,
+    strip_conversation_chrome,
+    strip_linkedin_noise,
+    truncate_linkedin_noise,
 )
 
 from .fields import COMPANY_SECTIONS, PERSON_SECTIONS
@@ -74,145 +106,6 @@ _NAV_DELAY = 2.0
 
 # Backoff before retrying a temporarily blocked page
 _RATE_LIMIT_RETRY_DELAY = 5.0
-
-# Returned as section text when a page comes back with its content gone and
-# only LinkedIn's own navigation and footer left.
-#
-# Read carefully: that condition is a *guess* that the page was throttled, not
-# an observation of one. It arrived in d8b4c62 with no cited evidence, LinkedIn
-# documents no such behaviour, and nobody here has reproduced it deliberately —
-# doing so would mean provoking a real throttle on a real account. The log line
-# hedges with "likely" for the same reason.
-#
-# The same empty shell could also be a layout change, a resource this account
-# cannot see, or a load that gave up. A session LinkedIn ended is the one
-# alternative already ruled out elsewhere: every navigation checks the URL
-# against the auth-blocker patterns first, and a redirect to /login, /authwall
-# or /checkpoint raises before extraction is reached. That check stays on URLs
-# deliberately — body text would be a per-locale guess, and this project's
-# rule is that classification never depends on text values.
-_RATE_LIMITED_MSG = "[Rate limited] LinkedIn blocked this section. Try again later or request fewer sections."
-
-
-def _reconcile_search_references(
-    references: list[Reference], ids: list[str]
-) -> list[Reference]:
-    """Align one page's references with the job ids read from its rail.
-
-    References come from the whole `<main>`, which also holds the detail pane;
-    ids come from the selected results rail. The rail therefore decides which
-    jobs exist, while the DOM references supply richer labels when available.
-    Non-job references share the search-results cap's remaining allowance.
-    """
-    ordered_ids = list(dict.fromkeys(ids))
-    kept_ids = set(ordered_ids)
-    emitted_ids: set[str] = set()
-    ancillary_left = max(0, _SEARCH_RESULTS_REFERENCE_CAP - len(ordered_ids))
-    out: list[Reference] = []
-
-    for ref in references:
-        if ref.get("kind") == "job":
-            match = JOB_PATH_RE.match(str(ref.get("url", "")))
-            if match is None:
-                continue
-            job_id = match.group(1)
-            if job_id not in kept_ids or job_id in emitted_ids:
-                continue
-            out.append(ref)
-            emitted_ids.add(job_id)
-            continue
-
-        if ancillary_left:
-            out.append(ref)
-            ancillary_left -= 1
-
-    for job_id in ordered_ids:
-        if job_id not in emitted_ids:
-            out.append({"kind": "job", "url": f"/jobs/view/{job_id}/"})
-
-    return out
-
-
-def lost_keywords_section_error(asked: str, landed: str) -> dict[str, str]:
-    """The ``section_errors`` entry for a search that is not the one asked for.
-
-    Both values are named, because the one shape this cannot rule out is
-    LinkedIn re-encoding a query rather than changing it. `parse_qs` folds
-    `%20` and `+` together, so ordinary spacing differences are already gone
-    by the time they are compared; an unencoded `C++` read back as `C` and
-    two spaces is the measured exception, and naming both sides is what makes
-    that diagnosable from the response instead of from a debugger.
-    """
-    return {
-        "error_type": "search_replaced",
-        "error_message": (
-            f"LinkedIn answered a search for {landed!r} where {asked!r} was "
-            "asked for, so the results are about something else."
-        ),
-    }
-
-
-def dropped_offset_section_error(offset: int, landed: str) -> dict[str, str]:
-    """The ``section_errors`` entry for a list that cannot be paged further.
-
-    LinkedIn dropping the offset serves the first page again, so the loop
-    stops there. Stopping quietly is also what an exhausted list does, and the
-    caller cannot tell the two apart: it reads a short list as the whole list
-    and never asks again. Being told is what lets a client decide.
-    """
-    return {
-        "error_type": "pagination_stopped",
-        "error_message": (
-            f"LinkedIn did not keep offset {offset} (landed on {landed}), "
-            "so the list stops at the results already read."
-        ),
-    }
-
-
-def dropped_filters_section_error(names: list[str], landed: str) -> dict[str, str]:
-    """The ``section_errors`` entry for filters LinkedIn did not keep.
-
-    Reported rather than raised, and the results kept: they are broader than
-    the caller asked for and still about the same keywords, so a location or
-    a work type LinkedIn dropped costs relevance rather than correctness.
-    Saying nothing is what cannot be defended, since a search for remote
-    Python in Berlin then returns Python anywhere and reads as though Berlin
-    had none.
-    """
-    return {
-        "error_type": "filters_dropped",
-        "error_message": (
-            f"LinkedIn did not keep {', '.join(names)} (landed on {landed}), "
-            "so the results are broader than the search asked for."
-        ),
-    }
-
-
-def rate_limited_section_error() -> dict[str, str]:
-    """The ``section_errors`` entry for a section that came back empty.
-
-    One shape for every caller, because the alternative is what this codebase
-    did until now: most call sites dropped the sentinel and returned the
-    section as simply absent. An agent reading an empty section with no error
-    concludes there was nothing to find and calls again, which is the opposite
-    of what a rate limit asks for. Being told is what lets a client back off.
-
-    Note this reports the *heuristic's* verdict, with the caveats on
-    ``_RATE_LIMITED_MSG`` above, and does not make it more accurate. What it
-    changes is that a wrong verdict is now visible and can be argued with,
-    where a silently missing section could not be.
-    """
-    return {
-        "error_type": "rate_limit",
-        "error_message": _RATE_LIMITED_MSG,
-    }
-
-
-# LinkedIn's offset stride in the search URL. It is NOT how many cards a
-# page renders: a live search served 11 per navigation while advertising 25
-# per page, so paging by this number skipped 13 of every 24 jobs. Only the
-# "are we past the last page" check may use it.
-_RESULTS_PER_LINKEDIN_PAGE = 25
 
 # The id is the trailing run of digits, and LinkedIn serves the same job under
 # both `/jobs/view/1967281839/` and `/jobs/view/<title>-at-<company>-1967281839/`.
@@ -260,13 +153,6 @@ _JOB_IDS_JS = (
 }"""
 )
 
-# The routes a job search may legitimately end on. `/jobs/search` is what the
-# URL builder produces; `/jobs/search-results` is where LinkedIn's redesigned
-# experience redirects it. Compared as parsed paths rather than as a prefix,
-# because `/jobs/search?keywords=x` is the same route and puts a `?` where a
-# prefix test wants the slash.
-_JOB_SEARCH_PATHS = frozenset({"/jobs/search", "/jobs/search-results"})
-
 # How long to let `page.url` catch up with a navigation the sidebar scroll
 # suppressed. The lag itself measured 6ms across ten runs, min and max alike;
 # the rest of the budget is for a redirect chain that is still hopping. Only a
@@ -294,76 +180,6 @@ _URL_SETTLE_LAG = 0.3
 # renders after it commits, and an account picker was measured 200ms behind
 # its own navigation, so a page judged on arrival is judged empty.
 _DOCUMENT_READY_TIMEOUT = 5.0
-
-
-def _route(target: str) -> tuple[str, str]:
-    """Host and path, which is what identifies a LinkedIn page.
-
-    Not the whole URL: LinkedIn appends `currentJobId` to the query of a
-    search page by itself, measured across three live searches where neither
-    the path nor the rest of the query moved. The host has to come along, or
-    a redirect that keeps the path reads as no redirect at all.
-    """
-    parsed = urlparse(target)
-    return parsed.netloc, parsed.path.rstrip("/")
-
-
-def _same_job_search(before: tuple[str, str], after: tuple[str, str]) -> bool:
-    """Whether a route change is LinkedIn moving a search to its redesign.
-
-    `/jobs/search/` 302s to `/jobs/search-results/` for accounts on the new
-    experience. The destination is the same search: it keeps the keywords,
-    honours `start`, and renders the same results, so treating the hop as a
-    page replacement ended every such search on its first page.
-
-    Only between those two, and only on one host. The point of the comparison
-    around it is that a search which ends up somewhere else is not a search,
-    and an account picker served in place of one moves the route exactly like
-    this redirect does.
-    """
-    return (
-        before[0] == after[0]
-        and before[1] in _JOB_SEARCH_PATHS
-        and after[1] in _JOB_SEARCH_PATHS
-    )
-
-
-# Scrolling is bounded per navigation and across a whole search, because
-# max_pages reaches 10 and tool_timeout_seconds defaults to 180.
-_SCROLL_DEADLINE_MAX = 12.0
-_SCROLL_BUDGET_TOTAL = 60.0
-
-# A cancelled tool returns nothing, so the search stops itself while there is
-# still time to hand back what it has. Measured: ten navigations of a Paris
-# developer search take 83s in total, 6.5s each, so this leaves the normal case
-# untouched and only catches a run that is genuinely running out.
-#
-# This predicts, it does not guarantee. Only the decision to *start* a page is
-# bounded; once started, a page runs to its own timeouts, and `goto` alone
-# allows 30s. The reserve is what covers that gap, and it has three claims on
-# it: the extraction and assembly after the last navigation, a page slower than
-# every page before it, and the browser startup inside `get_ready_extractor`,
-# which FastMCP is already timing before this budget begins. A page that
-# overruns the reserve is still cancelled and still loses every page gathered.
-# Bounding that too means handing the remaining budget down into navigation
-# and the rate-limit retry; see #754 rather than the margin. Scrolling is
-# already handed a deadline, so it takes what is left of this budget when
-# that is less than its own cap.
-#
-# The timeout arrives as an argument because `get_config()` parses `sys.argv`
-# on its first call, and a scraping path is the wrong place to discover that.
-_SEARCH_TIMEOUT_FRACTION = 0.8
-
-_SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
-# Where a saved-jobs navigation may legitimately end. LinkedIn redirects the
-# first to the second and drops the query doing so, so the tool navigates to
-# one and arrives at the other.
-_SAVED_JOBS_PATHS = frozenset({"/my-items/saved-jobs", "/jobs-tracker"})
-
-# The my-items lists page in 10s, unlike job search. Verified live: ?start=10
-# returns the 11th saved job, while ?start=25 lands past the end of a two-page
-# list and yields nothing.
-_SAVED_JOBS_PAGE_SIZE = 10
 
 # Normalization maps for job search filters. Job search encodes recency as
 # ``f_TPR=r<seconds>``; content search uses named tokens, hence the separate
@@ -432,20 +248,6 @@ _DIALOG_PREMIUM_LINK_SELECTOR = (
 _DIALOG_TEXTAREA_SELECTOR = '[role="dialog"] textarea, dialog textarea'
 
 _MESSAGING_COMPOSE_SELECTOR = '[role="textbox"][contenteditable="true"]'
-
-# A submission is in flight from the moment the send is dispatched until the
-# whole path has produced a result, cleanup included, and an interruption in
-# that window cannot be reported. FastMCP runs every tool inside
-# `anyio.fail_after()`, so the deadline raises `CancelledError` past
-# `except Exception` and discards any result returned from the cancelled
-# scope. The caller gets a timeout that carries no `retry_safe`, and this line
-# is then the only record that a message may already have left. Answering the
-# caller instead needs the tool to know its own deadline, which is issue #889.
-SEND_INTERRUPTED_WARNING = (
-    "Message submission was interrupted while in flight. The send outcome is "
-    "unknown; check the conversation before retrying, as a retry may deliver "
-    "the message twice."
-)
 
 _PROFILE_MESSAGE_TARGET_JS = r"""() => {
     const visible = element => {
@@ -1673,114 +1475,6 @@ def _encode_list_facet(values: list[str]) -> str:
     return quote_plus(json.dumps(values, separators=(",", ":")))
 
 
-# Patterns that mark the start of LinkedIn page chrome (sidebar/footer).
-# Everything from the earliest match onwards is stripped.
-_NOISE_MARKERS: list[re.Pattern[str]] = [
-    # Footer nav links: "About" immediately followed by "Accessibility" or "Talent Solutions"
-    re.compile(r"^About\n+(?:Accessibility|Talent Solutions)", re.MULTILINE),
-    # Sidebar profile recommendations
-    re.compile(r"^More profiles for you$", re.MULTILINE),
-    # Sidebar premium upsell
-    re.compile(r"^Explore premium profiles$", re.MULTILINE),
-    # InMail upsell in contact info overlay
-    re.compile(r"^Get up to .+ replies when you message with InMail$", re.MULTILINE),
-    # Footer nav clusters in profile/posts pages
-    re.compile(
-        r"^(?:Careers|Privacy & Terms|Questions\?|Select language)\n+"
-        r"(?:Privacy & Terms|Questions\?|Select language|Advertising|Ad Choices|"
-        r"[A-Za-z]+ \([A-Za-z]+\))",
-        re.MULTILINE,
-    ),
-]
-
-_NOISE_LINES: list[re.Pattern[str]] = [
-    re.compile(r"^(?:Play|Pause|Playback speed|Turn fullscreen on|Fullscreen)$"),
-    re.compile(r"^(?:Show captions|Close modal window|Media player modal window)$"),
-    re.compile(r"^(?:Loaded:.*|Remaining time.*|Stream Type.*)$"),
-]
-
-
-@dataclass
-class ExtractedSection:
-    """Text and compact references extracted from a loaded LinkedIn section."""
-
-    text: str
-    references: list[Reference]
-    error: dict[str, Any] | None = None
-
-
-_FEED_RSC_MARKER = "sduiid=com.linkedin.sdui.pagers.feed.mainFeed"
-# Matches a LinkedIn post permalink in either plain or JSON-escaped form
-# (the initial /feed/ HTML embeds the RSC flight data with \u002f for slashes,
-# while paginated responses use plain slashes). Captures the slug portion so
-# we can rebuild a canonical URL regardless of the source encoding.
-_POST_SLUG_URL_RE = re.compile(
-    r"linkedin\.com(?:\\u002[fF]|/)posts(?:\\u002[fF]|/)"
-    r"(?P<slug>[A-Za-z0-9_-]+?-(?:ugcPost|activity|share)-\d+-[A-Za-z0-9_-]+)"
-)
-_FEED_DOCUMENT_URLS = {
-    "https://www.linkedin.com/feed",
-    "https://www.linkedin.com/feed/",
-}
-
-
-def _is_feed_payload_response(url: str) -> bool:
-    """True if the response URL is one that carries `postSlugUrl` fields."""
-    if _FEED_RSC_MARKER in url:
-        return True
-    return url.split("?", 1)[0] in _FEED_DOCUMENT_URLS
-
-
-def _build_feed_references(
-    raw_references: list[Any],
-    captured_urls: list[str],
-) -> list[Reference]:
-    """Compose feed references from DOM anchors + SDUI captures.
-
-    The feed page renders many anchors that are not post permalinks:
-    sidebar widgets, profile cards, employer logos, etc. Mixing them
-    into ``references["feed"]`` blurs the contract and competes with
-    SDUI permalinks for the per-section cap. We keep only the
-    ``feed_post`` slice from the DOM:
-
-    - DOM anchors → ``feed_post`` entries with ``/feed/update/<urn>/``
-      URLs (whatever ``classify_link`` recognises).
-    - SDUI captures → ``feed_post`` entries with ``/posts/<slug>`` URLs
-      for permalinks that the DOM does not surface as an anchor.
-
-    Both are deduped on exact URL string. The two shapes pointing at
-    the same underlying post will *not* collapse — ``dedupe_references``
-    matches strings, not URNs. Both are valid LinkedIn permalinks, so
-    consumers should treat ``feed_post`` as polymorphic on URL form;
-    URN-based equivalence is left to the consumer.
-    """
-    refs = [
-        ref
-        for ref in build_references(raw_references, "feed")
-        if ref["kind"] == "feed_post"
-    ]
-    existing = {r["url"] for r in refs}
-    for sdui_url in captured_urls:
-        # AGENTS.md mandates relative paths for LinkedIn references.
-        # The SDUI capture carries fully-qualified URLs like
-        # https://www.linkedin.com/posts/<slug>; strip the host so the
-        # relative-path convention holds. ``classify_link`` does not
-        # currently route ``/posts/<slug>`` paths to any kind, so we
-        # bypass it for this fallback append.
-        parsed = urlparse(sdui_url)
-        if not parsed.path.startswith("/posts/"):
-            continue
-        relative = parsed.path
-        if relative in existing:
-            continue
-        refs.append({"kind": "feed_post", "url": relative, "context": "feed"})
-        existing.add(relative)
-    # Cap kept in sync with _REFERENCE_CAPS["feed"] in link_metadata.py;
-    # changing one without the other will drop or duplicate entries
-    # silently. Matches get_feed's num_posts ceiling (Field(ge=1, le=50)).
-    return dedupe_references(refs, cap=50)
-
-
 async def _drain_listener_tasks(pending: list[asyncio.Task[None]]) -> None:
     """Bounded teardown for fire-and-forget response listener tasks.
 
@@ -1840,157 +1534,6 @@ async def _drain_listener_tasks(pending: list[asyncio.Task[None]]) -> None:
     await anyio.lowlevel.checkpoint()
 
 
-class FilterValidationError(ValueError):
-    """Invalid ``search_people`` filter input (network token / URN shape).
-
-    Subclassing ``ValueError`` keeps backward-compatible behaviour for
-    direct extractor callers (``pytest.raises(ValueError)`` matches), while
-    letting the MCP tool wrapper catch this case precisely and surface the
-    actionable message past ``mask_error_details``.
-    """
-
-
-def strip_linkedin_noise(text: str) -> str:
-    """Remove LinkedIn page chrome (footer, sidebar recommendations) from innerText.
-
-    Finds the earliest occurrence of any known noise marker and truncates there.
-    """
-    cleaned = _truncate_linkedin_noise(text)
-    return _filter_linkedin_noise_lines(cleaned)
-
-
-def _filter_linkedin_noise_lines(text: str) -> str:
-    """Remove known media/control noise lines from already-truncated content."""
-    filtered_lines = [
-        line
-        for line in text.splitlines()
-        if not any(pattern.match(line.strip()) for pattern in _NOISE_LINES)
-    ]
-    return "\n".join(filtered_lines).strip()
-
-
-def _truncate_linkedin_noise(text: str) -> str:
-    """Trim known LinkedIn chrome blocks before any per-line noise filtering."""
-    earliest = len(text)
-    for pattern in _NOISE_MARKERS:
-        match = pattern.search(text)
-        if match and match.start() < earliest:
-            earliest = match.start()
-
-    return text[:earliest].strip()
-
-
-# Messaging-page chrome around an opened conversation thread. innerText on
-# /messaging/thread/ pages carries no URL or attribute signal separating the
-# inbox sidebar from the thread, so the boundaries are matched on visible
-# strings — guarded by an explicit per-locale table (CLAUDE.md → Scraping
-# Rules). BrowserManager forces the context locale to en-US (core/browser.py),
-# so the "en" entry is the operative one; a locale without a table entry
-# passes through unstripped.
-@dataclass(frozen=True)
-class _MessagingChromeTable:
-    # Sidebar pagination control; the last line of the inbox sidebar. Pins
-    # the thread header so quoted UI text inside messages can't move the
-    # start boundary.
-    sidebar_end: str
-    # Screen-reader label on the options dropdown; appears once per sidebar
-    # entry and once in the opened thread's header. The thread's own line is
-    # the first occurrence after ``sidebar_end``.
-    thread_header_prefix: str
-    # First control of the trailing message-composer block.
-    composer_start: str
-    # Standalone controls of the composer block, matched exactly. At least
-    # one must follow a ``composer_start`` candidate to confirm it is the
-    # real composer rather than a message quoting the label. Controls whose
-    # text embeds the participant name (the Attach lines) are deliberately
-    # excluded: they would need prefix matching, and any prefix match lets
-    # quoted control text with a suffix confirm a false boundary.
-    composer_companions: tuple[str, ...]
-
-
-# How far below a composer-label candidate a companion control may sit and
-# still count as the same block. The observed block spans 6 lines; the slack
-# covers extra controls LinkedIn injects (e.g. "Press Enter to Send").
-_COMPOSER_COMPANION_WINDOW = 8
-
-_MESSAGING_CHROME_STRINGS: dict[str, _MessagingChromeTable] = {
-    "en": _MessagingChromeTable(
-        sidebar_end="Load more conversations",
-        thread_header_prefix="Open the options list in your conversation with",
-        composer_start="Maximize compose field",
-        composer_companions=(
-            "Open GIF Keyboard",
-            "Open Emoji Keyboard",
-            "Open send options",
-        ),
-    ),
-}
-
-
-def strip_conversation_chrome(text: str, locale: str = "en") -> str:
-    """Trim messaging chrome around an opened conversation thread.
-
-    A conversation page's innerText embeds the thread between three chrome
-    blocks: the messaging header, the inbox sidebar (which previews *other*
-    conversations), and the trailing message composer. Drops everything
-    through the thread-header line and everything from the composer onward.
-    Each boundary independently falls back to keeping the text when its
-    marker is absent (unknown locale, layout change), so a failed match
-    leaks chrome rather than dropping messages.
-    """
-    table = _MESSAGING_CHROME_STRINGS.get(locale)
-    if table is None:
-        return text
-
-    lines = text.splitlines()
-
-    # End boundary: the last composer-label line, accepted only when an
-    # exact companion control follows within the next few lines. The real
-    # composer block is contiguous (label + controls observed within 6
-    # lines), so a nearby companion confirms chrome, while a message that
-    # quotes the label — or control text with any suffix — falls through to
-    # the missing-marker fallback. A verbatim multi-line reproduction of the
-    # block inside a message remains indistinguishable from the block itself;
-    # that ambiguity is inherent to text-only stripping.
-    end = len(lines)
-    for i in range(len(lines) - 1, -1, -1):
-        if lines[i].strip() != table.composer_start:
-            continue
-        if any(
-            lines[j].strip() in table.composer_companions
-            for j in range(i + 1, min(i + 1 + _COMPOSER_COMPANION_WINDOW, len(lines)))
-        ):
-            end = i
-        break
-
-    # Start boundary: the sidebar's pagination line, when present, pins the
-    # real thread header as the first options line after it; quoted UI text
-    # inside messages can no longer pull the boundary into the thread. The
-    # sidebar omits the pagination control when there are few conversations —
-    # then fall back to the last options line before the composer.
-    start = 0
-    sidebar_end = next(
-        (i for i in range(end) if lines[i].strip() == table.sidebar_end), None
-    )
-    if sidebar_end is not None:
-        header = next(
-            (
-                i
-                for i in range(sidebar_end + 1, end)
-                if lines[i].strip().startswith(table.thread_header_prefix)
-            ),
-            None,
-        )
-        start = (header + 1) if header is not None else sidebar_end + 1
-    else:
-        for i in range(end - 1, -1, -1):
-            if lines[i].strip().startswith(table.thread_header_prefix):
-                start = i + 1
-                break
-
-    return "\n".join(lines[start:end]).strip()
-
-
 class LinkedInExtractor:
     """Extracts LinkedIn page content via navigate-scroll-innerText pattern."""
 
@@ -2021,35 +1564,6 @@ class LinkedInExtractor:
             if references:
                 result["references"] = {section_name: references}
         return result
-
-    @staticmethod
-    def _message_action_result(
-        url: str,
-        status: str,
-        message: str,
-        *,
-        recipient_selected: bool = False,
-        sent: bool = False,
-        retry_safe: bool = True,
-    ) -> dict[str, Any]:
-        """Build a structured response for the send_message tool.
-
-        ``sent`` is true only when the narrowly defined message-list UI
-        transition was observed after submission. It does not prove delivery
-        or that the recipient read the message. A caller keying a retry on it
-        alone can re-send a message that may already have arrived, which is
-        what ``retry_safe`` exists to say: it is false from the moment a
-        submission is attempted, and true only while nothing can have left
-        the composer.
-        """
-        return {
-            "url": url,
-            "status": status,
-            "message": message,
-            "recipient_selected": recipient_selected,
-            "sent": sent,
-            "retry_safe": retry_safe,
-        }
 
     async def _log_navigation_failure(
         self,
@@ -2562,7 +2076,7 @@ class LinkedInExtractor:
         pending_reads: list[asyncio.Task[None]] = []
 
         def _handle_response(resp: Any) -> None:
-            if not _is_feed_payload_response(resp.url):
+            if not is_feed_payload_response(resp.url):
                 return
 
             async def _read() -> None:
@@ -2573,7 +2087,7 @@ class LinkedInExtractor:
                 if not body:
                     return
                 text = body.decode("utf-8", errors="replace")
-                for match in _POST_SLUG_URL_RE.finditer(text):
+                for match in POST_SLUG_URL_RE.finditer(text):
                     post_url = f"https://www.linkedin.com/posts/{match.group('slug')}"
                     if post_url not in seen_urls:
                         seen_urls.add(post_url)
@@ -2697,16 +2211,16 @@ class LinkedInExtractor:
 
         if not raw:
             return ExtractedSection(text="", references=[])
-        truncated = _truncate_linkedin_noise(raw)
+        truncated = truncate_linkedin_noise(raw)
         if not truncated and raw.strip():
             logger.warning(
                 "Page %s returned only LinkedIn chrome (likely rate-limited)", url
             )
-            return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
-        cleaned = _filter_linkedin_noise_lines(truncated)
+            return ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
+        cleaned = filter_linkedin_noise_lines(truncated)
         return ExtractedSection(
             text=cleaned,
-            references=_build_feed_references(raw_result["references"], captured_urls),
+            references=build_feed_references(raw_result["references"], captured_urls),
         )
 
     async def extract_page(
@@ -2722,12 +2236,12 @@ class LinkedInExtractor:
         rate limit.
 
         Raises LinkedInScraperException subclasses (rate limit, auth, etc.).
-        Returns _RATE_LIMITED_MSG sentinel when soft-rate-limited after retry.
+        Returns RATE_LIMITED_SECTION_TEXT sentinel when soft-rate-limited after retry.
         Returns empty string for unexpected non-domain failures (error isolation).
         """
         try:
             result = await self._extract_page_once(url, section_name, max_scrolls)
-            if result.text != _RATE_LIMITED_MSG:
+            if result.text != RATE_LIMITED_SECTION_TEXT:
                 return result
 
             # Retry once after backoff
@@ -2903,13 +2417,13 @@ class LinkedInExtractor:
 
         if not raw:
             return ExtractedSection(text="", references=[])
-        truncated = _truncate_linkedin_noise(raw)
+        truncated = truncate_linkedin_noise(raw)
         if not truncated and raw.strip():
             logger.warning(
                 "Page %s returned only LinkedIn chrome (likely rate-limited)", url
             )
-            return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
-        cleaned = _filter_linkedin_noise_lines(truncated)
+            return ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
+        cleaned = filter_linkedin_noise_lines(truncated)
         return ExtractedSection(
             text=cleaned,
             references=build_references(raw_result["references"], section_name),
@@ -2930,7 +2444,7 @@ class LinkedInExtractor:
         """
         try:
             result = await self._extract_overlay_once(url, section_name)
-            if result.text != _RATE_LIMITED_MSG:
+            if result.text != RATE_LIMITED_SECTION_TEXT:
                 return result
 
             logger.info(
@@ -2982,14 +2496,14 @@ class LinkedInExtractor:
 
         if not raw:
             return ExtractedSection(text="", references=[])
-        truncated = _truncate_linkedin_noise(raw)
+        truncated = truncate_linkedin_noise(raw)
         if not truncated and raw.strip():
             logger.warning(
                 "Overlay %s returned only LinkedIn chrome (likely rate-limited)",
                 url,
             )
-            return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
-        cleaned = _filter_linkedin_noise_lines(truncated)
+            return ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
+        cleaned = filter_linkedin_noise_lines(truncated)
         return ExtractedSection(
             text=cleaned,
             references=build_references(raw_result["references"], section_name),
@@ -3057,7 +2571,7 @@ class LinkedInExtractor:
                             section_name=section_name,
                             max_scrolls=max_scrolls,
                         )
-                        if extracted.text == _RATE_LIMITED_MSG:
+                        if extracted.text == RATE_LIMITED_SECTION_TEXT:
                             logger.info(
                                 "Reuse path soft-rate-limited; falling back "
                                 "to extract_page for retry parity"
@@ -3078,11 +2592,11 @@ class LinkedInExtractor:
                             max_scrolls=max_scrolls,
                         )
 
-                    if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+                    if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
                         sections[section_name] = extracted.text
                         if extracted.references:
                             references[section_name] = extracted.references
-                    elif extracted.text == _RATE_LIMITED_MSG:
+                    elif extracted.text == RATE_LIMITED_SECTION_TEXT:
                         section_errors[section_name] = rate_limited_section_error()
                         # Stop rather than walk the remaining sections. Each one
                         # is another navigation, and LinkedIn has just said it
@@ -4289,11 +3803,11 @@ class LinkedInExtractor:
                             url, section_name=section_name
                         )
 
-                    if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+                    if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
                         sections[section_name] = extracted.text
                         if extracted.references:
                             references[section_name] = extracted.references
-                    elif extracted.text == _RATE_LIMITED_MSG:
+                    elif extracted.text == RATE_LIMITED_SECTION_TEXT:
                         section_errors[section_name] = rate_limited_section_error()
                         rate_limited = True
                     elif extracted.error:
@@ -4357,11 +3871,11 @@ class LinkedInExtractor:
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
         section_errors: dict[str, dict[str, Any]] = {}
-        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+        if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
             sections["employees"] = extracted.text
             if extracted.references:
                 references["employees"] = extracted.references
-        elif extracted.text == _RATE_LIMITED_MSG:
+        elif extracted.text == RATE_LIMITED_SECTION_TEXT:
             section_errors["employees"] = rate_limited_section_error()
         elif extracted.error:
             section_errors["employees"] = extracted.error
@@ -4389,11 +3903,11 @@ class LinkedInExtractor:
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
         section_errors: dict[str, dict[str, Any]] = {}
-        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+        if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
             sections["job_posting"] = extracted.text
             if extracted.references:
                 references["job_posting"] = extracted.references
-        elif extracted.text == _RATE_LIMITED_MSG:
+        elif extracted.text == RATE_LIMITED_SECTION_TEXT:
             section_errors["job_posting"] = rate_limited_section_error()
         elif extracted.error:
             section_errors["job_posting"] = extracted.error
@@ -4560,19 +4074,19 @@ class LinkedInExtractor:
         self,
         url: str,
         section_name: str,
-        scroll_deadline: float = _SCROLL_DEADLINE_MAX,
+        scroll_deadline: float = SCROLL_DEADLINE_MAX,
     ) -> ExtractedSection:
         """Extract innerText from a job search page with soft rate-limit retry.
 
         Mirrors the noise-only detection and single-retry behavior of
         ``extract_page`` / ``_extract_page_once`` so that callers get a
-        ``_RATE_LIMITED_MSG`` sentinel instead of silent empty results.
+        ``RATE_LIMITED_SECTION_TEXT`` sentinel instead of silent empty results.
         """
         try:
             result = await self._extract_search_page_once(
                 url, section_name, scroll_deadline
             )
-            if result.text != _RATE_LIMITED_MSG:
+            if result.text != RATE_LIMITED_SECTION_TEXT:
                 return result
 
             logger.info(
@@ -4584,7 +4098,7 @@ class LinkedInExtractor:
             result = await self._extract_search_page_once(
                 url, section_name, scroll_deadline / 2
             )
-            if result.text == _RATE_LIMITED_MSG:
+            if result.text == RATE_LIMITED_SECTION_TEXT:
                 logger.warning("Search page %s still rate-limited after retry", url)
             return result
 
@@ -4607,7 +4121,7 @@ class LinkedInExtractor:
         self,
         url: str,
         section_name: str,
-        scroll_deadline: float = _SCROLL_DEADLINE_MAX,
+        scroll_deadline: float = SCROLL_DEADLINE_MAX,
     ) -> ExtractedSection:
         """Single attempt to navigate, scroll sidebar, and extract innerText."""
         await self._navigate_to_page(url)
@@ -4646,7 +4160,7 @@ class LinkedInExtractor:
         # its own baseline and passes. Outside the `main_found` branch for the
         # same reason: a landing page with no `<main>` extracts to nothing, and
         # an empty section is what an exhausted search looks like.
-        before = _route(url)
+        before = route(url)
         moved = False
         navigated = False
         with self._watching_navigations() as hops:
@@ -4669,10 +4183,10 @@ class LinkedInExtractor:
             # behind when the document was replaced anyway: the scroll never
             # raised, so it reports no movement, and a reload moves no route,
             # so neither of the other two says anything happened.
-            if moved or hops or before != _route(self._page.url):
+            if moved or hops or before != route(self._page.url):
                 navigated = await self._settle_navigation(hops, origin)
 
-        after = _route(self._page.url)
+        after = route(self._page.url)
         if navigated or moved or not main_found or before != after:
             # Any of the three is enough, and none implies the others. A reload
             # keeps the address, so an account picker served in place of the
@@ -4684,7 +4198,7 @@ class LinkedInExtractor:
             # missed: an exhausted search renders no `<main>` either, which is
             # why the check has to decide it rather than the absence alone.
             await self._raise_if_auth_barrier(url)
-        if before != after and not _same_job_search(before, after):
+        if before != after and not same_job_search(before, after):
             # An expired session lands here as often as a layout change does,
             # and the two need different answers. A plain error is caught by
             # the generic handler above and returned as a section diagnostic,
@@ -4716,14 +4230,14 @@ class LinkedInExtractor:
 
         if not raw:
             return ExtractedSection(text="", references=[])
-        truncated = _truncate_linkedin_noise(raw)
+        truncated = truncate_linkedin_noise(raw)
         if not truncated and raw.strip():
             logger.warning(
                 "Search page %s returned only LinkedIn chrome (likely rate-limited)",
                 url,
             )
-            return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
-        cleaned = _filter_linkedin_noise_lines(truncated)
+            return ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
+        cleaned = filter_linkedin_noise_lines(truncated)
         return ExtractedSection(
             text=cleaned,
             references=build_references(
@@ -4856,7 +4370,7 @@ class LinkedInExtractor:
         # it, so asking for more pages returned fewer jobs than asking for
         # three. Each page now takes the per-page cap or what is left,
         # whichever is smaller, and the total is the same 60s.
-        scroll_budget_left = _SCROLL_BUDGET_TOTAL
+        scroll_budget_left = SCROLL_BUDGET_TOTAL
         self._scroll_seconds = 0.0
         # The offset follows what the pages actually rendered. LinkedIn's own
         # stride would skip every result it renders beyond it.
@@ -4866,14 +4380,14 @@ class LinkedInExtractor:
         # a constant: the real figure is 6.5s and the `goto` timeout alone is
         # 30s, so a fixed guess is wrong in both directions.
         started = time.monotonic()
-        budget = tool_timeout * _SEARCH_TIMEOUT_FRACTION
+        budget = tool_timeout * SEARCH_TIMEOUT_FRACTION
         slowest_page = 0.0
 
         for page_num in range(max_pages):
             # Stop once the offset is past the last advertised result
             if (
                 total_pages is not None
-                and offset >= total_pages * _RESULTS_PER_LINKEDIN_PAGE
+                and offset >= total_pages * RESULTS_PER_LINKEDIN_PAGE
             ):
                 logger.debug(
                     "Offset %d is past the %d advertised pages, stopping",
@@ -4913,7 +4427,7 @@ class LinkedInExtractor:
             # already told how long it may run, so it is the one part this can
             # bound without handing the budget down into navigation.
             scroll_deadline = min(
-                _SCROLL_DEADLINE_MAX,
+                SCROLL_DEADLINE_MAX,
                 scroll_budget_left,
                 max(0.0, budget - (time.monotonic() - started)),
             )
@@ -4933,7 +4447,7 @@ class LinkedInExtractor:
                 # accepted yet, because a redirect that dropped the keywords,
                 # filters or offset can render empty too. Calling that "no jobs"
                 # is a successful answer to a different search.
-                if extracted.text == _RATE_LIMITED_MSG:
+                if extracted.text == RATE_LIMITED_SECTION_TEXT:
                     section_errors["search_results"] = rate_limited_section_error()
                     break
                 if not extracted.text and extracted.error:
@@ -4961,7 +4475,7 @@ class LinkedInExtractor:
                 parsed_url = urlparse(self._page.url)
                 if (
                     parsed_url.netloc != "www.linkedin.com"
-                    or parsed_url.path.rstrip("/") not in _JOB_SEARCH_PATHS
+                    or parsed_url.path.rstrip("/") not in JOB_SEARCH_PATHS
                 ):
                     logger.debug(
                         "Unexpected page URL after extraction: %s — "
@@ -5079,7 +4593,7 @@ class LinkedInExtractor:
                 offset += len(page_ids)
                 new_ids = [jid for jid in page_ids if jid not in seen_ids]
 
-                page_refs = _reconcile_search_references(extracted.references, page_ids)
+                page_refs = reconcile_search_references(extracted.references, page_ids)
 
                 if not new_ids:
                     page_texts.append(extracted.text)
@@ -5143,7 +4657,7 @@ class LinkedInExtractor:
         with self._watching_navigations() as hops:
             try:
                 result = await self._extract_saved_jobs_page_once(url, section_name)
-                if result.text != _RATE_LIMITED_MSG:
+                if result.text != RATE_LIMITED_SECTION_TEXT:
                     return result
 
                 logger.info(
@@ -5153,7 +4667,7 @@ class LinkedInExtractor:
                 )
                 await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
                 result = await self._extract_saved_jobs_page_once(url, section_name)
-                if result.text == _RATE_LIMITED_MSG:
+                if result.text == RATE_LIMITED_SECTION_TEXT:
                     logger.warning(
                         "Saved jobs page %s still rate-limited after retry", url
                     )
@@ -5257,14 +4771,14 @@ class LinkedInExtractor:
 
         if not raw:
             return ExtractedSection(text="", references=[])
-        truncated = _truncate_linkedin_noise(raw)
+        truncated = truncate_linkedin_noise(raw)
         if not truncated and raw.strip():
             logger.warning(
                 "Saved jobs page %s returned only LinkedIn chrome (likely rate-limited)",
                 url,
             )
-            return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
-        cleaned = _filter_linkedin_noise_lines(truncated)
+            return ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
+        cleaned = filter_linkedin_noise_lines(truncated)
         return ExtractedSection(
             text=cleaned,
             references=build_references(raw_result["references"], section_name),
@@ -5311,7 +4825,7 @@ class LinkedInExtractor:
         Returns:
             {url, sections: {saved_jobs: text}, job_ids: [str]}
         """
-        base_url = _SAVED_JOBS_URL
+        base_url = SAVED_JOBS_URL
         all_job_ids: list[str] = []
         seen_ids: set[str] = set()
         page_texts: list[str] = []
@@ -5331,7 +4845,7 @@ class LinkedInExtractor:
             url = (
                 base_url
                 if page_num == 0
-                else f"{base_url}?start={page_num * _SAVED_JOBS_PAGE_SIZE}"
+                else f"{base_url}?start={page_num * SAVED_JOBS_PAGE_SIZE}"
             )
 
             try:
@@ -5343,7 +4857,7 @@ class LinkedInExtractor:
                 # page that was throttled may carry a generic error too. Then
                 # the extraction error, which names what actually failed and
                 # would be masked by the route guard below.
-                if extracted.text == _RATE_LIMITED_MSG:
+                if extracted.text == RATE_LIMITED_SECTION_TEXT:
                     section_errors["saved_jobs"] = rate_limited_section_error()
                     break
                 if extracted.error:
@@ -5365,7 +4879,7 @@ class LinkedInExtractor:
                 parsed_url = urlparse(self._page.url)
                 if (
                     parsed_url.netloc != "www.linkedin.com"
-                    or parsed_url.path.rstrip("/") not in _SAVED_JOBS_PATHS
+                    or parsed_url.path.rstrip("/") not in SAVED_JOBS_PATHS
                 ):
                     logger.debug(
                         "Unexpected page URL after saved-jobs extraction: %s "
@@ -5418,15 +4932,15 @@ class LinkedInExtractor:
                 landed_start = parse_qs(urlparse(self._page.url).query).get(
                     "start", ["0"]
                 )[0]
-                if landed_start != str(page_num * _SAVED_JOBS_PAGE_SIZE):
+                if landed_start != str(page_num * SAVED_JOBS_PAGE_SIZE):
                     logger.debug(
                         "Saved-jobs offset %d did not survive navigation "
                         "(landed on %s), stopping",
-                        page_num * _SAVED_JOBS_PAGE_SIZE,
+                        page_num * SAVED_JOBS_PAGE_SIZE,
                         self._page.url,
                     )
                     section_errors["saved_jobs"] = dropped_offset_section_error(
-                        page_num * _SAVED_JOBS_PAGE_SIZE, self._page.url
+                        page_num * SAVED_JOBS_PAGE_SIZE, self._page.url
                     )
                     break
 
@@ -5534,11 +5048,11 @@ class LinkedInExtractor:
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
         section_errors: dict[str, dict[str, Any]] = {}
-        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+        if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
             sections["search_results"] = extracted.text
             if extracted.references:
                 references["search_results"] = extracted.references
-        elif extracted.text == _RATE_LIMITED_MSG:
+        elif extracted.text == RATE_LIMITED_SECTION_TEXT:
             section_errors["search_results"] = rate_limited_section_error()
         elif extracted.error:
             section_errors["search_results"] = extracted.error
@@ -5568,11 +5082,11 @@ class LinkedInExtractor:
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
         section_errors: dict[str, dict[str, Any]] = {}
-        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+        if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
             sections["search_results"] = extracted.text
             if extracted.references:
                 references["search_results"] = extracted.references
-        elif extracted.text == _RATE_LIMITED_MSG:
+        elif extracted.text == RATE_LIMITED_SECTION_TEXT:
             section_errors["search_results"] = rate_limited_section_error()
         elif extracted.error:
             section_errors["search_results"] = extracted.error
@@ -5665,11 +5179,11 @@ class LinkedInExtractor:
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
         section_errors: dict[str, dict[str, Any]] = {}
-        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+        if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
             sections["search_results"] = extracted.text
             if extracted.references:
                 references["search_results"] = extracted.references
-        elif extracted.text == _RATE_LIMITED_MSG:
+        elif extracted.text == RATE_LIMITED_SECTION_TEXT:
             section_errors["search_results"] = {
                 "error_type": "rate_limit",
                 "error_message": extracted.text,
@@ -5983,7 +5497,7 @@ class LinkedInExtractor:
             profile_urn: Optional profile URN (e.g. ACoAAB...) to verify against
                 the recipient resolved from the loaded profile snapshot.
         """
-        refusal = refuse_an_invalid_message(linkedin_username, message)
+        refusal = contracts.refuse_an_invalid_message(linkedin_username, message)
         if refusal is not None:
             return refusal
         linkedin_username = normalize_person_identifier(linkedin_username)
@@ -5999,7 +5513,7 @@ class LinkedInExtractor:
 
         resolution = await self._read_profile_message_target()
         if resolution.status == "unavailable":
-            return self._message_action_result(
+            return contracts.message_action_result(
                 profile_url,
                 "message_unavailable",
                 "LinkedIn did not expose a normal Message action for this profile. "
@@ -6008,7 +5522,7 @@ class LinkedInExtractor:
             )
         target = resolution.target
         if target is None:
-            return self._message_action_result(
+            return contracts.message_action_result(
                 profile_url,
                 "recipient_resolution_failed",
                 "LinkedIn did not expose one unambiguous recipient-specific Message "
@@ -6017,7 +5531,7 @@ class LinkedInExtractor:
 
         supplied_urn = _normalize_profile_urn(profile_urn) if profile_urn else None
         if profile_urn is not None and supplied_urn != target.profile_urn:
-            return self._message_action_result(
+            return contracts.message_action_result(
                 profile_url,
                 "recipient_resolution_failed",
                 "The supplied profile URN did not match the loaded profile.",
@@ -6030,7 +5544,7 @@ class LinkedInExtractor:
         await self._navigate_to_page(target.compose_url)
         expected_route = self._page.url
         if not _message_page_url_is_safe(expected_route, target.profile_urn):
-            return self._message_action_result(
+            return contracts.message_action_result(
                 expected_route,
                 "recipient_resolution_failed",
                 "LinkedIn opened an unexpected messaging URL.",
@@ -6038,7 +5552,7 @@ class LinkedInExtractor:
 
         await detect_rate_limit(self._page)
         if self._page.url != expected_route:
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
                 "The messaging URL changed while the composer was loading.",
@@ -6049,7 +5563,7 @@ class LinkedInExtractor:
         except PlaywrightTimeoutError:
             logger.debug("Compose page did not fully load for %s", linkedin_username)
         if self._page.url != expected_route:
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
                 "The messaging URL changed while the composer was loading.",
@@ -6057,7 +5571,7 @@ class LinkedInExtractor:
 
         message_surface = await self._wait_for_message_surface(target)
         if self._page.url != expected_route:
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
                 "The messaging URL changed while the composer was loading.",
@@ -6066,7 +5580,7 @@ class LinkedInExtractor:
             "Message surface for %s was %s", linkedin_username, message_surface
         )
         if message_surface != "composer":
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "composer_unavailable",
                 "LinkedIn did not expose one usable message composer.",
@@ -6074,7 +5588,7 @@ class LinkedInExtractor:
 
         state = await self._read_message_composer_state(target)
         if self._page.url != expected_route:
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
                 "The messaging URL changed during recipient verification.",
@@ -6085,7 +5599,7 @@ class LinkedInExtractor:
                 linkedin_username,
                 state.get("status"),
             )
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
                 "The local composer did not identify exactly the requested profile.",
@@ -6093,7 +5607,7 @@ class LinkedInExtractor:
         recipient_selected = True
 
         if not confirm_send:
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "confirmation_required",
                 "Set confirm_send=true to send the message.",
@@ -6101,7 +5615,7 @@ class LinkedInExtractor:
             )
 
         if self._page.url != expected_route:
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
                 "The messaging URL changed before text entry.",
@@ -6109,7 +5623,7 @@ class LinkedInExtractor:
             )
         state = await self._read_message_composer_state(target)
         if self._page.url != expected_route:
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
                 "The messaging URL changed before text entry.",
@@ -6118,7 +5632,7 @@ class LinkedInExtractor:
         if state.get("status") == "valid" and state.get("empty") is not True:
             # Text already in the editor belongs to whoever typed it. Clearing
             # it would trade a recipient leak for destroying their draft.
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "composer_occupied",
                 "The composer already holds a draft that would be sent along "
@@ -6126,14 +5640,14 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
         if state.get("status") != "valid":
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "compose_interact_failed",
                 "The verified message composer changed before text entry.",
                 recipient_selected=recipient_selected,
             )
         if state.get("submitCount") != 1:
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "send_unavailable",
                 "The local submit path was missing or ambiguous.",
@@ -6146,7 +5660,7 @@ class LinkedInExtractor:
                 target, expected_route=expected_route
             )
             if owner is None:
-                return self._message_action_result(
+                return contracts.message_action_result(
                     self._page.url,
                     "recipient_resolution_failed",
                     "The verified message composer changed before text entry.",
@@ -6160,14 +5674,14 @@ class LinkedInExtractor:
                     owner=owner,
                 )
                 if not _message_page_url_is_safe(self._page.url, target.profile_urn):
-                    return self._message_action_result(
+                    return contracts.message_action_result(
                         self._page.url,
                         "recipient_resolution_failed",
                         "The messaging URL changed during text entry.",
                         recipient_selected=recipient_selected,
                     )
                 if write_result == "occupied":
-                    return self._message_action_result(
+                    return contracts.message_action_result(
                         self._page.url,
                         "composer_occupied",
                         "The composer already holds a draft that would be sent along "
@@ -6175,7 +5689,7 @@ class LinkedInExtractor:
                         recipient_selected=recipient_selected,
                     )
                 if write_result != "written":
-                    return self._message_action_result(
+                    return contracts.message_action_result(
                         self._page.url,
                         "compose_interact_failed",
                         "The verified message editor could not accept the message.",
@@ -6187,7 +5701,7 @@ class LinkedInExtractor:
                     target=target,
                     owner=owner,
                 ):
-                    return self._message_action_result(
+                    return contracts.message_action_result(
                         self._page.url,
                         "send_unavailable",
                         "The pinned submit button did not become available without "
@@ -6201,7 +5715,7 @@ class LinkedInExtractor:
                     owner=owner,
                 )
                 if confirmation is None:
-                    return self._message_action_result(
+                    return contracts.message_action_result(
                         self._page.url,
                         "recipient_resolution_failed",
                         "The verified message composer changed before submission.",
@@ -6222,7 +5736,7 @@ class LinkedInExtractor:
                         logger.debug(
                             "Message submission did not complete", exc_info=True
                         )
-                        return self._message_action_result(
+                        return contracts.message_action_result(
                             self._page.url,
                             "send_unconfirmed",
                             "The message submission was interrupted and LinkedIn did "
@@ -6234,7 +5748,7 @@ class LinkedInExtractor:
 
                     if submission != "clicked":
                         may_have_submitted = False
-                        return self._message_action_result(
+                        return contracts.message_action_result(
                             self._page.url,
                             "send_unavailable",
                             "The local submit path was missing, disabled, or ambiguous.",
@@ -6248,7 +5762,7 @@ class LinkedInExtractor:
                         confirmation=confirmation,
                     )
                     if not confirmed:
-                        return self._message_action_result(
+                        return contracts.message_action_result(
                             self._page.url,
                             "send_unconfirmed",
                             "The message was submitted but LinkedIn did not confirm "
@@ -6259,7 +5773,7 @@ class LinkedInExtractor:
                             retry_safe=False,
                         )
 
-                    return self._message_action_result(
+                    return contracts.message_action_result(
                         self._page.url,
                         "sent",
                         "Message submitted and confirmed in the conversation UI.",
@@ -6283,7 +5797,7 @@ class LinkedInExtractor:
             logger.debug(
                 "Message send failed after a possible submission", exc_info=True
             )
-            return self._message_action_result(
+            return contracts.message_action_result(
                 self._page.url,
                 "send_unconfirmed",
                 "The message may already have been submitted when the send "
@@ -6302,7 +5816,7 @@ class LinkedInExtractor:
             # Silent before explicit submission: nothing can have left yet,
             # and a warning about duplicate delivery would be false.
             if may_have_submitted:
-                logger.warning(SEND_INTERRUPTED_WARNING)
+                logger.warning(contracts.SEND_INTERRUPTED_WARNING)
             raise
 
     async def _extract_root_content(
@@ -6413,24 +5927,3 @@ class LinkedInExtractor:
             {"selectors": selectors},
         )
         return result
-
-
-def refuse_an_invalid_message(
-    linkedin_username: str, message: str
-) -> dict[str, Any] | None:
-    """Return the shared browser-free refusal for an unsafe message."""
-    reason = None
-    if not message.strip():
-        reason = "Message must contain non-whitespace characters."
-    elif any(ord(character) < 32 or ord(character) == 127 for character in message):
-        # Keep the browser-side insertion contract to plain message text.
-        # Reject every C0 control and DEL before a session is acquired so no
-        # control input can reach the contenteditable surface.
-        reason = "Message must not contain control characters or line breaks."
-    if reason is None:
-        return None
-    return LinkedInExtractor._message_action_result(
-        person_profile_url(normalize_person_identifier(linkedin_username), "/"),
-        "invalid_message",
-        reason,
-    )

--- a/linkedin_mcp_server/scraping/feed_payload.py
+++ b/linkedin_mcp_server/scraping/feed_payload.py
@@ -1,0 +1,85 @@
+"""Feed permalink recognition across DOM anchors and SDUI payloads."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+import re
+
+from linkedin_mcp_server.scraping.link_metadata import (
+    Reference,
+    build_references,
+    dedupe_references,
+)
+
+_FEED_RSC_MARKER = "sduiid=com.linkedin.sdui.pagers.feed.mainFeed"
+# Matches a LinkedIn post permalink in either plain or JSON-escaped form
+# (the initial /feed/ HTML embeds the RSC flight data with \u002f for slashes,
+# while paginated responses use plain slashes). Captures the slug portion so
+# we can rebuild a canonical URL regardless of the source encoding.
+POST_SLUG_URL_RE = re.compile(
+    r"linkedin\.com(?:\\u002[fF]|/)posts(?:\\u002[fF]|/)"
+    r"(?P<slug>[A-Za-z0-9_-]+?-(?:ugcPost|activity|share)-\d+-[A-Za-z0-9_-]+)"
+)
+_FEED_DOCUMENT_URLS = {
+    "https://www.linkedin.com/feed",
+    "https://www.linkedin.com/feed/",
+}
+
+
+def is_feed_payload_response(url: str) -> bool:
+    """True if the response URL is one that carries `postSlugUrl` fields."""
+    if _FEED_RSC_MARKER in url:
+        return True
+    return url.split("?", 1)[0] in _FEED_DOCUMENT_URLS
+
+
+def build_feed_references(
+    raw_references: list[Any],
+    captured_urls: list[str],
+) -> list[Reference]:
+    """Compose feed references from DOM anchors + SDUI captures.
+
+    The feed page renders many anchors that are not post permalinks:
+    sidebar widgets, profile cards, employer logos, etc. Mixing them
+    into ``references["feed"]`` blurs the contract and competes with
+    SDUI permalinks for the per-section cap. We keep only the
+    ``feed_post`` slice from the DOM:
+
+    - DOM anchors → ``feed_post`` entries with ``/feed/update/<urn>/``
+      URLs (whatever ``classify_link`` recognises).
+    - SDUI captures → ``feed_post`` entries with ``/posts/<slug>`` URLs
+      for permalinks that the DOM does not surface as an anchor.
+
+    Both are deduped on exact URL string. The two shapes pointing at
+    the same underlying post will *not* collapse — ``dedupe_references``
+    matches strings, not URNs. Both are valid LinkedIn permalinks, so
+    consumers should treat ``feed_post`` as polymorphic on URL form;
+    URN-based equivalence is left to the consumer.
+    """
+    refs = [
+        ref
+        for ref in build_references(raw_references, "feed")
+        if ref["kind"] == "feed_post"
+    ]
+    existing = {r["url"] for r in refs}
+    for sdui_url in captured_urls:
+        # AGENTS.md mandates relative paths for LinkedIn references.
+        # The SDUI capture carries fully-qualified URLs like
+        # https://www.linkedin.com/posts/<slug>; strip the host so the
+        # relative-path convention holds. ``classify_link`` does not
+        # currently route ``/posts/<slug>`` paths to any kind, so we
+        # bypass it for this fallback append.
+        parsed = urlparse(sdui_url)
+        if not parsed.path.startswith("/posts/"):
+            continue
+        relative = parsed.path
+        if relative in existing:
+            continue
+        refs.append({"kind": "feed_post", "url": relative, "context": "feed"})
+        existing.add(relative)
+    # Cap kept in sync with _REFERENCE_CAPS["feed"] in link_metadata.py;
+    # changing one without the other will drop or duplicate entries
+    # silently. Matches get_feed's num_posts ceiling (Field(ge=1, le=50)).
+    return dedupe_references(refs, cap=50)

--- a/linkedin_mcp_server/scraping/job_policy.py
+++ b/linkedin_mcp_server/scraping/job_policy.py
@@ -1,0 +1,189 @@
+"""Routing, paging and reporting policy for the job list workflows."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from linkedin_mcp_server.scraping.link_metadata import (
+    JOB_PATH_RE,
+    Reference,
+    _SEARCH_RESULTS_REFERENCE_CAP,
+)
+
+
+def reconcile_search_references(
+    references: list[Reference], ids: list[str]
+) -> list[Reference]:
+    """Align one page's references with the job ids read from its rail.
+
+    References come from the whole `<main>`, which also holds the detail pane;
+    ids come from the selected results rail. The rail therefore decides which
+    jobs exist, while the DOM references supply richer labels when available.
+    Non-job references share the search-results cap's remaining allowance.
+    """
+    ordered_ids = list(dict.fromkeys(ids))
+    kept_ids = set(ordered_ids)
+    emitted_ids: set[str] = set()
+    ancillary_left = max(0, _SEARCH_RESULTS_REFERENCE_CAP - len(ordered_ids))
+    out: list[Reference] = []
+
+    for ref in references:
+        if ref.get("kind") == "job":
+            match = JOB_PATH_RE.match(str(ref.get("url", "")))
+            if match is None:
+                continue
+            job_id = match.group(1)
+            if job_id not in kept_ids or job_id in emitted_ids:
+                continue
+            out.append(ref)
+            emitted_ids.add(job_id)
+            continue
+
+        if ancillary_left:
+            out.append(ref)
+            ancillary_left -= 1
+
+    for job_id in ordered_ids:
+        if job_id not in emitted_ids:
+            out.append({"kind": "job", "url": f"/jobs/view/{job_id}/"})
+
+    return out
+
+
+def lost_keywords_section_error(asked: str, landed: str) -> dict[str, str]:
+    """The ``section_errors`` entry for a search that is not the one asked for.
+
+    Both values are named, because the one shape this cannot rule out is
+    LinkedIn re-encoding a query rather than changing it. `parse_qs` folds
+    `%20` and `+` together, so ordinary spacing differences are already gone
+    by the time they are compared; an unencoded `C++` read back as `C` and
+    two spaces is the measured exception, and naming both sides is what makes
+    that diagnosable from the response instead of from a debugger.
+    """
+    return {
+        "error_type": "search_replaced",
+        "error_message": (
+            f"LinkedIn answered a search for {landed!r} where {asked!r} was "
+            "asked for, so the results are about something else."
+        ),
+    }
+
+
+def dropped_offset_section_error(offset: int, landed: str) -> dict[str, str]:
+    """The ``section_errors`` entry for a list that cannot be paged further.
+
+    LinkedIn dropping the offset serves the first page again, so the loop
+    stops there. Stopping quietly is also what an exhausted list does, and the
+    caller cannot tell the two apart: it reads a short list as the whole list
+    and never asks again. Being told is what lets a client decide.
+    """
+    return {
+        "error_type": "pagination_stopped",
+        "error_message": (
+            f"LinkedIn did not keep offset {offset} (landed on {landed}), "
+            "so the list stops at the results already read."
+        ),
+    }
+
+
+def dropped_filters_section_error(names: list[str], landed: str) -> dict[str, str]:
+    """The ``section_errors`` entry for filters LinkedIn did not keep.
+
+    Reported rather than raised, and the results kept: they are broader than
+    the caller asked for and still about the same keywords, so a location or
+    a work type LinkedIn dropped costs relevance rather than correctness.
+    Saying nothing is what cannot be defended, since a search for remote
+    Python in Berlin then returns Python anywhere and reads as though Berlin
+    had none.
+    """
+    return {
+        "error_type": "filters_dropped",
+        "error_message": (
+            f"LinkedIn did not keep {', '.join(names)} (landed on {landed}), "
+            "so the results are broader than the search asked for."
+        ),
+    }
+
+
+# LinkedIn's offset stride in the search URL. It is NOT how many cards a
+# page renders: a live search served 11 per navigation while advertising 25
+# per page, so paging by this number skipped 13 of every 24 jobs. Only the
+# "are we past the last page" check may use it.
+RESULTS_PER_LINKEDIN_PAGE = 25
+
+# The routes a job search may legitimately end on. `/jobs/search` is what the
+# URL builder produces; `/jobs/search-results` is where LinkedIn's redesigned
+# experience redirects it. Compared as parsed paths rather than as a prefix,
+# because `/jobs/search?keywords=x` is the same route and puts a `?` where a
+# prefix test wants the slash.
+JOB_SEARCH_PATHS = frozenset({"/jobs/search", "/jobs/search-results"})
+
+
+def route(target: str) -> tuple[str, str]:
+    """Host and path, which is what identifies a LinkedIn page.
+
+    Not the whole URL: LinkedIn appends `currentJobId` to the query of a
+    search page by itself, measured across three live searches where neither
+    the path nor the rest of the query moved. The host has to come along, or
+    a redirect that keeps the path reads as no redirect at all.
+    """
+    parsed = urlparse(target)
+    return parsed.netloc, parsed.path.rstrip("/")
+
+
+def same_job_search(before: tuple[str, str], after: tuple[str, str]) -> bool:
+    """Whether a route change is LinkedIn moving a search to its redesign.
+
+    `/jobs/search/` 302s to `/jobs/search-results/` for accounts on the new
+    experience. The destination is the same search: it keeps the keywords,
+    honours `start`, and renders the same results, so treating the hop as a
+    page replacement ended every such search on its first page.
+
+    Only between those two, and only on one host. The point of the comparison
+    around it is that a search which ends up somewhere else is not a search,
+    and an account picker served in place of one moves the route exactly like
+    this redirect does.
+    """
+    return (
+        before[0] == after[0]
+        and before[1] in JOB_SEARCH_PATHS
+        and after[1] in JOB_SEARCH_PATHS
+    )
+
+
+# Scrolling is bounded per navigation and across a whole search, because
+# max_pages reaches 10 and tool_timeout_seconds defaults to 180.
+SCROLL_DEADLINE_MAX = 12.0
+SCROLL_BUDGET_TOTAL = 60.0
+
+# A cancelled tool returns nothing, so the search stops itself while there is
+# still time to hand back what it has. Measured: ten navigations of a Paris
+# developer search take 83s in total, 6.5s each, so this leaves the normal case
+# untouched and only catches a run that is genuinely running out.
+#
+# This predicts, it does not guarantee. Only the decision to *start* a page is
+# bounded; once started, a page runs to its own timeouts, and `goto` alone
+# allows 30s. The reserve is what covers that gap, and it has three claims on
+# it: the extraction and assembly after the last navigation, a page slower than
+# every page before it, and the browser startup inside `get_ready_extractor`,
+# which FastMCP is already timing before this budget begins. A page that
+# overruns the reserve is still cancelled and still loses every page gathered.
+# Bounding that too means handing the remaining budget down into navigation
+# and the rate-limit retry; see #754 rather than the margin. Scrolling is
+# already handed a deadline, so it takes what is left of this budget when
+# that is less than its own cap.
+#
+# The timeout arrives as an argument because `get_config()` parses `sys.argv`
+# on its first call, and a scraping path is the wrong place to discover that.
+SEARCH_TIMEOUT_FRACTION = 0.8
+
+SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
+# Where a saved-jobs navigation may legitimately end. LinkedIn redirects the
+# first to the second and drops the query doing so, so the tool navigates to
+# one and arrives at the other.
+SAVED_JOBS_PATHS = frozenset({"/my-items/saved-jobs", "/jobs-tracker"})
+
+# The my-items lists page in 10s, unlike job search. Verified live: ?start=10
+# returns the 11th saved job, while ?start=25 lands past the end of a two-page
+# list and yields nothing.
+SAVED_JOBS_PAGE_SIZE = 10

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -114,7 +114,7 @@ _REFERENCE_CAPS = {
     "inbox": 30,
     "conversation": 12,
     # Headroom for get_feed's num_posts ceiling (Field(ge=1, le=50)).
-    # Kept in sync with the literal cap=50 in extractor._build_feed_references
+    # Kept in sync with the literal cap=50 in feed_payload.build_feed_references
     # where SDUI-derived /posts/<slug> permalinks are appended.
     "feed": 50,
 }

--- a/linkedin_mcp_server/scraping/text.py
+++ b/linkedin_mcp_server/scraping/text.py
@@ -1,0 +1,174 @@
+"""Locale-guarded cleanup of LinkedIn innerText captures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import re
+
+# Patterns that mark the start of LinkedIn page chrome (sidebar/footer).
+# Everything from the earliest match onwards is stripped.
+_NOISE_MARKERS: list[re.Pattern[str]] = [
+    # Footer nav links: "About" immediately followed by "Accessibility" or "Talent Solutions"
+    re.compile(r"^About\n+(?:Accessibility|Talent Solutions)", re.MULTILINE),
+    # Sidebar profile recommendations
+    re.compile(r"^More profiles for you$", re.MULTILINE),
+    # Sidebar premium upsell
+    re.compile(r"^Explore premium profiles$", re.MULTILINE),
+    # InMail upsell in contact info overlay
+    re.compile(r"^Get up to .+ replies when you message with InMail$", re.MULTILINE),
+    # Footer nav clusters in profile/posts pages
+    re.compile(
+        r"^(?:Careers|Privacy & Terms|Questions\?|Select language)\n+"
+        r"(?:Privacy & Terms|Questions\?|Select language|Advertising|Ad Choices|"
+        r"[A-Za-z]+ \([A-Za-z]+\))",
+        re.MULTILINE,
+    ),
+]
+
+_NOISE_LINES: list[re.Pattern[str]] = [
+    re.compile(r"^(?:Play|Pause|Playback speed|Turn fullscreen on|Fullscreen)$"),
+    re.compile(r"^(?:Show captions|Close modal window|Media player modal window)$"),
+    re.compile(r"^(?:Loaded:.*|Remaining time.*|Stream Type.*)$"),
+]
+
+
+def strip_linkedin_noise(text: str) -> str:
+    """Remove LinkedIn page chrome (footer, sidebar recommendations) from innerText.
+
+    Finds the earliest occurrence of any known noise marker and truncates there.
+    """
+    cleaned = truncate_linkedin_noise(text)
+    return filter_linkedin_noise_lines(cleaned)
+
+
+def filter_linkedin_noise_lines(text: str) -> str:
+    """Remove known media/control noise lines from already-truncated content."""
+    filtered_lines = [
+        line
+        for line in text.splitlines()
+        if not any(pattern.match(line.strip()) for pattern in _NOISE_LINES)
+    ]
+    return "\n".join(filtered_lines).strip()
+
+
+def truncate_linkedin_noise(text: str) -> str:
+    """Trim known LinkedIn chrome blocks before any per-line noise filtering."""
+    earliest = len(text)
+    for pattern in _NOISE_MARKERS:
+        match = pattern.search(text)
+        if match and match.start() < earliest:
+            earliest = match.start()
+
+    return text[:earliest].strip()
+
+
+# Messaging-page chrome around an opened conversation thread. innerText on
+# /messaging/thread/ pages carries no URL or attribute signal separating the
+# inbox sidebar from the thread, so the boundaries are matched on visible
+# strings — guarded by an explicit per-locale table (CLAUDE.md → Scraping
+# Rules). BrowserManager forces the context locale to en-US (core/browser.py),
+# so the "en" entry is the operative one; a locale without a table entry
+# passes through unstripped.
+@dataclass(frozen=True)
+class _MessagingChromeTable:
+    # Sidebar pagination control; the last line of the inbox sidebar. Pins
+    # the thread header so quoted UI text inside messages can't move the
+    # start boundary.
+    sidebar_end: str
+    # Screen-reader label on the options dropdown; appears once per sidebar
+    # entry and once in the opened thread's header. The thread's own line is
+    # the first occurrence after ``sidebar_end``.
+    thread_header_prefix: str
+    # First control of the trailing message-composer block.
+    composer_start: str
+    # Standalone controls of the composer block, matched exactly. At least
+    # one must follow a ``composer_start`` candidate to confirm it is the
+    # real composer rather than a message quoting the label. Controls whose
+    # text embeds the participant name (the Attach lines) are deliberately
+    # excluded: they would need prefix matching, and any prefix match lets
+    # quoted control text with a suffix confirm a false boundary.
+    composer_companions: tuple[str, ...]
+
+
+# How far below a composer-label candidate a companion control may sit and
+# still count as the same block. The observed block spans 6 lines; the slack
+# covers extra controls LinkedIn injects (e.g. "Press Enter to Send").
+_COMPOSER_COMPANION_WINDOW = 8
+
+_MESSAGING_CHROME_STRINGS: dict[str, _MessagingChromeTable] = {
+    "en": _MessagingChromeTable(
+        sidebar_end="Load more conversations",
+        thread_header_prefix="Open the options list in your conversation with",
+        composer_start="Maximize compose field",
+        composer_companions=(
+            "Open GIF Keyboard",
+            "Open Emoji Keyboard",
+            "Open send options",
+        ),
+    ),
+}
+
+
+def strip_conversation_chrome(text: str, locale: str = "en") -> str:
+    """Trim messaging chrome around an opened conversation thread.
+
+    A conversation page's innerText embeds the thread between three chrome
+    blocks: the messaging header, the inbox sidebar (which previews *other*
+    conversations), and the trailing message composer. Drops everything
+    through the thread-header line and everything from the composer onward.
+    Each boundary independently falls back to keeping the text when its
+    marker is absent (unknown locale, layout change), so a failed match
+    leaks chrome rather than dropping messages.
+    """
+    table = _MESSAGING_CHROME_STRINGS.get(locale)
+    if table is None:
+        return text
+
+    lines = text.splitlines()
+
+    # End boundary: the last composer-label line, accepted only when an
+    # exact companion control follows within the next few lines. The real
+    # composer block is contiguous (label + controls observed within 6
+    # lines), so a nearby companion confirms chrome, while a message that
+    # quotes the label — or control text with any suffix — falls through to
+    # the missing-marker fallback. A verbatim multi-line reproduction of the
+    # block inside a message remains indistinguishable from the block itself;
+    # that ambiguity is inherent to text-only stripping.
+    end = len(lines)
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip() != table.composer_start:
+            continue
+        if any(
+            lines[j].strip() in table.composer_companions
+            for j in range(i + 1, min(i + 1 + _COMPOSER_COMPANION_WINDOW, len(lines)))
+        ):
+            end = i
+        break
+
+    # Start boundary: the sidebar's pagination line, when present, pins the
+    # real thread header as the first options line after it; quoted UI text
+    # inside messages can no longer pull the boundary into the thread. The
+    # sidebar omits the pagination control when there are few conversations —
+    # then fall back to the last options line before the composer.
+    start = 0
+    sidebar_end = next(
+        (i for i in range(end) if lines[i].strip() == table.sidebar_end), None
+    )
+    if sidebar_end is not None:
+        header = next(
+            (
+                i
+                for i in range(sidebar_end + 1, end)
+                if lines[i].strip().startswith(table.thread_header_prefix)
+            ),
+            None,
+        )
+        start = (header + 1) if header is not None else sidebar_end + 1
+    else:
+        for i in range(end - 1, -1, -1):
+            if lines[i].strip().startswith(table.thread_header_prefix):
+                start = i + 1
+                break
+
+    return "\n".join(lines[start:end]).strip()

--- a/linkedin_mcp_server/tools/company.py
+++ b/linkedin_mcp_server/tools/company.py
@@ -16,10 +16,8 @@ from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.scraping import parse_company_sections
-from linkedin_mcp_server.scraping.extractor import (
-    _RATE_LIMITED_MSG,
-    rate_limited_section_error,
-)
+from linkedin_mcp_server.scraping.contracts import RATE_LIMITED_SECTION_TEXT
+from linkedin_mcp_server.scraping.extractor import rate_limited_section_error
 from linkedin_mcp_server.scraping.identifiers import (
     company_page_url,
     normalize_company_identifier,
@@ -142,11 +140,11 @@ def register_company_tools(
             sections: dict[str, str] = {}
             references: dict[str, list[Reference]] = {}
             section_errors: dict[str, dict[str, Any]] = {}
-            if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+            if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
                 sections["posts"] = extracted.text
                 if extracted.references:
                     references["posts"] = extracted.references
-            elif extracted.text == _RATE_LIMITED_MSG:
+            elif extracted.text == RATE_LIMITED_SECTION_TEXT:
                 section_errors["posts"] = rate_limited_section_error()
             elif extracted.error:
                 section_errors["posts"] = extracted.error

--- a/linkedin_mcp_server/tools/feed.py
+++ b/linkedin_mcp_server/tools/feed.py
@@ -18,10 +18,8 @@ from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
 from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
-from linkedin_mcp_server.scraping.extractor import (
-    _RATE_LIMITED_MSG,
-    rate_limited_section_error,
-)
+from linkedin_mcp_server.scraping.contracts import RATE_LIMITED_SECTION_TEXT
+from linkedin_mcp_server.scraping.extractor import rate_limited_section_error
 from linkedin_mcp_server.scraping.link_metadata import Reference
 
 logger = logging.getLogger(__name__)
@@ -83,11 +81,11 @@ def register_feed_tools(
             sections: dict[str, str] = {}
             references: dict[str, list[Reference]] = {}
             section_errors: dict[str, dict[str, Any]] = {}
-            if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+            if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
                 sections["feed"] = extracted.text
                 if extracted.references:
                     references["feed"] = extracted.references
-            elif extracted.text == _RATE_LIMITED_MSG:
+            elif extracted.text == RATE_LIMITED_SECTION_TEXT:
                 section_errors["feed"] = rate_limited_section_error()
             elif extracted.error:
                 section_errors["feed"] = extracted.error

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -17,7 +17,7 @@ from linkedin_mcp_server.core.exceptions import (
 )
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
-from linkedin_mcp_server.scraping.extractor import (
+from linkedin_mcp_server.scraping.contracts import (
     SEND_INTERRUPTED_WARNING,
     refuse_an_invalid_message,
 )

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -93,8 +93,6 @@ _PRIVATE_OWNERS: dict[str, tuple[str, int]] = {
     "_message_send_confirmed": ("message_sender.MessageSender", 12),
     "_dispose_message_confirmation": ("message_sender.MessageSender", 12),
     "_drain_listener_tasks": ("feed.FeedScraper", 5),
-    "_build_feed_references": ("feed_payload.build_feed_references", 1),
-    "_truncate_linkedin_noise": ("text.truncate_linkedin_noise", 1),
 }
 
 # Module-level names patched through scraping.extractor. These aliases remain
@@ -118,9 +116,6 @@ _BOUNDARY_OWNERS = {
 
 _IMPORT_OWNERS = {
     "LinkedInExtractor": ("facade.LinkedInExtractor", 14),
-    "_RATE_LIMITED_MSG": ("contracts.RATE_LIMITED_SECTION_TEXT", 1),
-    "_truncate_linkedin_noise": ("text.truncate_linkedin_noise", 1),
-    "_build_feed_references": ("feed_payload.build_feed_references", 1),
     "_CONTENT_DATE_POSTED_MAP": ("search_urls.CONTENT_DATE_POSTED_MAP", 2),
     "_ACTION_SIGNALS_JS": ("connection_actions.ACTION_SIGNALS_JS", 7),
     "_CLICK_INCOMING_ACCEPT_JS": ("connection_actions.CLICK_INCOMING_ACCEPT_JS", 7),

--- a/tests/fixtures/scraping-policy/migration-manifest.json
+++ b/tests/fixtures/scraping-policy/migration-manifest.json
@@ -19,60 +19,20 @@
       "target": "LinkedInExtractor"
     },
     {
-      "canonical_owner": "contracts.message_action_result",
-      "kind": "private_facade_access",
-      "line": 6432,
-      "migration_stage": 1,
-      "path": "linkedin_mcp_server/scraping/extractor.py",
-      "target": "_message_action_result"
-    },
-    {
-      "canonical_owner": "contracts.RATE_LIMITED_SECTION_TEXT",
-      "kind": "direct_import",
-      "line": 19,
-      "migration_stage": 1,
-      "path": "linkedin_mcp_server/tools/company.py",
-      "target": "_RATE_LIMITED_MSG"
-    },
-    {
       "canonical_owner": "contracts.rate_limited_section_error",
       "kind": "permanent_alias_import",
-      "line": 19,
+      "line": 20,
       "migration_stage": null,
       "path": "linkedin_mcp_server/tools/company.py",
       "target": "rate_limited_section_error"
     },
     {
-      "canonical_owner": "contracts.RATE_LIMITED_SECTION_TEXT",
-      "kind": "direct_import",
-      "line": 21,
-      "migration_stage": 1,
-      "path": "linkedin_mcp_server/tools/feed.py",
-      "target": "_RATE_LIMITED_MSG"
-    },
-    {
       "canonical_owner": "contracts.rate_limited_section_error",
       "kind": "permanent_alias_import",
-      "line": 21,
+      "line": 22,
       "migration_stage": null,
       "path": "linkedin_mcp_server/tools/feed.py",
       "target": "rate_limited_section_error"
-    },
-    {
-      "canonical_owner": "contracts.SEND_INTERRUPTED_WARNING",
-      "kind": "direct_import",
-      "line": 20,
-      "migration_stage": 1,
-      "path": "linkedin_mcp_server/tools/messaging.py",
-      "target": "SEND_INTERRUPTED_WARNING"
-    },
-    {
-      "canonical_owner": "contracts.refuse_an_invalid_message",
-      "kind": "direct_import",
-      "line": 20,
-      "migration_stage": 1,
-      "path": "linkedin_mcp_server/tools/messaging.py",
-      "target": "refuse_an_invalid_message"
     },
     {
       "canonical_owner": "contracts.FilterValidationError",
@@ -381,15 +341,55 @@
     {
       "canonical_owner": "facade.LinkedInExtractor",
       "kind": "direct_import",
-      "line": 16,
+      "line": 17,
       "migration_stage": 14,
       "path": "tests/scraping/test_facade_contracts.py",
       "target": "LinkedInExtractor"
     },
     {
+      "canonical_owner": "contracts.ExtractedSection",
+      "kind": "permanent_alias_import",
+      "line": 17,
+      "migration_stage": null,
+      "path": "tests/scraping/test_facade_contracts.py",
+      "target": "ExtractedSection"
+    },
+    {
+      "canonical_owner": "contracts.FilterValidationError",
+      "kind": "permanent_alias_import",
+      "line": 17,
+      "migration_stage": null,
+      "path": "tests/scraping/test_facade_contracts.py",
+      "target": "FilterValidationError"
+    },
+    {
+      "canonical_owner": "contracts.rate_limited_section_error",
+      "kind": "permanent_alias_import",
+      "line": 17,
+      "migration_stage": null,
+      "path": "tests/scraping/test_facade_contracts.py",
+      "target": "rate_limited_section_error"
+    },
+    {
+      "canonical_owner": "text.strip_conversation_chrome",
+      "kind": "permanent_alias_import",
+      "line": 17,
+      "migration_stage": null,
+      "path": "tests/scraping/test_facade_contracts.py",
+      "target": "strip_conversation_chrome"
+    },
+    {
+      "canonical_owner": "text.strip_linkedin_noise",
+      "kind": "permanent_alias_import",
+      "line": 17,
+      "migration_stage": null,
+      "path": "tests/scraping/test_facade_contracts.py",
+      "target": "strip_linkedin_noise"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._page",
       "kind": "private_facade_access",
-      "line": 70,
+      "line": 78,
       "migration_stage": 14,
       "path": "tests/scraping/test_facade_contracts.py",
       "target": "_page"
@@ -845,7 +845,7 @@
     {
       "canonical_owner": "facade.LinkedInExtractor",
       "kind": "direct_import",
-      "line": 30,
+      "line": 31,
       "migration_stage": 14,
       "path": "tests/test_scraping.py",
       "target": "LinkedInExtractor"
@@ -853,7 +853,7 @@
     {
       "canonical_owner": "search_urls.CONTENT_DATE_POSTED_MAP",
       "kind": "direct_import",
-      "line": 30,
+      "line": 31,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_CONTENT_DATE_POSTED_MAP"
@@ -861,7 +861,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_COMPOSER_OWNER_JS",
       "kind": "direct_import",
-      "line": 30,
+      "line": 31,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGE_COMPOSER_OWNER_JS"
@@ -869,7 +869,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_CONFIRMATION_DISPOSE_JS",
       "kind": "direct_import",
-      "line": 30,
+      "line": 31,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGE_CONFIRMATION_DISPOSE_JS"
@@ -877,7 +877,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_CONFIRMATION_PREPARE_JS",
       "kind": "direct_import",
-      "line": 30,
+      "line": 31,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGE_CONFIRMATION_PREPARE_JS"
@@ -885,58 +885,26 @@
     {
       "canonical_owner": "message_sender.MESSAGE_CONFIRMATION_READY_JS",
       "kind": "direct_import",
-      "line": 30,
+      "line": 31,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGE_CONFIRMATION_READY_JS"
     },
     {
-      "canonical_owner": "contracts.RATE_LIMITED_SECTION_TEXT",
-      "kind": "direct_import",
-      "line": 30,
-      "migration_stage": 1,
-      "path": "tests/test_scraping.py",
-      "target": "_RATE_LIMITED_MSG"
-    },
-    {
-      "canonical_owner": "feed_payload.build_feed_references",
-      "kind": "direct_import",
-      "line": 30,
-      "migration_stage": 1,
-      "path": "tests/test_scraping.py",
-      "target": "_build_feed_references"
-    },
-    {
-      "canonical_owner": "text.truncate_linkedin_noise",
-      "kind": "direct_import",
-      "line": 30,
-      "migration_stage": 1,
-      "path": "tests/test_scraping.py",
-      "target": "_truncate_linkedin_noise"
-    },
-    {
       "canonical_owner": "contracts.ExtractedSection",
       "kind": "permanent_alias_import",
-      "line": 30,
+      "line": 31,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "ExtractedSection"
     },
     {
-      "canonical_owner": "text.strip_conversation_chrome",
-      "kind": "permanent_alias_import",
-      "line": 30,
-      "migration_stage": null,
+      "canonical_owner": "search_urls.build_job_search_url",
+      "kind": "private_facade_access",
+      "line": 56,
+      "migration_stage": 2,
       "path": "tests/test_scraping.py",
-      "target": "strip_conversation_chrome"
-    },
-    {
-      "canonical_owner": "text.strip_linkedin_noise",
-      "kind": "permanent_alias_import",
-      "line": 30,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "strip_linkedin_noise"
+      "target": "_build_job_search_url"
     },
     {
       "canonical_owner": "search_urls.build_job_search_url",
@@ -949,7 +917,7 @@
     {
       "canonical_owner": "search_urls.build_job_search_url",
       "kind": "private_facade_access",
-      "line": 64,
+      "line": 65,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_job_search_url"
@@ -973,7 +941,7 @@
     {
       "canonical_owner": "search_urls.build_job_search_url",
       "kind": "private_facade_access",
-      "line": 77,
+      "line": 79,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_job_search_url"
@@ -981,7 +949,7 @@
     {
       "canonical_owner": "search_urls.build_job_search_url",
       "kind": "private_facade_access",
-      "line": 83,
+      "line": 85,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_job_search_url"
@@ -997,7 +965,7 @@
     {
       "canonical_owner": "search_urls.build_job_search_url",
       "kind": "private_facade_access",
-      "line": 93,
+      "line": 95,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_job_search_url"
@@ -1037,7 +1005,7 @@
     {
       "canonical_owner": "search_urls.build_job_search_url",
       "kind": "private_facade_access",
-      "line": 115,
+      "line": 117,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_job_search_url"
@@ -1051,17 +1019,9 @@
       "target": "_build_job_search_url"
     },
     {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 125,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 253,
+      "line": 249,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -1069,7 +1029,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 257,
+      "line": 253,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1077,7 +1037,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 261,
+      "line": 257,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1085,7 +1045,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_facade_access",
-      "line": 286,
+      "line": 282,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -1093,7 +1053,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> error_diagnostics.build_issue_diagnostics",
       "kind": "string_patch",
-      "line": 304,
+      "line": 300,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics"
@@ -1101,7 +1061,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 321,
+      "line": 317,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -1109,63 +1069,63 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 338,
+      "line": 334,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 358,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
       "line": 362,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 366,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 370,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 375,
+      "line": 371,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 407,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
       "line": 411,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 415,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 419,
+      "line": 415,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1173,7 +1133,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 424,
+      "line": 420,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -1181,7 +1141,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 448,
+      "line": 444,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -1189,7 +1149,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 452,
+      "line": 448,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1197,7 +1157,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 456,
+      "line": 452,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1205,7 +1165,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 462,
+      "line": 458,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -1213,7 +1173,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 475,
+      "line": 471,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1221,7 +1181,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 483,
+      "line": 479,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
@@ -1229,7 +1189,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 512,
+      "line": 508,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1237,31 +1197,31 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 518,
+      "line": 514,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 519,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 523,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 527,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 533,
+      "line": 529,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
@@ -1269,7 +1229,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 555,
+      "line": 551,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1277,7 +1237,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 561,
+      "line": 557,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1285,7 +1245,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 566,
+      "line": 562,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1293,7 +1253,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 570,
+      "line": 566,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1301,7 +1261,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 577,
+      "line": 573,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
@@ -1309,7 +1269,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 599,
+      "line": 595,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1317,7 +1277,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 605,
+      "line": 601,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_raise_if_auth_barrier"
@@ -1325,7 +1285,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 611,
+      "line": 607,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1333,7 +1293,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 616,
+      "line": 612,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1341,7 +1301,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 622,
+      "line": 618,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
@@ -1349,31 +1309,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 661,
+      "line": 657,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 658,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 662,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 666,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 671,
+      "line": 667,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1381,7 +1341,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 678,
+      "line": 674,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1389,31 +1349,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 702,
+      "line": 698,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 699,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 703,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 707,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 712,
+      "line": 708,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1421,7 +1381,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 718,
+      "line": 714,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1429,47 +1389,47 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 751,
+      "line": 747,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 748,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 752,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 756,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 757,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
       "line": 761,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 765,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 771,
+      "line": 767,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1477,31 +1437,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 792,
+      "line": 788,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 789,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 793,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 797,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 802,
+      "line": 798,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1509,7 +1469,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 807,
+      "line": 803,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -1517,7 +1477,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 814,
+      "line": 810,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1525,31 +1485,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 833,
+      "line": 829,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 830,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 834,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 838,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 843,
+      "line": 839,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1557,7 +1517,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 848,
+      "line": 844,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -1565,7 +1525,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 854,
+      "line": 850,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1573,31 +1533,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 880,
+      "line": 876,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 877,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 881,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 885,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 890,
+      "line": 886,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1605,7 +1565,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 894,
+      "line": 890,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -1613,7 +1573,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 901,
+      "line": 897,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1621,7 +1581,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 928,
+      "line": 924,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1629,7 +1589,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 929,
+      "line": 925,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1637,7 +1597,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 933,
+      "line": 929,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1645,7 +1605,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 938,
+      "line": 934,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1653,7 +1613,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 942,
+      "line": 938,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -1661,7 +1621,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 947,
+      "line": 943,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1669,7 +1629,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 986,
+      "line": 982,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -1677,7 +1637,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 987,
+      "line": 983,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1685,7 +1645,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 988,
+      "line": 984,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1693,7 +1653,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 992,
+      "line": 988,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1701,7 +1661,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 997,
+      "line": 993,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1709,7 +1669,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1002,
+      "line": 998,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1717,7 +1677,7 @@
     {
       "canonical_owner": "session.ScrapingSession._scroll_seconds",
       "kind": "private_facade_access",
-      "line": 1009,
+      "line": 1005,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_scroll_seconds"
@@ -1725,7 +1685,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1033,
+      "line": 1029,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1733,7 +1693,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 1034,
+      "line": 1030,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1741,7 +1701,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 1038,
+      "line": 1034,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1749,7 +1709,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1043,
+      "line": 1039,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1757,7 +1717,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 1048,
+      "line": 1044,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -1765,7 +1725,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1051,
+      "line": 1047,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -1773,7 +1733,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1057,
+      "line": 1053,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1781,31 +1741,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1084,
+      "line": 1080,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 1081,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 1085,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1089,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1094,
+      "line": 1090,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1813,7 +1773,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1100,
+      "line": 1096,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1821,31 +1781,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1126,
+      "line": 1122,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 1123,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 1127,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1131,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1136,
+      "line": 1132,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1853,7 +1813,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1142,
+      "line": 1138,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1861,31 +1821,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1171,
+      "line": 1167,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 1168,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 1172,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1176,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1181,
+      "line": 1177,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1893,7 +1853,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1187,
+      "line": 1183,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1901,31 +1861,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1209,
+      "line": 1205,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 1206,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 1210,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1214,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1220,
+      "line": 1216,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1933,31 +1893,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1252,
+      "line": 1248,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 1249,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 1253,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1257,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1262,
+      "line": 1258,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1965,7 +1925,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1268,
+      "line": 1264,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1973,7 +1933,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1299,
+      "line": 1295,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1981,7 +1941,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 1300,
+      "line": 1296,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1989,7 +1949,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 1304,
+      "line": 1300,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1997,7 +1957,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1309,
+      "line": 1305,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -2005,7 +1965,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1315,
+      "line": 1311,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -2013,7 +1973,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1338,
+      "line": 1334,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -2021,7 +1981,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1343,
+      "line": 1339,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick"
@@ -2029,7 +1989,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 1349,
+      "line": 1345,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -2037,7 +1997,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1372,
+      "line": 1368,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -2045,7 +2005,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1377,
+      "line": 1373,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick"
@@ -2053,7 +2013,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 1383,
+      "line": 1379,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -2061,7 +2021,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1406,
+      "line": 1402,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -2069,7 +2029,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1411,
+      "line": 1407,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.record_page_trace"
@@ -2077,7 +2037,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1415,
+      "line": 1411,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -2085,7 +2045,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 1422,
+      "line": 1418,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -2093,7 +2053,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1456,
+      "line": 1452,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -2101,7 +2061,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1461,
+      "line": 1457,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -2109,7 +2069,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1466,
+      "line": 1462,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_log_navigation_failure"
@@ -2117,7 +2077,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 1473,
+      "line": 1469,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -2125,7 +2085,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1486,
+      "line": 1482,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -2133,7 +2093,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1491,
+      "line": 1487,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -2141,7 +2101,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1496,
+      "line": 1492,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_log_navigation_failure"
@@ -2149,7 +2109,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 1503,
+      "line": 1499,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -2157,7 +2117,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1519,
+      "line": 1515,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2165,7 +2125,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1525,
+      "line": 1521,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2173,7 +2133,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1531,
+      "line": 1527,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2181,7 +2141,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1546,
+      "line": 1542,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2189,7 +2149,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1552,
+      "line": 1548,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2197,7 +2157,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1558,
+      "line": 1554,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2205,7 +2165,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1581,
+      "line": 1577,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2213,7 +2173,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1587,
+      "line": 1583,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2221,7 +2181,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1593,
+      "line": 1589,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2229,7 +2189,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1610,
+      "line": 1606,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2237,7 +2197,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1627,
+      "line": 1623,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2245,7 +2205,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1633,
+      "line": 1629,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2253,7 +2213,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1639,
+      "line": 1635,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2261,7 +2221,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 1658,
+      "line": 1654,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2269,7 +2229,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1664,
+      "line": 1660,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2277,7 +2237,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1683,
+      "line": 1679,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2285,7 +2245,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1692,
+      "line": 1688,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2293,31 +2253,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1707,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1713,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1719,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1751,
+      "line": 1703,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2325,7 +2261,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1757,
+      "line": 1709,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2333,7 +2269,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1763,
+      "line": 1715,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2341,7 +2277,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1793,
+      "line": 1747,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2349,7 +2285,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1799,
+      "line": 1753,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2357,7 +2293,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1805,
+      "line": 1759,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2365,7 +2301,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1819,
+      "line": 1789,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2373,7 +2309,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1825,
+      "line": 1795,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2381,7 +2317,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1831,
+      "line": 1801,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2389,7 +2325,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1845,
+      "line": 1815,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2397,7 +2333,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1851,
+      "line": 1821,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2405,7 +2341,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1857,
+      "line": 1827,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2413,7 +2349,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1871,
+      "line": 1841,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2421,7 +2357,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1877,
+      "line": 1847,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2429,7 +2365,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1883,
+      "line": 1853,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2437,7 +2373,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1897,
+      "line": 1867,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2445,7 +2381,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1903,
+      "line": 1873,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2453,7 +2389,31 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1909,
+      "line": 1879,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1893,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1899,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1905,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2461,7 +2421,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2088,
+      "line": 2084,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2469,7 +2429,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2093,
+      "line": 2089,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2477,7 +2437,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2099,
+      "line": 2095,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2485,7 +2445,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2104,
+      "line": 2100,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2493,7 +2453,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2110,
+      "line": 2106,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2501,7 +2461,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2131,
+      "line": 2127,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2509,7 +2469,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2134,
+      "line": 2130,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2517,7 +2477,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2140,
+      "line": 2136,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2525,7 +2485,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2141,
+      "line": 2137,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2533,7 +2493,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2144,
+      "line": 2140,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2541,7 +2501,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2168,
+      "line": 2164,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2549,7 +2509,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2201,
+      "line": 2197,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2557,7 +2517,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2204,
+      "line": 2200,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2565,7 +2525,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2210,
+      "line": 2206,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2573,7 +2533,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2214,
+      "line": 2210,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2581,7 +2541,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2262,
+      "line": 2258,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2589,7 +2549,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2270,
+      "line": 2266,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_fill_dialog_textarea"
@@ -2597,7 +2557,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2276,
+      "line": 2272,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2605,7 +2565,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2282,
+      "line": 2278,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2613,7 +2573,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2288,
+      "line": 2284,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2621,7 +2581,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2292,
+      "line": 2288,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2629,7 +2589,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2304,
+      "line": 2300,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2637,7 +2597,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2305,
+      "line": 2301,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2645,7 +2605,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2311,
+      "line": 2307,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2653,7 +2613,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2312,
+      "line": 2308,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2661,7 +2621,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2315,
+      "line": 2311,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2669,7 +2629,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2327,
+      "line": 2323,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2677,7 +2637,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2328,
+      "line": 2324,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2685,7 +2645,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2345,
+      "line": 2341,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2693,7 +2653,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2346,
+      "line": 2342,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2701,7 +2661,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2368,
+      "line": 2364,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2709,7 +2669,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2373,
+      "line": 2369,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2717,7 +2677,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2386,
+      "line": 2382,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2725,7 +2685,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2392,
+      "line": 2388,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2733,7 +2693,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2395,
+      "line": 2391,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2741,7 +2701,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2401,
+      "line": 2397,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2749,7 +2709,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2426,
+      "line": 2422,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2757,7 +2717,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2427,
+      "line": 2423,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2765,7 +2725,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2437,
+      "line": 2433,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2773,7 +2733,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2443,
+      "line": 2439,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2781,7 +2741,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2446,
+      "line": 2442,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2789,7 +2749,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2467,
+      "line": 2463,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2797,7 +2757,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2468,
+      "line": 2464,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2805,7 +2765,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2477,
+      "line": 2473,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2813,7 +2773,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2483,
+      "line": 2479,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2821,7 +2781,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2486,
+      "line": 2482,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_probe_invite_note_limit"
@@ -2829,7 +2789,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2492,
+      "line": 2488,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2837,7 +2797,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2515,
+      "line": 2511,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2845,7 +2805,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2516,
+      "line": 2512,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2853,7 +2813,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2522,
+      "line": 2518,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2861,7 +2821,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2528,
+      "line": 2524,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2869,7 +2829,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2531,
+      "line": 2527,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2877,7 +2837,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2549,
+      "line": 2545,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2885,7 +2845,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2550,
+      "line": 2546,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2893,7 +2853,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2556,
+      "line": 2552,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2901,7 +2861,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2559,
+      "line": 2555,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2909,7 +2869,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2577,
+      "line": 2573,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2917,7 +2877,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2582,
+      "line": 2578,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2925,7 +2885,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2591,
+      "line": 2587,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2933,7 +2893,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2597,
+      "line": 2593,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2941,7 +2901,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2602,
+      "line": 2598,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2949,7 +2909,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2622,
+      "line": 2618,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2957,7 +2917,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2627,
+      "line": 2623,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2965,7 +2925,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2633,
+      "line": 2629,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2973,7 +2933,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2639,
+      "line": 2635,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "click_button_by_text"
@@ -2981,7 +2941,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2645,
+      "line": 2641,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2989,7 +2949,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2664,
+      "line": 2660,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2997,7 +2957,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2674,
+      "line": 2670,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -3005,7 +2965,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2680,
+      "line": 2676,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -3013,7 +2973,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2686,
+      "line": 2682,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3021,7 +2981,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2711,
+      "line": 2707,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -3029,7 +2989,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2716,
+      "line": 2712,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -3037,7 +2997,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2726,
+      "line": 2722,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -3045,7 +3005,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2732,
+      "line": 2728,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3053,7 +3013,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2748,
+      "line": 2744,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -3061,7 +3021,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2749,
+      "line": 2745,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -3069,7 +3029,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2755,
+      "line": 2751,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -3077,7 +3037,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2756,
+      "line": 2752,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -3085,7 +3045,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2759,
+      "line": 2755,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -3093,7 +3053,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2769,
+      "line": 2765,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -3101,7 +3061,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2842,
+      "line": 2838,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -3109,7 +3069,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2845,
+      "line": 2841,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -3117,7 +3077,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2856,
+      "line": 2852,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -3125,7 +3085,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2869,
+      "line": 2865,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3133,7 +3093,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 2896,
+      "line": 2892,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3141,7 +3101,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2902,
+      "line": 2898,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3149,7 +3109,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2928,
+      "line": 2924,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3157,7 +3117,7 @@
     {
       "canonical_owner": "person.PersonScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "string_patch",
-      "line": 2933,
+      "line": 2929,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics"
@@ -3165,7 +3125,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 2937,
+      "line": 2933,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3173,7 +3133,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2943,
+      "line": 2939,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3181,7 +3141,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2973,
+      "line": 2969,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3189,7 +3149,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 2982,
+      "line": 2978,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3197,7 +3157,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2988,
+      "line": 2984,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3205,7 +3165,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 3011,
+      "line": 3007,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3213,7 +3173,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 3017,
+      "line": 3013,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -3221,7 +3181,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3023,
+      "line": 3019,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3229,7 +3189,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 3037,
+      "line": 3033,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3237,7 +3197,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 3046,
+      "line": 3042,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3245,7 +3205,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3052,
+      "line": 3048,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3253,7 +3213,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 3068,
+      "line": 3064,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3261,7 +3221,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3074,
+      "line": 3070,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3269,7 +3229,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 3090,
+      "line": 3086,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3277,7 +3237,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3096,
+      "line": 3092,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3285,7 +3245,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 3111,
+      "line": 3107,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3293,7 +3253,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3117,
+      "line": 3113,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3301,7 +3261,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 3138,
+      "line": 3134,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3309,7 +3269,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3147,
+      "line": 3143,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3317,7 +3277,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 3187,
+      "line": 3183,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -3325,7 +3285,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 3193,
+      "line": 3189,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -3333,7 +3293,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 3197,
+      "line": 3193,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -3341,7 +3301,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 3201,
+      "line": 3197,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -3349,7 +3309,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3206,
+      "line": 3202,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3357,7 +3317,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 3227,
+      "line": 3223,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3365,7 +3325,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 3242,
+      "line": 3238,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3373,7 +3333,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 3257,
+      "line": 3253,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3381,7 +3341,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3303,
+      "line": 3299,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3389,7 +3349,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3309,
+      "line": 3305,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3397,7 +3357,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3315,
+      "line": 3311,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3405,7 +3365,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3321,
+      "line": 3317,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3413,7 +3373,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3334,
+      "line": 3330,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3421,7 +3381,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3343,
+      "line": 3339,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3429,7 +3389,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3349,
+      "line": 3345,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3437,7 +3397,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3355,
+      "line": 3351,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3445,7 +3405,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3385,
+      "line": 3381,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3453,7 +3413,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3390,
+      "line": 3386,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3461,7 +3421,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3396,
+      "line": 3392,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3469,7 +3429,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3402,
+      "line": 3398,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3477,7 +3437,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 3464,
+      "line": 3460,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -3485,7 +3445,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 3465,
+      "line": 3461,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -3493,7 +3453,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3471,
+      "line": 3467,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3501,7 +3461,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3477,
+      "line": 3473,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3509,31 +3469,31 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 3483,
+      "line": 3479,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 3484,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 3488,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 3492,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3562,
+      "line": 3558,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3541,7 +3501,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3568,
+      "line": 3564,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3549,7 +3509,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3574,
+      "line": 3570,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3557,7 +3517,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3580,
+      "line": 3576,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3565,7 +3525,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3599,
+      "line": 3595,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3573,7 +3533,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3605,
+      "line": 3601,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3581,7 +3541,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3611,
+      "line": 3607,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3589,7 +3549,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3617,
+      "line": 3613,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3597,7 +3557,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3649,
+      "line": 3645,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3605,7 +3565,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3650,
+      "line": 3646,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3613,7 +3573,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3656,
+      "line": 3652,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3621,7 +3581,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3662,
+      "line": 3658,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3629,7 +3589,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 3717,
+      "line": 3713,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -3637,7 +3597,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 3718,
+      "line": 3714,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -3645,7 +3605,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3724,
+      "line": 3720,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3653,7 +3613,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3730,
+      "line": 3726,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3661,7 +3621,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 3736,
+      "line": 3732,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -3669,7 +3629,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 3741,
+      "line": 3737,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -3677,7 +3637,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 3745,
+      "line": 3741,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -3685,7 +3645,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3750,
+      "line": 3746,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3693,7 +3653,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3775,
+      "line": 3771,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3701,7 +3661,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3780,
+      "line": 3776,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3709,7 +3669,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3786,
+      "line": 3782,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3717,7 +3677,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3792,
+      "line": 3788,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3725,7 +3685,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 3816,
+      "line": 3812,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3733,7 +3693,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3832,
+      "line": 3828,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3741,7 +3701,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3841,
+      "line": 3837,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3749,7 +3709,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3847,
+      "line": 3843,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3757,7 +3717,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3853,
+      "line": 3849,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3765,7 +3725,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3894,
+      "line": 3890,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3773,7 +3733,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3895,
+      "line": 3891,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3781,7 +3741,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3901,
+      "line": 3897,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3789,7 +3749,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3907,
+      "line": 3903,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3797,7 +3757,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3933,
+      "line": 3929,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3805,7 +3765,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3942,
+      "line": 3938,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3813,7 +3773,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3948,
+      "line": 3944,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3821,7 +3781,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3954,
+      "line": 3950,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3829,7 +3789,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3981,
+      "line": 3977,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3837,7 +3797,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3992,
+      "line": 3988,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3845,7 +3805,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3998,
+      "line": 3994,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3853,7 +3813,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4004,
+      "line": 4000,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3861,7 +3821,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4027,
+      "line": 4023,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3869,7 +3829,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4038,
+      "line": 4034,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3877,7 +3837,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4044,
+      "line": 4040,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3885,7 +3845,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4050,
+      "line": 4046,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3893,7 +3853,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4082,
+      "line": 4078,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3901,7 +3861,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4087,
+      "line": 4083,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3909,7 +3869,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4093,
+      "line": 4089,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3917,7 +3877,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4099,
+      "line": 4095,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3925,7 +3885,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4123,
+      "line": 4119,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3933,7 +3893,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4132,
+      "line": 4128,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3941,7 +3901,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4138,
+      "line": 4134,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3949,7 +3909,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4144,
+      "line": 4140,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3957,7 +3917,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4202,
+      "line": 4198,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3965,7 +3925,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4203,
+      "line": 4199,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3973,7 +3933,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4209,
+      "line": 4205,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3981,7 +3941,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4215,
+      "line": 4211,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3989,7 +3949,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4249,
+      "line": 4245,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3997,7 +3957,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4255,
+      "line": 4251,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4005,7 +3965,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4261,
+      "line": 4257,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4013,7 +3973,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4267,
+      "line": 4263,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4021,7 +3981,7 @@
     {
       "canonical_owner": "session.ScrapingSession._scroll_seconds",
       "kind": "private_facade_access",
-      "line": 4307,
+      "line": 4303,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_scroll_seconds"
@@ -4029,7 +3989,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 4318,
+      "line": 4314,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4037,7 +3997,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4319,
+      "line": 4315,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4045,7 +4005,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4320,
+      "line": 4316,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4053,7 +4013,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4326,
+      "line": 4322,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4061,7 +4021,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4332,
+      "line": 4328,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4069,7 +4029,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 4376,
+      "line": 4372,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4077,7 +4037,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4377,
+      "line": 4373,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4085,7 +4045,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4378,
+      "line": 4374,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4093,7 +4053,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4384,
+      "line": 4380,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4101,7 +4061,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4390,
+      "line": 4386,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4109,7 +4069,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 4440,
+      "line": 4436,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4117,7 +4077,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4441,
+      "line": 4437,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4125,7 +4085,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4442,
+      "line": 4438,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4133,7 +4093,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4448,
+      "line": 4444,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4141,7 +4101,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4454,
+      "line": 4450,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4149,7 +4109,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 4500,
+      "line": 4496,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4157,7 +4117,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4501,
+      "line": 4497,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4165,7 +4125,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4502,
+      "line": 4498,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4173,7 +4133,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4508,
+      "line": 4504,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4181,7 +4141,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4514,
+      "line": 4510,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4189,7 +4149,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4531,
+      "line": 4527,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4197,7 +4157,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4537,
+      "line": 4533,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4205,7 +4165,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4543,
+      "line": 4539,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4213,7 +4173,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4549,
+      "line": 4545,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4221,7 +4181,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4563,
+      "line": 4559,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4229,7 +4189,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4569,
+      "line": 4565,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4237,7 +4197,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4575,
+      "line": 4571,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4245,7 +4205,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4581,
+      "line": 4577,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4253,7 +4213,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4609,
+      "line": 4605,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4261,7 +4221,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4617,
+      "line": 4613,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4269,7 +4229,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4623,
+      "line": 4619,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4277,7 +4237,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4629,
+      "line": 4625,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4285,7 +4245,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4645,
+      "line": 4641,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4293,7 +4253,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4650,
+      "line": 4646,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4301,7 +4261,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4656,
+      "line": 4652,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4309,7 +4269,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4662,
+      "line": 4658,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4317,7 +4277,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4684,
+      "line": 4680,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4325,7 +4285,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4693,
+      "line": 4689,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4333,7 +4293,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4699,
+      "line": 4695,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4341,7 +4301,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4705,
+      "line": 4701,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4349,7 +4309,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4723,
+      "line": 4719,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4357,7 +4317,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4734,
+      "line": 4730,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4365,7 +4325,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4740,
+      "line": 4736,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4373,7 +4333,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4746,
+      "line": 4742,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4381,7 +4341,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4785,
+      "line": 4781,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4389,7 +4349,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4790,
+      "line": 4786,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4397,7 +4357,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4796,
+      "line": 4792,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4405,7 +4365,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4802,
+      "line": 4798,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4413,7 +4373,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4819,
+      "line": 4815,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4421,7 +4381,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4829,
+      "line": 4825,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4429,7 +4389,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4835,
+      "line": 4831,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4437,7 +4397,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4841,
+      "line": 4837,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4445,31 +4405,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 4861,
+      "line": 4857,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 4858,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 4862,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 4866,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 4871,
+      "line": 4867,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -4477,7 +4437,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 4877,
+      "line": 4873,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4485,7 +4445,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 4907,
+      "line": 4903,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -4493,7 +4453,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 4908,
+      "line": 4904,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4501,7 +4461,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 4912,
+      "line": 4908,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4509,7 +4469,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 4917,
+      "line": 4913,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -4517,7 +4477,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 4923,
+      "line": 4919,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4525,7 +4485,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4939,
+      "line": 4935,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4533,7 +4493,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4948,
+      "line": 4944,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4541,7 +4501,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4954,
+      "line": 4950,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4549,7 +4509,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4960,
+      "line": 4956,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4557,7 +4517,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4981,
+      "line": 4977,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4565,7 +4525,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4990,
+      "line": 4986,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4573,7 +4533,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4996,
+      "line": 4992,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4581,7 +4541,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5002,
+      "line": 4998,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4589,7 +4549,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5019,
+      "line": 5015,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4597,7 +4557,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5025,
+      "line": 5021,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4605,7 +4565,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5031,
+      "line": 5027,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4613,7 +4573,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5037,
+      "line": 5033,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4621,7 +4581,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5053,
+      "line": 5049,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4629,7 +4589,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5062,
+      "line": 5058,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4637,7 +4597,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5068,
+      "line": 5064,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4645,7 +4605,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5088,
+      "line": 5084,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4653,7 +4613,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5097,
+      "line": 5093,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4661,7 +4621,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5103,
+      "line": 5099,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4669,7 +4629,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5159,
+      "line": 5155,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_document_origin"
@@ -4677,7 +4637,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 5175,
+      "line": 5171,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4685,7 +4645,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5176,
+      "line": 5172,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4693,23 +4653,23 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
+      "line": 5178,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_settle_navigation"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
+      "kind": "module_attribute",
+      "line": 5181,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_URL_SETTLE_QUIET"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_LAG",
+      "kind": "module_attribute",
       "line": 5182,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_settle_navigation"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
-      "kind": "module_attribute",
-      "line": 5185,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_URL_SETTLE_QUIET"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_LAG",
-      "kind": "module_attribute",
-      "line": 5186,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_URL_SETTLE_LAG"
@@ -4717,7 +4677,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 5199,
+      "line": 5195,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4725,7 +4685,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5200,
+      "line": 5196,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4733,7 +4693,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5206,
+      "line": 5202,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_settle_navigation"
@@ -4741,7 +4701,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 5223,
+      "line": 5219,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4749,7 +4709,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5224,
+      "line": 5220,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4757,15 +4717,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
+      "line": 5226,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_settle_navigation"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
+      "kind": "module_attribute",
       "line": 5230,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_settle_navigation"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
-      "kind": "module_attribute",
-      "line": 5234,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_URL_SETTLE_QUIET"
@@ -4773,7 +4733,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 5253,
+      "line": 5249,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4781,7 +4741,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5254,
+      "line": 5250,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4789,7 +4749,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5259,
+      "line": 5255,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_settle_navigation"
@@ -4797,7 +4757,7 @@
     {
       "canonical_owner": "navigation.PageNavigator.URL_SETTLE_LAG",
       "kind": "module_attribute",
-      "line": 5261,
+      "line": 5257,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_URL_SETTLE_LAG"
@@ -4805,7 +4765,7 @@
     {
       "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
       "kind": "module_attribute",
-      "line": 5262,
+      "line": 5258,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_URL_SETTLE_QUIET"
@@ -4813,7 +4773,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 5280,
+      "line": 5276,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4821,7 +4781,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5281,
+      "line": 5277,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4829,7 +4789,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5286,
+      "line": 5282,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_settle_navigation"
@@ -4837,7 +4797,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 5315,
+      "line": 5311,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -4845,7 +4805,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5316,
+      "line": 5312,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4853,7 +4813,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5320,
+      "line": 5316,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4861,7 +4821,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 5325,
+      "line": 5321,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -4869,7 +4829,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 5329,
+      "line": 5325,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -4877,7 +4837,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 5332,
+      "line": 5328,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -4885,7 +4845,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5338,
+      "line": 5334,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4893,7 +4853,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 5372,
+      "line": 5368,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -4901,7 +4861,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5373,
+      "line": 5369,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4909,7 +4869,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5377,
+      "line": 5373,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4917,7 +4877,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 5382,
+      "line": 5378,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -4925,7 +4885,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 5386,
+      "line": 5382,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -4933,7 +4893,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5392,
+      "line": 5388,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4941,7 +4901,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5420,
+      "line": 5416,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4949,7 +4909,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5426,
+      "line": 5422,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4957,7 +4917,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5432,
+      "line": 5428,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4965,7 +4925,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5438,
+      "line": 5434,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4973,7 +4933,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5460,
+      "line": 5456,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4981,7 +4941,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5466,
+      "line": 5462,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4989,7 +4949,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5472,
+      "line": 5468,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4997,7 +4957,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5478,
+      "line": 5474,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5005,7 +4965,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5495,
+      "line": 5491,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5013,7 +4973,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5504,
+      "line": 5500,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5021,7 +4981,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5510,
+      "line": 5506,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5029,7 +4989,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5516,
+      "line": 5512,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5037,7 +4997,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5532,
+      "line": 5528,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5045,7 +5005,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5539,
+      "line": 5535,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5053,7 +5013,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5545,
+      "line": 5541,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5061,7 +5021,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5551,
+      "line": 5547,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5069,7 +5029,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5573,
+      "line": 5569,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5077,7 +5037,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5576,
+      "line": 5572,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5085,7 +5045,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5582,
+      "line": 5578,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5093,7 +5053,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5588,
+      "line": 5584,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5101,7 +5061,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5606,
+      "line": 5602,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5109,7 +5069,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5611,
+      "line": 5607,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5117,7 +5077,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5617,
+      "line": 5613,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5125,7 +5085,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5623,
+      "line": 5619,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5133,7 +5093,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 5648,
+      "line": 5644,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -5141,7 +5101,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5649,
+      "line": 5645,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5149,7 +5109,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5653,
+      "line": 5649,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5157,7 +5117,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 5658,
+      "line": 5654,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -5165,7 +5125,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 5697,
+      "line": 5693,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -5173,7 +5133,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5698,
+      "line": 5694,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5181,7 +5141,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5702,
+      "line": 5698,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5189,7 +5149,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 5707,
+      "line": 5703,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5197,7 +5157,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5726,
+      "line": 5722,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5205,7 +5165,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5732,
+      "line": 5728,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5213,7 +5173,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5738,
+      "line": 5734,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5221,7 +5181,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5753,
+      "line": 5749,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5229,7 +5189,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5759,
+      "line": 5755,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5237,7 +5197,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5765,
+      "line": 5761,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5245,7 +5205,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5786,
+      "line": 5782,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5253,7 +5213,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5795,
+      "line": 5791,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5261,7 +5221,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5801,
+      "line": 5797,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5269,7 +5229,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5807,
+      "line": 5803,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5277,7 +5237,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5828,
+      "line": 5824,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5285,7 +5245,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5833,
+      "line": 5829,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5293,7 +5253,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5839,
+      "line": 5835,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5301,7 +5261,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5845,
+      "line": 5841,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5309,7 +5269,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5868,
+      "line": 5864,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5317,7 +5277,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5874,
+      "line": 5870,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5325,7 +5285,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5880,
+      "line": 5876,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5333,7 +5293,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5886,
+      "line": 5882,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5341,7 +5301,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5910,
+      "line": 5906,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5349,7 +5309,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5916,
+      "line": 5912,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5357,7 +5317,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5922,
+      "line": 5918,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5365,7 +5325,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5928,
+      "line": 5924,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5373,7 +5333,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5948,
+      "line": 5944,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5381,7 +5341,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5954,
+      "line": 5950,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5389,7 +5349,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5960,
+      "line": 5956,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5397,7 +5357,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5966,
+      "line": 5962,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5405,7 +5365,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5989,
+      "line": 5985,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5413,7 +5373,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5995,
+      "line": 5991,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5421,7 +5381,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 6001,
+      "line": 5997,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5429,7 +5389,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6007,
+      "line": 6003,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5437,7 +5397,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6039,
+      "line": 6035,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5445,7 +5405,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 6039,
+      "line": 6035,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5453,7 +5413,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6054,
+      "line": 6050,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5461,7 +5421,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6076,
+      "line": 6072,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5469,7 +5429,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6088,
+      "line": 6084,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5477,7 +5437,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6100,
+      "line": 6096,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5485,7 +5445,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6129,
+      "line": 6125,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5493,7 +5453,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6141,
+      "line": 6137,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5501,7 +5461,7 @@
     {
       "canonical_owner": "search_urls.build_content_search_url",
       "kind": "private_facade_access",
-      "line": 6164,
+      "line": 6160,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_content_search_url"
@@ -5509,7 +5469,7 @@
     {
       "canonical_owner": "search_urls.build_content_search_url",
       "kind": "private_facade_access",
-      "line": 6171,
+      "line": 6167,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_content_search_url"
@@ -5517,7 +5477,7 @@
     {
       "canonical_owner": "search_urls.build_content_search_url",
       "kind": "private_facade_access",
-      "line": 6177,
+      "line": 6173,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_content_search_url"
@@ -5525,7 +5485,7 @@
     {
       "canonical_owner": "search_urls.build_content_search_url",
       "kind": "private_facade_access",
-      "line": 6187,
+      "line": 6183,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_content_search_url"
@@ -5533,7 +5493,7 @@
     {
       "canonical_owner": "search_urls.build_content_search_url",
       "kind": "private_facade_access",
-      "line": 6194,
+      "line": 6190,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_content_search_url"
@@ -5541,7 +5501,7 @@
     {
       "canonical_owner": "search_urls.build_content_search_url",
       "kind": "private_facade_access",
-      "line": 6200,
+      "line": 6196,
       "migration_stage": 2,
       "path": "tests/test_scraping.py",
       "target": "_build_content_search_url"
@@ -5549,7 +5509,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6208,
+      "line": 6204,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5557,7 +5517,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6226,
+      "line": 6222,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5565,7 +5525,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6240,
+      "line": 6236,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5573,7 +5533,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6259,
+      "line": 6255,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5581,7 +5541,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6273,
+      "line": 6269,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5589,7 +5549,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6286,
+      "line": 6282,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5597,7 +5557,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6522,
+      "line": 6316,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5605,7 +5565,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6526,
+      "line": 6320,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5613,7 +5573,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6530,
+      "line": 6324,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5621,7 +5581,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6536,
+      "line": 6330,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5629,7 +5589,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6563,
+      "line": 6357,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5637,7 +5597,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6567,
+      "line": 6361,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5645,7 +5605,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6571,
+      "line": 6365,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5653,7 +5613,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6577,
+      "line": 6371,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5661,7 +5621,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6602,
+      "line": 6396,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5669,7 +5629,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6606,
+      "line": 6400,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5677,7 +5637,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6610,
+      "line": 6404,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5685,7 +5645,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6616,
+      "line": 6410,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5693,7 +5653,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6635,
+      "line": 6429,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5701,7 +5661,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6639,
+      "line": 6433,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5709,7 +5669,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6643,
+      "line": 6437,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5717,7 +5677,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6649,
+      "line": 6443,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5725,7 +5685,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6672,
+      "line": 6466,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5733,7 +5693,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6676,
+      "line": 6470,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5741,7 +5701,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6680,
+      "line": 6474,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5749,7 +5709,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6686,
+      "line": 6480,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5757,7 +5717,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6709,
+      "line": 6503,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5765,7 +5725,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6713,
+      "line": 6507,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5773,7 +5733,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6717,
+      "line": 6511,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5781,7 +5741,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6723,
+      "line": 6517,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5789,7 +5749,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6745,
+      "line": 6539,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5797,7 +5757,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6749,
+      "line": 6543,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5805,7 +5765,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6753,
+      "line": 6547,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5813,7 +5773,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6759,
+      "line": 6553,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5821,7 +5781,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6793,
+      "line": 6587,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5829,7 +5789,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6797,
+      "line": 6591,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5837,7 +5797,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6801,
+      "line": 6595,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5845,7 +5805,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6806,
+      "line": 6600,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5853,7 +5813,175 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6811,
+      "line": 6605,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6636,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6640,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6644,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 6649,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6654,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6684,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6688,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6692,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6698,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6718,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6722,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6726,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6732,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6759,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6763,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6767,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6773,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6804,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6808,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6812,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6818,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5883,17 +6011,9 @@
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 6855,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6860,
+      "line": 6856,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5901,7 +6021,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6890,
+      "line": 6872,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5909,7 +6029,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6894,
+      "line": 6876,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5917,7 +6037,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6898,
+      "line": 6880,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5925,7 +6045,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6904,
+      "line": 6886,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5933,7 +6053,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6924,
+      "line": 6906,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5941,7 +6061,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6928,
+      "line": 6910,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5949,7 +6069,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6932,
+      "line": 6914,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5957,167 +6077,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6938,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6965,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6969,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6973,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6979,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 7010,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7014,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7018,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 7024,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 7048,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7052,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7056,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 7062,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 7078,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7082,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7086,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 7092,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 7112,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7116,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7120,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 7126,
+      "line": 6920,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -6125,7 +6085,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7146,
+      "line": 6940,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6133,7 +6093,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 7152,
+      "line": 6946,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -6141,7 +6101,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7158,
+      "line": 6952,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6149,7 +6109,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7189,
+      "line": 6983,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6157,7 +6117,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7195,
+      "line": 6989,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6165,7 +6125,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7213,
+      "line": 7007,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6173,7 +6133,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7219,
+      "line": 7013,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6181,7 +6141,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7244,
+      "line": 7038,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6189,7 +6149,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7245,
+      "line": 7039,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -6197,7 +6157,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 7262,
+      "line": 7056,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_loaded_section"
@@ -6205,7 +6165,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7268,
+      "line": 7062,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6213,7 +6173,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7271,
+      "line": 7065,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6221,7 +6181,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7272,
+      "line": 7066,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6229,7 +6189,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7291,
+      "line": 7085,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6237,7 +6197,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 7297,
+      "line": 7091,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_loaded_section"
@@ -6245,23 +6205,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7302,
+      "line": 7096,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "contracts.RATE_LIMITED_SECTION_TEXT",
-      "kind": "direct_import",
-      "line": 7318,
-      "migration_stage": 1,
-      "path": "tests/test_scraping.py",
-      "target": "_RATE_LIMITED_MSG"
-    },
-    {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 7321,
+      "line": 7113,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_loaded_section"
@@ -6269,7 +6221,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7327,
+      "line": 7119,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6277,7 +6229,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7333,
+      "line": 7125,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6285,7 +6237,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 7359,
+      "line": 7151,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6293,7 +6245,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7365,
+      "line": 7157,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6301,7 +6253,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7414,
+      "line": 7206,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6309,7 +6261,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7415,
+      "line": 7207,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6317,7 +6269,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7419,
+      "line": 7211,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6325,7 +6277,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7424,
+      "line": 7216,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6333,7 +6285,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7470,
+      "line": 7262,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6341,7 +6293,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7476,
+      "line": 7268,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6349,7 +6301,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7480,
+      "line": 7272,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6357,7 +6309,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7500,
+      "line": 7292,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6365,7 +6317,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7506,
+      "line": 7298,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6373,7 +6325,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7510,
+      "line": 7302,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6381,7 +6333,7 @@
     {
       "canonical_owner": "person.PersonScraper -> owner-local logger binding",
       "kind": "imported_module_patch",
-      "line": 7515,
+      "line": 7307,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "logger.debug"
@@ -6389,7 +6341,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7543,
+      "line": 7335,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6397,7 +6349,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7544,
+      "line": 7336,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6405,7 +6357,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7548,
+      "line": 7340,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6413,7 +6365,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7581,
+      "line": 7373,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6421,7 +6373,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7582,
+      "line": 7374,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6429,7 +6381,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7586,
+      "line": 7378,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6437,7 +6389,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7591,
+      "line": 7383,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6445,7 +6397,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7610,
+      "line": 7402,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6453,7 +6405,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7611,
+      "line": 7403,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6461,7 +6413,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7615,
+      "line": 7407,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6469,7 +6421,7 @@
     {
       "canonical_owner": "message_sender.profile_urn_from_compose_url",
       "kind": "module_attribute",
-      "line": 7676,
+      "line": 7468,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_profile_urn_from_compose_url"
@@ -6477,7 +6429,7 @@
     {
       "canonical_owner": "message_sender.profile_path_from_url",
       "kind": "module_attribute",
-      "line": 7694,
+      "line": 7486,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_profile_path_from_url"
@@ -6485,7 +6437,7 @@
     {
       "canonical_owner": "message_sender.message_page_url_is_safe",
       "kind": "module_attribute",
-      "line": 7755,
+      "line": 7547,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_page_url_is_safe"
@@ -6493,7 +6445,7 @@
     {
       "canonical_owner": "message_sender.PROFILE_MESSAGE_TARGET_JS",
       "kind": "module_attribute",
-      "line": 7776,
+      "line": 7568,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_PROFILE_MESSAGE_TARGET_JS"
@@ -6501,7 +6453,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7823,
+      "line": 7615,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6509,7 +6461,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7829,
+      "line": 7621,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -6517,7 +6469,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7835,
+      "line": 7627,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6525,7 +6477,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7848,
+      "line": 7640,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6533,7 +6485,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7854,
+      "line": 7646,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -6541,10 +6493,282 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7860,
+      "line": 7652,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 7667,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7672,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7676,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7680,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7685,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7690,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7699,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 7703,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7707,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 7724,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7725,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7729,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7733,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7734,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7737,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7743,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7747,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 7776,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7777,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7781,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7785,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7786,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7789,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7798,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 7802,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7806,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 7829,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7830,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7834,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7838,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7839,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7842,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7848,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 7852,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
     },
     {
       "canonical_owner": "navigation.PageNavigator",
@@ -6557,71 +6781,55 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
+      "line": 7876,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
       "line": 7880,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
       "line": 7884,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+      "target": "_wait_for_main_text"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7885,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
       "line": 7888,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7893,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7898,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 7907,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7911,
+      "line": 7894,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
     },
     {
-      "canonical_owner": "conversations.ConversationReader",
+      "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
       "line": 7915,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7932,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6629,7 +6837,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7933,
+      "line": 7916,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6637,7 +6845,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7937,
+      "line": 7920,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6645,7 +6853,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7941,
+      "line": 7924,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6653,15 +6861,31 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7942,
+      "line": 7925,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
     },
     {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 7928,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7934,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 7945,
+      "line": 7943,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -6669,71 +6893,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7951,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7955,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7984,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7985,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7989,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7993,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7994,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7997,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 8006,
+      "line": 7949,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -6741,79 +6901,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 8010,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8014,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8037,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8038,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8042,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8046,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8047,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 8050,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 8056,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 8060,
+      "line": 7953,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -6821,7 +6909,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8083,
+      "line": 7973,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6829,7 +6917,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8084,
+      "line": 7974,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6837,7 +6925,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 8088,
+      "line": 7978,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6845,7 +6933,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8092,
+      "line": 7982,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6853,31 +6941,167 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8093,
+      "line": 7983,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
     },
     {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 7986,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7992,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 8096,
+      "line": 8001,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
     },
     {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 8007,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
+      "line": 8011,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 8030,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 8031,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 8035,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 8039,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 8045,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 8062,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 8063,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 8067,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 8071,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 8077,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 8094,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
       "line": 8102,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+      "target": "_strip_select_conversation_prefix"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 8112,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 8119,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
     },
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8123,
+      "line": 8149,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6885,7 +7109,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8124,
+      "line": 8150,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6893,7 +7117,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 8128,
+      "line": 8154,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6901,7 +7125,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8132,
+      "line": 8158,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6909,55 +7133,31 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8133,
+      "line": 8159,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
     },
     {
-      "canonical_owner": "profile_page.ProfilePageReader",
+      "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8136,
-      "migration_stage": 6,
+      "line": 8162,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
+      "target": "_extract_conversation_thread_refs"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8142,
+      "kind": "private_facade_access",
+      "line": 8169,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 8151,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 8157,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 8161,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8181,
+      "line": 8192,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6965,7 +7165,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8182,
+      "line": 8193,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6973,7 +7173,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 8186,
+      "line": 8197,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6981,7 +7181,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8190,
+      "line": 8201,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6989,487 +7189,239 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8191,
+      "line": 8202,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
     },
     {
-      "canonical_owner": "profile_page.ProfilePageReader",
+      "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8194,
-      "migration_stage": 6,
+      "line": 8205,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
+      "target": "_extract_conversation_thread_refs"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8200,
+      "kind": "private_facade_access",
+      "line": 8207,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 8209,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 8215,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 8219,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8238,
+      "line": 8234,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 8235,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 8239,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
       "line": 8243,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 8247,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8253,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8270,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8271,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8275,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 8279,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8285,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 8302,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
-    },
-    {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 8310,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
-    },
-    {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 8320,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
-    },
-    {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 8327,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8357,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8358,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8362,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8366,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
+      "line": 8244,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 8247,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_facade_access",
+      "line": 8249,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_facade_access",
+      "line": 8273,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 8287,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 8288,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 8292,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 8296,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 8297,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 8303,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 8307,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 8311,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 8347,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 8348,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 8352,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 8356,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 8357,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 8363,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
       "line": 8367,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8370,
+      "line": 8371,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
     },
     {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8377,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8400,
+      "line": 8398,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8401,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8405,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8409,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8410,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8413,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8415,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8442,
+      "line": 8431,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8443,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8447,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8451,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8452,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
+      "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
       "line": 8455,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8457,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8481,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8495,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8496,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8500,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8504,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 8505,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 8511,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 8515,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8519,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8555,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8556,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8560,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8564,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 8565,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 8571,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 8575,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8579,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8606,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8639,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8663,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7477,7 +7429,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8666,
+      "line": 8458,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7485,7 +7437,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8670,
+      "line": 8462,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7493,7 +7445,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8674,
+      "line": 8466,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7501,7 +7453,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8678,
+      "line": 8470,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_message_surface"
@@ -7509,7 +7461,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8681,
+      "line": 8473,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_message_composer_state"
@@ -7517,7 +7469,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8684,
+      "line": 8476,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_focus_verified_message_editor"
@@ -7525,7 +7477,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8689,
+      "line": 8481,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -7533,7 +7485,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8720,
+      "line": 8512,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7541,7 +7493,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8721,
+      "line": 8513,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7549,7 +7501,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8725,
+      "line": 8517,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7557,7 +7509,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8729,
+      "line": 8521,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7565,7 +7517,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTarget",
       "kind": "module_attribute",
-      "line": 8742,
+      "line": 8534,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTarget"
@@ -7573,7 +7525,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8792,
+      "line": 8584,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7581,7 +7533,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8793,
+      "line": 8585,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7589,7 +7541,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8797,
+      "line": 8589,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7597,7 +7549,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8801,
+      "line": 8593,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7605,7 +7557,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8805,
+      "line": 8597,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_message_surface"
@@ -7613,7 +7565,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8811,
+      "line": 8603,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_message_composer_state"
@@ -7621,7 +7573,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8824,
+      "line": 8616,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_write_verified_message"
@@ -7629,7 +7581,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8830,
+      "line": 8622,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -7637,7 +7589,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 8836,
+      "line": 8628,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -7645,7 +7597,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8840,
+      "line": 8632,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7653,7 +7605,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8846,
+      "line": 8638,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7661,7 +7613,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8881,
+      "line": 8673,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7669,7 +7621,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8884,
+      "line": 8676,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7677,7 +7629,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8888,
+      "line": 8680,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7685,7 +7637,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8892,
+      "line": 8684,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7693,7 +7645,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9073,
+      "line": 8865,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -7701,7 +7653,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9219,
+      "line": 9011,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7709,7 +7661,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9225,
+      "line": 9017,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7717,7 +7669,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9298,
+      "line": 9090,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_verified_submit"
@@ -7725,7 +7677,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9304,
+      "line": 9096,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_cleanup_owned_message"
@@ -7733,7 +7685,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9404,
+      "line": 9196,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_write_verified_message"
@@ -7741,7 +7693,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9410,
+      "line": 9202,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -7749,7 +7701,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9417,
+      "line": 9209,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7757,7 +7709,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9423,
+      "line": 9215,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7765,7 +7717,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9458,
+      "line": 9250,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7773,7 +7725,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9583,
+      "line": 9375,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_confirmation"
@@ -7781,7 +7733,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9589,
+      "line": 9381,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_owner"
@@ -7789,7 +7741,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9640,
+      "line": 9432,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7797,7 +7749,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9646,
+      "line": 9438,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7805,7 +7757,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9678,
+      "line": 9470,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_compose_box"
@@ -7813,7 +7765,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_COMPOSE_SELECTOR",
       "kind": "module_attribute",
-      "line": 9681,
+      "line": 9473,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGING_COMPOSE_SELECTOR"
@@ -7821,7 +7773,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9703,
+      "line": 9495,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -7829,7 +7781,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9728,
+      "line": 9520,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -7837,7 +7789,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9740,
+      "line": 9532,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_owner"
@@ -7845,7 +7797,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9750,
+      "line": 9542,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7853,7 +7805,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9772,
+      "line": 9564,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7861,7 +7813,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9784,
+      "line": 9576,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7869,7 +7821,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9817,
+      "line": 9609,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7877,7 +7829,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9831,
+      "line": 9623,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_confirmation"
@@ -7885,7 +7837,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9971,
+      "line": 9659,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7893,7 +7845,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9985,
+      "line": 9673,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7901,7 +7853,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 10009,
+      "line": 9697,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7909,7 +7861,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 10034,
+      "line": 9722,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7917,7 +7869,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 10053,
+      "line": 9741,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7925,7 +7877,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 10073,
+      "line": 9761,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7933,7 +7885,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 10118,
+      "line": 9806,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7941,7 +7893,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 10179,
+      "line": 9867,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7949,7 +7901,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 10217,
+      "line": 9905,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7957,7 +7909,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 10252,
+      "line": 9940,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7965,7 +7917,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 10283,
+      "line": 9971,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -7973,7 +7925,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 10296,
+      "line": 9984,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.record_page_trace"
@@ -7981,7 +7933,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 10302,
+      "line": 9990,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -7989,7 +7941,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 10314,
+      "line": 10002,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -7997,7 +7949,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 10321,
+      "line": 10009,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -8005,7 +7957,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 10357,
+      "line": 10045,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -8013,7 +7965,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 10365,
+      "line": 10053,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -8021,7 +7973,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 10400,
+      "line": 10088,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -8029,7 +7981,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 10407,
+      "line": 10095,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -8037,7 +7989,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 10442,
+      "line": 10130,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8045,7 +7997,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 10448,
+      "line": 10136,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -8053,7 +8005,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 10449,
+      "line": 10137,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -8061,7 +8013,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 10464,
+      "line": 10152,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8069,7 +8021,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 10484,
+      "line": 10172,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8077,7 +8029,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 10484,
+      "line": 10172,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8085,7 +8037,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 10484,
+      "line": 10172,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8093,7 +8045,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 10484,
+      "line": 10172,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8101,7 +8053,7 @@
     {
       "canonical_owner": "conversations.ConversationReader dependency",
       "kind": "public_patch_object",
-      "line": 10484,
+      "line": 10172,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8109,7 +8061,7 @@
     {
       "canonical_owner": "message_sender.MessageSender dependency",
       "kind": "public_patch_object",
-      "line": 10484,
+      "line": 10172,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8117,7 +8069,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 10485,
+      "line": 10173,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -8125,7 +8077,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 10501,
+      "line": 10189,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -8133,7 +8085,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 10507,
+      "line": 10195,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -8141,7 +8093,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 10513,
+      "line": 10201,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -8315,17 +8267,9 @@
       "target": "_message_send_confirmed"
     },
     {
-      "canonical_owner": "contracts.RATE_LIMITED_SECTION_TEXT",
-      "kind": "direct_import",
-      "line": 12,
-      "migration_stage": 1,
-      "path": "tests/test_tools.py",
-      "target": "_RATE_LIMITED_MSG"
-    },
-    {
       "canonical_owner": "contracts.ExtractedSection",
       "kind": "permanent_alias_import",
-      "line": 12,
+      "line": 16,
       "migration_stage": null,
       "path": "tests/test_tools.py",
       "target": "ExtractedSection"
@@ -8333,23 +8277,15 @@
     {
       "canonical_owner": "contracts.FilterValidationError",
       "kind": "permanent_alias_import",
-      "line": 379,
+      "line": 383,
       "migration_stage": null,
       "path": "tests/test_tools.py",
       "target": "FilterValidationError"
     },
     {
-      "canonical_owner": "contracts.SEND_INTERRUPTED_WARNING",
-      "kind": "direct_import",
-      "line": 1144,
-      "migration_stage": 1,
-      "path": "tests/test_tools.py",
-      "target": "SEND_INTERRUPTED_WARNING"
-    },
-    {
       "canonical_owner": "feed.FeedScraper._drain_listener_tasks",
       "kind": "direct_import",
-      "line": 1443,
+      "line": 1446,
       "migration_stage": 5,
       "path": "tests/test_tools.py",
       "target": "_drain_listener_tasks"
@@ -8357,7 +8293,7 @@
     {
       "canonical_owner": "contracts.FilterValidationError",
       "kind": "permanent_alias_import",
-      "line": 1666,
+      "line": 1672,
       "migration_stage": null,
       "path": "tests/test_tools.py",
       "target": "FilterValidationError"

--- a/tests/scraping/test_contracts.py
+++ b/tests/scraping/test_contracts.py
@@ -1,0 +1,123 @@
+"""Tests for the section contracts every scraping workflow returns."""
+
+from typing import Any
+
+import pytest
+
+from linkedin_mcp_server.scraping import contracts
+from linkedin_mcp_server.scraping.contracts import (
+    RATE_LIMITED_SECTION_TEXT,
+    SEND_INTERRUPTED_WARNING,
+    ExtractedSection,
+    FilterValidationError,
+    message_action_result,
+    rate_limited_section_error,
+    refuse_an_invalid_message,
+)
+
+
+class TestRateLimitedSection:
+    def test_the_sentinel_text_is_what_reaches_the_client(self):
+        # Pinned as a literal on purpose. Every other assertion in the suite
+        # compares a result against this same constant, so it moves with any
+        # edit and none of them can see the message a client would read.
+        assert RATE_LIMITED_SECTION_TEXT == (
+            "[Rate limited] LinkedIn blocked this section. "
+            "Try again later or request fewer sections."
+        )
+
+    def test_the_reported_error_repeats_the_sentinel_verbatim(self):
+        # The tools compare a section's text against the sentinel and then
+        # report this error, so the two drifting apart would describe a
+        # section the caller never saw.
+        assert rate_limited_section_error() == {
+            "error_type": "rate_limit",
+            "error_message": RATE_LIMITED_SECTION_TEXT,
+        }
+
+
+class TestExtractedSection:
+    def test_a_section_without_an_error_carries_none(self):
+        section = ExtractedSection(text="Bill Gates", references=[])
+
+        assert section.error is None
+
+    def test_an_error_is_kept_beside_the_text(self):
+        section = ExtractedSection(
+            text="", references=[], error=rate_limited_section_error()
+        )
+
+        assert section.text == ""
+        assert section.error == rate_limited_section_error()
+
+
+class TestFilterValidationError:
+    def test_it_is_still_a_value_error(self):
+        # Direct extractor callers catch ValueError; the tool wrappers catch
+        # this subclass to surface the message past mask_error_details.
+        assert issubclass(FilterValidationError, ValueError)
+
+
+class TestMessageActionResult:
+    def test_the_retry_contract_is_explicit_on_every_result(self):
+        assert message_action_result(
+            "https://www.linkedin.com/messaging/compose/",
+            "sent",
+            "Message submitted.",
+            recipient_selected=True,
+            sent=True,
+            retry_safe=False,
+        ) == {
+            "url": "https://www.linkedin.com/messaging/compose/",
+            "status": "sent",
+            "message": "Message submitted.",
+            "recipient_selected": True,
+            "sent": True,
+            "retry_safe": False,
+        }
+
+    def test_the_interruption_warning_names_duplicate_delivery(self):
+        assert SEND_INTERRUPTED_WARNING == (
+            "Message submission was interrupted while in flight. The send outcome "
+            "is unknown; check the conversation before retrying, as a retry may "
+            "deliver the message twice."
+        )
+
+
+class TestRefuseAnInvalidMessage:
+    @pytest.mark.parametrize("message", ["line\nbreak", "before\tafter", "text\x7f"])
+    def test_every_c0_or_del_character_is_refused(self, message: str):
+        assert refuse_an_invalid_message("alice", message) == message_action_result(
+            "https://www.linkedin.com/in/alice/",
+            "invalid_message",
+            "Message must not contain control characters or line breaks.",
+        )
+
+    def test_whitespace_is_refused_before_normal_message_text(self):
+        assert refuse_an_invalid_message("alice", "   ") == message_action_result(
+            "https://www.linkedin.com/in/alice/",
+            "invalid_message",
+            "Message must contain non-whitespace characters.",
+        )
+
+    def test_safe_single_line_text_is_accepted(self):
+        assert refuse_an_invalid_message("alice", "Hello, Alice!") is None
+
+    def test_the_refusal_calls_the_owner_constructor_directly(self, monkeypatch):
+        calls: list[tuple[str, str, str]] = []
+        sentinel: dict[str, Any] = {"owner": "contracts"}
+
+        def constructor(url: str, status: str, message: str) -> dict[str, Any]:
+            calls.append((url, status, message))
+            return sentinel
+
+        monkeypatch.setattr(contracts, "message_action_result", constructor)
+
+        assert refuse_an_invalid_message("alice", "") is sentinel
+        assert calls == [
+            (
+                "https://www.linkedin.com/in/alice/",
+                "invalid_message",
+                "Message must contain non-whitespace characters.",
+            )
+        ]

--- a/tests/scraping/test_facade_contracts.py
+++ b/tests/scraping/test_facade_contracts.py
@@ -13,7 +13,15 @@ from patchright.async_api import Page
 
 from linkedin_mcp_server import dependencies
 from linkedin_mcp_server.scraping import LinkedInExtractor as PackageExtractor
-from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+from linkedin_mcp_server.scraping import contracts, text
+from linkedin_mcp_server.scraping.extractor import (
+    ExtractedSection,
+    FilterValidationError,
+    LinkedInExtractor,
+    rate_limited_section_error,
+    strip_conversation_chrome,
+    strip_linkedin_noise,
+)
 from linkedin_mcp_server.server import create_mcp_server
 
 from .policy_scenarios import COMPATIBILITY_METHODS, TOOL_FACADE_METHODS
@@ -71,6 +79,17 @@ async def test_constructor_export_and_dependency_use_the_same_facade(monkeypatch
     assert type(constructed) is LinkedInExtractor
     assert constructed._page is page
     assert calls == ["ready", "browser", "authenticated"]
+
+
+def test_permanent_facade_aliases_are_the_canonical_objects():
+    # Identity, not equality: an alias that merely compares equal would let a
+    # second copy of a contract live in the facade, and `except
+    # FilterValidationError` imported from one copy would not catch the other.
+    assert ExtractedSection is contracts.ExtractedSection
+    assert FilterValidationError is contracts.FilterValidationError
+    assert rate_limited_section_error is contracts.rate_limited_section_error
+    assert strip_linkedin_noise is text.strip_linkedin_noise
+    assert strip_conversation_chrome is text.strip_conversation_chrome
 
 
 async def test_registered_tools_and_extractor_delegates_are_counted_separately():

--- a/tests/scraping/test_feed_payload.py
+++ b/tests/scraping/test_feed_payload.py
@@ -1,0 +1,107 @@
+"""Tests for feed permalink recognition across DOM anchors and SDUI payloads."""
+
+from linkedin_mcp_server.scraping.feed_payload import build_feed_references
+
+
+class TestBuildFeedReferences:
+    """Tests for build_feed_references SDUI-capture / DOM-anchor merging."""
+
+    def test_sdui_urls_become_relative_feed_post_references(self):
+        captured = [
+            "https://www.linkedin.com/posts/alice_some-slug-ugcPost-1-xx",
+            "https://www.linkedin.com/posts/bob_other-post-share-2-yy",
+        ]
+        refs = build_feed_references([], captured)
+        assert refs == [
+            {
+                "kind": "feed_post",
+                "url": "/posts/alice_some-slug-ugcPost-1-xx",
+                "context": "feed",
+            },
+            {
+                "kind": "feed_post",
+                "url": "/posts/bob_other-post-share-2-yy",
+                "context": "feed",
+            },
+        ]
+
+    def test_duplicate_sdui_urls_are_deduped(self):
+        captured = [
+            "https://www.linkedin.com/posts/alice_x-ugcPost-1-xx",
+            "https://www.linkedin.com/posts/alice_x-ugcPost-1-xx",
+        ]
+        refs = build_feed_references([], captured)
+        assert len(refs) == 1
+        assert refs[0]["url"] == "/posts/alice_x-ugcPost-1-xx"
+
+    def test_dom_anchor_feed_update_passes_through(self):
+        # DOM anchors that classify_link recognises as feed_post survive
+        # the merge alongside SDUI captures.
+        raw_anchors = [
+            {
+                "href": "https://www.linkedin.com/feed/update/urn:li:activity:1234567890/",
+                "text": "View post",
+            }
+        ]
+        refs = build_feed_references(raw_anchors, [])
+        assert any(
+            r["url"] == "/feed/update/urn:li:activity:1234567890/"
+            and r["kind"] == "feed_post"
+            for r in refs
+        )
+
+    def test_non_posts_paths_in_sdui_capture_are_skipped(self):
+        # Defensive: only /posts/<slug> shapes count for SDUI append.
+        captured = [
+            "https://www.linkedin.com/in/someuser/",
+            "https://www.linkedin.com/posts/alice_x-ugcPost-1-xx",
+        ]
+        refs = build_feed_references([], captured)
+        assert [r["url"] for r in refs] == ["/posts/alice_x-ugcPost-1-xx"]
+
+    def test_cap_matches_num_posts_ceiling(self):
+        captured = [
+            f"https://www.linkedin.com/posts/p{i}-ugcPost-{i}-xx" for i in range(60)
+        ]
+        refs = build_feed_references([], captured)
+        # Cap is 50, mirroring _REFERENCE_CAPS["feed"] / num_posts <= 50.
+        assert len(refs) == 50
+
+    def test_non_feed_post_dom_anchors_are_filtered(self):
+        # Sidebar profile / company / external anchors must not crowd
+        # out SDUI permalinks — references["feed"] is feed_post-only.
+        raw_anchors = [
+            {
+                "href": "https://www.linkedin.com/in/sidebar-user/",
+                "text": "Sidebar User",
+            },
+            {
+                "href": "https://www.linkedin.com/company/some-corp/",
+                "text": "Some Corp",
+            },
+            {
+                "href": "https://example.com/external/",
+                "text": "External Link",
+            },
+        ]
+        refs = build_feed_references(raw_anchors, [])
+        assert refs == []
+
+    def test_feed_post_dom_anchors_coexist_with_sdui_captures(self):
+        # The two sources fold into the same feed_post kind without
+        # collapsing across URL shapes pointing at the same post.
+        raw_anchors = [
+            {
+                "href": "https://www.linkedin.com/feed/update/urn:li:activity:111/",
+                "text": "View post",
+            }
+        ]
+        captured = ["https://www.linkedin.com/posts/alice_x-ugcPost-1-xx"]
+        refs = build_feed_references(raw_anchors, captured)
+        urls = [r["url"] for r in refs]
+        kinds = {r["kind"] for r in refs}
+        assert urls == [
+            "/feed/update/urn:li:activity:111/",
+            "/posts/alice_x-ugcPost-1-xx",
+        ]
+        assert kinds == {"feed_post"}

--- a/tests/scraping/test_job_policy.py
+++ b/tests/scraping/test_job_policy.py
@@ -1,0 +1,96 @@
+"""Tests for the routing and reference policy of the job list workflows."""
+
+from linkedin_mcp_server.scraping.job_policy import (
+    reconcile_search_references,
+    route,
+    same_job_search,
+)
+from linkedin_mcp_server.scraping.link_metadata import (
+    Reference,
+    _SEARCH_RESULTS_REFERENCE_CAP,
+)
+
+
+def job(job_id: str, text: str | None = None) -> Reference:
+    reference: Reference = {"kind": "job", "url": f"/jobs/view/{job_id}/"}
+    if text is not None:
+        reference["text"] = text
+    return reference
+
+
+def company(name: str) -> Reference:
+    return {"kind": "company", "url": f"/company/{name}/"}
+
+
+class TestReconcileSearchReferences:
+    def test_the_rail_decides_which_jobs_the_page_has(self):
+        references = reconcile_search_references(
+            [job("100", "Kept"), job("999", "Detail pane")], ["100"]
+        )
+
+        assert references == [job("100", "Kept")]
+
+    def test_an_id_without_an_anchor_still_becomes_a_reference(self):
+        references = reconcile_search_references([job("100", "Kept")], ["100", "200"])
+
+        assert references == [job("100", "Kept"), job("200")]
+
+    def test_a_job_named_twice_is_emitted_once(self):
+        references = reconcile_search_references(
+            [job("100", "Anchor"), job("100", "Logo")], ["100"]
+        )
+
+        assert references == [job("100", "Anchor")]
+
+    def test_ancillary_references_share_what_the_rail_leaves(self):
+        ids = [str(index) for index in range(10)]
+        left = _SEARCH_RESULTS_REFERENCE_CAP - len(ids)
+        references = reconcile_search_references(
+            [company(f"c{index}") for index in range(left + 3)], ids
+        )
+
+        ancillary = [ref for ref in references if ref["kind"] != "job"]
+        assert len(ancillary) == left
+
+    def test_a_rail_past_the_cap_leaves_no_ancillary_allowance(self):
+        # Without the floor the remaining allowance goes negative, which is
+        # truthy, so an overfull rail would admit every sidebar link instead
+        # of none.
+        ids = [str(index) for index in range(_SEARCH_RESULTS_REFERENCE_CAP + 1)]
+        references = reconcile_search_references([company("acme")], ids)
+
+        assert all(ref["kind"] == "job" for ref in references)
+        assert len(references) == len(ids)
+
+
+class TestRoute:
+    def test_a_route_is_the_host_and_the_path(self):
+        assert route("https://www.linkedin.com/jobs/search/?keywords=python") == (
+            "www.linkedin.com",
+            "/jobs/search",
+        )
+
+    def test_the_query_linkedin_appends_is_not_part_of_it(self):
+        assert route("https://www.linkedin.com/jobs/search?currentJobId=1") == route(
+            "https://www.linkedin.com/jobs/search/"
+        )
+
+
+class TestSameJobSearch:
+    def test_the_redesign_redirect_is_the_same_search(self):
+        assert same_job_search(
+            ("www.linkedin.com", "/jobs/search"),
+            ("www.linkedin.com", "/jobs/search-results"),
+        )
+
+    def test_a_third_route_is_not(self):
+        assert not same_job_search(
+            ("www.linkedin.com", "/jobs/search"),
+            ("www.linkedin.com", "/checkpoint/challenge"),
+        )
+
+    def test_the_same_path_on_another_host_is_not(self):
+        assert not same_job_search(
+            ("www.linkedin.com", "/jobs/search"),
+            ("evil.example", "/jobs/search-results"),
+        )

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -85,10 +85,8 @@ def test_manifest_covers_production_callers_not_only_tests():
     assert production == {
         "linkedin_mcp_server/dependencies.py",
         "linkedin_mcp_server/scraping/__init__.py",
-        "linkedin_mcp_server/scraping/extractor.py",
         "linkedin_mcp_server/tools/company.py",
         "linkedin_mcp_server/tools/feed.py",
-        "linkedin_mcp_server/tools/messaging.py",
         "linkedin_mcp_server/tools/person.py",
         "linkedin_mcp_server/tools/post.py",
     }
@@ -96,15 +94,13 @@ def test_manifest_covers_production_callers_not_only_tests():
         seam["target"]
         for seam in current["seams"]
         if seam["path"].startswith("linkedin_mcp_server/")
-    } == {
-        "_RATE_LIMITED_MSG",
-        "rate_limited_section_error",
-        "FilterValidationError",
-        "SEND_INTERRUPTED_WARNING",
-        "refuse_an_invalid_message",
-        "LinkedInExtractor",
-        "_message_action_result",
-    }
+    } == {"rate_limited_section_error", "FilterValidationError", "LinkedInExtractor"}
+    assert all(
+        seam["kind"] == "permanent_alias_import"
+        for seam in current["seams"]
+        if seam["path"].startswith("linkedin_mcp_server/")
+        and seam["target"] != "LinkedInExtractor"
+    )
 
 
 def test_final_messaging_seams_have_only_the_approved_stage_owners():
@@ -114,10 +110,10 @@ def test_final_messaging_seams_have_only_the_approved_stage_owners():
         for seam in current
         if seam["path"] == "linkedin_mcp_server/tools/messaging.py"
     }
-    assert browser_free == {
-        "SEND_INTERRUPTED_WARNING": ("contracts.SEND_INTERRUPTED_WARNING", 1),
-        "refuse_an_invalid_message": ("contracts.refuse_an_invalid_message", 1),
-    }
+    # The tool imports both browser-free contracts from their owner. Keeping
+    # either on the extractor facade would create a Stage 1 seam that can go
+    # stale when the facade is decomposed.
+    assert browser_free == {}
 
     message_paths = {
         "tests/test_message_recipient_dom.py",
@@ -328,8 +324,10 @@ def test_manifest_is_canonical_portable_json():
 
 
 def test_checker_rejects_obsolete_seams_at_their_migration_stage():
+    # One stage ahead of the tree, which is the smallest override the gate
+    # accepts and the only one that can still surface an unclosed seam.
     result = subprocess.run(
-        [sys.executable, str(CHECKER), "--check", "--stage", "1"],
+        [sys.executable, str(CHECKER), "--check", "--stage", "2"],
         cwd=ROOT,
         text=True,
         capture_output=True,
@@ -337,7 +335,7 @@ def test_checker_rejects_obsolete_seams_at_their_migration_stage():
     )
 
     assert result.returncode == 1
-    assert "obsolete at stage 1:" in result.stderr
+    assert "obsolete at stage 2:" in result.stderr
     assert "direct_import" in result.stderr
 
 
@@ -963,8 +961,8 @@ def test_manifest_includes_extractor_access_from_nested_closure():
         (seam["line"], seam["canonical_owner"], seam["migration_stage"])
         for seam in accesses
     } == {
-        (1009, "session.ScrapingSession._scroll_seconds", 3),
-        (4307, "session.ScrapingSession._scroll_seconds", 3),
+        (1005, "session.ScrapingSession._scroll_seconds", 3),
+        (4303, "session.ScrapingSession._scroll_seconds", 3),
     }
 
 

--- a/tests/scraping/test_text.py
+++ b/tests/scraping/test_text.py
@@ -1,0 +1,209 @@
+"""Tests for LinkedIn innerText cleanup."""
+
+from linkedin_mcp_server.scraping.text import (
+    strip_conversation_chrome,
+    strip_linkedin_noise,
+    truncate_linkedin_noise,
+)
+
+
+class TestStripLinkedInNoise:
+    def test_strips_footer(self):
+        text = "Bill Gates\nChair, Gates Foundation\n\nAbout\nAccessibility\nTalent Solutions\nCareers"
+        assert strip_linkedin_noise(text) == "Bill Gates\nChair, Gates Foundation"
+
+    def test_strips_footer_with_talent_solutions_variant(self):
+        text = "Profile content here\n\nAbout\nTalent Solutions\nMore footer"
+        assert strip_linkedin_noise(text) == "Profile content here"
+
+    def test_strips_sidebar_recommendations(self):
+        text = "Experience\nCo-chair\nGates Foundation\n\nMore profiles for you\nSundar Pichai\nCEO at Google"
+        assert strip_linkedin_noise(text) == "Experience\nCo-chair\nGates Foundation"
+
+    def test_strips_premium_upsell(self):
+        text = "Education\nHarvard University\n\nExplore premium profiles\nRandom Person\nSoftware Engineer"
+        assert strip_linkedin_noise(text) == "Education\nHarvard University"
+
+    def test_picks_earliest_marker(self):
+        text = "Content\n\nExplore premium profiles\nStuff\n\nMore profiles for you\nMore stuff\n\nAbout\nAccessibility"
+        assert strip_linkedin_noise(text) == "Content"
+
+    def test_no_noise_returns_unchanged(self):
+        text = "Clean content with no LinkedIn chrome"
+        assert strip_linkedin_noise(text) == "Clean content with no LinkedIn chrome"
+
+    def test_empty_string(self):
+        assert strip_linkedin_noise("") == ""
+
+    def test_truncate_noise_preserves_media_controls_for_rate_limit_detection(self):
+        text = "Play\nLoaded: 100.00%\nRemaining time 0:07\nShow captions"
+        assert truncate_linkedin_noise(text) == text
+        assert strip_linkedin_noise(text) == ""
+
+    def test_about_in_profile_content_not_stripped(self):
+        """'About' followed by actual content (not 'Accessibility') should be preserved."""
+        text = "About\nChair of the Gates Foundation.\n\nFeatured\nPost"
+        assert (
+            strip_linkedin_noise(text)
+            == "About\nChair of the Gates Foundation.\n\nFeatured\nPost"
+        )
+
+    def test_real_footer_with_languages(self):
+        text = (
+            "Company info\n\n"
+            "About\nAccessibility\nTalent Solutions\nCareers\n"
+            "Select language\nEnglish (English)\nDeutsch (German)"
+        )
+        assert strip_linkedin_noise(text) == "Company info"
+
+    def test_preserves_real_careers_content(self):
+        text = "Careers\nWe're hiring globally.\nOpen roles in engineering and design."
+        assert strip_linkedin_noise(text) == text
+
+    def test_preserves_real_questions_content(self):
+        text = "Questions?\nReach out to our recruiting team for details."
+        assert strip_linkedin_noise(text) == text
+
+    def test_strips_media_controls_lines(self):
+        text = (
+            "Feed post number 1\n"
+            "Play\n"
+            "Loaded: 100.00%\n"
+            "Remaining time 0:07\n"
+            "Playback speed\n"
+            "Actual post content\n"
+            "Show captions\n"
+            "Close modal window"
+        )
+        assert strip_linkedin_noise(text) == "Feed post number 1\nActual post content"
+
+
+class TestStripConversationChrome:
+    THREAD = (
+        "MAY 25\n"
+        "Grace Hopper sent the following message at 5:27 PM\n"
+        "Grace Hopper  5:27 PM\n"
+        "\n"
+        "Hello!"
+    )
+    PAGE = (
+        "Messaging\n"
+        "Search messages\n"
+        "Compose a new message\n"
+        "Inbox\n"
+        "Attention screen reader users, messaging items continuously update.\n"
+        "Ada Lovelace\n"
+        "Jun 8\n"
+        "Ada: Preview belonging to a different conversation\n"
+        ". Press return to go to conversation details\n"
+        "Open the options list in your conversation with Ada Lovelace and Grace Hopper\n"
+        "Status is reachable\n"
+        "Load more conversations\n"
+        "Grace Hopper\n"
+        "Status is online\n"
+        "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
+        + THREAD
+        + "\n"
+        "Maximize compose field\n"
+        "Attach an image to your conversation with Grace Hopper\n"
+        "Open GIF Keyboard\n"
+        "Send\n"
+        "Open send options"
+    )
+
+    def test_strips_sidebar_and_composer(self):
+        assert strip_conversation_chrome(self.PAGE) == self.THREAD
+
+    def test_other_conversation_previews_removed(self):
+        assert "different conversation" not in strip_conversation_chrome(self.PAGE)
+        assert "Ada Lovelace" not in strip_conversation_chrome(self.PAGE)
+
+    def test_missing_composer_strips_only_leading_chrome(self):
+        text = (
+            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
+            + self.THREAD
+        )
+        assert strip_conversation_chrome(text) == self.THREAD
+
+    def test_missing_thread_header_strips_only_composer(self):
+        text = self.THREAD + "\nMaximize compose field\nOpen send options"
+        assert strip_conversation_chrome(text) == self.THREAD
+
+    def test_quoted_composer_string_in_message_survives(self):
+        text = (
+            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
+            "Maximize compose field\n"
+            "is the label I keep seeing\n"
+            "Maximize compose field\n"
+            "Open send options"
+        )
+        assert (
+            strip_conversation_chrome(text)
+            == "Maximize compose field\nis the label I keep seeing"
+        )
+
+    def test_quoted_companion_with_suffix_does_not_confirm_composer(self):
+        text = "Hello!\nMaximize compose field\nOpen send options is what I clicked"
+        assert strip_conversation_chrome(text) == text
+
+    def test_quoted_attach_text_does_not_confirm_composer(self):
+        text = (
+            "Hello!\n"
+            "Maximize compose field\n"
+            "Attach an image to your conversation with Grace is the label I clicked"
+        )
+        assert strip_conversation_chrome(text) == text
+
+    def test_distant_companion_text_does_not_confirm_composer(self):
+        filler = "\n".join(f"message {n}" for n in range(10))
+        text = (
+            "Maximize compose field\n"
+            + filler
+            + "\nOpen send options is what I clicked"
+        )
+        assert strip_conversation_chrome(text) == text
+
+    def test_quoted_composer_without_companions_does_not_truncate(self):
+        text = (
+            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
+            "Hello!\n"
+            "Maximize compose field\n"
+            "is what the button says"
+        )
+        assert (
+            strip_conversation_chrome(text)
+            == "Hello!\nMaximize compose field\nis what the button says"
+        )
+
+    def test_quoted_thread_header_in_message_keeps_earlier_messages(self):
+        text = (
+            "Load more conversations\n"
+            "Grace Hopper\n"
+            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
+            "Hello!\n"
+            "Open the options list in your conversation with is a label I quoted\n"
+            "Bye!\n"
+            "Maximize compose field\n"
+            "Open send options"
+        )
+        assert strip_conversation_chrome(text) == (
+            "Hello!\n"
+            "Open the options list in your conversation with is a label I quoted\n"
+            "Bye!"
+        )
+
+    def test_sidebar_end_without_thread_header_still_strips_sidebar(self):
+        text = (
+            "Ada: Preview belonging to a different conversation\n"
+            "Load more conversations\n" + self.THREAD
+        )
+        assert strip_conversation_chrome(text) == self.THREAD
+
+    def test_unknown_locale_returns_unchanged(self):
+        assert strip_conversation_chrome(self.PAGE, locale="de") == self.PAGE
+
+    def test_no_markers_returns_stripped_text(self):
+        assert strip_conversation_chrome("Hello!\nHi there!") == "Hello!\nHi there!"
+
+    def test_empty_string(self):
+        assert strip_conversation_chrome("") == ""

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -27,6 +27,7 @@ from linkedin_mcp_server.scraping.connection import (
     detect_connection_state,
 )
 from linkedin_mcp_server.scraping import extractor as extractor_module
+from linkedin_mcp_server.scraping.contracts import RATE_LIMITED_SECTION_TEXT
 from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
@@ -35,11 +36,6 @@ from linkedin_mcp_server.scraping.extractor import (
     _MESSAGE_CONFIRMATION_DISPOSE_JS,
     _MESSAGE_CONFIRMATION_PREPARE_JS,
     _MESSAGE_CONFIRMATION_READY_JS,
-    _RATE_LIMITED_MSG,
-    _build_feed_references,
-    _truncate_linkedin_noise,
-    strip_conversation_chrome,
-    strip_linkedin_noise,
 )
 from linkedin_mcp_server.scraping.link_metadata import Reference
 
@@ -382,7 +378,7 @@ class TestExtractPage:
                 section_name="experience",
             )
 
-        assert result.text == _RATE_LIMITED_MSG
+        assert result.text == RATE_LIMITED_SECTION_TEXT
         # goto called twice (initial + retry)
         assert mock_page.goto.await_count == 2
 
@@ -2975,7 +2971,7 @@ class TestConnectWithPerson:
                 "extract_page",
                 new_callable=AsyncMock,
                 side_effect=[
-                    extracted(_RATE_LIMITED_MSG),
+                    extracted(RATE_LIMITED_SECTION_TEXT),
                     extracted("Post text"),
                 ],
             ) as mock_extract,
@@ -3012,7 +3008,7 @@ class TestConnectWithPerson:
                 extractor,
                 "extract_page",
                 new_callable=AsyncMock,
-                return_value=extracted(_RATE_LIMITED_MSG),
+                return_value=extracted(RATE_LIMITED_SECTION_TEXT),
             ),
             patch.object(
                 extractor,
@@ -3040,7 +3036,7 @@ class TestConnectWithPerson:
                 new_callable=AsyncMock,
                 side_effect=[
                     extracted("Profile text"),
-                    extracted(_RATE_LIMITED_MSG),
+                    extracted(RATE_LIMITED_SECTION_TEXT),
                 ],
             ),
             patch.object(
@@ -3140,7 +3136,7 @@ class TestScrapeCompany:
                 "extract_page",
                 new_callable=AsyncMock,
                 side_effect=[
-                    extracted(_RATE_LIMITED_MSG),
+                    extracted(RATE_LIMITED_SECTION_TEXT),
                     extracted("Posts text"),
                 ],
             ) as mock_extract,
@@ -3243,7 +3239,7 @@ class TestScrapeJob:
             extractor,
             "extract_page",
             new_callable=AsyncMock,
-            return_value=extracted(_RATE_LIMITED_MSG),
+            return_value=extracted(RATE_LIMITED_SECTION_TEXT),
         ):
             result = await extractor.scrape_job("12345")
 
@@ -3876,7 +3872,7 @@ class TestSearchJobs:
         pages = iter(
             [
                 extracted("python jobs"),
-                extracted(_RATE_LIMITED_MSG),
+                extracted(RATE_LIMITED_SECTION_TEXT),
             ]
         )
         urls = iter(
@@ -3916,7 +3912,7 @@ class TestSearchJobs:
         assert result["job_ids"] == ["901"]
         message = result["section_errors"]["search_results"]["error_message"]
         assert "location" in message
-        assert _RATE_LIMITED_MSG in message
+        assert RATE_LIMITED_SECTION_TEXT in message
 
     async def test_a_search_answered_for_something_else_stops_the_loop(self, mock_page):
         """The route can be right and the offset right while the query is gone.
@@ -5020,7 +5016,7 @@ class TestSearchJobs:
                 extractor,
                 "_extract_search_page",
                 new_callable=AsyncMock,
-                return_value=extracted(_RATE_LIMITED_MSG),
+                return_value=extracted(RATE_LIMITED_SECTION_TEXT),
             ),
             patch.object(
                 extractor,
@@ -5055,7 +5051,7 @@ class TestSearchJobs:
                 "_extract_search_page",
                 side_effect=self._navigating(
                     mock_page,
-                    [extracted(_RATE_LIMITED_MSG)],
+                    [extracted(RATE_LIMITED_SECTION_TEXT)],
                     lands_on="https://www.linkedin.com/feed/",
                 ),
             ),
@@ -5863,7 +5859,7 @@ class TestGetSavedJobs:
         were no more pages" — which look identical otherwise.
         """
         extractor = LinkedInExtractor(mock_page)
-        pages = iter([extracted("first page"), extracted(_RATE_LIMITED_MSG)])
+        pages = iter([extracted("first page"), extracted(RATE_LIMITED_SECTION_TEXT)])
         with (
             patch.object(
                 extractor,
@@ -6040,7 +6036,7 @@ class TestSingleSectionRateLimits:
             extractor,
             "extract_page",
             new_callable=AsyncMock,
-            return_value=extracted(_RATE_LIMITED_MSG),
+            return_value=extracted(RATE_LIMITED_SECTION_TEXT),
         ):
             result = await getattr(extractor, method)(*args)
 
@@ -6274,7 +6270,7 @@ class TestSearchPosts:
             extractor,
             "extract_page",
             new_callable=AsyncMock,
-            return_value=extracted(_RATE_LIMITED_MSG),
+            return_value=extracted(RATE_LIMITED_SECTION_TEXT),
         ):
             result = await extractor.search_posts("python")
 
@@ -6298,208 +6294,6 @@ class TestSearchPosts:
             "error_type": "navigation_error",
             "error_message": "timeout",
         }
-
-
-class TestStripLinkedInNoise:
-    def test_strips_footer(self):
-        text = "Bill Gates\nChair, Gates Foundation\n\nAbout\nAccessibility\nTalent Solutions\nCareers"
-        assert strip_linkedin_noise(text) == "Bill Gates\nChair, Gates Foundation"
-
-    def test_strips_footer_with_talent_solutions_variant(self):
-        text = "Profile content here\n\nAbout\nTalent Solutions\nMore footer"
-        assert strip_linkedin_noise(text) == "Profile content here"
-
-    def test_strips_sidebar_recommendations(self):
-        text = "Experience\nCo-chair\nGates Foundation\n\nMore profiles for you\nSundar Pichai\nCEO at Google"
-        assert strip_linkedin_noise(text) == "Experience\nCo-chair\nGates Foundation"
-
-    def test_strips_premium_upsell(self):
-        text = "Education\nHarvard University\n\nExplore premium profiles\nRandom Person\nSoftware Engineer"
-        assert strip_linkedin_noise(text) == "Education\nHarvard University"
-
-    def test_picks_earliest_marker(self):
-        text = "Content\n\nExplore premium profiles\nStuff\n\nMore profiles for you\nMore stuff\n\nAbout\nAccessibility"
-        assert strip_linkedin_noise(text) == "Content"
-
-    def test_no_noise_returns_unchanged(self):
-        text = "Clean content with no LinkedIn chrome"
-        assert strip_linkedin_noise(text) == "Clean content with no LinkedIn chrome"
-
-    def test_empty_string(self):
-        assert strip_linkedin_noise("") == ""
-
-    def test_truncate_noise_preserves_media_controls_for_rate_limit_detection(self):
-        text = "Play\nLoaded: 100.00%\nRemaining time 0:07\nShow captions"
-        assert _truncate_linkedin_noise(text) == text
-        assert strip_linkedin_noise(text) == ""
-
-    def test_about_in_profile_content_not_stripped(self):
-        """'About' followed by actual content (not 'Accessibility') should be preserved."""
-        text = "About\nChair of the Gates Foundation.\n\nFeatured\nPost"
-        assert (
-            strip_linkedin_noise(text)
-            == "About\nChair of the Gates Foundation.\n\nFeatured\nPost"
-        )
-
-    def test_real_footer_with_languages(self):
-        text = (
-            "Company info\n\n"
-            "About\nAccessibility\nTalent Solutions\nCareers\n"
-            "Select language\nEnglish (English)\nDeutsch (German)"
-        )
-        assert strip_linkedin_noise(text) == "Company info"
-
-    def test_preserves_real_careers_content(self):
-        text = "Careers\nWe're hiring globally.\nOpen roles in engineering and design."
-        assert strip_linkedin_noise(text) == text
-
-    def test_preserves_real_questions_content(self):
-        text = "Questions?\nReach out to our recruiting team for details."
-        assert strip_linkedin_noise(text) == text
-
-    def test_strips_media_controls_lines(self):
-        text = (
-            "Feed post number 1\n"
-            "Play\n"
-            "Loaded: 100.00%\n"
-            "Remaining time 0:07\n"
-            "Playback speed\n"
-            "Actual post content\n"
-            "Show captions\n"
-            "Close modal window"
-        )
-        assert strip_linkedin_noise(text) == "Feed post number 1\nActual post content"
-
-
-class TestStripConversationChrome:
-    THREAD = (
-        "MAY 25\n"
-        "Grace Hopper sent the following message at 5:27 PM\n"
-        "Grace Hopper  5:27 PM\n"
-        "\n"
-        "Hello!"
-    )
-    PAGE = (
-        "Messaging\n"
-        "Search messages\n"
-        "Compose a new message\n"
-        "Inbox\n"
-        "Attention screen reader users, messaging items continuously update.\n"
-        "Ada Lovelace\n"
-        "Jun 8\n"
-        "Ada: Preview belonging to a different conversation\n"
-        ". Press return to go to conversation details\n"
-        "Open the options list in your conversation with Ada Lovelace and Grace Hopper\n"
-        "Status is reachable\n"
-        "Load more conversations\n"
-        "Grace Hopper\n"
-        "Status is online\n"
-        "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
-        + THREAD
-        + "\n"
-        "Maximize compose field\n"
-        "Attach an image to your conversation with Grace Hopper\n"
-        "Open GIF Keyboard\n"
-        "Send\n"
-        "Open send options"
-    )
-
-    def test_strips_sidebar_and_composer(self):
-        assert strip_conversation_chrome(self.PAGE) == self.THREAD
-
-    def test_other_conversation_previews_removed(self):
-        assert "different conversation" not in strip_conversation_chrome(self.PAGE)
-        assert "Ada Lovelace" not in strip_conversation_chrome(self.PAGE)
-
-    def test_missing_composer_strips_only_leading_chrome(self):
-        text = (
-            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
-            + self.THREAD
-        )
-        assert strip_conversation_chrome(text) == self.THREAD
-
-    def test_missing_thread_header_strips_only_composer(self):
-        text = self.THREAD + "\nMaximize compose field\nOpen send options"
-        assert strip_conversation_chrome(text) == self.THREAD
-
-    def test_quoted_composer_string_in_message_survives(self):
-        text = (
-            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
-            "Maximize compose field\n"
-            "is the label I keep seeing\n"
-            "Maximize compose field\n"
-            "Open send options"
-        )
-        assert (
-            strip_conversation_chrome(text)
-            == "Maximize compose field\nis the label I keep seeing"
-        )
-
-    def test_quoted_companion_with_suffix_does_not_confirm_composer(self):
-        text = "Hello!\nMaximize compose field\nOpen send options is what I clicked"
-        assert strip_conversation_chrome(text) == text
-
-    def test_quoted_attach_text_does_not_confirm_composer(self):
-        text = (
-            "Hello!\n"
-            "Maximize compose field\n"
-            "Attach an image to your conversation with Grace is the label I clicked"
-        )
-        assert strip_conversation_chrome(text) == text
-
-    def test_distant_companion_text_does_not_confirm_composer(self):
-        filler = "\n".join(f"message {n}" for n in range(10))
-        text = (
-            "Maximize compose field\n"
-            + filler
-            + "\nOpen send options is what I clicked"
-        )
-        assert strip_conversation_chrome(text) == text
-
-    def test_quoted_composer_without_companions_does_not_truncate(self):
-        text = (
-            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
-            "Hello!\n"
-            "Maximize compose field\n"
-            "is what the button says"
-        )
-        assert (
-            strip_conversation_chrome(text)
-            == "Hello!\nMaximize compose field\nis what the button says"
-        )
-
-    def test_quoted_thread_header_in_message_keeps_earlier_messages(self):
-        text = (
-            "Load more conversations\n"
-            "Grace Hopper\n"
-            "Open the options list in your conversation with Grace Hopper and Ada Lovelace\n"
-            "Hello!\n"
-            "Open the options list in your conversation with is a label I quoted\n"
-            "Bye!\n"
-            "Maximize compose field\n"
-            "Open send options"
-        )
-        assert strip_conversation_chrome(text) == (
-            "Hello!\n"
-            "Open the options list in your conversation with is a label I quoted\n"
-            "Bye!"
-        )
-
-    def test_sidebar_end_without_thread_header_still_strips_sidebar(self):
-        text = (
-            "Ada: Preview belonging to a different conversation\n"
-            "Load more conversations\n" + self.THREAD
-        )
-        assert strip_conversation_chrome(text) == self.THREAD
-
-    def test_unknown_locale_returns_unchanged(self):
-        assert strip_conversation_chrome(self.PAGE, locale="de") == self.PAGE
-
-    def test_no_markers_returns_stripped_text(self):
-        assert strip_conversation_chrome("Hello!\nHi there!") == "Hello!\nHi there!"
-
-    def test_empty_string(self):
-        assert strip_conversation_chrome("") == ""
 
 
 class TestActivityFeedExtraction:
@@ -7315,14 +7109,12 @@ class TestMainProfileAlreadyLoaded:
         extractor = LinkedInExtractor(mock_page)
         mock_page.url = "https://www.linkedin.com/in/foo/"
 
-        from linkedin_mcp_server.scraping.extractor import _RATE_LIMITED_MSG
-
         with (
             patch.object(
                 extractor,
                 "_extract_loaded_section",
                 new_callable=AsyncMock,
-                return_value=extracted(_RATE_LIMITED_MSG),
+                return_value=extracted(RATE_LIMITED_SECTION_TEXT),
             ) as loaded,
             patch.object(
                 extractor,
@@ -9834,110 +9626,6 @@ class TestMessageConfirmation:
             _MESSAGE_CONFIRMATION_DISPOSE_JS,
             {"owner": owner, "token": "confirmation-token"},
         )
-
-
-class TestBuildFeedReferences:
-    """Tests for _build_feed_references SDUI-capture / DOM-anchor merging."""
-
-    def test_sdui_urls_become_relative_feed_post_references(self):
-        captured = [
-            "https://www.linkedin.com/posts/alice_some-slug-ugcPost-1-xx",
-            "https://www.linkedin.com/posts/bob_other-post-share-2-yy",
-        ]
-        refs = _build_feed_references([], captured)
-        assert refs == [
-            {
-                "kind": "feed_post",
-                "url": "/posts/alice_some-slug-ugcPost-1-xx",
-                "context": "feed",
-            },
-            {
-                "kind": "feed_post",
-                "url": "/posts/bob_other-post-share-2-yy",
-                "context": "feed",
-            },
-        ]
-
-    def test_duplicate_sdui_urls_are_deduped(self):
-        captured = [
-            "https://www.linkedin.com/posts/alice_x-ugcPost-1-xx",
-            "https://www.linkedin.com/posts/alice_x-ugcPost-1-xx",
-        ]
-        refs = _build_feed_references([], captured)
-        assert len(refs) == 1
-        assert refs[0]["url"] == "/posts/alice_x-ugcPost-1-xx"
-
-    def test_dom_anchor_feed_update_passes_through(self):
-        # DOM anchors that classify_link recognises as feed_post survive
-        # the merge alongside SDUI captures.
-        raw_anchors = [
-            {
-                "href": "https://www.linkedin.com/feed/update/urn:li:activity:1234567890/",
-                "text": "View post",
-            }
-        ]
-        refs = _build_feed_references(raw_anchors, [])
-        assert any(
-            r["url"] == "/feed/update/urn:li:activity:1234567890/"
-            and r["kind"] == "feed_post"
-            for r in refs
-        )
-
-    def test_non_posts_paths_in_sdui_capture_are_skipped(self):
-        # Defensive: only /posts/<slug> shapes count for SDUI append.
-        captured = [
-            "https://www.linkedin.com/in/someuser/",
-            "https://www.linkedin.com/posts/alice_x-ugcPost-1-xx",
-        ]
-        refs = _build_feed_references([], captured)
-        assert [r["url"] for r in refs] == ["/posts/alice_x-ugcPost-1-xx"]
-
-    def test_cap_matches_num_posts_ceiling(self):
-        captured = [
-            f"https://www.linkedin.com/posts/p{i}-ugcPost-{i}-xx" for i in range(60)
-        ]
-        refs = _build_feed_references([], captured)
-        # Cap is 50, mirroring _REFERENCE_CAPS["feed"] / num_posts <= 50.
-        assert len(refs) == 50
-
-    def test_non_feed_post_dom_anchors_are_filtered(self):
-        # Sidebar profile / company / external anchors must not crowd
-        # out SDUI permalinks — references["feed"] is feed_post-only.
-        raw_anchors = [
-            {
-                "href": "https://www.linkedin.com/in/sidebar-user/",
-                "text": "Sidebar User",
-            },
-            {
-                "href": "https://www.linkedin.com/company/some-corp/",
-                "text": "Some Corp",
-            },
-            {
-                "href": "https://example.com/external/",
-                "text": "External Link",
-            },
-        ]
-        refs = _build_feed_references(raw_anchors, [])
-        assert refs == []
-
-    def test_feed_post_dom_anchors_coexist_with_sdui_captures(self):
-        # The two sources fold into the same feed_post kind without
-        # collapsing across URL shapes pointing at the same post.
-        raw_anchors = [
-            {
-                "href": "https://www.linkedin.com/feed/update/urn:li:activity:111/",
-                "text": "View post",
-            }
-        ]
-        captured = ["https://www.linkedin.com/posts/alice_x-ugcPost-1-xx"]
-        refs = _build_feed_references(raw_anchors, captured)
-        urls = [r["url"] for r in refs]
-        kinds = {r["kind"] for r in refs}
-        assert urls == [
-            "/feed/update/urn:li:activity:111/",
-            "/posts/alice_x-ugcPost-1-xx",
-        ]
-        assert kinds == {"feed_post"}
 
 
 class TestDrainListenerTasks:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -9,7 +9,11 @@ from fastmcp import FastMCP
 from fastmcp.tools import FunctionTool
 
 from linkedin_mcp_server.callbacks import MCPContextProgressCallback
-from linkedin_mcp_server.scraping.extractor import ExtractedSection, _RATE_LIMITED_MSG
+from linkedin_mcp_server.scraping.contracts import (
+    RATE_LIMITED_SECTION_TEXT,
+    SEND_INTERRUPTED_WARNING,
+)
+from linkedin_mcp_server.scraping.extractor import ExtractedSection
 
 
 async def get_tool_fn(
@@ -652,7 +656,7 @@ class TestCompanyTools:
     async def test_get_company_posts_omits_rate_limited_sentinel(self, mock_context):
         mock_extractor = MagicMock()
         mock_extractor.extract_page = AsyncMock(
-            return_value=ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+            return_value=ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
         )
 
         from linkedin_mcp_server.tools.company import register_company_tools
@@ -1141,7 +1145,6 @@ class TestMessagingTools:
         and not the status, which is why a confirmed send is parametrized
         here alongside an unconfirmed one.
         """
-        from linkedin_mcp_server.scraping.extractor import SEND_INTERRUPTED_WARNING
         from linkedin_mcp_server.tools.messaging import register_messaging_tools
 
         mock_extractor = _make_mock_extractor({})
@@ -1563,7 +1566,7 @@ class TestFeedTools:
         """Rate-limit sentinel becomes a typed section_errors entry."""
         mock_extractor = MagicMock()
         mock_extractor.extract_feed = AsyncMock(
-            return_value=ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
+            return_value=ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
         )
 
         from linkedin_mcp_server.tools.feed import register_feed_tools
@@ -1575,7 +1578,10 @@ class TestFeedTools:
         result = await tool_fn(mock_context, extractor=mock_extractor)
         assert "feed" not in result["sections"]
         assert result["section_errors"]["feed"]["error_type"] == "rate_limit"
-        assert result["section_errors"]["feed"]["error_message"] == _RATE_LIMITED_MSG
+        assert (
+            result["section_errors"]["feed"]["error_message"]
+            == RATE_LIMITED_SECTION_TEXT
+        )
 
     async def test_get_feed_returns_section_errors(self, mock_context):
         mock_extractor = MagicMock()


### PR DESCRIPTION
Part of #853. Stacked on #859.

`extractor.py` mixed browser workflows with policy that never touches a page, leaving text filtering, feed payload handling, job validation, and shared contracts difficult to test directly.

This stage moves those leaves into `contracts.py`, `text.py`, `feed_payload.py`, and `job_policy.py`, with owner-local tests. Messaging refusal and result contracts move together and still reject C0/DEL before browser use. Five public contracts retain identity aliases; all other callers import their canonical owner. Browser JavaScript, listeners, URL builders, feed drainage, and workflow ordering remain in place. Canonical policy traces are byte-identical.

Verification: both migration checkers, 178 owner/contract tests, Ruff, `ty`, pre-commit, and the full suite with 3,580 passing tests succeed.

## Synthetic prompt

> Extract browser-free scraping policy into owner modules without changing facade behavior, browser workflows, or canonical traces.

Generated with GPT-5.6 Sol + GPT-6 Astra
