### PR TITLE
feat(posts): Add sort_by to search_posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company |
 | `get_job_details` | Get detailed information about a specific job posting |
 | `get_feed` | Get recent posts from the authenticated user's home feed |
-| `search_posts` | Search posts/content globally by keyword (the "Posts" tab) with an optional recency filter (past-24h/past-week/past-month) |
+| `search_posts` | Search posts/content globally by keyword (the "Posts" tab) with optional recency (past-24h/past-week/past-month) and sort (`date` / Latest, `relevance` / Top match) |
 | `close_session` | Close browser session and clean up resources |
 
 <br/>

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4589,8 +4589,8 @@ class LinkedInExtractor:
         self,
         keywords: str,
         date_posted: str | None = None,
-        sort_by: str | None = None,
         max_pages: int = 3,
+        sort_by: str | None = None,
     ) -> dict[str, Any]:
         """Search LinkedIn posts/content and extract the results page.
 
@@ -4605,14 +4605,16 @@ class LinkedInExtractor:
                 ``FilterValidationError`` (a ``ValueError`` subclass) rather
                 than reaching LinkedIn, which would ignore them silently and
                 return unfiltered results that look filtered.
-            sort_by: Optional sort, one of the keys of ``_CONTENT_SORT_BY_MAP``
-                (``date`` / ``date_posted`` for Latest, ``relevance`` for Top
-                match). Same validation rule as ``date_posted``.
             max_pages: Scroll depth, expressed in result "pages" of roughly
                 ``_CONTENT_SCROLLS_PER_REQUESTED_PAGE`` scrolls each (default
                 3). Content search is an infinite scroll with no per-page URL,
                 so this caps how far the page is scrolled rather than fetching
                 discrete ``&start=`` pages.
+            sort_by: Optional sort, one of the keys of ``_CONTENT_SORT_BY_MAP``
+                (``date`` / ``date_posted`` for Latest, ``relevance`` for Top
+                match). Same validation rule as ``date_posted``. Appended after
+                ``max_pages`` so legacy positional callers that pass an int
+                third argument keep the old scroll-depth meaning.
 
         Returns:
             {url, sections: {search_results: text}} plus optional ``references``
@@ -4663,6 +4665,29 @@ class LinkedInExtractor:
             }
         elif extracted.error:
             section_errors["search_results"] = extracted.error
+
+        # Presence-only, same contract as search_jobs: LinkedIn may re-encode
+        # the facet value, but dropping the key means Top match results while
+        # the requested URL still advertises Latest.
+        asked = parse_qs(urlparse(url).query)
+        if asked.get("sortBy"):
+            landed_query = parse_qs(urlparse(self._page.url).query)
+            if not landed_query.get("sortBy"):
+                logger.debug(
+                    "Content-search sortBy did not survive navigation to %s",
+                    self._page.url,
+                )
+                filters_warning = dropped_filters_section_error(
+                    ["sortBy"], self._page.url
+                )
+                existing = section_errors.get("search_results")
+                if existing is None:
+                    section_errors["search_results"] = filters_warning
+                else:
+                    existing["error_message"] = (
+                        f"{existing['error_message']} "
+                        f"{filters_warning['error_message']}"
+                    )
 
         result: dict[str, Any] = {"url": url, "sections": sections}
         if references:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -416,6 +416,15 @@ _CONTENT_DATE_POSTED_MAP = {
     "past_month": "past-month",
 }
 
+# Content-search ``sortBy`` facet tokens, verified against LinkedIn's Posts
+# tab URL (Top match / Latest). ``date`` matches ``search_jobs`` spelling;
+# ``date_posted`` is LinkedIn's own Latest token.
+_CONTENT_SORT_BY_MAP = {
+    "date": "date_posted",
+    "date_posted": "date_posted",
+    "relevance": "relevance",
+}
+
 # Content search is an infinite scroll with no ``&start=`` pagination, so
 # ``max_pages`` caps scroll depth instead of fetching discrete pages. One
 # nominal "page" is this many scrolls.
@@ -4549,6 +4558,7 @@ class LinkedInExtractor:
     def _build_content_search_url(
         keywords: str,
         date_posted: str | None = None,
+        sort_by: str | None = None,
     ) -> str:
         """Build a LinkedIn content (post) search URL.
 
@@ -4556,12 +4566,13 @@ class LinkedInExtractor:
         Posts results tab, e.g. for "Buscamos Unity" in the past week:
         ``/search/results/content/?keywords=Buscamos+Unity&origin=FACETED_SEARCH&datePosted=%5B%22past-week%22%5D``
 
-        The ``datePosted`` facet is a one-element JSON list carrying a literal
-        LinkedIn token, URL-encoded — unlike job search, which uses
-        ``f_TPR=r<seconds>``. The value is mapped through
-        ``_CONTENT_DATE_POSTED_MAP`` so the server's own underscore spelling
-        reaches LinkedIn in the form it recognizes. An unmapped value would be
-        ignored rather than rejected, so callers validate first.
+        The ``datePosted`` and ``sortBy`` facets are one-element JSON lists
+        carrying literal LinkedIn tokens, URL-encoded — unlike job search,
+        which uses ``f_TPR=r<seconds>`` / ``sortBy=DD|R``. Values are mapped
+        through ``_CONTENT_DATE_POSTED_MAP`` / ``_CONTENT_SORT_BY_MAP`` so the
+        server's own spellings reach LinkedIn in the form it recognizes. An
+        unmapped value would be ignored rather than rejected, so callers
+        validate first.
         """
         params = f"keywords={quote_plus(keywords)}&origin=FACETED_SEARCH"
         if date_posted and date_posted.strip():
@@ -4569,12 +4580,16 @@ class LinkedInExtractor:
                 date_posted.strip(), date_posted.strip()
             )
             params += f"&datePosted={_encode_list_facet([token])}"
+        if sort_by and sort_by.strip():
+            token = _CONTENT_SORT_BY_MAP.get(sort_by.strip(), sort_by.strip())
+            params += f"&sortBy={_encode_list_facet([token])}"
         return f"https://www.linkedin.com/search/results/content/?{params}"
 
     async def search_posts(
         self,
         keywords: str,
         date_posted: str | None = None,
+        sort_by: str | None = None,
         max_pages: int = 3,
     ) -> dict[str, Any]:
         """Search LinkedIn posts/content and extract the results page.
@@ -4590,6 +4605,9 @@ class LinkedInExtractor:
                 ``FilterValidationError`` (a ``ValueError`` subclass) rather
                 than reaching LinkedIn, which would ignore them silently and
                 return unfiltered results that look filtered.
+            sort_by: Optional sort, one of the keys of ``_CONTENT_SORT_BY_MAP``
+                (``date`` / ``date_posted`` for Latest, ``relevance`` for Top
+                match). Same validation rule as ``date_posted``.
             max_pages: Scroll depth, expressed in result "pages" of roughly
                 ``_CONTENT_SCROLLS_PER_REQUESTED_PAGE`` scrolls each (default
                 3). Content search is an infinite scroll with no per-page URL,
@@ -4613,8 +4631,19 @@ class LinkedInExtractor:
                 f"Invalid date_posted {date_posted!r}; expected one of "
                 f"{list(_CONTENT_DATE_POSTED_MAP)!r}."
             )
+        if (
+            sort_by is not None
+            and sort_by.strip()
+            and sort_by.strip() not in _CONTENT_SORT_BY_MAP
+        ):
+            raise FilterValidationError(
+                f"Invalid sort_by {sort_by!r}; expected one of "
+                f"{list(_CONTENT_SORT_BY_MAP)!r}."
+            )
 
-        url = self._build_content_search_url(keywords, date_posted=date_posted)
+        url = self._build_content_search_url(
+            keywords, date_posted=date_posted, sort_by=sort_by
+        )
         max_scrolls = max(1, max_pages) * _CONTENT_SCROLLS_PER_REQUESTED_PAGE
         extracted = await self.extract_page(
             url, section_name="search_results", max_scrolls=max_scrolls

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -40,6 +40,7 @@ def register_post_tools(
         keywords: str,
         ctx: Context,
         date_posted: str | None = None,
+        sort_by: str | None = None,
         max_pages: Annotated[int, Field(ge=1, le=10)] = 3,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
@@ -59,6 +60,9 @@ def register_post_tools(
                 "past-week", "past-month"; the "past_24_hours" / "past_week" /
                 "past_month" spellings used by search_jobs are accepted too.
                 Omit for any time.
+            sort_by: Optional sort. "date" (or "date_posted") for Latest,
+                "relevance" for Top match — same spellings as search_jobs
+                where possible. Omit for LinkedIn's default Top match.
             max_pages: Scroll depth as result "pages" of ~5 scrolls each
                 (1-10, default 3). Content search is an infinite scroll, so
                 this caps how far the page is scrolled rather than fetching
@@ -77,9 +81,11 @@ def register_post_tools(
                 ctx, tool_name="search_posts"
             )
             logger.info(
-                "Searching posts: keywords='%s', date_posted='%s', max_pages=%d",
+                "Searching posts: keywords='%s', date_posted='%s', "
+                "sort_by='%s', max_pages=%d",
                 keywords,
                 date_posted,
+                sort_by,
                 max_pages,
             )
 
@@ -91,6 +97,7 @@ def register_post_tools(
                 result = await extractor.search_posts(
                     keywords,
                     date_posted=date_posted,
+                    sort_by=sort_by,
                     max_pages=max_pages,
                 )
             except FilterValidationError as e:

--- a/linkedin_mcp_server/tools/post.py
+++ b/linkedin_mcp_server/tools/post.py
@@ -40,8 +40,8 @@ def register_post_tools(
         keywords: str,
         ctx: Context,
         date_posted: str | None = None,
-        sort_by: str | None = None,
         max_pages: Annotated[int, Field(ge=1, le=10)] = 3,
+        sort_by: str | None = None,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -60,13 +60,15 @@ def register_post_tools(
                 "past-week", "past-month"; the "past_24_hours" / "past_week" /
                 "past_month" spellings used by search_jobs are accepted too.
                 Omit for any time.
-            sort_by: Optional sort. "date" (or "date_posted") for Latest,
-                "relevance" for Top match — same spellings as search_jobs
-                where possible. Omit for LinkedIn's default Top match.
             max_pages: Scroll depth as result "pages" of ~5 scrolls each
                 (1-10, default 3). Content search is an infinite scroll, so
                 this caps how far the page is scrolled rather than fetching
                 discrete pages.
+            sort_by: Optional sort. "date" (or "date_posted") for Latest,
+                "relevance" for Top match — same spellings as search_jobs
+                where possible. Omit for LinkedIn's default Top match.
+                Declared after max_pages so positional callers keep the prior
+                scroll-depth argument order.
 
         Returns:
             Dict with url, sections (search_results -> raw text), and optional
@@ -97,8 +99,8 @@ def register_post_tools(
                 result = await extractor.search_posts(
                     keywords,
                     date_posted=date_posted,
-                    sort_by=sort_by,
                     max_pages=max_pages,
+                    sort_by=sort_by,
                 )
             except FilterValidationError as e:
                 # Validation messages carry actionable detail; surface them as

--- a/manifest.json
+++ b/manifest.json
@@ -117,7 +117,7 @@
     },
     {
       "name": "search_posts",
-      "description": "Search LinkedIn posts/content globally by keyword (the 'Posts' tab) with optional recency (past-24h/past-week/past-month) and sort (date/Latest, relevance/Top match)"
+      "description": "Search LinkedIn posts/content globally by keyword (the 'Posts' tab) with an optional recency filter (past-24h/past-week/past-month)"
     },
     {
       "name": "close_session",

--- a/manifest.json
+++ b/manifest.json
@@ -117,7 +117,7 @@
     },
     {
       "name": "search_posts",
-      "description": "Search LinkedIn posts/content globally by keyword (the 'Posts' tab) with an optional recency filter (past-24h/past-week/past-month)"
+      "description": "Search LinkedIn posts/content globally by keyword (the 'Posts' tab) with optional recency (past-24h/past-week/past-month) and sort (date/Latest, relevance/Top match)"
     },
     {
       "name": "close_session",

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -6264,15 +6264,53 @@ class TestSearchPosts:
 
     async def test_sort_by_date_in_url(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
+
+        async def land(url, *args, **kwargs):
+            mock_page.url = url
+            return extracted("post")
+
+        with patch.object(extractor, "extract_page", side_effect=land):
+            result = await extractor.search_posts("python", sort_by="date")
+
+        assert "sortBy=%5B%22date_posted%22%5D" in result["url"]
+        assert "section_errors" not in result
+
+    async def test_positional_max_pages_still_means_scroll_depth(self, mock_page):
+        """Legacy ``search_posts(keywords, date_posted, max_pages)`` must not
+        bind the int as ``sort_by`` (which would call ``.strip()`` and crash).
+        """
+        extractor = LinkedInExtractor(mock_page)
         with patch.object(
             extractor,
             "extract_page",
             new_callable=AsyncMock,
             return_value=extracted("post"),
-        ):
+        ) as mock_extract:
+            await extractor.search_posts("python", None, 2)
+
+        mock_extract.assert_awaited_once_with(
+            ANY, section_name="search_results", max_scrolls=10
+        )
+
+    async def test_dropped_sort_by_reports_filters_dropped(self, mock_page):
+        """If LinkedIn navigates away from sortBy, keep results but say so."""
+        extractor = LinkedInExtractor(mock_page)
+
+        async def land_without_sort(url, *args, **kwargs):
+            mock_page.url = (
+                "https://www.linkedin.com/search/results/content/"
+                "?keywords=python&origin=FACETED_SEARCH"
+            )
+            return extracted("post")
+
+        with patch.object(extractor, "extract_page", side_effect=land_without_sort):
             result = await extractor.search_posts("python", sort_by="date")
 
+        assert result["sections"]["search_results"] == "post"
         assert "sortBy=%5B%22date_posted%22%5D" in result["url"]
+        error = result["section_errors"]["search_results"]
+        assert error["error_type"] == "filters_dropped"
+        assert "sortBy" in error["error_message"]
 
     async def test_invalid_sort_by_raises(self, mock_page):
         from linkedin_mcp_server.scraping.extractor import FilterValidationError

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -30,6 +30,7 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _CONTENT_DATE_POSTED_MAP,
+    _CONTENT_SORT_BY_MAP,
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
@@ -6195,6 +6196,37 @@ class TestBuildContentSearchUrl:
         url = LinkedInExtractor._build_content_search_url("python", date_posted="   ")
         assert "datePosted" not in url
 
+    def test_sort_by_date_uses_date_posted_token(self):
+        url = LinkedInExtractor._build_content_search_url("python", sort_by="date")
+        assert "sortBy=%5B%22date_posted%22%5D" in url
+
+    def test_sort_by_date_posted_alias(self):
+        url = LinkedInExtractor._build_content_search_url(
+            "python", sort_by="date_posted"
+        )
+        assert "sortBy=%5B%22date_posted%22%5D" in url
+
+    def test_sort_by_relevance(self):
+        url = LinkedInExtractor._build_content_search_url("python", sort_by="relevance")
+        assert "sortBy=%5B%22relevance%22%5D" in url
+
+    def test_every_accepted_sort_by_reaches_linkedin_as_a_real_token(self):
+        """LinkedIn ignores an unrecognized sortBy instead of rejecting it."""
+        for accepted, expected in _CONTENT_SORT_BY_MAP.items():
+            url = LinkedInExtractor._build_content_search_url(
+                "python", sort_by=accepted
+            )
+            assert expected in ("date_posted", "relevance")
+            assert f"%22{expected}%22" in url
+
+    def test_no_sort_by_omits_facet(self):
+        url = LinkedInExtractor._build_content_search_url("python")
+        assert "sortBy" not in url
+
+    def test_whitespace_sort_by_omits_facet(self):
+        url = LinkedInExtractor._build_content_search_url("python", sort_by="   ")
+        assert "sortBy" not in url
+
 
 @pytest.mark.asyncio
 class TestSearchPosts:
@@ -6229,6 +6261,25 @@ class TestSearchPosts:
             )
 
         assert "datePosted=%5B%22past-week%22%5D" in result["url"]
+
+    async def test_sort_by_date_in_url(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("post"),
+        ):
+            result = await extractor.search_posts("python", sort_by="date")
+
+        assert "sortBy=%5B%22date_posted%22%5D" in result["url"]
+
+    async def test_invalid_sort_by_raises(self, mock_page):
+        from linkedin_mcp_server.scraping.extractor import FilterValidationError
+
+        extractor = LinkedInExtractor(mock_page)
+        with pytest.raises(FilterValidationError, match="sort_by"):
+            await extractor.search_posts("python", sort_by="popularity")
 
     async def test_max_pages_controls_scroll_depth(self, mock_page):
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1397,8 +1397,8 @@ class TestPostTools:
         mock_extractor.search_posts.assert_awaited_once_with(
             "Buscamos Unity",
             date_posted="past-week",
-            sort_by=None,
             max_pages=3,
+            sort_by=None,
         )
 
     async def test_search_posts_passes_sort_by(self, mock_context):
@@ -1423,8 +1423,8 @@ class TestPostTools:
         mock_extractor.search_posts.assert_awaited_once_with(
             "python",
             date_posted=None,
-            sort_by="date",
             max_pages=3,
+            sort_by="date",
         )
 
     async def test_search_posts_validation_error_surfaced_as_tool_error(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1397,6 +1397,33 @@ class TestPostTools:
         mock_extractor.search_posts.assert_awaited_once_with(
             "Buscamos Unity",
             date_posted="past-week",
+            sort_by=None,
+            max_pages=3,
+        )
+
+    async def test_search_posts_passes_sort_by(self, mock_context):
+        mock_extractor = _make_mock_extractor(
+            {
+                "url": "https://www.linkedin.com/search/results/content/?keywords=python",
+                "sections": {"search_results": "post"},
+            }
+        )
+
+        from linkedin_mcp_server.tools.post import register_post_tools
+
+        mcp = FastMCP("test")
+        register_post_tools(mcp)
+        tool_fn = await get_tool_fn(mcp, "search_posts")
+        await tool_fn(
+            "python",
+            mock_context,
+            sort_by="date",
+            extractor=mock_extractor,
+        )
+        mock_extractor.search_posts.assert_awaited_once_with(
+            "python",
+            date_posted=None,
+            sort_by="date",
             max_pages=3,
         )
 


### PR DESCRIPTION
## Summary
- Adds optional `sort_by` (`date` / `date_posted` / `relevance`) to `search_posts`, wired through `_build_content_search_url` as LinkedIn's `sortBy` list facet (Latest vs Top match).
- Validates unknown values with `FilterValidationError` (same pattern as `date_posted`) so LinkedIn cannot silently ignore a bad token.
- Updates README / manifest tool descriptions and unit coverage for URL mapping, validation, and tool pass-through.

Closes #737

## Test plan
- [x] `uv run pytest tests/test_scraping.py::TestBuildContentSearchUrl tests/test_scraping.py::TestSearchPosts tests/test_tools.py::TestPostTools`
- [ ] CI green
- [ ] Optional live check: `search_posts(keywords=..., sort_by="date")` URL contains `sortBy=["date_posted"]` and results look newest-first

## Synthetic prompt

> Add an optional `sort_by` parameter to `search_posts` (`relevance` | `date`, plus LinkedIn's `date_posted` alias) that maps into the content-search `sortBy` URL facet the same way `date_posted` uses a list facet. Validate unknown values, update the tool/docs/manifest, and add unit tests.

Generated with Composer