### PR TITLE
refactor(scraping): Extract search URL grammar

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 from collections.abc import Iterator
 from dataclasses import dataclass
-import json
 import logging
 import re
 import time
@@ -46,7 +45,10 @@ from linkedin_mcp_server.scraping.connection import ActionSignals
 from linkedin_mcp_server.scraping.contracts import (
     RATE_LIMITED_SECTION_TEXT,
     ExtractedSection,
-    FilterValidationError,
+    # Re-exported, not used: the search filters that raise it moved to
+    # `search_urls`, while the MCP tool wrappers still catch the class through
+    # this module. The redundant alias is what marks that as deliberate.
+    FilterValidationError as FilterValidationError,
     rate_limited_section_error,
 )
 from linkedin_mcp_server.scraping.feed_payload import (
@@ -84,6 +86,12 @@ from linkedin_mcp_server.scraping.link_metadata import (
     Reference,
     build_references,
     dedupe_references,
+)
+from linkedin_mcp_server.scraping.search_urls import (
+    build_company_search_url,
+    build_content_search_url,
+    build_job_search_url,
+    build_people_search_url,
 )
 from linkedin_mcp_server.scraping.text import (
     filter_linkedin_noise_lines,
@@ -181,65 +189,10 @@ _URL_SETTLE_LAG = 0.3
 # its own navigation, so a page judged on arrival is judged empty.
 _DOCUMENT_READY_TIMEOUT = 5.0
 
-# Normalization maps for job search filters. Job search encodes recency as
-# ``f_TPR=r<seconds>``; content search uses named tokens, hence the separate
-# ``_CONTENT_DATE_POSTED_MAP`` below.
-_JOB_DATE_POSTED_MAP = {
-    "past_hour": "r3600",
-    "past_24_hours": "r86400",
-    "past_week": "r604800",
-    "past_month": "r2592000",
-}
-
-_EXPERIENCE_LEVEL_MAP = {
-    "internship": "1",
-    "entry": "2",
-    "associate": "3",
-    "mid_senior": "4",
-    "director": "5",
-    "executive": "6",
-}
-
-_JOB_TYPE_MAP = {
-    "full_time": "F",
-    "part_time": "P",
-    "contract": "C",
-    "temporary": "T",
-    "volunteer": "V",
-    "internship": "I",
-    "other": "O",
-}
-
-_WORK_TYPE_MAP = {"on_site": "1", "remote": "2", "hybrid": "3"}
-
-_SORT_BY_MAP = {"date": "DD", "relevance": "R"}
-
-# Content (post) search uses literal ``datePosted`` tokens inside a JSON-list
-# facet, e.g. ``datePosted=["past-week"]`` — unlike job search, which uses
-# ``f_TPR=r<seconds>`` codes. The three hyphenated values are LinkedIn's
-# complete set, verified live: the filter dropdown offers exactly Past 24
-# hours / week / month, and anything else is ignored while still being echoed
-# back in the url, so a near-miss spelling returns unfiltered results that
-# look filtered. The underscore keys are this server's own spelling, carried
-# over so ``date_posted`` reads the same here as in ``search_jobs``
-# (``_JOB_DATE_POSTED_MAP``); ``past_hour`` has no content-search equivalent.
-_CONTENT_DATE_POSTED_MAP = {
-    "past-24h": "past-24h",
-    "past_24_hours": "past-24h",
-    "past-week": "past-week",
-    "past_week": "past-week",
-    "past-month": "past-month",
-    "past_month": "past-month",
-}
-
 # Content search is an infinite scroll with no ``&start=`` pagination, so
 # ``max_pages`` caps scroll depth instead of fetching discrete pages. One
 # nominal "page" is this many scrolls.
 _CONTENT_SCROLLS_PER_REQUESTED_PAGE = 5
-
-# Valid tokens for the people-search ``network`` facet.
-# LinkedIn accepts "F" (1st-degree), "S" (2nd-degree), "O" (3rd-degree and beyond).
-_NETWORK_TOKENS = ("F", "S", "O")
 
 _DIALOG_SELECTOR = 'dialog[open], [role="dialog"]'
 _DIALOG_PREMIUM_LINK_SELECTOR = (
@@ -1457,22 +1410,6 @@ def _connection_result(
     if profile:
         result["profile"] = profile
     return result
-
-
-def _normalize_csv(value: str, mapping: dict[str, str]) -> str:
-    """Normalize a comma-separated filter value using the provided mapping."""
-    parts = [v.strip() for v in value.split(",")]
-    return ",".join(mapping.get(p, p) for p in parts)
-
-
-def _encode_list_facet(values: list[str]) -> str:
-    """Encode a list of string values for a LinkedIn people-search list facet.
-
-    LinkedIn's people-search URL uses JSON-list encoded facets of the form
-    ``["A","B"]``. This helper URL-encodes the rendered JSON so the final URL
-    contains e.g. ``%5B%22F%22%5D`` for ``["F"]``.
-    """
-    return quote_plus(json.dumps(values, separators=(",", ":")))
 
 
 async def _drain_listener_tasks(pending: list[asyncio.Task[None]]) -> None:
@@ -4269,44 +4206,6 @@ class LinkedInExtractor:
         match = re.search(r"of\s+(\d+)", text)
         return int(match.group(1)) if match else None
 
-    @staticmethod
-    def _build_job_search_url(
-        keywords: str,
-        location: str | None = None,
-        date_posted: str | None = None,
-        job_type: str | None = None,
-        experience_level: str | None = None,
-        work_type: str | None = None,
-        easy_apply: bool = False,
-        sort_by: str | None = None,
-    ) -> str:
-        """Build a LinkedIn job search URL with optional filters.
-
-        Human-readable names are normalized to LinkedIn URL codes.
-        Comma-separated values are normalized individually.
-        Unknown values pass through unchanged.
-        """
-        params = f"keywords={quote_plus(keywords)}"
-        if location:
-            params += f"&location={quote_plus(location)}"
-
-        if date_posted:
-            mapped = _JOB_DATE_POSTED_MAP.get(date_posted.strip(), date_posted)
-            params += f"&f_TPR={quote_plus(mapped)}"
-        if job_type:
-            params += f"&f_JT={_normalize_csv(job_type, _JOB_TYPE_MAP)}"
-        if experience_level:
-            params += f"&f_E={_normalize_csv(experience_level, _EXPERIENCE_LEVEL_MAP)}"
-        if work_type:
-            params += f"&f_WT={_normalize_csv(work_type, _WORK_TYPE_MAP)}"
-        if easy_apply:
-            params += "&f_EA=true"
-        if sort_by:
-            mapped = _SORT_BY_MAP.get(sort_by.strip(), sort_by)
-            params += f"&sortBy={quote_plus(mapped)}"
-
-        return f"https://www.linkedin.com/jobs/search/?{params}"
-
     async def search_jobs(
         self,
         keywords: str,
@@ -4340,7 +4239,7 @@ class LinkedInExtractor:
         Returns:
             {url, sections: {search_results: text}, job_ids: [str]}
         """
-        base_url = self._build_job_search_url(
+        base_url = build_job_search_url(
             keywords,
             location=location,
             date_posted=date_posted,
@@ -5018,31 +4917,14 @@ class LinkedInExtractor:
         Returns:
             {url, sections: {name: text}}
         """
-        if network is not None:
-            invalid = [t for t in network if t not in _NETWORK_TOKENS]
-            if invalid:
-                raise FilterValidationError(
-                    "Invalid network token(s) "
-                    f"{invalid!r}; expected any of {list(_NETWORK_TOKENS)!r}"
-                )
-
-        if current_company and not re.fullmatch(r"[0-9]+", current_company):
-            raise FilterValidationError(
-                f"current_company must be a numeric LinkedIn company URN id "
-                f"(e.g. '1115' for SAP); got {current_company!r}. Plain-text "
-                f"company names are silently ignored by LinkedIn. Look up the "
-                f'URN via get_company_profile -> references["about"].'
-            )
-
-        params = f"keywords={quote_plus(keywords)}"
-        if location:
-            params += f"&location={quote_plus(location)}"
-        if network:
-            params += f"&network={_encode_list_facet(network)}"
-        if current_company:
-            params += f"&currentCompany={_encode_list_facet([current_company])}"
-
-        url = f"https://www.linkedin.com/search/results/people/?{params}"
+        # Builds before it navigates, and the builder refuses a filter
+        # LinkedIn would swallow, so an invalid token costs no page load.
+        url = build_people_search_url(
+            keywords,
+            location=location,
+            network=network,
+            current_company=current_company,
+        )
         extracted = await self.extract_page(url, section_name="search_results")
 
         sections: dict[str, str] = {}
@@ -5076,7 +4958,7 @@ class LinkedInExtractor:
         Returns:
             {url, sections: {search_results: text}}
         """
-        url = f"https://www.linkedin.com/search/results/companies/?keywords={quote_plus(keywords)}"
+        url = build_company_search_url(keywords)
         extracted = await self.extract_page(url, section_name="search_results")
 
         sections: dict[str, str] = {}
@@ -5101,32 +4983,6 @@ class LinkedInExtractor:
             result["section_errors"] = section_errors
         return result
 
-    @staticmethod
-    def _build_content_search_url(
-        keywords: str,
-        date_posted: str | None = None,
-    ) -> str:
-        """Build a LinkedIn content (post) search URL.
-
-        Reproduces the ``FACETED_SEARCH`` URL LinkedIn produces from the
-        Posts results tab, e.g. for "Buscamos Unity" in the past week:
-        ``/search/results/content/?keywords=Buscamos+Unity&origin=FACETED_SEARCH&datePosted=%5B%22past-week%22%5D``
-
-        The ``datePosted`` facet is a one-element JSON list carrying a literal
-        LinkedIn token, URL-encoded — unlike job search, which uses
-        ``f_TPR=r<seconds>``. The value is mapped through
-        ``_CONTENT_DATE_POSTED_MAP`` so the server's own underscore spelling
-        reaches LinkedIn in the form it recognizes. An unmapped value would be
-        ignored rather than rejected, so callers validate first.
-        """
-        params = f"keywords={quote_plus(keywords)}&origin=FACETED_SEARCH"
-        if date_posted and date_posted.strip():
-            token = _CONTENT_DATE_POSTED_MAP.get(
-                date_posted.strip(), date_posted.strip()
-            )
-            params += f"&datePosted={_encode_list_facet([token])}"
-        return f"https://www.linkedin.com/search/results/content/?{params}"
-
     async def search_posts(
         self,
         keywords: str,
@@ -5142,7 +4998,7 @@ class LinkedInExtractor:
         Args:
             keywords: Free-text query (e.g. "Buscamos Unity", "estamos contratando").
             date_posted: Optional recency filter, one of the keys of
-                ``_CONTENT_DATE_POSTED_MAP``. Invalid values raise
+                ``search_urls.CONTENT_DATE_POSTED_MAP``. Invalid values raise
                 ``FilterValidationError`` (a ``ValueError`` subclass) rather
                 than reaching LinkedIn, which would ignore them silently and
                 return unfiltered results that look filtered.
@@ -5160,17 +5016,9 @@ class LinkedInExtractor:
             The LLM should parse the raw text to extract each post's author,
             headline, body, date, and reaction counts.
         """
-        if (
-            date_posted is not None
-            and date_posted.strip()
-            and date_posted.strip() not in _CONTENT_DATE_POSTED_MAP
-        ):
-            raise FilterValidationError(
-                f"Invalid date_posted {date_posted!r}; expected one of "
-                f"{list(_CONTENT_DATE_POSTED_MAP)!r}."
-            )
-
-        url = self._build_content_search_url(keywords, date_posted=date_posted)
+        # Builds before it navigates, so a recency filter LinkedIn would
+        # ignore is refused rather than answered with unfiltered results.
+        url = build_content_search_url(keywords, date_posted=date_posted)
         max_scrolls = max(1, max_pages) * _CONTENT_SCROLLS_PER_REQUESTED_PAGE
         extracted = await self.extract_page(
             url, section_name="search_results", max_scrolls=max_scrolls

--- a/linkedin_mcp_server/scraping/search_urls.py
+++ b/linkedin_mcp_server/scraping/search_urls.py
@@ -1,0 +1,209 @@
+"""URL grammar and filter validation for LinkedIn's four search surfaces."""
+
+from __future__ import annotations
+
+from urllib.parse import quote_plus
+
+import json
+import re
+
+from linkedin_mcp_server.scraping.contracts import FilterValidationError
+
+# Normalization maps for job search filters. Job search encodes recency as
+# ``f_TPR=r<seconds>``; content search uses named tokens, hence the separate
+# ``CONTENT_DATE_POSTED_MAP`` below.
+JOB_DATE_POSTED_MAP = {
+    "past_hour": "r3600",
+    "past_24_hours": "r86400",
+    "past_week": "r604800",
+    "past_month": "r2592000",
+}
+
+EXPERIENCE_LEVEL_MAP = {
+    "internship": "1",
+    "entry": "2",
+    "associate": "3",
+    "mid_senior": "4",
+    "director": "5",
+    "executive": "6",
+}
+
+JOB_TYPE_MAP = {
+    "full_time": "F",
+    "part_time": "P",
+    "contract": "C",
+    "temporary": "T",
+    "volunteer": "V",
+    "internship": "I",
+    "other": "O",
+}
+
+WORK_TYPE_MAP = {"on_site": "1", "remote": "2", "hybrid": "3"}
+
+SORT_BY_MAP = {"date": "DD", "relevance": "R"}
+
+# Content (post) search uses literal ``datePosted`` tokens inside a JSON-list
+# facet, e.g. ``datePosted=["past-week"]`` — unlike job search, which uses
+# ``f_TPR=r<seconds>`` codes. The three hyphenated values are LinkedIn's
+# complete set, verified live: the filter dropdown offers exactly Past 24
+# hours / week / month, and anything else is ignored while still being echoed
+# back in the url, so a near-miss spelling returns unfiltered results that
+# look filtered. The underscore keys are this server's own spelling, carried
+# over so ``date_posted`` reads the same here as in ``search_jobs``
+# (``JOB_DATE_POSTED_MAP``); ``past_hour`` has no content-search equivalent.
+CONTENT_DATE_POSTED_MAP = {
+    "past-24h": "past-24h",
+    "past_24_hours": "past-24h",
+    "past-week": "past-week",
+    "past_week": "past-week",
+    "past-month": "past-month",
+    "past_month": "past-month",
+}
+
+# Valid tokens for the people-search ``network`` facet.
+# LinkedIn accepts "F" (1st-degree), "S" (2nd-degree), "O" (3rd-degree and beyond).
+NETWORK_TOKENS = ("F", "S", "O")
+
+
+def _normalize_csv(value: str, mapping: dict[str, str]) -> str:
+    """Normalize a comma-separated filter value using the provided mapping."""
+    parts = [v.strip() for v in value.split(",")]
+    return ",".join(mapping.get(p, p) for p in parts)
+
+
+def _encode_list_facet(values: list[str]) -> str:
+    """Encode a list of string values for a LinkedIn search list facet.
+
+    LinkedIn's people- and content-search URLs use JSON-list encoded facets of
+    the form ``["A","B"]``. This helper URL-encodes the rendered JSON so the
+    final URL contains e.g. ``%5B%22F%22%5D`` for ``["F"]``.
+    """
+    return quote_plus(json.dumps(values, separators=(",", ":")))
+
+
+def build_job_search_url(
+    keywords: str,
+    location: str | None = None,
+    date_posted: str | None = None,
+    job_type: str | None = None,
+    experience_level: str | None = None,
+    work_type: str | None = None,
+    easy_apply: bool = False,
+    sort_by: str | None = None,
+) -> str:
+    """Build a LinkedIn job search URL with optional filters.
+
+    Human-readable names are normalized to LinkedIn URL codes.
+    Comma-separated values are normalized individually.
+    Unknown values pass through unchanged.
+    """
+    params = f"keywords={quote_plus(keywords)}"
+    if location:
+        params += f"&location={quote_plus(location)}"
+
+    if date_posted:
+        mapped = JOB_DATE_POSTED_MAP.get(date_posted.strip(), date_posted)
+        params += f"&f_TPR={quote_plus(mapped)}"
+    if job_type:
+        params += f"&f_JT={_normalize_csv(job_type, JOB_TYPE_MAP)}"
+    if experience_level:
+        params += f"&f_E={_normalize_csv(experience_level, EXPERIENCE_LEVEL_MAP)}"
+    if work_type:
+        params += f"&f_WT={_normalize_csv(work_type, WORK_TYPE_MAP)}"
+    if easy_apply:
+        params += "&f_EA=true"
+    if sort_by:
+        mapped = SORT_BY_MAP.get(sort_by.strip(), sort_by)
+        params += f"&sortBy={quote_plus(mapped)}"
+
+    return f"https://www.linkedin.com/jobs/search/?{params}"
+
+
+def build_people_search_url(
+    keywords: str,
+    location: str | None = None,
+    network: list[str] | None = None,
+    current_company: str | None = None,
+) -> str:
+    """Build a LinkedIn people search URL, refusing filters LinkedIn ignores.
+
+    Both refusals happen before a URL exists, so a workflow calling this can
+    never navigate on a filter LinkedIn would swallow. An unknown ``network``
+    token and a plain-text ``currentCompany`` are each accepted by the URL and
+    then dropped, which answers with the unfiltered result set while the
+    request still reads as filtered.
+    """
+    if network is not None:
+        invalid = [t for t in network if t not in NETWORK_TOKENS]
+        if invalid:
+            raise FilterValidationError(
+                "Invalid network token(s) "
+                f"{invalid!r}; expected any of {list(NETWORK_TOKENS)!r}"
+            )
+
+    if current_company and not re.fullmatch(r"[0-9]+", current_company):
+        raise FilterValidationError(
+            f"current_company must be a numeric LinkedIn company URN id "
+            f"(e.g. '1115' for SAP); got {current_company!r}. Plain-text "
+            f"company names are silently ignored by LinkedIn. Look up the "
+            f'URN via get_company_profile -> references["about"].'
+        )
+
+    params = f"keywords={quote_plus(keywords)}"
+    if location:
+        params += f"&location={quote_plus(location)}"
+    if network:
+        params += f"&network={_encode_list_facet(network)}"
+    if current_company:
+        params += f"&currentCompany={_encode_list_facet([current_company])}"
+
+    return f"https://www.linkedin.com/search/results/people/?{params}"
+
+
+def build_company_search_url(keywords: str) -> str:
+    """Build a LinkedIn company search URL.
+
+    One parameter today, and a function anyway: every search URL this server
+    navigates to is then written in one place, so the next caller has nothing
+    to assemble by hand and no second spelling of the host and route to keep
+    in step with the other three.
+    """
+    return (
+        "https://www.linkedin.com/search/results/companies/"
+        f"?keywords={quote_plus(keywords)}"
+    )
+
+
+def build_content_search_url(
+    keywords: str,
+    date_posted: str | None = None,
+) -> str:
+    """Build a LinkedIn content (post) search URL.
+
+    Reproduces the ``FACETED_SEARCH`` URL LinkedIn produces from the
+    Posts results tab, e.g. for "Buscamos Unity" in the past week:
+    ``/search/results/content/?keywords=Buscamos+Unity&origin=FACETED_SEARCH&datePosted=%5B%22past-week%22%5D``
+
+    The ``datePosted`` facet is a one-element JSON list carrying a literal
+    LinkedIn token, URL-encoded — unlike job search, which uses
+    ``f_TPR=r<seconds>``. The value is mapped through
+    ``CONTENT_DATE_POSTED_MAP`` so the server's own underscore spelling
+    reaches LinkedIn in the form it recognizes. An unmapped value is refused
+    here rather than sent, because LinkedIn ignores one instead of rejecting
+    it and answers an unfiltered search that reads as a filtered one.
+    """
+    if (
+        date_posted is not None
+        and date_posted.strip()
+        and date_posted.strip() not in CONTENT_DATE_POSTED_MAP
+    ):
+        raise FilterValidationError(
+            f"Invalid date_posted {date_posted!r}; expected one of "
+            f"{list(CONTENT_DATE_POSTED_MAP)!r}."
+        )
+
+    params = f"keywords={quote_plus(keywords)}&origin=FACETED_SEARCH"
+    if date_posted and date_posted.strip():
+        token = CONTENT_DATE_POSTED_MAP.get(date_posted.strip(), date_posted.strip())
+        params += f"&datePosted={_encode_list_facet([token])}"
+    return f"https://www.linkedin.com/search/results/content/?{params}"

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -116,7 +116,6 @@ _BOUNDARY_OWNERS = {
 
 _IMPORT_OWNERS = {
     "LinkedInExtractor": ("facade.LinkedInExtractor", 14),
-    "_CONTENT_DATE_POSTED_MAP": ("search_urls.CONTENT_DATE_POSTED_MAP", 2),
     "_ACTION_SIGNALS_JS": ("connection_actions.ACTION_SIGNALS_JS", 7),
     "_CLICK_INCOMING_ACCEPT_JS": ("connection_actions.CLICK_INCOMING_ACCEPT_JS", 7),
     "_JOB_IDS_JS": ("job_pages.JOB_IDS_JS", 9),

--- a/tests/fixtures/scraping-policy/migration-manifest.json
+++ b/tests/fixtures/scraping-policy/migration-manifest.json
@@ -851,14 +851,6 @@
       "target": "LinkedInExtractor"
     },
     {
-      "canonical_owner": "search_urls.CONTENT_DATE_POSTED_MAP",
-      "kind": "direct_import",
-      "line": 31,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_CONTENT_DATE_POSTED_MAP"
-    },
-    {
       "canonical_owner": "message_sender.MESSAGE_COMPOSER_OWNER_JS",
       "kind": "direct_import",
       "line": 31,
@@ -899,129 +891,9 @@
       "target": "ExtractedSection"
     },
     {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 56,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 60,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 65,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 69,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 73,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 79,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 85,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 89,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 95,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 99,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 103,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 107,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 111,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 117,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_job_search_url",
-      "kind": "private_facade_access",
-      "line": 121,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_job_search_url"
-    },
-    {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 249,
+      "line": 161,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -1029,7 +901,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 253,
+      "line": 165,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1037,7 +909,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 257,
+      "line": 169,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1045,7 +917,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_facade_access",
-      "line": 282,
+      "line": 194,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -1053,7 +925,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> error_diagnostics.build_issue_diagnostics",
       "kind": "string_patch",
-      "line": 300,
+      "line": 212,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics"
@@ -1061,7 +933,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 317,
+      "line": 229,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -1069,7 +941,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 334,
+      "line": 246,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1077,7 +949,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 358,
+      "line": 270,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -1085,7 +957,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 362,
+      "line": 274,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1093,7 +965,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 366,
+      "line": 278,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1101,7 +973,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 371,
+      "line": 283,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -1109,7 +981,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 407,
+      "line": 319,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -1117,7 +989,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 411,
+      "line": 323,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1125,7 +997,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 415,
+      "line": 327,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1133,7 +1005,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 420,
+      "line": 332,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -1141,7 +1013,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 444,
+      "line": 356,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -1149,7 +1021,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 448,
+      "line": 360,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1157,7 +1029,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 452,
+      "line": 364,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1165,7 +1037,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 458,
+      "line": 370,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -1173,7 +1045,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 471,
+      "line": 383,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1181,7 +1053,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 479,
+      "line": 391,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
@@ -1189,7 +1061,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 508,
+      "line": 420,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1197,7 +1069,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 514,
+      "line": 426,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1205,7 +1077,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 519,
+      "line": 431,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1213,7 +1085,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 523,
+      "line": 435,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1221,7 +1093,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 529,
+      "line": 441,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
@@ -1229,7 +1101,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 551,
+      "line": 463,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1237,7 +1109,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 557,
+      "line": 469,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1245,7 +1117,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 562,
+      "line": 474,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1253,7 +1125,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 566,
+      "line": 478,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1261,7 +1133,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 573,
+      "line": 485,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
@@ -1269,7 +1141,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 595,
+      "line": 507,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1277,7 +1149,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 601,
+      "line": 513,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_raise_if_auth_barrier"
@@ -1285,7 +1157,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 607,
+      "line": 519,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1293,7 +1165,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 612,
+      "line": 524,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1301,7 +1173,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 618,
+      "line": 530,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
@@ -1309,7 +1181,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 657,
+      "line": 569,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1317,7 +1189,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 658,
+      "line": 570,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1325,7 +1197,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 662,
+      "line": 574,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1333,7 +1205,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 667,
+      "line": 579,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1341,7 +1213,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 674,
+      "line": 586,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1349,7 +1221,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 698,
+      "line": 610,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1357,7 +1229,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 699,
+      "line": 611,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1365,7 +1237,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 703,
+      "line": 615,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1373,7 +1245,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 708,
+      "line": 620,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1381,7 +1253,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 714,
+      "line": 626,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1389,7 +1261,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 747,
+      "line": 659,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1397,7 +1269,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 748,
+      "line": 660,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1405,7 +1277,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 752,
+      "line": 664,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1413,7 +1285,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 757,
+      "line": 669,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1421,7 +1293,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 761,
+      "line": 673,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -1429,7 +1301,103 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 767,
+      "line": 679,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 700,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 701,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 705,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 710,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
+      "kind": "string_patch",
+      "line": 715,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 722,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 741,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 742,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 746,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 751,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
+      "kind": "string_patch",
+      "line": 756,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 762,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1469,7 +1437,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 803,
+      "line": 802,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -1477,7 +1445,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 810,
+      "line": 809,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1485,7 +1453,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 829,
+      "line": 836,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1493,7 +1461,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 830,
+      "line": 837,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1501,7 +1469,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 834,
+      "line": 841,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1509,7 +1477,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 839,
+      "line": 846,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1517,111 +1485,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 844,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
       "line": 850,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 876,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 877,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 881,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 886,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 890,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 897,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 924,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 925,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 929,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 934,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 938,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 943,
+      "line": 855,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1629,7 +1501,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 982,
+      "line": 894,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -1637,7 +1509,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 983,
+      "line": 895,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1645,7 +1517,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 984,
+      "line": 896,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1653,7 +1525,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 988,
+      "line": 900,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1661,7 +1533,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 993,
+      "line": 905,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1669,7 +1541,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 998,
+      "line": 910,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1677,7 +1549,7 @@
     {
       "canonical_owner": "session.ScrapingSession._scroll_seconds",
       "kind": "private_facade_access",
-      "line": 1005,
+      "line": 917,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_scroll_seconds"
@@ -1685,7 +1557,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1029,
+      "line": 941,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1693,7 +1565,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 1030,
+      "line": 942,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1701,7 +1573,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 1034,
+      "line": 946,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1709,7 +1581,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1039,
+      "line": 951,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1717,7 +1589,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 1044,
+      "line": 956,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -1725,7 +1597,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1047,
+      "line": 959,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -1733,7 +1605,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1053,
+      "line": 965,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1741,15 +1613,95 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
+      "line": 992,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 993,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 997,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 1002,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 1008,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 1034,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 1035,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 1039,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 1044,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 1050,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 1079,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
       "line": 1080,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 1081,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1757,7 +1709,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 1085,
+      "line": 1084,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1765,7 +1717,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1090,
+      "line": 1089,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1773,7 +1725,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1096,
+      "line": 1095,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1781,39 +1733,31 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
+      "line": 1117,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 1118,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
       "line": 1122,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 1123,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1127,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 1132,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1138,
+      "line": 1128,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1821,7 +1765,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1167,
+      "line": 1160,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1829,7 +1773,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 1168,
+      "line": 1161,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1837,7 +1781,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 1172,
+      "line": 1165,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1845,7 +1789,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1177,
+      "line": 1170,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1853,7 +1797,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1183,
+      "line": 1176,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1861,7 +1805,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 1205,
+      "line": 1207,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -1869,7 +1813,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 1206,
+      "line": 1208,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1877,39 +1821,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 1210,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 1216,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1248,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 1249,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1253,
+      "line": 1212,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1917,7 +1829,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1258,
+      "line": 1217,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1925,47 +1837,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1264,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1295,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 1296,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1300,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 1305,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 1311,
+      "line": 1223,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1973,7 +1845,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1334,
+      "line": 1246,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -1981,7 +1853,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1339,
+      "line": 1251,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick"
@@ -1989,7 +1861,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 1345,
+      "line": 1257,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -1997,7 +1869,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1368,
+      "line": 1280,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -2005,7 +1877,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1373,
+      "line": 1285,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick"
@@ -2013,7 +1885,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_facade_access",
-      "line": 1379,
+      "line": 1291,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
@@ -2021,7 +1893,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1402,
+      "line": 1314,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
@@ -2029,7 +1901,7 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 1407,
+      "line": 1319,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.record_page_trace"
@@ -2037,87 +1909,87 @@
     {
       "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
       "kind": "string_patch",
+      "line": 1323,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_facade_access",
+      "line": 1330,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_goto_with_auth_checks"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
+      "kind": "string_patch",
+      "line": 1364,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
+      "kind": "string_patch",
+      "line": 1369,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 1374,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_log_navigation_failure"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_facade_access",
+      "line": 1381,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_goto_with_auth_checks"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
+      "kind": "string_patch",
+      "line": 1394,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
+      "kind": "string_patch",
+      "line": 1399,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 1404,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_log_navigation_failure"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_facade_access",
       "line": 1411,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 1418,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1452,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1457,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1462,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_log_navigation_failure"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 1469,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1482,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1487,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1492,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_log_navigation_failure"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 1499,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
       "target": "_goto_with_auth_checks"
     },
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1515,
+      "line": 1427,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2125,7 +1997,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1521,
+      "line": 1433,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2133,7 +2005,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1527,
+      "line": 1439,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2141,7 +2013,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1542,
+      "line": 1454,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2149,7 +2021,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1548,
+      "line": 1460,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2157,7 +2029,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1554,
+      "line": 1466,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2165,7 +2037,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1577,
+      "line": 1489,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2173,7 +2045,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1583,
+      "line": 1495,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2181,7 +2053,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1589,
+      "line": 1501,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2189,7 +2061,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1606,
+      "line": 1518,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2197,7 +2069,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1623,
+      "line": 1535,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2205,7 +2077,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1629,
+      "line": 1541,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2213,7 +2085,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1635,
+      "line": 1547,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2221,7 +2093,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 1654,
+      "line": 1566,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2229,7 +2101,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1660,
+      "line": 1572,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2237,7 +2109,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1679,
+      "line": 1591,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2245,7 +2117,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1688,
+      "line": 1600,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2253,7 +2125,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1703,
+      "line": 1615,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2261,7 +2133,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1709,
+      "line": 1621,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2269,7 +2141,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1715,
+      "line": 1627,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2277,7 +2149,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1747,
+      "line": 1659,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2285,31 +2157,79 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
+      "line": 1665,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1671,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1701,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1707,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1713,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1727,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1733,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1739,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
       "line": 1753,
-      "migration_stage": 4,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
+      "target": "extract_page"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
       "line": 1759,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1789,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1795,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2317,7 +2237,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1801,
+      "line": 1765,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2325,7 +2245,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1815,
+      "line": 1779,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2333,7 +2253,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1821,
+      "line": 1785,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2341,7 +2261,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1827,
+      "line": 1791,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2349,7 +2269,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1841,
+      "line": 1805,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2357,7 +2277,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1847,
+      "line": 1811,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2365,55 +2285,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1853,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1867,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1873,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1879,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1893,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1899,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1905,
+      "line": 1817,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2421,7 +2293,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2084,
+      "line": 1996,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2429,7 +2301,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2089,
+      "line": 2001,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2437,7 +2309,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2095,
+      "line": 2007,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2445,7 +2317,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2100,
+      "line": 2012,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2453,7 +2325,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2106,
+      "line": 2018,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2461,7 +2333,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2127,
+      "line": 2039,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2469,7 +2341,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2130,
+      "line": 2042,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2477,7 +2349,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2136,
+      "line": 2048,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2485,7 +2357,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2137,
+      "line": 2049,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2493,7 +2365,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2140,
+      "line": 2052,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2501,7 +2373,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2164,
+      "line": 2076,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2509,7 +2381,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2197,
+      "line": 2109,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2517,7 +2389,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2200,
+      "line": 2112,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2525,7 +2397,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2206,
+      "line": 2118,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2533,7 +2405,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2210,
+      "line": 2122,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2541,7 +2413,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2258,
+      "line": 2170,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2549,7 +2421,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2266,
+      "line": 2178,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_fill_dialog_textarea"
@@ -2557,7 +2429,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2272,
+      "line": 2184,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2565,7 +2437,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2278,
+      "line": 2190,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2573,7 +2445,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2284,
+      "line": 2196,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2581,7 +2453,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2288,
+      "line": 2200,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2589,7 +2461,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2300,
+      "line": 2212,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2597,7 +2469,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2301,
+      "line": 2213,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2605,7 +2477,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2307,
+      "line": 2219,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2613,7 +2485,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2308,
+      "line": 2220,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2621,7 +2493,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2311,
+      "line": 2223,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2629,7 +2501,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2323,
+      "line": 2235,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2637,7 +2509,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2324,
+      "line": 2236,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2645,7 +2517,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2341,
+      "line": 2253,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2653,7 +2525,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2342,
+      "line": 2254,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2661,7 +2533,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2364,
+      "line": 2276,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2669,7 +2541,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2369,
+      "line": 2281,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2677,7 +2549,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2382,
+      "line": 2294,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2685,7 +2557,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2388,
+      "line": 2300,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2693,7 +2565,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2391,
+      "line": 2303,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2701,7 +2573,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2397,
+      "line": 2309,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2709,7 +2581,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2422,
+      "line": 2334,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2717,7 +2589,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2423,
+      "line": 2335,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2725,7 +2597,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2433,
+      "line": 2345,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2733,7 +2605,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2439,
+      "line": 2351,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2741,7 +2613,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2442,
+      "line": 2354,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2749,7 +2621,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2463,
+      "line": 2375,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2757,7 +2629,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2464,
+      "line": 2376,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2765,7 +2637,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2473,
+      "line": 2385,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2773,7 +2645,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2479,
+      "line": 2391,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2781,7 +2653,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2482,
+      "line": 2394,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_probe_invite_note_limit"
@@ -2789,7 +2661,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2488,
+      "line": 2400,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2797,7 +2669,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2511,
+      "line": 2423,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2805,7 +2677,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2512,
+      "line": 2424,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2813,7 +2685,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2518,
+      "line": 2430,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2821,7 +2693,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2524,
+      "line": 2436,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2829,7 +2701,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2527,
+      "line": 2439,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2837,7 +2709,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2545,
+      "line": 2457,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2845,7 +2717,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2546,
+      "line": 2458,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2853,7 +2725,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2552,
+      "line": 2464,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2861,7 +2733,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2555,
+      "line": 2467,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2869,7 +2741,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2573,
+      "line": 2485,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2877,7 +2749,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2578,
+      "line": 2490,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2885,7 +2757,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2587,
+      "line": 2499,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2893,7 +2765,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2593,
+      "line": 2505,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2901,7 +2773,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2598,
+      "line": 2510,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2909,7 +2781,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2618,
+      "line": 2530,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2917,7 +2789,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2623,
+      "line": 2535,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2925,7 +2797,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2629,
+      "line": 2541,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2933,7 +2805,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2635,
+      "line": 2547,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "click_button_by_text"
@@ -2941,7 +2813,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2641,
+      "line": 2553,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -2949,7 +2821,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2660,
+      "line": 2572,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2957,7 +2829,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2670,
+      "line": 2582,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2965,7 +2837,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2676,
+      "line": 2588,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2973,7 +2845,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2682,
+      "line": 2594,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2981,7 +2853,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2707,
+      "line": 2619,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2989,7 +2861,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2712,
+      "line": 2624,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2997,7 +2869,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2722,
+      "line": 2634,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -3005,7 +2877,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2728,
+      "line": 2640,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3013,7 +2885,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2744,
+      "line": 2656,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -3021,7 +2893,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2745,
+      "line": 2657,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -3029,7 +2901,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 2751,
+      "line": 2663,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -3037,7 +2909,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2752,
+      "line": 2664,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -3045,7 +2917,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2755,
+      "line": 2667,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -3053,7 +2925,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2765,
+      "line": 2677,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -3061,7 +2933,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2838,
+      "line": 2750,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -3069,7 +2941,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2841,
+      "line": 2753,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -3077,7 +2949,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2852,
+      "line": 2764,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -3085,7 +2957,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2865,
+      "line": 2777,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3093,7 +2965,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 2892,
+      "line": 2804,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3101,7 +2973,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2898,
+      "line": 2810,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3109,7 +2981,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2924,
+      "line": 2836,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3117,7 +2989,7 @@
     {
       "canonical_owner": "person.PersonScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "string_patch",
-      "line": 2929,
+      "line": 2841,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics"
@@ -3125,7 +2997,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 2933,
+      "line": 2845,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3133,7 +3005,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2939,
+      "line": 2851,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3141,7 +3013,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2969,
+      "line": 2881,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3149,7 +3021,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 2978,
+      "line": 2890,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3157,7 +3029,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2984,
+      "line": 2896,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3165,7 +3037,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 3007,
+      "line": 2919,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3173,7 +3045,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 3013,
+      "line": 2925,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -3181,7 +3053,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3019,
+      "line": 2931,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3189,7 +3061,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 3033,
+      "line": 2945,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3197,7 +3069,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 3042,
+      "line": 2954,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3205,7 +3077,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3048,
+      "line": 2960,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3213,7 +3085,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 3064,
+      "line": 2976,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3221,7 +3093,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3070,
+      "line": 2982,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3229,7 +3101,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 3086,
+      "line": 2998,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3237,7 +3109,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3092,
+      "line": 3004,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3245,7 +3117,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 3107,
+      "line": 3019,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3253,7 +3125,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3113,
+      "line": 3025,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3261,7 +3133,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 3134,
+      "line": 3046,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3269,7 +3141,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3143,
+      "line": 3055,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3277,7 +3149,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 3183,
+      "line": 3095,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -3285,7 +3157,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 3189,
+      "line": 3101,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -3293,7 +3165,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 3193,
+      "line": 3105,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -3301,7 +3173,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 3197,
+      "line": 3109,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -3309,7 +3181,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3202,
+      "line": 3114,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3317,55 +3189,55 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
+      "line": 3135,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper dependency",
+      "kind": "public_patch_object",
+      "line": 3150,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper dependency",
+      "kind": "public_patch_object",
+      "line": 3165,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3211,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3217,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 3223,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper dependency",
-      "kind": "public_patch_object",
-      "line": 3238,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper dependency",
-      "kind": "public_patch_object",
-      "line": 3253,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3299,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3305,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3311,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3317,
+      "line": 3229,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3373,7 +3245,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3330,
+      "line": 3242,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3381,7 +3253,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3339,
+      "line": 3251,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3389,7 +3261,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3345,
+      "line": 3257,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3397,7 +3269,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3351,
+      "line": 3263,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3405,7 +3277,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3381,
+      "line": 3293,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3413,7 +3285,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3386,
+      "line": 3298,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3421,7 +3293,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3392,
+      "line": 3304,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3429,7 +3301,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3398,
+      "line": 3310,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3437,7 +3309,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 3460,
+      "line": 3372,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -3445,7 +3317,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 3461,
+      "line": 3373,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -3453,7 +3325,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3467,
+      "line": 3379,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3461,7 +3333,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3473,
+      "line": 3385,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3469,7 +3341,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 3479,
+      "line": 3391,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -3477,7 +3349,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 3484,
+      "line": 3396,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -3485,7 +3357,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 3488,
+      "line": 3400,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -3493,10 +3365,82 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3558,
+      "line": 3470,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3476,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3482,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3488,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3507,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3513,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3519,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3525,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3557,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3558,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -3504,36 +3448,36 @@
       "line": 3564,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
+      "target": "_get_total_search_pages"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
       "line": 3570,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3576,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
+      "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 3595,
-      "migration_stage": 9,
+      "line": 3625,
+      "migration_stage": 3,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 3626,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3601,
+      "line": 3632,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3541,42 +3485,34 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3607,
+      "line": 3638,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3613,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3645,
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 3644,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3646,
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 3649,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3652,
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 3653,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
@@ -3587,73 +3523,9 @@
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 3713,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 3714,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3720,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3726,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 3732,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 3737,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 3741,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3746,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3771,
+      "line": 3683,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3661,7 +3533,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3776,
+      "line": 3688,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3669,7 +3541,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3782,
+      "line": 3694,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3677,7 +3549,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3788,
+      "line": 3700,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3685,7 +3557,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 3812,
+      "line": 3724,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3693,7 +3565,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3828,
+      "line": 3740,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3701,7 +3573,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3837,
+      "line": 3749,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3709,7 +3581,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3843,
+      "line": 3755,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3717,7 +3589,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3849,
+      "line": 3761,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3725,7 +3597,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3890,
+      "line": 3802,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3733,7 +3605,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3891,
+      "line": 3803,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3741,7 +3613,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3897,
+      "line": 3809,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3749,7 +3621,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3903,
+      "line": 3815,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3757,7 +3629,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3929,
+      "line": 3841,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3765,7 +3637,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3938,
+      "line": 3850,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3773,7 +3645,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3944,
+      "line": 3856,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3781,7 +3653,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3950,
+      "line": 3862,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3789,7 +3661,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3977,
+      "line": 3889,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3797,7 +3669,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3988,
+      "line": 3900,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3805,7 +3677,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3994,
+      "line": 3906,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3813,7 +3685,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4000,
+      "line": 3912,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3821,7 +3693,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4023,
+      "line": 3935,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3829,10 +3701,66 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4034,
+      "line": 3946,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3952,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3958,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3990,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3995,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4001,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4007,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4031,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -3840,36 +3768,12 @@
       "line": 4040,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 4046,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4078,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4083,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4089,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3877,7 +3781,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4095,
+      "line": 4052,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3885,7 +3789,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4119,
+      "line": 4110,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3893,7 +3797,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4128,
+      "line": 4111,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3901,7 +3805,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4134,
+      "line": 4117,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3909,7 +3813,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4140,
+      "line": 4123,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3917,7 +3821,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4198,
+      "line": 4157,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3925,7 +3829,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4199,
+      "line": 4163,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3933,7 +3837,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4205,
+      "line": 4169,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3941,39 +3845,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4211,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4245,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4251,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4257,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4263,
+      "line": 4175,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3981,7 +3853,7 @@
     {
       "canonical_owner": "session.ScrapingSession._scroll_seconds",
       "kind": "private_facade_access",
-      "line": 4303,
+      "line": 4215,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_scroll_seconds"
@@ -3989,7 +3861,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 4314,
+      "line": 4226,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -3997,7 +3869,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4315,
+      "line": 4227,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4005,7 +3877,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4316,
+      "line": 4228,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4013,7 +3885,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4322,
+      "line": 4234,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4021,7 +3893,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4328,
+      "line": 4240,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4029,7 +3901,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 4372,
+      "line": 4284,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4037,7 +3909,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4373,
+      "line": 4285,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4045,7 +3917,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4374,
+      "line": 4286,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4053,7 +3925,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4380,
+      "line": 4292,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4061,7 +3933,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4386,
+      "line": 4298,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4069,7 +3941,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 4436,
+      "line": 4348,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4077,7 +3949,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4437,
+      "line": 4349,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4085,7 +3957,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4438,
+      "line": 4350,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4093,7 +3965,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4444,
+      "line": 4356,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4101,7 +3973,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4450,
+      "line": 4362,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4109,7 +3981,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 4496,
+      "line": 4408,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4117,7 +3989,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4497,
+      "line": 4409,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4125,7 +3997,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4498,
+      "line": 4410,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4133,7 +4005,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4504,
+      "line": 4416,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4141,7 +4013,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4510,
+      "line": 4422,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4149,7 +4021,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4527,
+      "line": 4439,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4157,7 +4029,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4533,
+      "line": 4445,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4165,7 +4037,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4539,
+      "line": 4451,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4173,7 +4045,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4545,
+      "line": 4457,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4181,7 +4053,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4559,
+      "line": 4471,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4189,7 +4061,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4565,
+      "line": 4477,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4197,7 +4069,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4571,
+      "line": 4483,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4205,7 +4077,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4577,
+      "line": 4489,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4213,7 +4085,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4605,
+      "line": 4517,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4221,23 +4093,87 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
+      "line": 4525,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4531,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4537,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4553,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4558,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4564,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4570,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4592,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4601,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4607,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
       "line": 4613,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4619,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4625,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4245,7 +4181,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4641,
+      "line": 4631,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4253,7 +4189,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4646,
+      "line": 4642,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4261,7 +4197,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4652,
+      "line": 4648,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4269,7 +4205,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4658,
+      "line": 4654,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4277,7 +4213,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4680,
+      "line": 4693,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4285,7 +4221,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4689,
+      "line": 4698,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4293,7 +4229,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4695,
+      "line": 4704,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4301,7 +4237,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4701,
+      "line": 4710,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4309,7 +4245,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4719,
+      "line": 4727,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4317,7 +4253,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4730,
+      "line": 4737,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4325,7 +4261,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4736,
+      "line": 4743,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4333,151 +4269,159 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4742,
+      "line": 4749,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
+      "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 4781,
+      "line": 4769,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 4770,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 4774,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 4779,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 4785,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4786,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4792,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4798,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
+      "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
       "line": 4815,
-      "migration_stage": 9,
+      "migration_stage": 3,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_navigate_to_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 4816,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 4820,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
       "line": 4825,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
+      "kind": "private_facade_access",
       "line": 4831,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4837,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
+      "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4857,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 4858,
+      "line": 4847,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+      "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4856,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 4862,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+      "target": "_get_total_search_pages"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 4867,
-      "migration_stage": 9,
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4868,
+      "migration_stage": null,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+      "target": "asyncio.sleep"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 4873,
+      "kind": "private_patch_object",
+      "line": 4889,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
+      "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4903,
-      "migration_stage": 3,
+      "line": 4898,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
+      "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 4904,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+      "target": "_get_total_search_pages"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 4908,
-      "migration_stage": 9,
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4910,
+      "migration_stage": null,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 4913,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+      "target": "asyncio.sleep"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 4919,
+      "kind": "private_patch_object",
+      "line": 4927,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4485,15 +4429,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4935,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4944,
+      "line": 4933,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4501,7 +4437,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4950,
+      "line": 4939,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4509,7 +4445,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4956,
+      "line": 4945,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4517,7 +4453,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4977,
+      "line": 4961,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4525,23 +4461,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4986,
+      "line": 4970,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4992,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4998,
+      "line": 4976,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4549,7 +4477,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5015,
+      "line": 4996,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4557,39 +4485,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5021,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5027,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5033,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5049,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5058,
+      "line": 5005,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4597,31 +4493,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5064,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5084,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5093,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5099,
+      "line": 5011,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4629,7 +4501,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5155,
+      "line": 5067,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_document_origin"
@@ -4637,7 +4509,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 5171,
+      "line": 5083,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4645,7 +4517,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5172,
+      "line": 5084,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4653,7 +4525,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5178,
+      "line": 5090,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_settle_navigation"
@@ -4661,7 +4533,7 @@
     {
       "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
       "kind": "module_attribute",
-      "line": 5181,
+      "line": 5093,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_URL_SETTLE_QUIET"
@@ -4669,7 +4541,7 @@
     {
       "canonical_owner": "navigation.PageNavigator.URL_SETTLE_LAG",
       "kind": "module_attribute",
-      "line": 5182,
+      "line": 5094,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_URL_SETTLE_LAG"
@@ -4677,7 +4549,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 5195,
+      "line": 5107,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4685,7 +4557,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5196,
+      "line": 5108,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4693,7 +4565,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5202,
+      "line": 5114,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_settle_navigation"
@@ -4701,7 +4573,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 5219,
+      "line": 5131,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4709,7 +4581,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5220,
+      "line": 5132,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4717,7 +4589,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5226,
+      "line": 5138,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_settle_navigation"
@@ -4725,7 +4597,7 @@
     {
       "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
       "kind": "module_attribute",
-      "line": 5230,
+      "line": 5142,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_URL_SETTLE_QUIET"
@@ -4733,7 +4605,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 5249,
+      "line": 5161,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4741,7 +4613,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5250,
+      "line": 5162,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4749,7 +4621,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5255,
+      "line": 5167,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_settle_navigation"
@@ -4757,7 +4629,7 @@
     {
       "canonical_owner": "navigation.PageNavigator.URL_SETTLE_LAG",
       "kind": "module_attribute",
-      "line": 5257,
+      "line": 5169,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_URL_SETTLE_LAG"
@@ -4765,7 +4637,7 @@
     {
       "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
       "kind": "module_attribute",
-      "line": 5258,
+      "line": 5170,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_URL_SETTLE_QUIET"
@@ -4773,7 +4645,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 5276,
+      "line": 5188,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -4781,7 +4653,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5277,
+      "line": 5189,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4789,7 +4661,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5282,
+      "line": 5194,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_settle_navigation"
@@ -4797,7 +4669,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 5311,
+      "line": 5223,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -4805,7 +4677,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5312,
+      "line": 5224,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4813,7 +4685,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5316,
+      "line": 5228,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4821,7 +4693,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 5321,
+      "line": 5233,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -4829,7 +4701,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 5325,
+      "line": 5237,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -4837,7 +4709,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 5328,
+      "line": 5240,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -4845,7 +4717,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5334,
+      "line": 5246,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4853,7 +4725,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 5368,
+      "line": 5280,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -4861,7 +4733,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5369,
+      "line": 5281,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4869,7 +4741,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5373,
+      "line": 5285,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4877,7 +4749,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 5378,
+      "line": 5290,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -4885,7 +4757,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 5382,
+      "line": 5294,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -4893,7 +4765,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5388,
+      "line": 5300,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4901,7 +4773,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5416,
+      "line": 5328,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4909,7 +4781,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5422,
+      "line": 5334,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4917,7 +4789,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5428,
+      "line": 5340,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4925,7 +4797,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5434,
+      "line": 5346,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4933,7 +4805,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5456,
+      "line": 5368,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4941,7 +4813,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5462,
+      "line": 5374,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4949,7 +4821,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5468,
+      "line": 5380,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4957,7 +4829,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5474,
+      "line": 5386,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4965,7 +4837,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5491,
+      "line": 5403,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4973,7 +4845,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5500,
+      "line": 5412,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4981,7 +4853,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5506,
+      "line": 5418,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4989,7 +4861,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5512,
+      "line": 5424,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4997,7 +4869,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5528,
+      "line": 5440,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5005,7 +4877,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5535,
+      "line": 5447,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5013,7 +4885,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5541,
+      "line": 5453,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5021,7 +4893,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5547,
+      "line": 5459,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5029,7 +4901,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5569,
+      "line": 5481,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5037,7 +4909,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5572,
+      "line": 5484,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5045,7 +4917,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5578,
+      "line": 5490,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5053,7 +4925,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5584,
+      "line": 5496,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5061,7 +4933,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5602,
+      "line": 5514,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5069,7 +4941,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5607,
+      "line": 5519,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5077,7 +4949,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5613,
+      "line": 5525,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5085,7 +4957,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5619,
+      "line": 5531,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5093,7 +4965,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 5644,
+      "line": 5556,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -5101,7 +4973,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5645,
+      "line": 5557,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5109,7 +4981,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5649,
+      "line": 5561,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5117,7 +4989,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> navigation.PageNavigator",
       "kind": "string_patch",
-      "line": 5654,
+      "line": 5566,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
@@ -5125,7 +4997,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 5693,
+      "line": 5605,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -5133,7 +5005,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5694,
+      "line": 5606,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5141,7 +5013,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5698,
+      "line": 5610,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5149,7 +5021,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 5703,
+      "line": 5615,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5157,7 +5029,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5722,
+      "line": 5634,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5165,7 +5037,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5728,
+      "line": 5640,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5173,7 +5045,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5734,
+      "line": 5646,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5181,7 +5053,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5749,
+      "line": 5661,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5189,7 +5061,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5755,
+      "line": 5667,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5197,10 +5069,82 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5761,
+      "line": 5673,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5694,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5703,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5709,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 5715,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5736,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5741,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5747,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 5753,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5776,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -5208,20 +5152,12 @@
       "line": 5782,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5791,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5797,
+      "line": 5788,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5229,10 +5165,18 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5803,
+      "line": 5794,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5818,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -5240,20 +5184,12 @@
       "line": 5824,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5829,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5835,
+      "line": 5830,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5261,7 +5197,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5841,
+      "line": 5836,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5269,7 +5205,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5864,
+      "line": 5856,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5277,7 +5213,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5870,
+      "line": 5862,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5285,7 +5221,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5876,
+      "line": 5868,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5293,7 +5229,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5882,
+      "line": 5874,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5301,7 +5237,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5906,
+      "line": 5897,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5309,7 +5245,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5912,
+      "line": 5903,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5317,7 +5253,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5918,
+      "line": 5909,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5325,71 +5261,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5924,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5944,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5950,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5956,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5962,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5985,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5991,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5997,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 6003,
+      "line": 5915,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5397,7 +5269,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6035,
+      "line": 5947,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5405,7 +5277,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 6035,
+      "line": 5947,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5413,7 +5285,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6050,
+      "line": 5962,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5421,7 +5293,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6072,
+      "line": 5984,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5429,143 +5301,95 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6084,
+      "line": 5996,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
       "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 6008,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 6043,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 6055,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "posts.PostSearch dependency",
+      "kind": "public_patch_object",
+      "line": 6078,
+      "migration_stage": 10,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
       "line": 6096,
-      "migration_stage": 6,
+      "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "person.PersonScraper dependency",
+      "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6125,
-      "migration_stage": 6,
+      "line": 6110,
+      "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "person.PersonScraper dependency",
+      "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6137,
-      "migration_stage": 6,
+      "line": 6131,
+      "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "search_urls.build_content_search_url",
-      "kind": "private_facade_access",
-      "line": 6160,
-      "migration_stage": 2,
+      "canonical_owner": "posts.PostSearch dependency",
+      "kind": "public_patch_object",
+      "line": 6145,
+      "migration_stage": 10,
       "path": "tests/test_scraping.py",
-      "target": "_build_content_search_url"
+      "target": "extract_page"
     },
     {
-      "canonical_owner": "search_urls.build_content_search_url",
-      "kind": "private_facade_access",
-      "line": 6167,
-      "migration_stage": 2,
+      "canonical_owner": "posts.PostSearch dependency",
+      "kind": "public_patch_object",
+      "line": 6158,
+      "migration_stage": 10,
       "path": "tests/test_scraping.py",
-      "target": "_build_content_search_url"
+      "target": "extract_page"
     },
     {
-      "canonical_owner": "search_urls.build_content_search_url",
-      "kind": "private_facade_access",
-      "line": 6173,
-      "migration_stage": 2,
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6192,
+      "migration_stage": 4,
       "path": "tests/test_scraping.py",
-      "target": "_build_content_search_url"
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
     },
     {
-      "canonical_owner": "search_urls.build_content_search_url",
-      "kind": "private_facade_access",
-      "line": 6183,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_content_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_content_search_url",
-      "kind": "private_facade_access",
-      "line": 6190,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_content_search_url"
-    },
-    {
-      "canonical_owner": "search_urls.build_content_search_url",
-      "kind": "private_facade_access",
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
       "line": 6196,
-      "migration_stage": 2,
-      "path": "tests/test_scraping.py",
-      "target": "_build_content_search_url"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 6204,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 6222,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 6236,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 6255,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 6269,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 6282,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6316,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6320,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5573,7 +5397,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6324,
+      "line": 6200,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5581,7 +5405,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6330,
+      "line": 6206,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5589,7 +5413,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6357,
+      "line": 6233,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5597,7 +5421,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6361,
+      "line": 6237,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5605,7 +5429,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6365,
+      "line": 6241,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5613,7 +5437,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6371,
+      "line": 6247,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5621,7 +5445,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6396,
+      "line": 6272,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5629,7 +5453,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6400,
+      "line": 6276,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5637,7 +5461,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6404,
+      "line": 6280,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5645,7 +5469,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6410,
+      "line": 6286,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5653,39 +5477,135 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
+      "line": 6305,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6309,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6313,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6319,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6342,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6346,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6350,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6356,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6379,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6383,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6387,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6393,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6415,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6419,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6423,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
       "line": 6429,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6433,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6437,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6443,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
     },
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6466,
+      "line": 6463,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5693,7 +5613,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6470,
+      "line": 6467,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5701,103 +5621,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6474,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6480,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6503,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6507,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6511,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6517,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6539,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6543,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6547,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6553,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6587,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6591,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6595,
+      "line": 6471,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5805,7 +5629,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6600,
+      "line": 6476,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5813,7 +5637,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6605,
+      "line": 6481,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5821,7 +5645,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6636,
+      "line": 6512,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5829,7 +5653,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6640,
+      "line": 6516,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5837,7 +5661,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6644,
+      "line": 6520,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5845,39 +5669,135 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
+      "line": 6525,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6530,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6560,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6564,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6568,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6574,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6594,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6598,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6602,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6608,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6635,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6639,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6643,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
       "line": 6649,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6654,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
     },
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6680,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
       "line": 6684,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6688,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6692,
+      "line": 6688,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5885,7 +5805,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6698,
+      "line": 6694,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5925,7 +5845,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6759,
+      "line": 6748,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5933,7 +5853,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6763,
+      "line": 6752,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5941,7 +5861,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6767,
+      "line": 6756,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5949,7 +5869,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6773,
+      "line": 6762,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5957,7 +5877,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6804,
+      "line": 6782,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5965,7 +5885,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6808,
+      "line": 6786,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5973,7 +5893,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6812,
+      "line": 6790,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5981,103 +5901,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6818,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6842,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6846,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6850,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6856,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6872,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6876,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6880,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6886,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6906,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6910,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6914,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6920,
+      "line": 6796,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -6085,7 +5909,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6940,
+      "line": 6816,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6093,7 +5917,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 6946,
+      "line": 6822,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -6101,7 +5925,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6952,
+      "line": 6828,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6109,7 +5933,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6983,
+      "line": 6859,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6117,7 +5941,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6989,
+      "line": 6865,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6125,7 +5949,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7007,
+      "line": 6883,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6133,7 +5957,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7013,
+      "line": 6889,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6141,7 +5965,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7038,
+      "line": 6914,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6149,7 +5973,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7039,
+      "line": 6915,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -6157,7 +5981,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 7056,
+      "line": 6932,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_loaded_section"
@@ -6165,7 +5989,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7062,
+      "line": 6938,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6173,7 +5997,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7065,
+      "line": 6941,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6181,7 +6005,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7066,
+      "line": 6942,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6189,7 +6013,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7085,
+      "line": 6961,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6197,7 +6021,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 7091,
+      "line": 6967,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_loaded_section"
@@ -6205,7 +6029,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7096,
+      "line": 6972,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6213,7 +6037,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 7113,
+      "line": 6989,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_loaded_section"
@@ -6221,7 +6045,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7119,
+      "line": 6995,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6229,7 +6053,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7125,
+      "line": 7001,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6237,7 +6061,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 7151,
+      "line": 7027,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6245,7 +6069,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7157,
+      "line": 7033,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6253,7 +6077,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7206,
+      "line": 7082,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6261,7 +6085,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7207,
+      "line": 7083,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6269,7 +6093,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7211,
+      "line": 7087,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6277,7 +6101,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7216,
+      "line": 7092,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6285,7 +6109,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7262,
+      "line": 7138,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6293,7 +6117,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7268,
+      "line": 7144,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6301,7 +6125,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7272,
+      "line": 7148,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6309,7 +6133,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7292,
+      "line": 7168,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6317,7 +6141,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7298,
+      "line": 7174,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6325,7 +6149,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7302,
+      "line": 7178,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6333,7 +6157,7 @@
     {
       "canonical_owner": "person.PersonScraper -> owner-local logger binding",
       "kind": "imported_module_patch",
-      "line": 7307,
+      "line": 7183,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "logger.debug"
@@ -6341,7 +6165,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7335,
+      "line": 7211,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6349,7 +6173,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7336,
+      "line": 7212,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6357,7 +6181,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7340,
+      "line": 7216,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6365,7 +6189,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7373,
+      "line": 7249,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6373,7 +6197,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7374,
+      "line": 7250,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6381,7 +6205,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7378,
+      "line": 7254,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6389,7 +6213,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7383,
+      "line": 7259,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6397,7 +6221,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7402,
+      "line": 7278,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6405,7 +6229,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7403,
+      "line": 7279,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6413,7 +6237,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7407,
+      "line": 7283,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6421,7 +6245,7 @@
     {
       "canonical_owner": "message_sender.profile_urn_from_compose_url",
       "kind": "module_attribute",
-      "line": 7468,
+      "line": 7344,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_profile_urn_from_compose_url"
@@ -6429,7 +6253,7 @@
     {
       "canonical_owner": "message_sender.profile_path_from_url",
       "kind": "module_attribute",
-      "line": 7486,
+      "line": 7362,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_profile_path_from_url"
@@ -6437,7 +6261,7 @@
     {
       "canonical_owner": "message_sender.message_page_url_is_safe",
       "kind": "module_attribute",
-      "line": 7547,
+      "line": 7423,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_page_url_is_safe"
@@ -6445,7 +6269,7 @@
     {
       "canonical_owner": "message_sender.PROFILE_MESSAGE_TARGET_JS",
       "kind": "module_attribute",
-      "line": 7568,
+      "line": 7444,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_PROFILE_MESSAGE_TARGET_JS"
@@ -6453,7 +6277,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7615,
+      "line": 7491,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6461,7 +6285,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7621,
+      "line": 7497,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -6469,7 +6293,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7627,
+      "line": 7503,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6477,7 +6301,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7640,
+      "line": 7516,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6485,7 +6309,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7646,
+      "line": 7522,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -6493,7 +6317,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7652,
+      "line": 7528,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6501,7 +6325,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7667,
+      "line": 7543,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6509,7 +6333,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7672,
+      "line": 7548,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6517,7 +6341,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7676,
+      "line": 7552,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6525,7 +6349,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7680,
+      "line": 7556,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6533,7 +6357,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7685,
+      "line": 7561,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -6541,7 +6365,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 7690,
+      "line": 7566,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -6549,7 +6373,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7699,
+      "line": 7575,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -6557,7 +6381,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7703,
+      "line": 7579,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -6565,7 +6389,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7707,
+      "line": 7583,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -6573,119 +6397,191 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
+      "line": 7600,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7601,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7605,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7609,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7610,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7613,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7619,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7623,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 7652,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7653,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7657,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7661,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7662,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7665,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7674,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 7678,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7682,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 7705,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7706,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7710,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7714,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7715,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7718,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
       "line": 7724,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7725,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7729,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7733,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7734,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7737,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 7743,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7747,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7776,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7777,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7781,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7785,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7786,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7789,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 7798,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -6693,23 +6589,15 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7802,
+      "line": 7728,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
     },
     {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7806,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7829,
+      "line": 7751,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6717,7 +6605,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7830,
+      "line": 7752,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6725,7 +6613,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7834,
+      "line": 7756,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6733,7 +6621,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7838,
+      "line": 7760,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6741,7 +6629,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7839,
+      "line": 7761,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -6749,71 +6637,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 7842,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 7848,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 7852,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7875,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7876,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7880,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7884,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7885,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7888,
+      "line": 7764,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -6821,7 +6645,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7894,
+      "line": 7770,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -6829,7 +6653,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7915,
+      "line": 7791,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6837,7 +6661,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7916,
+      "line": 7792,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6845,7 +6669,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7920,
+      "line": 7796,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6853,7 +6677,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7924,
+      "line": 7800,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6861,7 +6685,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7925,
+      "line": 7801,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -6869,7 +6693,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7928,
+      "line": 7804,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_display_name"
@@ -6877,7 +6701,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7934,
+      "line": 7810,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -6885,7 +6709,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 7943,
+      "line": 7819,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -6893,7 +6717,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7949,
+      "line": 7825,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -6901,15 +6725,207 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
+      "line": 7829,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 7849,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7850,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7854,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7858,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7859,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 7862,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7868,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7877,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7883,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 7887,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 7906,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7907,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7911,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 7915,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7921,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 7938,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_navigate_to_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7939,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7943,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 7947,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
       "line": 7953,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 7970,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 7978,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 7988,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 7995,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
     },
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 7973,
+      "line": 8025,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -6917,7 +6933,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7974,
+      "line": 8026,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6925,7 +6941,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7978,
+      "line": 8030,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6933,7 +6949,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7982,
+      "line": 8034,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6941,86 +6957,22 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7983,
+      "line": 8035,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
     },
     {
-      "canonical_owner": "profile_page.ProfilePageReader",
+      "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7986,
-      "migration_stage": 6,
+      "line": 8038,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
+      "target": "_extract_conversation_thread_refs"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7992,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 8001,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 8007,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 8011,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8030,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8031,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8035,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 8039,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
+      "kind": "private_facade_access",
       "line": 8045,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
@@ -7029,7 +6981,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8062,
+      "line": 8068,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7037,7 +6989,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8063,
+      "line": 8069,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7045,18 +6997,10 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 8067,
+      "line": 8073,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 8071,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
@@ -7064,44 +7008,100 @@
       "line": 8077,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 8078,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 8081,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_facade_access",
+      "line": 8083,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
     },
     {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 8094,
-      "migration_stage": 11,
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 8110,
+      "migration_stage": 3,
       "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
+      "target": "_navigate_to_page"
     },
     {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 8102,
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 8111,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 8112,
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 8115,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
       "line": 8119,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
+      "target": "_wait_for_main_text"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
+      "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
+      "line": 8120,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 8123,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_facade_access",
+      "line": 8125,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_facade_access",
       "line": 8149,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_patch_object",
+      "line": 8163,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7109,7 +7109,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8150,
+      "line": 8164,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7117,7 +7117,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 8154,
+      "line": 8168,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -7125,39 +7125,47 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8158,
+      "line": 8172,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
     },
     {
-      "canonical_owner": "conversations.ConversationReader",
+      "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 8159,
+      "line": 8173,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 8179,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 8183,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8162,
+      "line": 8187,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
     },
     {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8169,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8192,
+      "line": 8223,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7165,7 +7173,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8193,
+      "line": 8224,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7173,7 +7181,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 8197,
+      "line": 8228,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -7181,74 +7189,34 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8201,
+      "line": 8232,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
     },
     {
-      "canonical_owner": "conversations.ConversationReader",
+      "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 8202,
-      "migration_stage": 11,
+      "line": 8233,
+      "migration_stage": 4,
       "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
+      "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8205,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8207,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8234,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8235,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
       "line": 8239,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
     },
     {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
       "line": 8243,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8244,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
@@ -7259,153 +7227,17 @@
       "target": "_extract_conversation_thread_refs"
     },
     {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8249,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8273,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8287,
+      "line": 8274,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
     },
     {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8288,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8292,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
+      "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8296,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 8297,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 8303,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
       "line": 8307,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8311,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8347,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8348,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8352,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8356,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 8357,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 8363,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 8367,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8371,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8398,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7413,15 +7245,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8431,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8455,
+      "line": 8331,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7429,7 +7253,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8458,
+      "line": 8334,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7437,7 +7261,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8462,
+      "line": 8338,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7445,7 +7269,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8466,
+      "line": 8342,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7453,7 +7277,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8470,
+      "line": 8346,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_message_surface"
@@ -7461,7 +7285,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8473,
+      "line": 8349,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_message_composer_state"
@@ -7469,7 +7293,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8476,
+      "line": 8352,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_focus_verified_message_editor"
@@ -7477,7 +7301,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8481,
+      "line": 8357,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -7485,7 +7309,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8512,
+      "line": 8388,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7493,7 +7317,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8513,
+      "line": 8389,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7501,7 +7325,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8517,
+      "line": 8393,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7509,7 +7333,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8521,
+      "line": 8397,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7517,7 +7341,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTarget",
       "kind": "module_attribute",
-      "line": 8534,
+      "line": 8410,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTarget"
@@ -7525,7 +7349,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8584,
+      "line": 8460,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7533,7 +7357,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8585,
+      "line": 8461,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7541,7 +7365,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8589,
+      "line": 8465,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7549,7 +7373,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8593,
+      "line": 8469,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7557,7 +7381,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8597,
+      "line": 8473,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_message_surface"
@@ -7565,7 +7389,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8603,
+      "line": 8479,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_message_composer_state"
@@ -7573,7 +7397,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8616,
+      "line": 8492,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_write_verified_message"
@@ -7581,7 +7405,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8622,
+      "line": 8498,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -7589,7 +7413,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 8628,
+      "line": 8504,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -7597,7 +7421,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8632,
+      "line": 8508,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7605,7 +7429,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8638,
+      "line": 8514,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7613,7 +7437,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 8673,
+      "line": 8549,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -7621,7 +7445,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8676,
+      "line": 8552,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7629,7 +7453,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8680,
+      "line": 8556,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7637,7 +7461,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8684,
+      "line": 8560,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7645,7 +7469,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8865,
+      "line": 8741,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -7653,7 +7477,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9011,
+      "line": 8887,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7661,7 +7485,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9017,
+      "line": 8893,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7669,7 +7493,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9090,
+      "line": 8966,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_verified_submit"
@@ -7677,7 +7501,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9096,
+      "line": 8972,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_cleanup_owned_message"
@@ -7685,7 +7509,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9196,
+      "line": 9072,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_write_verified_message"
@@ -7693,7 +7517,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9202,
+      "line": 9078,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -7701,7 +7525,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9209,
+      "line": 9085,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7709,7 +7533,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9215,
+      "line": 9091,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7717,7 +7541,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9250,
+      "line": 9126,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7725,7 +7549,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9375,
+      "line": 9251,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_confirmation"
@@ -7733,7 +7557,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9381,
+      "line": 9257,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_owner"
@@ -7741,7 +7565,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9432,
+      "line": 9308,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7749,7 +7573,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9438,
+      "line": 9314,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7757,7 +7581,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9470,
+      "line": 9346,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_compose_box"
@@ -7765,7 +7589,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_COMPOSE_SELECTOR",
       "kind": "module_attribute",
-      "line": 9473,
+      "line": 9349,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGING_COMPOSE_SELECTOR"
@@ -7773,7 +7597,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9495,
+      "line": 9371,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -7781,7 +7605,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9520,
+      "line": 9396,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -7789,7 +7613,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9532,
+      "line": 9408,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_owner"
@@ -7797,7 +7621,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9542,
+      "line": 9418,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7805,7 +7629,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9564,
+      "line": 9440,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7813,7 +7637,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9576,
+      "line": 9452,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7821,7 +7645,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9609,
+      "line": 9485,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7829,7 +7653,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9623,
+      "line": 9499,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_confirmation"
@@ -7837,7 +7661,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9659,
+      "line": 9535,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7845,7 +7669,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9673,
+      "line": 9549,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7853,7 +7677,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9697,
+      "line": 9573,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7861,7 +7685,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9722,
+      "line": 9598,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7869,7 +7693,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9741,
+      "line": 9617,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7877,7 +7701,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9761,
+      "line": 9637,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7885,7 +7709,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9806,
+      "line": 9682,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7893,7 +7717,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9867,
+      "line": 9743,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7901,7 +7725,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9905,
+      "line": 9781,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7909,10 +7733,74 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9940,
+      "line": 9816,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_facade_access",
+      "line": 9847,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_goto_with_auth_checks"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
+      "kind": "string_patch",
+      "line": 9860,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.record_page_trace"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_facade_access",
+      "line": 9866,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_goto_with_auth_checks"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
+      "kind": "string_patch",
+      "line": 9878,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_facade_access",
+      "line": 9885,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_goto_with_auth_checks"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
+      "kind": "string_patch",
+      "line": 9921,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator",
+      "kind": "private_facade_access",
+      "line": 9929,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "_goto_with_auth_checks"
+    },
+    {
+      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
+      "kind": "string_patch",
+      "line": 9964,
+      "migration_stage": 3,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
     },
     {
       "canonical_owner": "navigation.PageNavigator",
@@ -7923,73 +7811,9 @@
       "target": "_goto_with_auth_checks"
     },
     {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 9984,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.record_page_trace"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 9990,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 10002,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 10009,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 10045,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 10053,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 10088,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 10095,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 10130,
+      "line": 10006,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -7997,7 +7821,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 10136,
+      "line": 10012,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -8005,7 +7829,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 10137,
+      "line": 10013,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -8013,7 +7837,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 10152,
+      "line": 10028,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8021,7 +7845,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 10172,
+      "line": 10048,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8029,7 +7853,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 10172,
+      "line": 10048,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8037,7 +7861,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 10172,
+      "line": 10048,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8045,7 +7869,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 10172,
+      "line": 10048,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8053,7 +7877,7 @@
     {
       "canonical_owner": "conversations.ConversationReader dependency",
       "kind": "public_patch_object",
-      "line": 10172,
+      "line": 10048,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8061,7 +7885,7 @@
     {
       "canonical_owner": "message_sender.MessageSender dependency",
       "kind": "public_patch_object",
-      "line": 10172,
+      "line": 10048,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -8069,7 +7893,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 10173,
+      "line": 10049,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"
@@ -8077,7 +7901,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 10189,
+      "line": 10065,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -8085,7 +7909,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 10195,
+      "line": 10071,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -8093,7 +7917,7 @@
     {
       "canonical_owner": "navigation.PageNavigator",
       "kind": "private_patch_object",
-      "line": 10201,
+      "line": 10077,
       "migration_stage": 3,
       "path": "tests/test_scraping.py",
       "target": "_navigate_to_page"

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -324,10 +324,12 @@ def test_manifest_is_canonical_portable_json():
 
 
 def test_checker_rejects_obsolete_seams_at_their_migration_stage():
-    # One stage ahead of the tree, which is the smallest override the gate
-    # accepts and the only one that can still surface an unclosed seam.
+    # The lowest stage that still holds an unclosed seam, which is the only
+    # kind of override that can surface one. Stages at or below the tree's own
+    # completed stage are closed by definition, so an override there proves
+    # nothing; raise this number as each stage lands.
     result = subprocess.run(
-        [sys.executable, str(CHECKER), "--check", "--stage", "2"],
+        [sys.executable, str(CHECKER), "--check", "--stage", "3"],
         cwd=ROOT,
         text=True,
         capture_output=True,
@@ -335,8 +337,8 @@ def test_checker_rejects_obsolete_seams_at_their_migration_stage():
     )
 
     assert result.returncode == 1
-    assert "obsolete at stage 2:" in result.stderr
-    assert "direct_import" in result.stderr
+    assert "obsolete at stage 3:" in result.stderr
+    assert "string_patch" in result.stderr
 
 
 def test_checkers_offer_no_fixture_update_mode():
@@ -961,8 +963,8 @@ def test_manifest_includes_extractor_access_from_nested_closure():
         (seam["line"], seam["canonical_owner"], seam["migration_stage"])
         for seam in accesses
     } == {
-        (1005, "session.ScrapingSession._scroll_seconds", 3),
-        (4303, "session.ScrapingSession._scroll_seconds", 3),
+        (917, "session.ScrapingSession._scroll_seconds", 3),
+        (4215, "session.ScrapingSession._scroll_seconds", 3),
     }
 
 

--- a/tests/scraping/test_search_urls.py
+++ b/tests/scraping/test_search_urls.py
@@ -1,0 +1,500 @@
+"""Tests for the URL grammar of LinkedIn's four search surfaces.
+
+Browser-free by construction: every assertion here is against a string the
+builders return, so nothing in this file needs a page, a mock or an event
+loop. The expected codes are written out rather than read back from the maps
+under test, because a test that derives its expectation from the table it
+checks agrees with any table.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from linkedin_mcp_server.scraping.contracts import FilterValidationError
+from linkedin_mcp_server.scraping.search_urls import (
+    CONTENT_DATE_POSTED_MAP,
+    EXPERIENCE_LEVEL_MAP,
+    JOB_DATE_POSTED_MAP,
+    JOB_TYPE_MAP,
+    NETWORK_TOKENS,
+    SORT_BY_MAP,
+    WORK_TYPE_MAP,
+    build_company_search_url,
+    build_content_search_url,
+    build_job_search_url,
+    build_people_search_url,
+)
+
+JOBS = "https://www.linkedin.com/jobs/search/?"
+PEOPLE = "https://www.linkedin.com/search/results/people/?"
+COMPANIES = "https://www.linkedin.com/search/results/companies/?"
+CONTENT = "https://www.linkedin.com/search/results/content/?"
+
+# One keyword per encoding hazard: the plus sign LinkedIn would otherwise read
+# as a space, non-ASCII that has to survive as UTF-8 percent-escapes, and a
+# script with no ASCII in it at all.
+ENCODED_KEYWORDS = [
+    ("C++", "C%2B%2B"),
+    ("Müller", "M%C3%BCller"),
+    ("软件工程师", "%E8%BD%AF%E4%BB%B6%E5%B7%A5%E7%A8%8B%E5%B8%88"),
+    ("a&b=c", "a%26b%3Dc"),
+    ("python developer", "python+developer"),
+]
+
+
+class TestFilterTables:
+    """The vocabulary itself, written out once so a silent edit is visible."""
+
+    def test_job_date_posted_codes_are_linkedin_second_windows(self):
+        assert JOB_DATE_POSTED_MAP == {
+            "past_hour": "r3600",
+            "past_24_hours": "r86400",
+            "past_week": "r604800",
+            "past_month": "r2592000",
+        }
+
+    def test_experience_levels_are_linkedin_ordinals(self):
+        assert EXPERIENCE_LEVEL_MAP == {
+            "internship": "1",
+            "entry": "2",
+            "associate": "3",
+            "mid_senior": "4",
+            "director": "5",
+            "executive": "6",
+        }
+
+    def test_job_types_are_linkedin_initials(self):
+        assert JOB_TYPE_MAP == {
+            "full_time": "F",
+            "part_time": "P",
+            "contract": "C",
+            "temporary": "T",
+            "volunteer": "V",
+            "internship": "I",
+            "other": "O",
+        }
+
+    def test_work_types_are_linkedin_ordinals(self):
+        assert WORK_TYPE_MAP == {"on_site": "1", "remote": "2", "hybrid": "3"}
+
+    def test_sort_by_codes(self):
+        assert SORT_BY_MAP == {"date": "DD", "relevance": "R"}
+
+    def test_network_tokens_are_the_three_degrees(self):
+        assert NETWORK_TOKENS == ("F", "S", "O")
+
+    def test_content_date_posted_accepts_both_spellings(self):
+        assert CONTENT_DATE_POSTED_MAP == {
+            "past-24h": "past-24h",
+            "past_24_hours": "past-24h",
+            "past-week": "past-week",
+            "past_week": "past-week",
+            "past-month": "past-month",
+            "past_month": "past-month",
+        }
+
+    def test_past_hour_is_the_one_job_window_content_search_has_not(self):
+        # Documented asymmetry rather than an oversight: LinkedIn's Posts tab
+        # offers Past 24 hours / week / month and nothing shorter. Reading it
+        # off both tables keeps the two from drifting into an hour token that
+        # LinkedIn would ignore while echoing it back.
+        assert set(JOB_DATE_POSTED_MAP) - set(CONTENT_DATE_POSTED_MAP) == {"past_hour"}
+        assert "past_hour" in JOB_DATE_POSTED_MAP
+
+    def test_content_search_refuses_the_job_only_hour_window(self):
+        with pytest.raises(FilterValidationError, match="Invalid date_posted"):
+            build_content_search_url("python", date_posted="past_hour")
+
+    def test_every_content_token_is_one_linkedin_recognizes(self):
+        assert set(CONTENT_DATE_POSTED_MAP.values()) == {
+            "past-24h",
+            "past-week",
+            "past-month",
+        }
+
+
+class TestBuildJobSearchUrl:
+    def test_keywords_only(self):
+        assert build_job_search_url("python developer") == (
+            f"{JOBS}keywords=python+developer"
+        )
+
+    def test_every_parameter_keeps_its_recorded_position(self):
+        # Whole-URL equality locks the concatenation order. Substring
+        # assertions pass under any permutation.
+        assert build_job_search_url(
+            "python",
+            location="Berlin",
+            date_posted="past_week",
+            job_type="full_time",
+            experience_level="entry,mid_senior",
+            work_type="remote",
+            easy_apply=True,
+            sort_by="date",
+        ) == (
+            f"{JOBS}keywords=python&location=Berlin&f_TPR=r604800&f_JT=F"
+            "&f_E=2,4&f_WT=2&f_EA=true&sortBy=DD"
+        )
+
+    @pytest.mark.parametrize("keywords,encoded", ENCODED_KEYWORDS)
+    def test_keywords_are_percent_encoded(self, keywords: str, encoded: str):
+        assert build_job_search_url(keywords) == f"{JOBS}keywords={encoded}"
+
+    def test_empty_keywords_still_produce_the_parameter(self):
+        assert build_job_search_url("") == f"{JOBS}keywords="
+
+    def test_location_is_percent_encoded(self):
+        assert build_job_search_url("python", location="New York") == (
+            f"{JOBS}keywords=python&location=New+York"
+        )
+
+    @pytest.mark.parametrize(
+        "date_posted,code",
+        [
+            ("past_hour", "r3600"),
+            ("past_24_hours", "r86400"),
+            ("past_week", "r604800"),
+            ("past_month", "r2592000"),
+        ],
+    )
+    def test_date_posted_aliases(self, date_posted: str, code: str):
+        assert build_job_search_url("python", date_posted=date_posted) == (
+            f"{JOBS}keywords=python&f_TPR={code}"
+        )
+
+    def test_date_posted_alias_coverage_is_exhaustive(self):
+        assert set(JOB_DATE_POSTED_MAP) == {
+            "past_hour",
+            "past_24_hours",
+            "past_week",
+            "past_month",
+        }
+
+    def test_unknown_date_posted_passes_through(self):
+        assert build_job_search_url("python", date_posted="r7200") == (
+            f"{JOBS}keywords=python&f_TPR=r7200"
+        )
+
+    def test_padded_date_posted_looks_up_trimmed_but_falls_back_untrimmed(self):
+        # The lookup strips, the fallback does not. A padded known alias is
+        # therefore mapped, while a padded unknown value reaches LinkedIn with
+        # its spaces encoded — which is what makes such a filter visible in the
+        # url rather than silently ignored.
+        assert build_job_search_url("python", date_posted="  past_week ") == (
+            f"{JOBS}keywords=python&f_TPR=r604800"
+        )
+        assert build_job_search_url("python", date_posted=" r7200 ") == (
+            f"{JOBS}keywords=python&f_TPR=+r7200+"
+        )
+
+    @pytest.mark.parametrize(
+        "level,code",
+        [
+            ("internship", "1"),
+            ("entry", "2"),
+            ("associate", "3"),
+            ("mid_senior", "4"),
+            ("director", "5"),
+            ("executive", "6"),
+        ],
+    )
+    def test_experience_level_aliases(self, level: str, code: str):
+        assert build_job_search_url("python", experience_level=level) == (
+            f"{JOBS}keywords=python&f_E={code}"
+        )
+
+    @pytest.mark.parametrize(
+        "job_type,code",
+        [
+            ("full_time", "F"),
+            ("part_time", "P"),
+            ("contract", "C"),
+            ("temporary", "T"),
+            ("volunteer", "V"),
+            ("internship", "I"),
+            ("other", "O"),
+        ],
+    )
+    def test_job_type_aliases(self, job_type: str, code: str):
+        assert build_job_search_url("python", job_type=job_type) == (
+            f"{JOBS}keywords=python&f_JT={code}"
+        )
+
+    @pytest.mark.parametrize(
+        "work_type,code", [("on_site", "1"), ("remote", "2"), ("hybrid", "3")]
+    )
+    def test_work_type_aliases(self, work_type: str, code: str):
+        assert build_job_search_url("python", work_type=work_type) == (
+            f"{JOBS}keywords=python&f_WT={code}"
+        )
+
+    @pytest.mark.parametrize("sort_by,code", [("date", "DD"), ("relevance", "R")])
+    def test_sort_by_aliases(self, sort_by: str, code: str):
+        assert build_job_search_url("python", sort_by=sort_by) == (
+            f"{JOBS}keywords=python&sortBy={code}"
+        )
+
+    def test_csv_values_are_normalized_element_by_element(self):
+        assert build_job_search_url(
+            "python",
+            job_type="full_time,contract",
+            experience_level="entry,director",
+            work_type="on_site,hybrid",
+        ) == (f"{JOBS}keywords=python&f_JT=F,C&f_E=2,5&f_WT=1,3")
+
+    def test_csv_elements_are_trimmed_before_lookup(self):
+        assert build_job_search_url(
+            "python", experience_level=" entry , director "
+        ) == (f"{JOBS}keywords=python&f_E=2,5")
+
+    def test_unknown_csv_elements_pass_through_beside_known_ones(self):
+        # LinkedIn's own codes are accepted verbatim, so a caller who already
+        # knows one is not forced through this server's spelling.
+        assert build_job_search_url("python", job_type="F,other,X") == (
+            f"{JOBS}keywords=python&f_JT=F,O,X"
+        )
+
+    def test_unknown_sort_by_passes_through(self):
+        assert build_job_search_url("python", sort_by="XX") == (
+            f"{JOBS}keywords=python&sortBy=XX"
+        )
+
+    def test_easy_apply_true_adds_the_flag(self):
+        assert build_job_search_url("python", easy_apply=True) == (
+            f"{JOBS}keywords=python&f_EA=true"
+        )
+
+    def test_easy_apply_false_omits_the_flag(self):
+        assert build_job_search_url("python", easy_apply=False) == (
+            f"{JOBS}keywords=python"
+        )
+
+    def test_empty_filter_values_are_omitted_entirely(self):
+        assert build_job_search_url(
+            "python",
+            location="",
+            date_posted="",
+            job_type="",
+            experience_level="",
+            work_type="",
+            sort_by="",
+        ) == (f"{JOBS}keywords=python")
+
+    def test_whitespace_filter_values_are_sent_rather_than_dropped(self):
+        # Only emptiness is a "no filter" signal here. Whitespace survives to
+        # the url, where LinkedIn ignores it: visible in the request rather
+        # than quietly discarded on the way out.
+        assert build_job_search_url("python", location="  ") == (
+            f"{JOBS}keywords=python&location=++"
+        )
+
+
+class TestBuildPeopleSearchUrl:
+    def test_keywords_only(self):
+        assert build_people_search_url("recruiter") == f"{PEOPLE}keywords=recruiter"
+
+    def test_every_parameter_keeps_its_recorded_position(self):
+        assert build_people_search_url(
+            "engineer",
+            location="Seattle",
+            network=["F"],
+            current_company="1115",
+        ) == (
+            f"{PEOPLE}keywords=engineer&location=Seattle"
+            "&network=%5B%22F%22%5D&currentCompany=%5B%221115%22%5D"
+        )
+
+    @pytest.mark.parametrize("keywords,encoded", ENCODED_KEYWORDS)
+    def test_keywords_are_percent_encoded(self, keywords: str, encoded: str):
+        assert build_people_search_url(keywords) == f"{PEOPLE}keywords={encoded}"
+
+    def test_empty_keywords_still_produce_the_parameter(self):
+        assert build_people_search_url("") == f"{PEOPLE}keywords="
+
+    @pytest.mark.parametrize(
+        "token,encoded",
+        [("F", "%5B%22F%22%5D"), ("S", "%5B%22S%22%5D"), ("O", "%5B%22O%22%5D")],
+    )
+    def test_every_network_token_is_accepted(self, token: str, encoded: str):
+        assert build_people_search_url("engineer", network=[token]) == (
+            f"{PEOPLE}keywords=engineer&network={encoded}"
+        )
+
+    def test_multiple_network_tokens_share_one_json_facet(self):
+        assert build_people_search_url("engineer", network=["F", "S"]) == (
+            f"{PEOPLE}keywords=engineer&network=%5B%22F%22%2C%22S%22%5D"
+        )
+
+    def test_network_token_order_is_the_caller_order(self):
+        assert build_people_search_url("engineer", network=["S", "F"]) == (
+            f"{PEOPLE}keywords=engineer&network=%5B%22S%22%2C%22F%22%5D"
+        )
+
+    @pytest.mark.parametrize("token", ["X", "f", "1st", "", " F"])
+    def test_invalid_network_token_is_refused(self, token: str):
+        with pytest.raises(FilterValidationError) as error:
+            build_people_search_url("engineer", network=[token])
+
+        assert repr(token) in str(error.value)
+        assert "['F', 'S', 'O']" in str(error.value)
+
+    def test_every_invalid_token_is_named_at_once(self):
+        with pytest.raises(FilterValidationError) as error:
+            build_people_search_url("engineer", network=["F", "X", "Y"])
+
+        assert str(error.value) == (
+            "Invalid network token(s) ['X', 'Y']; expected any of ['F', 'S', 'O']"
+        )
+
+    def test_empty_network_list_is_validated_and_then_omitted(self):
+        assert build_people_search_url("engineer", network=[]) == (
+            f"{PEOPLE}keywords=engineer"
+        )
+
+    def test_absent_network_is_omitted(self):
+        assert build_people_search_url("engineer", network=None) == (
+            f"{PEOPLE}keywords=engineer"
+        )
+
+    def test_numeric_current_company_becomes_a_json_facet(self):
+        assert build_people_search_url("engineer", current_company="1115") == (
+            f"{PEOPLE}keywords=engineer&currentCompany=%5B%221115%22%5D"
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "SAP",
+            "1115 ",
+            " 1115",
+            "11 15",
+            "+1115",
+            "-1115",
+            "1115.0",
+            "urn:li:fsd_company:1115",
+            # ASCII decimal only: str.isdigit() accepts Arabic-Indic digits,
+            # and LinkedIn's URN ids are never written in them.
+            "١١١٥",
+        ],
+    )
+    def test_non_numeric_current_company_is_refused(self, value: str):
+        with pytest.raises(FilterValidationError) as error:
+            build_people_search_url("engineer", current_company=value)
+
+        assert repr(value) in str(error.value)
+        assert "numeric LinkedIn company URN id" in str(error.value)
+
+    def test_empty_current_company_is_omitted_rather_than_refused(self):
+        assert build_people_search_url("engineer", current_company="") == (
+            f"{PEOPLE}keywords=engineer"
+        )
+
+    def test_location_is_percent_encoded(self):
+        assert build_people_search_url("engineer", location="São Paulo") == (
+            f"{PEOPLE}keywords=engineer&location=S%C3%A3o+Paulo"
+        )
+
+    def test_network_is_refused_before_a_company_urn_is_looked_at(self):
+        # Order matters for the message a caller reads back: both filters are
+        # wrong here and the network token is the one reported.
+        with pytest.raises(FilterValidationError, match="Invalid network token"):
+            build_people_search_url("engineer", network=["X"], current_company="SAP")
+
+
+class TestBuildCompanySearchUrl:
+    def test_keywords_only(self):
+        assert build_company_search_url("engine") == f"{COMPANIES}keywords=engine"
+
+    @pytest.mark.parametrize("keywords,encoded", ENCODED_KEYWORDS)
+    def test_keywords_are_percent_encoded(self, keywords: str, encoded: str):
+        assert build_company_search_url(keywords) == f"{COMPANIES}keywords={encoded}"
+
+    def test_empty_keywords_still_produce_the_parameter(self):
+        assert build_company_search_url("") == f"{COMPANIES}keywords="
+
+    def test_whitespace_keywords_reach_linkedin_encoded(self):
+        assert build_company_search_url("   ") == f"{COMPANIES}keywords=+++"
+
+
+class TestBuildContentSearchUrl:
+    def test_keywords_carry_the_faceted_search_origin(self):
+        assert build_content_search_url("Buscamos Unity") == (
+            f"{CONTENT}keywords=Buscamos+Unity&origin=FACETED_SEARCH"
+        )
+
+    def test_every_parameter_keeps_its_recorded_position(self):
+        assert build_content_search_url("Buscamos Unity", date_posted="past-week") == (
+            f"{CONTENT}keywords=Buscamos+Unity&origin=FACETED_SEARCH"
+            "&datePosted=%5B%22past-week%22%5D"
+        )
+
+    @pytest.mark.parametrize("keywords,encoded", ENCODED_KEYWORDS)
+    def test_keywords_are_percent_encoded(self, keywords: str, encoded: str):
+        assert build_content_search_url(keywords) == (
+            f"{CONTENT}keywords={encoded}&origin=FACETED_SEARCH"
+        )
+
+    def test_empty_keywords_still_produce_the_parameter(self):
+        assert build_content_search_url("") == (
+            f"{CONTENT}keywords=&origin=FACETED_SEARCH"
+        )
+
+    @pytest.mark.parametrize(
+        "date_posted,token",
+        [
+            ("past-24h", "past-24h"),
+            ("past_24_hours", "past-24h"),
+            ("past-week", "past-week"),
+            ("past_week", "past-week"),
+            ("past-month", "past-month"),
+            ("past_month", "past-month"),
+        ],
+    )
+    def test_date_posted_aliases(self, date_posted: str, token: str):
+        assert build_content_search_url("python", date_posted=date_posted) == (
+            f"{CONTENT}keywords=python&origin=FACETED_SEARCH"
+            f"&datePosted=%5B%22{token}%22%5D"
+        )
+
+    def test_date_posted_alias_coverage_is_exhaustive(self):
+        assert set(CONTENT_DATE_POSTED_MAP) == {
+            "past-24h",
+            "past_24_hours",
+            "past-week",
+            "past_week",
+            "past-month",
+            "past_month",
+        }
+
+    def test_padded_date_posted_is_trimmed_before_lookup(self):
+        assert build_content_search_url("python", date_posted="  past_week ") == (
+            f"{CONTENT}keywords=python&origin=FACETED_SEARCH"
+            "&datePosted=%5B%22past-week%22%5D"
+        )
+
+    def test_absent_date_posted_omits_the_facet(self):
+        assert "datePosted" not in build_content_search_url("python")
+
+    @pytest.mark.parametrize("date_posted", ["", "   ", "\t\n"])
+    def test_blank_date_posted_omits_the_facet(self, date_posted: str):
+        # Blank is "no filter", not an invalid token: appending it would send
+        # an empty facet LinkedIn ignores while the request reads as filtered.
+        assert build_content_search_url("python", date_posted=date_posted) == (
+            f"{CONTENT}keywords=python&origin=FACETED_SEARCH"
+        )
+
+    @pytest.mark.parametrize(
+        "date_posted", ["past-day", "past_hour", "PAST-WEEK", "past week", "r604800"]
+    )
+    def test_unknown_date_posted_is_refused_rather_than_passed_through(
+        self, date_posted: str
+    ):
+        # The opposite of job search, and deliberately so: LinkedIn echoes an
+        # unrecognized content token back in the url and then ignores it, so
+        # passing one through returns an unfiltered answer that looks filtered.
+        with pytest.raises(FilterValidationError) as error:
+            build_content_search_url("python", date_posted=date_posted)
+
+        assert repr(date_posted) in str(error.value)
+        assert "past-24h" in str(error.value)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -31,7 +31,6 @@ from linkedin_mcp_server.scraping.contracts import RATE_LIMITED_SECTION_TEXT
 from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
-    _CONTENT_DATE_POSTED_MAP,
     _MESSAGE_COMPOSER_OWNER_JS,
     _MESSAGE_CONFIRMATION_DISPOSE_JS,
     _MESSAGE_CONFIRMATION_PREPARE_JS,
@@ -47,93 +46,6 @@ def extracted(
 ) -> ExtractedSection:
     """Create an ExtractedSection for tests."""
     return ExtractedSection(text=text, references=references or [], error=error)
-
-
-class TestBuildJobSearchUrl:
-    """Tests for _build_job_search_url URL construction."""
-
-    def test_keywords_only(self):
-        url = LinkedInExtractor._build_job_search_url("python developer")
-        assert url == "https://www.linkedin.com/jobs/search/?keywords=python+developer"
-
-    def test_with_location(self):
-        url = LinkedInExtractor._build_job_search_url("python", location="Remote")
-        assert "keywords=python" in url
-        assert "location=Remote" in url
-
-    def test_date_posted_normalization(self):
-        url = LinkedInExtractor._build_job_search_url("python", date_posted="past_week")
-        assert "f_TPR=r604800" in url
-
-    def test_date_posted_passthrough(self):
-        url = LinkedInExtractor._build_job_search_url("python", date_posted="r3600")
-        assert "f_TPR=r3600" in url
-
-    def test_experience_level_normalization(self):
-        url = LinkedInExtractor._build_job_search_url(
-            "python", experience_level="entry"
-        )
-        assert "f_E=2" in url
-
-    def test_experience_level_csv(self):
-        url = LinkedInExtractor._build_job_search_url(
-            "python", experience_level="entry,director"
-        )
-        assert "f_E=2,5" in url
-
-    def test_work_type_normalization(self):
-        url = LinkedInExtractor._build_job_search_url("python", work_type="remote")
-        assert "f_WT=2" in url
-
-    def test_work_type_csv(self):
-        url = LinkedInExtractor._build_job_search_url(
-            "python", work_type="on_site,hybrid"
-        )
-        assert "f_WT=1,3" in url
-
-    def test_easy_apply(self):
-        url = LinkedInExtractor._build_job_search_url("python", easy_apply=True)
-        assert "f_EA=true" in url
-
-    def test_easy_apply_false_omitted(self):
-        url = LinkedInExtractor._build_job_search_url("python", easy_apply=False)
-        assert "f_EA" not in url
-
-    def test_sort_by_normalization(self):
-        url = LinkedInExtractor._build_job_search_url("python", sort_by="date")
-        assert "sortBy=DD" in url
-
-    def test_job_type_normalization(self):
-        url = LinkedInExtractor._build_job_search_url("python", job_type="full_time")
-        assert "f_JT=F" in url
-
-    def test_job_type_csv(self):
-        url = LinkedInExtractor._build_job_search_url(
-            "python", job_type="full_time,contract"
-        )
-        assert "f_JT=F,C" in url
-
-    def test_job_type_passthrough(self):
-        url = LinkedInExtractor._build_job_search_url("python", job_type="F")
-        assert "f_JT=F" in url
-
-    def test_all_filters_combined(self):
-        url = LinkedInExtractor._build_job_search_url(
-            "python",
-            location="Berlin",
-            date_posted="past_week",
-            experience_level="entry,mid_senior",
-            work_type="remote",
-            easy_apply=True,
-            sort_by="date",
-        )
-        assert "keywords=python" in url
-        assert "location=Berlin" in url
-        assert "f_TPR=r604800" in url
-        assert "f_E=2,4" in url
-        assert "f_WT=2" in url
-        assert "f_EA=true" in url
-        assert "sortBy=DD" in url
 
 
 @pytest.fixture
@@ -6108,10 +6020,14 @@ class TestSearchPeople:
         with pytest.raises(ValueError, match="Invalid network token"):
             await extractor.search_people("engineer", network=["X"])
 
+        mock_page.goto.assert_not_awaited()
+
     async def test_search_people_rejects_plain_company_name(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         with pytest.raises(ValueError, match="must be a numeric"):
             await extractor.search_people("engineer", current_company="SAP")
+
+        mock_page.goto.assert_not_awaited()
 
     async def test_search_people_rejects_unicode_digit_company(self, mock_page):
         """LinkedIn URN ids are ASCII decimal; reject Unicode digits even
@@ -6119,6 +6035,8 @@ class TestSearchPeople:
         extractor = LinkedInExtractor(mock_page)
         with pytest.raises(ValueError, match="must be a numeric"):
             await extractor.search_people("engineer", current_company="١١١٥")
+
+        mock_page.goto.assert_not_awaited()
 
     async def test_search_people_empty_current_company_is_noop(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
@@ -6151,50 +6069,6 @@ class TestSearchPeople:
         assert "location=Seattle" in result["url"]
         assert "network=%5B%22F%22%5D" in result["url"]
         assert "currentCompany=%5B%221115%22%5D" in result["url"]
-
-
-class TestBuildContentSearchUrl:
-    """Tests for _build_content_search_url URL construction."""
-
-    def test_basic_keywords(self):
-        url = LinkedInExtractor._build_content_search_url("Buscamos Unity")
-        assert url == (
-            "https://www.linkedin.com/search/results/content/"
-            "?keywords=Buscamos+Unity&origin=FACETED_SEARCH"
-        )
-
-    def test_date_posted_past_week(self):
-        url = LinkedInExtractor._build_content_search_url(
-            "Buscamos Unity", date_posted="past-week"
-        )
-        assert "datePosted=%5B%22past-week%22%5D" in url
-
-    def test_date_posted_alias_normalized(self):
-        url = LinkedInExtractor._build_content_search_url(
-            "python", date_posted="past_24_hours"
-        )
-        assert "datePosted=%5B%22past-24h%22%5D" in url
-
-    def test_every_accepted_date_posted_reaches_linkedin_as_a_real_token(self):
-        """LinkedIn ignores an unrecognized token instead of rejecting it, so
-        an accepted value that never maps to one of its three would return
-        unfiltered results while looking filtered."""
-        for accepted, expected in _CONTENT_DATE_POSTED_MAP.items():
-            url = LinkedInExtractor._build_content_search_url(
-                "python", date_posted=accepted
-            )
-            assert expected in ("past-24h", "past-week", "past-month")
-            assert f"%22{expected}%22" in url
-
-    def test_no_date_posted_omits_facet(self):
-        url = LinkedInExtractor._build_content_search_url("python")
-        assert "datePosted" not in url
-
-    def test_whitespace_date_posted_omits_facet(self):
-        # Whitespace-only date_posted must be ignored, not appended as an
-        # invalid facet token (regression guard).
-        url = LinkedInExtractor._build_content_search_url("python", date_posted="   ")
-        assert "datePosted" not in url
 
 
 @pytest.mark.asyncio
@@ -6249,6 +6123,8 @@ class TestSearchPosts:
         extractor = LinkedInExtractor(mock_page)
         with pytest.raises(ValueError, match="Invalid date_posted"):
             await extractor.search_posts("python", date_posted="last-year")
+
+        mock_page.goto.assert_not_awaited()
 
     async def test_empty_results_omit_optional_keys(self, mock_page):
         extractor = LinkedInExtractor(mock_page)


### PR DESCRIPTION
Part of #853. Stacked on #872.

Search URL construction was embedded in `extractor.py`, mixing browser workflows with encoding, filter validation, and LinkedIn query vocabulary.

This stage moves job, people, company, and content search grammar into browser-free `search_urls.py`. It preserves parameter order, Unicode and `C++` encoding, empty-value handling, date aliases, network facets, and existing validation errors before navigation. `StrList`, `BeforeValidator`, and `_coerce_str_list` remain at the MCP tool boundary; the pure people builder receives normalized lists. Owner-local tests replace private extractor patches, and the migration manifest points to the canonical owner. Canonical policy traces remain byte-identical.

Verification: both migration checkers, 297 owner/contract tests, Ruff, `ty`, pre-commit, and the full suite with 3,678 passing tests succeed.

## Synthetic prompt

> Extract search URL grammar into a browser-free owner while preserving validation, encoding, tool coercion, and trace behavior.

Generated with GPT-5.6 Sol + GPT-6 Astra
