### PR TITLE
fix(bootstrap): allow configurable installer temp directory (#878)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@
 # session from this server; otherwise start once with --claim-profile-root.
 USER_DATA_DIR=~/.linkedin-mcp/profile
 
+# Temporary parent directory used during browser installation bootstrap (optional)
+# Defaults to system tempdir. Useful when system tempdir ancestry has non-standard ACLs or permissions.
+INSTALLER_TEMP_DIR=
+
 # Browser mode (default: true outside Docker; the image overrides it to false)
 # true = Chromium's headless mode; false = headed. Docker's headed window lives
 # on a virtual display and never appears on the host.

--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ The local server uses the same managed-runtime flow as MCPB and `uvx`: it prepar
 - `--timeout MS` - Timeout for a single page operation (default: 5000)
 - `--tool-timeout SECONDS` - Timeout for a whole tool call (default: 180). Raise it for heavy scrapes, slow networks, or a cold-start browser.
 - `--user-data-dir PATH` - Browser profile directory (default: ~/.linkedin-mcp/profile). Rotating or clearing a session deletes this directory *and its parent*, which holds the stored cookies and derived profiles.
+- `--installer-temp-dir PATH` - Parent directory for temporary files created during browser installation bootstrap (default: system temporary directory). Useful when system %TEMP% ancestry has non-standard ACLs or permissions.
 - `--claim-profile-root` - Take over a profile directory the server will not claim on its own, such as one whose parent already holds other files. Needed once per directory.
 - `--slow-mo MS` - Delay between browser actions (default: 0, useful for debugging)
 - `--viewport WxH` - Viewport size (default: 1280x720). Applies to windowless mode only; a headed launch uses the real window size.

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -2005,7 +2005,15 @@ def _installer_temporary_parent() -> Path:
     is pinned, and the pins have to be held across the creation that happens
     after this function has already returned.
     """
-    parent = Path(tempfile.gettempdir()).resolve(strict=True)
+    configured_parent: str | None = os.environ.get("INSTALLER_TEMP_DIR")
+    if configured_parent is None:
+        with contextlib.suppress(Exception):
+            configured_parent = get_config().browser.installer_temp_dir
+
+    if configured_parent:
+        parent = Path(configured_parent).resolve(strict=True)
+    else:
+        parent = Path(tempfile.gettempdir()).resolve(strict=True)
     if os.name == "nt":
         return parent
 

--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -2005,10 +2005,11 @@ def _installer_temporary_parent() -> Path:
     is pinned, and the pins have to be held across the creation that happens
     after this function has already returned.
     """
-    configured_parent: str | None = os.environ.get("INSTALLER_TEMP_DIR")
+    configured_parent: str | None = None
+    with contextlib.suppress(Exception):
+        configured_parent = get_config().browser.installer_temp_dir
     if configured_parent is None:
-        with contextlib.suppress(Exception):
-            configured_parent = get_config().browser.installer_temp_dir
+        configured_parent = os.environ.get("INSTALLER_TEMP_DIR")
 
     if configured_parent:
         parent = Path(configured_parent).resolve(strict=True)

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -145,6 +145,7 @@ class EnvironmentKeys:
     AUTO_IMPORT_FROM_BROWSER = "AUTO_IMPORT_FROM_BROWSER"
     EAGER_FULL_CHROMIUM = "EAGER_FULL_CHROMIUM"
     DAEMON_ENABLED = "DAEMON_ENABLED"
+    INSTALLER_TEMP_DIR = "INSTALLER_TEMP_DIR"
 
 
 # What ``manifest.json`` fills from ``user_config``, and the exact string each
@@ -250,6 +251,10 @@ def load_from_env(config: AppConfig) -> AppConfig:
     # Persistent browser profile directory
     if user_data_dir := os.environ.get(EnvironmentKeys.USER_DATA_DIR):
         config.browser.user_data_dir = user_data_dir
+
+    # Temporary directory parent used during browser installation bootstrap
+    if installer_temp_dir := os.environ.get(EnvironmentKeys.INSTALLER_TEMP_DIR):
+        config.browser.installer_temp_dir = installer_temp_dir
 
     # Timeout for page operations (validated in BrowserConfig.validate())
     if timeout_env := os.environ.get(EnvironmentKeys.TIMEOUT):
@@ -654,6 +659,14 @@ def load_from_args(config: AppConfig) -> AppConfig:
     )
 
     parser.add_argument(
+        "--installer-temp-dir",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to temporary parent directory for browser installation bootstrap",
+    )
+
+    parser.add_argument(
         "--claim-profile-root",
         action="store_true",
         help=(
@@ -831,6 +844,9 @@ def load_from_args(config: AppConfig) -> AppConfig:
 
     if args.user_data_dir:
         config.browser.user_data_dir = args.user_data_dir
+
+    if args.installer_temp_dir:
+        config.browser.installer_temp_dir = args.installer_temp_dir
 
     if args.claim_profile_root:
         config.server.claim_profile_root = True

--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -194,6 +194,9 @@ class BrowserConfig:
     # being readable, so it can never be asked to stand down. Both can go once
     # owner turnover survives a fingerprint change.
     eager_full_chromium: bool = False
+    # Temporary directory parent used during browser installation bootstrap.
+    # Defaults to system tempdir (tempfile.gettempdir()) when None.
+    installer_temp_dir: str | None = None
 
     def validate(self) -> None:
         """Validate browser configuration values."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4179,6 +4179,34 @@ class TestPatchrightInstallStreaming:
         assert root.path == temporary_root
         assert created == [tmp_path]
 
+    def test_installer_temporary_parent_respects_configured_installer_temp_dir(
+        self, tmp_path, monkeypatch
+    ):
+        from linkedin_mcp_server import bootstrap
+
+        custom_temp = tmp_path / "custom_temp"
+        custom_temp.mkdir()
+
+        fake_config = SimpleNamespace(
+            browser=SimpleNamespace(installer_temp_dir=str(custom_temp))
+        )
+        monkeypatch.setattr(bootstrap, "get_config", lambda: fake_config)
+
+        assert bootstrap._installer_temporary_parent() == custom_temp.resolve()
+
+    def test_installer_temporary_parent_defaults_to_gettempdir_when_unset(
+        self, tmp_path, monkeypatch
+    ):
+        from linkedin_mcp_server import bootstrap
+
+        fake_config = SimpleNamespace(browser=SimpleNamespace(installer_temp_dir=None))
+        monkeypatch.setattr(bootstrap, "get_config", lambda: fake_config)
+        default_temp = tmp_path / "default_temp"
+        default_temp.mkdir()
+        monkeypatch.setattr(bootstrap.tempfile, "gettempdir", lambda: str(default_temp))
+
+        assert bootstrap._installer_temporary_parent() == default_temp.resolve()
+
     @pytest.mark.skipif(os.name == "nt", reason="POSIX directory modes are required")
     def test_replaceable_temporary_parent_is_refused_before_creation(
         self, tmp_path, monkeypatch

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4194,6 +4194,24 @@ class TestPatchrightInstallStreaming:
 
         assert bootstrap._installer_temporary_parent() == custom_temp.resolve()
 
+    def test_installer_temporary_parent_prefers_config_over_env(
+        self, tmp_path, monkeypatch
+    ):
+        from linkedin_mcp_server import bootstrap
+
+        cli_temp = tmp_path / "cli_temp"
+        cli_temp.mkdir()
+        env_temp = tmp_path / "env_temp"
+        env_temp.mkdir()
+
+        monkeypatch.setenv("INSTALLER_TEMP_DIR", str(env_temp))
+        fake_config = SimpleNamespace(
+            browser=SimpleNamespace(installer_temp_dir=str(cli_temp))
+        )
+        monkeypatch.setattr(bootstrap, "get_config", lambda: fake_config)
+
+        assert bootstrap._installer_temporary_parent() == cli_temp.resolve()
+
     def test_installer_temporary_parent_defaults_to_gettempdir_when_unset(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -897,6 +897,19 @@ class TestLoaders:
         config = load_from_args(AppConfig())
         assert config.browser.installer_temp_dir == "/custom/installer/temp"
 
+    def test_load_from_args_installer_temp_dir_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("INSTALLER_TEMP_DIR", "/env/installer/temp")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["linkedin-mcp-server", "--installer-temp-dir", "/cli/installer/temp"],
+        )
+        from linkedin_mcp_server.config.loaders import load_from_args, load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.installer_temp_dir == "/env/installer/temp"
+        config = load_from_args(config)
+        assert config.browser.installer_temp_dir == "/cli/installer/temp"
+
     def test_load_from_env_import_from_browser(self, monkeypatch):
         monkeypatch.setenv("IMPORT_FROM_BROWSER", "brave")
         from linkedin_mcp_server.config.loaders import load_from_env

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -880,6 +880,23 @@ class TestLoaders:
         config = load_from_env(AppConfig())
         assert config.browser.user_data_dir == "/custom/profile"
 
+    def test_load_from_env_installer_temp_dir(self, monkeypatch):
+        monkeypatch.setenv("INSTALLER_TEMP_DIR", "/custom/installer/temp")
+        from linkedin_mcp_server.config.loaders import load_from_env
+
+        config = load_from_env(AppConfig())
+        assert config.browser.installer_temp_dir == "/custom/installer/temp"
+
+    def test_load_from_args_installer_temp_dir(self, monkeypatch):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["linkedin-mcp-server", "--installer-temp-dir", "/custom/installer/temp"],
+        )
+        from linkedin_mcp_server.config.loaders import load_from_args
+
+        config = load_from_args(AppConfig())
+        assert config.browser.installer_temp_dir == "/custom/installer/temp"
+
     def test_load_from_env_import_from_browser(self, monkeypatch):
         monkeypatch.setenv("IMPORT_FROM_BROWSER", "brave")
         from linkedin_mcp_server.config.loaders import load_from_env


### PR DESCRIPTION
### Summary

Resolves #878.

During browser installation bootstrap, `_create_installer_temporary_root()` creates an owner-only directory under `_installer_temporary_parent()`. On Windows, `windows_acl.verify_ancestry_cannot_be_replaced()` verifies each ancestor of that parent directory. If any parent directory in `%TEMP%`'s ancestry (such as `C:\Users\username`) contains non-standard DACL inheritance or permissions granted to sandbox groups/sub-accounts (common in developer sandboxes and enterprise environments), `PrivateStateError` is raised, preventing the server from bootstrapping browser dependencies.

This PR adds:
- `INSTALLER_TEMP_DIR` environment variable and `--installer-temp-dir` CLI flag to configure the parent temporary directory used during installation bootstrap.
- Configuration loading into `BrowserConfig.installer_temp_dir`.
- Usage of `INSTALLER_TEMP_DIR` / `get_config().browser.installer_temp_dir` in `_installer_temporary_parent()` before falling back to `tempfile.gettempdir()`, correctly preserving CLI-over-environment precedence.
- Comprehensive red-green unit tests in `tests/test_config.py` and `tests/test_bootstrap.py`.
- Documentation updates in `README.md` and `.env.example`.

### Testing

- Unit tests in `tests/test_config.py` verifying `load_from_env` and `load_from_args` populate `config.browser.installer_temp_dir`, and that CLI arguments override environment variables.
- Unit tests in `tests/test_bootstrap.py` verifying `_installer_temporary_parent()` resolves and returns the configured installer directory, prefers configuration over environment variables, and falls back to `tempfile.gettempdir()` when unset.
- Full `test_config.py` suite (235 passed).
- Linting and formatting verified with `ruff check .` and `ruff format --check .`.

## Synthetic prompt

> Add `INSTALLER_TEMP_DIR` environment variable and `--installer-temp-dir` CLI argument to allow configuring the parent temporary directory used by `_installer_temporary_parent()` during browser bootstrap. Wire into `BrowserConfig`, loaders, and bootstrap logic with unit tests and doc updates.
