### PR TITLE
fix(jobs): Cap search pages by remaining budget

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -74,6 +74,11 @@ _NAV_DELAY = 2.0
 
 # Backoff before retrying a temporarily blocked page
 _RATE_LIMIT_RETRY_DELAY = 5.0
+# Minimum wall time a rate-limit retry itself needs after the backoff —
+# navigation, modal handling, and a capped ``<main>`` wait. Checking only
+# the backoff lets a 5.1s remainder sleep away the page budget and still
+# start work that can overrun the outer tool reserve (#882 / Greptile).
+_RATE_LIMIT_RETRY_WORK = 5.0
 
 # Returned as section text when a page comes back with its content gone and
 # only LinkedIn's own navigation and footer left.
@@ -3559,7 +3564,7 @@ class LinkedInExtractor:
 
         ``page_deadline`` is an absolute monotonic end of the search budget.
         Navigation, the ``<main>`` wait, scrolling, and the rate-limit backoff
-        are each capped by what remains of it. When the backoff alone would
+        are each capped by what remains of it. When the backoff plus a minimum retry-work reserve would
         overrun, the rate-limited sentinel is returned without retrying.
         """
         try:
@@ -3571,13 +3576,16 @@ class LinkedInExtractor:
 
             if page_deadline is not None:
                 remaining = page_deadline - time.monotonic()
-                if remaining < _RATE_LIMIT_RETRY_DELAY:
+                retry_need = _RATE_LIMIT_RETRY_DELAY + _RATE_LIMIT_RETRY_WORK
+                if remaining < retry_need:
                     logger.info(
                         "Skipping search page retry on %s: %.1fs left, "
-                        "need %.1fs backoff",
+                        "need %.1fs (%.1fs backoff + %.1fs retry work)",
                         url,
                         remaining,
+                        retry_need,
                         _RATE_LIMIT_RETRY_DELAY,
+                        _RATE_LIMIT_RETRY_WORK,
                     )
                     return result
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -338,21 +338,39 @@ _SCROLL_BUDGET_TOTAL = 60.0
 # developer search take 83s in total, 6.5s each, so this leaves the normal case
 # untouched and only catches a run that is genuinely running out.
 #
-# This predicts, it does not guarantee. Only the decision to *start* a page is
-# bounded; once started, a page runs to its own timeouts, and `goto` alone
-# allows 30s. The reserve is what covers that gap, and it has three claims on
-# it: the extraction and assembly after the last navigation, a page slower than
-# every page before it, and the browser startup inside `get_ready_extractor`,
-# which FastMCP is already timing before this budget begins. A page that
-# overruns the reserve is still cancelled and still loses every page gathered.
-# Bounding that too means handing the remaining budget down into navigation
-# and the rate-limit retry; see #754 rather than the margin. Scrolling is
-# already handed a deadline, so it takes what is left of this budget when
-# that is less than its own cap.
+# The loop predicts before admitting page N. Once admitted, the page is also
+# handed `page_deadline` (the same absolute end of this budget) so `goto`, the
+# `<main>` wait, scrolling, and the soft rate-limit backoff cannot each spend
+# their own constant past what is left. The 20% reserve still covers assembly
+# after the last navigation, a page slower than every page before it, and
+# browser startup inside `get_ready_extractor`, which FastMCP is already timing
+# before this budget begins.
 #
 # The timeout arrives as an argument because `get_config()` parses `sys.argv`
 # on its first call, and a scraping path is the wrong place to discover that.
 _SEARCH_TIMEOUT_FRACTION = 0.8
+
+# Playwright `goto` default used everywhere navigation is uncapped. Search
+# pages replace this with whatever remains of `page_deadline`.
+_GOTO_TIMEOUT_MS = 30_000.0
+
+
+def _timeout_ms_until(
+    deadline: float | None, *, default_ms: float = _GOTO_TIMEOUT_MS
+) -> float:
+    """Milliseconds allowed until *deadline*, or *default_ms* when unbound.
+
+    A non-positive remainder becomes ``1`` so Playwright still treats it as an
+    explicit short timeout rather than falling back to the page default (its
+    behaviour for ``timeout=0``).
+    """
+    if deadline is None:
+        return default_ms
+    remaining_ms = (deadline - time.monotonic()) * 1000
+    if remaining_ms <= 0:
+        return 1.0
+    return min(default_ms, remaining_ms)
+
 
 _SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"
 # Where a saved-jobs navigation may legitimately end. LinkedIn redirects the
@@ -1158,6 +1176,7 @@ class LinkedInExtractor:
         *,
         wait_until: WaitUntil = "domcontentloaded",
         allow_remember_me: bool = True,
+        timeout_ms: float = _GOTO_TIMEOUT_MS,
     ) -> None:
         """Navigate to a LinkedIn page and fail fast on auth barriers."""
         hops: list[str] = []
@@ -1186,7 +1205,7 @@ class LinkedInExtractor:
                 extra={"target_url": url, "wait_until": wait_until},
             )
             try:
-                await self._page.goto(url, wait_until=wait_until, timeout=30000)
+                await self._page.goto(url, wait_until=wait_until, timeout=timeout_ms)
                 await stabilize_navigation(f"goto {url}", logger)
                 await record_page_trace(
                     self._page,
@@ -1230,6 +1249,7 @@ class LinkedInExtractor:
                         url,
                         wait_until=wait_until,
                         allow_remember_me=False,
+                        timeout_ms=timeout_ms,
                     )
                     return
                 await record_page_trace(
@@ -1270,6 +1290,7 @@ class LinkedInExtractor:
                     url,
                     wait_until=wait_until,
                     allow_remember_me=False,
+                    timeout_ms=timeout_ms,
                 )
                 return
 
@@ -1286,10 +1307,12 @@ class LinkedInExtractor:
         finally:
             unregister_navigation_listener()
 
-    async def _navigate_to_page(self, url: str) -> None:
+    async def _navigate_to_page(
+        self, url: str, *, timeout_ms: float = _GOTO_TIMEOUT_MS
+    ) -> None:
         """Navigate to a LinkedIn page and fail fast on auth barriers."""
-        logger.debug("_navigate_to_page: target=%s", url)
-        await self._goto_with_auth_checks(url)
+        logger.debug("_navigate_to_page: target=%s timeout_ms=%.0f", url, timeout_ms)
+        await self._goto_with_auth_checks(url, timeout_ms=timeout_ms)
 
     # ------------------------------------------------------------------
     # Generic browser helpers for LLM-driven connection flow
@@ -3519,19 +3542,37 @@ class LinkedInExtractor:
         url: str,
         section_name: str,
         scroll_deadline: float = _SCROLL_DEADLINE_MAX,
+        page_deadline: float | None = None,
     ) -> ExtractedSection:
         """Extract innerText from a job search page with soft rate-limit retry.
 
         Mirrors the noise-only detection and single-retry behavior of
         ``extract_page`` / ``_extract_page_once`` so that callers get a
         ``_RATE_LIMITED_MSG`` sentinel instead of silent empty results.
+
+        ``page_deadline`` is an absolute monotonic end of the search budget.
+        Navigation, the ``<main>`` wait, scrolling, and the rate-limit backoff
+        are each capped by what remains of it. When the backoff alone would
+        overrun, the rate-limited sentinel is returned without retrying.
         """
         try:
             result = await self._extract_search_page_once(
-                url, section_name, scroll_deadline
+                url, section_name, scroll_deadline, page_deadline=page_deadline
             )
             if result.text != _RATE_LIMITED_MSG:
                 return result
+
+            if page_deadline is not None:
+                remaining = page_deadline - time.monotonic()
+                if remaining < _RATE_LIMIT_RETRY_DELAY:
+                    logger.info(
+                        "Skipping search page retry on %s: %.1fs left, "
+                        "need %.1fs backoff",
+                        url,
+                        remaining,
+                        _RATE_LIMIT_RETRY_DELAY,
+                    )
+                    return result
 
             logger.info(
                 "Retrying search page %s after %.0fs backoff",
@@ -3540,7 +3581,10 @@ class LinkedInExtractor:
             )
             await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
             result = await self._extract_search_page_once(
-                url, section_name, scroll_deadline / 2
+                url,
+                section_name,
+                scroll_deadline / 2,
+                page_deadline=page_deadline,
             )
             if result.text == _RATE_LIMITED_MSG:
                 logger.warning("Search page %s still rate-limited after retry", url)
@@ -3566,9 +3610,17 @@ class LinkedInExtractor:
         url: str,
         section_name: str,
         scroll_deadline: float = _SCROLL_DEADLINE_MAX,
+        page_deadline: float | None = None,
     ) -> ExtractedSection:
         """Single attempt to navigate, scroll sidebar, and extract innerText."""
-        await self._navigate_to_page(url)
+        await self._navigate_to_page(url, timeout_ms=_timeout_ms_until(page_deadline))
+        # Navigation spent wall clock the scroll budget does not own. Re-cap
+        # against what is left so a slow `goto` cannot leave scrolling the
+        # original twelve seconds on a budget that already expired.
+        if page_deadline is not None:
+            scroll_deadline = min(
+                scroll_deadline, max(0.0, page_deadline - time.monotonic())
+            )
         await detect_rate_limit(self._page)
         # Above the selector wait and the modal close, so the window this
         # opens covers everything read from here on. Taken between them, a
@@ -3578,7 +3630,12 @@ class LinkedInExtractor:
 
         main_found = True
         try:
-            await self._page.wait_for_selector("main")
+            if page_deadline is not None:
+                await self._page.wait_for_selector(
+                    "main", timeout=_timeout_ms_until(page_deadline)
+                )
+            else:
+                await self._page.wait_for_selector("main")
         except PlaywrightTimeoutError:
             logger.debug("No <main> element found on %s", url)
             main_found = False
@@ -3864,17 +3921,18 @@ class LinkedInExtractor:
 
             url = base_url if offset == 0 else f"{base_url}&start={offset}"
             # Against what is left of the tool's own timeout as well. The
-            # per-page cap is twelve seconds and the whole search gets
+            # per-page scroll cap is twelve seconds and the whole search gets
             # `tool_timeout` times the fraction above, so a caller passing ten
             # seconds had the first scroll alone allowed to outlast the call
-            # and take every page gathered with it. Scrolling is the one part
-            # already told how long it may run, so it is the one part this can
-            # bound without handing the budget down into navigation.
+            # and take every page gathered with it. Navigation and the soft
+            # rate-limit retry share the same absolute end via `page_deadline`.
+            remaining = max(0.0, budget - (time.monotonic() - started))
             scroll_deadline = min(
                 _SCROLL_DEADLINE_MAX,
                 scroll_budget_left,
-                max(0.0, budget - (time.monotonic() - started)),
+                remaining,
             )
+            page_deadline = started + budget
             self._scroll_seconds = 0.0
 
             try:
@@ -3882,6 +3940,7 @@ class LinkedInExtractor:
                     url,
                     section_name="search_results",
                     scroll_deadline=scroll_deadline,
+                    page_deadline=page_deadline,
                 )
                 slowest_page = max(slowest_page, time.monotonic() - page_started)
                 scroll_budget_left = max(0.0, scroll_budget_left - self._scroll_seconds)

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1176,11 +1176,18 @@ class LinkedInExtractor:
         *,
         wait_until: WaitUntil = "domcontentloaded",
         allow_remember_me: bool = True,
-        timeout_ms: float = _GOTO_TIMEOUT_MS,
+        deadline: float | None = None,
     ) -> None:
-        """Navigate to a LinkedIn page and fail fast on auth barriers."""
+        """Navigate to a LinkedIn page and fail fast on auth barriers.
+
+        ``deadline`` is an absolute monotonic end. Each ``goto`` — including
+        remember-me retries — recomputes its Playwright timeout from what is
+        left, so a slow first attempt cannot hand the original allowance to a
+        second navigation (#754 / #882).
+        """
         hops: list[str] = []
         listener_registered = False
+        timeout_ms = _timeout_ms_until(deadline)
 
         def record_navigation(frame: Any) -> None:
             if frame != self._page.main_frame:
@@ -1249,7 +1256,7 @@ class LinkedInExtractor:
                         url,
                         wait_until=wait_until,
                         allow_remember_me=False,
-                        timeout_ms=timeout_ms,
+                        deadline=deadline,
                     )
                     return
                 await record_page_trace(
@@ -1290,7 +1297,7 @@ class LinkedInExtractor:
                     url,
                     wait_until=wait_until,
                     allow_remember_me=False,
-                    timeout_ms=timeout_ms,
+                    deadline=deadline,
                 )
                 return
 
@@ -1308,11 +1315,11 @@ class LinkedInExtractor:
             unregister_navigation_listener()
 
     async def _navigate_to_page(
-        self, url: str, *, timeout_ms: float = _GOTO_TIMEOUT_MS
+        self, url: str, *, deadline: float | None = None
     ) -> None:
         """Navigate to a LinkedIn page and fail fast on auth barriers."""
-        logger.debug("_navigate_to_page: target=%s timeout_ms=%.0f", url, timeout_ms)
-        await self._goto_with_auth_checks(url, timeout_ms=timeout_ms)
+        logger.debug("_navigate_to_page: target=%s deadline=%s", url, deadline)
+        await self._goto_with_auth_checks(url, deadline=deadline)
 
     # ------------------------------------------------------------------
     # Generic browser helpers for LLM-driven connection flow
@@ -3613,7 +3620,7 @@ class LinkedInExtractor:
         page_deadline: float | None = None,
     ) -> ExtractedSection:
         """Single attempt to navigate, scroll sidebar, and extract innerText."""
-        await self._navigate_to_page(url, timeout_ms=_timeout_ms_until(page_deadline))
+        await self._navigate_to_page(url, deadline=page_deadline)
         # Navigation spent wall clock the scroll budget does not own. Re-cap
         # against what is left so a slow `goto` cannot leave scrolling the
         # original twelve seconds on a budget that already expired.

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4519,6 +4519,191 @@ class TestSearchJobs:
         assert len(seen) == 6
         assert result["job_ids"] == [jid for page in pages[:6] for jid in page]
 
+    async def test_search_jobs_hands_the_page_deadline_down(self, mock_page):
+        """An admitted page must know when the search budget ends.
+
+        The loop already predicts before starting a page. Without also handing
+        the absolute end down, `goto` still allows 30s and the rate-limit
+        backoff still sleeps 5s, either of which can overrun the reserve and
+        cancel the tool with every prior page discarded (#754).
+        """
+
+        class Clock:
+            def __init__(self) -> None:
+                self.now = 0.0
+
+            def monotonic(self) -> float:
+                return self.now
+
+        clock = Clock()
+        extractor = LinkedInExtractor(mock_page)
+        seen: list[float | None] = []
+
+        async def capture(
+            url, section_name, scroll_deadline=None, page_deadline=None, **kwargs
+        ):
+            seen.append(page_deadline)
+            navigate(mock_page, url)
+            return extracted("Job results")
+
+        with (
+            patch.object(extractor_module, "time", clock),
+            patch.object(extractor, "_extract_search_page", side_effect=capture),
+            patch.object(
+                extractor,
+                "_extract_job_ids",
+                new_callable=AsyncMock,
+                return_value=["1", "2"],
+            ),
+            patch.object(
+                extractor,
+                "_get_total_search_pages",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await extractor.search_jobs("python", max_pages=1, tool_timeout=50)
+
+        # 50 * 0.8 = 40s budget from t=0.
+        assert seen == [40.0]
+
+    async def test_search_page_goto_timeout_follows_page_deadline(self, mock_page):
+        """Navigation may not keep its own 30s once the search is short on time.
+
+        Mutating away the deadline cap leaves `timeout_ms` at 30000 and leaves
+        scrolling the original twelve seconds after a slow `goto` has already
+        spent most of what remained.
+        """
+
+        class Clock:
+            def __init__(self) -> None:
+                self.now = 10.0
+
+            def monotonic(self) -> float:
+                return self.now
+
+        clock = Clock()
+        seen_timeouts: list[float] = []
+        seen_scroll: list[float | None] = []
+
+        async def navigate(url, *, timeout_ms=extractor_module._GOTO_TIMEOUT_MS):
+            seen_timeouts.append(timeout_ms)
+            clock.now += 2.5
+            return None
+
+        async def scroll(page, **kwargs):
+            seen_scroll.append(kwargs.get("deadline"))
+            return False
+
+        mock_page.url = "https://www.linkedin.com/jobs/search/?keywords=test"
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor_module, "time", clock),
+            patch.object(extractor, "_navigate_to_page", side_effect=navigate),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar",
+                side_effect=scroll,
+            ),
+        ):
+            await extractor._extract_search_page_once(
+                "https://www.linkedin.com/jobs/search/?keywords=test",
+                section_name="search_results",
+                scroll_deadline=12.0,
+                page_deadline=14.0,
+            )
+
+        assert seen_timeouts == [4000.0]
+        assert seen_scroll == [1.5]
+
+    async def test_search_page_skips_rate_limit_retry_when_backoff_would_overrun(
+        self, mock_page
+    ):
+        """A soft rate-limit must not sleep past the remaining search budget.
+
+        The predictor never costed the 5s backoff. Sleeping it on a page that
+        already returned noise is what still cancelled the tool with earlier
+        pages in hand.
+        """
+        once = AsyncMock(return_value=extracted(_RATE_LIMITED_MSG))
+        sleep = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+
+        class Clock:
+            def __init__(self) -> None:
+                self.now = 0.0
+
+            def monotonic(self) -> float:
+                return self.now
+
+        clock = Clock()
+        with (
+            patch.object(extractor_module, "time", clock),
+            patch.object(extractor, "_extract_search_page_once", once),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                sleep,
+            ),
+        ):
+            result = await extractor._extract_search_page(
+                "https://www.linkedin.com/jobs/search/?keywords=test",
+                section_name="search_results",
+                page_deadline=3.0,
+            )
+
+        assert result.text == _RATE_LIMITED_MSG
+        assert once.await_count == 1
+        sleep.assert_not_awaited()
+
+    async def test_search_page_still_retries_when_backoff_fits(self, mock_page):
+        """The skip is only for a backoff that cannot finish in time."""
+        once = AsyncMock(
+            side_effect=[
+                extracted(_RATE_LIMITED_MSG),
+                extracted("Python Developer\nAcme Corp"),
+            ]
+        )
+        sleep = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+
+        class Clock:
+            def __init__(self) -> None:
+                self.now = 0.0
+
+            def monotonic(self) -> float:
+                return self.now
+
+        clock = Clock()
+        with (
+            patch.object(extractor_module, "time", clock),
+            patch.object(extractor, "_extract_search_page_once", once),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                sleep,
+            ),
+        ):
+            result = await extractor._extract_search_page(
+                "https://www.linkedin.com/jobs/search/?keywords=test",
+                section_name="search_results",
+                page_deadline=30.0,
+            )
+
+        assert "Python Developer" in result.text
+        assert once.await_count == 2
+        sleep.assert_awaited_once_with(5.0)
+
     async def test_zero_max_pages_fetches_nothing(self, mock_page):
         """max_pages=0 should fetch zero pages (validation at tool boundary)."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4574,9 +4574,9 @@ class TestSearchJobs:
     async def test_search_page_goto_timeout_follows_page_deadline(self, mock_page):
         """Navigation may not keep its own 30s once the search is short on time.
 
-        Mutating away the deadline cap leaves `timeout_ms` at 30000 and leaves
-        scrolling the original twelve seconds after a slow `goto` has already
-        spent most of what remained.
+        Mutating away the deadline hand-off leaves `_navigate_to_page` unbound
+        and leaves scrolling the original twelve seconds after a slow `goto`
+        has already spent most of what remained.
         """
 
         class Clock:
@@ -4587,11 +4587,11 @@ class TestSearchJobs:
                 return self.now
 
         clock = Clock()
-        seen_timeouts: list[float] = []
+        seen_deadlines: list[float | None] = []
         seen_scroll: list[float | None] = []
 
-        async def navigate(url, *, timeout_ms=extractor_module._GOTO_TIMEOUT_MS):
-            seen_timeouts.append(timeout_ms)
+        async def navigate(url, *, deadline=None):
+            seen_deadlines.append(deadline)
             clock.now += 2.5
             return None
 
@@ -4625,8 +4625,59 @@ class TestSearchJobs:
                 page_deadline=14.0,
             )
 
-        assert seen_timeouts == [4000.0]
+        assert seen_deadlines == [14.0]
         assert seen_scroll == [1.5]
+
+    async def test_remember_me_retry_recomputes_goto_timeout(self, mock_page):
+        """A remember-me retry must not reuse the first attempt's allowance.
+
+        Converting the absolute deadline to a relative timeout once, then
+        forwarding that same number into the recursive retry, lets a page
+        admitted with four seconds left spend those four seconds twice —
+        once on the failed goto and again after the prompt (#882).
+        """
+
+        class Clock:
+            def __init__(self) -> None:
+                self.now = 0.0
+
+            def monotonic(self) -> float:
+                return self.now
+
+        clock = Clock()
+        timeouts: list[float] = []
+        calls = 0
+
+        async def goto(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            timeouts.append(kwargs["timeout"])
+            if calls == 1:
+                clock.now += 2.5
+                raise Exception("net::ERR_TOO_MANY_REDIRECTS")
+            return None
+
+        mock_page.goto = AsyncMock(side_effect=goto)
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor_module, "time", clock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                side_effect=[True],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            await extractor._goto_with_auth_checks(
+                "https://www.linkedin.com/jobs/search/?keywords=test",
+                deadline=4.0,
+            )
+
+        assert timeouts == [4000.0, 1500.0]
 
     async def test_search_page_skips_rate_limit_retry_when_backoff_would_overrun(
         self, mock_page

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -4718,8 +4718,45 @@ class TestSearchJobs:
         assert once.await_count == 1
         sleep.assert_not_awaited()
 
+    async def test_search_page_skips_retry_when_only_backoff_fits(self, mock_page):
+        """Backoff alone is not enough — the retry attempt needs budget too.
+
+        Mutation target: compare remaining only to ``_RATE_LIMIT_RETRY_DELAY``.
+        At 6s remaining the backoff fits, the sleep runs, and a second extract
+        starts with almost no page budget left (#882 / Greptile).
+        """
+        once = AsyncMock(return_value=extracted(_RATE_LIMITED_MSG))
+        sleep = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+
+        class Clock:
+            def __init__(self) -> None:
+                self.now = 0.0
+
+            def monotonic(self) -> float:
+                return self.now
+
+        clock = Clock()
+        with (
+            patch.object(extractor_module, "time", clock),
+            patch.object(extractor, "_extract_search_page_once", once),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                sleep,
+            ),
+        ):
+            result = await extractor._extract_search_page(
+                "https://www.linkedin.com/jobs/search/?keywords=test",
+                section_name="search_results",
+                page_deadline=6.0,
+            )
+
+        assert result.text == _RATE_LIMITED_MSG
+        assert once.await_count == 1
+        sleep.assert_not_awaited()
+
     async def test_search_page_still_retries_when_backoff_fits(self, mock_page):
-        """The skip is only for a backoff that cannot finish in time."""
+        """Retry when both the backoff and a minimum retry-work reserve fit."""
         once = AsyncMock(
             side_effect=[
                 extracted(_RATE_LIMITED_MSG),


### PR DESCRIPTION
## Summary
- Pass an absolute `page_deadline` (end of the 80% search budget) into `_extract_search_page` so an admitted page cannot keep its own constants past what is left.
- Cap `goto` / `_navigate_to_page` timeout, the `<main>` wait, and post-navigation scroll against remaining budget; skip the soft rate-limit 5s backoff when it would overrun.
- Add mutation-aware unit tests for deadline plumbing, goto/scroll caps, and retry skip vs retry-when-fits.

Closes #754

## Test plan
- [x] `uv run pytest tests/test_scraping.py -k "page_deadline or hands_the_page_deadline or skips_rate_limit_retry or still_retries_when_backoff or slow_search_stops or next_navigation_delay"`
- [x] `uv run ty check linkedin_mcp_server/scraping/extractor.py`
- [ ] CI green on the PR

## Synthetic prompt

> After #751, `search_jobs` still predicts only before admitting a page. Once started, `goto` allows 30s and the soft rate-limit path sleeps 5s then retries, either of which can overrun FastMCP's fail_after and discard every page already gathered. Pass the remaining search budget as an absolute `page_deadline` into `_extract_search_page` / `_extract_search_page_once`: cap navigation and `<main>` wait timeouts, re-cap scroll after goto, and skip the rate-limit backoff when it cannot finish in time. Update the #754 comment in extractor.py and add tests that fail if the deadline is not handed down or not applied.

Generated with Composer