### PR TITLE
feat(server): Add optional minimum interval between MCP tool calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ TIMEOUT=5000
 # cold-start Chromium) hit the FastMCP "Tool ... execution timed out" error.
 TOOL_TIMEOUT=180.0
 
+# Minimum seconds between MCP tool-call starts (0 = disabled). Waits rather
+# than failing; does not hold the browser lease while waiting.
+# MIN_TOOL_INTERVAL=15
+
 # Manual login wait timeout in seconds (default: 1800; 0 = no limit)
 # How long the --login browser window waits for you to finish signing in
 # (including 2FA, captcha, and security challenges) before giving up.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ AI agent? Get a quick confirmation from the user before enabling automatic updat
 - `--host HOST` / `--port PORT` / `--path PATH` - HTTP server address (defaults: 127.0.0.1, 8000, /mcp)
 - `--timeout MS` - Timeout for a single page operation (default: 5000)
 - `--tool-timeout SECONDS` - Timeout for a whole tool call (default: 180). Raise it for heavy scrapes, slow networks, or a cold-start browser.
+- `--min-tool-interval SECONDS` - Minimum seconds between MCP tool-call starts (default: 0 = off). Waits rather than failing; does not hold the browser lease while waiting. Also `MIN_TOOL_INTERVAL`.
 - `--login-timeout SECONDS` - How long the login browser waits for you to finish signing in (default: 1800; 0 = no limit). `--login-viewer` ends the session after 30 minutes either way.
 - `--login-viewer` - Docker only: show the `--login` browser at a token-protected URL on port 6080 (see [Authentication](#authentication))
 - `--login-inline-wait SECONDS` - How long a tool call waits for a login to finish before telling the model to retry (default: 25, max 45; 0 = return at once)
@@ -400,6 +401,7 @@ username.
 - `--logout` - Clear the stored session and every profile derived from it
 - `--timeout MS` - Timeout for a single page operation (default: 5000)
 - `--tool-timeout SECONDS` - Timeout for a whole tool call (default: 180). Raise it for heavy scrapes, slow networks, or a cold-start browser.
+- `--min-tool-interval SECONDS` - Minimum seconds between MCP tool-call starts (default: 0 = off). Waits rather than failing; does not hold the browser lease while waiting. Also `MIN_TOOL_INTERVAL`.
 - `--login-timeout SECONDS` - How long the login browser waits for you to finish signing in (default: 1800; 0 = no limit). `--login-viewer` ends the session after 30 minutes either way.
 - `--login-viewer` - With `--login`, show the login browser at a token-protected URL on port 6080. Needs the profile mount from [Authentication](#authentication).
 - `--login-inline-wait SECONDS` - How long a tool call waits for a login to finish before telling the model to retry (default: 25, max 45; 0 = return at once)
@@ -590,6 +592,7 @@ The local server uses the same managed-runtime flow as MCPB and `uvx`: it prepar
 - `--host HOST` / `--port PORT` / `--path PATH` - HTTP server address (defaults: 127.0.0.1, 8000, /mcp)
 - `--timeout MS` - Timeout for a single page operation (default: 5000)
 - `--tool-timeout SECONDS` - Timeout for a whole tool call (default: 180). Raise it for heavy scrapes, slow networks, or a cold-start browser.
+- `--min-tool-interval SECONDS` - Minimum seconds between MCP tool-call starts (default: 0 = off). Waits rather than failing; does not hold the browser lease while waiting. Also `MIN_TOOL_INTERVAL`.
 - `--user-data-dir PATH` - Browser profile directory (default: ~/.linkedin-mcp/profile). Rotating or clearing a session deletes this directory *and its parent*, which holds the stored cookies and derived profiles.
 - `--claim-profile-root` - Take over a profile directory the server will not claim on its own, such as one whose parent already holds other files. Needed once per directory.
 - `--slow-mo MS` - Delay between browser actions (default: 0, useful for debugging)

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ AI agent? Get a quick confirmation from the user before enabling automatic updat
 - `--host HOST` / `--port PORT` / `--path PATH` - HTTP server address (defaults: 127.0.0.1, 8000, /mcp)
 - `--timeout MS` - Timeout for a single page operation (default: 5000)
 - `--tool-timeout SECONDS` - Timeout for a whole tool call (default: 180). Raise it for heavy scrapes, slow networks, or a cold-start browser.
-- `--min-tool-interval SECONDS` - Minimum seconds between MCP tool-call starts (default: 0 = off). Waits rather than failing; does not hold the browser lease while waiting. Also `MIN_TOOL_INTERVAL`.
+- `--min-tool-interval SECONDS` - Minimum seconds between MCP tool-call starts (default: 0 = off). Waits rather than failing; does not hold the browser lease while waiting. In daemon mode a single wait cannot exceed the frontend's 30s proxy margin (or the call errors instead of hanging). Also `MIN_TOOL_INTERVAL`.
 - `--login-timeout SECONDS` - How long the login browser waits for you to finish signing in (default: 1800; 0 = no limit). `--login-viewer` ends the session after 30 minutes either way.
 - `--login-viewer` - Docker only: show the `--login` browser at a token-protected URL on port 6080 (see [Authentication](#authentication))
 - `--login-inline-wait SECONDS` - How long a tool call waits for a login to finish before telling the model to retry (default: 25, max 45; 0 = return at once)
@@ -401,7 +401,7 @@ username.
 - `--logout` - Clear the stored session and every profile derived from it
 - `--timeout MS` - Timeout for a single page operation (default: 5000)
 - `--tool-timeout SECONDS` - Timeout for a whole tool call (default: 180). Raise it for heavy scrapes, slow networks, or a cold-start browser.
-- `--min-tool-interval SECONDS` - Minimum seconds between MCP tool-call starts (default: 0 = off). Waits rather than failing; does not hold the browser lease while waiting. Also `MIN_TOOL_INTERVAL`.
+- `--min-tool-interval SECONDS` - Minimum seconds between MCP tool-call starts (default: 0 = off). Waits rather than failing; does not hold the browser lease while waiting. In daemon mode a single wait cannot exceed the frontend's 30s proxy margin (or the call errors instead of hanging). Also `MIN_TOOL_INTERVAL`.
 - `--login-timeout SECONDS` - How long the login browser waits for you to finish signing in (default: 1800; 0 = no limit). `--login-viewer` ends the session after 30 minutes either way.
 - `--login-viewer` - With `--login`, show the login browser at a token-protected URL on port 6080. Needs the profile mount from [Authentication](#authentication).
 - `--login-inline-wait SECONDS` - How long a tool call waits for a login to finish before telling the model to retry (default: 25, max 45; 0 = return at once)
@@ -592,7 +592,7 @@ The local server uses the same managed-runtime flow as MCPB and `uvx`: it prepar
 - `--host HOST` / `--port PORT` / `--path PATH` - HTTP server address (defaults: 127.0.0.1, 8000, /mcp)
 - `--timeout MS` - Timeout for a single page operation (default: 5000)
 - `--tool-timeout SECONDS` - Timeout for a whole tool call (default: 180). Raise it for heavy scrapes, slow networks, or a cold-start browser.
-- `--min-tool-interval SECONDS` - Minimum seconds between MCP tool-call starts (default: 0 = off). Waits rather than failing; does not hold the browser lease while waiting. Also `MIN_TOOL_INTERVAL`.
+- `--min-tool-interval SECONDS` - Minimum seconds between MCP tool-call starts (default: 0 = off). Waits rather than failing; does not hold the browser lease while waiting. In daemon mode a single wait cannot exceed the frontend's 30s proxy margin (or the call errors instead of hanging). Also `MIN_TOOL_INTERVAL`.
 - `--user-data-dir PATH` - Browser profile directory (default: ~/.linkedin-mcp/profile). Rotating or clearing a session deletes this directory *and its parent*, which holds the stored cookies and derived profiles.
 - `--claim-profile-root` - Take over a profile directory the server will not claim on its own, such as one whose parent already holds other files. Needed once per directory.
 - `--slow-mo MS` - Delay between browser actions (default: 0, useful for debugging)

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -136,6 +136,7 @@ class EnvironmentKeys:
     PROXY_BYPASS = "PROXY_BYPASS"
     USER_DATA_DIR = "USER_DATA_DIR"
     TOOL_TIMEOUT = "TOOL_TIMEOUT"
+    MIN_TOOL_INTERVAL = "MIN_TOOL_INTERVAL"
     LOGIN_TIMEOUT = "LOGIN_TIMEOUT"
     LOGIN_INLINE_WAIT = "LOGIN_INLINE_WAIT"
     BROWSER_WAIT = "BROWSER_WAIT"
@@ -273,6 +274,24 @@ def load_from_env(config: AppConfig) -> AppConfig:
                 f"Invalid TOOL_TIMEOUT: '{tool_timeout_env}'. Must be a positive finite number."
             )
         config.server.tool_timeout_seconds = tool_timeout_value
+
+    # Minimum seconds between MCP tool-call starts; 0 = disabled (validated in
+    # ServerConfig.validate())
+    if min_tool_interval_env := os.environ.get(EnvironmentKeys.MIN_TOOL_INTERVAL):
+        try:
+            min_tool_interval_value = float(min_tool_interval_env)
+        except ValueError:
+            raise ConfigurationError(
+                f"Invalid MIN_TOOL_INTERVAL: '{min_tool_interval_env}'. Must be a number."
+            )
+        if not (
+            math.isfinite(min_tool_interval_value) and min_tool_interval_value >= 0
+        ):
+            raise ConfigurationError(
+                f"Invalid MIN_TOOL_INTERVAL: '{min_tool_interval_env}'. "
+                "Must be a non-negative finite number (0 = disabled)."
+            )
+        config.server.min_tool_interval_seconds = min_tool_interval_value
 
     # Manual-login wait timeout in seconds; 0 = no limit (validated in
     # BrowserConfig.validate())
@@ -525,6 +544,17 @@ def load_from_args(config: AppConfig) -> AppConfig:
         default=None,
         metavar="SECONDS",
         help="Per-tool MCP execution timeout in seconds (default: 180.0)",
+    )
+
+    parser.add_argument(
+        "--min-tool-interval",
+        type=non_negative_float,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Minimum seconds between MCP tool-call starts (default: 0 = disabled; "
+            "max 3600). Waits rather than failing; does not hold the browser lease"
+        ),
     )
 
     parser.add_argument(
@@ -787,6 +817,9 @@ def load_from_args(config: AppConfig) -> AppConfig:
 
     if args.tool_timeout is not None:
         config.server.tool_timeout_seconds = args.tool_timeout
+
+    if args.min_tool_interval is not None:
+        config.server.min_tool_interval_seconds = args.min_tool_interval
 
     if args.login_timeout is not None:
         config.browser.login_timeout_seconds = args.login_timeout

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -514,8 +514,7 @@ class AppConfig:
         # longer than the timeout can never be honoured by waiting, so clamp.
         if (
             self.server.min_tool_interval_seconds > 0
-            and self.server.min_tool_interval_seconds
-            > self.server.tool_timeout_seconds
+            and self.server.min_tool_interval_seconds > self.server.tool_timeout_seconds
         ):
             logger.warning(
                 "min_tool_interval_seconds %.1f exceeds tool_timeout_seconds "

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -22,6 +22,10 @@ DEFAULT_LOGIN_INLINE_WAIT_SECONDS: float = 25.0  # bounded inline wait
 # call and the smallest MCP client timeout is ~60s, so the wait alone must stay
 # well under that floor.
 MAX_LOGIN_INLINE_WAIT_SECONDS: float = 45.0
+# Optional pacing between MCP tool-call starts. 0 disables. Above an hour is
+# almost certainly a misconfiguration rather than a deliberate throttle.
+DEFAULT_MIN_TOOL_INTERVAL_SECONDS: float = 0.0
+MAX_MIN_TOOL_INTERVAL_SECONDS: float = 3600.0
 
 # How long a tool call waits for another process to hand over the browser. Same
 # budget and ceiling as the login inline wait, for the same reason: the wait is
@@ -433,6 +437,9 @@ class ServerConfig:
     port: int = 8000
     path: str = "/mcp"
     tool_timeout_seconds: float = DEFAULT_TOOL_TIMEOUT_SECONDS
+    # Minimum seconds between MCP tool-call starts. 0 disables. Enforced by
+    # SequentialToolExecutionMiddleware without holding the profile lease.
+    min_tool_interval_seconds: float = DEFAULT_MIN_TOOL_INTERVAL_SECONDS
     # Serve every stdio client from one browser-owning process instead of
     # giving each its own. Off while the supervision and liveness work is
     # unfinished: an owner that outlives its client must be provably unable to
@@ -448,6 +455,21 @@ class ServerConfig:
             raise ConfigurationError(
                 f"tool_timeout_seconds must be a positive finite number, got {self.tool_timeout_seconds}"
             )
+        if not (
+            math.isfinite(self.min_tool_interval_seconds)
+            and self.min_tool_interval_seconds >= 0
+        ):
+            raise ConfigurationError(
+                "min_tool_interval_seconds must be a non-negative finite number, "
+                f"got {self.min_tool_interval_seconds}"
+            )
+        if self.min_tool_interval_seconds > MAX_MIN_TOOL_INTERVAL_SECONDS:
+            logger.warning(
+                "min_tool_interval_seconds %.1f exceeds the %.1fs ceiling; clamping.",
+                self.min_tool_interval_seconds,
+                MAX_MIN_TOOL_INTERVAL_SECONDS,
+            )
+            self.min_tool_interval_seconds = MAX_MIN_TOOL_INTERVAL_SECONDS
         if self.login_viewer:
             if not self.login:
                 raise ConfigurationError("--login-viewer requires --login")

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -518,7 +518,8 @@ class AppConfig:
         ):
             logger.warning(
                 "min_tool_interval_seconds %.1f exceeds tool_timeout_seconds "
-                "%.1f; clamping (pacing shares the call's timeout budget).",
+                "%.1f; clamping (a paced wait still has to leave room for the "
+                "tool inside the daemon frontend deadline).",
                 self.server.min_tool_interval_seconds,
                 self.server.tool_timeout_seconds,
             )

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -510,6 +510,20 @@ class AppConfig:
         """Validate all configuration values. Call after modifying config."""
         self.browser.validate()
         self.server.validate()
+        # Interval wait shares each call's tool-timeout budget. An interval
+        # longer than the timeout can never be honoured by waiting, so clamp.
+        if (
+            self.server.min_tool_interval_seconds > 0
+            and self.server.min_tool_interval_seconds
+            > self.server.tool_timeout_seconds
+        ):
+            logger.warning(
+                "min_tool_interval_seconds %.1f exceeds tool_timeout_seconds "
+                "%.1f; clamping (pacing shares the call's timeout budget).",
+                self.server.min_tool_interval_seconds,
+                self.server.tool_timeout_seconds,
+            )
+            self.server.min_tool_interval_seconds = self.server.tool_timeout_seconds
         if self.server.transport == "streamable-http":
             self._validate_transport_config()
             self._validate_path_format()

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -315,7 +315,7 @@ class FrontendAuthRepairMiddleware(Middleware):
             # showed why. Bounding it locally left the owner finishing the
             # mutation after the frontend had reported failure: cancellation is
             # not forwarded across the hop, which
-            # `daemon_proxy._TIMEOUT_MARGIN_SECONDS` already records. Measured
+            # `daemon_proxy.TIMEOUT_MARGIN_SECONDS` already records. Measured
             # over a real loopback owner, the client was answered at 0.66s with
             # an error and the effect landed 0.7s later. Removing the bound only
             # moved the deadline: an MCP client that gives up on its own call

--- a/linkedin_mcp_server/daemon_config.py
+++ b/linkedin_mcp_server/daemon_config.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
 #: whole section: transport, host, port and the one-shot flags all describe the
 #: *frontend's* invocation, and an owner that adopted them would try to run the
 #: client's transport or re-run its ``--login``.
-_SERVER_FIELDS = ("tool_timeout_seconds", "log_level")
+_SERVER_FIELDS = ("tool_timeout_seconds", "min_tool_interval_seconds", "log_level")
 STARTUP_PROTOCOL_VERSION = 3
 _PREDECESSOR_STARTUP_PROTOCOL_VERSION = 1
 _PIPE_COMMIT_STARTUP_PROTOCOL_VERSION = 2

--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -809,6 +809,7 @@ def config_fingerprint(config: AppConfig, *, key: str) -> str:
         for name in SHARED_CONFIG_FIELDS
     }
     material["tool_timeout_seconds"] = config.server.tool_timeout_seconds
+    material["min_tool_interval_seconds"] = config.server.min_tool_interval_seconds
     return hmac.new(
         key.encode("utf-8"), _canonical(material).encode("utf-8"), hashlib.sha256
     ).hexdigest()
@@ -828,6 +829,11 @@ def mismatched_fields(config: AppConfig, other: AppConfig) -> tuple[str, ...]:
     ]
     if config.server.tool_timeout_seconds != other.server.tool_timeout_seconds:
         differing.append("tool_timeout_seconds")
+    if (
+        config.server.min_tool_interval_seconds
+        != other.server.min_tool_interval_seconds
+    ):
+        differing.append("min_tool_interval_seconds")
     return tuple(differing)
 
 

--- a/linkedin_mcp_server/daemon_proxy.py
+++ b/linkedin_mcp_server/daemon_proxy.py
@@ -106,7 +106,12 @@ _call_being_made: contextvars.ContextVar[_CallBinding | None] = contextvars.Cont
 #: waiting its turn, and because cancellation is not forwarded, the owner may go
 #: on scraping afterwards. That is the orphaned call #606 names, and the heartbeat
 #: is what will bound it.
-_TIMEOUT_MARGIN_SECONDS = 30.0
+#:
+#: Middleware that runs *outside* that tool ``fail_after`` (the min-tool-interval
+#: wait) may only spend this margin: wait + tool execution must fit inside
+#: ``tool_timeout + TIMEOUT_MARGIN_SECONDS``.
+TIMEOUT_MARGIN_SECONDS = 30.0
+
 
 #: The provider's component cache, switched off. FastMCP's default is 300
 #: seconds and this module used to take it, on the stated grounds that an owner's
@@ -567,7 +572,7 @@ def create_proxy_provider(
     """Serve the owner's tools as if they were this server's own."""
     from fastmcp.server.providers.proxy import ProxyProvider
 
-    timeout = tool_timeout + _TIMEOUT_MARGIN_SECONDS
+    timeout = tool_timeout + TIMEOUT_MARGIN_SECONDS
     logger.debug(
         "Forwarding tool calls to the shared browser owner at %s (deadline %.0fs)",
         backend.attachment.descriptor.url,

--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -17,9 +17,19 @@ from linkedin_mcp_server.daemon_proxy import TIMEOUT_MARGIN_SECONDS
 from linkedin_mcp_server.exceptions import BrowserBusyError
 from linkedin_mcp_server.profile_lease import get_profile_lease
 from linkedin_mcp_server.server_role import ServerRole, process_role
-from linkedin_mcp_server.tool_interval import try_claim_start
+from linkedin_mcp_server.tool_interval import (
+    force_claim_start,
+    future_stamp_skew_seconds,
+    try_claim_start,
+)
 
 logger = logging.getLogger(__name__)
+
+# Leave this much of the owner's pre-tool margin for raising and proxying a
+# ToolError after a contended lease wait. Spending the entire remainder on
+# ``lease.acquire`` lets the frontend deadline expire first and surfaces a
+# transport timeout instead of the structured error (#877).
+_PRE_TOOL_RESPONSE_RESERVE_SECONDS = 2.0
 
 
 class SequentialToolExecutionMiddleware(Middleware):
@@ -146,6 +156,35 @@ class SequentialToolExecutionMiddleware(Middleware):
             if wait <= 0:
                 self._last_start_mono = time.monotonic()
                 return
+            remaining = deadline - time.monotonic()
+            skew = future_stamp_skew_seconds(auth_root)
+            # A stamp farther ahead than this call can wait will never
+            # converge inside the budget: each retry only chips interval-
+            # sized pieces off the skew and then raises. Pace once, claim
+            # at local time, and proceed.
+            if skew > remaining:
+                pace = min(interval, max(0.0, remaining))
+                logger.debug(
+                    "Tool '%s' absorbing %.1fs future stamp skew "
+                    "(%.1fs budget left) with a %.1fs pace then claiming "
+                    "locally",
+                    tool_name,
+                    skew,
+                    remaining,
+                    pace,
+                )
+                if pace > 0:
+                    await self._sleep_reporting(
+                        context,
+                        pace,
+                        message=(
+                            f"Waiting {pace:.1f}s for minimum tool-call "
+                            "interval (shared profile clock skew)"
+                        ),
+                    )
+                force_claim_start(auth_root)
+                self._last_start_mono = time.monotonic()
+                return
             logger.debug(
                 "Tool '%s' waiting %.3fs for cross-process min interval",
                 tool_name,
@@ -230,13 +269,18 @@ class SequentialToolExecutionMiddleware(Middleware):
             budget = get_config().browser.browser_wait_seconds
             if pre_tool_deadline is not None:
                 remaining = pre_tool_deadline - time.monotonic()
-                if remaining <= 0:
+                usable = remaining - _PRE_TOOL_RESPONSE_RESERVE_SECONDS
+                if usable <= 0:
                     raise ToolError(
                         "The daemon proxy margin was spent waiting for the "
                         "minimum tool-call interval, with no time left to "
                         "wait for the shared browser. Retry shortly."
                     )
-                budget = min(budget, remaining)
+                # Keep a slice of the margin for constructing and delivering
+                # the ToolError if acquire times out; otherwise the frontend
+                # deadline expires first and the client sees a transport
+                # failure instead of BrowserBusyError.
+                budget = min(budget, usable)
             acquired = await lease.acquire(timeout=budget)
 
         if not acquired:

--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -166,8 +166,8 @@ class SequentialToolExecutionMiddleware(Middleware):
                 pace = min(interval, max(0.0, remaining))
                 logger.debug(
                     "Tool '%s' absorbing %.1fs future stamp skew "
-                    "(%.1fs budget left) with a %.1fs pace then claiming "
-                    "locally",
+                    "(%.1fs budget left) with a %.1fs pace then proceeding "
+                    "without rewinding the shared stamp",
                     tool_name,
                     skew,
                     remaining,

--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -13,6 +13,7 @@ from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import ToolResult
 
 from linkedin_mcp_server.config import get_config
+from linkedin_mcp_server.daemon_proxy import TIMEOUT_MARGIN_SECONDS
 from linkedin_mcp_server.exceptions import BrowserBusyError
 from linkedin_mcp_server.profile_lease import get_profile_lease
 from linkedin_mcp_server.tool_interval import try_claim_start
@@ -89,12 +90,14 @@ class SequentialToolExecutionMiddleware(Middleware):
         if interval <= 0:
             return
 
-        # Pacing shares this call's tool-timeout budget with the scrape. The
-        # daemon frontend's deadline is that budget plus a fixed margin, so a
-        # wait longer than the tool timeout makes the frontend give up while
-        # the owner is still sleeping — the opposite of "wait rather than
-        # fail". Refuse when the remaining wait cannot fit.
-        budget = config.tool_timeout_seconds
+        # The interval wait runs in middleware *before* FastMCP's tool
+        # ``fail_after(tool_timeout)``. The daemon frontend's deadline is
+        # ``tool_timeout + TIMEOUT_MARGIN_SECONDS``, so the wait may only
+        # spend that margin — otherwise the tool can still take a full
+        # timeout and the client sees a transport failure instead of a
+        # result or a pacing error. Refuse when the remaining wait cannot
+        # fit.
+        budget = TIMEOUT_MARGIN_SECONDS
         wait_started = time.monotonic()
 
         async def sleep_within_budget(seconds: float, *, message: str) -> None:
@@ -104,8 +107,9 @@ class SequentialToolExecutionMiddleware(Middleware):
             if seconds > remaining:
                 raise ToolError(
                     f"Minimum tool-call interval ({interval:g}s) has not "
-                    f"elapsed, and waiting would exceed this call's "
-                    f"{budget:g}s tool timeout. Retry shortly."
+                    f"elapsed, and waiting would exceed the {budget:g}s "
+                    f"daemon proxy margin reserved beyond the tool timeout. "
+                    f"Retry shortly."
                 )
             await self._sleep_reporting(context, seconds, message=message)
 

--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -16,6 +16,7 @@ from linkedin_mcp_server.config import get_config
 from linkedin_mcp_server.daemon_proxy import TIMEOUT_MARGIN_SECONDS
 from linkedin_mcp_server.exceptions import BrowserBusyError
 from linkedin_mcp_server.profile_lease import get_profile_lease
+from linkedin_mcp_server.server_role import ServerRole, process_role
 from linkedin_mcp_server.tool_interval import try_claim_start
 
 logger = logging.getLogger(__name__)
@@ -83,32 +84,42 @@ class SequentialToolExecutionMiddleware(Middleware):
         self,
         context: MiddlewareContext[mt.CallToolRequestParams],
         tool_name: str,
+        *,
+        deadline: float | None = None,
     ) -> None:
-        """Wait until this tool call may start under the configured interval."""
+        """Wait until this tool call may start under the configured interval.
+
+        ``deadline`` is an absolute monotonic end for pre-tool waiting. Daemon
+        owners pass the frontend's proxy margin; a standalone DIRECT server
+        leaves it ``None`` and uses the tool timeout instead, because there is
+        no proxy deadline to protect.
+        """
         config = get_config().server
         interval = config.min_tool_interval_seconds
         if interval <= 0:
             return
 
-        # The interval wait runs in middleware *before* FastMCP's tool
-        # ``fail_after(tool_timeout)``. The daemon frontend's deadline is
-        # ``tool_timeout + TIMEOUT_MARGIN_SECONDS``, so the wait may only
-        # spend that margin — otherwise the tool can still take a full
-        # timeout and the client sees a transport failure instead of a
-        # result or a pacing error. Refuse when the remaining wait cannot
-        # fit.
-        budget = TIMEOUT_MARGIN_SECONDS
-        wait_started = time.monotonic()
+        if deadline is None:
+            # DIRECT: middleware runs before FastMCP's fail_after, and there is
+            # no daemon frontend. Waiting the full configured interval is the
+            # documented "wait rather than fail" behaviour; the tool timeout is
+            # the interval's ceiling (see ServerConfig.validate).
+            deadline = time.monotonic() + config.tool_timeout_seconds
+            budget_label = f"{config.tool_timeout_seconds:g}s tool timeout"
+        else:
+            budget_label = (
+                f"{TIMEOUT_MARGIN_SECONDS:g}s daemon proxy margin "
+                "reserved beyond the tool timeout"
+            )
 
         async def sleep_within_budget(seconds: float, *, message: str) -> None:
             if seconds <= 0:
                 return
-            remaining = budget - (time.monotonic() - wait_started)
+            remaining = deadline - time.monotonic()
             if seconds > remaining:
                 raise ToolError(
                     f"Minimum tool-call interval ({interval:g}s) has not "
-                    f"elapsed, and waiting would exceed the {budget:g}s "
-                    f"daemon proxy margin reserved beyond the tool timeout. "
+                    f"elapsed, and waiting would exceed the {budget_label}. "
                     f"Retry shortly."
                 )
             await self._sleep_reporting(context, seconds, message=message)
@@ -173,14 +184,30 @@ class SequentialToolExecutionMiddleware(Middleware):
                 message="Scraper lock acquired, starting tool",
             )
             # Interval before the lease: waiting must not pin the browser.
-            await self._await_min_interval(context, tool_name)
-            return await self._run_owning_the_profile(context, call_next, tool_name)
+            # On the daemon owner the frontend's deadline is
+            # tool_timeout + TIMEOUT_MARGIN_SECONDS; everything before the
+            # tool body — interval wait *and* contended lease acquisition —
+            # shares that margin, or the client sees a transport timeout.
+            pre_tool_deadline: float | None = None
+            if process_role() is ServerRole.OWNER:
+                pre_tool_deadline = time.monotonic() + TIMEOUT_MARGIN_SECONDS
+            await self._await_min_interval(
+                context, tool_name, deadline=pre_tool_deadline
+            )
+            return await self._run_owning_the_profile(
+                context,
+                call_next,
+                tool_name,
+                pre_tool_deadline=pre_tool_deadline,
+            )
 
     async def _run_owning_the_profile(
         self,
         context: MiddlewareContext[mt.CallToolRequestParams],
         call_next: CallNext[mt.CallToolRequestParams, ToolResult],
         tool_name: str,
+        *,
+        pre_tool_deadline: float | None = None,
     ) -> ToolResult:
         """Run the tool while this process owns the browser profile."""
         # Imported here so the module stays importable without the driver.
@@ -201,6 +228,15 @@ class SequentialToolExecutionMiddleware(Middleware):
                 ),
             )
             budget = get_config().browser.browser_wait_seconds
+            if pre_tool_deadline is not None:
+                remaining = pre_tool_deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ToolError(
+                        "The daemon proxy margin was spent waiting for the "
+                        "minimum tool-call interval, with no time left to "
+                        "wait for the shared browser. Retry shortly."
+                    )
+                budget = min(budget, remaining)
             acquired = await lease.acquire(timeout=budget)
 
         if not acquired:

--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -84,9 +84,30 @@ class SequentialToolExecutionMiddleware(Middleware):
         tool_name: str,
     ) -> None:
         """Wait until this tool call may start under the configured interval."""
-        interval = get_config().server.min_tool_interval_seconds
+        config = get_config().server
+        interval = config.min_tool_interval_seconds
         if interval <= 0:
             return
+
+        # Pacing shares this call's tool-timeout budget with the scrape. The
+        # daemon frontend's deadline is that budget plus a fixed margin, so a
+        # wait longer than the tool timeout makes the frontend give up while
+        # the owner is still sleeping — the opposite of "wait rather than
+        # fail". Refuse when the remaining wait cannot fit.
+        budget = config.tool_timeout_seconds
+        wait_started = time.monotonic()
+
+        async def sleep_within_budget(seconds: float, *, message: str) -> None:
+            if seconds <= 0:
+                return
+            remaining = budget - (time.monotonic() - wait_started)
+            if seconds > remaining:
+                raise ToolError(
+                    f"Minimum tool-call interval ({interval:g}s) has not "
+                    f"elapsed, and waiting would exceed this call's "
+                    f"{budget:g}s tool timeout. Retry shortly."
+                )
+            await self._sleep_reporting(context, seconds, message=message)
 
         if self._last_start_mono is not None:
             mono_wait = interval - (time.monotonic() - self._last_start_mono)
@@ -96,8 +117,7 @@ class SequentialToolExecutionMiddleware(Middleware):
                     tool_name,
                     mono_wait,
                 )
-                await self._sleep_reporting(
-                    context,
+                await sleep_within_budget(
                     mono_wait,
                     message=(
                         f"Waiting {mono_wait:.1f}s for minimum tool-call interval"
@@ -116,8 +136,7 @@ class SequentialToolExecutionMiddleware(Middleware):
                 tool_name,
                 wait,
             )
-            await self._sleep_reporting(
-                context,
+            await sleep_within_budget(
                 wait,
                 message=(
                     f"Waiting {wait:.1f}s for minimum tool-call interval "

--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -15,6 +15,7 @@ from fastmcp.tools import ToolResult
 from linkedin_mcp_server.config import get_config
 from linkedin_mcp_server.exceptions import BrowserBusyError
 from linkedin_mcp_server.profile_lease import get_profile_lease
+from linkedin_mcp_server.tool_interval import try_claim_start
 
 logger = logging.getLogger(__name__)
 
@@ -31,10 +32,15 @@ class SequentialToolExecutionMiddleware(Middleware):
 
     Without the second layer two processes open that profile simultaneously and
     the last one to close silently overwrites the other's cookies.
+
+    An optional minimum interval between tool-call starts (see
+    ``min_tool_interval_seconds``) is enforced after the in-process lock and
+    before the profile lease, so waiting never holds the browser.
     """
 
     def __init__(self) -> None:
         self._lock = asyncio.Lock()
+        self._last_start_mono: float | None = None
 
     async def _report_progress(
         self,
@@ -51,6 +57,73 @@ class SequentialToolExecutionMiddleware(Middleware):
             total=100,
             message=message,
         )
+
+    async def _sleep_reporting(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        seconds: float,
+        *,
+        message: str,
+    ) -> None:
+        """Sleep *seconds*, honouring cancellation and reporting progress."""
+        if seconds <= 0:
+            return
+        await self._report_progress(context, message=message)
+        # Chunk so a cancel reaches the waiter without waiting out the full
+        # interval, and so progress can be re-announced on long waits.
+        deadline = time.monotonic() + seconds
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            await asyncio.sleep(min(remaining, 0.5))
+
+    async def _await_min_interval(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        tool_name: str,
+    ) -> None:
+        """Wait until this tool call may start under the configured interval."""
+        interval = get_config().server.min_tool_interval_seconds
+        if interval <= 0:
+            return
+
+        if self._last_start_mono is not None:
+            mono_wait = interval - (time.monotonic() - self._last_start_mono)
+            if mono_wait > 0:
+                logger.debug(
+                    "Tool '%s' waiting %.3fs for in-process min interval",
+                    tool_name,
+                    mono_wait,
+                )
+                await self._sleep_reporting(
+                    context,
+                    mono_wait,
+                    message=(
+                        f"Waiting {mono_wait:.1f}s for minimum tool-call interval"
+                    ),
+                )
+
+        lease = get_profile_lease()
+        auth_root = lease.auth_root
+        while True:
+            wait = try_claim_start(auth_root, interval)
+            if wait <= 0:
+                self._last_start_mono = time.monotonic()
+                return
+            logger.debug(
+                "Tool '%s' waiting %.3fs for cross-process min interval",
+                tool_name,
+                wait,
+            )
+            await self._sleep_reporting(
+                context,
+                wait,
+                message=(
+                    f"Waiting {wait:.1f}s for minimum tool-call interval "
+                    "(shared profile)"
+                ),
+            )
 
     async def on_call_tool(
         self,
@@ -76,6 +149,8 @@ class SequentialToolExecutionMiddleware(Middleware):
                 context,
                 message="Scraper lock acquired, starting tool",
             )
+            # Interval before the lease: waiting must not pin the browser.
+            await self._await_min_interval(context, tool_name)
             return await self._run_owning_the_profile(context, call_next, tool_name)
 
     async def _run_owning_the_profile(

--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -211,6 +211,15 @@ class SequentialToolExecutionMiddleware(Middleware):
             message="Queued waiting for scraper lock",
         )
 
+        # Capture the owner pre-tool budget *before* queueing on the
+        # in-process lock so lock wait counts against the frontend margin
+        # (#877 / Greptile). Creating it after acquire would let queued
+        # owner calls outlive the proxy deadline and surface a transport
+        # timeout instead of a structured ToolError.
+        pre_tool_deadline: float | None = None
+        if process_role() is ServerRole.OWNER:
+            pre_tool_deadline = time.monotonic() + TIMEOUT_MARGIN_SECONDS
+
         async with self._lock:
             wait_seconds = time.perf_counter() - wait_started
             logger.debug(
@@ -222,14 +231,18 @@ class SequentialToolExecutionMiddleware(Middleware):
                 context,
                 message="Scraper lock acquired, starting tool",
             )
+            if pre_tool_deadline is not None and time.monotonic() >= pre_tool_deadline:
+                raise ToolError(
+                    "The daemon proxy margin was spent waiting for the "
+                    "in-process scraper lock, with no time left for the "
+                    "minimum tool-call interval. Retry shortly."
+                )
             # Interval before the lease: waiting must not pin the browser.
             # On the daemon owner the frontend's deadline is
             # tool_timeout + TIMEOUT_MARGIN_SECONDS; everything before the
-            # tool body — interval wait *and* contended lease acquisition —
-            # shares that margin, or the client sees a transport timeout.
-            pre_tool_deadline: float | None = None
-            if process_role() is ServerRole.OWNER:
-                pre_tool_deadline = time.monotonic() + TIMEOUT_MARGIN_SECONDS
+            # tool body — lock wait, interval wait, *and* contended lease
+            # acquisition — shares that margin, or the client sees a
+            # transport timeout.
             await self._await_min_interval(
                 context, tool_name, deadline=pre_tool_deadline
             )

--- a/linkedin_mcp_server/sequential_tool_middleware.py
+++ b/linkedin_mcp_server/sequential_tool_middleware.py
@@ -18,7 +18,6 @@ from linkedin_mcp_server.exceptions import BrowserBusyError
 from linkedin_mcp_server.profile_lease import get_profile_lease
 from linkedin_mcp_server.server_role import ServerRole, process_role
 from linkedin_mcp_server.tool_interval import (
-    force_claim_start,
     future_stamp_skew_seconds,
     try_claim_start,
 )
@@ -163,11 +162,16 @@ class SequentialToolExecutionMiddleware(Middleware):
             # sized pieces off the skew and then raises. Pace once, claim
             # at local time, and proceed.
             if skew > remaining:
+                # Leave the shared stamp alone. A slow clock cannot close a
+                # peer stamp that sits beyond this call's budget; rewriting
+                # it to local time would make that peer see an ancient stamp
+                # and skip the configured interval (#877 / Greptile). Pace
+                # once locally, then proceed without a shared claim.
                 pace = min(interval, max(0.0, remaining))
                 logger.debug(
                     "Tool '%s' absorbing %.1fs future stamp skew "
                     "(%.1fs budget left) with a %.1fs pace then proceeding "
-                    "without rewinding the shared stamp",
+                    "without touching the shared stamp",
                     tool_name,
                     skew,
                     remaining,
@@ -182,7 +186,6 @@ class SequentialToolExecutionMiddleware(Middleware):
                             "interval (shared profile clock skew)"
                         ),
                     )
-                force_claim_start(auth_root)
                 self._last_start_mono = time.monotonic()
                 return
             logger.debug(

--- a/linkedin_mcp_server/tool_interval.py
+++ b/linkedin_mcp_server/tool_interval.py
@@ -75,14 +75,16 @@ def remaining_wait_seconds(
     """How long to wait before the next start may claim the interval slot."""
     if interval <= 0 or last_start_wall is None:
         return 0.0
-    # Clock stepped backwards past tolerance: refuse to wait forever on a
-    # stamp from "the future", and refuse to treat a small NTP step as a
-    # fresh start either.
+    # Stamp absurdly in the future (large clock jump / corruption): reclaim
+    # immediately rather than waiting forever.
     if last_start_wall - now_wall > _CLOCK_SKEW_TOLERANCE_SECONDS:
         return 0.0
-    if now_wall < last_start_wall:
-        return 0.0
-    return max(0.0, interval - (now_wall - last_start_wall))
+    # A small clock step backwards must not look like the interval already
+    # elapsed (``now - last`` would be negative and ``max(0, interval - …)``
+    # would grant the slot at once). Treat elapsed time as zero until wall
+    # time catches the stamp again.
+    elapsed = max(0.0, now_wall - last_start_wall)
+    return max(0.0, interval - elapsed)
 
 
 def try_claim_start(auth_root: Path, interval: float) -> float:

--- a/linkedin_mcp_server/tool_interval.py
+++ b/linkedin_mcp_server/tool_interval.py
@@ -122,3 +122,36 @@ def try_claim_start(auth_root: Path, interval: float) -> float:
             os.close(fd)
         except OSError:
             logger.debug("Closing tool-interval lock fd failed", exc_info=True)
+
+
+def force_claim_start(auth_root: Path) -> None:
+    """Write a local-time start stamp, ignoring any prior wait.
+
+    Used when a future peer stamp cannot be converged on inside this call's
+    wait budget (the daemon owner's 30s proxy margin). Marching toward that
+    stamp would reject the call; claiming at local time completes one pacing
+    step and lets the tool proceed.
+    """
+    _, lock_path = interval_paths(auth_root)
+    fd = acquire_locked_fd(lock_path, exclusive=True)
+    if fd is None:
+        # Best-effort: another process holds the lock. Writing without it can
+        # race, but the next claim still re-checks under the lock.
+        write_last_start_wall(auth_root, time.time())
+        return
+    try:
+        write_last_start_wall(auth_root, time.time())
+    finally:
+        _release_locked_fd(fd)
+        try:
+            os.close(fd)
+        except OSError:
+            logger.debug("Closing tool-interval lock fd failed", exc_info=True)
+
+
+def future_stamp_skew_seconds(auth_root: Path) -> float:
+    """How far ahead of wall time the shared stamp is, or ``0`` if none/past."""
+    last = read_last_start_wall(auth_root)
+    if last is None:
+        return 0.0
+    return max(0.0, last - time.time())

--- a/linkedin_mcp_server/tool_interval.py
+++ b/linkedin_mcp_server/tool_interval.py
@@ -78,13 +78,16 @@ def remaining_wait_seconds(
     """How long to wait before the next start may claim the interval slot."""
     if interval <= 0 or last_start_wall is None:
         return 0.0
-    # Only reclaim stamps that are absurdly in the future. Any smaller
-    # backward step (or peer clock slightly ahead) must wait the full
-    # interval — treating it as "already elapsed" would bypass pacing.
-    if last_start_wall - now_wall > _CORRUPT_FUTURE_SECONDS:
+    skew = last_start_wall - now_wall
+    # Only reclaim stamps that are absurdly in the future.
+    if skew > _CORRUPT_FUTURE_SECONDS:
         return 0.0
-    elapsed = max(0.0, now_wall - last_start_wall)
-    return max(0.0, interval - elapsed)
+    if skew > 0:
+        # Peer clock ahead / local rollback: waiting the full interval on
+        # every retry never advances (elapsed stays 0) and burns the wait
+        # budget. Catch up toward the stamp in interval-sized steps instead.
+        return min(interval, skew)
+    return max(0.0, interval - (now_wall - last_start_wall))
 
 
 def try_claim_start(auth_root: Path, interval: float) -> float:

--- a/linkedin_mcp_server/tool_interval.py
+++ b/linkedin_mcp_server/tool_interval.py
@@ -125,22 +125,30 @@ def try_claim_start(auth_root: Path, interval: float) -> float:
 
 
 def force_claim_start(auth_root: Path) -> None:
-    """Write a local-time start stamp, ignoring any prior wait.
+    """Mark a start without rewinding a future shared stamp.
 
     Used when a future peer stamp cannot be converged on inside this call's
     wait budget (the daemon owner's 30s proxy margin). Marching toward that
-    stamp would reject the call; claiming at local time completes one pacing
-    step and lets the tool proceed.
+    stamp would reject the call; proceeding after one local pace lets the
+    tool run. The stamp is set to ``max(now, last)`` so a slower clock never
+    replaces a faster peer's start time — that rewrite would make the peer
+    see the stamp as ancient and skip the configured interval (#877).
     """
     _, lock_path = interval_paths(auth_root)
     fd = acquire_locked_fd(lock_path, exclusive=True)
+
+    def _write_monotone(now: float) -> None:
+        last = read_last_start_wall(auth_root)
+        stamp = now if last is None else max(now, last)
+        write_last_start_wall(auth_root, stamp)
+
     if fd is None:
         # Best-effort: another process holds the lock. Writing without it can
         # race, but the next claim still re-checks under the lock.
-        write_last_start_wall(auth_root, time.time())
+        _write_monotone(time.time())
         return
     try:
-        write_last_start_wall(auth_root, time.time())
+        _write_monotone(time.time())
     finally:
         _release_locked_fd(fd)
         try:

--- a/linkedin_mcp_server/tool_interval.py
+++ b/linkedin_mcp_server/tool_interval.py
@@ -1,0 +1,119 @@
+"""Cross-process minimum interval between MCP tool-call starts.
+
+Complements ``SequentialToolExecutionMiddleware``: the in-process lock serializes
+calls inside one server, and this module paces starts across every process that
+shares the same LinkedIn auth root. The profile lease is deliberately not used
+here — waiting for the interval must not hold the browser.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+from linkedin_mcp_server.common_utils import secure_write_text
+from linkedin_mcp_server.profile_lease import (
+    _release_locked_fd,
+    acquire_locked_fd,
+)
+
+logger = logging.getLogger(__name__)
+
+_TIMESTAMP_FILE = "tool-interval.json"
+_LOCK_FILE = "tool-interval.lock"
+# Wall-clock skew larger than this treats the stored stamp as unusable.
+_CLOCK_SKEW_TOLERANCE_SECONDS = 5.0
+
+
+def interval_paths(auth_root: Path) -> tuple[Path, Path]:
+    """Return ``(timestamp_path, lock_path)`` under *auth_root*."""
+    root = auth_root.expanduser().resolve()
+    return root / _TIMESTAMP_FILE, root / _LOCK_FILE
+
+
+def read_last_start_wall(auth_root: Path) -> float | None:
+    """Return the last tool-start wall time, or ``None`` if unset/unusable."""
+    path, _ = interval_paths(auth_root)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.debug("Could not read tool-interval stamp at %s: %s", path, exc)
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.debug("Ignoring malformed tool-interval stamp at %s", path)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("last_start_wall")
+    if isinstance(value, (int, float)) and value == value:  # not NaN
+        return float(value)
+    return None
+
+
+def write_last_start_wall(auth_root: Path, when: float) -> None:
+    """Persist *when* as the last tool-start wall time under *auth_root*."""
+    path, _ = interval_paths(auth_root)
+    secure_write_text(
+        path,
+        json.dumps({"last_start_wall": when}, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def remaining_wait_seconds(
+    *,
+    interval: float,
+    last_start_wall: float | None,
+    now_wall: float,
+) -> float:
+    """How long to wait before the next start may claim the interval slot."""
+    if interval <= 0 or last_start_wall is None:
+        return 0.0
+    # Clock stepped backwards past tolerance: refuse to wait forever on a
+    # stamp from "the future", and refuse to treat a small NTP step as a
+    # fresh start either.
+    if last_start_wall - now_wall > _CLOCK_SKEW_TOLERANCE_SECONDS:
+        return 0.0
+    if now_wall < last_start_wall:
+        return 0.0
+    return max(0.0, interval - (now_wall - last_start_wall))
+
+
+def try_claim_start(auth_root: Path, interval: float) -> float:
+    """Claim a tool-start slot under *auth_root*, or return seconds still to wait.
+
+    Holds the interval lock only for the read/decide/write. A positive return
+    means the caller should sleep that long (without holding any lock) and try
+    again. ``0.0`` means this process owns the start and the stamp was updated.
+    """
+    if interval <= 0:
+        return 0.0
+
+    _, lock_path = interval_paths(auth_root)
+    fd = acquire_locked_fd(lock_path, exclusive=True)
+    if fd is None:
+        # Another process is deciding; a short wait and retry is enough.
+        return min(0.05, interval)
+
+    try:
+        now = time.time()
+        last = read_last_start_wall(auth_root)
+        wait = remaining_wait_seconds(
+            interval=interval, last_start_wall=last, now_wall=now
+        )
+        if wait > 0:
+            return wait
+        write_last_start_wall(auth_root, now)
+        return 0.0
+    finally:
+        _release_locked_fd(fd)
+        try:
+            os.close(fd)
+        except OSError:
+            logger.debug("Closing tool-interval lock fd failed", exc_info=True)

--- a/linkedin_mcp_server/tool_interval.py
+++ b/linkedin_mcp_server/tool_interval.py
@@ -24,8 +24,11 @@ logger = logging.getLogger(__name__)
 
 _TIMESTAMP_FILE = "tool-interval.json"
 _LOCK_FILE = "tool-interval.lock"
-# Wall-clock skew larger than this treats the stored stamp as unusable.
-_CLOCK_SKEW_TOLERANCE_SECONDS = 5.0
+# A stamp this far ahead of wall time is treated as corrupt (or from a
+# wildly desynchronized clock) and reclaimed. Smaller steps backwards —
+# including multi-minute NTP corrections — must not grant an immediate
+# start; they count as zero elapsed time so the full interval is waited.
+_CORRUPT_FUTURE_SECONDS = 3600.0
 
 
 def interval_paths(auth_root: Path) -> tuple[Path, Path]:
@@ -75,14 +78,11 @@ def remaining_wait_seconds(
     """How long to wait before the next start may claim the interval slot."""
     if interval <= 0 or last_start_wall is None:
         return 0.0
-    # Stamp absurdly in the future (large clock jump / corruption): reclaim
-    # immediately rather than waiting forever.
-    if last_start_wall - now_wall > _CLOCK_SKEW_TOLERANCE_SECONDS:
+    # Only reclaim stamps that are absurdly in the future. Any smaller
+    # backward step (or peer clock slightly ahead) must wait the full
+    # interval — treating it as "already elapsed" would bypass pacing.
+    if last_start_wall - now_wall > _CORRUPT_FUTURE_SECONDS:
         return 0.0
-    # A small clock step backwards must not look like the interval already
-    # elapsed (``now - last`` would be negative and ``max(0, interval - …)``
-    # would grant the slot at once). Treat elapsed time as zero until wall
-    # time catches the stamp again.
     elapsed = max(0.0, now_wall - last_start_wall)
     return max(0.0, interval - elapsed)
 

--- a/linkedin_mcp_server/tool_interval.py
+++ b/linkedin_mcp_server/tool_interval.py
@@ -143,9 +143,10 @@ def force_claim_start(auth_root: Path) -> None:
         write_last_start_wall(auth_root, stamp)
 
     if fd is None:
-        # Best-effort: another process holds the lock. Writing without it can
-        # race, but the next claim still re-checks under the lock.
-        _write_monotone(time.time())
+        # Do not write without the lock. A concurrent holder may have a newer
+        # stamp; an unlocked write can rewind it and let a fast peer skip the
+        # configured interval (#877 / Greptile). Local pacing already elapsed —
+        # leave the shared stamp alone.
         return
     try:
         _write_monotone(time.time())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -192,6 +192,7 @@ class TestServerConfig:
         assert config.transport == "stdio"
         assert config.port == 8000
         assert config.tool_timeout_seconds == 180.0
+        assert config.min_tool_interval_seconds == 0.0
 
     def test_validate_passes(self):
         ServerConfig().validate()  # No error
@@ -202,6 +203,23 @@ class TestServerConfig:
     def test_validate_invalid_tool_timeout(self, bad_value):
         with pytest.raises(ConfigurationError):
             ServerConfig(tool_timeout_seconds=bad_value).validate()
+
+    @pytest.mark.parametrize(
+        "bad_value", [-1.0, float("nan"), float("inf"), float("-inf")]
+    )
+    def test_validate_invalid_min_tool_interval(self, bad_value):
+        with pytest.raises(ConfigurationError):
+            ServerConfig(min_tool_interval_seconds=bad_value).validate()
+
+    def test_min_tool_interval_zero_is_allowed(self):
+        config = ServerConfig(min_tool_interval_seconds=0.0)
+        config.validate()
+        assert config.min_tool_interval_seconds == 0.0
+
+    def test_min_tool_interval_is_clamped(self):
+        config = ServerConfig(min_tool_interval_seconds=10_000.0)
+        config.validate()
+        assert config.min_tool_interval_seconds == 3600.0
 
 
 class TestAppConfig:
@@ -485,6 +503,30 @@ class TestLoaders:
 
         config = load_from_args(AppConfig())
         assert config.server.tool_timeout_seconds == 7.5
+
+    def test_load_from_env_min_tool_interval(self, monkeypatch):
+        monkeypatch.setenv("MIN_TOOL_INTERVAL", "15")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.server.min_tool_interval_seconds == 15.0
+
+    @pytest.mark.parametrize("bad_value", ["abc", "-1", "nan", "inf"])
+    def test_load_from_env_invalid_min_tool_interval(self, monkeypatch, bad_value):
+        monkeypatch.setenv("MIN_TOOL_INTERVAL", bad_value)
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        with pytest.raises(ConfigurationError, match="Invalid MIN_TOOL_INTERVAL"):
+            load_from_env(AppConfig())
+
+    def test_load_from_args_min_tool_interval(self, monkeypatch):
+        monkeypatch.setattr(
+            "sys.argv", ["linkedin-mcp-server", "--min-tool-interval", "12.5"]
+        )
+        from linkedin_mcp_server.config.loaders import load_from_args
+
+        config = load_from_args(AppConfig())
+        assert config.server.min_tool_interval_seconds == 12.5
 
     def test_claim_profile_root_defaults_off(self, monkeypatch):
         """Taking over an occupied directory is never the default."""

--- a/tests/test_daemon_config.py
+++ b/tests/test_daemon_config.py
@@ -233,6 +233,15 @@ class TestRoundTrip:
 
         assert restored.server.tool_timeout_seconds == 42.5
 
+    def test_the_min_tool_interval_crosses_with_the_owner(self):
+        original = AppConfig()
+        original.browser.user_data_dir = "~/p/profile"
+        original.server.min_tool_interval_seconds = 15.0
+
+        restored = daemon_config.decode(daemon_config.encode(original))
+
+        assert restored.server.min_tool_interval_seconds == 15.0
+
 
 class TestDaemonLogState:
     @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are required")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -667,7 +667,9 @@ class TestSequentialToolExecutionMiddleware:
     async def test_min_tool_interval_disabled_by_default(self, monkeypatch):
         """Default 0 must not delay consecutive tool calls."""
 
-        async def fake_owning(self, context, call_next, tool_name):
+        async def fake_owning(
+            self, context, call_next, tool_name, *, pre_tool_deadline=None
+        ):
             return await call_next(context)
 
         monkeypatch.setattr(
@@ -702,7 +704,9 @@ class TestSequentialToolExecutionMiddleware:
             sequential_middleware_module, "get_profile_lease", lambda: lease
         )
 
-        async def fake_owning(self, context, call_next, tool_name):
+        async def fake_owning(
+            self, context, call_next, tool_name, *, pre_tool_deadline=None
+        ):
             return await call_next(context)
 
         monkeypatch.setattr(
@@ -755,6 +759,10 @@ class TestSequentialToolExecutionMiddleware:
         self, monkeypatch, tmp_path
     ):
         from fastmcp.exceptions import ToolError
+        from linkedin_mcp_server.server_role import ServerRole, set_process_role
+
+        # The 30s margin is a daemon-owner constraint only.
+        set_process_role(ServerRole.OWNER)
 
         config = AppConfig()
         # Wait needed (~60s) exceeds the daemon proxy margin (30s).
@@ -778,6 +786,191 @@ class TestSequentialToolExecutionMiddleware:
         )
 
         with pytest.raises(ToolError, match="proxy margin"):
+            await middleware.on_call_tool(context, call_next)
+        call_next.assert_not_awaited()
+
+    async def test_direct_server_may_wait_past_proxy_margin(
+        self, monkeypatch, tmp_path
+    ):
+        """A standalone DIRECT server has no proxy deadline to protect.
+
+        Applying the daemon margin unconditionally made a valid 60s interval
+        fail immediately on DIRECT even though the tool timeout still had
+        room for the wait (#877).
+        """
+        config = AppConfig()
+        config.server.min_tool_interval_seconds = 60.0
+        config.server.tool_timeout_seconds = 180.0
+        set_config(config)
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir(exist_ok=True)
+        lease = ProfileLease(auth_root)
+        monkeypatch.setattr(
+            sequential_middleware_module, "get_profile_lease", lambda: lease
+        )
+
+        slept: list[float] = []
+
+        async def capture_sleep(self, context, seconds, *, message):
+            slept.append(seconds)
+
+        async def fake_owning(
+            self, context, call_next, tool_name, *, pre_tool_deadline=None
+        ):
+            return await call_next(context)
+
+        monkeypatch.setattr(
+            SequentialToolExecutionMiddleware, "_sleep_reporting", capture_sleep
+        )
+        monkeypatch.setattr(
+            SequentialToolExecutionMiddleware,
+            "_run_owning_the_profile",
+            fake_owning,
+        )
+
+        middleware = SequentialToolExecutionMiddleware()
+        middleware._last_start_mono = time.monotonic()
+        call_next = AsyncMock(return_value=MagicMock())
+        context = MiddlewareContext(
+            message=mt.CallToolRequestParams(name="slow_tool", arguments={}),
+            method="tools/call",
+        )
+
+        await middleware.on_call_tool(context, call_next)
+
+        assert slept
+        assert max(slept) >= 59.0
+        call_next.assert_awaited_once()
+
+    async def test_owner_lease_wait_is_capped_by_remaining_margin(
+        self, monkeypatch, tmp_path
+    ):
+        """Contended lease acquisition must share the owner's proxy margin.
+
+        Mutating away the remaining-budget cap leaves ``browser_wait_seconds``
+        unbounded after a long interval wait, and the frontend times out.
+        """
+        from linkedin_mcp_server.server_role import ServerRole, set_process_role
+
+        set_process_role(ServerRole.OWNER)
+
+        config = AppConfig()
+        config.server.min_tool_interval_seconds = 0.0
+        config.browser.browser_wait_seconds = 120.0
+        set_config(config)
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir(exist_ok=True)
+        lease = ProfileLease(auth_root)
+        monkeypatch.setattr(
+            sequential_middleware_module, "get_profile_lease", lambda: lease
+        )
+
+        class Clock:
+            def __init__(self) -> None:
+                self.now = 0.0
+
+            def monotonic(self) -> float:
+                return self.now
+
+            def perf_counter(self) -> float:
+                return self.now
+
+        clock = Clock()
+        seen_timeouts: list[float] = []
+
+        async def burn_interval(self, context, tool_name, *, deadline=None):
+            assert deadline is not None
+            clock.now += 25.0
+
+        async def capture_acquire(self, timeout):
+            seen_timeouts.append(timeout)
+            return True
+
+        monkeypatch.setattr(sequential_middleware_module, "time", clock)
+        monkeypatch.setattr(
+            SequentialToolExecutionMiddleware,
+            "_await_min_interval",
+            burn_interval,
+        )
+        monkeypatch.setattr(ProfileLease, "try_acquire", lambda self: False)
+        monkeypatch.setattr(ProfileLease, "acquire", capture_acquire)
+        monkeypatch.setattr(ProfileLease, "release", lambda self: None)
+
+        import linkedin_mcp_server.drivers.browser as browser_module
+
+        monkeypatch.setattr(browser_module, "note_call_started", lambda: None)
+        monkeypatch.setattr(browser_module, "note_activity", lambda: None)
+        monkeypatch.setattr(
+            browser_module,
+            "release_profile_if_idle_or_requested",
+            AsyncMock(),
+        )
+
+        middleware = SequentialToolExecutionMiddleware()
+        call_next = AsyncMock(return_value=MagicMock())
+        context = MiddlewareContext(
+            message=mt.CallToolRequestParams(name="slow_tool", arguments={}),
+            method="tools/call",
+        )
+
+        await middleware.on_call_tool(context, call_next)
+
+        assert seen_timeouts == [5.0]
+        call_next.assert_awaited_once()
+
+    async def test_owner_refuses_lease_wait_when_margin_is_spent(
+        self, monkeypatch, tmp_path
+    ):
+        from fastmcp.exceptions import ToolError
+        from linkedin_mcp_server.server_role import ServerRole, set_process_role
+
+        set_process_role(ServerRole.OWNER)
+
+        config = AppConfig()
+        config.server.min_tool_interval_seconds = 0.0
+        config.browser.browser_wait_seconds = 120.0
+        set_config(config)
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir(exist_ok=True)
+        lease = ProfileLease(auth_root)
+        monkeypatch.setattr(
+            sequential_middleware_module, "get_profile_lease", lambda: lease
+        )
+
+        class Clock:
+            def __init__(self) -> None:
+                self.now = 0.0
+
+            def monotonic(self) -> float:
+                return self.now
+
+            def perf_counter(self) -> float:
+                return self.now
+
+        clock = Clock()
+
+        async def burn_all(self, context, tool_name, *, deadline=None):
+            clock.now += 31.0
+
+        monkeypatch.setattr(sequential_middleware_module, "time", clock)
+        monkeypatch.setattr(
+            SequentialToolExecutionMiddleware,
+            "_await_min_interval",
+            burn_all,
+        )
+        monkeypatch.setattr(ProfileLease, "try_acquire", lambda self: False)
+
+        middleware = SequentialToolExecutionMiddleware()
+        call_next = AsyncMock(return_value=MagicMock())
+        context = MiddlewareContext(
+            message=mt.CallToolRequestParams(name="slow_tool", arguments={}),
+            method="tools/call",
+        )
+
+        with pytest.raises(ToolError, match="no time left"):
             await middleware.on_call_tool(context, call_next)
         call_next.assert_not_awaited()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import subprocess
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -14,6 +15,7 @@ from fastmcp.server.providers.proxy import ProxyClient
 
 import linkedin_mcp_server.server as server_module
 from linkedin_mcp_server import __version__
+from linkedin_mcp_server.config import reset_config, set_config
 from linkedin_mcp_server.sequential_tool_middleware import (
     SequentialToolExecutionMiddleware,
 )
@@ -25,6 +27,8 @@ from linkedin_mcp_server.server_role import (
     process_role,
 )
 from linkedin_mcp_server.update_check import UpdateNoticeMiddleware
+from linkedin_mcp_server.profile_lease import ProfileLease
+import linkedin_mcp_server.sequential_tool_middleware as sequential_middleware_module
 
 
 def _has_middleware(mcp: FastMCP, kind: type) -> bool:
@@ -577,6 +581,13 @@ class TestOwnerAuthentication:
 
 
 class TestSequentialToolExecutionMiddleware:
+    @pytest.fixture(autouse=True)
+    def _install_default_config(self):
+        """Keep middleware hermetic: get_config must not parse pytest argv."""
+        set_config(AppConfig())
+        yield
+        reset_config()
+
     async def test_create_mcp_server_registers_sequential_tool_middleware(self):
         mcp = create_mcp_server()
 
@@ -652,6 +663,93 @@ class TestSequentialToolExecutionMiddleware:
                 ),
             ]
         )
+
+    async def test_min_tool_interval_disabled_by_default(self, monkeypatch):
+        """Default 0 must not delay consecutive tool calls."""
+
+        async def fake_owning(self, context, call_next, tool_name):
+            return await call_next(context)
+
+        monkeypatch.setattr(
+            SequentialToolExecutionMiddleware,
+            "_run_owning_the_profile",
+            fake_owning,
+        )
+
+        mcp = FastMCP("test")
+        mcp.add_middleware(SequentialToolExecutionMiddleware())
+
+        @mcp.tool
+        async def quick_tool() -> dict[str, str]:
+            return {"ok": "yes"}
+
+        started = time.perf_counter()
+        await mcp.call_tool("quick_tool", {})
+        await mcp.call_tool("quick_tool", {})
+        assert time.perf_counter() - started < 0.5
+
+    async def test_min_tool_interval_spaces_sequential_calls(
+        self, monkeypatch, tmp_path
+    ):
+        config = AppConfig()
+        config.server.min_tool_interval_seconds = 0.2
+        set_config(config)
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir(exist_ok=True)
+        lease = ProfileLease(auth_root)
+        monkeypatch.setattr(
+            sequential_middleware_module, "get_profile_lease", lambda: lease
+        )
+
+        async def fake_owning(self, context, call_next, tool_name):
+            return await call_next(context)
+
+        monkeypatch.setattr(
+            SequentialToolExecutionMiddleware,
+            "_run_owning_the_profile",
+            fake_owning,
+        )
+
+        mcp = FastMCP("test")
+        mcp.add_middleware(SequentialToolExecutionMiddleware())
+
+        @mcp.tool
+        async def quick_tool() -> dict[str, str]:
+            return {"ok": "yes"}
+
+        started = time.perf_counter()
+        await mcp.call_tool("quick_tool", {})
+        await mcp.call_tool("quick_tool", {})
+        elapsed = time.perf_counter() - started
+        assert elapsed >= 0.15
+
+    async def test_min_tool_interval_honours_cancellation(self, monkeypatch, tmp_path):
+        config = AppConfig()
+        config.server.min_tool_interval_seconds = 5.0
+        set_config(config)
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir(exist_ok=True)
+        lease = ProfileLease(auth_root)
+        monkeypatch.setattr(
+            sequential_middleware_module, "get_profile_lease", lambda: lease
+        )
+
+        middleware = SequentialToolExecutionMiddleware()
+        middleware._last_start_mono = time.monotonic()
+        call_next = AsyncMock(return_value=MagicMock())
+        context = MiddlewareContext(
+            message=mt.CallToolRequestParams(name="slow_tool", arguments={}),
+            method="tools/call",
+        )
+
+        task = asyncio.create_task(middleware.on_call_tool(context, call_next))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        call_next.assert_not_awaited()
 
 
 class TestBrowserLifespan:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -751,6 +751,35 @@ class TestSequentialToolExecutionMiddleware:
             await task
         call_next.assert_not_awaited()
 
+    async def test_min_tool_interval_refuses_wait_past_tool_timeout(
+        self, monkeypatch, tmp_path
+    ):
+        from fastmcp.exceptions import ToolError
+
+        config = AppConfig()
+        config.server.min_tool_interval_seconds = 30.0
+        config.server.tool_timeout_seconds = 5.0
+        set_config(config)
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir(exist_ok=True)
+        lease = ProfileLease(auth_root)
+        monkeypatch.setattr(
+            sequential_middleware_module, "get_profile_lease", lambda: lease
+        )
+
+        middleware = SequentialToolExecutionMiddleware()
+        middleware._last_start_mono = time.monotonic()
+        call_next = AsyncMock(return_value=MagicMock())
+        context = MiddlewareContext(
+            message=mt.CallToolRequestParams(name="slow_tool", arguments={}),
+            method="tools/call",
+        )
+
+        with pytest.raises(ToolError, match="tool timeout"):
+            await middleware.on_call_tool(context, call_next)
+        call_next.assert_not_awaited()
+
 
 class TestBrowserLifespan:
     """The lifespan owns the background handoff poller.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1002,7 +1002,8 @@ class TestSequentialToolExecutionMiddleware:
         )
 
         # Stamp 120s ahead: more than the 30s owner margin can close.
-        write_last_start_wall(auth_root, time.time() + 120.0)
+        future = time.time() + 120.0
+        write_last_start_wall(auth_root, future)
 
         slept: list[float] = []
 
@@ -1032,11 +1033,12 @@ class TestSequentialToolExecutionMiddleware:
 
         await middleware.on_call_tool(context, call_next)
 
-        # One interval-sized pace, then local claim — not 30s of retries.
+        # One interval-sized pace, then proceed — stamp must stay ahead so a
+        # fast-clock peer cannot treat it as ancient and skip the interval.
         assert slept == [15.0]
         call_next.assert_awaited_once()
         stamp = json.loads((auth_root / "tool-interval.json").read_text())
-        assert stamp["last_start_wall"] == pytest.approx(time.time(), abs=2.0)
+        assert stamp["last_start_wall"] == pytest.approx(future)
 
 
 class TestBrowserLifespan:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import subprocess
 import sys
 import time
@@ -917,7 +918,7 @@ class TestSequentialToolExecutionMiddleware:
 
         await middleware.on_call_tool(context, call_next)
 
-        assert seen_timeouts == [5.0]
+        assert seen_timeouts == [3.0]
         call_next.assert_awaited_once()
 
     async def test_owner_refuses_lease_wait_when_margin_is_spent(
@@ -973,6 +974,69 @@ class TestSequentialToolExecutionMiddleware:
         with pytest.raises(ToolError, match="no time left"):
             await middleware.on_call_tool(context, call_next)
         call_next.assert_not_awaited()
+
+    async def test_owner_absorbs_unreachable_future_stamp_skew(
+        self, monkeypatch, tmp_path
+    ):
+        """Large future skew must not burn the proxy margin then reject.
+
+        Mutating away the force-claim path leaves the loop sleeping
+        ``min(interval, skew)`` until the 30s budget is gone and raising
+        ToolError — rejecting calls until clocks converge (#877).
+        """
+        from linkedin_mcp_server.server_role import ServerRole, set_process_role
+        from linkedin_mcp_server.tool_interval import write_last_start_wall
+
+        set_process_role(ServerRole.OWNER)
+
+        config = AppConfig()
+        config.server.min_tool_interval_seconds = 15.0
+        config.server.tool_timeout_seconds = 180.0
+        set_config(config)
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir(exist_ok=True)
+        lease = ProfileLease(auth_root)
+        monkeypatch.setattr(
+            sequential_middleware_module, "get_profile_lease", lambda: lease
+        )
+
+        # Stamp 120s ahead: more than the 30s owner margin can close.
+        write_last_start_wall(auth_root, time.time() + 120.0)
+
+        slept: list[float] = []
+
+        async def capture_sleep(self, context, seconds, *, message):
+            slept.append(seconds)
+
+        async def fake_owning(
+            self, context, call_next, tool_name, *, pre_tool_deadline=None
+        ):
+            return await call_next(context)
+
+        monkeypatch.setattr(
+            SequentialToolExecutionMiddleware, "_sleep_reporting", capture_sleep
+        )
+        monkeypatch.setattr(
+            SequentialToolExecutionMiddleware,
+            "_run_owning_the_profile",
+            fake_owning,
+        )
+
+        middleware = SequentialToolExecutionMiddleware()
+        call_next = AsyncMock(return_value=MagicMock())
+        context = MiddlewareContext(
+            message=mt.CallToolRequestParams(name="slow_tool", arguments={}),
+            method="tools/call",
+        )
+
+        await middleware.on_call_tool(context, call_next)
+
+        # One interval-sized pace, then local claim — not 30s of retries.
+        assert slept == [15.0]
+        call_next.assert_awaited_once()
+        stamp = json.loads((auth_root / "tool-interval.json").read_text())
+        assert stamp["last_start_wall"] == pytest.approx(time.time(), abs=2.0)
 
 
 class TestBrowserLifespan:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -751,14 +751,15 @@ class TestSequentialToolExecutionMiddleware:
             await task
         call_next.assert_not_awaited()
 
-    async def test_min_tool_interval_refuses_wait_past_tool_timeout(
+    async def test_min_tool_interval_refuses_wait_past_proxy_margin(
         self, monkeypatch, tmp_path
     ):
         from fastmcp.exceptions import ToolError
 
         config = AppConfig()
-        config.server.min_tool_interval_seconds = 30.0
-        config.server.tool_timeout_seconds = 5.0
+        # Wait needed (~60s) exceeds the daemon proxy margin (30s).
+        config.server.min_tool_interval_seconds = 60.0
+        config.server.tool_timeout_seconds = 180.0
         set_config(config)
 
         auth_root = tmp_path / "auth"
@@ -776,7 +777,7 @@ class TestSequentialToolExecutionMiddleware:
             method="tools/call",
         )
 
-        with pytest.raises(ToolError, match="tool timeout"):
+        with pytest.raises(ToolError, match="proxy margin"):
             await middleware.on_call_tool(context, call_next)
         call_next.assert_not_awaited()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1041,6 +1041,59 @@ class TestSequentialToolExecutionMiddleware:
         assert stamp["last_start_wall"] == pytest.approx(future)
 
 
+    async def test_owner_lock_wait_counts_against_proxy_margin(
+        self, monkeypatch, tmp_path
+    ):
+        """Owner pre-tool deadline must start before the in-process lock (#877).
+
+        Mutation target: move ``pre_tool_deadline = ...`` back inside
+        ``async with self._lock``. A call that spends the whole proxy margin
+        queued on the lock would then get a fresh budget and reach the tool
+        instead of raising ToolError.
+        """
+        from fastmcp.exceptions import ToolError
+        from linkedin_mcp_server.server_role import ServerRole, set_process_role
+
+        set_process_role(ServerRole.OWNER)
+
+        config = AppConfig()
+        config.server.min_tool_interval_seconds = 0.0
+        set_config(config)
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir(exist_ok=True)
+        lease = ProfileLease(auth_root)
+        monkeypatch.setattr(
+            sequential_middleware_module, "get_profile_lease", lambda: lease
+        )
+        monkeypatch.setattr(
+            sequential_middleware_module, "TIMEOUT_MARGIN_SECONDS", 0.05
+        )
+
+        middleware = SequentialToolExecutionMiddleware()
+        call_next = AsyncMock(return_value=MagicMock())
+        context = MiddlewareContext(
+            message=mt.CallToolRequestParams(name="slow_tool", arguments={}),
+            method="tools/call",
+        )
+
+        await middleware._lock.acquire()
+
+        async def release_after_queue() -> None:
+            await asyncio.sleep(0.1)
+            middleware._lock.release()
+
+        releaser = asyncio.create_task(release_after_queue())
+        try:
+            with pytest.raises(ToolError, match="scraper lock"):
+                await middleware.on_call_tool(context, call_next)
+        finally:
+            await releaser
+            if middleware._lock.locked():
+                middleware._lock.release()
+        call_next.assert_not_awaited()
+
+
 class TestBrowserLifespan:
     """The lifespan owns the background handoff poller.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -980,9 +980,9 @@ class TestSequentialToolExecutionMiddleware:
     ):
         """Large future skew must not burn the proxy margin then reject.
 
-        Mutating away the force-claim path leaves the loop sleeping
-        ``min(interval, skew)`` until the 30s budget is gone and raising
-        ToolError — rejecting calls until clocks converge (#877).
+        Mutation target: write the local wall time into the shared stamp on
+        the skew-absorb path. A fast-clock peer would then see an ancient
+        stamp and skip the configured interval (#877 / Greptile).
         """
         from linkedin_mcp_server.server_role import ServerRole, set_process_role
         from linkedin_mcp_server.tool_interval import write_last_start_wall

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1040,7 +1040,6 @@ class TestSequentialToolExecutionMiddleware:
         stamp = json.loads((auth_root / "tool-interval.json").read_text())
         assert stamp["last_start_wall"] == pytest.approx(future)
 
-
     async def test_owner_lock_wait_counts_against_proxy_margin(
         self, monkeypatch, tmp_path
     ):

--- a/tests/test_tool_interval.py
+++ b/tests/test_tool_interval.py
@@ -48,18 +48,28 @@ class TestRemainingWaitSeconds:
             == 0.0
         )
 
-    def test_small_clock_rollback_still_waits_full_interval(self):
-        # Stamp is 2s ahead of now. Must not grant immediately.
+    def test_small_clock_rollback_waits_only_the_skew(self):
+        # Stamp is 2s ahead of now. Must not grant immediately, but must not
+        # restart a full interval on every retry either — catch up by the skew.
         assert (
             remaining_wait_seconds(interval=15, last_start_wall=102.0, now_wall=100.0)
-            == 15.0
+            == 2.0
         )
 
-    def test_multi_minute_clock_rollback_still_waits_full_interval(self):
-        # Ten minutes backwards is still a real clock step, not a corrupt stamp.
+    def test_multi_minute_clock_rollback_catches_up_in_interval_steps(self):
+        # Ten minutes backwards: each retry advances by at most ``interval``,
+        # so the wait budget is not burned on identical full-interval sleeps.
         assert (
             remaining_wait_seconds(interval=15, last_start_wall=700.0, now_wall=100.0)
             == 15.0
+        )
+        assert (
+            remaining_wait_seconds(interval=15, last_start_wall=700.0, now_wall=115.0)
+            == 15.0
+        )
+        assert (
+            remaining_wait_seconds(interval=15, last_start_wall=700.0, now_wall=690.0)
+            == 10.0
         )
 
 

--- a/tests/test_tool_interval.py
+++ b/tests/test_tool_interval.py
@@ -1,0 +1,92 @@
+"""Tests for the cross-process minimum tool-call interval gate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from linkedin_mcp_server.tool_interval import (
+    remaining_wait_seconds,
+    try_claim_start,
+    write_last_start_wall,
+)
+
+
+class TestRemainingWaitSeconds:
+    def test_disabled_interval_never_waits(self):
+        assert (
+            remaining_wait_seconds(interval=0, last_start_wall=100.0, now_wall=100.5)
+            == 0.0
+        )
+
+    def test_first_call_never_waits(self):
+        assert (
+            remaining_wait_seconds(interval=15, last_start_wall=None, now_wall=100.0)
+            == 0.0
+        )
+
+    def test_reports_remaining_time(self):
+        assert (
+            remaining_wait_seconds(interval=15, last_start_wall=100.0, now_wall=105.0)
+            == 10.0
+        )
+
+    def test_elapsed_interval_is_ready(self):
+        assert (
+            remaining_wait_seconds(interval=15, last_start_wall=100.0, now_wall=120.0)
+            == 0.0
+        )
+
+    def test_future_stamp_beyond_skew_is_ignored(self):
+        assert (
+            remaining_wait_seconds(interval=15, last_start_wall=200.0, now_wall=100.0)
+            == 0.0
+        )
+
+
+class TestTryClaimStart:
+    def test_claims_and_blocks_until_interval(self, tmp_path: Path, monkeypatch):
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir()
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tool_interval.time.time", lambda: 1000.0
+        )
+
+        assert try_claim_start(auth_root, 15.0) == 0.0
+        stamp = json.loads((auth_root / "tool-interval.json").read_text())
+        assert stamp["last_start_wall"] == 1000.0
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tool_interval.time.time", lambda: 1005.0
+        )
+        assert try_claim_start(auth_root, 15.0) == pytest.approx(10.0)
+
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tool_interval.time.time", lambda: 1015.0
+        )
+        assert try_claim_start(auth_root, 15.0) == 0.0
+
+    def test_disabled_interval_skips_files(self, tmp_path: Path):
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir()
+        assert try_claim_start(auth_root, 0.0) == 0.0
+        assert not (auth_root / "tool-interval.json").exists()
+
+    def test_two_auth_roots_are_independent(self, tmp_path: Path, monkeypatch):
+        one = tmp_path / "one"
+        two = tmp_path / "two"
+        one.mkdir()
+        two.mkdir()
+        monkeypatch.setattr("linkedin_mcp_server.tool_interval.time.time", lambda: 50.0)
+        assert try_claim_start(one, 10.0) == 0.0
+        assert try_claim_start(two, 10.0) == 0.0
+        monkeypatch.setattr("linkedin_mcp_server.tool_interval.time.time", lambda: 55.0)
+        # Each root tracks its own stamp: both still have 5s remaining.
+        assert try_claim_start(one, 10.0) == pytest.approx(5.0)
+        assert try_claim_start(two, 10.0) == pytest.approx(5.0)
+        # Advancing only one's clock still leaves the other waiting.
+        write_last_start_wall(one, 40.0)
+        assert try_claim_start(one, 10.0) == 0.0
+        assert try_claim_start(two, 10.0) == pytest.approx(5.0)

--- a/tests/test_tool_interval.py
+++ b/tests/test_tool_interval.py
@@ -45,6 +45,13 @@ class TestRemainingWaitSeconds:
             == 0.0
         )
 
+    def test_small_clock_rollback_still_waits_full_interval(self):
+        # Stamp is 2s ahead of now — within skew. Must not grant immediately.
+        assert (
+            remaining_wait_seconds(interval=15, last_start_wall=102.0, now_wall=100.0)
+            == 15.0
+        )
+
 
 class TestTryClaimStart:
     def test_claims_and_blocks_until_interval(self, tmp_path: Path, monkeypatch):

--- a/tests/test_tool_interval.py
+++ b/tests/test_tool_interval.py
@@ -117,3 +117,16 @@ class TestTryClaimStart:
         write_last_start_wall(one, 40.0)
         assert try_claim_start(one, 10.0) == 0.0
         assert try_claim_start(two, 10.0) == pytest.approx(5.0)
+
+    def test_force_claim_overwrites_future_stamp(self, tmp_path: Path, monkeypatch):
+        from linkedin_mcp_server.tool_interval import force_claim_start
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir()
+        write_last_start_wall(auth_root, 2000.0)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tool_interval.time.time", lambda: 1000.0
+        )
+        force_claim_start(auth_root)
+        stamp = json.loads((auth_root / "tool-interval.json").read_text())
+        assert stamp["last_start_wall"] == 1000.0

--- a/tests/test_tool_interval.py
+++ b/tests/test_tool_interval.py
@@ -40,15 +40,25 @@ class TestRemainingWaitSeconds:
         )
 
     def test_future_stamp_beyond_skew_is_ignored(self):
+        # More than an hour ahead of wall time: treat as corrupt and reclaim.
         assert (
-            remaining_wait_seconds(interval=15, last_start_wall=200.0, now_wall=100.0)
+            remaining_wait_seconds(
+                interval=15, last_start_wall=100.0 + 3601.0, now_wall=100.0
+            )
             == 0.0
         )
 
     def test_small_clock_rollback_still_waits_full_interval(self):
-        # Stamp is 2s ahead of now — within skew. Must not grant immediately.
+        # Stamp is 2s ahead of now. Must not grant immediately.
         assert (
             remaining_wait_seconds(interval=15, last_start_wall=102.0, now_wall=100.0)
+            == 15.0
+        )
+
+    def test_multi_minute_clock_rollback_still_waits_full_interval(self):
+        # Ten minutes backwards is still a real clock step, not a corrupt stamp.
+        assert (
+            remaining_wait_seconds(interval=15, last_start_wall=700.0, now_wall=100.0)
             == 15.0
         )
 

--- a/tests/test_tool_interval.py
+++ b/tests/test_tool_interval.py
@@ -118,7 +118,7 @@ class TestTryClaimStart:
         assert try_claim_start(one, 10.0) == 0.0
         assert try_claim_start(two, 10.0) == pytest.approx(5.0)
 
-    def test_force_claim_overwrites_future_stamp(self, tmp_path: Path, monkeypatch):
+    def test_force_claim_never_rewinds_future_stamp(self, tmp_path: Path, monkeypatch):
         from linkedin_mcp_server.tool_interval import force_claim_start
 
         auth_root = tmp_path / "auth"
@@ -129,4 +129,41 @@ class TestTryClaimStart:
         )
         force_claim_start(auth_root)
         stamp = json.loads((auth_root / "tool-interval.json").read_text())
+        # A slower clock must not replace a faster peer's stamp (#877).
+        assert stamp["last_start_wall"] == 2000.0
+
+    def test_force_claim_advances_a_stale_stamp(self, tmp_path: Path, monkeypatch):
+        from linkedin_mcp_server.tool_interval import force_claim_start
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir()
+        write_last_start_wall(auth_root, 500.0)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tool_interval.time.time", lambda: 1000.0
+        )
+        force_claim_start(auth_root)
+        stamp = json.loads((auth_root / "tool-interval.json").read_text())
         assert stamp["last_start_wall"] == 1000.0
+
+    def test_force_claim_keeps_fast_peer_waiting(self, tmp_path: Path, monkeypatch):
+        """Rewinding the stamp would let a fast peer skip the interval (#877)."""
+        from linkedin_mcp_server.tool_interval import force_claim_start
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir()
+        # Fast peer wrote a start at wall=2000.
+        write_last_start_wall(auth_root, 2000.0)
+        # Slow peer (wall=1000) absorbs unreachable skew.
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tool_interval.time.time", lambda: 1000.0
+        )
+        force_claim_start(auth_root)
+        # Fast peer shortly after its own start must still wait.
+        assert (
+            remaining_wait_seconds(
+                interval=15.0, last_start_wall=2000.0, now_wall=2005.0
+            )
+            == 10.0
+        )
+        stamp = json.loads((auth_root / "tool-interval.json").read_text())
+        assert stamp["last_start_wall"] == 2000.0

--- a/tests/test_tool_interval.py
+++ b/tests/test_tool_interval.py
@@ -167,3 +167,28 @@ class TestTryClaimStart:
         )
         stamp = json.loads((auth_root / "tool-interval.json").read_text())
         assert stamp["last_start_wall"] == 2000.0
+
+    def test_force_claim_skips_write_when_lock_unavailable(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Unlocked force-claim must not rewind a peer stamp (#877).
+
+        Mutation target: restore unlocked ``_write_monotone(time.time())``.
+        With the lock unavailable and a slow local clock, that write replaces
+        a newer peer stamp and this assertion fails.
+        """
+        from linkedin_mcp_server.tool_interval import force_claim_start
+
+        auth_root = tmp_path / "auth"
+        auth_root.mkdir()
+        write_last_start_wall(auth_root, 2000.0)
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tool_interval.time.time", lambda: 1000.0
+        )
+        monkeypatch.setattr(
+            "linkedin_mcp_server.tool_interval.acquire_locked_fd",
+            lambda *args, **kwargs: None,
+        )
+        force_claim_start(auth_root)
+        stamp = json.loads((auth_root / "tool-interval.json").read_text())
+        assert stamp["last_start_wall"] == 2000.0


### PR DESCRIPTION
## Summary
Closes #860.

Adds an optional, disabled-by-default minimum interval between MCP **tool-call starts**, enforced in `SequentialToolExecutionMiddleware`.

- Config: `MIN_TOOL_INTERVAL` / `--min-tool-interval` → `server.min_tool_interval_seconds` (default `0`, max `3600`)
- Waits rather than failing; reports progress while waiting; honours cancellation
- Measured between tool-call starts (in-process monotonic + cross-process wall stamp under the auth root)
- Interval wait runs **after** the in-process lock and **before** the profile lease, so waiting does not pin the browser
- Included in the daemon config fingerprint alongside `tool_timeout_seconds` so owner/clients agree

Does not throttle `initialize` / `tools/list` (middleware is `on_call_tool` only). Complements `--slow-mo` (per-action) rather than replacing it.

## Test plan
- [x] `uv run ruff check` / `ruff format` on touched files
- [x] `uv run ty check` on new/changed Python
- [x] `tests/test_tool_interval.py` — claim/wait/skew/independent auth roots
- [x] `TestSequentialToolExecutionMiddleware` — default off, sequential spacing, cancellation
- [x] Config env/CLI validation + clamp tests
- [x] Daemon fingerprint tests still pass

## Synthetic prompt

> Add an optional min_tool_interval_seconds (env MIN_TOOL_INTERVAL, CLI --min-tool-interval, default 0) enforced in SequentialToolExecutionMiddleware between tool-call starts. Wait with progress and cancellation, use in-process monotonic time plus a locked auth-root timestamp for cross-process pacing, and do not hold the profile lease while waiting. Wire config validation/docs/tests.

Generated with Composer