### PR TITLE
feat(jobs): Report why search_jobs pagination stopped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,6 @@ Optional additional keys:
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs and get_saved_jobs)
 - `pagination: {pages_fetched, next_offset, reason}` (search_jobs planned stops) — `reason` is `complete`, `max_pages`, `time_budget`, or `no_new_ids`. Hard failures use `section_errors` and omit this key.
-- `pagination: {pages_fetched, next_offset, reason}` (search_jobs planned stops) — `reason` is `complete`, `max_pages`, `time_budget`, or `no_new_ids`. Hard failures use `section_errors` and omit this key.
 - `references["feed"]` (get_feed only) — every entry is `kind: "feed_post"`; non-post anchors (sidebar profiles, employer logos) are filtered. URLs may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) form; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
 
 ## Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,8 @@ Optional additional keys:
 - `section_errors: {section_name: {error_type, error_message, issue_template_path, runtime, ...}}`
 - `unknown_sections: [name, ...]`
 - `job_ids: [id, ...]` (search_jobs and get_saved_jobs)
+- `pagination: {pages_fetched, next_offset, reason}` (search_jobs planned stops) — `reason` is `complete`, `max_pages`, `time_budget`, or `no_new_ids`. Hard failures use `section_errors` and omit this key.
+- `pagination: {pages_fetched, next_offset, reason}` (search_jobs planned stops) — `reason` is `complete`, `max_pages`, `time_budget`, or `no_new_ids`. Hard failures use `section_errors` and omit this key.
 - `references["feed"]` (get_feed only) — every entry is `kind: "feed_post"`; non-post anchors (sidebar profiles, employer logos) are filtered. URLs may carry either `/feed/update/<urn>/` (DOM-anchor-derived) or `/posts/<slug>` (SDUI-derived) form; both are valid LinkedIn permalinks. Cap is 50 entries, matching `get_feed`'s `num_posts` ceiling.
 
 ## Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,10 @@ for section_name, (suffix, is_overlay) in PERSON_SECTIONS.items():
 {"url": str, "sections": {name: raw_text}, "unknown_sections": [name, ...]}
 # search_jobs and get_saved_jobs also return:
 {"url": str, "sections": {name: raw_text}, "job_ids": [id, ...]}
+# search_jobs planned stops also return:
+{"url": str, "sections": {name: raw_text}, "job_ids": [id, ...],
+ "pagination": {"pages_fetched": int, "next_offset": int,
+                "reason": "complete"|"max_pages"|"time_budget"|"no_new_ids"}}
 ```
 
 `sections` remains the main readable payload. `references` is a compact supplement for entity/article traversal. LinkedIn references are emitted as relative paths to minimize token use.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3782,7 +3782,11 @@ class LinkedInExtractor:
             sort_by: Sort results (date, relevance)
 
         Returns:
-            {url, sections: {search_results: text}, job_ids: [str]}
+            {url, sections: {search_results: text}, job_ids: [str],
+            pagination: {pages_fetched, next_offset, reason}}. ``reason`` is
+            one of ``complete``, ``max_pages``, ``time_budget``, or
+            ``no_new_ids`` for planned stops. Hard failures still use
+            ``section_errors`` and omit ``pagination``.
         """
         base_url = self._build_job_search_url(
             keywords,
@@ -3806,6 +3810,12 @@ class LinkedInExtractor:
         filters_warning: dict[str, str] | None = None
         total_pages: int | None = None
         total_pages_queried = False
+        # Planned stop reason for the ``pagination`` key. Hard failures leave
+        # this unset and report via ``section_errors`` instead — those are not
+        # successful partial deliveries dressed as complete searches.
+        stop_reason: str | None = None
+        pages_fetched = 0
+        hard_stop = False
 
         # The search-wide scroll budget is spent as it goes rather than
         # divided up front, because dividing it charges every navigation for
@@ -3838,6 +3848,7 @@ class LinkedInExtractor:
                     offset,
                     total_pages,
                 )
+                stop_reason = "complete"
                 break
 
             elapsed = time.monotonic() - started
@@ -3850,6 +3861,7 @@ class LinkedInExtractor:
                     _NAV_DELAY + slowest_page,
                     budget,
                 )
+                stop_reason = "time_budget"
                 break
 
             if page_num > 0:
@@ -3893,10 +3905,17 @@ class LinkedInExtractor:
                 # is a successful answer to a different search.
                 if extracted.text == _RATE_LIMITED_MSG:
                     section_errors["search_results"] = rate_limited_section_error()
+                    hard_stop = True
                     break
                 if not extracted.text and extracted.error:
                     section_errors["search_results"] = extracted.error
+                    hard_stop = True
                     break
+
+                # Count only pages that passed extraction without a hard
+                # failure. Time-budget and advertised-complete stops happen
+                # before this navigation, so they leave the count alone.
+                pages_fetched += 1
 
                 # Prove the destination still represents the requested search
                 # before accepting even an empty result. The id extraction is
@@ -3972,6 +3991,7 @@ class LinkedInExtractor:
                     section_errors["search_results"] = lost_keywords_section_error(
                         asked_keywords, landed_keywords
                     )
+                    hard_stop = True
                     break
 
                 # Presence only for the rest, where the keywords are compared
@@ -4004,12 +4024,14 @@ class LinkedInExtractor:
                     section_errors["search_results"] = dropped_offset_section_error(
                         offset, self._page.url
                     )
+                    hard_stop = True
                     break
 
                 if not extracted.text:
                     # The route and query survived, so this is a real empty
                     # result rather than a redirect that silently replaced the
                     # search. Do not read ids from a DOM that supplied no text.
+                    stop_reason = "complete"
                     break
 
                 # Read total pages from pagination state (once only, best-effort)
@@ -4044,6 +4066,7 @@ class LinkedInExtractor:
                     if page_refs:
                         page_references.extend(page_refs)
                     logger.debug("No new job IDs on page %d, stopping", page_num + 1)
+                    stop_reason = "no_new_ids"
                     break
 
                 for jid in new_ids:
@@ -4064,6 +4087,7 @@ class LinkedInExtractor:
                     target_url=url,
                     section_name="search_results",
                 )
+                hard_stop = True
                 break
 
         result: dict[str, Any] = {
@@ -4090,6 +4114,20 @@ class LinkedInExtractor:
                 )
         if section_errors:
             result["section_errors"] = section_errors
+        # Planned stops only. A hard failure already explains itself in
+        # ``section_errors``; attaching ``pagination`` there would dress an
+        # interrupted search as a deliberate partial delivery.
+        # ``filters_dropped`` is a warning on kept results, not a hard stop.
+        if not hard_stop and (
+            stop_reason is not None or max_pages == 0 or pages_fetched > 0
+        ):
+            if stop_reason is None:
+                stop_reason = "max_pages" if pages_fetched >= max_pages else "complete"
+            result["pagination"] = {
+                "pages_fetched": pages_fetched,
+                "next_offset": offset,
+                "reason": stop_reason,
+            }
         return result
 
     async def _extract_saved_jobs_page(

--- a/linkedin_mcp_server/tools/job.py
+++ b/linkedin_mcp_server/tools/job.py
@@ -110,7 +110,10 @@ def register_job_tools(
 
         Returns:
             Dict with url, sections (name -> raw text), job_ids (list of
-            numeric job ID strings usable with get_job_details), and optional references.
+            numeric job ID strings usable with get_job_details), optional
+            references, and pagination ({pages_fetched, next_offset, reason})
+            explaining why paging stopped (complete, max_pages, time_budget,
+            or no_new_ids). Hard failures use section_errors instead.
         """
         try:
             # Before the browser, because FastMCP is already timing this call

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -3673,6 +3673,11 @@ class TestSearchJobs:
         # start=30, which is exactly what a stride regression would produce.
         page2 = parse_qs(urlparse(urls_visited[1]).query)
         assert page2["start"] == ["3"]  # page 1 rendered three cards
+        assert result["pagination"] == {
+            "pages_fetched": 2,
+            "next_offset": 5,
+            "reason": "max_pages",
+        }
 
     async def test_references_keep_all_jobs_beyond_the_per_section_cap(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
@@ -4152,6 +4157,8 @@ class TestSearchJobs:
             result["section_errors"]["search_results"]["error_type"]
             == "pagination_stopped"
         )
+        # Hard stop: planned ``pagination`` is omitted; section_errors explains.
+        assert "pagination" not in result
 
     async def test_no_new_id_page_can_upgrade_duplicate_metadata(self, mock_page):
         """The stopping page still contributes richer duplicate metadata."""
@@ -4227,6 +4234,11 @@ class TestSearchJobs:
                 },
             ]
         }
+        assert result["pagination"] == {
+            "pages_fetched": 2,
+            "next_offset": 4,
+            "reason": "no_new_ids",
+        }
 
     async def test_stops_once_past_the_advertised_results(self, mock_page):
         """Stop when the offset passes the last result LinkedIn advertises.
@@ -4270,6 +4282,11 @@ class TestSearchJobs:
         assert mock_extract.await_count == 1
         assert mock_total_pages.await_count == 1
         assert result["job_ids"] == [str(i) for i in range(25)]
+        assert result["pagination"] == {
+            "pages_fetched": 1,
+            "next_offset": 25,
+            "reason": "complete",
+        }
 
     async def test_the_scroll_budget_is_spent_and_not_divided(self, mock_page):
         """Asking for more pages must not shorten the first one.
@@ -4456,6 +4473,11 @@ class TestSearchJobs:
         # Seven pages end at 142.9s; an eighth would need 163.6s.
         assert len(seen) == 7
         assert result["job_ids"] == [jid for page in pages[:7] for jid in page]
+        assert result["pagination"] == {
+            "pages_fetched": 7,
+            "next_offset": 70,
+            "reason": "time_budget",
+        }
 
     async def test_the_next_navigation_delay_is_part_of_the_prediction(self, mock_page):
         """The guard budgets the delay before a page, not just the page.
@@ -4518,6 +4540,11 @@ class TestSearchJobs:
 
         assert len(seen) == 6
         assert result["job_ids"] == [jid for page in pages[:6] for jid in page]
+        assert result["pagination"] == {
+            "pages_fetched": 6,
+            "next_offset": 60,
+            "reason": "time_budget",
+        }
 
     async def test_zero_max_pages_fetches_nothing(self, mock_page):
         """max_pages=0 should fetch zero pages (validation at tool boundary)."""
@@ -4550,6 +4577,11 @@ class TestSearchJobs:
 
         assert result["job_ids"] == []
         assert mock_extract.await_count == 0
+        assert result["pagination"] == {
+            "pages_fetched": 0,
+            "next_offset": 0,
+            "reason": "max_pages",
+        }
 
     async def test_single_page(self, mock_page):
         """max_pages=1 should only visit one page; filters appear in URL."""
@@ -4594,6 +4626,11 @@ class TestSearchJobs:
         assert "f_WT=2" in result["url"]
         assert "f_EA=true" in result["url"]
         assert mock_extract.await_count == 1
+        assert result["pagination"] == {
+            "pages_fetched": 1,
+            "next_offset": 1,
+            "reason": "max_pages",
+        }
 
     async def test_page_texts_joined_with_separator(self, mock_page):
         """Multiple pages should join text with --- separator."""


### PR DESCRIPTION
## Summary
Closes #756.

`search_jobs` already stops early for a wall-clock budget, `max_pages`, repeated ids, or an empty/exhausted result set, but the response shape matched a search that simply ran out of LinkedIn results. Callers could not tell whether to resume, narrow, or treat the list as complete.

Adds a planned-stop `pagination` key:

```json
{
  "pages_fetched": 4,
  "next_offset": 40,
  "reason": "time_budget"
}
```

`reason` is one of `complete`, `max_pages`, `time_budget`, or `no_new_ids`. Hard failures (rate limit, dropped offset, lost keywords, extraction errors) still use `section_errors` and omit `pagination`, so a deliberate partial delivery is not confused with an interrupted one. A `filters_dropped` warning on kept results still gets `pagination`.

Docs updated in the tool docstring, `AGENTS.md` / `CONTRIBUTING.md` return-format notes.

## Test plan
- [x] `uv run ruff check` / `ruff format` on touched Python
- [x] `uv run ty check` on touched Python
- [x] `uv run pytest tests/test_scraping.py -k "TestSearchJobs or search_jobs"` (38 passed)
- [x] Assertions covering `time_budget`, `max_pages`, `no_new_ids`, `complete`, and hard-stop omission of `pagination`

## Synthetic prompt

> search_jobs stops for time budget, max_pages, no new ids, or exhausted results but returns the same shape as a complete search. Add a pagination key with pages_fetched, next_offset, and reason (complete|max_pages|time_budget|no_new_ids) for planned stops only; keep hard failures on section_errors. Update docs and tests.

Generated with Composer