### PR TITLE
feat: add get_group_members tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 | `get_company_posts` | Get recent posts from a company's LinkedIn feed |
 | `search_companies` | Search for companies on LinkedIn by keywords |
 | `get_company_employees` | List employees at a company from the /people/ page, with optional keyword filter |
+| `get_group_members` | List members of a LinkedIn group from its /members/ page, with optional keyword filter (full list requires the account to be a group member) |
 | `search_jobs` | Search for jobs with keywords and location filters |
 | `get_saved_jobs` | List job postings saved by the authenticated user |
 | `search_people` | Search for people by keywords, location, connection degree (1st/2nd/3rd), and current company |

--- a/linkedin_mcp_server/core/utils.py
+++ b/linkedin_mcp_server/core/utils.py
@@ -164,7 +164,7 @@ async def detect_rate_limit(page: Page) -> None:
 
 
 async def scroll_to_bottom(
-    page: Page, pause_time: float = 1.0, max_scrolls: int = 10
+    page: Page, pause_time: float = 1.0, max_scrolls: int = 10, max_stalls: int = 1
 ) -> None:
     """Scroll to the bottom of the page to trigger lazy loading.
 
@@ -172,7 +172,13 @@ async def scroll_to_bottom(
         page: Patchright page object
         pause_time: Time to pause between scrolls (seconds)
         max_scrolls: Maximum number of scroll attempts
+        max_stalls: Consecutive no-growth scrolls tolerated before treating
+            the page as fully loaded. The default of 1 keeps the historic
+            stop-on-first-stall behavior; deep infinite-scroll listings
+            (e.g. group member lists) pass a higher value so one slow XHR
+            response is not mistaken for the end of the list.
     """
+    stalls = 0
     for i in range(max_scrolls):
         previous_height = await page.evaluate("document.body.scrollHeight")
         await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
@@ -180,8 +186,12 @@ async def scroll_to_bottom(
 
         new_height = await page.evaluate("document.body.scrollHeight")
         if new_height == previous_height:
-            logger.debug("Reached bottom after %d scrolls", i + 1)
-            break
+            stalls += 1
+            if stalls >= max_stalls:
+                logger.debug("Reached bottom after %d scrolls", i + 1)
+                break
+        else:
+            stalls = 0
 
 
 async def scroll_job_sidebar(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1860,8 +1860,13 @@ class LinkedInExtractor:
         # timeout instead of the 10s pattern shared with is_search/is_details
         # — empty/restricted listings are common here (small companies,
         # privacy settings) and a full 10s wait per call adds up.
+        # Group members pages (/groups/<id>/members/) hydrate the same way:
+        # the group header renders first and the member list fills in via JS,
+        # so they share the wait. Restricted listings (non-member visitors)
+        # are common there too, matching the short-timeout rationale.
         is_company_people = "/company/" in url and "/people/" in url
-        if is_company_people:
+        is_group_members = "/groups/" in url and "/members/" in url
+        if is_company_people or is_group_members:
             try:
                 await self._page.wait_for_function(
                     """() => {
@@ -3323,6 +3328,46 @@ class LinkedInExtractor:
             section_errors["employees"] = rate_limited_section_error()
         elif extracted.error:
             section_errors["employees"] = extracted.error
+
+        result: dict[str, Any] = {
+            "url": url,
+            "sections": sections,
+        }
+        if references:
+            result["references"] = references
+        if section_errors:
+            result["section_errors"] = section_errors
+        return result
+
+    async def get_group_members(
+        self,
+        group_id: str,
+        max_scrolls: int | None = None,
+    ) -> dict[str, Any]:
+        """List members of a LinkedIn group from the /members/ page.
+
+        The member list is only fully visible when the logged-in account
+        is a member of the group; otherwise LinkedIn redirects to the
+        group's landing page or shows a restricted listing. Either way
+        the extracted text reflects what the page actually served.
+
+        Returns:
+            {url, sections: {members: text}, references: {members: [...]}}
+        """
+        url = f"https://www.linkedin.com/groups/{group_id}/members/"
+        extracted = await self.extract_page(
+            url, section_name="members", max_scrolls=max_scrolls
+        )
+
+        sections: dict[str, str] = {}
+        references: dict[str, list[Reference]] = {}
+        section_errors: dict[str, dict[str, Any]] = {}
+        if extracted.text and extracted.text != _RATE_LIMITED_MSG:
+            sections["members"] = extracted.text
+            if extracted.references:
+                references["members"] = extracted.references
+        elif extracted.error:
+            section_errors["members"] = extracted.error
 
         result: dict[str, Any] = {
             "url": url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1929,6 +1929,14 @@ class LinkedInExtractor:
         if is_activity:
             scrolls = max_scrolls if max_scrolls is not None else 10
             await scroll_to_bottom(self._page, pause_time=1.0, max_scrolls=scrolls)
+        elif is_group_members:
+            # Deep member pulls need the slower pause plus stall tolerance:
+            # at 0.5s a slow pagination XHR reads as "no new content" and the
+            # loop stops hundreds of members early (verified live).
+            scrolls = max_scrolls if max_scrolls is not None else 5
+            await scroll_to_bottom(
+                self._page, pause_time=1.0, max_scrolls=scrolls, max_stalls=3
+            )
         else:
             scrolls = max_scrolls if max_scrolls is not None else 5
             await scroll_to_bottom(self._page, pause_time=0.5, max_scrolls=scrolls)

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3350,6 +3350,7 @@ class LinkedInExtractor:
     async def get_group_members(
         self,
         group_id: str,
+        keywords: str | None = None,
         max_scrolls: int | None = None,
     ) -> dict[str, Any]:
         """List members of a LinkedIn group from the /members/ page.
@@ -3359,13 +3360,25 @@ class LinkedInExtractor:
         group's landing page or shows a restricted listing. Either way
         the extracted text reflects what the page actually served.
 
+        LinkedIn serves at most ~500 rows per listing regardless of scroll
+        depth (verified live). ``keywords`` filters server-side via the
+        page's member search box — the only filter mechanism the page has;
+        a ``?q=`` URL param is accepted but ignored by LinkedIn. Each
+        keyword slice gets its own ~500-row budget, so slicing is the way
+        to enumerate groups larger than the cap.
+
         Returns:
             {url, sections: {members: text}, references: {members: [...]}}
         """
         url = f"https://www.linkedin.com/groups/{group_id}/members/"
-        extracted = await self.extract_page(
-            url, section_name="members", max_scrolls=max_scrolls
-        )
+        if keywords:
+            extracted = await self._extract_group_members_filtered(
+                url, keywords, max_scrolls
+            )
+        else:
+            extracted = await self.extract_page(
+                url, section_name="members", max_scrolls=max_scrolls
+            )
 
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
@@ -3386,6 +3399,59 @@ class LinkedInExtractor:
         if section_errors:
             result["section_errors"] = section_errors
         return result
+
+    async def _extract_group_members_filtered(
+        self,
+        url: str,
+        keywords: str,
+        max_scrolls: int | None,
+    ) -> ExtractedSection:
+        """Filter the group member list via the page's search box, then extract.
+
+        The members page exposes exactly one text input inside <main> (the
+        member search box), so the structural ``main input[type="text"]``
+        selector is locale-independent — placeholder/aria text is not.
+        Filling it triggers a server-side filtered fetch that replaces the
+        listing in place (the URL does not change).
+        """
+        try:
+            await self._navigate_to_page(url)
+            await detect_rate_limit(self._page)
+            try:
+                await self._page.wait_for_selector(
+                    'main input[type="text"]', timeout=5000
+                )
+            except PlaywrightTimeoutError:
+                logger.debug("Member search input did not appear on %s", url)
+
+            search_box = self._page.locator('main input[type="text"]').first
+            if await search_box.count() > 0:
+                await search_box.click()
+                await search_box.fill(keywords)
+                # Debounced server-side fetch replaces the listing in place.
+                await asyncio.sleep(2.5)
+            else:
+                logger.warning(
+                    "No member search input on %s; returning unfiltered list", url
+                )
+
+            return await self._extract_loaded_section(
+                url, "members", max_scrolls=max_scrolls
+            )
+        except LinkedInScraperException:
+            raise
+        except Exception as e:
+            logger.warning("Failed to extract filtered group members %s: %s", url, e)
+            return ExtractedSection(
+                text="",
+                references=[],
+                error=build_issue_diagnostics(
+                    e,
+                    context="get_group_members",
+                    target_url=url,
+                    section_name="members",
+                ),
+            )
 
     async def scrape_job(self, job_id: str) -> dict[str, Any]:
         """Scrape a single job posting.

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -111,9 +111,11 @@ _REFERENCE_CAPS = {
     "contact_info": 8,
     "inbox": 30,
     "conversation": 12,
-    # Group member listings are the payload of get_group_members; the low
-    # default cap would discard most member profile links after one scroll.
-    "members": 50,
+    # Group member listings are the payload of get_group_members: profile
+    # URLs per member are the point of the tool, so the cap matches
+    # LinkedIn's ~500-row serving limit per (optionally keyword-filtered)
+    # listing rather than the compact default.
+    "members": 500,
     # Headroom for get_feed's num_posts ceiling (Field(ge=1, le=50)).
     # Kept in sync with the literal cap=50 in extractor._build_feed_references
     # where SDUI-derived /posts/<slug> permalinks are appended.

--- a/linkedin_mcp_server/scraping/link_metadata.py
+++ b/linkedin_mcp_server/scraping/link_metadata.py
@@ -87,6 +87,7 @@ _SECTION_CONTEXTS = {
     "job_posting": "job posting",
     "inbox": "inbox",
     "conversation": "conversation",
+    "members": "group member",
 }
 
 _DEFAULT_REFERENCE_CAP = 12
@@ -110,6 +111,9 @@ _REFERENCE_CAPS = {
     "contact_info": 8,
     "inbox": 30,
     "conversation": 12,
+    # Group member listings are the payload of get_group_members; the low
+    # default cap would discard most member profile links after one scroll.
+    "members": 50,
     # Headroom for get_feed's num_posts ceiling (Field(ge=1, le=50)).
     # Kept in sync with the literal cap=50 in extractor._build_feed_references
     # where SDUI-derived /posts/<slug> permalinks are appended.

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -48,6 +48,7 @@ from linkedin_mcp_server.server_role import (
 from linkedin_mcp_server.update_check import UpdateNoticeMiddleware
 from linkedin_mcp_server.tools.company import register_company_tools
 from linkedin_mcp_server.tools.feed import register_feed_tools
+from linkedin_mcp_server.tools.group import register_group_tools
 from linkedin_mcp_server.tools.job import register_job_tools
 from linkedin_mcp_server.tools.messaging import register_messaging_tools
 from linkedin_mcp_server.tools.person import register_person_tools
@@ -294,6 +295,7 @@ def create_mcp_server(
         register_messaging_tools(mcp, tool_timeout=tool_timeout)
         register_feed_tools(mcp, tool_timeout=tool_timeout)
         register_post_tools(mcp, tool_timeout=tool_timeout)
+        register_group_tools(mcp, tool_timeout=tool_timeout)
 
         # Inside the gate with the rest, and easy to miss because it is the one
         # tool defined here rather than in a `register_*` call. Left out of the

--- a/linkedin_mcp_server/tools/group.py
+++ b/linkedin_mcp_server/tools/group.py
@@ -1,0 +1,92 @@
+"""
+LinkedIn group scraping tools.
+
+Uses innerText extraction for resilient group member listing capture.
+"""
+
+import logging
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.core.exceptions import AuthenticationError
+from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
+from linkedin_mcp_server.error_handler import raise_tool_error
+
+logger = logging.getLogger(__name__)
+
+
+def register_group_tools(
+    mcp: FastMCP, *, tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS
+) -> None:
+    """Register all group-related tools with the MCP server."""
+
+    @mcp.tool(
+        timeout=tool_timeout,
+        title="Get Group Members",
+        annotations={"readOnlyHint": True, "openWorldHint": True},
+        tags={"group", "scraping"},
+        exclude_args=["extractor"],
+    )
+    async def get_group_members(
+        group_id: str,
+        ctx: Context,
+        max_scrolls: Annotated[int, Field(ge=1, le=50)] | None = None,
+        extractor: Any | None = None,
+    ) -> dict[str, Any]:
+        """
+        List members of a LinkedIn group from its /members/ page.
+
+        The full member list is only visible when the logged-in account is a
+        member of the group. For groups the account has not joined, LinkedIn
+        typically redirects to the group landing page or shows only a
+        restricted preview; the returned text reflects whatever the page
+        actually served, so an unexpectedly short members section usually
+        means the account is not in that group.
+
+        group_id is the numeric id from the group URL — the path segment
+        after /groups/ (e.g. "12345" for linkedin.com/groups/12345/).
+
+        Args:
+            group_id: Numeric LinkedIn group id (e.g., "12345")
+            ctx: FastMCP context for progress reporting
+            max_scrolls: Maximum scroll-to-bottom iterations to load more
+                members. The listing is an infinite-scroll list, so each
+                scroll loads roughly one more page of members. Default (None)
+                uses 5. Increase for large groups (e.g., max_scrolls=20).
+
+        Returns:
+            Dict with url, sections (members -> raw text), and optional
+            references. References include /in/ profile paths for listed
+            members. The LLM should parse the raw text to extract member
+            names, headlines, and locations.
+        """
+        try:
+            extractor = extractor or await get_ready_extractor(
+                ctx, tool_name="get_group_members"
+            )
+            logger.info(
+                "Scraping group members: %s (max_scrolls=%s)", group_id, max_scrolls
+            )
+
+            await ctx.report_progress(
+                progress=0, total=100, message="Loading group members"
+            )
+
+            result = await extractor.get_group_members(
+                group_id, max_scrolls=max_scrolls
+            )
+
+            await ctx.report_progress(progress=100, total=100, message="Complete")
+
+            return result
+
+        except AuthenticationError as e:
+            try:
+                await handle_auth_error(e, ctx)
+            except Exception as relogin_exc:
+                raise_tool_error(relogin_exc, "get_group_members")
+        except Exception as e:
+            raise_tool_error(e, "get_group_members")  # NoReturn

--- a/linkedin_mcp_server/tools/group.py
+++ b/linkedin_mcp_server/tools/group.py
@@ -33,7 +33,7 @@ def register_group_tools(
     async def get_group_members(
         group_id: str,
         ctx: Context,
-        max_scrolls: Annotated[int, Field(ge=1, le=50)] | None = None,
+        max_scrolls: Annotated[int, Field(ge=1, le=2000)] | None = None,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
         """
@@ -53,9 +53,15 @@ def register_group_tools(
             group_id: Numeric LinkedIn group id (e.g., "12345")
             ctx: FastMCP context for progress reporting
             max_scrolls: Maximum scroll-to-bottom iterations to load more
-                members. The listing is an infinite-scroll list, so each
-                scroll loads roughly one more page of members. Default (None)
-                uses 5. Increase for large groups (e.g., max_scrolls=20).
+                members. The listing is an infinite-scroll list (no page
+                URLs), so a fresh call always restarts from the top — the
+                only way to reach deeper members is a single call with a
+                larger budget, not repeated calls. Each scroll loads roughly
+                5 more members and takes about a second. Default (None) uses
+                5. For a full pull of a large group, size the budget at
+                members/5 (e.g., ~1200 for a 6,000-member group) and raise
+                the server's --tool-timeout accordingly; the default 180s
+                timeout supports roughly 150 scrolls.
 
         Returns:
             Dict with url, sections (members -> raw text), and optional

--- a/linkedin_mcp_server/tools/group.py
+++ b/linkedin_mcp_server/tools/group.py
@@ -33,6 +33,7 @@ def register_group_tools(
     async def get_group_members(
         group_id: str,
         ctx: Context,
+        keywords: str | None = None,
         max_scrolls: Annotated[int, Field(ge=1, le=2000)] | None = None,
         extractor: Any | None = None,
     ) -> dict[str, Any]:
@@ -49,19 +50,27 @@ def register_group_tools(
         group_id is the numeric id from the group URL — the path segment
         after /groups/ (e.g. "12345" for linkedin.com/groups/12345/).
 
+        LinkedIn serves at most ~500 member rows per listing no matter how
+        far the page is scrolled. To enumerate a larger group, make multiple
+        calls with different keywords values (e.g. common first names or
+        role terms) — each filtered slice gets its own ~500-row budget —
+        and merge/dedupe the results by profile URL.
+
         Args:
             group_id: Numeric LinkedIn group id (e.g., "12345")
             ctx: FastMCP context for progress reporting
+            keywords: Optional server-side member filter (name, headline
+                term). Filters via the page's member search box.
             max_scrolls: Maximum scroll-to-bottom iterations to load more
                 members. The listing is an infinite-scroll list (no page
                 URLs), so a fresh call always restarts from the top — the
-                only way to reach deeper members is a single call with a
+                only way to reach deeper members within one slice is a
                 larger budget, not repeated calls. Each scroll loads roughly
                 5 more members and takes about a second. Default (None) uses
-                5. For a full pull of a large group, size the budget at
-                members/5 (e.g., ~1200 for a 6,000-member group) and raise
-                the server's --tool-timeout accordingly; the default 180s
-                timeout supports roughly 150 scrolls.
+                5. ~100 scrolls reaches the ~500-row serving cap; budgets
+                beyond that only add time. Raise the server's --tool-timeout
+                for deep pulls (the default 180s supports roughly 150
+                scrolls).
 
         Returns:
             Dict with url, sections (members -> raw text), and optional
@@ -74,7 +83,10 @@ def register_group_tools(
                 ctx, tool_name="get_group_members"
             )
             logger.info(
-                "Scraping group members: %s (max_scrolls=%s)", group_id, max_scrolls
+                "Scraping group members: %s (keywords=%s, max_scrolls=%s)",
+                group_id,
+                keywords,
+                max_scrolls,
             )
 
             await ctx.report_progress(
@@ -82,7 +94,7 @@ def register_group_tools(
             )
 
             result = await extractor.get_group_members(
-                group_id, max_scrolls=max_scrolls
+                group_id, keywords=keywords, max_scrolls=max_scrolls
             )
 
             await ctx.report_progress(progress=100, total=100, message="Complete")

--- a/manifest.json
+++ b/manifest.json
@@ -80,6 +80,10 @@
       "description": "List employees at a company from the LinkedIn /people/ page, with optional keyword filter by name, title, or skill"
     },
     {
+      "name": "get_group_members",
+      "description": "List members of a LinkedIn group from its /members/ page; the full list requires the authenticated account to be a member of the group"
+    },
+    {
       "name": "get_job_details",
       "description": "Retrieve specific job posting details using LinkedIn job IDs"
     },

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -141,3 +141,56 @@ class TestScrollDeadline:
         await scroll_job_sidebar(page, deadline=0.0004)
 
         assert page.wait_for_selector.await_args.kwargs["timeout"] == 1
+
+
+class TestScrollToBottom:
+    """Stall tolerance in scroll_to_bottom."""
+
+    @staticmethod
+    def _page_with_heights(heights: list[int]) -> MagicMock:
+        """Mock page whose scrollHeight evaluates to successive values.
+
+        Each scroll iteration reads the height twice (before/after);
+        window.scrollTo evaluations return None and are interleaved.
+        """
+        page = MagicMock()
+        height_iter = iter(heights)
+
+        async def evaluate(script: str) -> int | None:
+            if "scrollHeight" in script and "scrollTo" not in script:
+                return next(height_iter)
+            return None
+
+        page.evaluate = AsyncMock(side_effect=evaluate)
+        return page
+
+    async def test_default_stops_on_first_stall(self):
+        from linkedin_mcp_server.core.utils import scroll_to_bottom
+
+        # Iteration 1: 100 -> 200 (growth). Iteration 2: 200 -> 200 (stall).
+        page = self._page_with_heights([100, 200, 200, 200, 999, 999])
+        await scroll_to_bottom(page, pause_time=0, max_scrolls=10)
+        # 2 iterations x 3 evaluate calls (read, scroll, read) each
+        assert page.evaluate.await_count == 6
+
+    async def test_max_stalls_tolerates_slow_responses(self):
+        from linkedin_mcp_server.core.utils import scroll_to_bottom
+
+        # Iteration 1: growth. Iteration 2: stall. Iteration 3: growth
+        # (late XHR landed). Iteration 4 + 5: two consecutive stalls -> stop.
+        page = self._page_with_heights(
+            [100, 200, 200, 200, 200, 300, 300, 300, 300, 300]
+        )
+        await scroll_to_bottom(page, pause_time=0, max_scrolls=10, max_stalls=2)
+        assert page.evaluate.await_count == 15
+
+    async def test_stall_counter_resets_on_growth(self):
+        from linkedin_mcp_server.core.utils import scroll_to_bottom
+
+        # Alternating stall/growth never accumulates max_stalls=2 in a row,
+        # so the loop runs out of max_scrolls instead of stopping early.
+        page = self._page_with_heights(
+            [100, 100, 100, 200, 200, 200, 200, 300, 300, 300, 300, 400]
+        )
+        await scroll_to_bottom(page, pause_time=0, max_scrolls=4, max_stalls=2)
+        assert page.evaluate.await_count == 12

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -4728,7 +4728,7 @@ class TestRealOwner:
             # in a `register_*` call.
             assert "get_person_profile" in names
             assert "close_session" in names
-            assert len(names) == 19, sorted(names)
+            assert len(names) == 20, sorted(names)
         finally:
             _stop(result.get("pid"))
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -7099,6 +7099,31 @@ class TestGroupMembersExtraction:
         assert result["sections"]["members"] == "Jane Doe\nResearch Engineer"
         assert result["references"]["members"][0]["url"] == "/in/janedoe/"
 
+    async def test_get_group_members_keywords_routes_to_filtered_path(self, mock_page):
+        """A keywords value routes through the search-box filter helper
+        instead of the plain extract_page path."""
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "_extract_group_members_filtered",
+                new_callable=AsyncMock,
+                return_value=ExtractedSection(text="Maria Doe", references=[]),
+            ) as mock_filtered,
+            patch.object(
+                extractor, "extract_page", new_callable=AsyncMock
+            ) as mock_plain,
+        ):
+            result = await extractor.get_group_members(
+                "12345", keywords="maria", max_scrolls=10
+            )
+
+        mock_filtered.assert_awaited_once_with(
+            "https://www.linkedin.com/groups/12345/members/", "maria", 10
+        )
+        mock_plain.assert_not_awaited()
+        assert result["sections"]["members"] == "Maria Doe"
+
     async def test_get_group_members_rate_limited_omits_section(self, mock_page):
         """The _RATE_LIMITED_MSG sentinel is not surfaced as member text."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -7025,6 +7025,95 @@ class TestCompanyPeopleExtraction:
         assert result.text  # non-empty placeholder text from the mock
 
 
+class TestGroupMembersExtraction:
+    """Tests for get_group_members and the /groups/<id>/members/ hydration wait."""
+
+    async def test_waits_for_member_listing(self, mock_page):
+        """Group members pages share the company-people hydration wait:
+        wait until an /in/ profile anchor appears inside <main> (5s)."""
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "AI Builders\nMembers\nJane Doe\nResearch Engineer",
+                "references": [],
+            }
+        )
+        mock_page.wait_for_function = AsyncMock()
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ) as mock_scroll,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await extractor._extract_page_once(
+                "https://www.linkedin.com/groups/12345/members/",
+                section_name="members",
+            )
+
+        mock_page.wait_for_function.assert_awaited_once()
+        wait_predicate = mock_page.wait_for_function.call_args[0][0]
+        wait_kwargs = mock_page.wait_for_function.call_args.kwargs
+        assert "/in/" in wait_predicate
+        assert wait_kwargs["timeout"] == 5000
+        mock_scroll.assert_awaited_once()
+
+    async def test_get_group_members_builds_url_and_result(self, mock_page):
+        """get_group_members navigates to /groups/<id>/members/ and wraps
+        the extracted section in the standard {url, sections, references}
+        result shape, passing max_scrolls through to extract_page."""
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=ExtractedSection(
+                text="Jane Doe\nResearch Engineer",
+                references=[
+                    {
+                        "kind": "person",
+                        "url": "/in/janedoe/",
+                        "text": "Jane Doe",
+                        "context": "group member",
+                    }
+                ],
+            ),
+        ) as mock_extract:
+            result = await extractor.get_group_members("12345", max_scrolls=20)
+
+        mock_extract.assert_awaited_once_with(
+            "https://www.linkedin.com/groups/12345/members/",
+            section_name="members",
+            max_scrolls=20,
+        )
+        assert result["url"] == "https://www.linkedin.com/groups/12345/members/"
+        assert result["sections"]["members"] == "Jane Doe\nResearch Engineer"
+        assert result["references"]["members"][0]["url"] == "/in/janedoe/"
+
+    async def test_get_group_members_rate_limited_omits_section(self, mock_page):
+        """The _RATE_LIMITED_MSG sentinel is not surfaced as member text."""
+        extractor = LinkedInExtractor(mock_page)
+        with patch.object(
+            extractor,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=ExtractedSection(text=_RATE_LIMITED_MSG, references=[]),
+        ):
+            result = await extractor.get_group_members("12345")
+
+        assert result["sections"] == {}
+        assert "references" not in result
+
+
 class TestSearchResultsExtraction:
     """Tests for search results page detection and wait behavior in _extract_page_once."""
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1269,7 +1269,25 @@ class TestGetGroupMembersTool:
         result = await tool_fn("12345", mock_context, extractor=mock_extractor)
         assert "members" in result["sections"]
         mock_extractor.get_group_members.assert_awaited_once_with(
-            "12345", max_scrolls=None
+            "12345", keywords=None, max_scrolls=None
+        )
+
+    async def test_get_group_members_passes_keywords(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/groups/12345/members/",
+            "sections": {"members": "Maria Doe"},
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.group import register_group_tools
+
+        mcp = FastMCP("test")
+        register_group_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_group_members")
+        await tool_fn("12345", mock_context, keywords="maria", extractor=mock_extractor)
+        mock_extractor.get_group_members.assert_awaited_once_with(
+            "12345", keywords="maria", max_scrolls=None
         )
 
     async def test_get_group_members_passes_max_scrolls(self, mock_context):
@@ -1287,7 +1305,7 @@ class TestGetGroupMembersTool:
         tool_fn = await get_tool_fn(mcp, "get_group_members")
         await tool_fn("12345", mock_context, max_scrolls=20, extractor=mock_extractor)
         mock_extractor.get_group_members.assert_awaited_once_with(
-            "12345", max_scrolls=20
+            "12345", keywords=None, max_scrolls=20
         )
 
     async def test_get_group_members_error(self, mock_context):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -40,6 +40,7 @@ def _make_mock_extractor(scrape_result: dict) -> MagicMock:
     mock.search_companies = AsyncMock(return_value=scrape_result)
     mock.search_posts = AsyncMock(return_value=scrape_result)
     mock.get_company_employees = AsyncMock(return_value=scrape_result)
+    mock.get_group_members = AsyncMock(return_value=scrape_result)
     mock.extract_page = AsyncMock(
         return_value=ExtractedSection(text="some text", references=[])
     )
@@ -1251,6 +1252,62 @@ class TestFeedToolDeadline:
             await self._call(use_session=False)
 
 
+class TestGetGroupMembersTool:
+    async def test_get_group_members_success(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/groups/12345/members/",
+            "sections": {"members": "Jane Doe\nResearch Engineer\nSan Francisco"},
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.group import register_group_tools
+
+        mcp = FastMCP("test")
+        register_group_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_group_members")
+        result = await tool_fn("12345", mock_context, extractor=mock_extractor)
+        assert "members" in result["sections"]
+        mock_extractor.get_group_members.assert_awaited_once_with(
+            "12345", max_scrolls=None
+        )
+
+    async def test_get_group_members_passes_max_scrolls(self, mock_context):
+        expected = {
+            "url": "https://www.linkedin.com/groups/12345/members/",
+            "sections": {"members": "Jane Doe"},
+        }
+        mock_extractor = _make_mock_extractor(expected)
+
+        from linkedin_mcp_server.tools.group import register_group_tools
+
+        mcp = FastMCP("test")
+        register_group_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_group_members")
+        await tool_fn("12345", mock_context, max_scrolls=20, extractor=mock_extractor)
+        mock_extractor.get_group_members.assert_awaited_once_with(
+            "12345", max_scrolls=20
+        )
+
+    async def test_get_group_members_error(self, mock_context):
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.exceptions import SessionExpiredError
+
+        mock_extractor = MagicMock()
+        mock_extractor.get_group_members = AsyncMock(side_effect=SessionExpiredError())
+
+        from linkedin_mcp_server.tools.group import register_group_tools
+
+        mcp = FastMCP("test")
+        register_group_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "get_group_members")
+        with pytest.raises(ToolError, match="Session expired"):
+            await tool_fn("12345", mock_context, extractor=mock_extractor)
+
+
 class TestFeedTools:
     async def test_get_feed_success(self, mock_context):
         mock_extractor = MagicMock()
@@ -1489,6 +1546,7 @@ class TestToolTimeouts:
             "get_company_posts",
             "search_companies",
             "get_company_employees",
+            "get_group_members",
             "get_job_details",
             "search_jobs",
             "get_saved_jobs",


### PR DESCRIPTION
## What

Adds a `get_group_members` tool that lists the members of a LinkedIn group from its `/members/` page, with an optional server-side `keywords` filter and a `max_scrolls` budget for the infinite-scroll listing.

- New `linkedin_mcp_server/tools/group.py` registering the tool; wired into `server.py`.
- New `LinkedInExtractor.get_group_members` reusing the standard `extract_page` pipeline (rate-limit retry, noise filtering, references), returning the usual `{url, sections: {members: raw_text}, references}` shape.
- Group members pages share the company-people hydration wait (wait for `/in/` anchors in `<main>`, 5s timeout).
- `scroll_to_bottom` gains a backwards-compatible `max_stalls` parameter; group member pages scroll at a 1s pause with `max_stalls=3`.
- `keywords` filters via the page's member search box using the structural, locale-independent selector `main input[type="text"]` (the page has exactly one text input in `<main>`); a `?q=` URL param is accepted by LinkedIn but ignored — verified live.
- Person references in the members section carry `context: "group member"` and the section's reference cap is 500.
- README and manifest.json tool listings updated.

## Why

There was no way to enumerate a group's membership. Live findings that shaped the design (all verified against a 5,912-member group):

- The unfiltered listing is **server-capped at ~500 rows** regardless of scroll depth (two independent deep pulls both stopped at exactly 501), so repeated identical calls can never see past the top of the list.
- Keyword-filtered slices each get their own deep pagination (single-letter slices returned 1,000+ rows), and matching is word-prefix on names — so a–z slices merged by profile URL enumerated 5,841/5,912 members (98.8%; the remainder appears to be stale counts/deactivated profiles).
- At the previous 0.5s scroll pause, one slow pagination XHR read as "end of list" and cut pulls off hundreds of members early — hence the stall tolerance.

The tool docstring teaches MCP clients this slicing strategy directly.

## Reviewer notes

- Detection stays locale-independent per the scraping rules: URL shapes, structural selectors, and attribute presence only — no text-value matching.
- Deep pulls need a raised `--tool-timeout` (default 180s ≈ 150 scrolls); the docstring says so.
- Unit tests cover tool registration/pass-through, extractor URL/result assembly, the hydration wait, keyword routing, and the `scroll_to_bottom` stall logic. `uv run pytest` (784 passed), `ruff`, and `ty` are green.
- No linked issue — implemented and live-verified in one session; happy to file one retroactively if preferred.

## Synthetic prompt

> Add a `get_group_members` tool that scrapes a LinkedIn group's `/members/` page (numeric group id), following the get_company_employees pattern. Support `max_scrolls` for the infinite-scroll list and an optional `keywords` filter via the page's member search box. Verify live: handle the ~500-row cap on the unfiltered listing, add scroll stall tolerance so slow pagination XHRs don't end pulls early, and tag member references with a "group member" context. Update tests, README, and manifest.
