### PR TITLE
refactor(scraping): Extract section capture

### DIFF
--- a/linkedin_mcp_server/scraping/capture.py
+++ b/linkedin_mcp_server/scraping/capture.py
@@ -1,0 +1,335 @@
+"""Generic page and overlay section capture."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import logging
+import re
+
+from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+from linkedin_mcp_server.core.exceptions import LinkedInScraperException
+from linkedin_mcp_server.error_diagnostics import build_issue_diagnostics
+from linkedin_mcp_server.scraping.content import PageContentReader
+from linkedin_mcp_server.scraping.contracts import (
+    RATE_LIMITED_SECTION_TEXT,
+    ExtractedSection,
+)
+from linkedin_mcp_server.scraping.link_metadata import build_references
+from linkedin_mcp_server.scraping.navigation import PageNavigator
+from linkedin_mcp_server.scraping.session import ScrapingSession
+from linkedin_mcp_server.scraping.text import (
+    filter_linkedin_noise_lines,
+    truncate_linkedin_noise,
+)
+
+logger = logging.getLogger(__name__)
+
+# Backoff before retrying a temporarily blocked page. Owned here rather than
+# copied, because the job-page reads that still sit on the facade share it: two
+# constants would let one relocation give the two retry paths different policies
+# without anything failing.
+RATE_LIMIT_RETRY_DELAY = 5.0
+
+
+class SectionCapture:
+    """Capture one section from a loaded page or from an overlay dialog."""
+
+    def __init__(
+        self,
+        session: ScrapingSession,
+        navigator: PageNavigator,
+        content: PageContentReader,
+    ):
+        self._session = session
+        self._navigator = navigator
+        self._content = content
+
+    async def extract_page(
+        self,
+        url: str,
+        section_name: str,
+        max_scrolls: int | None = None,
+    ) -> ExtractedSection:
+        """Navigate to a URL, scroll to load lazy content, and extract innerText.
+
+        Retries once after a backoff when the page returns only LinkedIn chrome
+        (sidebar/footer noise with no actual content), which indicates a soft
+        rate limit.
+
+        Raises LinkedInScraperException subclasses (rate limit, auth, etc.).
+        Returns RATE_LIMITED_SECTION_TEXT sentinel when soft-rate-limited after retry.
+        Returns empty string for unexpected non-domain failures (error isolation).
+        """
+        try:
+            result = await self._extract_page_once(url, section_name, max_scrolls)
+            if result.text != RATE_LIMITED_SECTION_TEXT:
+                return result
+
+            # Retry once after backoff
+            logger.info("Retrying %s after %.0fs backoff", url, RATE_LIMIT_RETRY_DELAY)
+            await self._session.delay(RATE_LIMIT_RETRY_DELAY)
+            return await self._extract_page_once(url, section_name, max_scrolls)
+
+        except LinkedInScraperException:
+            raise
+        except Exception as e:
+            logger.warning("Failed to extract page %s: %s", url, e)
+            return ExtractedSection(
+                text="",
+                references=[],
+                error=build_issue_diagnostics(
+                    e,
+                    context="extract_page",
+                    target_url=url,
+                    section_name=section_name,
+                ),
+            )
+
+    async def _extract_page_once(
+        self,
+        url: str,
+        section_name: str,
+        max_scrolls: int | None = None,
+    ) -> ExtractedSection:
+        """Single attempt to navigate, scroll, and extract innerText."""
+        await self._navigator._navigate_to_page(url)
+        return await self._extract_loaded_section(url, section_name, max_scrolls)
+
+    async def _extract_loaded_section(
+        self,
+        url: str,
+        section_name: str,
+        max_scrolls: int | None = None,
+    ) -> ExtractedSection:
+        """Run the post-navigation extraction pipeline on the current page.
+
+        Assumes the bound page already points at ``url`` (or its post-redirect
+        equivalent). Performs rate-limit detection, modal dismissal, lazy-load
+        scrolling, innerText extraction, noise truncation, and reference
+        building — everything ``_extract_page_once`` does after the goto.
+        """
+        await self._session.check_rate_limit()
+
+        # Wait for main content to render
+        try:
+            await self._session.page.wait_for_selector("main")
+        except PlaywrightTimeoutError:
+            logger.debug("No <main> element found on %s", url)
+
+        # Dismiss any modals blocking content
+        await self._session.dismiss_modal()
+
+        # Activity feed pages lazy-load post content after the tab header.
+        # Company posts pages (/company/<slug>/posts/) lazy-load the same way
+        # but don't carry a /recent-activity/ path, so match them too. Matched
+        # on the parsed path, since the url can carry a query string
+        # (?viewAsMember=true) that a raw suffix check would miss.
+        path = urlparse(url).path
+        is_activity = "/recent-activity/" in path or (
+            "/company/" in path and path.rstrip("/").endswith("/posts")
+        )
+        if is_activity:
+            try:
+                await self._session.page.wait_for_function(
+                    """() => {
+                        const main = document.querySelector('main');
+                        if (!main) return false;
+                        return main.innerText.length > 200;
+                    }""",
+                    timeout=10000,
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Activity feed content did not appear on %s", url)
+
+        # Search results pages load a placeholder first then fill in results
+        # via JavaScript. Wait for actual content before extracting.
+        is_search = "/search/results/" in url
+        if is_search:
+            try:
+                await self._session.page.wait_for_function(
+                    """() => {
+                        const main = document.querySelector('main');
+                        if (!main) return false;
+                        return main.innerText.length > 100;
+                    }""",
+                    timeout=10000,
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Search results content did not appear on %s", url)
+
+        # Company people pages (/company/<slug>/people/) initially render only
+        # the company header in <main>; the employee listing hydrates later
+        # via JS. Wait until at least one /in/ profile anchor appears inside
+        # <main> so innerText extraction sees the actual list. Use a 5s
+        # timeout instead of the 10s pattern shared with is_search/is_details
+        # — empty/restricted listings are common here (small companies,
+        # privacy settings) and a full 10s wait per call adds up.
+        is_company_people = "/company/" in url and "/people/" in url
+        if is_company_people:
+            try:
+                await self._session.page.wait_for_function(
+                    """() => {
+                        const main = document.querySelector('main');
+                        if (!main) return false;
+                        return main.querySelectorAll('a[href*="/in/"]').length > 0;
+                    }""",
+                    timeout=5000,
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Company people listing did not appear on %s", url)
+
+        # Profile detail pages (/details/experience/, /details/education/, etc.)
+        # initially render sidebar recommendations into <main> while the section
+        # panel loads asynchronously. Wait until the panel replaces the sidebar.
+        # The sidebar placeholder starts with "Load more" or "More profiles for you".
+        is_details = "/details/" in url
+        if is_details:
+            try:
+                await self._session.page.wait_for_function(
+                    """() => {
+                        const main = document.querySelector('main');
+                        if (!main) return false;
+                        const text = main.innerText.trimStart();
+                        return !text.startsWith('Load more')
+                            && !text.startsWith('More profiles for you')
+                            && !text.startsWith('Explore premium profiles');
+                    }""",
+                    timeout=10000,
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Detail section content did not appear on %s", url)
+
+        # Detail pages paginate with a "Show more" button inside <main>, not scroll.
+        # Click it until it disappears or the budget runs out.
+        if is_details:
+            max_clicks = max_scrolls if max_scrolls is not None else 5
+            for i in range(max_clicks):
+                button = self._session.page.locator("main button").filter(
+                    has_text=re.compile(r"^Show (more|all)\b", re.IGNORECASE)
+                )
+                try:
+                    if await button.count() == 0:
+                        logger.debug("No 'Show more' button after %d clicks", i)
+                        break
+                    target = button.first
+                    if not await target.is_visible():
+                        break
+                    await target.scroll_into_view_if_needed(timeout=2000)
+                    await target.click(timeout=2000)
+                    await self._session.delay(1.0)
+                except PlaywrightTimeoutError:
+                    logger.debug("Show more click timed out after %d clicks", i)
+                    break
+                except Exception as e:
+                    logger.debug("Show more click failed: %s", e)
+                    break
+
+        # Scroll to trigger lazy loading
+        if is_activity:
+            scrolls = max_scrolls if max_scrolls is not None else 10
+            await self._session.scroll_body(pause_time=1.0, max_scrolls=scrolls)
+        else:
+            scrolls = max_scrolls if max_scrolls is not None else 5
+            await self._session.scroll_body(pause_time=0.5, max_scrolls=scrolls)
+
+        # Extract text from main content area
+        raw_result = await self._content._extract_root_content(["main"])
+        raw = raw_result["text"]
+
+        if not raw:
+            return ExtractedSection(text="", references=[])
+        truncated = truncate_linkedin_noise(raw)
+        if not truncated and raw.strip():
+            logger.warning(
+                "Page %s returned only LinkedIn chrome (likely rate-limited)", url
+            )
+            return ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
+        cleaned = filter_linkedin_noise_lines(truncated)
+        return ExtractedSection(
+            text=cleaned,
+            references=build_references(raw_result["references"], section_name),
+        )
+
+    async def _extract_overlay(
+        self,
+        url: str,
+        section_name: str,
+    ) -> ExtractedSection:
+        """Extract content from an overlay/modal page (e.g. contact info).
+
+        LinkedIn renders contact info as a native <dialog> element.
+        Falls back to `<main>` if no dialog is found.
+
+        Retries once after a backoff when the overlay returns only LinkedIn
+        chrome (noise), mirroring `extract_page` behavior.
+        """
+        try:
+            result = await self._extract_overlay_once(url, section_name)
+            if result.text != RATE_LIMITED_SECTION_TEXT:
+                return result
+
+            logger.info(
+                "Retrying overlay %s after %.0fs backoff",
+                url,
+                RATE_LIMIT_RETRY_DELAY,
+            )
+            await self._session.delay(RATE_LIMIT_RETRY_DELAY)
+            return await self._extract_overlay_once(url, section_name)
+
+        except LinkedInScraperException:
+            raise
+        except Exception as e:
+            logger.warning("Failed to extract overlay %s: %s", url, e)
+            return ExtractedSection(
+                text="",
+                references=[],
+                error=build_issue_diagnostics(
+                    e,
+                    context="extract_overlay",
+                    target_url=url,
+                    section_name=section_name,
+                ),
+            )
+
+    async def _extract_overlay_once(
+        self,
+        url: str,
+        section_name: str,
+    ) -> ExtractedSection:
+        """Single attempt to extract content from an overlay/modal page."""
+        await self._navigator._navigate_to_page(url)
+        await self._session.check_rate_limit()
+
+        # Wait for the dialog/modal to render (LinkedIn uses native <dialog>)
+        try:
+            await self._session.page.wait_for_selector(
+                "dialog[open], .artdeco-modal__content"
+            )
+        except PlaywrightTimeoutError:
+            logger.debug("No modal overlay found on %s, falling back to main", url)
+
+        # NOTE: Do NOT dismiss a modal here — the contact-info overlay *is* a
+        # dialog/modal. Dismissing it would destroy the content before the JS
+        # evaluation below can read it.
+
+        raw_result = await self._content._extract_root_content(
+            ["dialog[open]", ".artdeco-modal__content", "main"],
+        )
+        raw = raw_result["text"]
+
+        if not raw:
+            return ExtractedSection(text="", references=[])
+        truncated = truncate_linkedin_noise(raw)
+        if not truncated and raw.strip():
+            logger.warning(
+                "Overlay %s returned only LinkedIn chrome (likely rate-limited)",
+                url,
+            )
+            return ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
+        cleaned = filter_linkedin_noise_lines(truncated)
+        return ExtractedSection(
+            text=cleaned,
+            references=build_references(raw_result["references"], section_name),
+        )

--- a/linkedin_mcp_server/scraping/content.py
+++ b/linkedin_mcp_server/scraping/content.py
@@ -1,0 +1,123 @@
+"""Raw page content reads shared by every scraping workflow."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from linkedin_mcp_server.scraping.session import ScrapingSession
+
+
+class PageContentReader:
+    """Read innerText and raw anchor metadata off the bound page."""
+
+    def __init__(self, session: ScrapingSession):
+        self._session = session
+
+    async def _extract_root_content(
+        self,
+        selectors: list[str],
+    ) -> dict[str, Any]:
+        """Extract innerText and raw anchor metadata from the first matching root."""
+        result = await self._session.page.evaluate(
+            """({ selectors }) => {
+                const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
+                const containerSelector = 'section, article, li, div';
+                const headingSelector = 'h1, h2, h3';
+                const directHeadingSelector = ':scope > h1, :scope > h2, :scope > h3';
+                const MAX_HEADING_CONTAINERS = 300;
+                const MAX_REFERENCE_ANCHORS = 500;
+
+                const getHeadingText = element => {
+                    if (!element) return '';
+
+                    const heading =
+                        element.matches && element.matches(headingSelector)
+                            ? element
+                            : element.querySelector
+                              ? element.querySelector(directHeadingSelector)
+                              : null;
+
+                    return normalize(heading?.innerText || heading?.textContent);
+                };
+
+                const getPreviousHeading = node => {
+                    let sibling = node?.previousElementSibling || null;
+                    for (let index = 0; sibling && index < 3; index += 1) {
+                        const heading = getHeadingText(sibling);
+                        if (heading) {
+                            return heading;
+                        }
+                        sibling = sibling.previousElementSibling;
+                    }
+                    return '';
+                };
+
+                const root = selectors
+                    .map(selector => document.querySelector(selector))
+                    .find(Boolean);
+                const source = root ? 'root' : 'body';
+                const container = root || document.body;
+                const text = container ? (container.innerText || '').trim() : '';
+                const headingMap = new WeakMap();
+
+                const candidateContainers = [
+                    container,
+                    ...Array.from(container.querySelectorAll(containerSelector)).slice(
+                        0,
+                        MAX_HEADING_CONTAINERS,
+                    ),
+                ];
+                candidateContainers.forEach(node => {
+                    const ownHeading = getHeadingText(node);
+                    const previousHeading = getPreviousHeading(node);
+                    const heading = ownHeading || previousHeading;
+                    if (heading) {
+                        headingMap.set(node, heading);
+                    }
+                });
+
+                const findHeading = element => {
+                    let current = element.closest(containerSelector) || container;
+                    for (let depth = 0; current && depth < 4; depth += 1) {
+                        const heading = headingMap.get(current);
+                        if (heading) {
+                            return heading;
+                        }
+                        if (current === container) {
+                            break;
+                        }
+                        current = current.parentElement?.closest(containerSelector) || null;
+                    }
+                    return '';
+                };
+
+                const references = Array.from(container.querySelectorAll('a[href]'))
+                    .slice(0, MAX_REFERENCE_ANCHORS)
+                    .map(anchor => {
+                        const rawHref = (anchor.getAttribute('href') || '').trim();
+                        if (!rawHref || rawHref === '#') {
+                            return null;
+                        }
+
+                        const href = rawHref.startsWith('#')
+                            ? rawHref
+                            : (anchor.href || rawHref);
+
+                        return {
+                            href,
+                            text: normalize(anchor.innerText || anchor.textContent),
+                            aria_label: normalize(anchor.getAttribute('aria-label')),
+                            title: normalize(anchor.getAttribute('title')),
+                            heading: findHeading(anchor),
+                            in_article: Boolean(anchor.closest('article')),
+                            in_nav: Boolean(anchor.closest('nav')),
+                            in_footer: Boolean(anchor.closest('footer')),
+                        };
+                    })
+                    .filter(Boolean);
+
+                return { source, text, references };
+            }""",
+            {"selectors": selectors},
+        )
+        return result

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -26,7 +26,12 @@ from linkedin_mcp_server.core.utils import (
     scroll_to_bottom,
 )
 from linkedin_mcp_server.scraping import contracts
+from linkedin_mcp_server.scraping.capture import (
+    RATE_LIMIT_RETRY_DELAY,
+    SectionCapture,
+)
 from linkedin_mcp_server.scraping.connection import ActionSignals
+from linkedin_mcp_server.scraping.content import PageContentReader
 from linkedin_mcp_server.scraping.contracts import (
     RATE_LIMITED_SECTION_TEXT,
     ExtractedSection,
@@ -96,9 +101,6 @@ logger = logging.getLogger(__name__)
 
 # Pacing between page navigations
 _NAV_DELAY = 2.0
-
-# Backoff before retrying a temporarily blocked page
-_RATE_LIMIT_RETRY_DELAY = 5.0
 
 # The id is the trailing run of digits, and LinkedIn serves the same job under
 # both `/jobs/view/1967281839/` and `/jobs/view/<title>-at-<company>-1967281839/`.
@@ -1434,6 +1436,8 @@ class LinkedInExtractor:
     def __init__(self, page: Page):
         self._session = ScrapingSession(page)
         self._navigator = PageNavigator(self._session)
+        self._content = PageContentReader(self._session)
+        self._capture = SectionCapture(self._session, self._navigator, self._content)
         self._page = page
         # What the sidebar scroll spent on the page being read, so that a
         # multi-page search charges its scroll budget for scrolling alone.
@@ -1886,7 +1890,7 @@ class LinkedInExtractor:
         # Give any in-flight response reads a beat to finish recording URLs.
         await asyncio.sleep(0.2)
 
-        raw_result = await self._extract_root_content(["main"])
+        raw_result = await self._content._extract_root_content(["main"])
         raw = raw_result["text"]
 
         if not raw:
@@ -1909,285 +1913,8 @@ class LinkedInExtractor:
         section_name: str,
         max_scrolls: int | None = None,
     ) -> ExtractedSection:
-        """Navigate to a URL, scroll to load lazy content, and extract innerText.
-
-        Retries once after a backoff when the page returns only LinkedIn chrome
-        (sidebar/footer noise with no actual content), which indicates a soft
-        rate limit.
-
-        Raises LinkedInScraperException subclasses (rate limit, auth, etc.).
-        Returns RATE_LIMITED_SECTION_TEXT sentinel when soft-rate-limited after retry.
-        Returns empty string for unexpected non-domain failures (error isolation).
-        """
-        try:
-            result = await self._extract_page_once(url, section_name, max_scrolls)
-            if result.text != RATE_LIMITED_SECTION_TEXT:
-                return result
-
-            # Retry once after backoff
-            logger.info("Retrying %s after %.0fs backoff", url, _RATE_LIMIT_RETRY_DELAY)
-            await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
-            return await self._extract_page_once(url, section_name, max_scrolls)
-
-        except LinkedInScraperException:
-            raise
-        except Exception as e:
-            logger.warning("Failed to extract page %s: %s", url, e)
-            return ExtractedSection(
-                text="",
-                references=[],
-                error=build_issue_diagnostics(
-                    e,
-                    context="extract_page",
-                    target_url=url,
-                    section_name=section_name,
-                ),
-            )
-
-    async def _extract_page_once(
-        self,
-        url: str,
-        section_name: str,
-        max_scrolls: int | None = None,
-    ) -> ExtractedSection:
-        """Single attempt to navigate, scroll, and extract innerText."""
-        await self._navigator._navigate_to_page(url)
-        return await self._extract_loaded_section(url, section_name, max_scrolls)
-
-    async def _extract_loaded_section(
-        self,
-        url: str,
-        section_name: str,
-        max_scrolls: int | None = None,
-    ) -> ExtractedSection:
-        """Run the post-navigation extraction pipeline on the current page.
-
-        Assumes ``self._page`` already points at ``url`` (or its post-redirect
-        equivalent). Performs rate-limit detection, modal dismissal, lazy-load
-        scrolling, innerText extraction, noise truncation, and reference
-        building — everything ``_extract_page_once`` does after the goto.
-        """
-        await detect_rate_limit(self._page)
-
-        # Wait for main content to render
-        try:
-            await self._page.wait_for_selector("main")
-        except PlaywrightTimeoutError:
-            logger.debug("No <main> element found on %s", url)
-
-        # Dismiss any modals blocking content
-        await handle_modal_close(self._page)
-
-        # Activity feed pages lazy-load post content after the tab header.
-        # Company posts pages (/company/<slug>/posts/) lazy-load the same way
-        # but don't carry a /recent-activity/ path, so match them too. Matched
-        # on the parsed path, since the url can carry a query string
-        # (?viewAsMember=true) that a raw suffix check would miss.
-        path = urlparse(url).path
-        is_activity = "/recent-activity/" in path or (
-            "/company/" in path and path.rstrip("/").endswith("/posts")
-        )
-        if is_activity:
-            try:
-                await self._page.wait_for_function(
-                    """() => {
-                        const main = document.querySelector('main');
-                        if (!main) return false;
-                        return main.innerText.length > 200;
-                    }""",
-                    timeout=10000,
-                )
-            except PlaywrightTimeoutError:
-                logger.debug("Activity feed content did not appear on %s", url)
-
-        # Search results pages load a placeholder first then fill in results
-        # via JavaScript. Wait for actual content before extracting.
-        is_search = "/search/results/" in url
-        if is_search:
-            try:
-                await self._page.wait_for_function(
-                    """() => {
-                        const main = document.querySelector('main');
-                        if (!main) return false;
-                        return main.innerText.length > 100;
-                    }""",
-                    timeout=10000,
-                )
-            except PlaywrightTimeoutError:
-                logger.debug("Search results content did not appear on %s", url)
-
-        # Company people pages (/company/<slug>/people/) initially render only
-        # the company header in <main>; the employee listing hydrates later
-        # via JS. Wait until at least one /in/ profile anchor appears inside
-        # <main> so innerText extraction sees the actual list. Use a 5s
-        # timeout instead of the 10s pattern shared with is_search/is_details
-        # — empty/restricted listings are common here (small companies,
-        # privacy settings) and a full 10s wait per call adds up.
-        is_company_people = "/company/" in url and "/people/" in url
-        if is_company_people:
-            try:
-                await self._page.wait_for_function(
-                    """() => {
-                        const main = document.querySelector('main');
-                        if (!main) return false;
-                        return main.querySelectorAll('a[href*="/in/"]').length > 0;
-                    }""",
-                    timeout=5000,
-                )
-            except PlaywrightTimeoutError:
-                logger.debug("Company people listing did not appear on %s", url)
-
-        # Profile detail pages (/details/experience/, /details/education/, etc.)
-        # initially render sidebar recommendations into <main> while the section
-        # panel loads asynchronously. Wait until the panel replaces the sidebar.
-        # The sidebar placeholder starts with "Load more" or "More profiles for you".
-        is_details = "/details/" in url
-        if is_details:
-            try:
-                await self._page.wait_for_function(
-                    """() => {
-                        const main = document.querySelector('main');
-                        if (!main) return false;
-                        const text = main.innerText.trimStart();
-                        return !text.startsWith('Load more')
-                            && !text.startsWith('More profiles for you')
-                            && !text.startsWith('Explore premium profiles');
-                    }""",
-                    timeout=10000,
-                )
-            except PlaywrightTimeoutError:
-                logger.debug("Detail section content did not appear on %s", url)
-
-        # Detail pages paginate with a "Show more" button inside <main>, not scroll.
-        # Click it until it disappears or the budget runs out.
-        if is_details:
-            max_clicks = max_scrolls if max_scrolls is not None else 5
-            for i in range(max_clicks):
-                button = self._page.locator("main button").filter(
-                    has_text=re.compile(r"^Show (more|all)\b", re.IGNORECASE)
-                )
-                try:
-                    if await button.count() == 0:
-                        logger.debug("No 'Show more' button after %d clicks", i)
-                        break
-                    target = button.first
-                    if not await target.is_visible():
-                        break
-                    await target.scroll_into_view_if_needed(timeout=2000)
-                    await target.click(timeout=2000)
-                    await asyncio.sleep(1.0)
-                except PlaywrightTimeoutError:
-                    logger.debug("Show more click timed out after %d clicks", i)
-                    break
-                except Exception as e:
-                    logger.debug("Show more click failed: %s", e)
-                    break
-
-        # Scroll to trigger lazy loading
-        if is_activity:
-            scrolls = max_scrolls if max_scrolls is not None else 10
-            await scroll_to_bottom(self._page, pause_time=1.0, max_scrolls=scrolls)
-        else:
-            scrolls = max_scrolls if max_scrolls is not None else 5
-            await scroll_to_bottom(self._page, pause_time=0.5, max_scrolls=scrolls)
-
-        # Extract text from main content area
-        raw_result = await self._extract_root_content(["main"])
-        raw = raw_result["text"]
-
-        if not raw:
-            return ExtractedSection(text="", references=[])
-        truncated = truncate_linkedin_noise(raw)
-        if not truncated and raw.strip():
-            logger.warning(
-                "Page %s returned only LinkedIn chrome (likely rate-limited)", url
-            )
-            return ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
-        cleaned = filter_linkedin_noise_lines(truncated)
-        return ExtractedSection(
-            text=cleaned,
-            references=build_references(raw_result["references"], section_name),
-        )
-
-    async def _extract_overlay(
-        self,
-        url: str,
-        section_name: str,
-    ) -> ExtractedSection:
-        """Extract content from an overlay/modal page (e.g. contact info).
-
-        LinkedIn renders contact info as a native <dialog> element.
-        Falls back to `<main>` if no dialog is found.
-
-        Retries once after a backoff when the overlay returns only LinkedIn
-        chrome (noise), mirroring `extract_page` behavior.
-        """
-        try:
-            result = await self._extract_overlay_once(url, section_name)
-            if result.text != RATE_LIMITED_SECTION_TEXT:
-                return result
-
-            logger.info(
-                "Retrying overlay %s after %.0fs backoff",
-                url,
-                _RATE_LIMIT_RETRY_DELAY,
-            )
-            await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
-            return await self._extract_overlay_once(url, section_name)
-
-        except LinkedInScraperException:
-            raise
-        except Exception as e:
-            logger.warning("Failed to extract overlay %s: %s", url, e)
-            return ExtractedSection(
-                text="",
-                references=[],
-                error=build_issue_diagnostics(
-                    e,
-                    context="extract_overlay",
-                    target_url=url,
-                    section_name=section_name,
-                ),
-            )
-
-    async def _extract_overlay_once(
-        self,
-        url: str,
-        section_name: str,
-    ) -> ExtractedSection:
-        """Single attempt to extract content from an overlay/modal page."""
-        await self._navigator._navigate_to_page(url)
-        await detect_rate_limit(self._page)
-
-        # Wait for the dialog/modal to render (LinkedIn uses native <dialog>)
-        try:
-            await self._page.wait_for_selector("dialog[open], .artdeco-modal__content")
-        except PlaywrightTimeoutError:
-            logger.debug("No modal overlay found on %s, falling back to main", url)
-
-        # NOTE: Do NOT call handle_modal_close() here — the contact-info
-        # overlay *is* a dialog/modal. Dismissing it would destroy the
-        # content before the JS evaluation below can read it.
-
-        raw_result = await self._extract_root_content(
-            ["dialog[open]", ".artdeco-modal__content", "main"],
-        )
-        raw = raw_result["text"]
-
-        if not raw:
-            return ExtractedSection(text="", references=[])
-        truncated = truncate_linkedin_noise(raw)
-        if not truncated and raw.strip():
-            logger.warning(
-                "Overlay %s returned only LinkedIn chrome (likely rate-limited)",
-                url,
-            )
-            return ExtractedSection(text=RATE_LIMITED_SECTION_TEXT, references=[])
-        cleaned = filter_linkedin_noise_lines(truncated)
-        return ExtractedSection(
-            text=cleaned,
-            references=build_references(raw_result["references"], section_name),
-        )
+        """Navigate to a URL, scroll to load lazy content, and extract innerText."""
+        return await self._capture.extract_page(url, section_name, max_scrolls)
 
     async def scrape_person(
         self,
@@ -2246,7 +1973,7 @@ class LinkedInExtractor:
                         == urlparse(base_url).path.rstrip("/")
                     )
                     if can_reuse_main:
-                        extracted = await self._extract_loaded_section(
+                        extracted = await self._capture._extract_loaded_section(
                             url,
                             section_name=section_name,
                             max_scrolls=max_scrolls,
@@ -2262,7 +1989,7 @@ class LinkedInExtractor:
                                 max_scrolls=max_scrolls,
                             )
                     elif is_overlay:
-                        extracted = await self._extract_overlay(
+                        extracted = await self._capture._extract_overlay(
                             url, section_name=section_name
                         )
                     else:
@@ -3475,7 +3202,7 @@ class LinkedInExtractor:
                 url = base_url + suffix
                 try:
                     if is_overlay:
-                        extracted = await self._extract_overlay(
+                        extracted = await self._capture._extract_overlay(
                             url, section_name=section_name
                         )
                     else:
@@ -3637,8 +3364,8 @@ class LinkedInExtractor:
         """Extract innerText from a job search page with soft rate-limit retry.
 
         Mirrors the noise-only detection and single-retry behavior of
-        ``extract_page`` / ``_extract_page_once`` so that callers get a
-        ``RATE_LIMITED_SECTION_TEXT`` sentinel instead of silent empty results.
+        ``SectionCapture`` so that callers get a ``RATE_LIMITED_SECTION_TEXT``
+        sentinel instead of silent empty results.
         """
         try:
             result = await self._extract_search_page_once(
@@ -3650,9 +3377,9 @@ class LinkedInExtractor:
             logger.info(
                 "Retrying search page %s after %.0fs backoff",
                 url,
-                _RATE_LIMIT_RETRY_DELAY,
+                RATE_LIMIT_RETRY_DELAY,
             )
-            await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
+            await asyncio.sleep(RATE_LIMIT_RETRY_DELAY)
             result = await self._extract_search_page_once(
                 url, section_name, scroll_deadline / 2
             )
@@ -3766,7 +3493,7 @@ class LinkedInExtractor:
                 f"Page navigated to {self._page.url} while scrolling {url}"
             )
 
-        raw_result = await self._extract_root_content(["main"])
+        raw_result = await self._content._extract_root_content(["main"])
 
         # The watcher covers the scroll and nothing else, and the read sits
         # outside it at both ends: a reload committing after the listener came
@@ -4183,9 +3910,9 @@ class LinkedInExtractor:
                 logger.info(
                     "Retrying saved jobs page %s after %.0fs backoff",
                     url,
-                    _RATE_LIMIT_RETRY_DELAY,
+                    RATE_LIMIT_RETRY_DELAY,
                 )
-                await asyncio.sleep(_RATE_LIMIT_RETRY_DELAY)
+                await asyncio.sleep(RATE_LIMIT_RETRY_DELAY)
                 result = await self._extract_saved_jobs_page_once(url, section_name)
                 if result.text == RATE_LIMITED_SECTION_TEXT:
                     logger.warning(
@@ -4278,7 +4005,7 @@ class LinkedInExtractor:
         # Asked after the read rather than before it, or the gap between the
         # two is a window of its own and the text that came back is not the
         # text the check judged.
-        raw_result = await self._extract_root_content(["main"])
+        raw_result = await self._content._extract_root_content(["main"])
         if origin is not None and await self._navigator._document_origin() != origin:
             logger.debug("The saved-jobs document was replaced before it was read")
             await self._navigator._raise_if_auth_barrier(self._page.url)
@@ -4682,7 +4409,7 @@ class LinkedInExtractor:
             position="bottom", attempts=scrolls, pause_time=0.5
         )
 
-        raw_result = await self._extract_root_content(["main"])
+        raw_result = await self._content._extract_root_content(["main"])
         raw = raw_result["text"]
         cleaned = strip_linkedin_noise(raw) if raw else ""
         references: list[Reference] = (
@@ -4878,7 +4605,7 @@ class LinkedInExtractor:
             position="top", attempts=3, pause_time=0.5
         )
 
-        raw_result = await self._extract_root_content(["main"])
+        raw_result = await self._content._extract_root_content(["main"])
         raw = raw_result["text"]
         # Conversation chrome first: a sidebar preview containing a generic
         # noise marker would otherwise truncate the page before the thread
@@ -4920,7 +4647,7 @@ class LinkedInExtractor:
         await handle_modal_close(self._page)
         await self._wait_for_main_text(log_context="Messaging search")
 
-        raw_result = await self._extract_root_content(["main"])
+        raw_result = await self._content._extract_root_content(["main"])
         raw = raw_result["text"]
         cleaned = strip_linkedin_noise(raw) if raw else ""
         references: list[Reference] = (
@@ -5291,112 +5018,3 @@ class LinkedInExtractor:
             if may_have_submitted:
                 logger.warning(contracts.SEND_INTERRUPTED_WARNING)
             raise
-
-    async def _extract_root_content(
-        self,
-        selectors: list[str],
-    ) -> dict[str, Any]:
-        """Extract innerText and raw anchor metadata from the first matching root."""
-        result = await self._page.evaluate(
-            """({ selectors }) => {
-                const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
-                const containerSelector = 'section, article, li, div';
-                const headingSelector = 'h1, h2, h3';
-                const directHeadingSelector = ':scope > h1, :scope > h2, :scope > h3';
-                const MAX_HEADING_CONTAINERS = 300;
-                const MAX_REFERENCE_ANCHORS = 500;
-
-                const getHeadingText = element => {
-                    if (!element) return '';
-
-                    const heading =
-                        element.matches && element.matches(headingSelector)
-                            ? element
-                            : element.querySelector
-                              ? element.querySelector(directHeadingSelector)
-                              : null;
-
-                    return normalize(heading?.innerText || heading?.textContent);
-                };
-
-                const getPreviousHeading = node => {
-                    let sibling = node?.previousElementSibling || null;
-                    for (let index = 0; sibling && index < 3; index += 1) {
-                        const heading = getHeadingText(sibling);
-                        if (heading) {
-                            return heading;
-                        }
-                        sibling = sibling.previousElementSibling;
-                    }
-                    return '';
-                };
-
-                const root = selectors
-                    .map(selector => document.querySelector(selector))
-                    .find(Boolean);
-                const source = root ? 'root' : 'body';
-                const container = root || document.body;
-                const text = container ? (container.innerText || '').trim() : '';
-                const headingMap = new WeakMap();
-
-                const candidateContainers = [
-                    container,
-                    ...Array.from(container.querySelectorAll(containerSelector)).slice(
-                        0,
-                        MAX_HEADING_CONTAINERS,
-                    ),
-                ];
-                candidateContainers.forEach(node => {
-                    const ownHeading = getHeadingText(node);
-                    const previousHeading = getPreviousHeading(node);
-                    const heading = ownHeading || previousHeading;
-                    if (heading) {
-                        headingMap.set(node, heading);
-                    }
-                });
-
-                const findHeading = element => {
-                    let current = element.closest(containerSelector) || container;
-                    for (let depth = 0; current && depth < 4; depth += 1) {
-                        const heading = headingMap.get(current);
-                        if (heading) {
-                            return heading;
-                        }
-                        if (current === container) {
-                            break;
-                        }
-                        current = current.parentElement?.closest(containerSelector) || null;
-                    }
-                    return '';
-                };
-
-                const references = Array.from(container.querySelectorAll('a[href]'))
-                    .slice(0, MAX_REFERENCE_ANCHORS)
-                    .map(anchor => {
-                        const rawHref = (anchor.getAttribute('href') || '').trim();
-                        if (!rawHref || rawHref === '#') {
-                            return null;
-                        }
-
-                        const href = rawHref.startsWith('#')
-                            ? rawHref
-                            : (anchor.href || rawHref);
-
-                        return {
-                            href,
-                            text: normalize(anchor.innerText || anchor.textContent),
-                            aria_label: normalize(anchor.getAttribute('aria-label')),
-                            title: normalize(anchor.getAttribute('title')),
-                            heading: findHeading(anchor),
-                            in_article: Boolean(anchor.closest('article')),
-                            in_nav: Boolean(anchor.closest('nav')),
-                            in_footer: Boolean(anchor.closest('footer')),
-                        };
-                    })
-                    .filter(Boolean);
-
-                return { source, text, references };
-            }""",
-            {"selectors": selectors},
-        )
-        return result

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -149,10 +149,17 @@ _IMPORT_OWNERS = {
     ),
 }
 
+# `_content` and `_capture` are the facade's own wiring rather than a
+# collaborator a test could build for itself: reaching them is how a workflow
+# still living on the facade gets its capture stubbed, so the seam closes with
+# the facade and not with the module that owns the class. `_session` and
+# `_navigator` carry no such consumer and stay pinned to their own stage.
 _INSTANCE_ATTRIBUTE_OWNERS = {
     "_page": ("facade.LinkedInExtractor._page", 14),
     "_session": ("session.ScrapingSession", 3),
     "_navigator": ("navigation.PageNavigator", 3),
+    "_content": ("facade.LinkedInExtractor._content", 14),
+    "_capture": ("facade.LinkedInExtractor._capture", 14),
     "_scroll_seconds": ("facade.LinkedInExtractor._scroll_seconds", 14),
 }
 
@@ -260,8 +267,6 @@ _EXPLICIT_CALLER_CONTEXTS: dict[tuple[str, str, str], tuple[str, ...]] = {
         "boundaries",
         "detect_rate_limit",
     ): (
-        "_extract_loaded_section",
-        "_extract_overlay_once",
         "_extract_feed_body",
         "get_sidebar_profiles",
         "_extract_search_page_once",
@@ -278,7 +283,6 @@ _EXPLICIT_CALLER_CONTEXTS: dict[tuple[str, str, str], tuple[str, ...]] = {
         "boundaries",
         "handle_modal_close",
     ): (
-        "_extract_loaded_section",
         "_extract_feed_body",
         "get_sidebar_profiles",
         "_extract_search_page_once",
@@ -294,7 +298,7 @@ _EXPLICIT_CALLER_CONTEXTS: dict[tuple[str, str, str], tuple[str, ...]] = {
         "tests/scraping/policy_scenarios.py",
         "boundaries",
         "scroll_to_bottom",
-    ): ("_extract_loaded_section", "_extract_saved_jobs_page_once"),
+    ): ("_extract_saved_jobs_page_once",),
     (
         "tests/scraping/policy_scenarios.py",
         "boundaries",
@@ -306,8 +310,6 @@ _EXPLICIT_CALLER_CONTEXTS: dict[tuple[str, str, str], tuple[str, ...]] = {
         "build_issue_diagnostics",
     ): (
         "extract_feed",
-        "extract_page",
-        "_extract_overlay",
         "scrape_person",
         "scrape_company",
         "_extract_search_page",

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -152,15 +152,31 @@ _IMPORT_OWNERS = {
 # `_content` and `_capture` are the facade's own wiring rather than a
 # collaborator a test could build for itself: reaching them is how a workflow
 # still living on the facade gets its capture stubbed, so the seam closes with
-# the facade and not with the module that owns the class. `_session` and
-# `_navigator` carry no such consumer and stay pinned to their own stage.
+# the last workflow that still asks the facade for it, not with the module that
+# owns the class and not with the facade. Measured over every reach-through in
+# the tree: all 19 `_capture` sites sit in `scrape_person` tests, which move at
+# stage 6, and the 14 `_content` sites spread over `scrape_company` (8),
+# `_extract_search_page`, `search_jobs`, `_extract_saved_jobs_page` (9) and
+# `get_inbox`, `get_conversation`, `search_conversations` (11). Pinning either
+# at the facade's own stage 14 would leave a stale reach-through unflagged for
+# the rest of the migration. `_session` and `_navigator` carry no such consumer
+# and stay pinned to their own stage.
 _INSTANCE_ATTRIBUTE_OWNERS = {
     "_page": ("facade.LinkedInExtractor._page", 14),
     "_session": ("session.ScrapingSession", 3),
     "_navigator": ("navigation.PageNavigator", 3),
-    "_content": ("facade.LinkedInExtractor._content", 14),
-    "_capture": ("facade.LinkedInExtractor._capture", 14),
+    "_content": ("facade.LinkedInExtractor._content", 11),
+    "_capture": ("facade.LinkedInExtractor._capture", 6),
     "_scroll_seconds": ("facade.LinkedInExtractor._scroll_seconds", 14),
+}
+
+# The collaborator behind each of those two attributes. A patch routed through
+# the attribute lands on the collaborator's own method, so the seam records the
+# collaborator as its owner while the stage stays the attribute's: what expires
+# is the reach-through, not the method.
+_FACADE_COLLABORATORS = {
+    "_content": "content.PageContentReader",
+    "_capture": "capture.SectionCapture",
 }
 
 _MODULE_ATTRIBUTE_OWNERS = {
@@ -1057,6 +1073,34 @@ def extractor_methods(package: Path = PACKAGE) -> tuple[frozenset[str], frozense
                 frozenset(name for name in methods if name.startswith("_")),
             )
     raise AssertionError("LinkedInExtractor not found in scraping/extractor.py")
+
+
+# One patched attribute per site re-reads the owning module, so the answer is
+# kept. Keyed by package too, because a caller may point the reader at a tree
+# other than this one.
+_COLLABORATOR_METHODS: dict[tuple[Path, str], frozenset[str]] = {}
+
+
+def collaborator_methods(owner: str, package: Path = PACKAGE) -> frozenset[str]:
+    """Read the method names of a facade collaborator named ``module.Class``."""
+
+    cached = _COLLABORATOR_METHODS.get((package, owner))
+    if cached is not None:
+        return cached
+    module, class_name = owner.split(".", 1)
+    tree = ast.parse(
+        (package / "scraping" / f"{module}.py").read_text(encoding="utf-8")
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            methods = frozenset(
+                item.name
+                for item in node.body
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
+            _COLLABORATOR_METHODS[package, owner] = methods
+            return methods
+    raise AssertionError(f"{class_name} not found in scraping/{module}.py")
 
 
 class Scanner(ast.NodeVisitor):
@@ -1984,6 +2028,30 @@ class Scanner(ast.NodeVisitor):
                 "unknown extractor module object patch",
             )
             return
+
+        if (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and (target.value.id in bindings or target.value.id in self.class_names)
+        ):
+            self._collaborator_patch(node, target.attr, name)
+            return
+
+    def _collaborator_patch(self, node: ast.Call, attribute: str, name: str) -> None:
+        owner = _FACADE_COLLABORATORS.get(attribute)
+        owner_stage = _INSTANCE_ATTRIBUTE_OWNERS.get(attribute)
+        patch_target = f"{attribute}.{name}"
+        if owner is None or owner_stage is None:
+            self._error(node, patch_target, "unknown facade collaborator patch")
+            return
+        if name not in collaborator_methods(owner):
+            self._error(node, patch_target, f"unknown {owner} patch")
+            return
+        _, stage = owner_stage
+        if name.startswith("_"):
+            self._add("private_patch_object", node, name, owner, stage)
+            return
+        self._add("public_patch_object", node, name, f"{owner} dependency", stage)
 
 
 def scan_source(

--- a/tests/fixtures/scraping-policy/migration-manifest.json
+++ b/tests/fixtures/scraping-policy/migration-manifest.json
@@ -53,7 +53,7 @@
     {
       "canonical_owner": "owner-local scraping modules",
       "kind": "module_alias",
-      "line": 25,
+      "line": 26,
       "migration_stage": 14,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "extractor_module"
@@ -61,23 +61,15 @@
     {
       "canonical_owner": "facade.LinkedInExtractor",
       "kind": "direct_import",
-      "line": 28,
+      "line": 29,
       "migration_stage": 14,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "LinkedInExtractor"
     },
     {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "module_attribute",
-      "line": 114,
-      "migration_stage": 4,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "scroll_to_bottom"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "module_attribute",
-      "line": 114,
+      "line": 115,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_to_bottom"
@@ -85,7 +77,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "module_attribute",
-      "line": 115,
+      "line": 116,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_job_sidebar"
@@ -93,23 +85,15 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 116,
+      "line": 117,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "_drain_listener_tasks"
     },
     {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "boundary_patch_object",
-      "line": 180,
-      "migration_stage": 4,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "detect_rate_limit"
-    },
-    {
       "canonical_owner": "feed.FeedScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 180,
+      "line": 187,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -117,7 +101,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 180,
+      "line": 187,
       "migration_stage": 6,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -125,7 +109,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 180,
+      "line": 187,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -133,7 +117,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 180,
+      "line": 187,
       "migration_stage": 11,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -141,23 +125,15 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 180,
+      "line": 187,
       "migration_stage": 12,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
     },
     {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "boundary_patch_object",
-      "line": 181,
-      "migration_stage": 4,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "handle_modal_close"
-    },
-    {
       "canonical_owner": "feed.FeedScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 181,
+      "line": 189,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -165,7 +141,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 181,
+      "line": 189,
       "migration_stage": 6,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -173,7 +149,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 181,
+      "line": 189,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -181,7 +157,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 181,
+      "line": 189,
       "migration_stage": 11,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -189,23 +165,15 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 181,
+      "line": 189,
       "migration_stage": 12,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
     },
     {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "boundary_patch_object",
-      "line": 182,
-      "migration_stage": 4,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "scroll_to_bottom"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "boundary_patch_object",
-      "line": 182,
+      "line": 191,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_to_bottom"
@@ -213,23 +181,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "boundary_patch_object",
-      "line": 183,
+      "line": 192,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_job_sidebar"
     },
     {
-      "canonical_owner": "capture.SectionCapture -> error_diagnostics.build_issue_diagnostics",
-      "kind": "boundary_patch_object",
-      "line": 184,
-      "migration_stage": 4,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "build_issue_diagnostics"
-    },
-    {
       "canonical_owner": "feed.FeedScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 184,
+      "line": 194,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -237,7 +197,7 @@
     {
       "canonical_owner": "person.PersonScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 184,
+      "line": 194,
       "migration_stage": 6,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -245,7 +205,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 184,
+      "line": 194,
       "migration_stage": 8,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -253,7 +213,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 184,
+      "line": 194,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -261,7 +221,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 184,
+      "line": 194,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -269,7 +229,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "private_patch_object",
-      "line": 185,
+      "line": 195,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "_drain_listener_tasks"
@@ -835,153 +795,9 @@
       "target": "ExtractedSection"
     },
     {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 64,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 68,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 72,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_facade_access",
-      "line": 97,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> error_diagnostics.build_issue_diagnostics",
-      "kind": "string_patch",
-      "line": 115,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 149,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 173,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 177,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 181,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 186,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 222,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 226,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 230,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 235,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 259,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 263,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 267,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 273,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 294,
+      "line": 66,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page_once"
@@ -989,7 +805,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 329,
+      "line": 101,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -997,7 +813,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 334,
+      "line": 106,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1005,7 +821,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 338,
+      "line": 110,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1013,23 +829,167 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
+      "line": 116,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page_once"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 144,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 149,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 153,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 160,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page_once"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 194,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 199,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 205,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page_once"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 245,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 249,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 254,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 261,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 286,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 290,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 295,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 301,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 335,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 339,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
       "line": 344,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page_once"
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 372,
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 354,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 377,
+      "line": 376,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1037,71 +997,87 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 381,
+      "line": 380,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 388,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page_once"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 422,
+      "line": 385,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 397,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 427,
+      "line": 417,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 433,
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 421,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page_once"
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 426,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 437,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 464,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 468,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
       "line": 473,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 477,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 482,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 489,
+      "line": 484,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1109,7 +1085,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 514,
+      "line": 512,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1117,7 +1093,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 518,
+      "line": 516,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1125,7 +1101,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 523,
+      "line": 521,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1133,167 +1109,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 529,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 563,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 567,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 572,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 582,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 604,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 608,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 613,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 625,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 645,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 649,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 654,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 665,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 692,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 696,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 701,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 712,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 740,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 744,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 749,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 758,
+      "line": 530,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1301,7 +1117,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 797,
+      "line": 569,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -1309,7 +1125,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 799,
+      "line": 571,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1317,7 +1133,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 803,
+      "line": 575,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1325,7 +1141,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 808,
+      "line": 580,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -1333,7 +1149,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 813,
+      "line": 585,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1341,7 +1157,7 @@
     {
       "canonical_owner": "facade.LinkedInExtractor._scroll_seconds",
       "kind": "private_facade_access",
-      "line": 820,
+      "line": 592,
       "migration_stage": 14,
       "path": "tests/test_scraping.py",
       "target": "_scroll_seconds"
@@ -1349,7 +1165,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 845,
+      "line": 617,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1357,7 +1173,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 849,
+      "line": 621,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -1365,23 +1181,23 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 854,
+      "line": 626,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 859,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 632,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 868,
+      "line": 642,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -1389,7 +1205,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 896,
+      "line": 670,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -1397,279 +1213,279 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
+      "line": 674,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 679,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 685,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 712,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 716,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 721,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 727,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 757,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 761,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 766,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 772,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 795,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 799,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 805,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 838,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 842,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 847,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 853,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 885,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 889,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 894,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
       "line": 900,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 905,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 911,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 938,
-      "migration_stage": 9,
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 916,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+      "target": "extract_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 942,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 947,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
+      "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
-      "line": 953,
-      "migration_stage": 9,
+      "line": 923,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_capture"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 983,
-      "migration_stage": 9,
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 928,
+      "migration_stage": null,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+      "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 987,
-      "migration_stage": 9,
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 943,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+      "target": "extract_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 992,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
+      "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
-      "line": 998,
-      "migration_stage": 9,
+      "line": 950,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_capture"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 1021,
-      "migration_stage": 9,
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 955,
+      "migration_stage": null,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+      "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1025,
-      "migration_stage": 9,
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 978,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+      "target": "extract_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 985,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_capture"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 990,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1007,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1024,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1031,
-      "migration_stage": 9,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 1064,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1068,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 1073,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 1079,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 1111,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 1115,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 1120,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 1126,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1142,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1148,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
+      "target": "_capture"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1154,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1169,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1175,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1181,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1204,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1210,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1216,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1233,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1250,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1256,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1262,
+      "line": 1036,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -1677,7 +1493,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 1281,
+      "line": 1055,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -1685,7 +1501,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 1287,
+      "line": 1061,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -1693,183 +1509,183 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
+      "line": 1080,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1089,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1104,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 1111,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_capture"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1116,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1148,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 1155,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_capture"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1160,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1190,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 1197,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_capture"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1202,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1216,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 1223,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_capture"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1228,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1242,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 1249,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_capture"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1254,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1268,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 1275,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_capture"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1280,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1294,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 1301,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_capture"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
       "line": 1306,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1315,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1330,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1336,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1342,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1374,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1380,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1386,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1416,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1422,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1428,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1442,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1448,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1454,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1468,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1474,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1480,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1494,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1500,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1506,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1520,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1526,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1532,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -1877,7 +1693,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1711,
+      "line": 1485,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -1885,7 +1701,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1716,
+      "line": 1490,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -1893,7 +1709,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1727,
+      "line": 1501,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -1901,7 +1717,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1733,
+      "line": 1507,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -1909,7 +1725,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1754,
+      "line": 1528,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -1917,7 +1733,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1757,
+      "line": 1531,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -1925,7 +1741,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1764,
+      "line": 1538,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -1933,7 +1749,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1767,
+      "line": 1541,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -1941,7 +1757,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 1791,
+      "line": 1565,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -1949,7 +1765,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1824,
+      "line": 1598,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -1957,7 +1773,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1827,
+      "line": 1601,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -1965,7 +1781,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1833,
+      "line": 1607,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -1973,7 +1789,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 1837,
+      "line": 1611,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -1981,7 +1797,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1885,
+      "line": 1659,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -1989,7 +1805,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1893,
+      "line": 1667,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_fill_dialog_textarea"
@@ -1997,7 +1813,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1899,
+      "line": 1673,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2005,7 +1821,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1905,
+      "line": 1679,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2013,7 +1829,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1911,
+      "line": 1685,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2021,7 +1837,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 1915,
+      "line": 1689,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2029,7 +1845,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1927,
+      "line": 1701,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2037,7 +1853,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1928,
+      "line": 1702,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2045,7 +1861,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1935,
+      "line": 1709,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2053,7 +1869,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1938,
+      "line": 1712,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2061,7 +1877,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1950,
+      "line": 1724,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2069,7 +1885,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1951,
+      "line": 1725,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2077,7 +1893,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1968,
+      "line": 1742,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2085,7 +1901,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1969,
+      "line": 1743,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2093,7 +1909,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1991,
+      "line": 1765,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2101,7 +1917,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1996,
+      "line": 1770,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2109,7 +1925,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2009,
+      "line": 1783,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2117,7 +1933,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2018,
+      "line": 1792,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2125,7 +1941,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2024,
+      "line": 1798,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -2133,7 +1949,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2049,
+      "line": 1823,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2141,7 +1957,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2050,
+      "line": 1824,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2149,7 +1965,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2060,
+      "line": 1834,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2157,7 +1973,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2069,
+      "line": 1843,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2165,7 +1981,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2090,
+      "line": 1864,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2173,7 +1989,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2091,
+      "line": 1865,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2181,7 +1997,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2100,
+      "line": 1874,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2189,7 +2005,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2109,
+      "line": 1883,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_probe_invite_note_limit"
@@ -2197,7 +2013,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2115,
+      "line": 1889,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2205,7 +2021,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2138,
+      "line": 1912,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2213,7 +2029,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2139,
+      "line": 1913,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2221,7 +2037,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2145,
+      "line": 1919,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2229,7 +2045,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2154,
+      "line": 1928,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2237,7 +2053,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2172,
+      "line": 1946,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2245,7 +2061,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2173,
+      "line": 1947,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2253,7 +2069,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2182,
+      "line": 1956,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2261,7 +2077,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2200,
+      "line": 1974,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2269,7 +2085,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2205,
+      "line": 1979,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2277,7 +2093,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2214,
+      "line": 1988,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2285,7 +2101,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2225,
+      "line": 1999,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2293,7 +2109,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2245,
+      "line": 2019,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2301,7 +2117,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2250,
+      "line": 2024,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2309,7 +2125,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2256,
+      "line": 2030,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2317,7 +2133,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2262,
+      "line": 2036,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "click_button_by_text"
@@ -2325,7 +2141,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2287,
+      "line": 2061,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2333,7 +2149,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2297,
+      "line": 2071,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2341,7 +2157,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2303,
+      "line": 2077,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2349,7 +2165,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2309,
+      "line": 2083,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2357,7 +2173,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2334,
+      "line": 2108,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2365,7 +2181,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2339,
+      "line": 2113,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2373,7 +2189,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2349,
+      "line": 2123,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2381,7 +2197,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2355,
+      "line": 2129,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2389,7 +2205,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2371,
+      "line": 2145,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2397,7 +2213,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2372,
+      "line": 2146,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2405,7 +2221,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2379,
+      "line": 2153,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2413,7 +2229,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2382,
+      "line": 2156,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2421,7 +2237,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2392,
+      "line": 2166,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2429,7 +2245,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2465,
+      "line": 2239,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2437,7 +2253,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2468,
+      "line": 2242,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2445,7 +2261,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2479,
+      "line": 2253,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2453,23 +2269,23 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2492,
+      "line": 2266,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 2519,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 2294,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
+      "target": "_capture"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2525,
+      "line": 2299,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2477,7 +2293,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2551,
+      "line": 2325,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2485,23 +2301,23 @@
     {
       "canonical_owner": "person.PersonScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "string_patch",
-      "line": 2556,
+      "line": 2330,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics"
     },
     {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 2560,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 2335,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
+      "target": "_capture"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2566,
+      "line": 2340,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2509,23 +2325,23 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2596,
+      "line": 2370,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 2605,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 2380,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
+      "target": "_capture"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2611,
+      "line": 2385,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2533,7 +2349,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2634,
+      "line": 2408,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2541,7 +2357,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 2640,
+      "line": 2414,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -2549,7 +2365,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2646,
+      "line": 2420,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2557,23 +2373,23 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 2660,
+      "line": 2434,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 2669,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 2444,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
+      "target": "_capture"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2675,
+      "line": 2449,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2581,7 +2397,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 2691,
+      "line": 2465,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2589,7 +2405,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2697,
+      "line": 2471,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2597,7 +2413,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 2713,
+      "line": 2487,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2605,7 +2421,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2719,
+      "line": 2493,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2613,7 +2429,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 2734,
+      "line": 2508,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2621,7 +2437,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2740,
+      "line": 2514,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2629,7 +2445,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 2761,
+      "line": 2535,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2637,23 +2453,23 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2770,
+      "line": 2544,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 2810,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 2585,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 2816,
+      "line": 2590,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -2661,7 +2477,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 2820,
+      "line": 2594,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -2669,7 +2485,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 2824,
+      "line": 2598,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -2677,7 +2493,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2829,
+      "line": 2603,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2685,7 +2501,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 2850,
+      "line": 2624,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2693,7 +2509,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 2865,
+      "line": 2639,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2701,15 +2517,159 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
+      "line": 2654,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2700,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2706,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2712,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2718,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2731,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2740,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2746,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2752,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2782,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2787,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2793,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2799,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 2863,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_content"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2868,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2874,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
       "line": 2880,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "extract_page"
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 2885,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 2889,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2926,
+      "line": 2959,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -2717,7 +2677,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2932,
+      "line": 2965,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -2725,7 +2685,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2938,
+      "line": 2971,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -2733,7 +2693,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2944,
+      "line": 2977,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2741,7 +2701,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2957,
+      "line": 2996,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -2749,26 +2709,10 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2966,
+      "line": 3002,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 2972,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 2978,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -2776,12 +2720,28 @@
       "line": 3008,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3014,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3046,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3013,
+      "line": 3047,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -2789,7 +2749,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3019,
+      "line": 3053,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -2797,23 +2757,23 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3025,
+      "line": 3059,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 3088,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 3116,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3094,
+      "line": 3121,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -2821,7 +2781,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3100,
+      "line": 3127,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -2829,7 +2789,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 3106,
+      "line": 3133,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -2837,7 +2797,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 3111,
+      "line": 3138,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -2845,151 +2805,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 3115,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3185,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3191,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3197,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3203,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3222,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3228,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3234,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3240,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3272,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3273,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3279,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3285,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 3341,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3347,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3353,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 3359,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 3364,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 3368,
+      "line": 3142,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -2997,7 +2813,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3373,
+      "line": 3147,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3005,7 +2821,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3398,
+      "line": 3172,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3013,7 +2829,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3403,
+      "line": 3177,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3021,7 +2837,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3409,
+      "line": 3183,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3029,7 +2845,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3415,
+      "line": 3189,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3037,7 +2853,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 3439,
+      "line": 3213,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3045,7 +2861,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3455,
+      "line": 3229,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3053,7 +2869,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3464,
+      "line": 3238,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3061,7 +2877,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3470,
+      "line": 3244,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3069,7 +2885,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3476,
+      "line": 3250,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3077,7 +2893,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3517,
+      "line": 3291,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3085,7 +2901,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3518,
+      "line": 3292,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3093,7 +2909,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3524,
+      "line": 3298,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3101,7 +2917,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3530,
+      "line": 3304,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3109,7 +2925,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3556,
+      "line": 3330,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3117,7 +2933,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3565,
+      "line": 3339,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3125,7 +2941,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3571,
+      "line": 3345,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3133,7 +2949,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3577,
+      "line": 3351,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3141,7 +2957,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3604,
+      "line": 3378,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3149,7 +2965,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3615,
+      "line": 3389,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3157,7 +2973,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3621,
+      "line": 3395,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3165,7 +2981,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3627,
+      "line": 3401,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3173,7 +2989,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3650,
+      "line": 3424,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3181,7 +2997,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3661,
+      "line": 3435,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3189,7 +3005,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3667,
+      "line": 3441,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3197,7 +3013,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3673,
+      "line": 3447,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3205,7 +3021,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3705,
+      "line": 3479,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3213,7 +3029,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3710,
+      "line": 3484,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3221,7 +3037,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3716,
+      "line": 3490,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3229,7 +3045,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3722,
+      "line": 3496,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3237,7 +3053,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3746,
+      "line": 3520,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3245,7 +3061,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3755,
+      "line": 3529,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3253,7 +3069,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3761,
+      "line": 3535,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3261,7 +3077,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3767,
+      "line": 3541,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3269,7 +3085,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3825,
+      "line": 3599,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3277,7 +3093,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3826,
+      "line": 3600,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3285,7 +3101,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3832,
+      "line": 3606,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3293,7 +3109,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3838,
+      "line": 3612,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3301,7 +3117,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3872,
+      "line": 3646,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3309,7 +3125,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3878,
+      "line": 3652,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3317,7 +3133,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3884,
+      "line": 3658,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3325,7 +3141,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3890,
+      "line": 3664,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3333,7 +3149,7 @@
     {
       "canonical_owner": "facade.LinkedInExtractor._scroll_seconds",
       "kind": "private_facade_access",
-      "line": 3930,
+      "line": 3704,
       "migration_stage": 14,
       "path": "tests/test_scraping.py",
       "target": "_scroll_seconds"
@@ -3341,7 +3157,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 3941,
+      "line": 3715,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -3349,7 +3165,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3942,
+      "line": 3716,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3357,7 +3173,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3943,
+      "line": 3717,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3365,7 +3181,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3949,
+      "line": 3723,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3373,7 +3189,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3955,
+      "line": 3729,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3381,7 +3197,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 3999,
+      "line": 3773,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -3389,7 +3205,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4000,
+      "line": 3774,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3397,7 +3213,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4001,
+      "line": 3775,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3405,7 +3221,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4007,
+      "line": 3781,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3413,7 +3229,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4013,
+      "line": 3787,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3421,7 +3237,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 4063,
+      "line": 3837,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -3429,7 +3245,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4064,
+      "line": 3838,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3437,7 +3253,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4065,
+      "line": 3839,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3445,7 +3261,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4071,
+      "line": 3845,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3453,7 +3269,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4077,
+      "line": 3851,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3461,7 +3277,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
       "kind": "module_rebind_patch",
-      "line": 4123,
+      "line": 3897,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "time"
@@ -3469,7 +3285,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4124,
+      "line": 3898,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3477,10 +3293,194 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4125,
+      "line": 3899,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3905,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3911,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3928,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3934,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3940,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3946,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3960,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3966,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3972,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3978,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4006,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4014,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4020,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4026,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4042,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4047,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4053,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4059,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4081,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4090,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4096,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4102,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4120,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -3488,36 +3488,12 @@
       "line": 4131,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 4137,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4154,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4160,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4166,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3525,7 +3501,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4172,
+      "line": 4143,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3533,7 +3509,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4186,
+      "line": 4182,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3541,7 +3517,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4192,
+      "line": 4187,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3549,7 +3525,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4198,
+      "line": 4193,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3557,10 +3533,26 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4204,
+      "line": 4199,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4216,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4226,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -3568,188 +3560,12 @@
       "line": 4232,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4240,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4246,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4252,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4268,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4273,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4279,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4285,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4307,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4316,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4322,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4328,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4346,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4357,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4363,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4369,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4408,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4413,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4419,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4425,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4442,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4452,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4458,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4464,
+      "line": 4238,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3757,7 +3573,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 4485,
+      "line": 4259,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -3765,7 +3581,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 4489,
+      "line": 4263,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -3773,7 +3589,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "string_patch",
-      "line": 4494,
+      "line": 4268,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
@@ -3781,7 +3597,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 4500,
+      "line": 4274,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3789,7 +3605,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 4531,
+      "line": 4305,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -3797,90 +3613,242 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 4535,
+      "line": 4309,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 4314,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 4320,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4336,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4345,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4351,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4357,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4378,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4387,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4393,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4399,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4416,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4422,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4428,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4434,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4450,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4459,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4465,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4485,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4494,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4500,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 4536,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
       "line": 4540,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 4545,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 4550,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_content"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 4546,
+      "line": 4560,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_extract_saved_jobs_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4562,
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 4595,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4571,
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 4599,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4577,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4583,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
       "line": 4604,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4613,
+      "kind": "private_facade_access",
+      "line": 4614,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4619,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4625,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
+      "target": "_extract_saved_jobs_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -3888,7 +3856,7 @@
       "line": 4642,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_extract_saved_jobs_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -3904,7 +3872,7 @@
       "line": 4654,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_get_total_list_pages"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
@@ -3917,135 +3885,143 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4676,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4685,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4691,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4711,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4720,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4726,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 4762,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 4766,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 4771,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 4775,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 4784,
+      "line": 4682,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 4819,
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4688,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+      "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 4823,
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4694,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+      "target": "_get_total_list_pages"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4700,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4717,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4726,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4732,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4738,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4754,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4761,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4767,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4773,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4795,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4798,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4804,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4810,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 4828,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 4838,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4866,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4872,
+      "line": 4833,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4053,7 +4029,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4878,
+      "line": 4839,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4061,167 +4037,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4884,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4906,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4912,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4918,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4924,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4941,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4950,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4956,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4962,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4978,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4985,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4991,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4997,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5019,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5022,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5028,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5034,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5052,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5057,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5063,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5069,
+      "line": 4845,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4229,7 +4045,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5095,
+      "line": 4871,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4237,7 +4053,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5099,
+      "line": 4875,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4245,7 +4061,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 5144,
+      "line": 4920,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4253,7 +4069,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 5148,
+      "line": 4924,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4261,7 +4077,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 5153,
+      "line": 4929,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -4269,7 +4085,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5172,
+      "line": 4948,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4277,7 +4093,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5178,
+      "line": 4954,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4285,7 +4101,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5184,
+      "line": 4960,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4293,7 +4109,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5199,
+      "line": 4975,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4301,7 +4117,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5205,
+      "line": 4981,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4309,15 +4125,175 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
+      "line": 4987,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5008,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5017,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5023,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 5029,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5050,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5055,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5061,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 5067,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5090,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5096,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5102,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 5108,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5132,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5138,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5144,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 5150,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5170,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5176,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 5182,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 5188,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 5211,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5232,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4325,7 +4301,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5241,
+      "line": 5217,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4333,7 +4309,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5247,
+      "line": 5223,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4341,167 +4317,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5253,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5274,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5279,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5285,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5291,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5314,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5320,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5326,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5332,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5356,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5362,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5368,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5374,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5394,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5400,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5406,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5412,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5435,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5441,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 5447,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5453,
+      "line": 5229,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4509,7 +4325,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5485,
+      "line": 5261,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4517,7 +4333,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 5485,
+      "line": 5261,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4525,7 +4341,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5500,
+      "line": 5276,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4533,7 +4349,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5522,
+      "line": 5298,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4541,7 +4357,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5534,
+      "line": 5310,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4549,7 +4365,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5546,
+      "line": 5322,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4557,7 +4373,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5581,
+      "line": 5357,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4565,7 +4381,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 5593,
+      "line": 5369,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4573,7 +4389,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 5616,
+      "line": 5392,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4581,7 +4397,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 5634,
+      "line": 5410,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4589,7 +4405,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 5648,
+      "line": 5424,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4597,7 +4413,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 5669,
+      "line": 5445,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4605,7 +4421,7 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 5683,
+      "line": 5459,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4613,559 +4429,31 @@
     {
       "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 5696,
+      "line": 5472,
       "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 5730,
-      "migration_stage": 4,
+      "canonical_owner": "person.PersonScraper dependency",
+      "kind": "public_patch_object",
+      "line": 5501,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+      "target": "extract_page"
     },
     {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5734,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5738,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
+      "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
-      "line": 5744,
-      "migration_stage": 4,
+      "line": 5508,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 5771,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5775,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5779,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 5785,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 5810,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5814,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5818,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 5824,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 5843,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5847,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5851,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 5857,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 5880,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5884,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5888,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 5894,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 5917,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5921,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5925,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 5931,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 5953,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5957,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5961,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 5967,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6001,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6005,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6009,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+      "target": "_capture"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6014,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6019,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6050,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6054,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6058,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 6063,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6068,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6098,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6102,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6106,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6112,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6132,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6136,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6140,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6146,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6173,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6177,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6181,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6187,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6218,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6222,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6226,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6232,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6256,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6260,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6264,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6270,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6286,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6290,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6294,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6300,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 6320,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6324,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6328,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_facade_access",
-      "line": 6334,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_page_once"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 6354,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 6360,
-      "migration_stage": 4,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 6366,
+      "line": 5513,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5173,7 +4461,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6397,
+      "line": 5544,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5181,7 +4469,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6403,
+      "line": 5550,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5189,7 +4477,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6421,
+      "line": 5568,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5197,7 +4485,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6427,
+      "line": 5574,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5205,23 +4493,23 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6455,
+      "line": 5602,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
     },
     {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 6472,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 5620,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_loaded_section"
+      "target": "_capture"
     },
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6478,
+      "line": 5625,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5229,7 +4517,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6484,
+      "line": 5631,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5237,39 +4525,39 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6503,
+      "line": 5650,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 6509,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 5657,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_loaded_section"
+      "target": "_capture"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6514,
+      "line": 5661,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 6531,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "kind": "private_facade_access",
+      "line": 5679,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_loaded_section"
+      "target": "_capture"
     },
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 6537,
+      "line": 5684,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5277,7 +4565,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6543,
+      "line": 5690,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5285,7 +4573,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 6569,
+      "line": 5716,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5293,7 +4581,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6575,
+      "line": 5722,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5301,7 +4589,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6625,
+      "line": 5772,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5309,7 +4597,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6629,
+      "line": 5776,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5317,7 +4605,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6634,
+      "line": 5781,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5325,7 +4613,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6686,
+      "line": 5833,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5333,7 +4621,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6690,
+      "line": 5837,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5341,7 +4629,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6716,
+      "line": 5863,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5349,7 +4637,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6720,
+      "line": 5867,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5357,7 +4645,7 @@
     {
       "canonical_owner": "person.PersonScraper -> owner-local logger binding",
       "kind": "imported_module_patch",
-      "line": 6725,
+      "line": 5872,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "logger.debug"
@@ -5365,7 +4653,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6754,
+      "line": 5901,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5373,7 +4661,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6758,
+      "line": 5905,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5381,7 +4669,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6792,
+      "line": 5939,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5389,7 +4677,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6796,
+      "line": 5943,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5397,7 +4685,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 6801,
+      "line": 5948,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5405,7 +4693,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6821,
+      "line": 5968,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5413,7 +4701,7 @@
     {
       "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6825,
+      "line": 5972,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5421,7 +4709,7 @@
     {
       "canonical_owner": "message_sender.profile_urn_from_compose_url",
       "kind": "module_attribute",
-      "line": 6886,
+      "line": 6033,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_profile_urn_from_compose_url"
@@ -5429,7 +4717,7 @@
     {
       "canonical_owner": "message_sender.profile_path_from_url",
       "kind": "module_attribute",
-      "line": 6904,
+      "line": 6051,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_profile_path_from_url"
@@ -5437,7 +4725,7 @@
     {
       "canonical_owner": "message_sender.message_page_url_is_safe",
       "kind": "module_attribute",
-      "line": 6965,
+      "line": 6112,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_page_url_is_safe"
@@ -5445,7 +4733,7 @@
     {
       "canonical_owner": "message_sender.PROFILE_MESSAGE_TARGET_JS",
       "kind": "module_attribute",
-      "line": 6986,
+      "line": 6133,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_PROFILE_MESSAGE_TARGET_JS"
@@ -5453,7 +4741,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7033,
+      "line": 6180,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5461,7 +4749,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7039,
+      "line": 6186,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -5469,7 +4757,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7045,
+      "line": 6192,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5477,7 +4765,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 7058,
+      "line": 6205,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -5485,7 +4773,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7064,
+      "line": 6211,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_extract_profile_urn"
@@ -5493,7 +4781,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7070,
+      "line": 6217,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5501,7 +4789,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7090,
+      "line": 6237,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5509,7 +4797,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7094,
+      "line": 6241,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5517,7 +4805,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7098,
+      "line": 6245,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5525,23 +4813,23 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7103,
+      "line": 6250,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7108,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 6256,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7117,
+      "line": 6264,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5549,7 +4837,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7121,
+      "line": 6268,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5557,7 +4845,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7125,
+      "line": 6272,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5565,7 +4853,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7143,
+      "line": 6290,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5573,7 +4861,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7147,
+      "line": 6294,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5581,7 +4869,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7151,
+      "line": 6298,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5589,23 +4877,23 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7152,
+      "line": 6299,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7155,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 6303,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7161,
+      "line": 6308,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5613,7 +4901,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7165,
+      "line": 6312,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5621,7 +4909,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7195,
+      "line": 6342,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5629,7 +4917,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7199,
+      "line": 6346,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5637,7 +4925,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7203,
+      "line": 6350,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5645,23 +4933,23 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7204,
+      "line": 6351,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7207,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 6355,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7216,
+      "line": 6363,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5669,7 +4957,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7220,
+      "line": 6367,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5677,7 +4965,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7224,
+      "line": 6371,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5685,7 +4973,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7248,
+      "line": 6395,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5693,7 +4981,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7252,
+      "line": 6399,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5701,7 +4989,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7256,
+      "line": 6403,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5709,23 +4997,23 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7257,
+      "line": 6404,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7260,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 6408,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7266,
+      "line": 6413,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5733,7 +5021,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7270,
+      "line": 6417,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5741,7 +5029,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7294,
+      "line": 6441,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5749,7 +5037,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7298,
+      "line": 6445,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5757,7 +5045,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7302,
+      "line": 6449,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5765,23 +5053,23 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7303,
+      "line": 6450,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7306,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 6454,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7312,
+      "line": 6459,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5789,7 +5077,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7334,
+      "line": 6481,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5797,7 +5085,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7338,
+      "line": 6485,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5805,7 +5093,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7342,
+      "line": 6489,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5813,7 +5101,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7343,
+      "line": 6490,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -5821,7 +5109,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7346,
+      "line": 6493,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_display_name"
@@ -5829,23 +5117,23 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7352,
+      "line": 6499,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7361,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 6509,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7367,
+      "line": 6514,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5853,7 +5141,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7371,
+      "line": 6518,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5861,7 +5149,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7392,
+      "line": 6539,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5869,7 +5157,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7396,
+      "line": 6543,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5877,7 +5165,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7400,
+      "line": 6547,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5885,7 +5173,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7401,
+      "line": 6548,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -5893,7 +5181,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7404,
+      "line": 6551,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_display_name"
@@ -5901,23 +5189,23 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7410,
+      "line": 6557,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7419,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 6567,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7425,
+      "line": 6572,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5925,7 +5213,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7429,
+      "line": 6576,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5933,7 +5221,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7449,
+      "line": 6596,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5941,7 +5229,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7453,
+      "line": 6600,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5949,7 +5237,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7457,
+      "line": 6604,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_display_name"
@@ -5957,7 +5245,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7463,
+      "line": 6610,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -5965,7 +5253,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7481,
+      "line": 6628,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5973,7 +5261,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7485,
+      "line": 6632,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5981,7 +5269,7 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 7489,
+      "line": 6636,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_display_name"
@@ -5989,7 +5277,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7495,
+      "line": 6642,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -5997,7 +5285,7 @@
     {
       "canonical_owner": "conversations.strip_select_conversation_prefix",
       "kind": "private_facade_access",
-      "line": 7512,
+      "line": 6659,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_strip_select_conversation_prefix"
@@ -6005,7 +5293,7 @@
     {
       "canonical_owner": "conversations.strip_select_conversation_prefix",
       "kind": "private_facade_access",
-      "line": 7520,
+      "line": 6667,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_strip_select_conversation_prefix"
@@ -6013,7 +5301,7 @@
     {
       "canonical_owner": "conversations.strip_select_conversation_prefix",
       "kind": "private_facade_access",
-      "line": 7530,
+      "line": 6677,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_strip_select_conversation_prefix"
@@ -6021,7 +5309,7 @@
     {
       "canonical_owner": "conversations.strip_select_conversation_prefix",
       "kind": "private_facade_access",
-      "line": 7537,
+      "line": 6684,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_strip_select_conversation_prefix"
@@ -6029,7 +5317,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7568,
+      "line": 6715,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6037,7 +5325,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7572,
+      "line": 6719,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6045,7 +5333,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7576,
+      "line": 6723,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6053,7 +5341,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7577,
+      "line": 6724,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -6061,7 +5349,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7580,
+      "line": 6727,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -6069,7 +5357,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_facade_access",
-      "line": 7587,
+      "line": 6734,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -6077,7 +5365,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7611,
+      "line": 6758,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6085,7 +5373,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7615,
+      "line": 6762,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6093,7 +5381,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7619,
+      "line": 6766,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6101,7 +5389,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7620,
+      "line": 6767,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -6109,7 +5397,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7623,
+      "line": 6770,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -6117,7 +5405,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_facade_access",
-      "line": 7625,
+      "line": 6772,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -6125,7 +5413,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7653,
+      "line": 6800,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6133,7 +5421,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7657,
+      "line": 6804,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6141,7 +5429,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7661,
+      "line": 6808,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -6149,7 +5437,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7662,
+      "line": 6809,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -6157,7 +5445,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7665,
+      "line": 6812,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -6165,7 +5453,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_facade_access",
-      "line": 7667,
+      "line": 6814,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -6173,7 +5461,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_facade_access",
-      "line": 7691,
+      "line": 6838,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -6181,7 +5469,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7706,
+      "line": 6853,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6189,7 +5477,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7710,
+      "line": 6857,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6197,23 +5485,23 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7714,
+      "line": 6861,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7715,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 6863,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7721,
+      "line": 6868,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -6221,7 +5509,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7725,
+      "line": 6872,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -6229,7 +5517,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7729,
+      "line": 6876,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -6237,7 +5525,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7766,
+      "line": 6913,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6245,7 +5533,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 7770,
+      "line": 6917,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -6253,23 +5541,23 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7774,
+      "line": 6921,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
     },
     {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 7775,
-      "migration_stage": 4,
+      "canonical_owner": "facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 6923,
+      "migration_stage": 14,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_content"
     },
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 7781,
+      "line": 6928,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -6277,7 +5565,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 7785,
+      "line": 6932,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -6285,7 +5573,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 7789,
+      "line": 6936,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -6293,7 +5581,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7876,
+      "line": 7023,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6301,7 +5589,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7880,
+      "line": 7027,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -6309,7 +5597,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 7884,
+      "line": 7031,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -6317,7 +5605,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7888,
+      "line": 7035,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_message_surface"
@@ -6325,7 +5613,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7891,
+      "line": 7038,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_message_composer_state"
@@ -6333,7 +5621,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7894,
+      "line": 7041,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_focus_verified_message_editor"
@@ -6341,7 +5629,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7899,
+      "line": 7046,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -6349,7 +5637,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7931,
+      "line": 7078,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6357,7 +5645,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7935,
+      "line": 7082,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -6365,7 +5653,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 7939,
+      "line": 7086,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -6373,7 +5661,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTarget",
       "kind": "module_attribute",
-      "line": 7952,
+      "line": 7099,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTarget"
@@ -6381,7 +5669,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8003,
+      "line": 7150,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6389,7 +5677,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8007,
+      "line": 7154,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -6397,7 +5685,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8011,
+      "line": 7158,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -6405,7 +5693,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8015,
+      "line": 7162,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_message_surface"
@@ -6413,7 +5701,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8021,
+      "line": 7168,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_message_composer_state"
@@ -6421,7 +5709,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8034,
+      "line": 7181,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_write_verified_message"
@@ -6429,7 +5717,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8040,
+      "line": 7187,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -6437,7 +5725,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 8046,
+      "line": 7193,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6445,7 +5733,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8050,
+      "line": 7197,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -6453,7 +5741,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8056,
+      "line": 7203,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6461,7 +5749,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 8094,
+      "line": 7241,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -6469,7 +5757,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8098,
+      "line": 7245,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -6477,7 +5765,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 8102,
+      "line": 7249,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -6485,7 +5773,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8283,
+      "line": 7430,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -6493,7 +5781,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8429,
+      "line": 7576,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -6501,7 +5789,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8435,
+      "line": 7582,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6509,7 +5797,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8508,
+      "line": 7655,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_verified_submit"
@@ -6517,7 +5805,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8514,
+      "line": 7661,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_cleanup_owned_message"
@@ -6525,7 +5813,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8614,
+      "line": 7761,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_write_verified_message"
@@ -6533,7 +5821,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8620,
+      "line": 7767,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -6541,7 +5829,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8627,
+      "line": 7774,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -6549,7 +5837,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8633,
+      "line": 7780,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6557,7 +5845,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8668,
+      "line": 7815,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6565,7 +5853,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8793,
+      "line": 7940,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_confirmation"
@@ -6573,7 +5861,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8799,
+      "line": 7946,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_owner"
@@ -6581,7 +5869,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8850,
+      "line": 7997,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -6589,7 +5877,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8856,
+      "line": 8003,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6597,7 +5885,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8888,
+      "line": 8035,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_compose_box"
@@ -6605,7 +5893,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_COMPOSE_SELECTOR",
       "kind": "module_attribute",
-      "line": 8891,
+      "line": 8038,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGING_COMPOSE_SELECTOR"
@@ -6613,7 +5901,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8913,
+      "line": 8060,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -6621,7 +5909,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8938,
+      "line": 8085,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -6629,7 +5917,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8950,
+      "line": 8097,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_owner"
@@ -6637,7 +5925,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8960,
+      "line": 8107,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -6645,7 +5933,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8982,
+      "line": 8129,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -6653,7 +5941,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8994,
+      "line": 8141,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6661,7 +5949,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9027,
+      "line": 8174,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6669,7 +5957,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 9041,
+      "line": 8188,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_confirmation"
@@ -6677,7 +5965,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9077,
+      "line": 8224,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -6685,7 +5973,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9091,
+      "line": 8238,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -6693,7 +5981,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9115,
+      "line": 8262,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -6701,7 +5989,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9140,
+      "line": 8287,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -6709,7 +5997,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9159,
+      "line": 8306,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -6717,7 +6005,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9179,
+      "line": 8326,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -6725,7 +6013,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9224,
+      "line": 8371,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -6733,7 +6021,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9285,
+      "line": 8432,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -6741,7 +6029,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9323,
+      "line": 8470,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -6749,7 +6037,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "module_attribute",
-      "line": 9358,
+      "line": 8505,
       "migration_stage": 5,
       "path": "tests/test_scraping.py",
       "target": "_drain_listener_tasks"
@@ -6757,7 +6045,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 9403,
+      "line": 8550,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6765,7 +6053,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 9410,
+      "line": 8557,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -6773,7 +6061,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 9425,
+      "line": 8572,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6781,7 +6069,7 @@
     {
       "canonical_owner": "person.PersonScraper dependency",
       "kind": "public_patch_object",
-      "line": 9445,
+      "line": 8592,
       "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6789,7 +6077,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 9445,
+      "line": 8592,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6797,7 +6085,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 9445,
+      "line": 8592,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6805,7 +6093,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 9445,
+      "line": 8592,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6813,7 +6101,7 @@
     {
       "canonical_owner": "conversations.ConversationReader dependency",
       "kind": "public_patch_object",
-      "line": 9445,
+      "line": 8592,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6821,7 +6109,7 @@
     {
       "canonical_owner": "message_sender.MessageSender dependency",
       "kind": "public_patch_object",
-      "line": 9445,
+      "line": 8592,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -6829,7 +6117,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 9462,
+      "line": 8609,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -6837,7 +6125,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 9468,
+      "line": 8615,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"

--- a/tests/fixtures/scraping-policy/migration-manifest.json
+++ b/tests/fixtures/scraping-policy/migration-manifest.json
@@ -181,7 +181,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "boundary_patch_object",
-      "line": 192,
+      "line": 193,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_job_sidebar"
@@ -189,7 +189,7 @@
     {
       "canonical_owner": "feed.FeedScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 194,
+      "line": 195,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -197,7 +197,7 @@
     {
       "canonical_owner": "person.PersonScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 194,
+      "line": 195,
       "migration_stage": 6,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -205,7 +205,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 194,
+      "line": 195,
       "migration_stage": 8,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -213,7 +213,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 194,
+      "line": 195,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -221,7 +221,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 194,
+      "line": 195,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -229,7 +229,7 @@
     {
       "canonical_owner": "feed.FeedScraper",
       "kind": "private_patch_object",
-      "line": 195,
+      "line": 196,
       "migration_stage": 5,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "_drain_listener_tasks"
@@ -1187,10 +1187,18 @@
       "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 631,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 632,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -1395,10 +1403,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 922,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 923,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -1419,10 +1435,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 949,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 950,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -1443,10 +1467,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 984,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 985,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -1475,10 +1507,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1030,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1031,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -1531,10 +1571,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1110,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1111,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -1555,10 +1603,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1154,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1155,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -1579,10 +1635,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1196,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1197,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -1603,10 +1667,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1222,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1223,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -1627,10 +1699,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1248,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1249,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -1651,10 +1731,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1274,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1275,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -1675,10 +1763,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 1300,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1301,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -2275,10 +2371,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 2293,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 2294,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -2307,10 +2411,18 @@
       "target": "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 2334,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 2335,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -2331,10 +2443,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 2379,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 2380,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -2379,10 +2499,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 2443,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 2444,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -2459,10 +2587,18 @@
       "target": "asyncio.sleep"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 2584,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 2585,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -2619,10 +2755,18 @@
       "target": "asyncio.sleep"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 2862,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 2863,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -2763,10 +2907,18 @@
       "target": "asyncio.sleep"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 3115,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 3116,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -3803,10 +3955,18 @@
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 4549,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 4550,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -4443,10 +4603,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 5507,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_overlay"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 5508,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -4499,10 +4667,18 @@
       "target": "scrape_person"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 5619,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_loaded_section"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 5620,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -4531,10 +4707,18 @@
       "target": "extract_page"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 5656,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_loaded_section"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 5657,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -4547,10 +4731,18 @@
       "target": "asyncio.sleep"
     },
     {
+      "canonical_owner": "capture.SectionCapture",
+      "kind": "private_patch_object",
+      "line": 5678,
+      "migration_stage": 6,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_loaded_section"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 5679,
-      "migration_stage": 14,
+      "migration_stage": 6,
       "path": "tests/test_scraping.py",
       "target": "_capture"
     },
@@ -4819,10 +5011,18 @@
       "target": "_scroll_main_scrollable_region"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 6255,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6256,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -4883,10 +5083,18 @@
       "target": "_scroll_main_scrollable_region"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 6302,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6303,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -4939,10 +5147,18 @@
       "target": "_scroll_main_scrollable_region"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 6354,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6355,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -5003,10 +5219,18 @@
       "target": "_scroll_main_scrollable_region"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 6407,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6408,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -5059,10 +5283,18 @@
       "target": "_scroll_main_scrollable_region"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 6453,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6454,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -5123,10 +5355,18 @@
       "target": "_resolve_conversation_thread_urls"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 6508,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6509,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -5195,10 +5435,18 @@
       "target": "_resolve_conversation_thread_urls"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 6566,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6567,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -5491,10 +5739,18 @@
       "target": "_wait_for_main_text"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 6862,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6863,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -5547,10 +5803,18 @@
       "target": "_wait_for_main_text"
     },
     {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 6922,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
       "canonical_owner": "facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6923,
-      "migration_stage": 14,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },

--- a/tests/scraping/policy_scenarios.py
+++ b/tests/scraping/policy_scenarios.py
@@ -22,6 +22,7 @@ from patchright.async_api import Page
 from patchright.async_api import TimeoutError as PlaywrightTimeoutError
 
 from linkedin_mcp_server.callbacks import ProgressCallback
+from linkedin_mcp_server.scraping import capture as capture_module
 from linkedin_mcp_server.scraping import extractor as extractor_module
 from linkedin_mcp_server.scraping import navigation as navigation_module
 from linkedin_mcp_server.scraping import session as session_module
@@ -177,10 +178,19 @@ async def boundaries(
         patch.object(navigation_module, "detect_auth_barrier", auth),
         patch.object(navigation_module, "resolve_remember_me_prompt", remember),
         patch.object(navigation_module, "stabilize_navigation", stabilize),
+        # Both bindings of each shared boundary, because the workflows that
+        # reach it are split across the modules mid-relocation: generic capture
+        # goes through `ScrapingSession`, while the job, conversation and
+        # messaging workflows still call the imported helper on the facade.
+        # Patching one side only lets the real helper loose on a scripted page.
+        patch.object(session_module, "detect_rate_limit", rate_limit),
         patch.object(extractor_module, "detect_rate_limit", rate_limit),
+        patch.object(session_module, "handle_modal_close", modal),
         patch.object(extractor_module, "handle_modal_close", modal),
+        patch.object(session_module, "scroll_to_bottom", scroll_body),
         patch.object(extractor_module, "scroll_to_bottom", scroll_body),
         patch.object(extractor_module, "scroll_job_sidebar", scroll_sidebar),
+        patch.object(capture_module, "build_issue_diagnostics", diagnostics),
         patch.object(extractor_module, "build_issue_diagnostics", diagnostics),
         patch.object(extractor_module, "_drain_listener_tasks", drain),
         patch.object(session_module.asyncio, "sleep", clock.sleep),

--- a/tests/scraping/policy_scenarios.py
+++ b/tests/scraping/policy_scenarios.py
@@ -189,6 +189,7 @@ async def boundaries(
         patch.object(extractor_module, "handle_modal_close", modal),
         patch.object(session_module, "scroll_to_bottom", scroll_body),
         patch.object(extractor_module, "scroll_to_bottom", scroll_body),
+        patch.object(session_module, "scroll_job_sidebar", scroll_sidebar),
         patch.object(extractor_module, "scroll_job_sidebar", scroll_sidebar),
         patch.object(capture_module, "build_issue_diagnostics", diagnostics),
         patch.object(extractor_module, "build_issue_diagnostics", diagnostics),

--- a/tests/scraping/test_capture.py
+++ b/tests/scraping/test_capture.py
@@ -1,0 +1,986 @@
+"""Tests for the generic page and overlay capture owner."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from linkedin_mcp_server.core.exceptions import AuthenticationError
+from linkedin_mcp_server.scraping.capture import (
+    RATE_LIMIT_RETRY_DELAY,
+    SectionCapture,
+)
+from linkedin_mcp_server.scraping.content import PageContentReader
+from linkedin_mcp_server.scraping.contracts import RATE_LIMITED_SECTION_TEXT
+from linkedin_mcp_server.scraping.navigation import PageNavigator
+from linkedin_mcp_server.scraping.session import ScrapingSession
+
+
+def _capture(page) -> SectionCapture:
+    """Wire the capture owner the way the facade does."""
+    session = ScrapingSession(page)
+    return SectionCapture(session, PageNavigator(session), PageContentReader(session))
+
+
+class TestExtractPage:
+    async def test_extract_page_returns_text(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Sample profile text",
+                "references": [],
+            }
+        )
+        capture = _capture(mock_page)
+        # Patch scroll_to_bottom and detect_rate_limit to avoid complex mock chains
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await capture.extract_page(
+                "https://www.linkedin.com/in/testuser/",
+                section_name="main_profile",
+            )
+
+        assert result.text == "Sample profile text"
+        assert result.references == []
+        mock_page.goto.assert_awaited_once()
+
+    async def test_extract_page_returns_empty_on_failure(self, mock_page):
+        mock_page.goto = AsyncMock(side_effect=Exception("Network error"))
+        capture = _capture(mock_page)
+
+        with patch(
+            "linkedin_mcp_server.scraping.capture.build_issue_diagnostics",
+            return_value={"issue_template_path": "/tmp/issue.md"},
+        ):
+            result = await capture.extract_page(
+                "https://www.linkedin.com/in/bad/",
+                section_name="main_profile",
+            )
+        assert result.text == ""
+        assert result.references == []
+        assert result.error == {"issue_template_path": "/tmp/issue.md"}
+
+    async def test_extract_page_raises_auth_error_for_account_picker(self, mock_page):
+        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_TOO_MANY_REDIRECTS"))
+        capture = _capture(mock_page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
+                new_callable=AsyncMock,
+                return_value="auth barrier text: welcome back + sign in using another account",
+            ),
+            pytest.raises(AuthenticationError, match="--login"),
+        ):
+            await capture.extract_page(
+                "https://www.linkedin.com/in/testuser/",
+                section_name="main_profile",
+            )
+
+    async def test_rate_limit_detected(self, mock_page):
+        from linkedin_mcp_server.core.exceptions import RateLimitError
+
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+                side_effect=RateLimitError("Rate limited", suggested_wait_time=3600),
+            ),
+            pytest.raises(RateLimitError),
+        ):
+            await capture.extract_page(
+                "https://www.linkedin.com/in/testuser/",
+                section_name="main_profile",
+            )
+
+    async def test_returns_rate_limited_msg_after_retry(self, mock_page):
+        """When both attempts return only noise, surface rate limit message."""
+        noise_only = (
+            "More profiles for you\n\n"
+            "You've approached your profile search limit\n\n"
+            "About\nAccessibility\nTalent Solutions"
+        )
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": noise_only, "references": []}
+        )
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await capture.extract_page(
+                "https://www.linkedin.com/in/testuser/details/experience/",
+                section_name="experience",
+            )
+
+        assert result.text == RATE_LIMITED_SECTION_TEXT
+        # goto called twice (initial + retry)
+        assert mock_page.goto.await_count == 2
+
+    async def test_retry_succeeds_after_rate_limit(self, mock_page):
+        """When first attempt is rate-limited but retry succeeds, return content."""
+        noise_only = "More profiles for you\n\nAbout\nAccessibility\nTalent Solutions"
+        call_count = 0
+
+        async def evaluate_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                return noise_only
+            return "Education\nHarvard University\n1973 – 1975"
+
+        async def root_content_side_effect(*args, **kwargs):
+            return {
+                "source": "root",
+                "text": await evaluate_side_effect(),
+                "references": [],
+            }
+
+        mock_page.evaluate = AsyncMock(side_effect=root_content_side_effect)
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await capture.extract_page(
+                "https://www.linkedin.com/in/testuser/details/education/",
+                section_name="education",
+            )
+
+        assert result.text == "Education\nHarvard University\n1973 – 1975"
+
+    async def test_media_only_controls_are_not_misclassified_as_rate_limited(
+        self, mock_page
+    ):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Play\nLoaded: 100.00%\nRemaining time 0:07\nShow captions",
+                "references": [],
+            }
+        )
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await capture._extract_page_once(
+                "https://www.linkedin.com/in/testuser/recent-activity/all/",
+                section_name="posts",
+            )
+
+        assert result.text == ""
+        assert result.references == []
+
+
+class TestActivityFeedExtraction:
+    """Tests for activity page detection and wait behavior in _extract_page_once."""
+
+    async def test_activity_page_waits_for_content_and_uses_slow_scroll(
+        self, mock_page
+    ):
+        """Activity URLs should call wait_for_function and use slower scroll params."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Post content " * 50,
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/recent-activity/all/",
+                section_name="posts",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        mock_scroll.assert_awaited_once()
+        _, kwargs = mock_scroll.call_args
+        assert kwargs["pause_time"] == 1.0
+        assert kwargs["max_scrolls"] == 10
+        assert len(result.text) > 200
+
+    async def test_company_posts_page_waits_for_content_and_uses_slow_scroll(
+        self, mock_page
+    ):
+        """Company posts URLs get the same lazy-load wait and scroll budget
+        as person activity pages, even though they lack /recent-activity/."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Post content " * 50,
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await capture._extract_page_once(
+                "https://www.linkedin.com/company/microsoft/posts/",
+                section_name="posts",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        mock_scroll.assert_awaited_once()
+        _, kwargs = mock_scroll.call_args
+        assert kwargs["pause_time"] == 1.0
+        assert kwargs["max_scrolls"] == 10
+        assert len(result.text) > 200
+
+    async def test_company_posts_page_with_query_string_still_waits(self, mock_page):
+        """The lazy-load branch keys off the parsed path, so a company posts
+        url carrying a query string is not mistaken for a static page."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Post content " * 50,
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/company/microsoft/posts/?viewAsMember=true",
+                section_name="posts",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        _, kwargs = mock_scroll.call_args
+        assert kwargs["max_scrolls"] == 10
+
+    async def test_non_activity_non_details_page_skips_wait_and_uses_fast_scroll(
+        self, mock_page
+    ):
+        """Plain profile URLs (not activity, search, or details) skip wait_for_function."""
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": "Profile text", "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock()
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/",
+                section_name="main_profile",
+            )
+
+        mock_page.wait_for_function.assert_not_awaited()
+        mock_scroll.assert_awaited_once()
+        _, kwargs = mock_scroll.call_args
+        assert kwargs["pause_time"] == 0.5
+        assert kwargs["max_scrolls"] == 5
+
+    async def test_details_page_waits_for_panel_content(self, mock_page):
+        """Detail pages (/details/experience/ etc.) call wait_for_function to wait for the panel."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Experience\nSoftware Engineer",
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/details/experience/",
+                section_name="experience",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        mock_scroll.assert_awaited_once()
+        _, kwargs = mock_scroll.call_args
+        assert kwargs["pause_time"] == 0.5
+        assert kwargs["max_scrolls"] == 5
+
+    async def test_max_scrolls_override_passed_to_scroll_to_bottom(self, mock_page):
+        """Custom max_scrolls on a detail page overrides the default of 5."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Experience\nSoftware Engineer",
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/details/certifications/",
+                section_name="certifications",
+                max_scrolls=20,
+            )
+
+        mock_scroll.assert_awaited_once()
+        _, kwargs = mock_scroll.call_args
+        assert kwargs["max_scrolls"] == 20
+
+    async def test_default_scrolls_without_max_scrolls_override(self, mock_page):
+        """Without max_scrolls, detail pages use the default of 5."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Experience\nSoftware Engineer",
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/details/certifications/",
+                section_name="certifications",
+            )
+
+        mock_scroll.assert_awaited_once()
+        _, kwargs = mock_scroll.call_args
+        assert kwargs["max_scrolls"] == 5
+
+    async def test_details_page_clicks_show_more_until_gone(self, mock_page):
+        """Detail pages click 'Show more' in a loop until the button disappears."""
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": "text", "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock()
+
+        show_more = MagicMock()
+        # count() returns 1, 1, 0 across iterations — button disappears on 3rd check
+        show_more.count = AsyncMock(side_effect=[1, 1, 0])
+        show_more.is_visible = AsyncMock(return_value=True)
+        show_more.scroll_into_view_if_needed = AsyncMock()
+        show_more.click = AsyncMock()
+        show_more.first = show_more
+        show_more.filter = MagicMock(return_value=show_more)
+
+        def locator_side_effect(selector):
+            if selector == "main button":
+                return show_more
+            return MagicMock(count=AsyncMock(return_value=0))
+
+        mock_page.locator = MagicMock(side_effect=locator_side_effect)
+        capture = _capture(mock_page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/details/certifications/",
+                section_name="certifications",
+            )
+
+        assert show_more.click.await_count == 2
+
+    async def test_details_page_show_more_respects_max_scrolls_budget(self, mock_page):
+        """When 'Show more' never disappears, loop exits after max_scrolls clicks."""
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": "text", "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock()
+
+        show_more = MagicMock()
+        show_more.count = AsyncMock(return_value=1)  # always present
+        show_more.is_visible = AsyncMock(return_value=True)
+        show_more.scroll_into_view_if_needed = AsyncMock()
+        show_more.click = AsyncMock()
+        show_more.first = show_more
+        show_more.filter = MagicMock(return_value=show_more)
+
+        def locator_side_effect(selector):
+            if selector == "main button":
+                return show_more
+            return MagicMock(count=AsyncMock(return_value=0))
+
+        mock_page.locator = MagicMock(side_effect=locator_side_effect)
+        capture = _capture(mock_page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/details/experience/",
+                section_name="experience",
+                max_scrolls=3,
+            )
+
+        assert show_more.click.await_count == 3
+
+    async def test_non_details_page_does_not_click_show_more(self, mock_page):
+        """Non-details URLs (main profile, activity) skip the Show more loop."""
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": "text", "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock()
+
+        show_more = MagicMock()
+        show_more.count = AsyncMock(return_value=1)
+        show_more.click = AsyncMock()
+        show_more.first = show_more
+        show_more.filter = MagicMock(return_value=show_more)
+
+        def locator_side_effect(selector):
+            if selector == "main button":
+                return show_more
+            return MagicMock(count=AsyncMock(return_value=0))
+
+        mock_page.locator = MagicMock(side_effect=locator_side_effect)
+        capture = _capture(mock_page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/",
+                section_name="main_profile",
+            )
+
+        show_more.click.assert_not_awaited()
+
+    async def test_activity_page_timeout_proceeds_gracefully(self, mock_page):
+        """When activity feed content never loads, extraction proceeds with available text."""
+        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        tab_headers = "All activity\nPosts\nComments\nVideos\nImages"
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": tab_headers, "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("Timeout")
+        )
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/recent-activity/all/",
+                section_name="posts",
+            )
+
+        # Should return whatever text is available, not crash
+        assert result.text == tab_headers
+
+
+class TestCompanyPeopleExtraction:
+    """Tests for /company/<slug>/people/ hydration wait in _extract_page_once."""
+
+    async def test_waits_for_listing_with_5s_timeout(self, mock_page):
+        """Company /people/ pages call wait_for_function so the employee
+        listing has hydrated before scroll/extract. Empty/restricted listings
+        are common, so the timeout is 5s rather than the 10s pattern shared
+        with is_search/is_details."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Anthropic\nFollowing\nHome\nAbout\nPeople",
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/company/anthropicresearch/people/",
+                section_name="employees",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        wait_predicate = mock_page.wait_for_function.call_args[0][0]
+        wait_kwargs = mock_page.wait_for_function.call_args.kwargs
+        assert "/in/" in wait_predicate
+        assert "querySelectorAll" in wait_predicate
+        assert wait_kwargs["timeout"] == 5000
+        mock_scroll.assert_awaited_once()
+
+    async def test_continues_extraction_on_wait_timeout(self, mock_page):
+        """When the hydration wait times out (genuinely empty listing), the
+        extractor swallows PlaywrightTimeoutError and still scrolls + extracts
+        rather than propagating the error to the caller."""
+        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Empty company page",
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("Timeout")
+        )
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await capture._extract_page_once(
+                "https://www.linkedin.com/company/anthropicresearch/people/",
+                section_name="employees",
+            )
+
+        mock_scroll.assert_awaited_once()
+        assert result.text  # non-empty placeholder text from the mock
+
+
+class TestSearchResultsExtraction:
+    """Tests for search results page detection and wait behavior in _extract_page_once."""
+
+    async def test_search_results_page_waits_for_content(self, mock_page):
+        """Search results URLs should call wait_for_function to wait for content."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Search results for John Doe. " * 10,
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await capture._extract_page_once(
+                "https://www.linkedin.com/search/results/people/?keywords=John+Doe",
+                section_name="search_results",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        assert len(result.text) > 100
+
+    async def test_non_search_page_does_not_wait_for_search_content(self, mock_page):
+        """Non-search URLs should not trigger the search results wait."""
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": "Profile text", "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock()
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/",
+                section_name="main_profile",
+            )
+
+        mock_page.wait_for_function.assert_not_awaited()
+
+    async def test_search_results_timeout_proceeds_gracefully(self, mock_page):
+        """When search results never load, extraction proceeds with available text."""
+        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        placeholder = "Search results for John Doe. No results found"
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": placeholder, "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("Timeout")
+        )
+        capture = _capture(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await capture._extract_page_once(
+                "https://www.linkedin.com/search/results/people/?keywords=John+Doe",
+                section_name="search_results",
+            )
+
+        assert result.text == placeholder
+
+
+class TestExtractOverlay:
+    """Tests for the dialog read behind /overlay/contact-info/."""
+
+    OVERLAY_URL = "https://www.linkedin.com/in/testuser/overlay/contact-info/"
+    NOISE_ONLY = (
+        "More profiles for you\n\n"
+        "You've approached your profile search limit\n\n"
+        "About\nAccessibility\nTalent Solutions"
+    )
+
+    async def test_the_dialog_is_read_before_main_and_never_dismissed(self, mock_page):
+        """The contact-info overlay *is* the modal.
+
+        Dismissing it would destroy the content before the read, and the
+        fallback to ``main`` only applies once no dialog matched.
+        """
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Email\nada@example.com",
+                "references": [],
+            }
+        )
+        capture = _capture(mock_page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as modal,
+        ):
+            result = await capture._extract_overlay(
+                self.OVERLAY_URL, section_name="contact_info"
+            )
+
+        assert result.text == "Email\nada@example.com"
+        modal.assert_not_awaited()
+        mock_page.wait_for_selector.assert_awaited_once_with(
+            "dialog[open], .artdeco-modal__content"
+        )
+        await_args = mock_page.evaluate.await_args
+        assert await_args is not None
+        assert await_args.args[1] == {
+            "selectors": ["dialog[open]", ".artdeco-modal__content", "main"]
+        }
+
+    async def test_a_noise_only_overlay_is_read_again_after_the_backoff(
+        self, mock_page
+    ):
+        reads = [
+            {"source": "root", "text": self.NOISE_ONLY, "references": []},
+            {"source": "root", "text": "Email\nada@example.com", "references": []},
+        ]
+
+        async def read_or_pass_through(script, *args, **kwargs):
+            # Keyed on the program rather than on the call count: the
+            # navigation lifecycle evaluates scripts of its own, and a bare
+            # sequence would hand one of those the overlay's second read.
+            if "MAX_REFERENCE_ANCHORS" not in script:
+                return None
+            return reads.pop(0)
+
+        mock_page.evaluate = AsyncMock(side_effect=read_or_pass_through)
+        capture = _capture(mock_page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as sleep,
+        ):
+            result = await capture._extract_overlay(
+                self.OVERLAY_URL, section_name="contact_info"
+            )
+
+        assert result.text == "Email\nada@example.com"
+        assert mock_page.goto.await_count == 2
+        sleep.assert_awaited_once_with(RATE_LIMIT_RETRY_DELAY)
+
+    async def test_a_noise_only_retry_reports_the_rate_limit_sentinel(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": self.NOISE_ONLY, "references": []}
+        )
+        capture = _capture(mock_page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await capture._extract_overlay(
+                self.OVERLAY_URL, section_name="contact_info"
+            )
+
+        assert result.text == RATE_LIMITED_SECTION_TEXT
+        assert mock_page.goto.await_count == 2
+
+    async def test_an_overlay_failure_is_isolated_into_a_section_error(self, mock_page):
+        mock_page.goto = AsyncMock(side_effect=Exception("Network error"))
+        capture = _capture(mock_page)
+
+        with patch(
+            "linkedin_mcp_server.scraping.capture.build_issue_diagnostics",
+            return_value={"issue_template_path": "/tmp/issue.md"},
+        ) as diagnostics:
+            result = await capture._extract_overlay(
+                self.OVERLAY_URL, section_name="contact_info"
+            )
+
+        assert result.text == ""
+        assert result.error == {"issue_template_path": "/tmp/issue.md"}
+        assert diagnostics.call_args.kwargs["context"] == "extract_overlay"

--- a/tests/scraping/test_capture.py
+++ b/tests/scraping/test_capture.py
@@ -592,6 +592,62 @@ class TestActivityFeedExtraction:
 
         assert show_more.click.await_count == 3
 
+    async def test_details_page_show_more_default_ceiling_is_five_clicks(
+        self, mock_page
+    ):
+        """Without a budget the loop stops at the default ceiling, not later.
+
+        The two neighbouring tests both leave the default unmeasured: one
+        scripts the button away after two clicks, the other passes its own
+        budget. Lowering the literal has to fail somewhere.
+        """
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": "text", "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock()
+
+        show_more = MagicMock()
+        show_more.count = AsyncMock(return_value=1)  # always present
+        show_more.is_visible = AsyncMock(return_value=True)
+        show_more.scroll_into_view_if_needed = AsyncMock()
+        show_more.click = AsyncMock()
+        show_more.first = show_more
+        show_more.filter = MagicMock(return_value=show_more)
+
+        def locator_side_effect(selector):
+            if selector == "main button":
+                return show_more
+            return MagicMock(count=AsyncMock(return_value=0))
+
+        mock_page.locator = MagicMock(side_effect=locator_side_effect)
+        capture = _capture(mock_page)
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await capture._extract_page_once(
+                "https://www.linkedin.com/in/billgates/details/experience/",
+                section_name="experience",
+            )
+
+        assert show_more.click.await_count == 5
+
     async def test_non_details_page_does_not_click_show_more(self, mock_page):
         """Non-details URLs (main profile, activity) skip the Show more loop."""
         mock_page.evaluate = AsyncMock(

--- a/tests/scraping/test_content.py
+++ b/tests/scraping/test_content.py
@@ -1,0 +1,59 @@
+"""Tests for the raw page content reader."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from linkedin_mcp_server.scraping.content import PageContentReader
+from linkedin_mcp_server.scraping.session import ScrapingSession
+
+
+def _reader(page) -> PageContentReader:
+    return PageContentReader(ScrapingSession(page))
+
+
+async def test_root_content_filters_empty_href_before_resolution(mock_page):
+    mock_page.evaluate = AsyncMock(
+        return_value={
+            "source": "root",
+            "text": "Sample profile text",
+            "references": [],
+        }
+    )
+    reader = _reader(mock_page)
+
+    await reader._extract_root_content(["main"])
+
+    await_args = mock_page.evaluate.await_args
+    assert await_args is not None
+    script = await_args.args[0]
+    assert "MAX_HEADING_CONTAINERS = 300" in script
+    assert "MAX_REFERENCE_ANCHORS = 500" in script
+    assert "const getPreviousHeading = node =>" in script
+    assert "index < 3" in script
+    assert "if (!rawHref || rawHref === '#')" in script
+    assert ".slice(0, MAX_REFERENCE_ANCHORS)" in script
+    assert "in_list" not in script
+    assert ".filter(Boolean);" in script
+
+
+async def test_the_caller_selectors_reach_the_page_unchanged(mock_page):
+    """The overlay read names three roots in priority order.
+
+    A read that hard-codes ``main`` would still answer every profile-page
+    caller, and only the contact-info overlay would come back as page chrome.
+    """
+    mock_page.evaluate = AsyncMock(
+        return_value={"source": "root", "text": "Contact", "references": []}
+    )
+    reader = _reader(mock_page)
+
+    await reader._extract_root_content(
+        ["dialog[open]", ".artdeco-modal__content", "main"]
+    )
+
+    await_args = mock_page.evaluate.await_args
+    assert await_args is not None
+    assert await_args.args[1] == {
+        "selectors": ["dialog[open]", ".artdeco-modal__content", "main"]
+    }

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -24,11 +24,11 @@ SCRAPING_SYNTHETIC = (
 )
 
 _SHARED_BOUNDARY_STAGES = {
-    "detect_rate_limit": {4, 5, 6, 9, 11, 12},
-    "handle_modal_close": {4, 5, 6, 9, 11, 12},
-    "scroll_to_bottom": {4, 9},
+    "detect_rate_limit": {5, 6, 9, 11, 12},
+    "handle_modal_close": {5, 6, 9, 11, 12},
+    "scroll_to_bottom": {9},
     "scroll_job_sidebar": {9},
-    "build_issue_diagnostics": {4, 5, 6, 8, 9},
+    "build_issue_diagnostics": {5, 6, 8, 9},
 }
 
 
@@ -261,12 +261,6 @@ def test_shared_boundary_patches_retain_later_consumers_after_early_migration(
         for seam in seams
         if seam.kind == "boundary_patch_object" and seam.target == target
     } == expected_stages - {earliest_stage}
-    if target == "scroll_to_bottom":
-        assert {
-            seam.migration_stage
-            for seam in seams
-            if seam.kind == "module_attribute" and seam.target == target
-        } == expected_stages - {earliest_stage}
 
 
 def test_public_facade_patches_follow_each_calling_workflow():
@@ -329,7 +323,7 @@ def test_checker_rejects_obsolete_seams_at_their_migration_stage():
     # completed stage are closed by definition, so an override there proves
     # nothing; raise this number as each stage lands.
     result = subprocess.run(
-        [sys.executable, str(CHECKER), "--check", "--stage", "4"],
+        [sys.executable, str(CHECKER), "--check", "--stage", "5"],
         cwd=ROOT,
         text=True,
         capture_output=True,
@@ -337,8 +331,12 @@ def test_checker_rejects_obsolete_seams_at_their_migration_stage():
     )
 
     assert result.returncode == 1
-    assert "obsolete at stage 4:" in result.stderr
-    assert "string_patch" in result.stderr
+    assert "obsolete at stage 5:" in result.stderr
+    assert "module_attribute" in result.stderr
+    # Every extractor-rooted string patch aimed at generic capture moved with
+    # the test that held it, so no override below stage 6 can surface one. A
+    # capture test still reaching back through the facade would show up here.
+    assert "string_patch" not in result.stderr
 
 
 def test_checkers_offer_no_fixture_update_mode():
@@ -963,8 +961,8 @@ def test_manifest_includes_extractor_access_from_nested_closure():
         (seam["line"], seam["canonical_owner"], seam["migration_stage"])
         for seam in accesses
     } == {
-        (820, "facade.LinkedInExtractor._scroll_seconds", 14),
-        (3930, "facade.LinkedInExtractor._scroll_seconds", 14),
+        (592, "facade.LinkedInExtractor._scroll_seconds", 14),
+        (3704, "facade.LinkedInExtractor._scroll_seconds", 14),
     }
 
 
@@ -1335,7 +1333,7 @@ async def boundaries(tasks):
     assert {seam.canonical_owner for seam in matching("_drain_listener_tasks")} == {
         "feed.FeedScraper"
     }
-    assert {seam.migration_stage for seam in matching("scroll_to_bottom")} == {4, 9}
+    assert {seam.migration_stage for seam in matching("scroll_to_bottom")} == {9}
     assert {seam.migration_stage for seam in matching("scroll_job_sidebar")} == {9}
     assert {seam.migration_stage for seam in matching("_URL_SETTLE_LAG")} == {3}
     assert {seam.canonical_owner for seam in matching("_URL_SETTLE_LAG")} == {

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1471,6 +1471,76 @@ async def test_unknown(page):
         _scan_synthetic(source)
 
 
+def test_collaborator_patches_resolve_through_the_facade_attribute():
+    seams = _scan_synthetic(
+        """
+from unittest.mock import patch
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+
+async def test_reach_through(page, replacement):
+    extractor = LinkedInExtractor(page)
+    with (
+        patch.object(extractor._capture, "_extract_overlay", replacement),
+        patch.object(extractor._capture, "extract_page", replacement),
+        patch.object(extractor._content, "_extract_root_content", replacement),
+    ):
+        await extractor.scrape_person("ada")
+"""
+    )
+
+    assert [
+        (seam.kind, seam.target, seam.canonical_owner, seam.migration_stage)
+        for seam in seams
+        if seam.kind.endswith("_patch_object")
+    ] == [
+        ("private_patch_object", "_extract_overlay", "capture.SectionCapture", 6),
+        ("public_patch_object", "extract_page", "capture.SectionCapture dependency", 6),
+        (
+            "private_patch_object",
+            "_extract_root_content",
+            "content.PageContentReader",
+            11,
+        ),
+    ]
+    # The reach-through itself stays on the record next to the patch it
+    # carries, and both expire with the last workflow that still asks the
+    # facade for the collaborator.
+    assert {
+        (seam.target, seam.migration_stage)
+        for seam in seams
+        if seam.kind == "private_facade_access"
+    } == {("_capture", 6), ("_content", 11)}
+
+
+@pytest.mark.parametrize(
+    ("target", "message"),
+    [
+        ("extractor._capture, '_extract_overlayy'", "unknown capture.SectionCapture"),
+        ("extractor._content, '_extract_root'", "unknown content.PageContentReader"),
+        ("extractor._session, 'check_rate_limit'", "unknown facade collaborator"),
+    ],
+)
+def test_unknown_collaborator_patches_fail_closed(target, message):
+    # A misspelled member, or an attribute carrying no collaborator at all,
+    # intercepts nothing and reads as a passing test. Falling through without a
+    # seam is what let the whole shape go unrecorded, so it has to name its
+    # call site instead.
+    source = f"""
+from unittest.mock import patch
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+
+async def test_typo(page):
+    extractor = LinkedInExtractor(page)
+    with patch.object({target}):
+        pass
+"""
+
+    with pytest.raises(
+        migration.UnresolvedSeamError, match=rf"synthetic_inventory\.py:7 .*{message}"
+    ):
+        _scan_synthetic(source)
+
+
 @pytest.mark.parametrize(
     "suffix",
     ["", "\nreader = linkedin_mcp_server.scraping.extractor._drain_listener_tasks"],

--- a/tests/test_root_content_dom.py
+++ b/tests/test_root_content_dom.py
@@ -1,0 +1,227 @@
+"""Browser-DOM tests for the raw content read in ``scraping/content.py``.
+
+The unit suite mocks ``page.evaluate``, so the reader's JavaScript never runs
+there: root selection, the anchor filter, href resolution and the heading walk
+are asserted as source text and nothing else. These cases execute that program
+in headless chromium.
+
+Every fixture here drives a synthetic container, so each case is a claim about
+the algorithm and never about LinkedIn's markup. Skipped automatically when
+chromium is not installed; run locally after
+``uv run patchright install chromium --no-shell``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.scraping.content import PageContentReader
+from linkedin_mcp_server.scraping.session import ScrapingSession
+
+#: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
+#: worker so browser startups cannot compete with the DOM cases' wall-clock
+#: timers.
+#: Without that distribution mode the group mark is inert.
+pytestmark = [
+    pytest.mark.browser_dom,
+    pytest.mark.xdist_group("browser_runtime"),
+]
+
+BASE_URL = "https://www.linkedin.com/in/ada-lovelace/"
+
+
+@pytest.fixture
+async def dom_page():
+    """Real chromium page, or skip when no browser is installed.
+
+    Only launch/setup is guarded by the skip — the ``yield`` is outside it so
+    an assertion failure or JS error in a test body is never swallowed into a
+    skip.
+
+    ``channel="chromium"`` names the browser this project installs. Without it
+    Playwright picks the *binary* from the ``headless`` flag alone and asks for
+    ``chromium-headless-shell``, which nothing here installs since the setup
+    moved to ``--no-shell``.
+    """
+    async with async_playwright() as p:
+        try:
+            browser = await p.chromium.launch(channel="chromium", headless=True)
+            page = await browser.new_page()
+        except Exception as exc:  # browser binary missing
+            pytest.skip(f"chromium unavailable: {exc}")
+        try:
+            yield page
+        finally:
+            await browser.close()
+
+
+async def read(page: Any, html: str, selectors: list[str]) -> dict[str, Any]:
+    """Run the production read against `html` served from a LinkedIn origin.
+
+    The document needs a real origin because the reader reports ``anchor.href``,
+    which the browser resolves against the document address. Served from
+    ``about:blank`` a relative path resolves to ``about:blank`` and the case
+    would prove nothing about what a caller receives.
+    """
+    await page.route(
+        "https://www.linkedin.com/**",
+        lambda route: route.fulfill(content_type="text/html", body=html),
+    )
+    await page.goto(BASE_URL)
+    reader = PageContentReader(ScrapingSession(page))
+    return await reader._extract_root_content(selectors)
+
+
+def document(main_body: str, *, outside: str = "Outside the root") -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Content</title></head>
+  <body>
+    <p>{outside}</p>
+    <main>{main_body}</main>
+  </body>
+</html>
+"""
+
+
+class TestRootSelectionAgainstRealDom:
+    async def test_the_first_matching_selector_bounds_the_read(self, dom_page):
+        result = await read(
+            dom_page,
+            document("<h1>Root heading</h1><p>Inside the root</p>"),
+            ["#absent", "main"],
+        )
+
+        assert result["source"] == "root"
+        assert "Inside the root" in result["text"]
+        assert "Outside the root" not in result["text"]
+
+    async def test_no_matching_selector_falls_back_to_the_body(self, dom_page):
+        result = await read(
+            dom_page,
+            document("<p>Inside the root</p>"),
+            ["#absent"],
+        )
+
+        assert result["source"] == "body"
+        assert "Outside the root" in result["text"]
+
+
+class TestAnchorFilteringAgainstRealDom:
+    async def test_placeholder_anchors_are_dropped_and_the_rest_resolved(
+        self, dom_page
+    ):
+        result = await read(
+            dom_page,
+            document(
+                """
+                <h1>Root heading</h1>
+                <a href="">Empty</a>
+                <a href="   ">Blank</a>
+                <a href="#">Placeholder</a>
+                <a href="#experience">Fragment</a>
+                <a href="/in/grace-hopper/">Relative</a>
+                <a>No href at all</a>
+                """
+            ),
+            ["main"],
+        )
+
+        assert [reference["href"] for reference in result["references"]] == [
+            "#experience",
+            "https://www.linkedin.com/in/grace-hopper/",
+        ]
+        assert [reference["text"] for reference in result["references"]] == [
+            "Fragment",
+            "Relative",
+        ]
+
+    async def test_label_attributes_and_placement_flags_travel_with_the_anchor(
+        self, dom_page
+    ):
+        result = await read(
+            dom_page,
+            document(
+                """
+                <h1>Root heading</h1>
+                <nav><a href="/feed/" aria-label="Home feed">Feed</a></nav>
+                <article><a href="/posts/one/" title="First post">Post</a></article>
+                <footer><a href="/legal/">Legal</a></footer>
+                """
+            ),
+            ["main"],
+        )
+        by_text = {reference["text"]: reference for reference in result["references"]}
+
+        assert by_text["Feed"]["aria_label"] == "Home feed"
+        assert by_text["Feed"]["in_nav"] is True
+        assert by_text["Feed"]["in_article"] is False
+        assert by_text["Post"]["title"] == "First post"
+        assert by_text["Post"]["in_article"] is True
+        assert by_text["Legal"]["in_footer"] is True
+        assert by_text["Legal"]["in_nav"] is False
+
+    async def test_the_anchor_cap_bounds_a_page_that_links_to_everything(
+        self, dom_page
+    ):
+        anchors = "".join(
+            f'<a href="/in/person-{index}/">Person {index}</a>' for index in range(505)
+        )
+        result = await read(dom_page, document(anchors), ["main"])
+
+        assert len(result["references"]) == 500
+        assert result["references"][-1]["text"] == "Person 499"
+
+
+def sibling_document(fillers: int) -> str:
+    """A heading and an anchor separated by `fillers` sibling elements.
+
+    Kept flat under the root on purpose: nested inside a section the heading
+    would be reachable through the ancestor walk as well, and the sibling bound
+    this measures would hold whatever its limit was.
+    """
+    filler = "".join(f"<div>Filler {index}</div>" for index in range(fillers))
+    return document(
+        "<h1>Root heading</h1><h2>Skills</h2>"
+        f'{filler}<div><a href="/company/acme/">Acme</a></div>'
+    )
+
+
+class TestHeadingAttributionAgainstRealDom:
+    async def test_an_ancestor_container_labels_an_anchor_nested_below_it(
+        self, dom_page
+    ):
+        result = await read(
+            dom_page,
+            document(
+                """
+                <h1>Root heading</h1>
+                <section>
+                  <h2>Experience</h2>
+                  <ul><li><a href="/company/acme/">Acme</a></li></ul>
+                </section>
+                """
+            ),
+            ["main"],
+        )
+
+        assert [reference["heading"] for reference in result["references"]] == [
+            "Experience"
+        ]
+
+    async def test_a_heading_three_siblings_back_still_labels_the_anchor(
+        self, dom_page
+    ):
+        result = await read(dom_page, sibling_document(2), ["main"])
+
+        assert [reference["heading"] for reference in result["references"]] == [
+            "Skills"
+        ]
+
+    async def test_a_heading_four_siblings_back_is_out_of_reach(self, dom_page):
+        result = await read(dom_page, sibling_document(3), ["main"])
+
+        assert [reference["heading"] for reference in result["references"]] == [""]

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -49,235 +49,7 @@ def extracted(
     return ExtractedSection(text=text, references=references or [], error=error)
 
 
-class TestExtractPage:
-    async def test_extract_page_returns_text(self, mock_page):
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Sample profile text",
-                "references": [],
-            }
-        )
-        extractor = LinkedInExtractor(mock_page)
-        # Patch scroll_to_bottom and detect_rate_limit to avoid complex mock chains
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            result = await extractor.extract_page(
-                "https://www.linkedin.com/in/testuser/",
-                section_name="main_profile",
-            )
-
-        assert result.text == "Sample profile text"
-        assert result.references == []
-        mock_page.goto.assert_awaited_once()
-
-    async def test_root_content_filters_empty_href_before_resolution(self, mock_page):
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Sample profile text",
-                "references": [],
-            }
-        )
-        extractor = LinkedInExtractor(mock_page)
-
-        await extractor._extract_root_content(["main"])
-
-        await_args = mock_page.evaluate.await_args
-        assert await_args is not None
-        script = await_args.args[0]
-        assert "MAX_HEADING_CONTAINERS = 300" in script
-        assert "MAX_REFERENCE_ANCHORS = 500" in script
-        assert "const getPreviousHeading = node =>" in script
-        assert "index < 3" in script
-        assert "if (!rawHref || rawHref === '#')" in script
-        assert ".slice(0, MAX_REFERENCE_ANCHORS)" in script
-        assert "in_list" not in script
-        assert ".filter(Boolean);" in script
-
-    async def test_extract_page_returns_empty_on_failure(self, mock_page):
-        mock_page.goto = AsyncMock(side_effect=Exception("Network error"))
-        extractor = LinkedInExtractor(mock_page)
-
-        with patch(
-            "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics",
-            return_value={"issue_template_path": "/tmp/issue.md"},
-        ):
-            result = await extractor.extract_page(
-                "https://www.linkedin.com/in/bad/",
-                section_name="main_profile",
-            )
-        assert result.text == ""
-        assert result.references == []
-        assert result.error == {"issue_template_path": "/tmp/issue.md"}
-
-    async def test_extract_page_raises_auth_error_for_account_picker(self, mock_page):
-        mock_page.goto = AsyncMock(side_effect=Exception("net::ERR_TOO_MANY_REDIRECTS"))
-        extractor = LinkedInExtractor(mock_page)
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
-                new_callable=AsyncMock,
-                return_value="auth barrier text: welcome back + sign in using another account",
-            ),
-            pytest.raises(AuthenticationError, match="--login"),
-        ):
-            await extractor.extract_page(
-                "https://www.linkedin.com/in/testuser/",
-                section_name="main_profile",
-            )
-
-    async def test_rate_limit_detected(self, mock_page):
-        from linkedin_mcp_server.core.exceptions import RateLimitError
-
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-                side_effect=RateLimitError("Rate limited", suggested_wait_time=3600),
-            ),
-            pytest.raises(RateLimitError),
-        ):
-            await extractor.extract_page(
-                "https://www.linkedin.com/in/testuser/",
-                section_name="main_profile",
-            )
-
-    async def test_returns_rate_limited_msg_after_retry(self, mock_page):
-        """When both attempts return only noise, surface rate limit message."""
-        noise_only = (
-            "More profiles for you\n\n"
-            "You've approached your profile search limit\n\n"
-            "About\nAccessibility\nTalent Solutions"
-        )
-        mock_page.evaluate = AsyncMock(
-            return_value={"source": "root", "text": noise_only, "references": []}
-        )
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.extract_page(
-                "https://www.linkedin.com/in/testuser/details/experience/",
-                section_name="experience",
-            )
-
-        assert result.text == RATE_LIMITED_SECTION_TEXT
-        # goto called twice (initial + retry)
-        assert mock_page.goto.await_count == 2
-
-    async def test_retry_succeeds_after_rate_limit(self, mock_page):
-        """When first attempt is rate-limited but retry succeeds, return content."""
-        noise_only = "More profiles for you\n\nAbout\nAccessibility\nTalent Solutions"
-        call_count = 0
-
-        async def evaluate_side_effect(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count <= 1:
-                return noise_only
-            return "Education\nHarvard University\n1973 – 1975"
-
-        async def root_content_side_effect(*args, **kwargs):
-            return {
-                "source": "root",
-                "text": await evaluate_side_effect(),
-                "references": [],
-            }
-
-        mock_page.evaluate = AsyncMock(side_effect=root_content_side_effect)
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.extract_page(
-                "https://www.linkedin.com/in/testuser/details/education/",
-                section_name="education",
-            )
-
-        assert result.text == "Education\nHarvard University\n1973 – 1975"
-
-    async def test_media_only_controls_are_not_misclassified_as_rate_limited(
-        self, mock_page
-    ):
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Play\nLoaded: 100.00%\nRemaining time 0:07\nShow captions",
-                "references": [],
-            }
-        )
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            result = await extractor._extract_page_once(
-                "https://www.linkedin.com/in/testuser/recent-activity/all/",
-                section_name="posts",
-            )
-
-        assert result.text == ""
-        assert result.references == []
-
+class TestExtractSearchPage:
     async def test_extract_search_page_raises_auth_error_for_login_barrier(
         self, mock_page
     ):
@@ -857,7 +629,9 @@ class TestExtractPage:
                 return_value=False,
             ),
             patch.object(
-                extractor, "_extract_root_content", side_effect=reload_at_read
+                extractor._content,
+                "_extract_root_content",
+                side_effect=reload_at_read,
             ),
             patch(
                 "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
@@ -1146,7 +920,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("text"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -1173,7 +947,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("profile text"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -1208,7 +982,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("profile text"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -1254,7 +1028,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("profile text"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -1334,7 +1108,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("text"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -1378,7 +1152,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("text"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted("contact text"),
@@ -1420,7 +1194,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("Post 1\nPost 2"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -1446,7 +1220,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("Python for Data Science\nIBM"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -1472,7 +1246,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("Python\nData Analysis"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -1498,7 +1272,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("Portfolio Website\nBuilt with React"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -1524,7 +1298,7 @@ class TestScrapePersonUrls:
                 return_value=extracted("text"),
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -2517,7 +2291,7 @@ class TestConnectWithPerson:
                 ],
             ),
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -2558,7 +2332,7 @@ class TestConnectWithPerson:
                 return_value={"issue_template_path": "/tmp/issue.md"},
             ),
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -2603,7 +2377,7 @@ class TestConnectWithPerson:
                 ],
             ) as mock_extract,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -2667,7 +2441,7 @@ class TestConnectWithPerson:
                 ],
             ),
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted(""),
@@ -2808,7 +2582,7 @@ class TestScrapeCompany:
         }
         with (
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value=raw_root,
@@ -3086,7 +2860,7 @@ class TestSearchJobs:
         with (
             patch.object(PageNavigator, "_navigate_to_page", side_effect=navigate_page),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value=raw_page,
@@ -3339,7 +3113,7 @@ class TestSearchJobs:
         with (
             patch.object(PageNavigator, "_navigate_to_page", side_effect=navigate_page),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 side_effect=raw_pages,
@@ -4773,7 +4547,9 @@ class TestGetSavedJobs:
                 new_callable=AsyncMock,
             ),
             patch.object(
-                extractor, "_extract_root_content", side_effect=reload_at_read
+                extractor._content,
+                "_extract_root_content",
+                side_effect=reload_at_read,
             ),
             patch(
                 "linkedin_mcp_server.scraping.navigation.detect_auth_barrier",
@@ -5710,635 +5486,6 @@ class TestSearchPosts:
         }
 
 
-class TestActivityFeedExtraction:
-    """Tests for activity page detection and wait behavior in _extract_page_once."""
-
-    async def test_activity_page_waits_for_content_and_uses_slow_scroll(
-        self, mock_page
-    ):
-        """Activity URLs should call wait_for_function and use slower scroll params."""
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Post content " * 50,
-                "references": [],
-            }
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ) as mock_scroll,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            result = await extractor._extract_page_once(
-                "https://www.linkedin.com/in/billgates/recent-activity/all/",
-                section_name="posts",
-            )
-
-        mock_page.wait_for_function.assert_awaited_once()
-        mock_scroll.assert_awaited_once()
-        _, kwargs = mock_scroll.call_args
-        assert kwargs["pause_time"] == 1.0
-        assert kwargs["max_scrolls"] == 10
-        assert len(result.text) > 200
-
-    async def test_company_posts_page_waits_for_content_and_uses_slow_scroll(
-        self, mock_page
-    ):
-        """Company posts URLs get the same lazy-load wait and scroll budget
-        as person activity pages, even though they lack /recent-activity/."""
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Post content " * 50,
-                "references": [],
-            }
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ) as mock_scroll,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            result = await extractor._extract_page_once(
-                "https://www.linkedin.com/company/microsoft/posts/",
-                section_name="posts",
-            )
-
-        mock_page.wait_for_function.assert_awaited_once()
-        mock_scroll.assert_awaited_once()
-        _, kwargs = mock_scroll.call_args
-        assert kwargs["pause_time"] == 1.0
-        assert kwargs["max_scrolls"] == 10
-        assert len(result.text) > 200
-
-    async def test_company_posts_page_with_query_string_still_waits(self, mock_page):
-        """The lazy-load branch keys off the parsed path, so a company posts
-        url carrying a query string is not mistaken for a static page."""
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Post content " * 50,
-                "references": [],
-            }
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ) as mock_scroll,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/company/microsoft/posts/?viewAsMember=true",
-                section_name="posts",
-            )
-
-        mock_page.wait_for_function.assert_awaited_once()
-        _, kwargs = mock_scroll.call_args
-        assert kwargs["max_scrolls"] == 10
-
-    async def test_non_activity_non_details_page_skips_wait_and_uses_fast_scroll(
-        self, mock_page
-    ):
-        """Plain profile URLs (not activity, search, or details) skip wait_for_function."""
-        mock_page.evaluate = AsyncMock(
-            return_value={"source": "root", "text": "Profile text", "references": []}
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ) as mock_scroll,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/in/billgates/",
-                section_name="main_profile",
-            )
-
-        mock_page.wait_for_function.assert_not_awaited()
-        mock_scroll.assert_awaited_once()
-        _, kwargs = mock_scroll.call_args
-        assert kwargs["pause_time"] == 0.5
-        assert kwargs["max_scrolls"] == 5
-
-    async def test_details_page_waits_for_panel_content(self, mock_page):
-        """Detail pages (/details/experience/ etc.) call wait_for_function to wait for the panel."""
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Experience\nSoftware Engineer",
-                "references": [],
-            }
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ) as mock_scroll,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/in/billgates/details/experience/",
-                section_name="experience",
-            )
-
-        mock_page.wait_for_function.assert_awaited_once()
-        mock_scroll.assert_awaited_once()
-        _, kwargs = mock_scroll.call_args
-        assert kwargs["pause_time"] == 0.5
-        assert kwargs["max_scrolls"] == 5
-
-    async def test_max_scrolls_override_passed_to_scroll_to_bottom(self, mock_page):
-        """Custom max_scrolls on a detail page overrides the default of 5."""
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Experience\nSoftware Engineer",
-                "references": [],
-            }
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ) as mock_scroll,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/in/billgates/details/certifications/",
-                section_name="certifications",
-                max_scrolls=20,
-            )
-
-        mock_scroll.assert_awaited_once()
-        _, kwargs = mock_scroll.call_args
-        assert kwargs["max_scrolls"] == 20
-
-    async def test_default_scrolls_without_max_scrolls_override(self, mock_page):
-        """Without max_scrolls, detail pages use the default of 5."""
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Experience\nSoftware Engineer",
-                "references": [],
-            }
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ) as mock_scroll,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/in/billgates/details/certifications/",
-                section_name="certifications",
-            )
-
-        mock_scroll.assert_awaited_once()
-        _, kwargs = mock_scroll.call_args
-        assert kwargs["max_scrolls"] == 5
-
-    async def test_details_page_clicks_show_more_until_gone(self, mock_page):
-        """Detail pages click 'Show more' in a loop until the button disappears."""
-        mock_page.evaluate = AsyncMock(
-            return_value={"source": "root", "text": "text", "references": []}
-        )
-        mock_page.wait_for_function = AsyncMock()
-
-        show_more = MagicMock()
-        # count() returns 1, 1, 0 across iterations — button disappears on 3rd check
-        show_more.count = AsyncMock(side_effect=[1, 1, 0])
-        show_more.is_visible = AsyncMock(return_value=True)
-        show_more.scroll_into_view_if_needed = AsyncMock()
-        show_more.click = AsyncMock()
-        show_more.first = show_more
-        show_more.filter = MagicMock(return_value=show_more)
-
-        def locator_side_effect(selector):
-            if selector == "main button":
-                return show_more
-            return MagicMock(count=AsyncMock(return_value=0))
-
-        mock_page.locator = MagicMock(side_effect=locator_side_effect)
-        extractor = LinkedInExtractor(mock_page)
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/in/billgates/details/certifications/",
-                section_name="certifications",
-            )
-
-        assert show_more.click.await_count == 2
-
-    async def test_details_page_show_more_respects_max_scrolls_budget(self, mock_page):
-        """When 'Show more' never disappears, loop exits after max_scrolls clicks."""
-        mock_page.evaluate = AsyncMock(
-            return_value={"source": "root", "text": "text", "references": []}
-        )
-        mock_page.wait_for_function = AsyncMock()
-
-        show_more = MagicMock()
-        show_more.count = AsyncMock(return_value=1)  # always present
-        show_more.is_visible = AsyncMock(return_value=True)
-        show_more.scroll_into_view_if_needed = AsyncMock()
-        show_more.click = AsyncMock()
-        show_more.first = show_more
-        show_more.filter = MagicMock(return_value=show_more)
-
-        def locator_side_effect(selector):
-            if selector == "main button":
-                return show_more
-            return MagicMock(count=AsyncMock(return_value=0))
-
-        mock_page.locator = MagicMock(side_effect=locator_side_effect)
-        extractor = LinkedInExtractor(mock_page)
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/in/billgates/details/experience/",
-                section_name="experience",
-                max_scrolls=3,
-            )
-
-        assert show_more.click.await_count == 3
-
-    async def test_non_details_page_does_not_click_show_more(self, mock_page):
-        """Non-details URLs (main profile, activity) skip the Show more loop."""
-        mock_page.evaluate = AsyncMock(
-            return_value={"source": "root", "text": "text", "references": []}
-        )
-        mock_page.wait_for_function = AsyncMock()
-
-        show_more = MagicMock()
-        show_more.count = AsyncMock(return_value=1)
-        show_more.click = AsyncMock()
-        show_more.first = show_more
-        show_more.filter = MagicMock(return_value=show_more)
-
-        def locator_side_effect(selector):
-            if selector == "main button":
-                return show_more
-            return MagicMock(count=AsyncMock(return_value=0))
-
-        mock_page.locator = MagicMock(side_effect=locator_side_effect)
-        extractor = LinkedInExtractor(mock_page)
-
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/in/billgates/",
-                section_name="main_profile",
-            )
-
-        show_more.click.assert_not_awaited()
-
-    async def test_activity_page_timeout_proceeds_gracefully(self, mock_page):
-        """When activity feed content never loads, extraction proceeds with available text."""
-        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
-
-        tab_headers = "All activity\nPosts\nComments\nVideos\nImages"
-        mock_page.evaluate = AsyncMock(
-            return_value={"source": "root", "text": tab_headers, "references": []}
-        )
-        mock_page.wait_for_function = AsyncMock(
-            side_effect=PlaywrightTimeoutError("Timeout")
-        )
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            result = await extractor._extract_page_once(
-                "https://www.linkedin.com/in/billgates/recent-activity/all/",
-                section_name="posts",
-            )
-
-        # Should return whatever text is available, not crash
-        assert result.text == tab_headers
-
-
-class TestCompanyPeopleExtraction:
-    """Tests for /company/<slug>/people/ hydration wait in _extract_page_once."""
-
-    async def test_waits_for_listing_with_5s_timeout(self, mock_page):
-        """Company /people/ pages call wait_for_function so the employee
-        listing has hydrated before scroll/extract. Empty/restricted listings
-        are common, so the timeout is 5s rather than the 10s pattern shared
-        with is_search/is_details."""
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Anthropic\nFollowing\nHome\nAbout\nPeople",
-                "references": [],
-            }
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ) as mock_scroll,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/company/anthropicresearch/people/",
-                section_name="employees",
-            )
-
-        mock_page.wait_for_function.assert_awaited_once()
-        wait_predicate = mock_page.wait_for_function.call_args[0][0]
-        wait_kwargs = mock_page.wait_for_function.call_args.kwargs
-        assert "/in/" in wait_predicate
-        assert "querySelectorAll" in wait_predicate
-        assert wait_kwargs["timeout"] == 5000
-        mock_scroll.assert_awaited_once()
-
-    async def test_continues_extraction_on_wait_timeout(self, mock_page):
-        """When the hydration wait times out (genuinely empty listing), the
-        extractor swallows PlaywrightTimeoutError and still scrolls + extracts
-        rather than propagating the error to the caller."""
-        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
-
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Empty company page",
-                "references": [],
-            }
-        )
-        mock_page.wait_for_function = AsyncMock(
-            side_effect=PlaywrightTimeoutError("Timeout")
-        )
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ) as mock_scroll,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            result = await extractor._extract_page_once(
-                "https://www.linkedin.com/company/anthropicresearch/people/",
-                section_name="employees",
-            )
-
-        mock_scroll.assert_awaited_once()
-        assert result.text  # non-empty placeholder text from the mock
-
-
-class TestSearchResultsExtraction:
-    """Tests for search results page detection and wait behavior in _extract_page_once."""
-
-    async def test_search_results_page_waits_for_content(self, mock_page):
-        """Search results URLs should call wait_for_function to wait for content."""
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "source": "root",
-                "text": "Search results for John Doe. " * 10,
-                "references": [],
-            }
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            result = await extractor._extract_page_once(
-                "https://www.linkedin.com/search/results/people/?keywords=John+Doe",
-                section_name="search_results",
-            )
-
-        mock_page.wait_for_function.assert_awaited_once()
-        assert len(result.text) > 100
-
-    async def test_non_search_page_does_not_wait_for_search_content(self, mock_page):
-        """Non-search URLs should not trigger the search results wait."""
-        mock_page.evaluate = AsyncMock(
-            return_value={"source": "root", "text": "Profile text", "references": []}
-        )
-        mock_page.wait_for_function = AsyncMock()
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            await extractor._extract_page_once(
-                "https://www.linkedin.com/in/billgates/",
-                section_name="main_profile",
-            )
-
-        mock_page.wait_for_function.assert_not_awaited()
-
-    async def test_search_results_timeout_proceeds_gracefully(self, mock_page):
-        """When search results never load, extraction proceeds with available text."""
-        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
-
-        placeholder = "Search results for John Doe. No results found"
-        mock_page.evaluate = AsyncMock(
-            return_value={"source": "root", "text": placeholder, "references": []}
-        )
-        mock_page.wait_for_function = AsyncMock(
-            side_effect=PlaywrightTimeoutError("Timeout")
-        )
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch(
-                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            result = await extractor._extract_page_once(
-                "https://www.linkedin.com/search/results/people/?keywords=John+Doe",
-                section_name="search_results",
-            )
-
-        assert result.text == placeholder
-
-
 class TestScrapePersonCallbacks:
     """Test that scrape_person invokes callbacks at each stage."""
 
@@ -6358,7 +5505,7 @@ class TestScrapePersonCallbacks:
                 return_value=extracted("text"),
             ),
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_overlay",
                 new_callable=AsyncMock,
                 return_value=extracted("overlay text"),
@@ -6470,7 +5617,7 @@ class TestMainProfileAlreadyLoaded:
         mock_page.url = "https://www.linkedin.com/in/foo/"
         with (
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_loaded_section",
                 new_callable=AsyncMock,
                 return_value=extracted("reused"),
@@ -6507,7 +5654,7 @@ class TestMainProfileAlreadyLoaded:
                 return_value=extracted("fallback"),
             ) as extract_page,
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_loaded_section",
                 new_callable=AsyncMock,
             ) as loaded,
@@ -6529,7 +5676,7 @@ class TestMainProfileAlreadyLoaded:
 
         with (
             patch.object(
-                extractor,
+                extractor._capture,
                 "_extract_loaded_section",
                 new_callable=AsyncMock,
                 return_value=extracted(RATE_LIMITED_SECTION_TEXT),
@@ -7106,7 +6253,7 @@ class TestGetInbox:
                 new_callable=AsyncMock,
             ),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value={
@@ -7153,7 +6300,7 @@ class TestGetInbox:
                 extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
             ),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value={"text": "", "references": []},
@@ -7205,7 +6352,7 @@ class TestGetInbox:
                 extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
             ),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value={
@@ -7258,7 +6405,7 @@ class TestGetConversation:
                 extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
             ),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value={"text": "Hello!\nHi there!", "references": []},
@@ -7304,7 +6451,7 @@ class TestGetConversation:
                 extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
             ),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value={"text": raw, "references": []},
@@ -7359,7 +6506,7 @@ class TestGetConversation:
                 ],
             ),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value={"text": "msg", "references": []},
@@ -7417,7 +6564,7 @@ class TestGetConversation:
                 ],
             ),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value={"text": "msg", "references": []},
@@ -7713,7 +6860,7 @@ class TestSearchConversations:
             ),
             patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value={"text": "Result 1\nResult 2", "references": []},
@@ -7773,7 +6920,7 @@ class TestSearchConversations:
             ),
             patch.object(extractor, "_wait_for_main_text", new_callable=AsyncMock),
             patch.object(
-                extractor,
+                extractor._content,
                 "_extract_root_content",
                 new_callable=AsyncMock,
                 return_value={"text": "Jacki McMahan\nJacki McMahan", "references": []},


### PR DESCRIPTION
Part of #853. Stacked on #884.

Generic section capture sat inside `extractor.py`, so the raw read, the overlay retry, and the per-URL wait and scroll policy were reachable only through the facade, and the root-content JavaScript had no executable coverage.

This stage moves the raw read into `PageContentReader` and page and overlay capture into `SectionCapture`. Waits, scroll and click ceilings, modal handling, reference metadata, and error boundaries move mechanically; the extraction script is byte-identical. Both modules consume `ScrapingSession` and `PageNavigator`, not the facade. A new browser-DOM test runs root selection and its body fallback against real Chromium.

Review found the migration checker had stopped recording patches routed through a facade collaborator, accepting a misspelled method name in silence. The second commit restores those 33 seams and makes the shape fail loudly.

Verification: both checkers, 664 owner tests, Ruff, `ty`, pre-commit, and the full suite with 3,711 passing tests succeed. Canonical traces stay byte-identical.

## Synthetic prompt

> Extract raw content reading and generic capture into owner modules, preserving URL-derived policy mechanically, with real browser coverage for the root-content script.

Generated with Claude Opus 5 + GPT-6 Astra
