### PR TITLE
docs(messaging): Clarify send_message is compose-oriented, not reply-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_inbox` | List recent conversations from the LinkedIn messaging inbox |
 | `get_conversation` | Read a specific messaging conversation by username or thread ID |
 | `search_conversations` | Search messages by keyword |
-| `send_message` | Send a message to a LinkedIn user (requires confirmation) |
+| `send_message` | Compose/send a new message to a LinkedIn user (requires confirmation; profile-based targeting may open a separate DM instead of replying in an existing thread — see #483) |
 | `get_company_profile` | Extract company information with explicit section selection (posts, jobs); about-section references may include a `company_urn` entry carrying the numeric id used by LinkedIn's people-search `currentCompany` URL facet |
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed |
 | `search_companies` | Search for companies on LinkedIn by keywords |

--- a/docs/docker-hub.md
+++ b/docs/docker-hub.md
@@ -10,7 +10,7 @@ A Model Context Protocol (MCP) server that connects AI assistants to LinkedIn. A
 - **Own Profile**: Fetch the authenticated user's own profile to give agents self-context
 - **Profile Connections**: Send connection requests or accept incoming ones, with optional notes
 - **Sidebar Profiles**: Extract profile URLs from the sidebar recommendation sections on a profile page ("More profiles for you", "Explore premium profiles", "People you may know")
-- **Messaging**: List the inbox, read a conversation by username or thread ID, search messages by keyword, and send a message with explicit confirmation
+- **Messaging**: List the inbox, read a conversation by username or thread ID, search messages by keyword, and compose/send a new message with explicit confirmation (profile-based send may open a separate DM rather than reply in an existing thread)
 - **Company Profiles**: Extract comprehensive company data, including the LinkedIn company URN id (used by LinkedIn's people-search `currentCompany` URL facet)
 - **Company Employees**: List employees at a company with optional keyword filtering
 - **Company Search**: Search for companies by keyword

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4925,7 +4925,11 @@ class LinkedInExtractor:
         confirm_send: bool,
         profile_urn: str | None = None,
     ) -> dict[str, Any]:
-        """Send a message to a LinkedIn user with explicit confirmation gating.
+        """Compose and send a new message with explicit confirmation gating.
+
+        Opens LinkedIn's profile-based compose flow. That may create a separate
+        DM instead of replying in an existing recruiter/InMail or messaging
+        thread.
 
         Args:
             linkedin_username: LinkedIn username of the recipient.

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -227,7 +227,14 @@ def register_messaging_tools(
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
-        Send a message to a LinkedIn user.
+        Compose and send a new message to a LinkedIn user.
+
+        Profile-based targeting opens LinkedIn's compose flow. It is not a safe
+        reply path for an existing recruiter/InMail or messaging thread: it may
+        create a separate DM even after you read that thread with
+        get_conversation. Prefer get_conversation or search_conversations to
+        continue an existing thread until a thread-targeted send path is
+        available.
 
         The recipient must be directly messageable from the profile page. This is a
         write operation when confirm_send is True.

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -231,10 +231,10 @@ def register_messaging_tools(
 
         Profile-based targeting opens LinkedIn's compose flow. It is not a safe
         reply path for an existing recruiter/InMail or messaging thread: it may
-        create a separate DM even after you read that thread with
-        get_conversation. Prefer get_conversation or search_conversations to
-        continue an existing thread until a thread-targeted send path is
-        available.
+        create a separate DM even after you inspect that thread with
+        get_conversation or search_conversations. Those tools only read an
+        existing thread; they do not send a reply. Until a thread-targeted send
+        path is available, do not treat profile-based send_message as a reply.
 
         The recipient must be directly messageable from the profile page. This is a
         write operation when confirm_send is True.

--- a/manifest.json
+++ b/manifest.json
@@ -109,7 +109,7 @@
     },
     {
       "name": "send_message",
-      "description": "Send a message to a LinkedIn user with explicit confirmation and optional profile URN support"
+      "description": "Compose and send a new message to a LinkedIn user with explicit confirmation and optional profile URN support; profile-based targeting may create a separate DM instead of replying in an existing thread"
     },
     {
       "name": "get_feed",


### PR DESCRIPTION
## Summary
Closes #560.

Clarify that `send_message` is a **compose/send-to-person** tool, not a safe reply to an existing recruiter/InMail or messaging thread. Profile-based targeting opens LinkedIn's compose flow and may create a separate DM even after the caller read that thread with `get_conversation`.

Updates the surfaces MCP clients and humans actually see:
- `send_message` tool docstring (`tools/messaging.py`) — primary agent-facing contract
- extractor docstring for the same method
- README tool table (links #483 for the underlying behavior)
- `manifest.json` tool description
- `docs/docker-hub.md` messaging capability bullet

Docs only. Does not change send behavior; thread-targeted send remains #451 / #483.

## Test plan
- [x] `uv run ruff check` / `ruff format` on touched Python files
- [x] `uv run ty check linkedin_mcp_server/tools/messaging.py`
- [x] `uv run pytest tests/test_tools.py -k send_message`
- [x] Confirm MCP `tools/list` description for `send_message` includes the compose / separate-DM warning after install from this branch

## Synthetic prompt

> Clarify that profile-based `send_message` is compose-oriented and may create a separate DM instead of replying in an existing recruiter/InMail thread. Update the tool docstring, README table, manifest description, and docker-hub messaging bullet. Do not change send behavior.

Generated with Composer