### PR TITLE
feat(job): add unsave_job tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter |
 | `search_jobs` | Search for jobs with keywords and location filters |
 | `get_saved_jobs` | List job postings saved by the authenticated user |
+| `save_job` | Save a LinkedIn job posting to the authenticated user's saved jobs list |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company |
 | `get_job_details` | Get detailed information about a specific job posting |
 | `get_feed` | Get recent posts from the authenticated user's home feed |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `search_jobs` | Search for jobs with keywords and location filters |
 | `get_saved_jobs` | List job postings saved by the authenticated user |
 | `save_job` | Save a LinkedIn job posting to the authenticated user's saved jobs list |
+| `unsave_job` | Remove a job from the authenticated user's saved jobs list |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company |
 | `get_job_details` | Get detailed information about a specific job posting |
 | `get_feed` | Get recent posts from the authenticated user's home feed |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -17,6 +17,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Job Details**: Retrieve job posting information
 - **Job Search**: Search for jobs with keywords and location filters
 - **Saved Jobs**: List job postings saved by the authenticated user
+- **Save Job**: Save a LinkedIn job posting to the authenticated user's saved jobs list
 - **People Search**: Search for people by keywords and location
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -18,6 +18,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Job Search**: Search for jobs with keywords and location filters
 - **Saved Jobs**: List job postings saved by the authenticated user
 - **Save Job**: Save a LinkedIn job posting to the authenticated user's saved jobs list
+- **Unsave Job**: Remove a job from the authenticated user's saved jobs list
 - **People Search**: Search for people by keywords and location
 - **Person Posts**: Get recent activity/posts from a person's profile
 - **Company Posts**: Get recent posts from a company's LinkedIn feed

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -363,6 +363,15 @@ _SAVED_JOBS_PATHS = frozenset({"/my-items/saved-jobs", "/jobs-tracker"})
 # list and yields nothing.
 _SAVED_JOBS_PAGE_SIZE = 10
 
+# Save-state labels for the job Save control, keyed by browser locale.
+# The control's text is the only state signal LinkedIn exposes (no
+# distinguishing URL or attribute), so detection is guarded by this explicit
+# per-locale table and fails closed on unknown locales.
+_JOB_SAVE_LABELS_BY_LOCALE = {
+    "en": {"saved": "Saved", "unsaved": "Save"},
+    "en-US": {"saved": "Saved", "unsaved": "Save"},
+}
+
 # Normalization maps for job search filters. Job search encodes recency as
 # ``f_TPR=r<seconds>``; content search uses named tokens, hence the separate
 # ``_CONTENT_DATE_POSTED_MAP`` below.
@@ -4221,6 +4230,100 @@ class LinkedInExtractor:
             }"""
         )
         return int(value) if value is not None else None
+
+    async def save_job(self, job_id: str) -> dict[str, Any]:
+        """Save a single job posting to the authenticated LinkedIn account."""
+        url = f"https://www.linkedin.com/jobs/view/{job_id}/"
+        await self._navigate_to_page(url)
+        await detect_rate_limit(self._page)
+        await handle_modal_close(self._page)
+
+        state = await self._job_save_button_state()
+        if state == "saved":
+            return {"url": url, "job_id": job_id, "saved": True, "already_saved": True}
+
+        clicked = await self._click_job_save_button("unsaved")
+        if not clicked:
+            raise LinkedInScraperException(
+                "Could not find or click the LinkedIn Save button for this job."
+            )
+
+        await asyncio.sleep(1)
+        return {"url": url, "job_id": job_id, "saved": True, "already_saved": False}
+
+    async def _job_save_labels(self) -> dict[str, str]:
+        """Return labels for the active browser locale, or fail closed."""
+        locale = await self._page.evaluate("() => navigator.language || ''")
+        labels = (
+            _JOB_SAVE_LABELS_BY_LOCALE.get(locale) if isinstance(locale, str) else None
+        )
+        if labels is None:
+            raise LinkedInScraperException(
+                "Job save-state detection is not supported for browser locale "
+                f"{locale!r}."
+            )
+        return labels
+
+    async def _job_save_button_state(self) -> Literal["saved", "unsaved"]:
+        """Read the job Save control's state using the per-locale label table."""
+        labels = await self._job_save_labels()
+        state = await self._page.evaluate(
+            """({ labels }) => {
+                const root = document.querySelector('main') || document.body;
+                const normalize = value =>
+                    (value || '').replace(/\\s+/g, ' ').trim();
+                const controls = Array.from(
+                    root.querySelectorAll('button, [role="button"]')
+                ).filter(element => {
+                    if (element.hasAttribute('aria-expanded')) return false;
+                    if (element.hasAttribute('disabled')) return false;
+                    const text = normalize(element.innerText || element.textContent);
+                    return text === labels.saved || text === labels.unsaved;
+                });
+                if (controls.length !== 1) return null;
+                const text = normalize(
+                    controls[0].innerText || controls[0].textContent
+                );
+                return text === labels.saved ? 'saved' : 'unsaved';
+            }""",
+            {"labels": labels},
+        )
+        if state not in {"saved", "unsaved"}:
+            raise LinkedInScraperException(
+                "Could not uniquely identify the LinkedIn job Save control."
+            )
+        return state
+
+    async def _click_job_save_button(
+        self, expected_state: Literal["saved", "unsaved"] = "unsaved"
+    ) -> bool:
+        """Click the unique job Save control when it has *expected_state*."""
+        labels = await self._job_save_labels()
+        try:
+            return bool(
+                await self._page.evaluate(
+                    """({ expectedLabel }) => {
+                        const root = document.querySelector('main') || document.body;
+                        const normalize = value =>
+                            (value || '').replace(/\\s+/g, ' ').trim();
+                        const controls = Array.from(
+                            root.querySelectorAll('button, [role="button"]')
+                        ).filter(element =>
+                            !element.hasAttribute('aria-expanded') &&
+                            !element.hasAttribute('disabled') &&
+                            normalize(element.innerText || element.textContent) ===
+                                expectedLabel
+                        );
+                        if (controls.length !== 1) return false;
+                        controls[0].click();
+                        return true;
+                    }""",
+                    {"expectedLabel": labels[expected_state]},
+                )
+            )
+        except Exception:
+            logger.debug("Job Save button click failed", exc_info=True)
+            return False
 
     async def get_saved_jobs(self, max_pages: int = 3) -> dict[str, Any]:
         """List the authenticated user's saved job postings.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4251,6 +4251,36 @@ class LinkedInExtractor:
         await asyncio.sleep(1)
         return {"url": url, "job_id": job_id, "saved": True, "already_saved": False}
 
+    async def unsave_job(self, job_id: str) -> dict[str, Any]:
+        """Remove a job posting from the authenticated account's saved jobs."""
+        url = f"https://www.linkedin.com/jobs/view/{job_id}/"
+        await self._navigate_to_page(url)
+        await detect_rate_limit(self._page)
+        await handle_modal_close(self._page)
+
+        state = await self._job_save_button_state()
+        if state == "unsaved":
+            return {
+                "url": url,
+                "job_id": job_id,
+                "saved": False,
+                "already_unsaved": True,
+            }
+
+        clicked = await self._click_job_save_button("saved")
+        if not clicked:
+            raise LinkedInScraperException(
+                "Could not find or click the LinkedIn saved-job button for this job."
+            )
+
+        await asyncio.sleep(1)
+        return {
+            "url": url,
+            "job_id": job_id,
+            "saved": False,
+            "already_unsaved": False,
+        }
+
     async def _job_save_labels(self) -> dict[str, str]:
         """Return labels for the active browser locale, or fail closed."""
         locale = await self._page.evaluate("() => navigator.language || ''")

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -374,6 +374,44 @@ _JOB_SAVE_LABELS_BY_LOCALE = {
     "en-US": {"saved": "Saved", "unsaved": "Save"},
 }
 
+# Read the job Save control's state from the main content area. The control
+# is the one button-like element whose text equals one of the locale labels;
+# expanders (aria-expanded) and disabled controls are excluded so the "More"
+# menu and a mid-transition button never win. Exactly one match or null.
+_JOB_SAVE_STATE_JS = """({ labels }) => {
+    const root = document.querySelector('main') || document.body;
+    const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
+    const controls = Array.from(
+        root.querySelectorAll('button, [role="button"]')
+    ).filter(element => {
+        if (element.hasAttribute('aria-expanded')) return false;
+        if (element.hasAttribute('disabled')) return false;
+        const text = normalize(element.innerText || element.textContent);
+        return text === labels.saved || text === labels.unsaved;
+    });
+    if (controls.length !== 1) return null;
+    const text = normalize(controls[0].innerText || controls[0].textContent);
+    return text === labels.saved ? 'saved' : 'unsaved';
+}"""
+
+# Click the job Save control when its text matches the expected state's
+# label. Returns true iff exactly one control matched and the click
+# dispatched; the caller re-reads the state afterwards.
+_JOB_SAVE_CLICK_JS = """({ expectedLabel }) => {
+    const root = document.querySelector('main') || document.body;
+    const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
+    const controls = Array.from(
+        root.querySelectorAll('button, [role="button"]')
+    ).filter(element =>
+        !element.hasAttribute('aria-expanded') &&
+        !element.hasAttribute('disabled') &&
+        normalize(element.innerText || element.textContent) === expectedLabel
+    );
+    if (controls.length !== 1) return false;
+    controls[0].click();
+    return true;
+}"""
+
 # Normalization maps for job search filters. Job search encodes recency as
 # ``f_TPR=r<seconds>``; content search uses named tokens, hence the separate
 # ``_CONTENT_DATE_POSTED_MAP`` below.
@@ -4268,7 +4306,8 @@ class LinkedInExtractor:
 
     async def save_job(self, job_id: str) -> dict[str, Any]:
         """Save a single job posting to the authenticated LinkedIn account."""
-        url = f"https://www.linkedin.com/jobs/view/{job_id}/"
+        job_id = normalize_job_id(job_id)
+        url = job_view_url(job_id, "/")
         await self._navigate_to_page(url)
         await detect_rate_limit(self._page)
         await handle_modal_close(self._page)
@@ -4283,12 +4322,22 @@ class LinkedInExtractor:
                 "Could not find or click the LinkedIn Save button for this job."
             )
 
+        # The click helper only proves the DOM click dispatched. LinkedIn can
+        # swallow it (overlay, transient disable) without changing state, so
+        # report the observed state rather than the attempt. The tool is
+        # idempotent: a caller retry lands in the already-saved branch.
         await asyncio.sleep(1)
+        if await self._job_save_button_state() != "saved":
+            raise LinkedInScraperException(
+                "Clicked the LinkedIn Save button, but the control did not "
+                "switch to its saved state."
+            )
         return {"url": url, "job_id": job_id, "saved": True, "already_saved": False}
 
     async def unsave_job(self, job_id: str) -> dict[str, Any]:
         """Remove a job posting from the authenticated account's saved jobs."""
-        url = f"https://www.linkedin.com/jobs/view/{job_id}/"
+        job_id = normalize_job_id(job_id)
+        url = job_view_url(job_id, "/")
         await self._navigate_to_page(url)
         await detect_rate_limit(self._page)
         await handle_modal_close(self._page)
@@ -4305,10 +4354,19 @@ class LinkedInExtractor:
         clicked = await self._click_job_save_button("saved")
         if not clicked:
             raise LinkedInScraperException(
-                "Could not find or click the LinkedIn saved-job button for this job."
+                "Could not find or click the job's Save control in its "
+                "saved state for this job."
             )
 
+        # Same contract as save_job: the click dispatching is not the state
+        # changing. A retry is safe because an unsaved job lands in the
+        # already-unsaved branch.
         await asyncio.sleep(1)
+        if await self._job_save_button_state() != "unsaved":
+            raise LinkedInScraperException(
+                "Clicked the job's Save control, but it did not switch to "
+                "its unsaved state."
+            )
         return {
             "url": url,
             "job_id": job_id,
@@ -4332,27 +4390,7 @@ class LinkedInExtractor:
     async def _job_save_button_state(self) -> Literal["saved", "unsaved"]:
         """Read the job Save control's state using the per-locale label table."""
         labels = await self._job_save_labels()
-        state = await self._page.evaluate(
-            """({ labels }) => {
-                const root = document.querySelector('main') || document.body;
-                const normalize = value =>
-                    (value || '').replace(/\\s+/g, ' ').trim();
-                const controls = Array.from(
-                    root.querySelectorAll('button, [role="button"]')
-                ).filter(element => {
-                    if (element.hasAttribute('aria-expanded')) return false;
-                    if (element.hasAttribute('disabled')) return false;
-                    const text = normalize(element.innerText || element.textContent);
-                    return text === labels.saved || text === labels.unsaved;
-                });
-                if (controls.length !== 1) return null;
-                const text = normalize(
-                    controls[0].innerText || controls[0].textContent
-                );
-                return text === labels.saved ? 'saved' : 'unsaved';
-            }""",
-            {"labels": labels},
-        )
+        state = await self._page.evaluate(_JOB_SAVE_STATE_JS, {"labels": labels})
         if state not in {"saved", "unsaved"}:
             raise LinkedInScraperException(
                 "Could not uniquely identify the LinkedIn job Save control."
@@ -4367,22 +4405,7 @@ class LinkedInExtractor:
         try:
             return bool(
                 await self._page.evaluate(
-                    """({ expectedLabel }) => {
-                        const root = document.querySelector('main') || document.body;
-                        const normalize = value =>
-                            (value || '').replace(/\\s+/g, ' ').trim();
-                        const controls = Array.from(
-                            root.querySelectorAll('button, [role="button"]')
-                        ).filter(element =>
-                            !element.hasAttribute('aria-expanded') &&
-                            !element.hasAttribute('disabled') &&
-                            normalize(element.innerText || element.textContent) ===
-                                expectedLabel
-                        );
-                        if (controls.length !== 1) return false;
-                        controls[0].click();
-                        return true;
-                    }""",
+                    _JOB_SAVE_CLICK_JS,
                     {"expectedLabel": labels[expected_state]},
                 )
             )

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -161,6 +161,50 @@ def register_job_tools(
 
     @mcp.tool(
         timeout=tool_timeout,
+        title="Save Job",
+        annotations={"readOnlyHint": False, "openWorldHint": True},
+        tags={"job", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def save_job(
+        job_id: str,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        Save a LinkedIn job posting to the authenticated account's saved jobs list.
+
+        Args:
+            job_id: LinkedIn job ID (e.g., "4252026496", "3856789012")
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, job_id, saved, and already_saved status.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="save_job"
+            )
+            logger.info("Saving job: %s", job_id)
+
+            await ctx.report_progress(progress=0, total=100, message="Opening job")
+
+            result = await extractor.save_job(job_id)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "save_job")
+        except Exception as e:
+            raise_tool_error(e, "save_job")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
         title="Get Saved Jobs",
         annotations={"readOnlyHint": True, "openWorldHint": True},
         tags={"job", "scraping"},

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -205,6 +205,53 @@ def register_job_tools(
 
     @mcp.tool(
         timeout=tool_timeout,
+        title="Unsave Job",
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "openWorldHint": True,
+        },
+        tags={"job", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def unsave_job(
+        job_id: str,
+        ctx: Context,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """Remove a LinkedIn job posting from the saved jobs list.
+
+        Args:
+            job_id: LinkedIn job ID (e.g., "4252026496", "3856789012")
+            ctx: FastMCP context for progress reporting
+
+        Returns:
+            Dict with url, job_id, saved, and already_unsaved status.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="unsave_job"
+            )
+            logger.info("Unsaving job: %s", job_id)
+
+            await ctx.report_progress(progress=0, total=100, message="Opening job")
+
+            result = await extractor.unsave_job(job_id)
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "unsave_job")
+        except Exception as e:
+            raise_tool_error(e, "unsave_job")  # NoReturn
+
+    @mcp.tool(
+        timeout=tool_timeout,
         title="Get Saved Jobs",
         annotations={"readOnlyHint": True, "openWorldHint": True},
         tags={"job", "scraping"},

--- a/manifest.json
+++ b/manifest.json
@@ -92,6 +92,10 @@
       "description": "List job postings saved by the authenticated LinkedIn user"
     },
     {
+      "name": "save_job",
+      "description": "Save a LinkedIn job posting to the authenticated user's saved jobs list"
+    },
+    {
       "name": "search_people",
       "description": "Search for people on LinkedIn by keywords, location, connection degree (1st/2nd/3rd), and current company"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -96,6 +96,10 @@
       "description": "Save a LinkedIn job posting to the authenticated user's saved jobs list"
     },
     {
+      "name": "unsave_job",
+      "description": "Remove a LinkedIn job posting from the authenticated user's saved jobs list"
+    },
+    {
       "name": "search_people",
       "description": "Search for people on LinkedIn by keywords, location, connection degree (1st/2nd/3rd), and current company"
     },

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -4729,7 +4729,8 @@ class TestRealOwner:
             assert "get_person_profile" in names
             assert "close_session" in names
             assert "save_job" in names
-            assert len(names) == 20, sorted(names)
+            assert "unsave_job" in names
+            assert len(names) == 21, sorted(names)
         finally:
             _stop(result.get("pid"))
 

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -4728,7 +4728,8 @@ class TestRealOwner:
             # in a `register_*` call.
             assert "get_person_profile" in names
             assert "close_session" in names
-            assert len(names) == 19, sorted(names)
+            assert "save_job" in names
+            assert len(names) == 20, sorted(names)
         finally:
             _stop(result.get("pid"))
 

--- a/tests/test_job_save_dom.py
+++ b/tests/test_job_save_dom.py
@@ -137,18 +137,35 @@ class TestJobSaveStateJs:
 class TestJobSaveClickJs:
     async def test_click_dispatches_on_expected_label(self, dom_page):
         await dom_page.set_content(_page_html(UNSAVED_CARD))
+        await dom_page.evaluate(
+            """({ expectedLabel }) => {
+                const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
+                const target = Array.from(
+                    document.querySelectorAll('main button')
+                ).find(
+                    element =>
+                        normalize(element.innerText || element.textContent) ===
+                        expectedLabel
+                );
+                if (!target) throw new Error('Expected Save control was not found');
+                target.addEventListener('click', () => {
+                    target.dataset.clicked = 'true';
+                });
+            }""",
+            {"expectedLabel": LABELS["unsaved"]},
+        )
         clicked = await dom_page.evaluate(
             _JOB_SAVE_CLICK_JS, {"expectedLabel": LABELS["unsaved"]}
         )
         assert clicked is True
-        # The click really fired: mark the element and read it back.
+        # The event listener proves that the expected control received click().
         state = await dom_page.evaluate(
             """() => {
                 const buttons = document.querySelectorAll('main button');
                 return Array.from(buttons).some((b) => b.dataset.clicked);
             }"""
         )
-        assert state is False  # click() fired, no handler ran to set the marker
+        assert state is True
 
     async def test_click_refuses_when_label_not_found(self, dom_page):
         """Asking to click 'Saved' on an unsaved card dispatches nothing."""

--- a/tests/test_job_save_dom.py
+++ b/tests/test_job_save_dom.py
@@ -1,0 +1,176 @@
+# tests/test_job_save_dom.py
+"""Browser-DOM tests for the job Save control state and click JS.
+
+The unit suite mocks ``page.evaluate``, so the JS in ``_JOB_SAVE_STATE_JS``
+and ``_JOB_SAVE_CLICK_JS`` never executes there. These tests run the real JS
+against synthetic HTML in headless chromium. Skipped automatically when
+chromium is not installed; run locally after
+``uv run patchright install chromium --no-shell``.
+
+Fixture structure mirrors a job top card: the Save control is the only
+button-like element whose text matches a locale label, scoped to ``main``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.scraping.extractor import (
+    _JOB_SAVE_CLICK_JS,
+    _JOB_SAVE_STATE_JS,
+)
+
+pytestmark = [
+    pytest.mark.browser_dom,
+    pytest.mark.xdist_group("browser_runtime"),
+]
+
+LABELS = {"saved": "Saved", "unsaved": "Save"}
+
+SAVED_CARD = """
+<main><section class="top-card">
+  <h1>Platform Engineer</h1>
+  <div class="actions">
+    <button type="button" aria-label="Follow Acme">Follow</button>
+    <button type="button">Saved</button>
+  </div>
+</section></main>
+"""
+
+UNSAVED_CARD = """
+<main><section class="top-card">
+  <h1>Platform Engineer</h1>
+  <div class="actions">
+    <button type="button" aria-label="Follow Acme">Follow</button>
+    <button type="button">Save</button>
+  </div>
+</section></main>
+"""
+
+# The expander and the disabled control both carry a Save label but must be
+# excluded: the expander opens a menu, the disabled one cannot accept clicks.
+EXPANDER_AND_DISABLED_CARD = """
+<main><section class="top-card">
+  <button type="button" aria-expanded="false">Save</button>
+  <button type="button" disabled>Save</button>
+  <button type="button" id="real">Save</button>
+</section></main>
+"""
+
+AMBIGUOUS_CARD = """
+<main><section class="top-card">
+  <button type="button">Save</button>
+</section>
+<section class="job-details">
+  <button type="button" role="button">Save</button>
+</section></main>
+"""
+
+NO_CONTROL_CARD = """
+<main><section class="top-card">
+  <h1>Platform Engineer</h1>
+  <a href="/jobs/">Back to search</a>
+</section></main>
+"""
+
+
+def _page_html(body: str) -> str:
+    return f"<html><body>{body}</body></html>"
+
+
+@pytest.fixture
+async def dom_page():
+    """Real chromium page, or skip when no browser is installed.
+
+    Only launch/setup is guarded by the skip — the ``yield`` is outside it
+    so an assertion failure or JS error in a test body is never swallowed
+    into a skip.
+    """
+    async with async_playwright() as p:
+        try:
+            browser = await p.chromium.launch(channel="chromium", headless=True)
+            page = await browser.new_page()
+        except Exception as exc:  # browser binary missing
+            pytest.skip(f"chromium unavailable: {exc}")
+        try:
+            yield page
+        finally:
+            await browser.close()
+
+
+class TestJobSaveStateJs:
+    async def test_reads_saved_control(self, dom_page):
+        await dom_page.set_content(_page_html(SAVED_CARD))
+        assert (
+            await dom_page.evaluate(_JOB_SAVE_STATE_JS, {"labels": LABELS}) == "saved"
+        )
+
+    async def test_reads_unsaved_control(self, dom_page):
+        await dom_page.set_content(_page_html(UNSAVED_CARD))
+        assert (
+            await dom_page.evaluate(_JOB_SAVE_STATE_JS, {"labels": LABELS}) == "unsaved"
+        )
+
+    async def test_skips_expander_and_disabled_controls(self, dom_page):
+        """The disabled Save and the More expander lose to the real control.
+
+        All three buttons carry the unsaved label; without the attribute
+        exclusions the scan sees three matches and returns null, so "unsaved"
+        here proves exactly one control survived them.
+        """
+        await dom_page.set_content(_page_html(EXPANDER_AND_DISABLED_CARD))
+        assert (
+            await dom_page.evaluate(_JOB_SAVE_STATE_JS, {"labels": LABELS}) == "unsaved"
+        )
+
+    async def test_two_matching_controls_yield_null(self, dom_page):
+        """A sidebar Save button in main makes the scan ambiguous, fail closed."""
+        await dom_page.set_content(_page_html(AMBIGUOUS_CARD))
+        assert await dom_page.evaluate(_JOB_SAVE_STATE_JS, {"labels": LABELS}) is None
+
+    async def test_no_control_yields_null(self, dom_page):
+        await dom_page.set_content(_page_html(NO_CONTROL_CARD))
+        assert await dom_page.evaluate(_JOB_SAVE_STATE_JS, {"labels": LABELS}) is None
+
+
+class TestJobSaveClickJs:
+    async def test_click_dispatches_on_expected_label(self, dom_page):
+        await dom_page.set_content(_page_html(UNSAVED_CARD))
+        clicked = await dom_page.evaluate(
+            _JOB_SAVE_CLICK_JS, {"expectedLabel": LABELS["unsaved"]}
+        )
+        assert clicked is True
+        # The click really fired: mark the element and read it back.
+        state = await dom_page.evaluate(
+            """() => {
+                const buttons = document.querySelectorAll('main button');
+                return Array.from(buttons).some((b) => b.dataset.clicked);
+            }"""
+        )
+        assert state is False  # click() fired, no handler ran to set the marker
+
+    async def test_click_refuses_when_label_not_found(self, dom_page):
+        """Asking to click 'Saved' on an unsaved card dispatches nothing."""
+        await dom_page.set_content(_page_html(UNSAVED_CARD))
+        clicked = await dom_page.evaluate(
+            _JOB_SAVE_CLICK_JS, {"expectedLabel": LABELS["saved"]}
+        )
+        assert clicked is False
+
+    async def test_click_refuses_when_ambiguous(self, dom_page):
+        await dom_page.set_content(_page_html(AMBIGUOUS_CARD))
+        clicked = await dom_page.evaluate(
+            _JOB_SAVE_CLICK_JS, {"expectedLabel": LABELS["unsaved"]}
+        )
+        assert clicked is False
+
+    async def test_click_skips_disabled_control(self, dom_page):
+        """A disabled Save must not be clicked even when it is the only one."""
+        await dom_page.set_content(
+            _page_html('<main><button type="button" disabled>Save</button></main>')
+        )
+        clicked = await dom_page.evaluate(
+            _JOB_SAVE_CLICK_JS, {"expectedLabel": LABELS["unsaved"]}
+        )
+        assert clicked is False

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3378,6 +3378,103 @@ class TestSaveJob:
                 await extractor.save_job("12345")
 
 
+class TestUnsaveJob:
+    async def test_unsave_job_already_unsaved(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="unsaved",
+            ),
+            patch.object(
+                extractor, "_click_job_save_button", new_callable=AsyncMock
+            ) as click_unsave,
+        ):
+            result = await extractor.unsave_job("12345")
+
+        assert result == {
+            "url": "https://www.linkedin.com/jobs/view/12345/",
+            "job_id": "12345",
+            "saved": False,
+            "already_unsaved": True,
+        }
+        click_unsave.assert_not_awaited()
+
+    async def test_unsave_job_clicks_saved_control(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="saved",
+            ),
+            patch.object(
+                extractor,
+                "_click_job_save_button",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as click_unsave,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.unsave_job("12345")
+
+        assert result["saved"] is False
+        assert result["already_unsaved"] is False
+        click_unsave.assert_awaited_once_with("saved")
+
+    async def test_unsave_job_raises_when_saved_control_missing(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="saved",
+            ),
+            patch.object(
+                extractor,
+                "_click_job_save_button",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(LinkedInScraperException):
+                await extractor.unsave_job("12345")
+
+
 class TestSearchJobs:
     """Tests for search_jobs with job ID extraction and pagination."""
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3261,6 +3261,123 @@ class TestScrapeJob:
         assert "references" not in result
 
 
+class TestSaveJob:
+    async def test_job_save_button_state_uses_active_locale(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(side_effect=["en-US", "saved"])
+
+        result = await extractor._job_save_button_state()
+
+        assert result == "saved"
+        assert mock_page.evaluate.await_args_list[1].args[1] == {
+            "labels": {"saved": "Saved", "unsaved": "Save"}
+        }
+
+    async def test_job_save_button_state_rejects_unknown_locale(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value="de-DE")
+
+        with pytest.raises(
+            LinkedInScraperException, match="not supported for browser locale"
+        ):
+            await extractor._job_save_button_state()
+
+    async def test_save_job_already_saved(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="saved",
+            ),
+            patch.object(
+                extractor, "_click_job_save_button", new_callable=AsyncMock
+            ) as click_save,
+        ):
+            result = await extractor.save_job("12345")
+
+        assert result == {
+            "url": "https://www.linkedin.com/jobs/view/12345/",
+            "job_id": "12345",
+            "saved": True,
+            "already_saved": True,
+        }
+        click_save.assert_not_awaited()
+
+    async def test_save_job_clicks_save(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="unsaved",
+            ),
+            patch.object(
+                extractor,
+                "_click_job_save_button",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as click_save,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.save_job("12345")
+
+        assert result["saved"] is True
+        assert result["already_saved"] is False
+        click_save.assert_awaited_once_with("unsaved")
+
+    async def test_save_job_raises_when_save_button_missing(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="unsaved",
+            ),
+            patch.object(
+                extractor,
+                "_click_job_save_button",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(LinkedInScraperException):
+                await extractor.save_job("12345")
+
+
 class TestSearchJobs:
     """Tests for search_jobs with job ID extraction and pagination."""
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3333,8 +3333,8 @@ class TestSaveJob:
                 extractor,
                 "_job_save_button_state",
                 new_callable=AsyncMock,
-                return_value="unsaved",
-            ),
+                side_effect=["unsaved", "saved"],
+            ) as save_state,
             patch.object(
                 extractor,
                 "_click_job_save_button",
@@ -3348,9 +3348,83 @@ class TestSaveJob:
         ):
             result = await extractor.save_job("12345")
 
-        assert result["saved"] is True
-        assert result["already_saved"] is False
+        assert result == {
+            "url": "https://www.linkedin.com/jobs/view/12345/",
+            "job_id": "12345",
+            "saved": True,
+            "already_saved": False,
+        }
         click_save.assert_awaited_once_with("unsaved")
+        assert save_state.await_count == 2
+
+    async def test_save_job_raises_when_click_does_not_stick(self, mock_page):
+        """A dispatched click that leaves the control unsaved is a failure.
+
+        The click helper returns True the moment .click() goes out; LinkedIn
+        can swallow it. Reporting saved here would make callers treat the job
+        as persisted when it is not.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                side_effect=["unsaved", "unsaved"],
+            ),
+            patch.object(
+                extractor,
+                "_click_job_save_button",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            with pytest.raises(
+                LinkedInScraperException, match="did not switch to its saved state"
+            ):
+                await extractor.save_job("12345")
+
+    async def test_save_job_normalizes_a_job_reference(self, mock_page):
+        """A full job URL is accepted and reduced to the numeric id."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                return_value="saved",
+            ),
+        ):
+            result = await extractor.save_job("/jobs/view/4252026496/")
+
+        assert result == {
+            "url": "https://www.linkedin.com/jobs/view/4252026496/",
+            "job_id": "4252026496",
+            "saved": True,
+            "already_saved": True,
+        }
 
     async def test_save_job_raises_when_save_button_missing(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
@@ -3430,8 +3504,8 @@ class TestUnsaveJob:
                 extractor,
                 "_job_save_button_state",
                 new_callable=AsyncMock,
-                return_value="saved",
-            ),
+                side_effect=["saved", "unsaved"],
+            ) as save_state,
             patch.object(
                 extractor,
                 "_click_job_save_button",
@@ -3445,9 +3519,53 @@ class TestUnsaveJob:
         ):
             result = await extractor.unsave_job("12345")
 
-        assert result["saved"] is False
-        assert result["already_unsaved"] is False
+        assert result == {
+            "url": "https://www.linkedin.com/jobs/view/12345/",
+            "job_id": "12345",
+            "saved": False,
+            "already_unsaved": False,
+        }
         click_unsave.assert_awaited_once_with("saved")
+        assert save_state.await_count == 2
+
+    async def test_unsave_job_raises_when_click_does_not_stick(self, mock_page):
+        """A dispatched click that leaves the control saved is a failure.
+
+        The tool would otherwise report a removal that never happened, and
+        the caller stops treating the job as saved.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_job_save_button_state",
+                new_callable=AsyncMock,
+                side_effect=["saved", "saved"],
+            ),
+            patch.object(
+                extractor,
+                "_click_job_save_button",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            with pytest.raises(
+                LinkedInScraperException, match="did not switch to its unsaved state"
+            ):
+                await extractor.unsave_job("12345")
 
     async def test_unsave_job_raises_when_saved_control_missing(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
@@ -9775,6 +9893,8 @@ class TestEveryNormalizedEntryPoint:
             ("scrape_company", ("../../feed", {"about"}), {}),
             ("get_company_employees", ("../../feed",), {}),
             ("scrape_job", ("../../feed",), {}),
+            ("save_job", ("../../feed",), {}),
+            ("unsave_job", ("../../feed",), {}),
             ("get_conversation", (), {"thread_id": "../../feed"}),
         ],
     )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -28,6 +28,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.scrape_company = AsyncMock(return_value=scrape_result)
     mock.scrape_job = AsyncMock(return_value=scrape_result)
     mock.search_jobs = AsyncMock(return_value=scrape_result)
+    mock.save_job = AsyncMock(return_value=scrape_result)
     mock.get_saved_jobs = AsyncMock(return_value=scrape_result)
     mock.search_people = AsyncMock(return_value=scrape_result)
     mock.get_sidebar_profiles = AsyncMock(return_value=scrape_result)
@@ -755,6 +756,25 @@ class TestJobTools:
 
         passed = mock_extractor.search_jobs.await_args.kwargs["tool_timeout"]
         assert passed < 59.9
+
+    async def test_save_job(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/jobs/view/12345/",
+            "job_id": "12345",
+            "saved": True,
+            "already_saved": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "save_job")
+        result = await tool_fn("12345", mock_context, extractor=mock_extractor)
+        assert result["saved"] is True
+        mock_extractor.save_job.assert_awaited_once_with("12345")
 
     async def test_get_saved_jobs(self, mock_context):
         expected = {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -29,6 +29,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.scrape_job = AsyncMock(return_value=scrape_result)
     mock.search_jobs = AsyncMock(return_value=scrape_result)
     mock.save_job = AsyncMock(return_value=scrape_result)
+    mock.unsave_job = AsyncMock(return_value=scrape_result)
     mock.get_saved_jobs = AsyncMock(return_value=scrape_result)
     mock.search_people = AsyncMock(return_value=scrape_result)
     mock.get_sidebar_profiles = AsyncMock(return_value=scrape_result)
@@ -775,6 +776,25 @@ class TestJobTools:
         result = await tool_fn("12345", mock_context, extractor=mock_extractor)
         assert result["saved"] is True
         mock_extractor.save_job.assert_awaited_once_with("12345")
+
+    async def test_unsave_job(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/jobs/view/12345/",
+            "job_id": "12345",
+            "saved": False,
+            "already_unsaved": False,
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.job import register_job_tools
+
+        mcp = FastMCP("test")
+        register_job_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "unsave_job")
+        result = await tool_fn("12345", mock_context, extractor=mock_extractor)
+        assert result["saved"] is False
+        mock_extractor.unsave_job.assert_awaited_once_with("12345")
 
     async def test_get_saved_jobs(self, mock_context):
         expected = {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -837,7 +837,7 @@ class TestJobTools:
 
         tool_fn = await get_tool_fn(mcp, "save_job")
         result = await tool_fn("12345", mock_context, extractor=mock_extractor)
-        assert result["saved"] is True
+        assert result == expected
         mock_extractor.save_job.assert_awaited_once_with("12345")
 
     async def test_unsave_job(self, mock_context):
@@ -856,7 +856,7 @@ class TestJobTools:
 
         tool_fn = await get_tool_fn(mcp, "unsave_job")
         result = await tool_fn("12345", mock_context, extractor=mock_extractor)
-        assert result["saved"] is False
+        assert result == expected
         mock_extractor.unsave_job.assert_awaited_once_with("12345")
 
     async def test_get_saved_jobs(self, mock_context):


### PR DESCRIPTION
Closes #724. Contains #870 (save_job) below — review that first; this PR's own delta is the second commit.

Adds an `unsave_job` MCP tool mirroring `save_job`: navigates to `/jobs/view/{job_id}/`, reuses the per-locale Save-state table, clicks the saved-state control only when the posting is currently saved, returns idempotent `{url, job_id, saved, already_unsaved}`. Registered with `destructiveHint`.

Checklist: extractor method + tool registration, mock + tool-level + extractor-level tests (`TestUnsaveJob`, 3 new), README + docker-hub + manifest. `ruff check`, `ruff format --check`, `ty check` clean; `test_tools + test_scraping` 379 passed.

## Synthetic prompt

> Add an `unsave_job` MCP tool mirroring the save flow: extractor method on `/jobs/view/{job_id}/` reusing the locale-tabled Save-state detection, destructive-hint tool registration, tests, and docs.

Generated with Muse Spark (muse-spark-1.3)