### PR TITLE
refactor(scraping): Extract navigation lifecycle

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
-from collections.abc import Iterator
 from dataclasses import dataclass
 import logging
 import re
@@ -17,20 +15,7 @@ import anyio.lowlevel
 from patchright.async_api import Page, TimeoutError as PlaywrightTimeoutError
 
 from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
-from linkedin_mcp_server.core import (
-    detect_auth_barrier,
-    detect_auth_barrier_quick,
-    raise_if_proxy_error,
-    redact_proxy_credentials,
-    redacted_copy,
-    resolve_remember_me_prompt,
-)
-from linkedin_mcp_server.core.exceptions import (
-    AuthenticationError,
-    LinkedInScraperException,
-)
-from linkedin_mcp_server.debug_trace import record_page_trace
-from linkedin_mcp_server.debug_utils import stabilize_navigation
+from linkedin_mcp_server.core.exceptions import LinkedInScraperException
 from linkedin_mcp_server.error_diagnostics import build_issue_diagnostics
 from linkedin_mcp_server.core.utils import (
     _JOB_CARD_SELECTOR,
@@ -82,6 +67,8 @@ from linkedin_mcp_server.scraping.job_policy import (
     route,
     same_job_search,
 )
+from linkedin_mcp_server.scraping.navigation import PageNavigator
+from linkedin_mcp_server.scraping.session import ScrapingSession
 from linkedin_mcp_server.scraping.link_metadata import (
     Reference,
     build_references,
@@ -106,8 +93,6 @@ if TYPE_CHECKING:
     from linkedin_mcp_server.callbacks import ProgressCallback
 
 logger = logging.getLogger(__name__)
-
-WaitUntil = Literal["commit", "domcontentloaded", "load", "networkidle"]
 
 # Pacing between page navigations
 _NAV_DELAY = 2.0
@@ -160,34 +145,6 @@ _JOB_IDS_JS = (
     return {ids: ids, scoped: Boolean(picked)};
 }"""
 )
-
-# How long to let `page.url` catch up with a navigation the sidebar scroll
-# suppressed. The lag itself measured 6ms across ten runs, min and max alike;
-# the rest of the budget is for a redirect chain that is still hopping. Only a
-# page that already looks wrong pays it, so the ceiling costs a healthy
-# ten-page search nothing and a broken one 25s of its 180s tool timeout.
-_URL_SETTLE_TIMEOUT = 2.5
-_URL_SETTLE_POLL = 0.01
-# How long the route has to hold still before it counts as the destination. A
-# redirect chain hops through intermediate documents, and judging one of those
-# calls a checkpoint healthy, or a healthy page a checkpoint.
-_URL_SETTLE_QUIET = 0.5
-# How long a navigation has to announce itself before the page counts as
-# going nowhere. Measured across 300 evaluations destroyed by a navigation:
-# 0.37ms at worst idle, 0.81ms at the 99th percentile with twenty-four
-# workers saturating the machine. Paid in full only by a failure with no
-# navigation behind it, and by a page that only rewrote its own address.
-#
-# It is also the whole window: a redirect committing later than this after
-# the scroll returns is not seen here, and falls to the route comparison at
-# the end, which a reload leaves nothing for. Three hundred times the
-# measured announcement is the trade, the other side of it being the wait
-# every ordinary DOM failure pays before it can report itself.
-_URL_SETTLE_LAG = 0.3
-# How long the replacement document gets to reach `domcontentloaded`. It
-# renders after it commits, and an account picker was measured 200ms behind
-# its own navigation, so a page judged on arrival is judged empty.
-_DOCUMENT_READY_TIMEOUT = 5.0
 
 # Content search is an infinite scroll with no ``&start=`` pagination, so
 # ``max_pages`` caps scroll depth instead of fetching discrete pages. One
@@ -1475,17 +1432,12 @@ class LinkedInExtractor:
     """Extracts LinkedIn page content via navigate-scroll-innerText pattern."""
 
     def __init__(self, page: Page):
+        self._session = ScrapingSession(page)
+        self._navigator = PageNavigator(self._session)
         self._page = page
         # What the sidebar scroll spent on the page being read, so that a
         # multi-page search charges its scroll budget for scrolling alone.
         self._scroll_seconds = 0.0
-
-    @staticmethod
-    def _normalize_body_marker(value: Any) -> str:
-        """Compress body text into a short, single-line diagnostic marker."""
-        if not isinstance(value, str):
-            return ""
-        return re.sub(r"\s+", " ", value).strip()[:200]
 
     @staticmethod
     def _single_section_result(
@@ -1501,215 +1453,6 @@ class LinkedInExtractor:
             if references:
                 result["references"] = {section_name: references}
         return result
-
-    async def _log_navigation_failure(
-        self,
-        target_url: str,
-        wait_until: str,
-        navigation_error: Exception,
-        hops: list[str],
-    ) -> None:
-        """Emit structured diagnostics for a failed target navigation."""
-        try:
-            title = await self._page.title()
-        except Exception:
-            title = ""
-
-        try:
-            auth_barrier = await detect_auth_barrier(self._page)
-        except Exception:
-            auth_barrier = None
-
-        try:
-            remember_me_visible = (
-                await self._page.locator("#rememberme-div").count()
-            ) > 0
-        except Exception:
-            remember_me_visible = False
-
-        try:
-            body_marker = self._normalize_body_marker(
-                await self._page.evaluate("() => document.body?.innerText || ''")
-            )
-        except Exception:
-            body_marker = ""
-
-        logger.warning(
-            "Navigation to %s failed (wait_until=%s, error=%s). "
-            "current_url=%s title=%r auth_barrier=%s remember_me=%s hops=%s body_marker=%r",
-            target_url,
-            wait_until,
-            # Redacted like the traces above: a driver error can quote the
-            # proxy URL, and this log is what users paste into issue reports.
-            redact_proxy_credentials(
-                f"{type(navigation_error).__name__}: {navigation_error}"
-            ),
-            self._page.url,
-            title,
-            auth_barrier,
-            remember_me_visible,
-            hops,
-            body_marker,
-        )
-
-    async def _raise_if_auth_barrier(
-        self,
-        url: str,
-        *,
-        navigation_error: Exception | None = None,
-    ) -> None:
-        """Raise an auth error when LinkedIn shows login/account-picker UI."""
-        barrier = await detect_auth_barrier(self._page)
-        if not barrier:
-            return
-
-        logger.warning("Authentication barrier detected on %s: %s", url, barrier)
-        message = (
-            "LinkedIn requires interactive re-authentication. "
-            "Run with --login and complete the account selection/sign-in flow."
-        )
-        if navigation_error is not None:
-            raise AuthenticationError(message) from navigation_error
-        raise AuthenticationError(message)
-
-    async def _goto_with_auth_checks(
-        self,
-        url: str,
-        *,
-        wait_until: WaitUntil = "domcontentloaded",
-        allow_remember_me: bool = True,
-    ) -> None:
-        """Navigate to a LinkedIn page and fail fast on auth barriers."""
-        hops: list[str] = []
-        listener_registered = False
-
-        def record_navigation(frame: Any) -> None:
-            if frame != self._page.main_frame:
-                return
-            frame_url = getattr(frame, "url", "")
-            if frame_url and (not hops or hops[-1] != frame_url):
-                hops.append(frame_url)
-
-        def unregister_navigation_listener() -> None:
-            nonlocal listener_registered
-            if not listener_registered:
-                return
-            self._page.remove_listener("framenavigated", record_navigation)
-            listener_registered = False
-
-        self._page.on("framenavigated", record_navigation)
-        listener_registered = True
-        try:
-            await record_page_trace(
-                self._page,
-                "extractor-before-goto",
-                extra={"target_url": url, "wait_until": wait_until},
-            )
-            try:
-                await self._page.goto(url, wait_until=wait_until, timeout=30000)
-                await stabilize_navigation(f"goto {url}", logger)
-                await record_page_trace(
-                    self._page,
-                    "extractor-after-goto",
-                    extra={"target_url": url, "wait_until": wait_until},
-                )
-            except Exception as exc:
-                # Ahead of the traces below: they record the raw exception text,
-                # which for a proxy failure can quote the proxy URL and land a
-                # password in trace.jsonl. Converting here also keeps a proxy
-                # outage from being reported as a LinkedIn navigation problem.
-                raise_if_proxy_error(exc)
-                if allow_remember_me and await resolve_remember_me_prompt(self._page):
-                    await stabilize_navigation(
-                        f"remember-me resolution for {url}", logger
-                    )
-                    await record_page_trace(
-                        self._page,
-                        "extractor-navigation-error-before-remember-me-retry",
-                        extra={
-                            "target_url": url,
-                            "wait_until": wait_until,
-                            "error": redact_proxy_credentials(
-                                f"{type(exc).__name__}: {exc}"
-                            ),
-                            "hops": hops,
-                        },
-                    )
-                    await record_page_trace(
-                        self._page,
-                        "extractor-after-remember-me",
-                        extra={
-                            "target_url": url,
-                            "error": redact_proxy_credentials(
-                                f"{type(exc).__name__}: {exc}"
-                            ),
-                        },
-                    )
-                    unregister_navigation_listener()
-                    await self._goto_with_auth_checks(
-                        url,
-                        wait_until=wait_until,
-                        allow_remember_me=False,
-                    )
-                    return
-                await record_page_trace(
-                    self._page,
-                    "extractor-navigation-error",
-                    extra={
-                        "target_url": url,
-                        "wait_until": wait_until,
-                        "error": redact_proxy_credentials(
-                            f"{type(exc).__name__}: {exc}"
-                        ),
-                        "hops": hops,
-                    },
-                )
-                await self._log_navigation_failure(url, wait_until, exc, hops)
-                await self._raise_if_auth_barrier(url, navigation_error=exc)
-                # Re-raised as a redacted copy rather than the original: with a
-                # proxy configured, a driver error can quote the proxy URL, and
-                # everything downstream from here logs the exception -- the
-                # catch-all in error_handler, and FastMCP's own handler above
-                # that. Only the message is rewritten; the type is preserved so
-                # callers that branch on it are unaffected.
-                raise redacted_copy(exc) from None
-
-            barrier = await detect_auth_barrier_quick(self._page)
-            if not barrier:
-                return
-
-            if allow_remember_me and await resolve_remember_me_prompt(self._page):
-                await stabilize_navigation(f"remember-me retry for {url}", logger)
-                await record_page_trace(
-                    self._page,
-                    "extractor-after-remember-me-retry",
-                    extra={"target_url": url, "barrier": barrier},
-                )
-                unregister_navigation_listener()
-                await self._goto_with_auth_checks(
-                    url,
-                    wait_until=wait_until,
-                    allow_remember_me=False,
-                )
-                return
-
-            await record_page_trace(
-                self._page,
-                "extractor-auth-barrier",
-                extra={"target_url": url, "barrier": barrier},
-            )
-            logger.warning("Authentication barrier detected on %s: %s", url, barrier)
-            raise AuthenticationError(
-                "LinkedIn requires interactive re-authentication. "
-                "Run with --login and complete the account selection/sign-in flow."
-            )
-        finally:
-            unregister_navigation_listener()
-
-    async def _navigate_to_page(self, url: str) -> None:
-        """Navigate to a LinkedIn page and fail fast on auth barriers."""
-        logger.debug("_navigate_to_page: target=%s", url)
-        await self._goto_with_auth_checks(url)
 
     # ------------------------------------------------------------------
     # Generic browser helpers for LLM-driven connection flow
@@ -2051,7 +1794,7 @@ class LinkedInExtractor:
         captured_urls: list[str],
         pending_reads: list[asyncio.Task[None]],
     ) -> ExtractedSection:
-        await self._navigate_to_page(url)
+        await self._navigator._navigate_to_page(url)
         await detect_rate_limit(self._page)
 
         try:
@@ -2208,7 +1951,7 @@ class LinkedInExtractor:
         max_scrolls: int | None = None,
     ) -> ExtractedSection:
         """Single attempt to navigate, scroll, and extract innerText."""
-        await self._navigate_to_page(url)
+        await self._navigator._navigate_to_page(url)
         return await self._extract_loaded_section(url, section_name, max_scrolls)
 
     async def _extract_loaded_section(
@@ -2413,7 +2156,7 @@ class LinkedInExtractor:
         section_name: str,
     ) -> ExtractedSection:
         """Single attempt to extract content from an overlay/modal page."""
-        await self._navigate_to_page(url)
+        await self._navigator._navigate_to_page(url)
         await detect_rate_limit(self._page)
 
         # Wait for the dialog/modal to render (LinkedIn uses native <dialog>)
@@ -2611,7 +2354,7 @@ class LinkedInExtractor:
         Returns:
             {url, sections: {name: text}}
         """
-        await self._navigate_to_page("https://www.linkedin.com/in/me/")
+        await self._navigator._navigate_to_page("https://www.linkedin.com/in/me/")
         real_url = self._page.url  # post-redirect, e.g. /in/johndoe/
         match = re.search(r"/in/([^/?#]+)", real_url)
         username = match.group(1) if match else "me"
@@ -2978,7 +2721,7 @@ class LinkedInExtractor:
                     "because a personalized note was requested",
                     username,
                 )
-                await self._navigate_to_page(invite_url)
+                await self._navigator._navigate_to_page(invite_url)
                 note_limit_message = await self._probe_invite_note_limit()
                 if note_limit_message is not None:
                     return _connection_result(
@@ -2995,7 +2738,7 @@ class LinkedInExtractor:
                 profile=page_text,
             )
 
-        await self._navigate_to_page(invite_url)
+        await self._navigator._navigate_to_page(invite_url)
 
         submitted, note_sent, note_limit_message = await self._submit_invite_dialog(
             note
@@ -3058,7 +2801,7 @@ class LinkedInExtractor:
         """
         username = normalize_person_identifier(username)
         url = person_profile_url(username, "/")
-        await self._navigate_to_page(url)
+        await self._navigator._navigate_to_page(url)
         await detect_rate_limit(self._page)
 
         try:
@@ -3153,7 +2896,7 @@ class LinkedInExtractor:
             first_show_all = False
 
             try:
-                await self._navigate_to_page(show_all_url)
+                await self._navigator._navigate_to_page(show_all_url)
             except LinkedInScraperException:
                 raise
             except Exception:
@@ -3618,7 +3361,7 @@ class LinkedInExtractor:
 
         # Primary path: enumerate the plain inbox. Reliable for the recent
         # threads that the verify-after-send workflow needs (issue #434).
-        await self._navigate_to_page("https://www.linkedin.com/messaging/")
+        await self._navigator._navigate_to_page("https://www.linkedin.com/messaging/")
         await detect_rate_limit(self._page)
         await self._wait_for_main_text(log_context="Messaging inbox")
         await handle_modal_close(self._page)
@@ -3637,7 +3380,7 @@ class LinkedInExtractor:
         # "We didn't find anything" even for present threads, see #434), so it
         # runs only when the inbox scan came up empty — e.g. a thread buried
         # below the scrolled inbox window.
-        await self._navigate_to_page(
+        await self._navigator._navigate_to_page(
             f"https://www.linkedin.com/messaging/?searchTerm={quote_plus(display_name)}"
         )
         await detect_rate_limit(self._page)
@@ -3662,7 +3405,7 @@ class LinkedInExtractor:
 
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
-        await self._navigate_to_page(profile_url)
+        await self._navigator._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
 
         try:
@@ -3689,7 +3432,7 @@ class LinkedInExtractor:
                     f"thread(s) exist for {linkedin_username}."
                 )
 
-            await self._navigate_to_page(thread_urls[index])
+            await self._navigator._navigate_to_page(thread_urls[index])
         except PlaywrightTimeoutError as exc:
             raise LinkedInScraperException(
                 "Messaging search results did not load in time."
@@ -3859,128 +3602,6 @@ class LinkedInExtractor:
             result["section_errors"] = section_errors
         return result
 
-    @contextlib.contextmanager
-    def _watching_navigations(self) -> Iterator[list[str]]:
-        """Record main-frame navigations for the duration of the block.
-
-        The address is not the signal. A reload replaces the document and
-        leaves `page.url` exactly as it was, so a check that samples the URL
-        calls the replacement the same page and reads whatever it renders. The
-        browser says so directly, and this is the same listener
-        `_goto_with_auth_checks` uses.
-        """
-        hops: list[str] = []
-
-        def record(frame: Any) -> None:
-            if frame == self._page.main_frame:
-                hops.append(self._page.url)
-
-        self._page.on("framenavigated", record)
-        try:
-            yield hops
-        finally:
-            try:
-                self._page.remove_listener("framenavigated", record)
-            except Exception:
-                logger.debug("Could not remove navigation listener", exc_info=True)
-
-    async def _document_origin(self) -> float | None:
-        """A reading that is fixed when the document is created.
-
-        `framenavigated` fires for a same-document history change as readily
-        as for a replacement, and LinkedIn appends `currentJobId` to a search
-        URL that way by itself: measured locally, `pushState`, `replaceState`
-        and a bare hash change each raise the event on the main frame. Acting
-        on the event alone would make every healthy search page wait out a
-        chain that never ran.
-
-        `performance.timeOrigin` separates them, and separates them without
-        writing anything into the page. Measured against the same four
-        changes: identical across all three same-document ones, different
-        after a reload and after a navigation elsewhere.
-
-        `None` when the reading cannot be taken, which is what a context
-        destroyed by a navigation in flight looks like from here.
-        """
-        try:
-            origin = await self._page.evaluate("() => performance.timeOrigin")
-        except Exception:
-            return None
-        return origin if isinstance(origin, (int, float)) else None
-
-    async def _settle_navigation(self, hops: list[str], origin: float | None) -> bool:
-        """Wait out a navigation the page is in the middle of.
-
-        Returns whether one happened at all.
-
-        Three waits, and each answers a question the one before it cannot.
-
-        Whether the page navigated is answered by the listener and the
-        document identity together, the listener firing for a reload as well
-        as for a redirect. It is dispatched over the
-        channel that also updates `page.url`, so it arrives at the same moment
-        the address would have: measured across 300 destroyed evaluations,
-        0.37ms at worst on an idle machine and 0.81ms with twenty-four workers
-        saturating it. `_URL_SETTLE_LAG` is three hundred times that, and an
-        ordinary failure with nothing behind it pays exactly that and no more.
-
-        The listener overreports, so `_document_origin` decides which hop
-        counts: a page rewriting its own address raises the same event and
-        leaves nothing to settle.
-
-        Where it stopped is answered by the hops falling quiet. Counting them
-        rather than comparing addresses, or a chain that returns to the route
-        it started on reads as one that never left.
-
-        What the destination holds is answered by the document being ready. A
-        replacement renders after it commits, and the account picker measured
-        200ms behind its own navigation; judging that page on arrival calls a
-        barrier a loading screen.
-        """
-        # A hop says something moved, not that the document was replaced, so
-        # the wait is for a replacement and not for an event. Leaving on the
-        # first same-document hop is what a page rewriting its own address
-        # would buy, and it costs the redirect arriving right behind it: the
-        # search page announces `currentJobId` the moment a card is selected,
-        # and a checkpoint committing fifty milliseconds later would then be
-        # judged by a route comparison that has not been told yet.
-        #
-        # Each hop is read at most once, so a healthy page pays one evaluate
-        # and the wait, and only a page that keeps moving pays more.
-        lag_deadline = time.monotonic() + _URL_SETTLE_LAG
-        judged = 0
-        replaced = False
-        while time.monotonic() < lag_deadline:
-            if len(hops) > judged:
-                judged = len(hops)
-                if origin is None or await self._document_origin() != origin:
-                    replaced = True
-                    break
-            await asyncio.sleep(_URL_SETTLE_POLL)
-        if not replaced:
-            if hops:
-                logger.debug("Same document after %d history change(s)", len(hops))
-            return False
-
-        deadline = time.monotonic() + _URL_SETTLE_TIMEOUT
-        seen = len(hops)
-        quiet_since = time.monotonic()
-        while time.monotonic() < deadline:
-            await asyncio.sleep(_URL_SETTLE_POLL)
-            if len(hops) != seen:
-                seen = len(hops)
-                quiet_since = time.monotonic()
-            elif time.monotonic() - quiet_since >= _URL_SETTLE_QUIET:
-                break
-
-        try:
-            await self._page.wait_for_load_state(
-                "domcontentloaded", timeout=_DOCUMENT_READY_TIMEOUT * 1000
-            )
-        except Exception:
-            logger.debug("Replacement document was not ready in time", exc_info=True)
-        return True
-
     async def _extract_job_ids(self, *, scoped: bool = False) -> list[str]:
         """Extract unique job IDs from job card links on the current page.
 
@@ -4061,13 +3682,13 @@ class LinkedInExtractor:
         scroll_deadline: float = SCROLL_DEADLINE_MAX,
     ) -> ExtractedSection:
         """Single attempt to navigate, scroll sidebar, and extract innerText."""
-        await self._navigate_to_page(url)
+        await self._navigator._navigate_to_page(url)
         await detect_rate_limit(self._page)
         # Above the selector wait and the modal close, so the window this
         # opens covers everything read from here on. Taken between them, a
         # reload committing during either one became the baseline itself, and
         # `main_found` then described a document that no longer existed.
-        origin = await self._document_origin()
+        origin = await self._navigator._document_origin()
 
         main_found = True
         try:
@@ -4100,7 +3721,7 @@ class LinkedInExtractor:
         before = route(url)
         moved = False
         navigated = False
-        with self._watching_navigations() as hops:
+        with self._navigator._watching_navigations() as hops:
             if main_found:
                 scroll_started = time.monotonic()
                 try:
@@ -4121,7 +3742,7 @@ class LinkedInExtractor:
             # raised, so it reports no movement, and a reload moves no route,
             # so neither of the other two says anything happened.
             if moved or hops or before != route(self._page.url):
-                navigated = await self._settle_navigation(hops, origin)
+                navigated = await self._navigator._settle_navigation(hops, origin)
 
         after = route(self._page.url)
         if navigated or moved or not main_found or before != after:
@@ -4134,7 +3755,7 @@ class LinkedInExtractor:
             # That third one is the shape this check exists for and the one it
             # missed: an exhausted search renders no `<main>` either, which is
             # why the check has to decide it rather than the absence alone.
-            await self._raise_if_auth_barrier(url)
+            await self._navigator._raise_if_auth_barrier(url)
         if before != after and not same_job_search(before, after):
             # An expired session lands here as often as a layout change does,
             # and the two need different answers. A plain error is caught by
@@ -4152,9 +3773,9 @@ class LinkedInExtractor:
         # off, or during the extraction itself, moves no route and raises
         # nothing. The document says what neither the address nor the listener
         # can, and it is asked about the text that was actually read.
-        if origin is not None and await self._document_origin() != origin:
+        if origin is not None and await self._navigator._document_origin() != origin:
             logger.debug("The search document was replaced before it was read")
-            await self._raise_if_auth_barrier(url)
+            await self._navigator._raise_if_auth_barrier(url)
 
         raw = raw_result["text"]
         if raw_result["source"] == "body":
@@ -4386,7 +4007,7 @@ class LinkedInExtractor:
                     # carrying whatever job links it held. Raised rather than
                     # broken out of, because a result with no ids and nothing
                     # beside it is what an exhausted search looks like.
-                    await self._raise_if_auth_barrier(self._page.url)
+                    await self._navigator._raise_if_auth_barrier(self._page.url)
                     raise RuntimeError(f"Search navigation ended on {self._page.url}")
 
                 # The offset has to have survived as well as the route. A
@@ -4553,7 +4174,7 @@ class LinkedInExtractor:
         section_name: str,
     ) -> ExtractedSection:
         """Extract innerText from a saved-jobs page with soft rate-limit retry."""
-        with self._watching_navigations() as hops:
+        with self._navigator._watching_navigations() as hops:
             try:
                 result = await self._extract_saved_jobs_page_once(url, section_name)
                 if result.text != RATE_LIMITED_SECTION_TEXT:
@@ -4597,13 +4218,15 @@ class LinkedInExtractor:
                 # says so, and settling costs a moment on a path that has
                 # already failed.
                 try:
-                    await self._settle_navigation(hops, None)
+                    await self._navigator._settle_navigation(hops, None)
                 except Exception:
                     logger.debug(
                         "Could not settle the route after a saved-jobs failure",
                         exc_info=True,
                     )
-                await self._raise_if_auth_barrier(self._page.url, navigation_error=e)
+                await self._navigator._raise_if_auth_barrier(
+                    self._page.url, navigation_error=e
+                )
                 return ExtractedSection(
                     text="",
                     references=[],
@@ -4621,11 +4244,11 @@ class LinkedInExtractor:
         section_name: str,
     ) -> ExtractedSection:
         """Single attempt: navigate, scroll list, and extract innerText."""
-        await self._navigate_to_page(url)
+        await self._navigator._navigate_to_page(url)
         await detect_rate_limit(self._page)
         # Taken after this page's own navigation, so it belongs to the
         # document about to be read rather than to the one that was left.
-        origin = await self._document_origin()
+        origin = await self._navigator._document_origin()
 
         main_found = True
         try:
@@ -4643,7 +4266,7 @@ class LinkedInExtractor:
             # the body fallback returns the picker under `saved_jobs`. Missing
             # `<main>` is what is left, and an emptied list has none either,
             # which is why the check decides it rather than the absence.
-            await self._raise_if_auth_barrier(self._page.url)
+            await self._navigator._raise_if_auth_barrier(self._page.url)
 
         # A picker served by a reload keeps this page's address and this
         # page's title, so the route guard reads it as the list. Nothing else
@@ -4656,9 +4279,9 @@ class LinkedInExtractor:
         # two is a window of its own and the text that came back is not the
         # text the check judged.
         raw_result = await self._extract_root_content(["main"])
-        if origin is not None and await self._document_origin() != origin:
+        if origin is not None and await self._navigator._document_origin() != origin:
             logger.debug("The saved-jobs document was replaced before it was read")
-            await self._raise_if_auth_barrier(self._page.url)
+            await self._navigator._raise_if_auth_barrier(self._page.url)
         raw = raw_result["text"]
         if raw_result["source"] == "body":
             logger.debug("No <main> at evaluation time on %s, using body fallback", url)
@@ -4796,7 +4419,7 @@ class LinkedInExtractor:
                     # relogin path instead of a diagnostic. Against the page
                     # that answered, because that is where the barrier is; the
                     # address that was asked for is on the line above.
-                    await self._raise_if_auth_barrier(self._page.url)
+                    await self._navigator._raise_if_auth_barrier(self._page.url)
                     raise RuntimeError(
                         f"Saved jobs navigation ended on {self._page.url}"
                     )
@@ -5049,7 +4672,7 @@ class LinkedInExtractor:
     async def get_inbox(self, limit: int = 20) -> dict[str, Any]:
         """List recent conversations from the messaging inbox."""
         url = "https://www.linkedin.com/messaging/"
-        await self._navigate_to_page(url)
+        await self._navigator._navigate_to_page(url)
         await detect_rate_limit(self._page)
         await self._wait_for_main_text(log_context="Messaging inbox")
         await handle_modal_close(self._page)
@@ -5240,7 +4863,9 @@ class LinkedInExtractor:
 
         if thread_id:
             thread_id = normalize_thread_id(thread_id)
-            await self._navigate_to_page(messaging_thread_url(thread_id, "/"))
+            await self._navigator._navigate_to_page(
+                messaging_thread_url(thread_id, "/")
+            )
         else:
             await self._open_conversation_by_username(
                 linkedin_username or "", index=index
@@ -5290,7 +4915,7 @@ class LinkedInExtractor:
         search_url = (
             f"https://www.linkedin.com/messaging/?searchTerm={quote_plus(keywords)}"
         )
-        await self._navigate_to_page(search_url)
+        await self._navigator._navigate_to_page(search_url)
         await detect_rate_limit(self._page)
         await handle_modal_close(self._page)
         await self._wait_for_main_text(log_context="Messaging search")
@@ -5351,7 +4976,7 @@ class LinkedInExtractor:
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
 
-        await self._navigate_to_page(profile_url)
+        await self._navigator._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
 
         try:
@@ -5389,7 +5014,7 @@ class LinkedInExtractor:
         # recipient boundary. LinkedIn may strip the query and expose no local
         # identity, so capture the final route now and fail on any later change or
         # visible contradiction. Do not replace this with a Voyager/private API.
-        await self._navigate_to_page(target.compose_url)
+        await self._navigator._navigate_to_page(target.compose_url)
         expected_route = self._page.url
         if not _message_page_url_is_safe(expected_route, target.profile_urn):
             return contracts.message_action_result(

--- a/linkedin_mcp_server/scraping/navigation.py
+++ b/linkedin_mcp_server/scraping/navigation.py
@@ -1,0 +1,401 @@
+"""Authentication-aware page navigation lifecycle."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any, Literal
+
+import logging
+import re
+
+from linkedin_mcp_server.core import (
+    detect_auth_barrier,
+    detect_auth_barrier_quick,
+    raise_if_proxy_error,
+    redact_proxy_credentials,
+    redacted_copy,
+    resolve_remember_me_prompt,
+)
+from linkedin_mcp_server.core.exceptions import AuthenticationError
+from linkedin_mcp_server.debug_trace import record_page_trace
+from linkedin_mcp_server.debug_utils import stabilize_navigation
+from linkedin_mcp_server.scraping.session import ScrapingSession
+
+logger = logging.getLogger(__name__)
+
+WaitUntil = Literal["commit", "domcontentloaded", "load", "networkidle"]
+
+
+class PageNavigator:
+    """Own the complete lifecycle around navigation on one scraping page."""
+
+    # How long to let `page.url` catch up with a navigation the sidebar scroll
+    # suppressed. The lag itself measured 6ms across ten runs, min and max alike;
+    # the rest of the budget is for a redirect chain that is still hopping. Only a
+    # page that already looks wrong pays it, so the ceiling costs a healthy
+    # ten-page search nothing and a broken one 25s of its 180s tool timeout.
+    URL_SETTLE_TIMEOUT = 2.5
+    URL_SETTLE_POLL = 0.01
+    # How long the route has to hold still before it counts as the destination. A
+    # redirect chain hops through intermediate documents, and judging one of those
+    # calls a checkpoint healthy, or a healthy page a checkpoint.
+    URL_SETTLE_QUIET = 0.5
+    # How long a navigation has to announce itself before the page counts as
+    # going nowhere. Measured across 300 evaluations destroyed by a navigation:
+    # 0.37ms at worst idle, 0.81ms at the 99th percentile with twenty-four
+    # workers saturating the machine. Paid in full only by a failure with no
+    # navigation behind it, and by a page that only rewrote its own address.
+    #
+    # It is also the whole window: a redirect committing later than this after
+    # the scroll returns is not seen here, and falls to the route comparison at
+    # the end, which a reload leaves nothing for. Three hundred times the
+    # measured announcement is the trade, the other side of it being the wait
+    # every ordinary DOM failure pays before it can report itself.
+    URL_SETTLE_LAG = 0.3
+    # How long the replacement document gets to reach `domcontentloaded`. It
+    # renders after it commits, and an account picker was measured 200ms behind
+    # its own navigation, so a page judged on arrival is judged empty.
+    DOCUMENT_READY_TIMEOUT = 5.0
+
+    def __init__(self, session: ScrapingSession):
+        self._session = session
+
+    @staticmethod
+    def _normalize_body_marker(value: Any) -> str:
+        """Compress body text into a short, single-line diagnostic marker."""
+        if not isinstance(value, str):
+            return ""
+        return re.sub(r"\s+", " ", value).strip()[:200]
+
+    async def _log_navigation_failure(
+        self,
+        target_url: str,
+        wait_until: str,
+        navigation_error: Exception,
+        hops: list[str],
+    ) -> None:
+        """Emit structured diagnostics for a failed target navigation."""
+        page = self._session.page
+        try:
+            title = await page.title()
+        except Exception:
+            title = ""
+
+        try:
+            auth_barrier = await detect_auth_barrier(page)
+        except Exception:
+            auth_barrier = None
+
+        try:
+            remember_me_visible = (await page.locator("#rememberme-div").count()) > 0
+        except Exception:
+            remember_me_visible = False
+
+        try:
+            body_marker = self._normalize_body_marker(
+                await page.evaluate("() => document.body?.innerText || ''")
+            )
+        except Exception:
+            body_marker = ""
+
+        logger.warning(
+            "Navigation to %s failed (wait_until=%s, error=%s). "
+            "current_url=%s title=%r auth_barrier=%s remember_me=%s hops=%s body_marker=%r",
+            target_url,
+            wait_until,
+            # Redacted like the traces above: a driver error can quote the
+            # proxy URL, and this log is what users paste into issue reports.
+            redact_proxy_credentials(
+                f"{type(navigation_error).__name__}: {navigation_error}"
+            ),
+            page.url,
+            title,
+            auth_barrier,
+            remember_me_visible,
+            hops,
+            body_marker,
+        )
+
+    async def _raise_if_auth_barrier(
+        self,
+        url: str,
+        *,
+        navigation_error: Exception | None = None,
+    ) -> None:
+        """Raise an auth error when LinkedIn shows login/account-picker UI."""
+        barrier = await detect_auth_barrier(self._session.page)
+        if not barrier:
+            return
+
+        logger.warning("Authentication barrier detected on %s: %s", url, barrier)
+        message = (
+            "LinkedIn requires interactive re-authentication. "
+            "Run with --login and complete the account selection/sign-in flow."
+        )
+        if navigation_error is not None:
+            raise AuthenticationError(message) from navigation_error
+        raise AuthenticationError(message)
+
+    async def _goto_with_auth_checks(
+        self,
+        url: str,
+        *,
+        wait_until: WaitUntil = "domcontentloaded",
+        allow_remember_me: bool = True,
+    ) -> None:
+        """Navigate to a LinkedIn page and fail fast on auth barriers."""
+        page = self._session.page
+        hops: list[str] = []
+        listener_registered = False
+
+        def record_navigation(frame: Any) -> None:
+            if frame != page.main_frame:
+                return
+            frame_url = getattr(frame, "url", "")
+            if frame_url and (not hops or hops[-1] != frame_url):
+                hops.append(frame_url)
+
+        def unregister_navigation_listener() -> None:
+            nonlocal listener_registered
+            if not listener_registered:
+                return
+            page.remove_listener("framenavigated", record_navigation)
+            listener_registered = False
+
+        page.on("framenavigated", record_navigation)
+        listener_registered = True
+        try:
+            await record_page_trace(
+                page,
+                "extractor-before-goto",
+                extra={"target_url": url, "wait_until": wait_until},
+            )
+            try:
+                await page.goto(url, wait_until=wait_until, timeout=30000)
+                await stabilize_navigation(f"goto {url}", logger)
+                await record_page_trace(
+                    page,
+                    "extractor-after-goto",
+                    extra={"target_url": url, "wait_until": wait_until},
+                )
+            except Exception as exc:
+                # Ahead of the traces below: they record the raw exception text,
+                # which for a proxy failure can quote the proxy URL and land a
+                # password in trace.jsonl. Converting here also keeps a proxy
+                # outage from being reported as a LinkedIn navigation problem.
+                raise_if_proxy_error(exc)
+                if allow_remember_me and await resolve_remember_me_prompt(page):
+                    await stabilize_navigation(
+                        f"remember-me resolution for {url}", logger
+                    )
+                    await record_page_trace(
+                        page,
+                        "extractor-navigation-error-before-remember-me-retry",
+                        extra={
+                            "target_url": url,
+                            "wait_until": wait_until,
+                            "error": redact_proxy_credentials(
+                                f"{type(exc).__name__}: {exc}"
+                            ),
+                            "hops": hops,
+                        },
+                    )
+                    await record_page_trace(
+                        page,
+                        "extractor-after-remember-me",
+                        extra={
+                            "target_url": url,
+                            "error": redact_proxy_credentials(
+                                f"{type(exc).__name__}: {exc}"
+                            ),
+                        },
+                    )
+                    unregister_navigation_listener()
+                    await self._goto_with_auth_checks(
+                        url,
+                        wait_until=wait_until,
+                        allow_remember_me=False,
+                    )
+                    return
+                await record_page_trace(
+                    page,
+                    "extractor-navigation-error",
+                    extra={
+                        "target_url": url,
+                        "wait_until": wait_until,
+                        "error": redact_proxy_credentials(
+                            f"{type(exc).__name__}: {exc}"
+                        ),
+                        "hops": hops,
+                    },
+                )
+                await self._log_navigation_failure(url, wait_until, exc, hops)
+                await self._raise_if_auth_barrier(url, navigation_error=exc)
+                # Re-raised as a redacted copy rather than the original: with a
+                # proxy configured, a driver error can quote the proxy URL, and
+                # everything downstream from here logs the exception -- the
+                # catch-all in error_handler, and FastMCP's own handler above
+                # that. Only the message is rewritten; the type is preserved so
+                # callers that branch on it are unaffected.
+                raise redacted_copy(exc) from None
+
+            barrier = await detect_auth_barrier_quick(page)
+            if not barrier:
+                return
+
+            if allow_remember_me and await resolve_remember_me_prompt(page):
+                await stabilize_navigation(f"remember-me retry for {url}", logger)
+                await record_page_trace(
+                    page,
+                    "extractor-after-remember-me-retry",
+                    extra={"target_url": url, "barrier": barrier},
+                )
+                unregister_navigation_listener()
+                await self._goto_with_auth_checks(
+                    url,
+                    wait_until=wait_until,
+                    allow_remember_me=False,
+                )
+                return
+
+            await record_page_trace(
+                page,
+                "extractor-auth-barrier",
+                extra={"target_url": url, "barrier": barrier},
+            )
+            logger.warning("Authentication barrier detected on %s: %s", url, barrier)
+            raise AuthenticationError(
+                "LinkedIn requires interactive re-authentication. "
+                "Run with --login and complete the account selection/sign-in flow."
+            )
+        finally:
+            unregister_navigation_listener()
+
+    async def _navigate_to_page(self, url: str) -> None:
+        """Navigate to a LinkedIn page and fail fast on auth barriers."""
+        logger.debug("_navigate_to_page: target=%s", url)
+        await self._goto_with_auth_checks(url)
+
+    @contextmanager
+    def _watching_navigations(self) -> Iterator[list[str]]:
+        """Record main-frame navigations for the duration of the block.
+
+        The address is not the signal. A reload replaces the document and
+        leaves `page.url` exactly as it was, so a check that samples the URL
+        calls the replacement the same page and reads whatever it renders. The
+        browser says so directly, and this is the same listener
+        `_goto_with_auth_checks` uses.
+        """
+        page = self._session.page
+        hops: list[str] = []
+
+        def record(frame: Any) -> None:
+            if frame == page.main_frame:
+                hops.append(page.url)
+
+        page.on("framenavigated", record)
+        try:
+            yield hops
+        finally:
+            try:
+                page.remove_listener("framenavigated", record)
+            except Exception:
+                logger.debug("Could not remove navigation listener", exc_info=True)
+
+    async def _document_origin(self) -> float | None:
+        """A reading that is fixed when the document is created.
+
+        `framenavigated` fires for a same-document history change as readily
+        as for a replacement, and LinkedIn appends `currentJobId` to a search
+        URL that way by itself: measured locally, `pushState`, `replaceState`
+        and a bare hash change each raise the event on the main frame. Acting
+        on the event alone would make every healthy search page wait out a
+        chain that never ran.
+
+        `performance.timeOrigin` separates them, and separates them without
+        writing anything into the page. Measured against the same four
+        changes: identical across all three same-document ones, different
+        after a reload and after a navigation elsewhere.
+
+        `None` when the reading cannot be taken, which is what a context
+        destroyed by a navigation in flight looks like from here.
+        """
+        try:
+            origin = await self._session.page.evaluate("() => performance.timeOrigin")
+        except Exception:
+            return None
+        return origin if isinstance(origin, (int, float)) else None
+
+    async def _settle_navigation(self, hops: list[str], origin: float | None) -> bool:
+        """Wait out a navigation the page is in the middle of.
+
+        Returns whether one happened at all.
+
+        Three waits, and each answers a question the one before it cannot.
+
+        Whether the page navigated is answered by the listener and the
+        document identity together, the listener firing for a reload as well
+        as for a redirect. It is dispatched over the
+        channel that also updates `page.url`, so it arrives at the same moment
+        the address would have: measured across 300 destroyed evaluations,
+        0.37ms at worst on an idle machine and 0.81ms with twenty-four workers
+        saturating it. `_URL_SETTLE_LAG` is three hundred times that, and an
+        ordinary failure with nothing behind it pays exactly that and no more.
+
+        The listener overreports, so `_document_origin` decides which hop
+        counts: a page rewriting its own address raises the same event and
+        leaves nothing to settle.
+
+        Where it stopped is answered by the hops falling quiet. Counting them
+        rather than comparing addresses, or a chain that returns to the route
+        it started on reads as one that never left.
+
+        What the destination holds is answered by the document being ready. A
+        replacement renders after it commits, and the account picker measured
+        200ms behind its own navigation; judging that page on arrival calls a
+        barrier a loading screen.
+        """
+        # A hop says something moved, not that the document was replaced, so
+        # the wait is for a replacement and not for an event. Leaving on the
+        # first same-document hop is what a page rewriting its own address
+        # would buy, and it costs the redirect arriving right behind it: the
+        # search page announces `currentJobId` the moment a card is selected,
+        # and a checkpoint committing fifty milliseconds later would then be
+        # judged by a route comparison that has not been told yet.
+        #
+        # Each hop is read at most once, so a healthy page pays one evaluate
+        # and the wait, and only a page that keeps moving pays more.
+        lag_deadline = self._session.monotonic() + self.URL_SETTLE_LAG
+        judged = 0
+        replaced = False
+        while self._session.monotonic() < lag_deadline:
+            if len(hops) > judged:
+                judged = len(hops)
+                if origin is None or await self._document_origin() != origin:
+                    replaced = True
+                    break
+            await self._session.delay(self.URL_SETTLE_POLL)
+        if not replaced:
+            if hops:
+                logger.debug("Same document after %d history change(s)", len(hops))
+            return False
+
+        deadline = self._session.monotonic() + self.URL_SETTLE_TIMEOUT
+        seen = len(hops)
+        quiet_since = self._session.monotonic()
+        while self._session.monotonic() < deadline:
+            await self._session.delay(self.URL_SETTLE_POLL)
+            if len(hops) != seen:
+                seen = len(hops)
+                quiet_since = self._session.monotonic()
+            elif self._session.monotonic() - quiet_since >= self.URL_SETTLE_QUIET:
+                break
+
+        try:
+            await self._session.page.wait_for_load_state(
+                "domcontentloaded", timeout=self.DOCUMENT_READY_TIMEOUT * 1000
+            )
+        except Exception:
+            logger.debug("Replacement document was not ready in time", exc_info=True)
+        return True

--- a/linkedin_mcp_server/scraping/navigation.py
+++ b/linkedin_mcp_server/scraping/navigation.py
@@ -35,12 +35,12 @@ class PageNavigator:
     # the rest of the budget is for a redirect chain that is still hopping. Only a
     # page that already looks wrong pays it, so the ceiling costs a healthy
     # ten-page search nothing and a broken one 25s of its 180s tool timeout.
-    URL_SETTLE_TIMEOUT = 2.5
-    URL_SETTLE_POLL = 0.01
+    _URL_SETTLE_TIMEOUT = 2.5
+    _URL_SETTLE_POLL = 0.01
     # How long the route has to hold still before it counts as the destination. A
     # redirect chain hops through intermediate documents, and judging one of those
     # calls a checkpoint healthy, or a healthy page a checkpoint.
-    URL_SETTLE_QUIET = 0.5
+    _URL_SETTLE_QUIET = 0.5
     # How long a navigation has to announce itself before the page counts as
     # going nowhere. Measured across 300 evaluations destroyed by a navigation:
     # 0.37ms at worst idle, 0.81ms at the 99th percentile with twenty-four
@@ -52,11 +52,11 @@ class PageNavigator:
     # the end, which a reload leaves nothing for. Three hundred times the
     # measured announcement is the trade, the other side of it being the wait
     # every ordinary DOM failure pays before it can report itself.
-    URL_SETTLE_LAG = 0.3
+    _URL_SETTLE_LAG = 0.3
     # How long the replacement document gets to reach `domcontentloaded`. It
     # renders after it commits, and an account picker was measured 200ms behind
     # its own navigation, so a page judged on arrival is judged empty.
-    DOCUMENT_READY_TIMEOUT = 5.0
+    _DOCUMENT_READY_TIMEOUT = 5.0
 
     def __init__(self, session: ScrapingSession):
         self._session = session
@@ -366,7 +366,7 @@ class PageNavigator:
         #
         # Each hop is read at most once, so a healthy page pays one evaluate
         # and the wait, and only a page that keeps moving pays more.
-        lag_deadline = self._session.monotonic() + self.URL_SETTLE_LAG
+        lag_deadline = self._session.monotonic() + self._URL_SETTLE_LAG
         judged = 0
         replaced = False
         while self._session.monotonic() < lag_deadline:
@@ -375,26 +375,26 @@ class PageNavigator:
                 if origin is None or await self._document_origin() != origin:
                     replaced = True
                     break
-            await self._session.delay(self.URL_SETTLE_POLL)
+            await self._session.delay(self._URL_SETTLE_POLL)
         if not replaced:
             if hops:
                 logger.debug("Same document after %d history change(s)", len(hops))
             return False
 
-        deadline = self._session.monotonic() + self.URL_SETTLE_TIMEOUT
+        deadline = self._session.monotonic() + self._URL_SETTLE_TIMEOUT
         seen = len(hops)
         quiet_since = self._session.monotonic()
         while self._session.monotonic() < deadline:
-            await self._session.delay(self.URL_SETTLE_POLL)
+            await self._session.delay(self._URL_SETTLE_POLL)
             if len(hops) != seen:
                 seen = len(hops)
                 quiet_since = self._session.monotonic()
-            elif self._session.monotonic() - quiet_since >= self.URL_SETTLE_QUIET:
+            elif self._session.monotonic() - quiet_since >= self._URL_SETTLE_QUIET:
                 break
 
         try:
             await self._session.page.wait_for_load_state(
-                "domcontentloaded", timeout=self.DOCUMENT_READY_TIMEOUT * 1000
+                "domcontentloaded", timeout=self._DOCUMENT_READY_TIMEOUT * 1000
             )
         except Exception:
             logger.debug("Replacement document was not ready in time", exc_info=True)

--- a/linkedin_mcp_server/scraping/session.py
+++ b/linkedin_mcp_server/scraping/session.py
@@ -1,0 +1,66 @@
+"""Shared page binding and browser helper boundaries for scraping services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import asyncio
+import time
+
+from patchright.async_api import Page
+
+from linkedin_mcp_server.core.utils import (
+    detect_rate_limit,
+    handle_modal_close,
+    scroll_job_sidebar,
+    scroll_to_bottom,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ScrapingSession:
+    """Immutable page adapter shared by every scraping service."""
+
+    page: Page
+
+    def monotonic(self) -> float:
+        """Read the session clock."""
+        return time.monotonic()
+
+    async def delay(self, seconds: float) -> None:
+        """Pause through the session delay boundary."""
+        await asyncio.sleep(seconds)
+
+    async def check_rate_limit(self) -> None:
+        """Raise when the current page is rate-limited or challenged."""
+        await detect_rate_limit(self.page)
+
+    async def dismiss_modal(self) -> bool:
+        """Close an obstructing modal when one is present."""
+        return await handle_modal_close(self.page)
+
+    async def scroll_body(self, pause_time: float = 1.0, max_scrolls: int = 10) -> None:
+        """Scroll the page body through the shared utility boundary."""
+        await scroll_to_bottom(
+            self.page,
+            pause_time=pause_time,
+            max_scrolls=max_scrolls,
+        )
+
+    async def scroll_job_sidebar(
+        self,
+        settle_timeout: float = 3.0,
+        poll_interval: float = 0.15,
+        min_budget: float = 0.4,
+        max_scrolls: int = 10,
+        deadline: float = 12.0,
+    ) -> bool:
+        """Scroll the job rail through the shared utility boundary."""
+        return await scroll_job_sidebar(
+            self.page,
+            settle_timeout=settle_timeout,
+            poll_interval=poll_interval,
+            min_budget=min_budget,
+            max_scrolls=max_scrolls,
+            deadline=deadline,
+        )

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -157,8 +157,8 @@ _INSTANCE_ATTRIBUTE_OWNERS = {
 }
 
 _MODULE_ATTRIBUTE_OWNERS = {
-    "_URL_SETTLE_LAG": ("navigation.PageNavigator.URL_SETTLE_LAG", 3),
-    "_URL_SETTLE_QUIET": ("navigation.PageNavigator.URL_SETTLE_QUIET", 3),
+    "_URL_SETTLE_LAG": ("navigation.PageNavigator._URL_SETTLE_LAG", 3),
+    "_URL_SETTLE_QUIET": ("navigation.PageNavigator._URL_SETTLE_QUIET", 3),
     "_MESSAGING_COMPOSE_SELECTOR": ("message_sender.MESSAGE_COMPOSE_SELECTOR", 12),
     "_PROFILE_MESSAGE_TARGET_JS": ("message_sender.PROFILE_MESSAGE_TARGET_JS", 12),
     "_ProfileMessageTarget": ("message_sender.ProfileMessageTarget", 12),

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -37,9 +37,14 @@ _PRIVATE_OWNERS: dict[str, tuple[str, int]] = {
     "_message_action_result": ("contracts.message_action_result", 1),
     "_build_job_search_url": ("search_urls.build_job_search_url", 2),
     "_build_content_search_url": ("search_urls.build_content_search_url", 2),
-    "_navigate_to_page": ("navigation.PageNavigator", 3),
-    "_raise_if_auth_barrier": ("navigation.PageNavigator", 3),
+    "_normalize_body_marker": ("navigation.PageNavigator", 3),
     "_log_navigation_failure": ("navigation.PageNavigator", 3),
+    "_raise_if_auth_barrier": ("navigation.PageNavigator", 3),
+    "_goto_with_auth_checks": ("navigation.PageNavigator", 3),
+    "_navigate_to_page": ("navigation.PageNavigator", 3),
+    "_watching_navigations": ("navigation.PageNavigator", 3),
+    "_document_origin": ("navigation.PageNavigator", 3),
+    "_settle_navigation": ("navigation.PageNavigator", 3),
     "_extract_loaded_section": ("capture.SectionCapture", 4),
     "_extract_overlay": ("capture.SectionCapture", 4),
     "_extract_overlay_once": ("capture.SectionCapture", 4),
@@ -146,7 +151,9 @@ _IMPORT_OWNERS = {
 
 _INSTANCE_ATTRIBUTE_OWNERS = {
     "_page": ("facade.LinkedInExtractor._page", 14),
-    "_scroll_seconds": ("session.ScrapingSession._scroll_seconds", 3),
+    "_session": ("session.ScrapingSession", 3),
+    "_navigator": ("navigation.PageNavigator", 3),
+    "_scroll_seconds": ("facade.LinkedInExtractor._scroll_seconds", 14),
 }
 
 _MODULE_ATTRIBUTE_OWNERS = {
@@ -191,9 +198,9 @@ _WORKFLOW_OWNERS: dict[str, tuple[str, int]] = {
     "_goto_with_auth_checks": ("navigation.PageNavigator", 3),
     "_extract_page_once": ("capture.SectionCapture", 4),
     "_extract_feed_once": ("feed.FeedScraper", 5),
-    "_watching_navigations": ("job_pages.JobPageReader", 9),
-    "_document_origin": ("job_pages.JobPageReader", 9),
-    "_settle_navigation": ("job_pages.JobPageReader", 9),
+    "_watching_navigations": ("navigation.PageNavigator", 3),
+    "_document_origin": ("navigation.PageNavigator", 3),
+    "_settle_navigation": ("navigation.PageNavigator", 3),
     "_extract_search_page": ("job_pages.JobPageReader", 9),
     "_extract_saved_jobs_page": ("job_pages.JobPageReader", 9),
     "_open_conversation_by_username": ("conversations.ConversationReader", 11),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import sys
 
 import pytest
 
+pytest_plugins = ("scraping.support.navigation",)
+
 
 @pytest.fixture(autouse=True)
 def reset_singletons():

--- a/tests/fixtures/scraping-policy/migration-manifest.json
+++ b/tests/fixtures/scraping-policy/migration-manifest.json
@@ -61,7 +61,7 @@
     {
       "canonical_owner": "facade.LinkedInExtractor",
       "kind": "direct_import",
-      "line": 26,
+      "line": 28,
       "migration_stage": 14,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "LinkedInExtractor"
@@ -69,7 +69,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "module_attribute",
-      "line": 112,
+      "line": 114,
       "migration_stage": 4,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_to_bottom"
@@ -77,7 +77,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "module_attribute",
-      "line": 112,
+      "line": 114,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_to_bottom"
@@ -85,7 +85,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "module_attribute",
-      "line": 113,
+      "line": 115,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_job_sidebar"
@@ -93,55 +93,15 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 114,
+      "line": 116,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "_drain_listener_tasks"
     },
     {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "boundary_patch_object",
-      "line": 173,
-      "migration_stage": 3,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "record_page_trace"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "boundary_patch_object",
-      "line": 174,
-      "migration_stage": 3,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "detect_auth_barrier_quick"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "boundary_patch_object",
-      "line": 175,
-      "migration_stage": 3,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "boundary_patch_object",
-      "line": 176,
-      "migration_stage": 3,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "boundary_patch_object",
-      "line": 177,
-      "migration_stage": 3,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "stabilize_navigation"
-    },
-    {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 178,
+      "line": 180,
       "migration_stage": 4,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -149,7 +109,7 @@
     {
       "canonical_owner": "feed.FeedScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 178,
+      "line": 180,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -157,7 +117,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 178,
+      "line": 180,
       "migration_stage": 6,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -165,7 +125,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 178,
+      "line": 180,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -173,7 +133,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 178,
+      "line": 180,
       "migration_stage": 11,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -181,7 +141,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 178,
+      "line": 180,
       "migration_stage": 12,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -189,7 +149,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 179,
+      "line": 181,
       "migration_stage": 4,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -197,7 +157,7 @@
     {
       "canonical_owner": "feed.FeedScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 179,
+      "line": 181,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -205,7 +165,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 179,
+      "line": 181,
       "migration_stage": 6,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -213,7 +173,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 179,
+      "line": 181,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -221,7 +181,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 179,
+      "line": 181,
       "migration_stage": 11,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -229,7 +189,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 179,
+      "line": 181,
       "migration_stage": 12,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -237,7 +197,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "boundary_patch_object",
-      "line": 180,
+      "line": 182,
       "migration_stage": 4,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_to_bottom"
@@ -245,7 +205,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "boundary_patch_object",
-      "line": 180,
+      "line": 182,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_to_bottom"
@@ -253,7 +213,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "boundary_patch_object",
-      "line": 181,
+      "line": 183,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_job_sidebar"
@@ -261,7 +221,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 182,
+      "line": 184,
       "migration_stage": 4,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -269,7 +229,7 @@
     {
       "canonical_owner": "feed.FeedScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 182,
+      "line": 184,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -277,7 +237,7 @@
     {
       "canonical_owner": "person.PersonScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 182,
+      "line": 184,
       "migration_stage": 6,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -285,7 +245,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 182,
+      "line": 184,
       "migration_stage": 8,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -293,7 +253,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 182,
+      "line": 184,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -301,7 +261,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 182,
+      "line": 184,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -309,26 +269,10 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "private_patch_object",
-      "line": 183,
+      "line": 185,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "_drain_listener_tasks"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 184,
-      "migration_stage": null,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 185,
-      "migration_stage": null,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "time.monotonic"
     },
     {
       "canonical_owner": "facade.LinkedInExtractor",
@@ -837,7 +781,7 @@
     {
       "canonical_owner": "owner-local scraping modules",
       "kind": "module_alias",
-      "line": 29,
+      "line": 28,
       "migration_stage": 14,
       "path": "tests/test_scraping.py",
       "target": "extractor_module"
@@ -845,7 +789,7 @@
     {
       "canonical_owner": "facade.LinkedInExtractor",
       "kind": "direct_import",
-      "line": 31,
+      "line": 30,
       "migration_stage": 14,
       "path": "tests/test_scraping.py",
       "target": "LinkedInExtractor"
@@ -853,7 +797,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_COMPOSER_OWNER_JS",
       "kind": "direct_import",
-      "line": 31,
+      "line": 30,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGE_COMPOSER_OWNER_JS"
@@ -861,7 +805,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_CONFIRMATION_DISPOSE_JS",
       "kind": "direct_import",
-      "line": 31,
+      "line": 30,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGE_CONFIRMATION_DISPOSE_JS"
@@ -869,7 +813,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_CONFIRMATION_PREPARE_JS",
       "kind": "direct_import",
-      "line": 31,
+      "line": 30,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGE_CONFIRMATION_PREPARE_JS"
@@ -877,7 +821,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_CONFIRMATION_READY_JS",
       "kind": "direct_import",
-      "line": 31,
+      "line": 30,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGE_CONFIRMATION_READY_JS"
@@ -885,7 +829,7 @@
     {
       "canonical_owner": "contracts.ExtractedSection",
       "kind": "permanent_alias_import",
-      "line": 31,
+      "line": 30,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "ExtractedSection"
@@ -893,7 +837,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 161,
+      "line": 64,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -901,7 +845,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 165,
+      "line": 68,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -909,7 +853,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 169,
+      "line": 72,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -917,7 +861,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_facade_access",
-      "line": 194,
+      "line": 97,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -925,23 +869,15 @@
     {
       "canonical_owner": "capture.SectionCapture -> error_diagnostics.build_issue_diagnostics",
       "kind": "string_patch",
-      "line": 212,
+      "line": 115,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics"
     },
     {
-      "canonical_owner": "capture.SectionCapture -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 229,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 246,
+      "line": 149,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -949,7 +885,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 270,
+      "line": 173,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -957,7 +893,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 274,
+      "line": 177,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -965,7 +901,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 278,
+      "line": 181,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -973,7 +909,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 283,
+      "line": 186,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -981,7 +917,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 319,
+      "line": 222,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -989,7 +925,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 323,
+      "line": 226,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -997,7 +933,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 327,
+      "line": 230,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1005,7 +941,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 332,
+      "line": 235,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -1013,7 +949,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 356,
+      "line": 259,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -1021,7 +957,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 360,
+      "line": 263,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1029,7 +965,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 364,
+      "line": 267,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1037,39 +973,23 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 370,
+      "line": 273,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 383,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 391,
+      "line": 294,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 420,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 426,
+      "line": 329,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1077,7 +997,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 431,
+      "line": 334,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1085,7 +1005,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 435,
+      "line": 338,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1093,23 +1013,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 441,
+      "line": 344,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 463,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 469,
+      "line": 372,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1117,7 +1029,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 474,
+      "line": 377,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1125,7 +1037,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 478,
+      "line": 381,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1133,31 +1045,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 485,
+      "line": 388,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 507,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 513,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_raise_if_auth_barrier"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 519,
+      "line": 422,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1165,7 +1061,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 524,
+      "line": 427,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1173,23 +1069,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 530,
+      "line": 433,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 569,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 570,
+      "line": 473,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1197,7 +1085,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 574,
+      "line": 477,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1205,7 +1093,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 579,
+      "line": 482,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1213,23 +1101,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 586,
+      "line": 489,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 610,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 611,
+      "line": 514,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1237,7 +1117,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 615,
+      "line": 518,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1245,7 +1125,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 620,
+      "line": 523,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1253,23 +1133,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 626,
+      "line": 529,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 659,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 660,
+      "line": 563,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1277,7 +1149,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 664,
+      "line": 567,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1285,87 +1157,119 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 669,
+      "line": 572,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 673,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 679,
+      "line": 582,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 700,
-      "migration_stage": 3,
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 604,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 608,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 613,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 625,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 645,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 649,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 654,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 665,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 692,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 696,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
       "line": 701,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 705,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 710,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 715,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 722,
+      "line": 712,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 741,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 742,
+      "line": 740,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1373,7 +1277,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 746,
+      "line": 744,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1381,119 +1285,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 751,
+      "line": 749,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 756,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 762,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 788,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 789,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 793,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 798,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 802,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 809,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 836,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 837,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 841,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 846,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 850,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 855,
+      "line": 758,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1501,18 +1301,90 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 894,
+      "line": 797,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 895,
-      "migration_stage": 3,
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 799,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 803,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 808,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 813,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._scroll_seconds",
+      "kind": "private_facade_access",
+      "line": 820,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_seconds"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 845,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 849,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 854,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 859,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 868,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
@@ -1541,39 +1413,55 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 910,
+      "line": 911,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "session.ScrapingSession._scroll_seconds",
-      "kind": "private_facade_access",
-      "line": 917,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_seconds"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 941,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 938,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 942,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 947,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 953,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 983,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 946,
+      "line": 987,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1581,63 +1469,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 951,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 956,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 959,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 965,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
       "line": 992,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 993,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 997,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 1002,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1645,23 +1477,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1008,
+      "line": 998,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1034,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 1035,
+      "line": 1021,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1669,7 +1493,31 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 1039,
+      "line": 1025,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 1031,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 1064,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 1068,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1677,7 +1525,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1044,
+      "line": 1073,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1685,23 +1533,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1050,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
       "line": 1079,
-      "migration_stage": 3,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 1080,
+      "line": 1111,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1709,7 +1549,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 1084,
+      "line": 1115,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1717,7 +1557,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 1089,
+      "line": 1120,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1725,271 +1565,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 1095,
+      "line": 1126,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1117,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 1118,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1122,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 1128,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1160,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 1161,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1165,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 1170,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 1176,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1207,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 1208,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1212,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 1217,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 1223,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1246,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1251,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 1257,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1280,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1285,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 1291,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1314,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1319,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.record_page_trace"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1323,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 1330,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1364,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1369,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1374,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_log_navigation_failure"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 1381,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1394,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 1399,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1404,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_log_navigation_failure"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 1411,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
     },
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1427,
+      "line": 1142,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -1997,7 +1581,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1433,
+      "line": 1148,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2005,7 +1589,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1439,
+      "line": 1154,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2013,7 +1597,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1454,
+      "line": 1169,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2021,7 +1605,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1460,
+      "line": 1175,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2029,7 +1613,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1466,
+      "line": 1181,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2037,7 +1621,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1489,
+      "line": 1204,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2045,7 +1629,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1495,
+      "line": 1210,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2053,7 +1637,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1501,
+      "line": 1216,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2061,7 +1645,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1518,
+      "line": 1233,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2069,7 +1653,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1535,
+      "line": 1250,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2077,7 +1661,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1541,
+      "line": 1256,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2085,7 +1669,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1547,
+      "line": 1262,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2093,7 +1677,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 1566,
+      "line": 1281,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2101,7 +1685,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1572,
+      "line": 1287,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2109,7 +1693,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1591,
+      "line": 1306,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2117,7 +1701,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1600,
+      "line": 1315,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2125,31 +1709,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1615,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1621,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1627,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1659,
+      "line": 1330,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2157,7 +1717,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1665,
+      "line": 1336,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2165,7 +1725,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1671,
+      "line": 1342,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2173,7 +1733,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1701,
+      "line": 1374,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2181,7 +1741,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1707,
+      "line": 1380,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2189,7 +1749,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1713,
+      "line": 1386,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2197,7 +1757,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1727,
+      "line": 1416,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2205,7 +1765,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1733,
+      "line": 1422,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2213,7 +1773,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1739,
+      "line": 1428,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2221,7 +1781,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1753,
+      "line": 1442,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2229,7 +1789,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1759,
+      "line": 1448,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2237,7 +1797,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1765,
+      "line": 1454,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2245,7 +1805,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1779,
+      "line": 1468,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2253,7 +1813,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1785,
+      "line": 1474,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2261,7 +1821,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1791,
+      "line": 1480,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2269,7 +1829,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 1805,
+      "line": 1494,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2277,7 +1837,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 1811,
+      "line": 1500,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2285,7 +1845,31 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1817,
+      "line": 1506,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1520,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1526,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1532,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2293,7 +1877,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1996,
+      "line": 1711,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2301,23 +1885,15 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2001,
+      "line": 1716,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2007,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2012,
+      "line": 1727,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2325,7 +1901,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2018,
+      "line": 1733,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2333,7 +1909,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2039,
+      "line": 1754,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2341,23 +1917,15 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2042,
+      "line": 1757,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2048,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2049,
+      "line": 1764,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2365,7 +1933,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2052,
+      "line": 1767,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2373,7 +1941,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2076,
+      "line": 1791,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2381,7 +1949,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2109,
+      "line": 1824,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2389,7 +1957,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2112,
+      "line": 1827,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2397,7 +1965,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2118,
+      "line": 1833,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2405,7 +1973,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2122,
+      "line": 1837,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2413,7 +1981,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2170,
+      "line": 1885,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2421,7 +1989,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2178,
+      "line": 1893,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_fill_dialog_textarea"
@@ -2429,7 +1997,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2184,
+      "line": 1899,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2437,7 +2005,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2190,
+      "line": 1905,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2445,7 +2013,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2196,
+      "line": 1911,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2453,7 +2021,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2200,
+      "line": 1915,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2461,7 +2029,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2212,
+      "line": 1927,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2469,23 +2037,15 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2213,
+      "line": 1928,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2219,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2220,
+      "line": 1935,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2493,7 +2053,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2223,
+      "line": 1938,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2501,7 +2061,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2235,
+      "line": 1950,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2509,7 +2069,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2236,
+      "line": 1951,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2517,7 +2077,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2253,
+      "line": 1968,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2525,7 +2085,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2254,
+      "line": 1969,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2533,7 +2093,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2276,
+      "line": 1991,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2541,7 +2101,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2281,
+      "line": 1996,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2549,23 +2109,15 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2294,
+      "line": 2009,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2300,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2303,
+      "line": 2018,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2573,10 +2125,234 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2309,
+      "line": 2024,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions dependency",
+      "kind": "public_patch_object",
+      "line": 2049,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "scrape_person"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2050,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_read_action_signals"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2060,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_open_more_menu"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2069,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_submit_invite_dialog"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions dependency",
+      "kind": "public_patch_object",
+      "line": 2090,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "scrape_person"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2091,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_read_action_signals"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2100,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_open_more_menu"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2109,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_probe_invite_note_limit"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2115,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_submit_invite_dialog"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions dependency",
+      "kind": "public_patch_object",
+      "line": 2138,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "scrape_person"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2139,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_read_action_signals"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2145,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_open_more_menu"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2154,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_submit_invite_dialog"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions dependency",
+      "kind": "public_patch_object",
+      "line": 2172,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "scrape_person"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2173,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_read_action_signals"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2182,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_submit_invite_dialog"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions dependency",
+      "kind": "public_patch_object",
+      "line": 2200,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "scrape_person"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2205,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_read_action_signals"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2214,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_click_incoming_accept"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2225,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_submit_invite_dialog"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions dependency",
+      "kind": "public_patch_object",
+      "line": 2245,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "scrape_person"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2250,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_read_action_signals"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2256,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_click_incoming_accept"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions dependency",
+      "kind": "public_patch_object",
+      "line": 2262,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "click_button_by_text"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions dependency",
+      "kind": "public_patch_object",
+      "line": 2287,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "scrape_person"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2297,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_read_action_signals"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 2303,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_click_incoming_accept"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2309,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
     },
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
@@ -2589,7 +2365,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2335,
+      "line": 2339,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2597,247 +2373,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2345,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_open_more_menu"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2351,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2354,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_submit_invite_dialog"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 2375,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "scrape_person"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2376,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_read_action_signals"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2385,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_open_more_menu"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2391,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2394,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_probe_invite_note_limit"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2400,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_submit_invite_dialog"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 2423,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "scrape_person"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2424,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_read_action_signals"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2430,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_open_more_menu"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2436,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2439,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_submit_invite_dialog"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 2457,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "scrape_person"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2458,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_read_action_signals"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2464,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2467,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_submit_invite_dialog"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 2485,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "scrape_person"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2490,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_read_action_signals"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2499,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_click_incoming_accept"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2505,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2510,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_submit_invite_dialog"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 2530,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "scrape_person"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2535,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_read_action_signals"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2541,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_click_incoming_accept"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 2547,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "click_button_by_text"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2553,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 2572,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "scrape_person"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2582,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_read_action_signals"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2588,
+      "line": 2349,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2845,7 +2381,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2594,
+      "line": 2355,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2853,7 +2389,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2619,
+      "line": 2371,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2861,7 +2397,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2624,
+      "line": 2372,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2869,47 +2405,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2634,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_click_incoming_accept"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 2640,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 2656,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "scrape_person"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2657,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_read_action_signals"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 2663,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 2664,
+      "line": 2379,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2917,7 +2413,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2667,
+      "line": 2382,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2925,7 +2421,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2677,
+      "line": 2392,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2933,7 +2429,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2750,
+      "line": 2465,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2941,7 +2437,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2753,
+      "line": 2468,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2949,7 +2445,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2764,
+      "line": 2479,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2957,7 +2453,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2777,
+      "line": 2492,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2965,7 +2461,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 2804,
+      "line": 2519,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -2973,7 +2469,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2810,
+      "line": 2525,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2981,7 +2477,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2836,
+      "line": 2551,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2989,7 +2485,7 @@
     {
       "canonical_owner": "person.PersonScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "string_patch",
-      "line": 2841,
+      "line": 2556,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics"
@@ -2997,7 +2493,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 2845,
+      "line": 2560,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3005,7 +2501,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2851,
+      "line": 2566,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3013,7 +2509,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2881,
+      "line": 2596,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3021,7 +2517,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 2890,
+      "line": 2605,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3029,7 +2525,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2896,
+      "line": 2611,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3037,7 +2533,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2919,
+      "line": 2634,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3045,7 +2541,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 2925,
+      "line": 2640,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -3053,7 +2549,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2931,
+      "line": 2646,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3061,7 +2557,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2945,
+      "line": 2660,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3069,7 +2565,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 2954,
+      "line": 2669,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -3077,7 +2573,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2960,
+      "line": 2675,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3085,7 +2581,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 2976,
+      "line": 2691,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3093,7 +2589,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2982,
+      "line": 2697,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3101,7 +2597,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 2998,
+      "line": 2713,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -3109,7 +2605,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3004,
+      "line": 2719,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3117,10 +2613,186 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
+      "line": 2734,
+      "migration_stage": 8,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2740,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "company.CompanyScraper dependency",
+      "kind": "public_patch_object",
+      "line": 2761,
+      "migration_stage": 8,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2770,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 2810,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 2816,
+      "migration_stage": 8,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 2820,
+      "migration_stage": 8,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 2824,
+      "migration_stage": 8,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2829,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper dependency",
+      "kind": "public_patch_object",
+      "line": 2850,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper dependency",
+      "kind": "public_patch_object",
+      "line": 2865,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper dependency",
+      "kind": "public_patch_object",
+      "line": 2880,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2926,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2932,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2938,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2944,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2957,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2966,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2972,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2978,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3008,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3013,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 3019,
-      "migration_stage": 8,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "extract_page"
+      "target": "_get_total_search_pages"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
@@ -3131,193 +2803,9 @@
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "company.CompanyScraper dependency",
-      "kind": "public_patch_object",
-      "line": 3046,
-      "migration_stage": 8,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3055,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 3095,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 3101,
-      "migration_stage": 8,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 3105,
-      "migration_stage": 8,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 3109,
-      "migration_stage": 8,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3114,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper dependency",
-      "kind": "public_patch_object",
-      "line": 3135,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper dependency",
-      "kind": "public_patch_object",
-      "line": 3150,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper dependency",
-      "kind": "public_patch_object",
-      "line": 3165,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3211,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3217,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3223,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3229,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3242,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3251,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3257,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3263,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3293,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3298,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3304,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3310,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 3372,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 3373,
+      "line": 3088,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -3325,7 +2813,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3379,
+      "line": 3094,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3333,7 +2821,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3385,
+      "line": 3100,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3341,7 +2829,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 3391,
+      "line": 3106,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -3349,7 +2837,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 3396,
+      "line": 3111,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -3357,10 +2845,218 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 3400,
+      "line": 3115,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3185,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3191,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3197,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3203,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3222,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3228,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3234,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3240,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3272,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3273,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3279,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3285,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 3341,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3347,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3353,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 3359,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 3364,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 3368,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3373,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3398,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3403,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3409,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3415,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 3439,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3455,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3464,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -3368,28 +3064,12 @@
       "line": 3470,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_get_total_search_pages"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
       "line": 3476,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3482,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3488,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3397,7 +3077,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3507,
+      "line": 3517,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3405,7 +3085,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3513,
+      "line": 3518,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3413,7 +3093,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3519,
+      "line": 3524,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3421,7 +3101,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3525,
+      "line": 3530,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3429,7 +3109,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3557,
+      "line": 3556,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3437,7 +3117,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3558,
+      "line": 3565,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3445,7 +3125,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3564,
+      "line": 3571,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3453,71 +3133,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3570,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 3625,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 3626,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3632,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3638,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 3644,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 3649,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 3653,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3658,
+      "line": 3577,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3525,7 +3141,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3683,
+      "line": 3604,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3533,7 +3149,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3688,
+      "line": 3615,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3541,7 +3157,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3694,
+      "line": 3621,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3549,23 +3165,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3700,
+      "line": 3627,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 3724,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3740,
+      "line": 3650,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3573,10 +3181,66 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3749,
+      "line": 3661,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3667,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3673,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3705,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3710,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3716,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3722,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3746,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -3584,36 +3248,12 @@
       "line": 3755,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 3761,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3802,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3803,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3809,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3621,7 +3261,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3815,
+      "line": 3767,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3629,7 +3269,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3841,
+      "line": 3825,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3637,7 +3277,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3850,
+      "line": 3826,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3645,7 +3285,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3856,
+      "line": 3832,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3653,7 +3293,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3862,
+      "line": 3838,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3661,7 +3301,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3889,
+      "line": 3872,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3669,7 +3309,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3900,
+      "line": 3878,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3677,7 +3317,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3906,
+      "line": 3884,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3685,15 +3325,31 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3912,
+      "line": 3890,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
+      "canonical_owner": "facade.LinkedInExtractor._scroll_seconds",
+      "kind": "private_facade_access",
+      "line": 3930,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_seconds"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
+      "kind": "module_rebind_patch",
+      "line": 3941,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "time"
+    },
+    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3935,
+      "line": 3942,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3701,7 +3357,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3946,
+      "line": 3943,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3709,7 +3365,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3952,
+      "line": 3949,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3717,26 +3373,26 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3958,
+      "line": 3955,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3990,
+      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
+      "kind": "module_rebind_patch",
+      "line": 3999,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "time"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3995,
+      "line": 4000,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -3744,36 +3400,12 @@
       "line": 4001,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 4007,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4031,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4040,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4046,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3781,15 +3413,23 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4052,
+      "line": 4013,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
+      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
+      "kind": "module_rebind_patch",
+      "line": 4063,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "time"
+    },
+    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4110,
+      "line": 4064,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3797,7 +3437,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4111,
+      "line": 4065,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3805,7 +3445,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4117,
+      "line": 4071,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3813,55 +3453,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
+      "line": 4077,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
+      "kind": "module_rebind_patch",
       "line": 4123,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4157,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4163,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4169,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4175,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "session.ScrapingSession._scroll_seconds",
-      "kind": "private_facade_access",
-      "line": 4215,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_seconds"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 4226,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -3869,7 +3469,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4227,
+      "line": 4124,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3877,7 +3477,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4228,
+      "line": 4125,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3885,7 +3485,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4234,
+      "line": 4131,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3893,23 +3493,143 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
+      "line": 4137,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4154,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4160,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4166,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4172,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4186,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4192,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4198,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4204,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4232,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 4240,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4246,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4252,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 4284,
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4268,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "time"
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
+      "line": 4273,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4279,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
       "line": 4285,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4307,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3917,7 +3637,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4286,
+      "line": 4316,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3925,7 +3645,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4292,
+      "line": 4322,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3933,23 +3653,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4298,
+      "line": 4328,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 4348,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "time"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4349,
+      "line": 4346,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3957,7 +3669,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4350,
+      "line": 4357,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3965,7 +3677,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4356,
+      "line": 4363,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3973,31 +3685,23 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4362,
+      "line": 4369,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
-      "kind": "module_rebind_patch",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 4408,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "time"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4409,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4410,
+      "line": 4413,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4005,7 +3709,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4416,
+      "line": 4419,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4013,7 +3717,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4422,
+      "line": 4425,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4021,7 +3725,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4439,
+      "line": 4442,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4029,7 +3733,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4445,
+      "line": 4452,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4037,7 +3741,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4451,
+      "line": 4458,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4045,79 +3749,71 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4457,
+      "line": 4464,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4471,
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 4485,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4477,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4483,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
       "line": 4489,
-      "migration_stage": null,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 4494,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4517,
+      "kind": "private_facade_access",
+      "line": 4500,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4525,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
       "line": 4531,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4537,
-      "migration_stage": null,
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 4535,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 4540,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4553,
+      "kind": "private_facade_access",
+      "line": 4546,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4125,31 +3821,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4558,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4564,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4570,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4592,
+      "line": 4562,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4157,7 +3829,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4601,
+      "line": 4571,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4165,7 +3837,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4607,
+      "line": 4577,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4173,18 +3845,42 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
+      "line": 4583,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4604,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 4613,
-      "migration_stage": null,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
+      "target": "_extract_job_ids"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4631,
+      "line": 4619,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4625,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -4192,7 +3888,7 @@
       "line": 4642,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -4200,36 +3896,12 @@
       "line": 4648,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 4654,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4693,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4698,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4704,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -4237,7 +3909,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4710,
+      "line": 4660,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4245,7 +3917,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4727,
+      "line": 4676,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -4253,39 +3925,47 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4737,
+      "line": 4685,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4743,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4749,
+      "line": 4691,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
+      "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4769,
-      "migration_stage": 3,
+      "line": 4711,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4720,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4726,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 4770,
+      "line": 4762,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4293,399 +3973,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 4774,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 4779,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 4785,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 4815,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 4816,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 4820,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 4825,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 4831,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4847,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4856,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4862,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4868,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4889,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4898,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4904,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4910,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4927,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4933,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4939,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4945,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4961,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4970,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4976,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4996,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5005,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5011,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 5067,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_document_origin"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 5083,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "time"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5084,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 5090,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_settle_navigation"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
-      "kind": "module_attribute",
-      "line": 5093,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_URL_SETTLE_QUIET"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_LAG",
-      "kind": "module_attribute",
-      "line": 5094,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_URL_SETTLE_LAG"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 5107,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "time"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5108,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 5114,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_settle_navigation"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 5131,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "time"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5132,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 5138,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_settle_navigation"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
-      "kind": "module_attribute",
-      "line": 5142,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_URL_SETTLE_QUIET"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 5161,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "time"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5162,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 5167,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_settle_navigation"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_LAG",
-      "kind": "module_attribute",
-      "line": 5169,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_URL_SETTLE_LAG"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator.URL_SETTLE_QUIET",
-      "kind": "module_attribute",
-      "line": 5170,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_URL_SETTLE_QUIET"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 5188,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "time"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5189,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 5194,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_settle_navigation"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 5223,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5224,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5228,
+      "line": 4766,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4693,7 +3981,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 5233,
+      "line": 4771,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -4701,39 +3989,23 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 5237,
+      "line": 4775,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 5240,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5246,
+      "line": 4784,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 5280,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5281,
+      "line": 4819,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4741,7 +4013,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5285,
+      "line": 4823,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4749,23 +4021,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 5290,
+      "line": 4828,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 5294,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 5300,
+      "line": 4838,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4773,7 +4037,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5328,
+      "line": 4866,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4781,7 +4045,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5334,
+      "line": 4872,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4789,7 +4053,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5340,
+      "line": 4878,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4797,7 +4061,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5346,
+      "line": 4884,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4805,7 +4069,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5368,
+      "line": 4906,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4813,7 +4077,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5374,
+      "line": 4912,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4821,7 +4085,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5380,
+      "line": 4918,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4829,7 +4093,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5386,
+      "line": 4924,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4837,7 +4101,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5403,
+      "line": 4941,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4845,7 +4109,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5412,
+      "line": 4950,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4853,7 +4117,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5418,
+      "line": 4956,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4861,7 +4125,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5424,
+      "line": 4962,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4869,7 +4133,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5440,
+      "line": 4978,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4877,7 +4141,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5447,
+      "line": 4985,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4885,7 +4149,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5453,
+      "line": 4991,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4893,7 +4157,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5459,
+      "line": 4997,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4901,7 +4165,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5481,
+      "line": 5019,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4909,7 +4173,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5484,
+      "line": 5022,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4917,7 +4181,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5490,
+      "line": 5028,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4925,7 +4189,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5496,
+      "line": 5034,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4933,7 +4197,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5514,
+      "line": 5052,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4941,7 +4205,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5519,
+      "line": 5057,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4949,7 +4213,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5525,
+      "line": 5063,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4957,23 +4221,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5531,
+      "line": 5069,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 5556,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5557,
+      "line": 5095,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4981,31 +4237,15 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5561,
+      "line": 5099,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "jobs.JobScraper -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 5566,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_auth_barrier"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 5605,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5606,
+      "line": 5144,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5013,7 +4253,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5610,
+      "line": 5148,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5021,7 +4261,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 5615,
+      "line": 5153,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5029,7 +4269,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5634,
+      "line": 5172,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5037,7 +4277,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5640,
+      "line": 5178,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5045,7 +4285,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5646,
+      "line": 5184,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5053,7 +4293,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5661,
+      "line": 5199,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5061,7 +4301,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5667,
+      "line": 5205,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5069,7 +4309,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5673,
+      "line": 5211,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5077,7 +4317,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5694,
+      "line": 5232,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5085,7 +4325,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5703,
+      "line": 5241,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5093,7 +4333,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5709,
+      "line": 5247,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5101,7 +4341,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5715,
+      "line": 5253,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5109,7 +4349,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5736,
+      "line": 5274,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5117,7 +4357,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5741,
+      "line": 5279,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5125,7 +4365,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5747,
+      "line": 5285,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5133,7 +4373,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5753,
+      "line": 5291,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5141,7 +4381,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5776,
+      "line": 5314,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5149,7 +4389,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5782,
+      "line": 5320,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5157,7 +4397,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5788,
+      "line": 5326,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5165,7 +4405,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5794,
+      "line": 5332,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5173,7 +4413,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5818,
+      "line": 5356,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5181,7 +4421,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5824,
+      "line": 5362,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5189,7 +4429,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5830,
+      "line": 5368,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5197,7 +4437,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5836,
+      "line": 5374,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5205,7 +4445,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5856,
+      "line": 5394,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5213,7 +4453,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5862,
+      "line": 5400,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5221,7 +4461,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5868,
+      "line": 5406,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5229,7 +4469,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5874,
+      "line": 5412,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5237,7 +4477,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5897,
+      "line": 5435,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -5245,7 +4485,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5903,
+      "line": 5441,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -5253,7 +4493,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5909,
+      "line": 5447,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -5261,7 +4501,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5915,
+      "line": 5453,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5269,7 +4509,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5947,
+      "line": 5485,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5277,7 +4517,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 5947,
+      "line": 5485,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5285,7 +4525,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5962,
+      "line": 5500,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5293,7 +4533,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5984,
+      "line": 5522,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5301,7 +4541,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5996,
+      "line": 5534,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5309,7 +4549,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6008,
+      "line": 5546,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5317,7 +4557,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6043,
+      "line": 5581,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5325,7 +4565,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6055,
+      "line": 5593,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5333,7 +4573,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6078,
+      "line": 5616,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5341,7 +4581,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6096,
+      "line": 5634,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5349,7 +4589,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6110,
+      "line": 5648,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5357,7 +4597,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6131,
+      "line": 5669,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5365,7 +4605,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6145,
+      "line": 5683,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5373,7 +4613,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 6158,
+      "line": 5696,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5381,7 +4621,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6192,
+      "line": 5730,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5389,7 +4629,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6196,
+      "line": 5734,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5397,7 +4637,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6200,
+      "line": 5738,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5405,7 +4645,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6206,
+      "line": 5744,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5413,7 +4653,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6233,
+      "line": 5771,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5421,7 +4661,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6237,
+      "line": 5775,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5429,7 +4669,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6241,
+      "line": 5779,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5437,7 +4677,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6247,
+      "line": 5785,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5445,7 +4685,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6272,
+      "line": 5810,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5453,7 +4693,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6276,
+      "line": 5814,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5461,7 +4701,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6280,
+      "line": 5818,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5469,23 +4709,391 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
+      "line": 5824,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 5843,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 5847,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 5851,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 5857,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 5880,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 5884,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 5888,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 5894,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 5917,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 5921,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 5925,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 5931,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 5953,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 5957,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 5961,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 5967,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6001,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6005,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6009,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 6014,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6019,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6050,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6054,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6058,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 6063,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6068,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6098,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6102,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6106,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6112,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6132,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6136,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6140,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6146,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6173,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6177,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6181,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6187,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6218,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6222,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6226,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6232,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 6256,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 6260,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 6264,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_facade_access",
+      "line": 6270,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_page_once"
+    },
+    {
+      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
       "line": 6286,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6305,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
     },
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6309,
+      "line": 6290,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5493,7 +5101,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6313,
+      "line": 6294,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5501,7 +5109,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6319,
+      "line": 6300,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5509,7 +5117,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 6342,
+      "line": 6320,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -5517,7 +5125,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6346,
+      "line": 6324,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5525,7 +5133,7 @@
     {
       "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6350,
+      "line": 6328,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5533,375 +5141,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_facade_access",
-      "line": 6356,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6379,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6383,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6387,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6393,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6415,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6419,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6423,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6429,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6463,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6467,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6471,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 6476,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6481,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6512,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6516,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6520,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 6525,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6530,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6560,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6564,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6568,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6574,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6594,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6598,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6602,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6608,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6635,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6639,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6643,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6649,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6680,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6684,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6688,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6694,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6718,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6722,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6726,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6732,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6748,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6752,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6756,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6762,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6782,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6786,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6790,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6796,
+      "line": 6334,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_page_once"
@@ -5909,7 +5149,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6816,
+      "line": 6354,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5917,7 +5157,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 6822,
+      "line": 6360,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_overlay"
@@ -5925,7 +5165,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6828,
+      "line": 6366,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5933,7 +5173,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6859,
+      "line": 6397,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5941,7 +5181,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6865,
+      "line": 6403,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5949,7 +5189,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6883,
+      "line": 6421,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5957,23 +5197,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6889,
+      "line": 6427,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 6914,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6915,
+      "line": 6455,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -5981,7 +5213,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 6932,
+      "line": 6472,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_loaded_section"
@@ -5989,23 +5221,15 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6938,
+      "line": 6478,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 6941,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6942,
+      "line": 6484,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6013,7 +5237,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6961,
+      "line": 6503,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6021,7 +5245,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 6967,
+      "line": 6509,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_loaded_section"
@@ -6029,7 +5253,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6972,
+      "line": 6514,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6037,7 +5261,7 @@
     {
       "canonical_owner": "capture.SectionCapture",
       "kind": "private_patch_object",
-      "line": 6989,
+      "line": 6531,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_loaded_section"
@@ -6045,7 +5269,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6995,
+      "line": 6537,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6053,7 +5277,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7001,
+      "line": 6543,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6061,7 +5285,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 7027,
+      "line": 6569,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6069,23 +5293,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7033,
+      "line": 6575,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7082,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7083,
+      "line": 6625,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6093,7 +5309,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7087,
+      "line": 6629,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6101,23 +5317,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7092,
+      "line": 6634,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7138,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7144,
+      "line": 6686,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6125,23 +5333,15 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7148,
+      "line": 6690,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7168,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7174,
+      "line": 6716,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6149,7 +5349,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7178,
+      "line": 6720,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6157,23 +5357,15 @@
     {
       "canonical_owner": "person.PersonScraper -> owner-local logger binding",
       "kind": "imported_module_patch",
-      "line": 7183,
+      "line": 6725,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "logger.debug"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7211,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7212,
+      "line": 6754,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6181,23 +5373,15 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7216,
+      "line": 6758,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7249,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7250,
+      "line": 6792,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6205,7 +5389,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7254,
+      "line": 6796,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6213,23 +5397,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7259,
+      "line": 6801,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7278,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7279,
+      "line": 6821,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6237,7 +5413,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7283,
+      "line": 6825,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6245,7 +5421,7 @@
     {
       "canonical_owner": "message_sender.profile_urn_from_compose_url",
       "kind": "module_attribute",
-      "line": 7344,
+      "line": 6886,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_profile_urn_from_compose_url"
@@ -6253,7 +5429,7 @@
     {
       "canonical_owner": "message_sender.profile_path_from_url",
       "kind": "module_attribute",
-      "line": 7362,
+      "line": 6904,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_profile_path_from_url"
@@ -6261,7 +5437,7 @@
     {
       "canonical_owner": "message_sender.message_page_url_is_safe",
       "kind": "module_attribute",
-      "line": 7423,
+      "line": 6965,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_page_url_is_safe"
@@ -6269,7 +5445,7 @@
     {
       "canonical_owner": "message_sender.PROFILE_MESSAGE_TARGET_JS",
       "kind": "module_attribute",
-      "line": 7444,
+      "line": 6986,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_PROFILE_MESSAGE_TARGET_JS"
@@ -6277,7 +5453,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7491,
+      "line": 7033,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6285,7 +5461,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7497,
+      "line": 7039,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -6293,7 +5469,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7503,
+      "line": 7045,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6301,7 +5477,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7516,
+      "line": 7058,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6309,7 +5485,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7522,
+      "line": 7064,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -6317,23 +5493,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7528,
+      "line": 7070,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7543,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7548,
+      "line": 7090,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6341,7 +5509,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7552,
+      "line": 7094,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6349,7 +5517,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7556,
+      "line": 7098,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6357,7 +5525,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7561,
+      "line": 7103,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -6365,7 +5533,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 7566,
+      "line": 7108,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -6373,7 +5541,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7575,
+      "line": 7117,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -6381,7 +5549,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7579,
+      "line": 7121,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -6389,23 +5557,15 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7583,
+      "line": 7125,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7600,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7601,
+      "line": 7143,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6413,7 +5573,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7605,
+      "line": 7147,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6421,7 +5581,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7609,
+      "line": 7151,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6429,7 +5589,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7610,
+      "line": 7152,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -6437,7 +5597,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 7613,
+      "line": 7155,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -6445,10 +5605,506 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7619,
+      "line": 7161,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7165,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7195,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7199,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7203,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7204,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7207,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7216,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 7220,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7224,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7248,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7252,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7256,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7257,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7260,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7266,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 7270,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7294,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7298,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7302,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7303,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7306,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 7312,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7334,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7338,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7342,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7343,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 7346,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7352,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7361,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7367,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 7371,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7392,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7396,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7400,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7401,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 7404,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7410,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 7419,
+      "migration_stage": 4,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 7425,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 7429,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7449,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7453,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 7457,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7463,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7481,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7485,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 7489,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7495,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 7512,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 7520,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 7530,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
+    },
+    {
+      "canonical_owner": "conversations.strip_select_conversation_prefix",
+      "kind": "private_facade_access",
+      "line": 7537,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_strip_select_conversation_prefix"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7568,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7572,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7576,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7577,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7580,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_facade_access",
+      "line": 7587,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 7611,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 7615,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7619,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 7620,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
@@ -6459,12 +6115,12 @@
       "target": "_extract_conversation_thread_refs"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7652,
-      "migration_stage": 3,
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_facade_access",
+      "line": 7625,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
+      "target": "_resolve_conversation_thread_urls"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
@@ -6499,44 +6155,28 @@
       "target": "_scroll_main_scrollable_region"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7665,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 7674,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 7678,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7682,
+      "line": 7665,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7705,
-      "migration_stage": 3,
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_facade_access",
+      "line": 7667,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_facade_access",
+      "line": 7691,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_conversation_thread_refs"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
@@ -6563,17 +6203,9 @@
       "target": "_wait_for_main_text"
     },
     {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7715,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 7718,
+      "line": 7715,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -6581,7 +6213,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7724,
+      "line": 7721,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -6589,543 +6221,39 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7728,
+      "line": 7725,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
+      "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7751,
-      "migration_stage": 3,
+      "line": 7729,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
+      "target": "_extract_conversation_thread_refs"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7752,
+      "line": 7766,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7756,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7760,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7761,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7764,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
       "line": 7770,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7791,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7792,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7796,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7800,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7801,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 7804,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7810,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7819,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 7825,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 7829,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7849,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7850,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7854,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7858,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7859,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 7862,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7868,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7877,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 7883,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 7887,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7906,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7907,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7911,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 7915,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7921,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 7938,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 7939,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 7943,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 7947,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 7953,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 7970,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
-    },
-    {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 7978,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
-    },
-    {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 7988,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
-    },
-    {
-      "canonical_owner": "conversations.strip_select_conversation_prefix",
-      "kind": "private_facade_access",
-      "line": 7995,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_strip_select_conversation_prefix"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8025,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8026,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8030,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8034,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8035,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8038,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8045,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8068,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8069,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8073,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8077,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8078,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8081,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8083,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8110,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8111,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8115,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8119,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8120,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8123,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8125,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_facade_access",
-      "line": 8149,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8163,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8164,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8168,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8172,
+      "line": 7774,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -7133,7 +6261,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 8173,
+      "line": 7775,
       "migration_stage": 4,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -7141,7 +6269,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 8179,
+      "line": 7781,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -7149,7 +6277,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 8183,
+      "line": 7785,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -7157,103 +6285,15 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 8187,
+      "line": 7789,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8223,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 8224,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 8228,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8232,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 8233,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 8239,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 8243,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 8247,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_conversation_thread_refs"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8274,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8307,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8331,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8334,
+      "line": 7876,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7261,7 +6301,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8338,
+      "line": 7880,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7269,7 +6309,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8342,
+      "line": 7884,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7277,7 +6317,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8346,
+      "line": 7888,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_message_surface"
@@ -7285,7 +6325,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8349,
+      "line": 7891,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_message_composer_state"
@@ -7293,7 +6333,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8352,
+      "line": 7894,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_focus_verified_message_editor"
@@ -7301,23 +6341,15 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8357,
+      "line": 7899,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8388,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8389,
+      "line": 7931,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7325,7 +6357,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8393,
+      "line": 7935,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7333,7 +6365,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8397,
+      "line": 7939,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7341,23 +6373,15 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTarget",
       "kind": "module_attribute",
-      "line": 8410,
+      "line": 7952,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTarget"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8460,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8461,
+      "line": 8003,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7365,7 +6389,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8465,
+      "line": 8007,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7373,7 +6397,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8469,
+      "line": 8011,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7381,7 +6405,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8473,
+      "line": 8015,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_message_surface"
@@ -7389,7 +6413,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8479,
+      "line": 8021,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_message_composer_state"
@@ -7397,7 +6421,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8492,
+      "line": 8034,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_write_verified_message"
@@ -7405,7 +6429,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8498,
+      "line": 8040,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -7413,7 +6437,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 8504,
+      "line": 8046,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -7421,7 +6445,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8508,
+      "line": 8050,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7429,23 +6453,15 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8514,
+      "line": 8056,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 8549,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8552,
+      "line": 8094,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -7453,7 +6469,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8556,
+      "line": 8098,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -7461,7 +6477,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8560,
+      "line": 8102,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -7469,7 +6485,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8741,
+      "line": 8283,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -7477,7 +6493,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8887,
+      "line": 8429,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7485,7 +6501,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8893,
+      "line": 8435,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7493,7 +6509,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8966,
+      "line": 8508,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_verified_submit"
@@ -7501,7 +6517,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8972,
+      "line": 8514,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_cleanup_owned_message"
@@ -7509,7 +6525,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9072,
+      "line": 8614,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_write_verified_message"
@@ -7517,7 +6533,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9078,
+      "line": 8620,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -7525,7 +6541,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9085,
+      "line": 8627,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7533,7 +6549,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9091,
+      "line": 8633,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7541,7 +6557,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9126,
+      "line": 8668,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7549,7 +6565,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9251,
+      "line": 8793,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_confirmation"
@@ -7557,7 +6573,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9257,
+      "line": 8799,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_owner"
@@ -7565,7 +6581,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9308,
+      "line": 8850,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7573,7 +6589,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 9314,
+      "line": 8856,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7581,7 +6597,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9346,
+      "line": 8888,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_compose_box"
@@ -7589,7 +6605,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_COMPOSE_SELECTOR",
       "kind": "module_attribute",
-      "line": 9349,
+      "line": 8891,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGING_COMPOSE_SELECTOR"
@@ -7597,7 +6613,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9371,
+      "line": 8913,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -7605,7 +6621,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9396,
+      "line": 8938,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -7613,7 +6629,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9408,
+      "line": 8950,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_owner"
@@ -7621,7 +6637,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9418,
+      "line": 8960,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7629,7 +6645,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9440,
+      "line": 8982,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -7637,7 +6653,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9452,
+      "line": 8994,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7645,7 +6661,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9485,
+      "line": 9027,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -7653,7 +6669,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9499,
+      "line": 9041,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_confirmation"
@@ -7661,7 +6677,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9535,
+      "line": 9077,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7669,7 +6685,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9549,
+      "line": 9091,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7677,7 +6693,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9573,
+      "line": 9115,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7685,7 +6701,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9598,
+      "line": 9140,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7693,7 +6709,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9617,
+      "line": 9159,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7701,7 +6717,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9637,
+      "line": 9179,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7709,7 +6725,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9682,
+      "line": 9224,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7717,7 +6733,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9743,
+      "line": 9285,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7725,7 +6741,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9781,
+      "line": 9323,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -7733,103 +6749,23 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9816,
+      "line": 9358,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 9847,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 9860,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.record_page_trace"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 9866,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 9878,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 9885,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 9921,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 9929,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator -> navigation.PageNavigator",
-      "kind": "string_patch",
-      "line": 9964,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_facade_access",
-      "line": 9971,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_goto_with_auth_checks"
     },
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 10006,
+      "line": 9403,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 10012,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 10013,
+      "line": 9410,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -7837,7 +6773,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 10028,
+      "line": 9425,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -7845,7 +6781,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 10048,
+      "line": 9445,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -7853,7 +6789,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 10048,
+      "line": 9445,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -7861,7 +6797,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 10048,
+      "line": 9445,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -7869,7 +6805,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 10048,
+      "line": 9445,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -7877,7 +6813,7 @@
     {
       "canonical_owner": "conversations.ConversationReader dependency",
       "kind": "public_patch_object",
-      "line": 10048,
+      "line": 9445,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -7885,23 +6821,15 @@
     {
       "canonical_owner": "message_sender.MessageSender dependency",
       "kind": "public_patch_object",
-      "line": 10048,
+      "line": 9445,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 10049,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 10065,
+      "line": 9462,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -7909,18 +6837,10 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 10071,
+      "line": 9468,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
-    },
-    {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 10077,
-      "migration_stage": 3,
-      "path": "tests/test_scraping.py",
-      "target": "_navigate_to_page"
     },
     {
       "canonical_owner": "facade.LinkedInExtractor",
@@ -7947,17 +6867,9 @@
       "target": "_ProfileMessageTargetResolution"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 304,
-      "migration_stage": 3,
-      "path": "tests/test_send_message_confirmation_dom.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 305,
+      "line": 306,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_profile_message_target"
@@ -7965,7 +6877,7 @@
     {
       "canonical_owner": "message_sender.message_page_url_is_safe",
       "kind": "string_patch",
-      "line": 311,
+      "line": 312,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "linkedin_mcp_server.scraping.extractor._message_page_url_is_safe"
@@ -7973,7 +6885,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_facade_access",
-      "line": 378,
+      "line": 379,
       "migration_stage": 6,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_extract_profile_urn"
@@ -7981,23 +6893,15 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 514,
+      "line": 515,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_message_composer_state"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 527,
-      "migration_stage": 3,
-      "path": "tests/test_send_message_confirmation_dom.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 528,
+      "line": 529,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_profile_message_target"
@@ -8005,7 +6909,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 534,
+      "line": 535,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_message_composer_state"
@@ -8013,23 +6917,15 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 564,
+      "line": 565,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_resolve_message_owner"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 575,
-      "migration_stage": 3,
-      "path": "tests/test_send_message_confirmation_dom.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 576,
+      "line": 577,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_profile_message_target"
@@ -8037,7 +6933,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 582,
+      "line": 583,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_resolve_message_owner"
@@ -8045,23 +6941,15 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 1032,
+      "line": 1033,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_resolve_message_owner"
     },
     {
-      "canonical_owner": "navigation.PageNavigator",
-      "kind": "private_patch_object",
-      "line": 1044,
-      "migration_stage": 3,
-      "path": "tests/test_send_message_confirmation_dom.py",
-      "target": "_navigate_to_page"
-    },
-    {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 1045,
+      "line": 1046,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_profile_message_target"
@@ -8069,7 +6957,7 @@
     {
       "canonical_owner": "message_sender.message_page_url_is_safe",
       "kind": "string_patch",
-      "line": 1051,
+      "line": 1052,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "linkedin_mcp_server.scraping.extractor._message_page_url_is_safe"
@@ -8077,7 +6965,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 1055,
+      "line": 1056,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_resolve_message_owner"
@@ -8085,7 +6973,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 1058,
+      "line": 1059,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_message_send_confirmed"

--- a/tests/scraping/policy_scenarios.py
+++ b/tests/scraping/policy_scenarios.py
@@ -23,6 +23,8 @@ from patchright.async_api import TimeoutError as PlaywrightTimeoutError
 
 from linkedin_mcp_server.callbacks import ProgressCallback
 from linkedin_mcp_server.scraping import extractor as extractor_module
+from linkedin_mcp_server.scraping import navigation as navigation_module
+from linkedin_mcp_server.scraping import session as session_module
 from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
 from linkedin_mcp_server.scraping.fields import COMPANY_SECTIONS, PERSON_SECTIONS
 from linkedin_mcp_server.server import create_mcp_server
@@ -170,19 +172,19 @@ async def boundaries(
         }
 
     with (
-        patch.object(extractor_module, "record_page_trace", trace),
-        patch.object(extractor_module, "detect_auth_barrier_quick", auth_quick),
-        patch.object(extractor_module, "detect_auth_barrier", auth),
-        patch.object(extractor_module, "resolve_remember_me_prompt", remember),
-        patch.object(extractor_module, "stabilize_navigation", stabilize),
+        patch.object(navigation_module, "record_page_trace", trace),
+        patch.object(navigation_module, "detect_auth_barrier_quick", auth_quick),
+        patch.object(navigation_module, "detect_auth_barrier", auth),
+        patch.object(navigation_module, "resolve_remember_me_prompt", remember),
+        patch.object(navigation_module, "stabilize_navigation", stabilize),
         patch.object(extractor_module, "detect_rate_limit", rate_limit),
         patch.object(extractor_module, "handle_modal_close", modal),
         patch.object(extractor_module, "scroll_to_bottom", scroll_body),
         patch.object(extractor_module, "scroll_job_sidebar", scroll_sidebar),
         patch.object(extractor_module, "build_issue_diagnostics", diagnostics),
         patch.object(extractor_module, "_drain_listener_tasks", drain),
-        patch.object(extractor_module.asyncio, "sleep", clock.sleep),
-        patch.object(extractor_module.time, "monotonic", clock.monotonic),
+        patch.object(session_module.asyncio, "sleep", clock.sleep),
+        patch.object(session_module.time, "monotonic", clock.monotonic),
     ):
         yield
 

--- a/tests/scraping/support/navigation.py
+++ b/tests/scraping/support/navigation.py
@@ -1,0 +1,106 @@
+"""Page doubles shared by navigation and workflow tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_page():
+    """Create a mock Patchright page."""
+    page = MagicMock()
+    page.goto = AsyncMock()
+    page.title = AsyncMock(return_value="LinkedIn")
+    page.wait_for_selector = AsyncMock()
+    page.wait_for_function = AsyncMock()
+    page.url = "https://www.linkedin.com/in/testuser/"
+    page.locator = MagicMock()
+    # Default: no modals, no CAPTCHA
+    mock_locator = MagicMock()
+    mock_locator.count = AsyncMock(return_value=0)
+    mock_locator.is_visible = AsyncMock(return_value=False)
+    mock_locator.first = mock_locator
+    mock_locator.inner_text = AsyncMock(return_value="normal page content")
+    mock_locator.filter = MagicMock(return_value=mock_locator)
+    page.locator.return_value = mock_locator
+    # A real `Frame` carries the address it navigated to, and production
+    # reads it off the `framenavigated` argument rather than off the page.
+    # A bare object answers every attribute with nothing, which left hop
+    # recording looking correct here however broken it was.
+    page.main_frame = SimpleNamespace(url=page.url)
+    page.wait_for_load_state = AsyncMock()
+    # Real listeners, so that a double can navigate the way the browser does.
+    # A reload leaves `page.url` untouched, so the event is the only thing that
+    # says the document was replaced, and a double that only assigns the URL
+    # cannot express one.
+    listeners: dict[str, list] = {}
+    page.on = MagicMock(
+        side_effect=lambda event, cb: listeners.setdefault(event, []).append(cb)
+    )
+    page.remove_listener = MagicMock(
+        side_effect=lambda event, cb: (
+            listeners.get(event, []).remove(cb)
+            if cb in listeners.get(event, [])
+            else None
+        )
+    )
+    page.listeners = listeners
+    # The document's own identity, which `performance.timeOrigin` reports and
+    # `navigate()` moves. A double answering every script with one object
+    # claims a document that is never replaced, and the code under test reads
+    # that as a page rewriting its own address.
+    page.time_origin = 1_000.0
+    page.evaluate = with_document_identity(
+        page,
+        AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Sample page text",
+                "references": [],
+            }
+        ),
+    )
+    return page
+
+
+def with_document_identity(page, evaluate):
+    """Answer the document-identity read from `page.time_origin`.
+
+    Every other script keeps going to `evaluate`. A test that replaces
+    `page.evaluate` outright loses this and reads no identity at all, which
+    leaves the production code where it was before there was one: it settles
+    on the event alone.
+    """
+
+    async def dispatch(script, *args, **kwargs):
+        if "timeOrigin" in script:
+            return page.time_origin
+        return await evaluate(script, *args, **kwargs)
+
+    return AsyncMock(side_effect=dispatch)
+
+
+def navigate(page, url: str | None = None, same_document: bool = False) -> None:
+    """Move a mock page the way a navigation does: the address and the event.
+
+    `url` is omitted for a reload, which replaces the document and leaves the
+    address exactly as it was.
+
+    `same_document` is a `pushState`, a `replaceState` or a hash change. Each
+    raises `framenavigated` on the main frame exactly as a replacement does
+    (measured), and LinkedIn appends `currentJobId` to a search URL that way
+    on every healthy page. What separates them is the document surviving.
+    """
+    if url is not None:
+        page.url = url
+    if not same_document:
+        page.time_origin += 1.0
+    # The frame carries the address too, and production reads the hop off the
+    # frame rather than off the page. Leaving it behind is what let the hop
+    # recording look correct here however broken it was.
+    page.main_frame.url = page.url
+    for callback in list(page.listeners.get("framenavigated", [])):
+        callback(page.main_frame)

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -329,7 +329,7 @@ def test_checker_rejects_obsolete_seams_at_their_migration_stage():
     # completed stage are closed by definition, so an override there proves
     # nothing; raise this number as each stage lands.
     result = subprocess.run(
-        [sys.executable, str(CHECKER), "--check", "--stage", "3"],
+        [sys.executable, str(CHECKER), "--check", "--stage", "4"],
         cwd=ROOT,
         text=True,
         capture_output=True,
@@ -337,7 +337,7 @@ def test_checker_rejects_obsolete_seams_at_their_migration_stage():
     )
 
     assert result.returncode == 1
-    assert "obsolete at stage 3:" in result.stderr
+    assert "obsolete at stage 4:" in result.stderr
     assert "string_patch" in result.stderr
 
 
@@ -448,7 +448,7 @@ async def outer(page):
     accesses = [seam for seam in seams if seam.kind == "private_facade_access"]
     assert [
         (seam.target, seam.canonical_owner, seam.migration_stage) for seam in accesses
-    ] == [("_scroll_seconds", "session.ScrapingSession._scroll_seconds", 3)]
+    ] == [("_scroll_seconds", "facade.LinkedInExtractor._scroll_seconds", 14)]
 
 
 def test_unknown_private_closure_access_fails_closed():
@@ -963,8 +963,8 @@ def test_manifest_includes_extractor_access_from_nested_closure():
         (seam["line"], seam["canonical_owner"], seam["migration_stage"])
         for seam in accesses
     } == {
-        (917, "session.ScrapingSession._scroll_seconds", 3),
-        (4215, "session.ScrapingSession._scroll_seconds", 3),
+        (820, "facade.LinkedInExtractor._scroll_seconds", 14),
+        (3930, "facade.LinkedInExtractor._scroll_seconds", 14),
     }
 
 

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1339,11 +1339,11 @@ async def boundaries(tasks):
     assert {seam.migration_stage for seam in matching("scroll_job_sidebar")} == {9}
     assert {seam.migration_stage for seam in matching("_URL_SETTLE_LAG")} == {3}
     assert {seam.canonical_owner for seam in matching("_URL_SETTLE_LAG")} == {
-        "navigation.PageNavigator.URL_SETTLE_LAG"
+        "navigation.PageNavigator._URL_SETTLE_LAG"
     }
     assert {seam.migration_stage for seam in matching("_URL_SETTLE_QUIET")} == {3}
     assert {seam.canonical_owner for seam in matching("_URL_SETTLE_QUIET")} == {
-        "navigation.PageNavigator.URL_SETTLE_QUIET"
+        "navigation.PageNavigator._URL_SETTLE_QUIET"
     }
     messaging_targets = {
         "_MESSAGING_COMPOSE_SELECTOR",

--- a/tests/scraping/test_navigation.py
+++ b/tests/scraping/test_navigation.py
@@ -1,0 +1,550 @@
+"""Tests for the page navigation lifecycle owner."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from patchright.async_api import Error as PatchrightError
+
+import pytest
+
+from linkedin_mcp_server.core.exceptions import ProxyConnectionError
+from linkedin_mcp_server.scraping import session as session_module
+from linkedin_mcp_server.scraping.navigation import PageNavigator
+from linkedin_mcp_server.scraping.session import ScrapingSession
+from .support.navigation import navigate
+
+
+class TestNavigationDiagnostics:
+    async def test_goto_with_auth_checks_clicks_remember_me_and_retries(
+        self, mock_page
+    ):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+
+        async def goto_side_effect(*args, **kwargs):
+            if mock_page.goto.await_count == 1:
+                raise Exception("net::ERR_TOO_MANY_REDIRECTS")
+            return None
+
+        mock_page.goto = AsyncMock(side_effect=goto_side_effect)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                side_effect=[True],
+            ) as mock_resolve,
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier_quick",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        assert mock_page.goto.await_count == 2
+        mock_resolve.assert_awaited_once()
+
+    async def test_goto_with_auth_checks_unhooks_outer_listener_before_retry(
+        self, mock_page
+    ):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        listener_events: list[str] = []
+
+        def record_on(event_name, callback):
+            listener_events.append(f"on:{event_name}")
+
+        def record_remove(event_name, callback):
+            listener_events.append(f"off:{event_name}")
+
+        mock_page.on.side_effect = record_on
+        mock_page.remove_listener.side_effect = record_remove
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier_quick",
+                new_callable=AsyncMock,
+                side_effect=["account picker", None],
+            ),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        assert listener_events == [
+            "on:framenavigated",
+            "off:framenavigated",
+            "on:framenavigated",
+            "off:framenavigated",
+        ]
+
+    async def test_goto_with_auth_checks_records_original_failure_before_retry(
+        self, mock_page
+    ):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        mock_page.goto = AsyncMock(
+            side_effect=[
+                Exception("net::ERR_TOO_MANY_REDIRECTS"),
+                Exception("retry failed"),
+            ]
+        )
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                side_effect=[True, False],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.navigation.record_page_trace",
+                new_callable=AsyncMock,
+            ) as mock_trace,
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            pytest.raises(Exception, match="retry failed"),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        trace_steps = [call.args[1] for call in mock_trace.await_args_list]
+        assert "extractor-navigation-error-before-remember-me-retry" in trace_steps
+
+        trace_call = next(
+            call
+            for call in mock_trace.await_args_list
+            if call.args[1] == "extractor-navigation-error-before-remember-me-retry"
+        )
+        assert (
+            trace_call.kwargs["extra"]["error"]
+            == "Exception: net::ERR_TOO_MANY_REDIRECTS"
+        )
+
+    async def test_a_hop_on_the_way_reaches_the_failure_log(self, mock_page):
+        """Where a failed navigation went is the diagnostic it leaves behind.
+
+        The address is read off the frame the event carries and not off the
+        page, so a double whose frame never moves records nothing while
+        looking exactly like one that works.
+        """
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        checkpoint = "https://www.linkedin.com/checkpoint/challenge/"
+
+        async def goto_then_fail(*args, **kwargs):
+            navigate(mock_page, checkpoint)
+            raise Exception("net::ERR_ABORTED")
+
+        mock_page.goto = AsyncMock(side_effect=goto_then_fail)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                navigator,
+                "_log_navigation_failure",
+                new_callable=AsyncMock,
+            ) as mock_log_failure,
+            pytest.raises(Exception, match="ERR_ABORTED"),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        logged = mock_log_failure.await_args
+        assert logged is not None
+        assert logged.args[3] == [checkpoint]
+
+    async def test_goto_with_auth_checks_logs_failure_context(self, mock_page):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_TOO_MANY_REDIRECTS"))
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                navigator,
+                "_log_navigation_failure",
+                new_callable=AsyncMock,
+            ) as mock_log_failure,
+            pytest.raises(Exception, match="ERR_TOO_MANY_REDIRECTS"),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        mock_log_failure.assert_awaited_once()
+        mock_page.on.assert_called_once()
+        mock_page.remove_listener.assert_called_once()
+
+
+class TestWatchingNavigations:
+    def test_records_main_frame_hops_without_deduplicating_and_cleans_up(
+        self, mock_page
+    ):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+
+        with navigator._watching_navigations() as hops:
+            navigate(mock_page)
+            navigate(mock_page)
+            for callback in list(mock_page.listeners["framenavigated"]):
+                callback(object())
+
+        assert hops == [mock_page.url, mock_page.url]
+        assert mock_page.listeners["framenavigated"] == []
+
+    def test_cleans_up_when_the_watched_block_raises(self, mock_page):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+
+        with pytest.raises(RuntimeError, match="synthetic failure"):
+            with navigator._watching_navigations():
+                raise RuntimeError("synthetic failure")
+
+        assert mock_page.listeners["framenavigated"] == []
+
+
+class TestSettleNavigation:
+    """The listener decides whether anything happened; the URL cannot."""
+
+    class Clock:
+        def __init__(self) -> None:
+            self.now = 0.0
+
+        def monotonic(self) -> float:
+            return self.now
+
+    @staticmethod
+    def _sleep(clock, hops, page, schedule=()):
+        """Advance the clock per poll, landing each hop at its own moment.
+
+        Each hop replaces the document, which is what a reload and a redirect
+        both do. A same-document change is spelled by leaving `time_origin`
+        alone instead.
+        """
+        pending = list(schedule)
+
+        async def sleep(seconds: float) -> None:
+            clock.now += seconds
+            while pending and pending[0] <= clock.now:
+                pending.pop(0)
+                hops.append("hop")
+                page.time_origin += 1.0
+
+        return sleep
+
+    async def test_a_destroyed_context_reads_as_no_document(self, mock_page):
+        """A navigation in flight takes the context the reading needs with it.
+
+        The class patchright raises for that is `Error`, measured, and not a
+        `RuntimeError`. A handler narrowed to the latter would turn the
+        ordinary case this reading exists for into an unhandled exception,
+        so the double is held to the real class.
+        """
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        mock_page.evaluate = AsyncMock(
+            side_effect=PatchrightError(
+                "Page.evaluate: Execution context was destroyed, "
+                "most likely because of a navigation."
+            )
+        )
+
+        assert await navigator._document_origin() is None
+
+    async def test_a_page_going_nowhere_costs_the_lag_and_not_the_quiet(
+        self, mock_page
+    ):
+        """An ordinary failure has no navigation behind it.
+
+        Charging it the quiet window spends half a second on every DOM error,
+        and a call near its tool timeout loses the diagnostic it was about to
+        build.
+        """
+        clock = self.Clock()
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        hops: list[str] = []
+
+        with (
+            patch.object(session_module, "time", clock),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                side_effect=self._sleep(clock, hops, mock_page),
+            ),
+        ):
+            assert (
+                await navigator._settle_navigation(hops, mock_page.time_origin) is False
+            )
+
+        assert clock.now < PageNavigator.URL_SETTLE_QUIET
+        assert clock.now >= PageNavigator.URL_SETTLE_LAG
+
+    async def test_a_reload_is_a_navigation_though_the_address_holds(self, mock_page):
+        """A reload replaces the document and leaves the address alone.
+
+        Comparing addresses calls the replacement the same page, so a picker
+        served by a reload was read as search results. The event says so.
+        """
+        clock = self.Clock()
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        hops: list[str] = []
+
+        with (
+            patch.object(session_module, "time", clock),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                side_effect=self._sleep(clock, hops, mock_page, [0.05]),
+            ),
+        ):
+            assert (
+                await navigator._settle_navigation(hops, mock_page.time_origin) is True
+            )
+
+        assert mock_page.wait_for_load_state.await_count == 1
+
+    async def test_a_chain_is_followed_to_its_last_hop(self, mock_page):
+        """Hops are counted, not compared.
+
+        A chain that returns to the route it started on reads as one that
+        never left, and its last hop is what decides whether this is a
+        checkpoint.
+        """
+        clock = self.Clock()
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        hops: list[str] = []
+
+        with (
+            patch.object(session_module, "time", clock),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                side_effect=self._sleep(clock, hops, mock_page, [0.05, 0.4]),
+            ),
+        ):
+            assert (
+                await navigator._settle_navigation(hops, mock_page.time_origin) is True
+            )
+
+        assert len(hops) == 2
+        assert clock.now >= 0.4 + PageNavigator.URL_SETTLE_QUIET
+
+    async def test_a_history_change_is_not_a_navigation(self, mock_page):
+        """LinkedIn rewrites its own address, and the event cannot tell.
+
+        `pushState`, `replaceState` and a hash change each fire
+        `framenavigated` on the main frame, and a search page appends
+        `currentJobId` that way by itself. Settling on the event alone charges
+        every healthy page the quiet window plus a document wait plus the
+        barrier check that follows from it. The document surviving is what
+        says nothing was replaced.
+        """
+        clock = self.Clock()
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        origin = mock_page.time_origin
+        navigate(mock_page, same_document=True)
+        hops = ["https://www.linkedin.com/jobs/search/?currentJobId=1"]
+
+        with (
+            patch.object(session_module, "time", clock),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                side_effect=self._sleep(clock, hops, mock_page),
+            ),
+        ):
+            assert await navigator._settle_navigation(hops, origin) is False
+
+        assert clock.now >= PageNavigator.URL_SETTLE_LAG
+        assert clock.now < PageNavigator.URL_SETTLE_QUIET
+        assert mock_page.wait_for_load_state.await_count == 0
+
+    async def test_a_redirect_behind_a_history_change_is_still_caught(self, mock_page):
+        """The address is announced before the checkpoint commits.
+
+        A search page names its selected job the moment a card is chosen, and
+        a checkpoint arriving right behind it would be waved through by a
+        settler that left on the first hop. The wait is for a replaced
+        document, so the second hop is what ends it.
+        """
+        clock = self.Clock()
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        origin = mock_page.time_origin
+        navigate(mock_page, same_document=True)
+        hops = ["https://www.linkedin.com/jobs/search/?currentJobId=1"]
+
+        with (
+            patch.object(session_module, "time", clock),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                side_effect=self._sleep(clock, hops, mock_page, [0.05]),
+            ),
+        ):
+            assert await navigator._settle_navigation(hops, origin) is True
+
+        assert mock_page.wait_for_load_state.await_count == 1
+
+
+class TestProxyNavigationFailures:
+    """A proxy outage during an ordinary tool call is reported as itself."""
+
+    async def test_proxy_error_is_raised_instead_of_a_scraping_failure(self, mock_page):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        mock_page.goto = AsyncMock(
+            side_effect=Exception("net::ERR_PROXY_CONNECTION_FAILED at …")
+        )
+
+        with pytest.raises(ProxyConnectionError):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+    async def test_proxy_error_is_converted_before_it_reaches_a_trace(self, mock_page):
+        # The trace records the raw exception text, which for a proxy failure
+        # can quote the proxy URL and put a password into trace.jsonl.
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        mock_page.goto = AsyncMock(
+            side_effect=Exception("net::ERR_TUNNEL_CONNECTION_FAILED")
+        )
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.record_page_trace",
+                new_callable=AsyncMock,
+            ) as mock_trace,
+            pytest.raises(ProxyConnectionError),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        recorded = [call.args[1] for call in mock_trace.await_args_list]
+        assert "extractor-navigation-error" not in recorded
+
+    async def test_ordinary_navigation_failure_is_unaffected(self, mock_page):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_ABORTED"))
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            pytest.raises(Exception) as excinfo,
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        assert not isinstance(excinfo.value, ProxyConnectionError)
+
+
+class TestNavigationFailureLogRedaction:
+    """The navigation-failure log must not carry proxy credentials.
+
+    It reaches the log even for errors the marker check does not recognise as
+    proxy faults, and that log is what users paste into issue reports.
+    """
+
+    async def test_credentials_are_redacted_from_the_log(
+        self, mock_page, monkeypatch, caplog
+    ):
+        import logging
+
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        config = AppConfig()
+        config.browser.proxy_server = "http://gate.example:7000"
+        config.browser.proxy_username = "acctzone9"
+        config.browser.proxy_password = "s3cr3t"
+        monkeypatch.setattr("linkedin_mcp_server.config.get_config", lambda: config)
+
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        # No proxy marker, so it is not converted and reaches the logger.
+        mock_page.goto = AsyncMock(
+            side_effect=Exception(
+                "failed via http://acctzone9:s3cr3t@gate.example:7000"
+            )
+        )
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            caplog.at_level(logging.WARNING),
+            pytest.raises(Exception),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        assert "s3cr3t" not in caplog.text
+        assert "acctzone9" not in caplog.text
+
+
+class TestNavigationFailureCrossesTheToolBoundaryClean:
+    """The re-raised exception itself must be credential-free.
+
+    Redacting the extractor's own trace and log is not enough: everything
+    downstream logs the exception too, starting with the catch-all in
+    error_handler and FastMCP's handler above it.
+    """
+
+    async def test_reraised_exception_carries_no_credentials(
+        self, mock_page, monkeypatch
+    ):
+        from linkedin_mcp_server.config.schema import AppConfig
+
+        config = AppConfig()
+        config.browser.proxy_server = "http://gate.example:7000"
+        config.browser.proxy_username = "acctzone9"
+        config.browser.proxy_password = "s3cr3t"
+        monkeypatch.setattr("linkedin_mcp_server.config.get_config", lambda: config)
+
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        mock_page.goto = AsyncMock(
+            side_effect=Exception(
+                "failed via http://acctzone9:s3cr3t@gate.example:7000"
+            )
+        )
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            pytest.raises(Exception) as excinfo,
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        assert "s3cr3t" not in str(excinfo.value)
+        assert "acctzone9" not in str(excinfo.value)
+        # The raw error must not survive as a cause either: the handlers
+        # downstream print the whole chain.
+        assert excinfo.value.__cause__ is None

--- a/tests/scraping/test_navigation.py
+++ b/tests/scraping/test_navigation.py
@@ -146,9 +146,13 @@ class TestNavigationDiagnostics:
     async def test_a_hop_on_the_way_reaches_the_failure_log(self, mock_page):
         """Where a failed navigation went is the diagnostic it leaves behind.
 
-        The address is read off the frame the event carries and not off the
-        page, so a double whose frame never moves records nothing while
-        looking exactly like one that works.
+        The recorder reads the address off the frame the event carries, so a
+        double whose frame never moves records nothing while looking exactly
+        like one that works. That the frame and `page.url` agree is not an
+        accident this test could catch: patchright's `Page.url` returns
+        `self._main_frame.url`, and the frame's `_url` is set before
+        `framenavigated` is emitted, so for the main frame the two reads are
+        the same value at dispatch time.
         """
         navigator = PageNavigator(ScrapingSession(mock_page))
         checkpoint = "https://www.linkedin.com/checkpoint/challenge/"

--- a/tests/scraping/test_navigation.py
+++ b/tests/scraping/test_navigation.py
@@ -8,11 +8,24 @@ from patchright.async_api import Error as PatchrightError
 
 import pytest
 
-from linkedin_mcp_server.core.exceptions import ProxyConnectionError
+from linkedin_mcp_server.core.exceptions import (
+    AuthenticationError,
+    ProxyConnectionError,
+)
 from linkedin_mcp_server.scraping import session as session_module
 from linkedin_mcp_server.scraping.navigation import PageNavigator
 from linkedin_mcp_server.scraping.session import ScrapingSession
 from .support.navigation import navigate
+
+
+def _recorders_registered(page) -> list:
+    """Every callback the page was handed, in the order it was handed them."""
+    return [call.args[1] for call in page.on.call_args_list]
+
+
+def _recorders_removed(page) -> list:
+    """Every callback the page was asked to drop, in the same order."""
+    return [call.args[1] for call in page.remove_listener.call_args_list]
 
 
 class TestNavigationDiagnostics:
@@ -203,6 +216,170 @@ class TestNavigationDiagnostics:
         mock_page.remove_listener.assert_called_once()
 
 
+class TestNavigationListenerIdentity:
+    """The callback removed has to be the callback that was registered.
+
+    `remove_listener` matches on the object, so removing anything else is a
+    silent no-op and the recorder stays attached: one more listener on the
+    page per navigation, for the life of the session. Counting the calls
+    cannot see that, because the call happens either way. What the page still
+    holds afterwards can.
+    """
+
+    async def test_a_failed_navigation_leaves_no_recorder_behind(self, mock_page):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_TOO_MANY_REDIRECTS"))
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            pytest.raises(Exception, match="ERR_TOO_MANY_REDIRECTS"),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        assert _recorders_removed(mock_page) == _recorders_registered(mock_page)
+        assert mock_page.listeners["framenavigated"] == []
+
+    async def test_a_retry_after_a_failed_navigation_removes_both_recorders(
+        self, mock_page
+    ):
+        """The retry unhooks before it recurses, and the `finally` above it
+        then has nothing left to do.
+
+        Removing an object already gone is silent, so a guard that stopped
+        working would show up nowhere except in the removals outnumbering the
+        registrations.
+        """
+        navigator = PageNavigator(ScrapingSession(mock_page))
+
+        async def goto_side_effect(*args, **kwargs):
+            if mock_page.goto.await_count == 1:
+                raise Exception("net::ERR_TOO_MANY_REDIRECTS")
+            return None
+
+        mock_page.goto = AsyncMock(side_effect=goto_side_effect)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier_quick",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        assert len(_recorders_registered(mock_page)) == 2
+        assert _recorders_removed(mock_page) == _recorders_registered(mock_page)
+        assert mock_page.listeners["framenavigated"] == []
+
+    async def test_a_retry_behind_a_barrier_removes_both_recorders(self, mock_page):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier_quick",
+                new_callable=AsyncMock,
+                side_effect=["account picker", None],
+            ),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        assert len(_recorders_registered(mock_page)) == 2
+        assert _recorders_removed(mock_page) == _recorders_registered(mock_page)
+        assert mock_page.listeners["framenavigated"] == []
+
+    def test_the_watcher_removes_the_recorder_it_registered(self, mock_page):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+
+        with navigator._watching_navigations():
+            navigate(mock_page)
+
+        assert _recorders_removed(mock_page) == _recorders_registered(mock_page)
+        assert mock_page.listeners["framenavigated"] == []
+
+
+class TestRememberMeRetriesOnlyOnce:
+    """The second attempt stands on its own, whatever the page keeps showing.
+
+    A prompt that resolves and re-renders on the next load is resolved again,
+    and a retry that hands its own permission down recurses until the
+    interpreter stops it. That is a `RecursionError` inside a tool call, from
+    a page that did nothing but keep asking.
+    """
+
+    async def test_a_prompt_behind_a_failing_navigation_retries_once(self, mock_page):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_TOO_MANY_REDIRECTS"))
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_resolve,
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            pytest.raises(Exception, match="ERR_TOO_MANY_REDIRECTS") as excinfo,
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        assert not isinstance(excinfo.value, RecursionError)
+        assert mock_page.goto.await_count == 2
+        assert mock_resolve.await_count == 1
+
+    async def test_a_prompt_behind_a_standing_barrier_retries_once(self, mock_page):
+        navigator = PageNavigator(ScrapingSession(mock_page))
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.resolve_remember_me_prompt",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_resolve,
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier_quick",
+                new_callable=AsyncMock,
+                return_value="account picker",
+            ),
+            pytest.raises(AuthenticationError),
+        ):
+            await navigator._goto_with_auth_checks(
+                "https://www.linkedin.com/in/testuser/"
+            )
+
+        assert mock_page.goto.await_count == 2
+        assert mock_resolve.await_count == 1
+
+
 class TestWatchingNavigations:
     def test_records_main_frame_hops_without_deduplicating_and_cleans_up(
         self, mock_page
@@ -299,8 +476,8 @@ class TestSettleNavigation:
                 await navigator._settle_navigation(hops, mock_page.time_origin) is False
             )
 
-        assert clock.now < PageNavigator.URL_SETTLE_QUIET
-        assert clock.now >= PageNavigator.URL_SETTLE_LAG
+        assert clock.now < PageNavigator._URL_SETTLE_QUIET
+        assert clock.now >= PageNavigator._URL_SETTLE_LAG
 
     async def test_a_reload_is_a_navigation_though_the_address_holds(self, mock_page):
         """A reload replaces the document and leaves the address alone.
@@ -348,7 +525,7 @@ class TestSettleNavigation:
             )
 
         assert len(hops) == 2
-        assert clock.now >= 0.4 + PageNavigator.URL_SETTLE_QUIET
+        assert clock.now >= 0.4 + PageNavigator._URL_SETTLE_QUIET
 
     async def test_a_history_change_is_not_a_navigation(self, mock_page):
         """LinkedIn rewrites its own address, and the event cannot tell.
@@ -375,8 +552,8 @@ class TestSettleNavigation:
         ):
             assert await navigator._settle_navigation(hops, origin) is False
 
-        assert clock.now >= PageNavigator.URL_SETTLE_LAG
-        assert clock.now < PageNavigator.URL_SETTLE_QUIET
+        assert clock.now >= PageNavigator._URL_SETTLE_LAG
+        assert clock.now < PageNavigator._URL_SETTLE_QUIET
         assert mock_page.wait_for_load_state.await_count == 0
 
     async def test_a_redirect_behind_a_history_change_is_still_caught(self, mock_page):

--- a/tests/scraping/test_policy_traces.py
+++ b/tests/scraping/test_policy_traces.py
@@ -89,7 +89,7 @@ async def test_stabilization_trace_ignores_physical_logger_identity():
     relocated_logger = logging.getLogger("linkedin_mcp_server.scraping.navigation")
 
     async with boundaries(recorder, clock):
-        await policy_scenarios.extractor_module.stabilize_navigation(
+        await policy_scenarios.navigation_module.stabilize_navigation(
             "logical navigation", relocated_logger
         )
 
@@ -110,7 +110,7 @@ async def test_full_auth_boundary_propagates_a_detected_barrier():
 
     async with boundaries(recorder, clock, auth_result="account picker"):
         with pytest.raises(AuthenticationError, match="interactive re-authentication"):
-            await extractor._raise_if_auth_barrier(
+            await extractor._navigator._raise_if_auth_barrier(
                 "https://www.linkedin.com/jobs/search/"
             )
 

--- a/tests/scraping/test_session.py
+++ b/tests/scraping/test_session.py
@@ -1,0 +1,75 @@
+"""Tests for the shared scraping page adapter."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from unittest.mock import AsyncMock
+
+import pytest
+
+from linkedin_mcp_server.scraping import session as session_module
+from linkedin_mcp_server.scraping.session import ScrapingSession
+
+
+def test_page_binding_is_frozen(mock_page):
+    session = ScrapingSession(mock_page)
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(session, "page", mock_page)
+
+
+async def test_clock_and_delay_use_the_session_boundaries(mock_page, monkeypatch):
+    session = ScrapingSession(mock_page)
+    sleep = AsyncMock()
+
+    monkeypatch.setattr(session_module.time, "monotonic", lambda: 17.5)
+    monkeypatch.setattr(session_module.asyncio, "sleep", sleep)
+
+    assert session.monotonic() == 17.5
+    await session.delay(0.25)
+
+    sleep.assert_awaited_once_with(0.25)
+
+
+async def test_modal_and_rate_limit_helpers_receive_the_bound_page(
+    mock_page, monkeypatch
+):
+    session = ScrapingSession(mock_page)
+    rate_limit = AsyncMock()
+    modal = AsyncMock(return_value=True)
+
+    monkeypatch.setattr(session_module, "detect_rate_limit", rate_limit)
+    monkeypatch.setattr(session_module, "handle_modal_close", modal)
+
+    await session.check_rate_limit()
+    assert await session.dismiss_modal() is True
+
+    rate_limit.assert_awaited_once_with(mock_page)
+    modal.assert_awaited_once_with(mock_page)
+
+
+async def test_scroll_body_delegates_the_utility_defaults(mock_page, monkeypatch):
+    session = ScrapingSession(mock_page)
+    scroll = AsyncMock()
+    monkeypatch.setattr(session_module, "scroll_to_bottom", scroll)
+
+    await session.scroll_body()
+
+    scroll.assert_awaited_once_with(mock_page, pause_time=1.0, max_scrolls=10)
+
+
+async def test_scroll_sidebar_delegates_every_utility_default(mock_page, monkeypatch):
+    session = ScrapingSession(mock_page)
+    scroll = AsyncMock(return_value=True)
+    monkeypatch.setattr(session_module, "scroll_job_sidebar", scroll)
+
+    assert await session.scroll_job_sidebar() is True
+
+    scroll.assert_awaited_once_with(
+        mock_page,
+        settle_timeout=3.0,
+        poll_interval=0.15,
+        min_budget=0.4,
+        max_scrolls=10,
+        deadline=12.0,
+    )

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,7 +1,6 @@
 """Tests for the LinkedInExtractor scraping engine."""
 
 from contextlib import ExitStack
-from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -37,6 +36,8 @@ from linkedin_mcp_server.scraping.extractor import (
     _MESSAGE_CONFIRMATION_READY_JS,
 )
 from linkedin_mcp_server.scraping.link_metadata import Reference
+from linkedin_mcp_server.scraping.navigation import PageNavigator
+from scraping.support.navigation import navigate
 
 
 def extracted(
@@ -46,104 +47,6 @@ def extracted(
 ) -> ExtractedSection:
     """Create an ExtractedSection for tests."""
     return ExtractedSection(text=text, references=references or [], error=error)
-
-
-@pytest.fixture
-def mock_page():
-    """Create a mock Patchright page."""
-    page = MagicMock()
-    page.goto = AsyncMock()
-    page.title = AsyncMock(return_value="LinkedIn")
-    page.wait_for_selector = AsyncMock()
-    page.wait_for_function = AsyncMock()
-    page.url = "https://www.linkedin.com/in/testuser/"
-    page.locator = MagicMock()
-    # Default: no modals, no CAPTCHA
-    mock_locator = MagicMock()
-    mock_locator.count = AsyncMock(return_value=0)
-    mock_locator.is_visible = AsyncMock(return_value=False)
-    mock_locator.first = mock_locator
-    mock_locator.inner_text = AsyncMock(return_value="normal page content")
-    mock_locator.filter = MagicMock(return_value=mock_locator)
-    page.locator.return_value = mock_locator
-    # A real `Frame` carries the address it navigated to, and production
-    # reads it off the `framenavigated` argument rather than off the page.
-    # A bare object answers every attribute with nothing, which left hop
-    # recording looking correct here however broken it was.
-    page.main_frame = SimpleNamespace(url=page.url)
-    page.wait_for_load_state = AsyncMock()
-    # Real listeners, so that a double can navigate the way the browser does.
-    # A reload leaves `page.url` untouched, so the event is the only thing that
-    # says the document was replaced, and a double that only assigns the URL
-    # cannot express one.
-    listeners: dict[str, list] = {}
-    page.on = MagicMock(
-        side_effect=lambda event, cb: listeners.setdefault(event, []).append(cb)
-    )
-    page.remove_listener = MagicMock(
-        side_effect=lambda event, cb: (
-            listeners.get(event, []).remove(cb)
-            if cb in listeners.get(event, [])
-            else None
-        )
-    )
-    page.listeners = listeners
-    # The document's own identity, which `performance.timeOrigin` reports and
-    # `navigate()` moves. A double answering every script with one object
-    # claims a document that is never replaced, and the code under test reads
-    # that as a page rewriting its own address.
-    page.time_origin = 1_000.0
-    page.evaluate = with_document_identity(
-        page,
-        AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Sample page text",
-                "references": [],
-            }
-        ),
-    )
-    return page
-
-
-def with_document_identity(page, evaluate):
-    """Answer the document-identity read from `page.time_origin`.
-
-    Every other script keeps going to `evaluate`. A test that replaces
-    `page.evaluate` outright loses this and reads no identity at all, which
-    leaves the production code where it was before there was one: it settles
-    on the event alone.
-    """
-
-    async def dispatch(script, *args, **kwargs):
-        if "timeOrigin" in script:
-            return page.time_origin
-        return await evaluate(script, *args, **kwargs)
-
-    return AsyncMock(side_effect=dispatch)
-
-
-def navigate(page, url: str | None = None, same_document: bool = False) -> None:
-    """Move a mock page the way a navigation does: the address and the event.
-
-    `url` is omitted for a reload, which replaces the document and leaves the
-    address exactly as it was.
-
-    `same_document` is a `pushState`, a `replaceState` or a hash change. Each
-    raises `framenavigated` on the main frame exactly as a replacement does
-    (measured), and LinkedIn appends `currentJobId` to a search URL that way
-    on every healthy page. What separates them is the document surviving.
-    """
-    if url is not None:
-        page.url = url
-    if not same_document:
-        page.time_origin += 1.0
-    # The frame carries the address too, and production reads the hop off the
-    # frame rather than off the page. Leaving it behind is what let the hop
-    # recording look correct here however broken it was.
-    page.main_frame.url = page.url
-    for callback in list(page.listeners.get("framenavigated", [])):
-        callback(page.main_frame)
 
 
 class TestExtractPage:
@@ -227,7 +130,7 @@ class TestExtractPage:
 
         with (
             patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
                 new_callable=AsyncMock,
                 return_value="auth barrier text: welcome back + sign in using another account",
             ),
@@ -381,7 +284,7 @@ class TestExtractPage:
         extractor = LinkedInExtractor(mock_page)
         with (
             patch.object(
-                extractor,
+                PageNavigator,
                 "_navigate_to_page",
                 new_callable=AsyncMock,
                 side_effect=AuthenticationError("Run with --login"),
@@ -418,7 +321,7 @@ class TestExtractPage:
         extractor = LinkedInExtractor(mock_page)
         with (
             patch.object(
-                extractor,
+                PageNavigator,
                 "_navigate_to_page",
                 new_callable=AsyncMock,
                 side_effect=redirect_to_the_redesign,
@@ -461,7 +364,7 @@ class TestExtractPage:
         extractor = LinkedInExtractor(mock_page)
         with (
             patch.object(
-                extractor,
+                PageNavigator,
                 "_navigate_to_page",
                 new_callable=AsyncMock,
                 side_effect=redirect_to_the_feed,
@@ -505,13 +408,13 @@ class TestExtractPage:
         extractor = LinkedInExtractor(mock_page)
         with (
             patch.object(
-                extractor,
+                PageNavigator,
                 "_navigate_to_page",
                 new_callable=AsyncMock,
                 side_effect=redirect_to_the_redesign,
             ),
             patch.object(
-                extractor,
+                PageNavigator,
                 "_raise_if_auth_barrier",
                 new_callable=AsyncMock,
                 side_effect=AuthenticationError("Run with --login"),
@@ -566,7 +469,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -607,7 +510,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -656,7 +559,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -671,7 +574,7 @@ class TestExtractPage:
                 side_effect=reload_in_place,
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
                 side_effect=barrier,
             ),
             pytest.raises(AuthenticationError, match="--login"),
@@ -697,7 +600,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -713,7 +616,7 @@ class TestExtractPage:
                 return_value=False,
             ) as scroll,
             patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
                 new_callable=AsyncMock,
                 return_value="auth barrier text: welcome back + join now",
             ),
@@ -738,7 +641,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -754,7 +657,7 @@ class TestExtractPage:
                 return_value=False,
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
                 new_callable=AsyncMock,
                 return_value=None,
             ),
@@ -785,7 +688,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -800,7 +703,7 @@ class TestExtractPage:
                 side_effect=scroll_then_reload,
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
                 new_callable=AsyncMock,
                 return_value="account picker: #rememberme-div",
             ),
@@ -833,7 +736,7 @@ class TestExtractPage:
         barrier = AsyncMock(return_value=None)
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -848,7 +751,7 @@ class TestExtractPage:
                 side_effect=scroll_then_name_a_job,
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
                 barrier,
             ),
         ):
@@ -892,7 +795,7 @@ class TestExtractPage:
         extractor = LinkedInExtractor(mock_page)
         with (
             patch.object(extractor_module, "time", clock),
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -938,7 +841,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -957,7 +860,7 @@ class TestExtractPage:
                 extractor, "_extract_root_content", side_effect=reload_at_read
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
                 side_effect=barrier,
             ),
             pytest.raises(AuthenticationError, match="--login"),
@@ -989,7 +892,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -1031,7 +934,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -1076,7 +979,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -1114,7 +1017,7 @@ class TestExtractPage:
         )
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -1157,7 +1060,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -1204,7 +1107,7 @@ class TestExtractPage:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -1227,194 +1130,6 @@ class TestExtractPage:
 
         assert "Python Developer" in result.text
         assert result.error is None
-
-
-class TestNavigationDiagnostics:
-    async def test_goto_with_auth_checks_clicks_remember_me_and_retries(
-        self, mock_page
-    ):
-        extractor = LinkedInExtractor(mock_page)
-
-        async def goto_side_effect(*args, **kwargs):
-            if mock_page.goto.await_count == 1:
-                raise Exception("net::ERR_TOO_MANY_REDIRECTS")
-            return None
-
-        mock_page.goto = AsyncMock(side_effect=goto_side_effect)
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
-                new_callable=AsyncMock,
-                side_effect=[True],
-            ) as mock_resolve,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-        ):
-            await extractor._goto_with_auth_checks(
-                "https://www.linkedin.com/in/testuser/"
-            )
-
-        assert mock_page.goto.await_count == 2
-        mock_resolve.assert_awaited_once()
-
-    async def test_goto_with_auth_checks_unhooks_outer_listener_before_retry(
-        self, mock_page
-    ):
-        extractor = LinkedInExtractor(mock_page)
-        listener_events: list[str] = []
-
-        def record_on(event_name, callback):
-            listener_events.append(f"on:{event_name}")
-
-        def record_remove(event_name, callback):
-            listener_events.append(f"off:{event_name}")
-
-        mock_page.on.side_effect = record_on
-        mock_page.remove_listener.side_effect = record_remove
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier_quick",
-                new_callable=AsyncMock,
-                side_effect=["account picker", None],
-            ),
-        ):
-            await extractor._goto_with_auth_checks(
-                "https://www.linkedin.com/in/testuser/"
-            )
-
-        assert listener_events == [
-            "on:framenavigated",
-            "off:framenavigated",
-            "on:framenavigated",
-            "off:framenavigated",
-        ]
-
-    async def test_goto_with_auth_checks_records_original_failure_before_retry(
-        self, mock_page
-    ):
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.goto = AsyncMock(
-            side_effect=[
-                Exception("net::ERR_TOO_MANY_REDIRECTS"),
-                Exception("retry failed"),
-            ]
-        )
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
-                new_callable=AsyncMock,
-                side_effect=[True, False],
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.record_page_trace",
-                new_callable=AsyncMock,
-            ) as mock_trace,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            pytest.raises(Exception, match="retry failed"),
-        ):
-            await extractor._goto_with_auth_checks(
-                "https://www.linkedin.com/in/testuser/"
-            )
-
-        trace_steps = [call.args[1] for call in mock_trace.await_args_list]
-        assert "extractor-navigation-error-before-remember-me-retry" in trace_steps
-
-        trace_call = next(
-            call
-            for call in mock_trace.await_args_list
-            if call.args[1] == "extractor-navigation-error-before-remember-me-retry"
-        )
-        assert (
-            trace_call.kwargs["extra"]["error"]
-            == "Exception: net::ERR_TOO_MANY_REDIRECTS"
-        )
-
-    async def test_a_hop_on_the_way_reaches_the_failure_log(self, mock_page):
-        """Where a failed navigation went is the diagnostic it leaves behind.
-
-        The address is read off the frame the event carries and not off the
-        page, so a double whose frame never moves records nothing while
-        looking exactly like one that works.
-        """
-        extractor = LinkedInExtractor(mock_page)
-        checkpoint = "https://www.linkedin.com/checkpoint/challenge/"
-
-        async def goto_then_fail(*args, **kwargs):
-            navigate(mock_page, checkpoint)
-            raise Exception("net::ERR_ABORTED")
-
-        mock_page.goto = AsyncMock(side_effect=goto_then_fail)
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch.object(
-                extractor,
-                "_log_navigation_failure",
-                new_callable=AsyncMock,
-            ) as mock_log_failure,
-            pytest.raises(Exception, match="ERR_ABORTED"),
-        ):
-            await extractor._goto_with_auth_checks(
-                "https://www.linkedin.com/in/testuser/"
-            )
-
-        logged = mock_log_failure.await_args
-        assert logged is not None
-        assert logged.args[3] == [checkpoint]
-
-    async def test_goto_with_auth_checks_logs_failure_context(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_TOO_MANY_REDIRECTS"))
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch.object(
-                extractor,
-                "_log_navigation_failure",
-                new_callable=AsyncMock,
-            ) as mock_log_failure,
-            pytest.raises(Exception, match="ERR_TOO_MANY_REDIRECTS"),
-        ):
-            await extractor._goto_with_auth_checks(
-                "https://www.linkedin.com/in/testuser/"
-            )
-
-        mock_log_failure.assert_awaited_once()
-        mock_page.on.assert_called_once()
-        mock_page.remove_listener.assert_called_once()
 
 
 class TestScrapePersonUrls:
@@ -2005,7 +1720,7 @@ class TestConnectWithPerson:
                 side_effect=[self._signals(invite=True), self._signals()],
             ),
             patch.object(
-                extractor,
+                PageNavigator,
                 "_navigate_to_page",
                 new_callable=AsyncMock,
             ) as mock_nav,
@@ -2045,7 +1760,7 @@ class TestConnectWithPerson:
                 new_callable=AsyncMock,
                 side_effect=[self._signals(invite=True), self._signals(invite=True)],
             ),
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch.object(
                 extractor, "_dialog_is_open", new_callable=AsyncMock, return_value=True
             ),
@@ -2216,7 +1931,7 @@ class TestConnectWithPerson:
                 new_callable=AsyncMock,
                 return_value=self._signals(invite=True),
             ),
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch.object(
                 extractor, "_dialog_is_open", new_callable=AsyncMock, return_value=False
             ),
@@ -2298,7 +2013,7 @@ class TestConnectWithPerson:
                 return_value=True,
             ) as mock_open_more,
             patch.object(
-                extractor, "_navigate_to_page", new_callable=AsyncMock
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
             ) as mock_nav,
             patch.object(
                 extractor,
@@ -2349,7 +2064,7 @@ class TestConnectWithPerson:
                 return_value=True,
             ) as mock_open_more,
             patch.object(
-                extractor, "_navigate_to_page", new_callable=AsyncMock
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
             ) as mock_nav,
             patch.object(
                 extractor, "_submit_invite_dialog", new_callable=AsyncMock
@@ -2389,7 +2104,7 @@ class TestConnectWithPerson:
                 return_value=True,
             ),
             patch.object(
-                extractor, "_navigate_to_page", new_callable=AsyncMock
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
             ) as mock_nav,
             patch.object(
                 extractor,
@@ -2434,7 +2149,7 @@ class TestConnectWithPerson:
                 return_value=False,
             ),
             patch.object(
-                extractor, "_navigate_to_page", new_callable=AsyncMock
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
             ) as mock_nav,
             patch.object(
                 extractor, "_submit_invite_dialog", new_callable=AsyncMock
@@ -2462,7 +2177,7 @@ class TestConnectWithPerson:
                 return_value=self._signals(compose=True, labeled_anchor=True),
             ),
             patch.object(
-                extractor, "_navigate_to_page", new_callable=AsyncMock
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
             ) as mock_nav,
             patch.object(
                 extractor, "_submit_invite_dialog", new_callable=AsyncMock
@@ -2503,7 +2218,7 @@ class TestConnectWithPerson:
                 return_value=True,
             ) as mock_accept,
             patch.object(
-                extractor,
+                PageNavigator,
                 "_navigate_to_page",
                 new_callable=AsyncMock,
             ) as mock_nav,
@@ -2551,7 +2266,7 @@ class TestConnectWithPerson:
                 return_value=True,
             ) as mock_text_click,
             patch.object(
-                extractor,
+                PageNavigator,
                 "_navigate_to_page",
                 new_callable=AsyncMock,
             ) as mock_nav,
@@ -2660,7 +2375,7 @@ class TestConnectWithPerson:
                 new_callable=AsyncMock,
                 return_value=self._signals(),
             ),
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch.object(
                 extractor, "_dialog_is_open", new_callable=AsyncMock, return_value=False
             ),
@@ -3369,7 +3084,7 @@ class TestSearchJobs:
             navigate(mock_page, url)
 
         with (
-            patch.object(extractor, "_navigate_to_page", side_effect=navigate_page),
+            patch.object(PageNavigator, "_navigate_to_page", side_effect=navigate_page),
             patch.object(
                 extractor,
                 "_extract_root_content",
@@ -3622,7 +3337,7 @@ class TestSearchJobs:
             navigate(mock_page, url)
 
         with (
-            patch.object(extractor, "_navigate_to_page", side_effect=navigate_page),
+            patch.object(PageNavigator, "_navigate_to_page", side_effect=navigate_page),
             patch.object(
                 extractor,
                 "_extract_root_content",
@@ -4766,7 +4481,7 @@ class TestSearchJobs:
         mock_page.url = "https://www.linkedin.com/feed/"
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -4812,7 +4527,7 @@ class TestSearchJobs:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -5019,183 +4734,6 @@ class TestSearchJobs:
         mock_ids.assert_not_awaited()
 
 
-class TestSettleNavigation:
-    """The listener decides whether anything happened; the URL cannot."""
-
-    class Clock:
-        def __init__(self) -> None:
-            self.now = 0.0
-
-        def monotonic(self) -> float:
-            return self.now
-
-    @staticmethod
-    def _sleep(clock, hops, page, schedule=()):
-        """Advance the clock per poll, landing each hop at its own moment.
-
-        Each hop replaces the document, which is what a reload and a redirect
-        both do. A same-document change is spelled by leaving `time_origin`
-        alone instead.
-        """
-        pending = list(schedule)
-
-        async def sleep(seconds: float) -> None:
-            clock.now += seconds
-            while pending and pending[0] <= clock.now:
-                pending.pop(0)
-                hops.append("hop")
-                page.time_origin += 1.0
-
-        return sleep
-
-    async def test_a_destroyed_context_reads_as_no_document(self, mock_page):
-        """A navigation in flight takes the context the reading needs with it.
-
-        The class patchright raises for that is `Error`, measured, and not a
-        `RuntimeError`. A handler narrowed to the latter would turn the
-        ordinary case this reading exists for into an unhandled exception,
-        so the double is held to the real class.
-        """
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.evaluate = AsyncMock(
-            side_effect=PatchrightError(
-                "Page.evaluate: Execution context was destroyed, "
-                "most likely because of a navigation."
-            )
-        )
-
-        assert await extractor._document_origin() is None
-
-    async def test_a_page_going_nowhere_costs_the_lag_and_not_the_quiet(
-        self, mock_page
-    ):
-        """An ordinary failure has no navigation behind it.
-
-        Charging it the quiet window spends half a second on every DOM error,
-        and a call near its tool timeout loses the diagnostic it was about to
-        build.
-        """
-        clock = self.Clock()
-        extractor = LinkedInExtractor(mock_page)
-        hops: list[str] = []
-
-        with (
-            patch.object(extractor_module, "time", clock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                side_effect=self._sleep(clock, hops, mock_page),
-            ),
-        ):
-            assert (
-                await extractor._settle_navigation(hops, mock_page.time_origin) is False
-            )
-
-        assert clock.now < extractor_module._URL_SETTLE_QUIET
-        assert clock.now >= extractor_module._URL_SETTLE_LAG
-
-    async def test_a_reload_is_a_navigation_though_the_address_holds(self, mock_page):
-        """A reload replaces the document and leaves the address alone.
-
-        Comparing addresses calls the replacement the same page, so a picker
-        served by a reload was read as search results. The event says so.
-        """
-        clock = self.Clock()
-        extractor = LinkedInExtractor(mock_page)
-        hops: list[str] = []
-
-        with (
-            patch.object(extractor_module, "time", clock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                side_effect=self._sleep(clock, hops, mock_page, [0.05]),
-            ),
-        ):
-            assert (
-                await extractor._settle_navigation(hops, mock_page.time_origin) is True
-            )
-
-        assert mock_page.wait_for_load_state.await_count == 1
-
-    async def test_a_chain_is_followed_to_its_last_hop(self, mock_page):
-        """Hops are counted, not compared.
-
-        A chain that returns to the route it started on reads as one that
-        never left, and its last hop is what decides whether this is a
-        checkpoint.
-        """
-        clock = self.Clock()
-        extractor = LinkedInExtractor(mock_page)
-        hops: list[str] = []
-
-        with (
-            patch.object(extractor_module, "time", clock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                side_effect=self._sleep(clock, hops, mock_page, [0.05, 0.4]),
-            ),
-        ):
-            assert (
-                await extractor._settle_navigation(hops, mock_page.time_origin) is True
-            )
-
-        assert len(hops) == 2
-        assert clock.now >= 0.4 + extractor_module._URL_SETTLE_QUIET
-
-    async def test_a_history_change_is_not_a_navigation(self, mock_page):
-        """LinkedIn rewrites its own address, and the event cannot tell.
-
-        `pushState`, `replaceState` and a hash change each fire
-        `framenavigated` on the main frame, and a search page appends
-        `currentJobId` that way by itself. Settling on the event alone charges
-        every healthy page the quiet window plus a document wait plus the
-        barrier check that follows from it. The document surviving is what
-        says nothing was replaced.
-        """
-        clock = self.Clock()
-        extractor = LinkedInExtractor(mock_page)
-        origin = mock_page.time_origin
-        navigate(mock_page, same_document=True)
-        hops = ["https://www.linkedin.com/jobs/search/?currentJobId=1"]
-
-        with (
-            patch.object(extractor_module, "time", clock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                side_effect=self._sleep(clock, hops, mock_page),
-            ),
-        ):
-            assert await extractor._settle_navigation(hops, origin) is False
-
-        assert clock.now >= extractor_module._URL_SETTLE_LAG
-        assert clock.now < extractor_module._URL_SETTLE_QUIET
-        assert mock_page.wait_for_load_state.await_count == 0
-
-    async def test_a_redirect_behind_a_history_change_is_still_caught(self, mock_page):
-        """The address is announced before the checkpoint commits.
-
-        A search page names its selected job the moment a card is chosen, and
-        a checkpoint arriving right behind it would be waved through by a
-        settler that left on the first hop. The wait is for a replaced
-        document, so the second hop is what ends it.
-        """
-        clock = self.Clock()
-        extractor = LinkedInExtractor(mock_page)
-        origin = mock_page.time_origin
-        navigate(mock_page, same_document=True)
-        hops = ["https://www.linkedin.com/jobs/search/?currentJobId=1"]
-
-        with (
-            patch.object(extractor_module, "time", clock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                side_effect=self._sleep(clock, hops, mock_page, [0.05]),
-            ),
-        ):
-            assert await extractor._settle_navigation(hops, origin) is True
-
-        assert mock_page.wait_for_load_state.await_count == 1
-
-
 class TestGetSavedJobs:
     """Tests for get_saved_jobs with job ID extraction and pagination."""
 
@@ -5220,7 +4758,7 @@ class TestGetSavedJobs:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -5238,7 +4776,7 @@ class TestGetSavedJobs:
                 extractor, "_extract_root_content", side_effect=reload_at_read
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
                 side_effect=barrier,
             ),
             pytest.raises(AuthenticationError, match="--login"),
@@ -5277,7 +4815,7 @@ class TestGetSavedJobs:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -5292,7 +4830,7 @@ class TestGetSavedJobs:
                 side_effect=reload_in_place,
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
                 side_effect=barrier,
             ),
             pytest.raises(AuthenticationError, match="--login"),
@@ -5553,7 +5091,7 @@ class TestGetSavedJobs:
         )
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -5564,7 +5102,7 @@ class TestGetSavedJobs:
                 return_value=False,
             ),
             patch(
-                "linkedin_mcp_server.scraping.extractor.detect_auth_barrier",
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
                 new_callable=AsyncMock,
                 return_value="account picker: #rememberme-div",
             ),
@@ -5602,7 +5140,7 @@ class TestGetSavedJobs:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -6911,7 +6449,9 @@ class TestMainProfileAlreadyLoaded:
         extractor = LinkedInExtractor(mock_page)
         mock_page.url = "https://www.linkedin.com/in/realuser/"
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock) as nav,
+            patch.object(
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
+            ) as nav,
             patch.object(
                 extractor,
                 "scrape_person",
@@ -6938,7 +6478,9 @@ class TestMainProfileAlreadyLoaded:
             patch.object(
                 extractor, "extract_page", new_callable=AsyncMock
             ) as extract_page,
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock) as nav,
+            patch.object(
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
+            ) as nav,
             patch(
                 "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
                 new_callable=AsyncMock,
@@ -7079,7 +6621,7 @@ class TestGetSidebarProfiles:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7136,7 +6678,7 @@ class TestGetSidebarProfiles:
         extractor = LinkedInExtractor(mock_page)
         with (
             patch.object(
-                extractor,
+                PageNavigator,
                 "_navigate_to_page",
                 new_callable=AsyncMock,
                 side_effect=[None, error_type(message)],
@@ -7166,7 +6708,7 @@ class TestGetSidebarProfiles:
         extractor = LinkedInExtractor(mock_page)
         with (
             patch.object(
-                extractor,
+                PageNavigator,
                 "_navigate_to_page",
                 new_callable=AsyncMock,
                 side_effect=[None, RuntimeError("navigation failed")],
@@ -7208,7 +6750,7 @@ class TestGetSidebarProfiles:
         extractor = LinkedInExtractor(mock_page)
         navigate_mock = AsyncMock()
         with (
-            patch.object(extractor, "_navigate_to_page", navigate_mock),
+            patch.object(PageNavigator, "_navigate_to_page", navigate_mock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7246,7 +6788,7 @@ class TestGetSidebarProfiles:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", side_effect=fake_navigate),
+            patch.object(PageNavigator, "_navigate_to_page", side_effect=fake_navigate),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7275,7 +6817,7 @@ class TestGetSidebarProfiles:
 
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7541,7 +7083,7 @@ class TestGetInbox:
         extractor = LinkedInExtractor(mock_page)
         with (
             patch.object(
-                extractor,
+                PageNavigator,
                 "_navigate_to_page",
                 new_callable=AsyncMock,
             ),
@@ -7597,7 +7139,7 @@ class TestGetInbox:
         """get_inbox returns empty sections when page has no content."""
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7649,7 +7191,7 @@ class TestGetInbox:
             },
         ]
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7702,7 +7244,7 @@ class TestGetConversation:
         extractor = LinkedInExtractor(mock_page)
         nav_mock = AsyncMock()
         with (
-            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch.object(PageNavigator, "_navigate_to_page", nav_mock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7748,7 +7290,7 @@ class TestGetConversation:
         )
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7788,7 +7330,7 @@ class TestGetConversation:
         nav_mock = AsyncMock()
         mock_page.wait_for_selector = AsyncMock()
         with (
-            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch.object(PageNavigator, "_navigate_to_page", nav_mock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7846,7 +7388,7 @@ class TestGetConversation:
         nav_mock = AsyncMock()
         mock_page.wait_for_selector = AsyncMock()
         with (
-            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch.object(PageNavigator, "_navigate_to_page", nav_mock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7903,7 +7445,7 @@ class TestGetConversation:
         extractor = LinkedInExtractor(mock_page)
         mock_page.wait_for_selector = AsyncMock()
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -7935,7 +7477,7 @@ class TestGetConversation:
         extractor = LinkedInExtractor(mock_page)
         mock_page.wait_for_selector = AsyncMock()
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8022,7 +7564,7 @@ class TestResolveConversationThreadUrls:
             },
         ]
         with (
-            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch.object(PageNavigator, "_navigate_to_page", nav_mock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8065,7 +7607,7 @@ class TestResolveConversationThreadUrls:
             ]
         )
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8107,7 +7649,7 @@ class TestResolveConversationThreadUrls:
             ]
         )
         with (
-            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch.object(PageNavigator, "_navigate_to_page", nav_mock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8160,7 +7702,7 @@ class TestSearchConversations:
         nav_mock = AsyncMock()
 
         with (
-            patch.object(extractor, "_navigate_to_page", nav_mock),
+            patch.object(PageNavigator, "_navigate_to_page", nav_mock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8220,7 +7762,7 @@ class TestSearchConversations:
             },
         ]
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8272,7 +7814,7 @@ class TestSendMessage:
         mock_page.keyboard = keyboard
 
         with patch.object(
-            extractor, "_navigate_to_page", new_callable=AsyncMock
+            PageNavigator, "_navigate_to_page", new_callable=AsyncMock
         ) as navigate:
             result = await extractor.send_message(
                 "testuser", message, confirm_send=True
@@ -8305,7 +7847,7 @@ class TestSendMessage:
         mock_page.keyboard = MagicMock(type=AsyncMock(), press=AsyncMock())
 
         with patch.object(
-            extractor, "_navigate_to_page", new_callable=AsyncMock
+            PageNavigator, "_navigate_to_page", new_callable=AsyncMock
         ) as navigate:
             result = await extractor.send_message(
                 "testuser", message, confirm_send=True
@@ -8329,7 +7871,7 @@ class TestSendMessage:
 
         with (
             patch.object(
-                extractor, "_navigate_to_page", new_callable=AsyncMock
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
             ) as navigate,
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
@@ -8385,7 +7927,7 @@ class TestSendMessage:
     async def test_unresolved_profile_target_is_not_connection_handoff(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8457,7 +7999,7 @@ class TestSendMessage:
             states = [with_empty(state) for state in states]
         return (
             target,
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8547,7 +8089,7 @@ class TestSendMessage:
         target = self._target()
         with (
             patch.object(
-                extractor, "_navigate_to_page", new_callable=AsyncMock
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
             ) as navigate,
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
@@ -9834,151 +9376,6 @@ class TestDrainListenerTasks:
             await asyncio.wait({drain, read}, timeout=2.0)
 
 
-class TestProxyNavigationFailures:
-    """A proxy outage during an ordinary tool call is reported as itself."""
-
-    async def test_proxy_error_is_raised_instead_of_a_scraping_failure(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.goto = AsyncMock(
-            side_effect=Exception("net::ERR_PROXY_CONNECTION_FAILED at …")
-        )
-
-        with pytest.raises(ProxyConnectionError):
-            await extractor._goto_with_auth_checks(
-                "https://www.linkedin.com/in/testuser/"
-            )
-
-    async def test_proxy_error_is_converted_before_it_reaches_a_trace(self, mock_page):
-        # The trace records the raw exception text, which for a proxy failure
-        # can quote the proxy URL and put a password into trace.jsonl.
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.goto = AsyncMock(
-            side_effect=Exception("net::ERR_TUNNEL_CONNECTION_FAILED")
-        )
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.record_page_trace",
-                new_callable=AsyncMock,
-            ) as mock_trace,
-            pytest.raises(ProxyConnectionError),
-        ):
-            await extractor._goto_with_auth_checks(
-                "https://www.linkedin.com/in/testuser/"
-            )
-
-        recorded = [call.args[1] for call in mock_trace.await_args_list]
-        assert "extractor-navigation-error" not in recorded
-
-    async def test_ordinary_navigation_failure_is_unaffected(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_ABORTED"))
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            pytest.raises(Exception) as excinfo,
-        ):
-            await extractor._goto_with_auth_checks(
-                "https://www.linkedin.com/in/testuser/"
-            )
-
-        assert not isinstance(excinfo.value, ProxyConnectionError)
-
-
-class TestNavigationFailureLogRedaction:
-    """The navigation-failure log must not carry proxy credentials.
-
-    It reaches the log even for errors the marker check does not recognise as
-    proxy faults, and that log is what users paste into issue reports.
-    """
-
-    async def test_credentials_are_redacted_from_the_log(
-        self, mock_page, monkeypatch, caplog
-    ):
-        import logging
-
-        from linkedin_mcp_server.config.schema import AppConfig
-
-        config = AppConfig()
-        config.browser.proxy_server = "http://gate.example:7000"
-        config.browser.proxy_username = "acctzone9"
-        config.browser.proxy_password = "s3cr3t"
-        monkeypatch.setattr("linkedin_mcp_server.config.get_config", lambda: config)
-
-        extractor = LinkedInExtractor(mock_page)
-        # No proxy marker, so it is not converted and reaches the logger.
-        mock_page.goto = AsyncMock(
-            side_effect=Exception(
-                "failed via http://acctzone9:s3cr3t@gate.example:7000"
-            )
-        )
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            caplog.at_level(logging.WARNING),
-            pytest.raises(Exception),
-        ):
-            await extractor._goto_with_auth_checks(
-                "https://www.linkedin.com/in/testuser/"
-            )
-
-        assert "s3cr3t" not in caplog.text
-        assert "acctzone9" not in caplog.text
-
-
-class TestNavigationFailureCrossesTheToolBoundaryClean:
-    """The re-raised exception itself must be credential-free.
-
-    Redacting the extractor's own trace and log is not enough: everything
-    downstream logs the exception too, starting with the catch-all in
-    error_handler and FastMCP's handler above it.
-    """
-
-    async def test_reraised_exception_carries_no_credentials(
-        self, mock_page, monkeypatch
-    ):
-        from linkedin_mcp_server.config.schema import AppConfig
-
-        config = AppConfig()
-        config.browser.proxy_server = "http://gate.example:7000"
-        config.browser.proxy_username = "acctzone9"
-        config.browser.proxy_password = "s3cr3t"
-        monkeypatch.setattr("linkedin_mcp_server.config.get_config", lambda: config)
-
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.goto = AsyncMock(
-            side_effect=Exception(
-                "failed via http://acctzone9:s3cr3t@gate.example:7000"
-            )
-        )
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.resolve_remember_me_prompt",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            pytest.raises(Exception) as excinfo,
-        ):
-            await extractor._goto_with_auth_checks(
-                "https://www.linkedin.com/in/testuser/"
-            )
-
-        assert "s3cr3t" not in str(excinfo.value)
-        assert "acctzone9" not in str(excinfo.value)
-        # The raw error must not survive as a cause either: the handlers
-        # downstream print the whole chain.
-        assert excinfo.value.__cause__ is None
-
-
 def _no_signals() -> ActionSignals:
     """Every structural signal absent, which is all these tests need."""
     return ActionSignals(
@@ -10009,7 +9406,7 @@ class TestGetMyProfileAlias:
                 new_callable=AsyncMock,
                 return_value=extracted("profile text"),
             ) as mock_extract,
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
                 new_callable=AsyncMock,
@@ -10046,7 +9443,7 @@ class TestEveryNormalizedEntryPoint:
     def _calls(extractor: LinkedInExtractor):
         return (
             patch.object(extractor, "extract_page", new_callable=AsyncMock),
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
         )
 
     async def test_connect_with_person_normalizes_before_its_own_downstream_use(
@@ -10074,7 +9471,7 @@ class TestEveryNormalizedEntryPoint:
                 new_callable=AsyncMock,
                 side_effect=lambda username: seen.append(username) or _no_signals(),
             ),
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
         ):
             await extractor.connect_with_person(
                 "https://de.linkedin.com/in/williamhgates"

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -21,6 +21,7 @@ from linkedin_mcp_server.scraping.extractor import (
     _ProfileMessageTarget,
     _ProfileMessageTargetResolution,
 )
+from linkedin_mcp_server.scraping.navigation import PageNavigator
 
 pytestmark = [
     pytest.mark.browser_dom,
@@ -301,7 +302,7 @@ async def send(
     await page.set_content(html)
     extractor = LinkedInExtractor(page)
     with (
-        patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+        patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
         patch.object(
             extractor,
             "_read_profile_message_target",
@@ -524,7 +525,7 @@ class TestComposerRecipientDom:
             return await read_state(target)
 
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch.object(
                 extractor,
                 "_read_profile_message_target",
@@ -572,7 +573,7 @@ class TestComposerRecipientDom:
             return await resolve_owner(target, expected_route=expected_route)
 
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch.object(
                 extractor,
                 "_read_profile_message_target",
@@ -1041,7 +1042,7 @@ class TestSendConfirmationDom:
             await anyio.sleep_forever()
 
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
             patch.object(
                 extractor,
                 "_read_profile_message_target",


### PR DESCRIPTION
Part of #853. Stacked on #883.

Navigation lived inside `extractor.py`, so auth handling, remember-me retries, listener cleanup, and settling were reachable only through the facade, and their tests patched private extractor methods.

This stage moves the page adapter into `session.py` and the navigation lifecycle into `navigation.py`. `PageNavigator` keeps auth-aware navigation, remember-me recursion, proxy-safe diagnostics, exact listener callback removal, navigation watching, document-origin checks, and settling together, and stays their owner for later stages. Pacing remains private. The trace adapter injects session and navigation fakes instead.

Verification: both migration checkers, 320 owner tests, Ruff, `ty`, pre-commit, and the full suite succeed. Canonical traces stay byte-identical, and mutations confirm the listener-identity and recursion-bound tests fail when their code breaks.

## Synthetic prompt

> Extract the page session and navigation lifecycle into owner modules, migrate their tests off private extractor patches, and keep canonical traces byte-identical.

Generated with GPT-5.6 Sol + Claude Opus 5 + GPT-6 Astra
