### PR TITLE
fix(references): Add contexts for jobs, saved_jobs and feed

### DIFF
--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -87,6 +87,9 @@ _SECTION_CONTEXTS = {
     "job_posting": "job posting",
     "inbox": "inbox",
     "conversation": "conversation",
+    "jobs": "jobs",
+    "saved_jobs": "saved jobs",
+    "feed": "feed",
 }
 
 _DEFAULT_REFERENCE_CAP = 12

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -592,6 +592,27 @@ class TestBuildReferences:
             }
         ]
 
+    def test_names_the_context_for_jobs_saved_jobs_and_feed(self):
+        """The structural guard below only proves a context key exists, so it
+        survives a wrong label. These are the values themselves."""
+        raw: list[RawReference] = [
+            {
+                "href": "https://www.linkedin.com/jobs/view/123/",
+                "text": "Senior Engineer",
+            }
+        ]
+
+        contexts = {
+            section: build_references(raw, section)[0]["context"]
+            for section in ("jobs", "saved_jobs", "feed")
+        }
+
+        assert contexts == {
+            "jobs": "jobs",
+            "saved_jobs": "saved jobs",
+            "feed": "feed",
+        }
+
     def test_every_scraped_section_gives_its_references_a_context(self):
         """Nothing tied the context table to the section tables, which is how
         seven sections have now reached main without an entry. A context-less

--- a/tests/test_link_metadata.py
+++ b/tests/test_link_metadata.py
@@ -2,8 +2,9 @@
 
 from urllib.parse import quote
 
-from linkedin_mcp_server.scraping.fields import PERSON_SECTIONS
+from linkedin_mcp_server.scraping.fields import COMPANY_SECTIONS, PERSON_SECTIONS
 from linkedin_mcp_server.scraping.link_metadata import (
+    _REFERENCE_CAPS,
     RawReference,
     build_references,
     classify_link,
@@ -591,11 +592,15 @@ class TestBuildReferences:
             }
         ]
 
-    def test_every_person_section_gives_its_references_a_context(self):
-        """Nothing tied the context table to the section table, which is how
-        three sections reached main without an entry. A context-less reference
-        also scores below every duplicate that has one, so it loses cross-page
-        dedupe ties it should win."""
+    def test_every_scraped_section_gives_its_references_a_context(self):
+        """Nothing tied the context table to the section tables, which is how
+        seven sections have now reached main without an entry. A context-less
+        reference also scores below every duplicate that has one, so it loses
+        cross-page dedupe ties it should win.
+
+        Section names are declared in three separate places, and `saved_jobs`
+        is declared in none of them -- it exists only as a literal in the
+        extractor -- so it is named here explicitly."""
         raw: list[RawReference] = [
             {
                 "href": "https://www.linkedin.com/company/aws/",
@@ -603,11 +608,18 @@ class TestBuildReferences:
             }
         ]
 
-        missing = [
+        sections = (
+            set(PERSON_SECTIONS)
+            | set(COMPANY_SECTIONS)
+            | set(_REFERENCE_CAPS)
+            | {"saved_jobs"}
+        )
+
+        missing = sorted(
             section
-            for section in PERSON_SECTIONS
+            for section in sections
             if "context" not in build_references(raw, section)[0]
-        ]
+        )
 
         assert missing == []
 


### PR DESCRIPTION
Closes #844

`saved_jobs`, `jobs` and `feed` reach `derive_context` with no `_SECTION_CONTEXTS` entry, so their references arrive with no `context` key. `_reference_score` ranks a context-less reference below any duplicate that has one, so these sections lose cross-page dedupe ties.

Static rather than dynamic: post permalinks are dropped before `derive_context` runs, so what survives in `feed` is people, companies and jobs, and the `posts` labels would be wrong for two of the three.

- `jobs` → `"jobs"`, matching `employees`
- `saved_jobs` → `"saved jobs"`, matching `job_posting`
- `feed` → `"feed"`

The existing guard only walked `PERSON_SECTIONS`, which is why it stayed green through all three. It now walks every declared section. Names live in `PERSON_SECTIONS`, `COMPANY_SECTIONS` and `_REFERENCE_CAPS`, and `saved_jobs` is in none of them, so the test names it explicitly.

One unrelated failure, `test_daemon_descriptor.py::TestEndpointSpelling`, reproduces on clean `main` at 13734ba.
