### PR TITLE
fix(scraping): capture SDUI post permalinks on company/person posts pages

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -55,6 +55,8 @@ from linkedin_mcp_server.scraping.identifiers import (
 from linkedin_mcp_server.scraping.link_metadata import (
     JOB_PATH_RE,
     Reference,
+    _DEFAULT_REFERENCE_CAP,
+    _REFERENCE_CAPS,
     _SEARCH_RESULTS_REFERENCE_CAP,
     build_references,
     dedupe_references,
@@ -773,6 +775,82 @@ def _is_feed_payload_response(url: str) -> bool:
     return url.split("?", 1)[0] in _FEED_DOCUMENT_URLS
 
 
+# Content types that never carry the JSON/RSC payloads _POST_SLUG_URL_RE
+# matches against. Company/person posts pages don't expose a stable SDUI
+# marker analogous to _FEED_RSC_MARKER (unverified whether one exists), so
+# _is_post_listing_response casts a wider net than _is_feed_payload_response
+# and relies on this prefix list plus the regex itself to stay cheap and
+# correct rather than on a guessed marker string.
+_NON_PAYLOAD_CONTENT_TYPE_PREFIXES = (
+    "image/",
+    "video/",
+    "audio/",
+    "font/",
+    "text/css",
+)
+
+
+def _is_post_listing_response(resp: Any) -> bool:
+    """True if a response on a posts-listing page is worth scanning for permalinks."""
+    try:
+        content_type = resp.headers.get("content-type", "")
+    except Exception:
+        return True
+    content_type = content_type.split(";", 1)[0].strip().lower()
+    return not content_type.startswith(_NON_PAYLOAD_CONTENT_TYPE_PREFIXES)
+
+
+def _is_post_listing_page(url: str) -> bool:
+    """True for pages whose posts render without a DOM permalink anchor.
+
+    Company posts pages (``/company/<slug>/posts/``) and a person's activity
+    feed (``/recent-activity/...``) both lazy-load posts the same way the
+    main feed does, and LinkedIn does not render a real ``<a href>`` for the
+    individual post on either — only the main feed has a dedicated
+    DOM-anchor path (``feed_post`` via ``/feed/update/<urn>/``). Matched on
+    the parsed path since the url can carry a query string
+    (``?viewAsMember=true``) that a raw suffix check would miss.
+    """
+    path = urlparse(url).path
+    return "/recent-activity/" in path or (
+        "/company/" in path and path.rstrip("/").endswith("/posts")
+    )
+
+
+def _append_captured_post_permalinks(
+    refs: list[Reference],
+    captured_urls: list[str],
+    *,
+    context: str,
+) -> list[Reference]:
+    """Append ``/posts/<slug>`` permalinks captured from network responses.
+
+    Skips any capture already present as an exact URL match. The two shapes
+    that can point at the same underlying post (a DOM-derived reference vs.
+    a captured ``/posts/<slug>`` permalink) will *not* collapse —
+    ``dedupe_references`` matches strings, not URNs. Both are valid
+    LinkedIn permalinks; URN-based equivalence is left to the consumer.
+    """
+    existing = {r["url"] for r in refs}
+    merged = list(refs)
+    for sdui_url in captured_urls:
+        # AGENTS.md mandates relative paths for LinkedIn references.
+        # The capture carries fully-qualified URLs like
+        # https://www.linkedin.com/posts/<slug>; strip the host so the
+        # relative-path convention holds. ``classify_link`` does not
+        # currently route ``/posts/<slug>`` paths to any kind, so we
+        # bypass it for this fallback append.
+        parsed = urlparse(sdui_url)
+        if not parsed.path.startswith("/posts/"):
+            continue
+        relative = parsed.path
+        if relative in existing:
+            continue
+        merged.append({"kind": "feed_post", "url": relative, "context": context})
+        existing.add(relative)
+    return merged
+
+
 def _build_feed_references(
     raw_references: list[Any],
     captured_urls: list[str],
@@ -789,34 +867,13 @@ def _build_feed_references(
       URLs (whatever ``classify_link`` recognises).
     - SDUI captures → ``feed_post`` entries with ``/posts/<slug>`` URLs
       for permalinks that the DOM does not surface as an anchor.
-
-    Both are deduped on exact URL string. The two shapes pointing at
-    the same underlying post will *not* collapse — ``dedupe_references``
-    matches strings, not URNs. Both are valid LinkedIn permalinks, so
-    consumers should treat ``feed_post`` as polymorphic on URL form;
-    URN-based equivalence is left to the consumer.
     """
     refs = [
         ref
         for ref in build_references(raw_references, "feed")
         if ref["kind"] == "feed_post"
     ]
-    existing = {r["url"] for r in refs}
-    for sdui_url in captured_urls:
-        # AGENTS.md mandates relative paths for LinkedIn references.
-        # The SDUI capture carries fully-qualified URLs like
-        # https://www.linkedin.com/posts/<slug>; strip the host so the
-        # relative-path convention holds. ``classify_link`` does not
-        # currently route ``/posts/<slug>`` paths to any kind, so we
-        # bypass it for this fallback append.
-        parsed = urlparse(sdui_url)
-        if not parsed.path.startswith("/posts/"):
-            continue
-        relative = parsed.path
-        if relative in existing:
-            continue
-        refs.append({"kind": "feed_post", "url": relative, "context": "feed"})
-        existing.add(relative)
+    refs = _append_captured_post_permalinks(refs, captured_urls, context="feed")
     # Cap kept in sync with _REFERENCE_CAPS["feed"] in link_metadata.py;
     # changing one without the other will drop or duplicate entries
     # silently. Matches get_feed's num_posts ceiling (Field(ge=1, le=50)).
@@ -1788,14 +1845,60 @@ class LinkedInExtractor:
         max_scrolls: int | None = None,
     ) -> ExtractedSection:
         """Single attempt to navigate, scroll, and extract innerText."""
-        await self._navigate_to_page(url)
-        return await self._extract_loaded_section(url, section_name, max_scrolls)
+        if not _is_post_listing_page(url):
+            await self._navigate_to_page(url)
+            return await self._extract_loaded_section(url, section_name, max_scrolls)
+
+        # Company/person posts pages don't render a DOM anchor for the
+        # individual post (see _is_post_listing_page), so listen for the
+        # permalink the same way _extract_feed_once does for the main feed:
+        # a network response carrying the post's real /posts/<slug> url.
+        # The listener must be live before navigation — the initial page
+        # load's own response can carry the first batch of permalinks.
+        captured_urls: list[str] = []
+        seen_urls: set[str] = set()
+        pending_reads: list[asyncio.Task[None]] = []
+
+        def _handle_response(resp: Any) -> None:
+            if not _is_post_listing_response(resp):
+                return
+
+            async def _read() -> None:
+                try:
+                    body = await resp.body()
+                except Exception:
+                    return
+                if not body:
+                    return
+                text = body.decode("utf-8", errors="replace")
+                for match in _POST_SLUG_URL_RE.finditer(text):
+                    post_url = f"https://www.linkedin.com/posts/{match.group('slug')}"
+                    if post_url not in seen_urls:
+                        seen_urls.add(post_url)
+                        captured_urls.append(post_url)
+
+            pending_reads.append(asyncio.create_task(_read()))
+
+        self._page.on("response", _handle_response)
+        try:
+            await self._navigate_to_page(url)
+            return await self._extract_loaded_section(
+                url, section_name, max_scrolls, captured_post_urls=captured_urls
+            )
+        finally:
+            try:
+                self._page.remove_listener("response", _handle_response)
+            except Exception:
+                pass
+            await _drain_listener_tasks(pending_reads)
 
     async def _extract_loaded_section(
         self,
         url: str,
         section_name: str,
         max_scrolls: int | None = None,
+        *,
+        captured_post_urls: list[str] | None = None,
     ) -> ExtractedSection:
         """Run the post-navigation extraction pipeline on the current page.
 
@@ -1817,13 +1920,8 @@ class LinkedInExtractor:
 
         # Activity feed pages lazy-load post content after the tab header.
         # Company posts pages (/company/<slug>/posts/) lazy-load the same way
-        # but don't carry a /recent-activity/ path, so match them too. Matched
-        # on the parsed path, since the url can carry a query string
-        # (?viewAsMember=true) that a raw suffix check would miss.
-        path = urlparse(url).path
-        is_activity = "/recent-activity/" in path or (
-            "/company/" in path and path.rstrip("/").endswith("/posts")
-        )
+        # but don't carry a /recent-activity/ path, so match them too.
+        is_activity = _is_post_listing_page(url)
         if is_activity:
             try:
                 await self._page.wait_for_function(
@@ -1928,6 +2026,11 @@ class LinkedInExtractor:
             scrolls = max_scrolls if max_scrolls is not None else 5
             await scroll_to_bottom(self._page, pause_time=0.5, max_scrolls=scrolls)
 
+        if captured_post_urls is not None:
+            # Give any in-flight response reads a beat to finish recording
+            # URLs before we read them (mirrors _extract_feed_body).
+            await asyncio.sleep(0.2)
+
         # Extract text from main content area
         raw_result = await self._extract_root_content(["main"])
         raw = raw_result["text"]
@@ -1941,10 +2044,24 @@ class LinkedInExtractor:
             )
             return ExtractedSection(text=_RATE_LIMITED_MSG, references=[])
         cleaned = _filter_linkedin_noise_lines(truncated)
-        return ExtractedSection(
-            text=cleaned,
-            references=build_references(raw_result["references"], section_name),
-        )
+
+        if captured_post_urls is not None:
+            # Merge DOM-derived references with permalinks captured from
+            # network responses before applying the section's cap, so the
+            # two compete fairly for the available slots (see
+            # _append_captured_post_permalinks).
+            refs = build_references(
+                raw_result["references"], section_name, apply_cap=False
+            )
+            refs = _append_captured_post_permalinks(
+                refs, captured_post_urls, context=section_name
+            )
+            cap = _REFERENCE_CAPS.get(section_name, _DEFAULT_REFERENCE_CAP)
+            references = dedupe_references(refs, cap=cap)
+        else:
+            references = build_references(raw_result["references"], section_name)
+
+        return ExtractedSection(text=cleaned, references=references)
 
     async def _extract_overlay(
         self,

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -31,7 +31,10 @@ from linkedin_mcp_server.scraping.extractor import (
     LinkedInExtractor,
     _CONTENT_DATE_POSTED_MAP,
     _RATE_LIMITED_MSG,
+    _append_captured_post_permalinks,
     _build_feed_references,
+    _is_post_listing_page,
+    _is_post_listing_response,
     _truncate_linkedin_noise,
     strip_conversation_chrome,
     strip_linkedin_noise,
@@ -8972,7 +8975,164 @@ class TestBuildFeedReferences:
         assert kinds == {"feed_post"}
 
 
-class TestDrainListenerTasks:
+class TestIsPostListingPage:
+    """Tests for _is_post_listing_page URL matching (issue #788)."""
+
+    def test_recent_activity_path_matches(self):
+        assert _is_post_listing_page(
+            "https://www.linkedin.com/in/billgates/recent-activity/all/"
+        )
+
+    def test_company_posts_path_matches(self):
+        assert _is_post_listing_page(
+            "https://www.linkedin.com/company/microsoft/posts/"
+        )
+
+    def test_company_posts_path_with_query_string_matches(self):
+        assert _is_post_listing_page(
+            "https://www.linkedin.com/company/microsoft/posts/?viewAsMember=true"
+        )
+
+    def test_plain_profile_path_does_not_match(self):
+        assert not _is_post_listing_page("https://www.linkedin.com/in/billgates/")
+
+    def test_company_about_path_does_not_match(self):
+        assert not _is_post_listing_page(
+            "https://www.linkedin.com/company/microsoft/about/"
+        )
+
+
+class TestIsPostListingResponse:
+    """Tests for _is_post_listing_response content-type filtering."""
+
+    @staticmethod
+    def _response(content_type: str) -> SimpleNamespace:
+        return SimpleNamespace(headers={"content-type": content_type})
+
+    def test_json_response_is_capturable(self):
+        assert _is_post_listing_response(self._response("application/json"))
+
+    def test_html_response_is_capturable(self):
+        assert _is_post_listing_response(self._response("text/html; charset=utf-8"))
+
+    def test_missing_content_type_is_capturable(self):
+        assert _is_post_listing_response(SimpleNamespace(headers={}))
+
+    def test_image_response_is_skipped(self):
+        assert not _is_post_listing_response(self._response("image/png"))
+
+    def test_video_response_is_skipped(self):
+        assert not _is_post_listing_response(self._response("video/mp4"))
+
+    def test_css_response_is_skipped(self):
+        assert not _is_post_listing_response(self._response("text/css"))
+
+    def test_header_lookup_failure_defaults_to_capturable(self):
+        class ExplodingHeaders:
+            def get(self, *args, **kwargs):
+                raise RuntimeError("boom")
+
+        assert _is_post_listing_response(SimpleNamespace(headers=ExplodingHeaders()))
+
+
+class TestAppendCapturedPostPermalinks:
+    """Tests for _append_captured_post_permalinks (shared feed/posts merge)."""
+
+    def test_appends_new_permalink_with_given_context(self):
+        refs = _append_captured_post_permalinks(
+            [],
+            ["https://www.linkedin.com/posts/idsa_slug-activity-1-xx"],
+            context="posts",
+        )
+        assert refs == [
+            {
+                "kind": "feed_post",
+                "url": "/posts/idsa_slug-activity-1-xx",
+                "context": "posts",
+            }
+        ]
+
+    def test_skips_url_already_present(self):
+        existing: list[Reference] = [
+            {"kind": "company", "url": "/posts/idsa_slug-activity-1-xx"},
+        ]
+        refs = _append_captured_post_permalinks(
+            existing,
+            ["https://www.linkedin.com/posts/idsa_slug-activity-1-xx"],
+            context="posts",
+        )
+        assert refs == existing
+
+    def test_skips_non_posts_paths(self):
+        refs = _append_captured_post_permalinks(
+            [], ["https://www.linkedin.com/company/idsa/"], context="posts"
+        )
+        assert refs == []
+
+
+class TestExtractPageCapturesCompanyPostPermalinks:
+    """End-to-end: a company/person posts page's real network response
+    permalink (unreachable via DOM anchors, see issue #788) survives into
+    the final references."""
+
+    async def test_company_posts_page_merges_captured_permalink(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "source": "root",
+                "text": "Post content " * 50,
+                "references": [
+                    {
+                        "href": "https://www.linkedin.com/company/idsa/",
+                        "text": "International Data Spaces Association",
+                    }
+                ],
+            }
+        )
+
+        async def fake_body():
+            return (
+                b'{"postSlugUrl":"https://www.linkedin.com/posts/'
+                b'idsa_some-slug-activity-1234567890-xxXX"}'
+            )
+
+        fake_response = SimpleNamespace(
+            headers={"content-type": "application/json"},
+            body=fake_body,
+        )
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.extractor.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            extractor = LinkedInExtractor(mock_page)
+            call = asyncio.ensure_future(
+                extractor._extract_page_once(
+                    "https://www.linkedin.com/company/idsa/posts/",
+                    section_name="posts",
+                )
+            )
+            # Let _extract_page_once install its "response" listener before
+            # firing the simulated network event.
+            await asyncio.sleep(0)
+            for handler in mock_page.listeners.get("response", []):
+                handler(fake_response)
+            result = await call
+
+        urls = [r["url"] for r in result.references]
+        assert "/posts/idsa_some-slug-activity-1234567890-xxXX" in urls
+        assert any(r["url"] == "/company/idsa/" for r in result.references)
+
     """Teardown of the feed response reads, on every path out of it.
 
     The reads are fire-and-forget: ``_extract_feed_once`` unsubscribes the


### PR DESCRIPTION
## Summary

`get_company_posts` (and `get_person_profile`'s `posts` section) never surfaced a real `/posts/<slug>` permalink for the individual post, even where one demonstrably exists — see #788. `get_feed` already works around the same underlying problem (LinkedIn renders no DOM `<a href>` for an individual post's permalink) via a dedicated network-response listener, `_build_feed_references()`, that scans responses for the `postSlugUrl` field.

This PR generalises that technique to any posts-listing page:

- `_is_post_listing_page(url)` identifies company posts pages (`/company/<slug>/posts/`) and a person's activity feed (`/recent-activity/...`) — both already share the same lazy-load handling (`is_activity`) in `_extract_loaded_section`.
- `_extract_page_once` now installs a `response` listener *before navigating* whenever `_is_post_listing_page(url)` is true (the initial page load itself can carry the first batch of permalinks — see verification below), reusing the same `_POST_SLUG_URL_RE` the feed path already relies on.
- Captured permalinks are merged into the section's DOM-derived references before the section's reference cap is applied (`_append_captured_post_permalinks`, factored out of `_build_feed_references` so both paths share the merge logic).

## Why not reuse the feed's exact marker (`_FEED_RSC_MARKER`)?

The feed listens for a specific SDUI marker string in the response URL. Company/person posts pages turned out to use a *different* API surface entirely (see verification below), so guessing a marker string by analogy would have been wrong. Instead, `_is_post_listing_response` filters by content-type only (skipping obvious binary media — images/video/audio/fonts/css) and lets the existing permalink regex be the actual correctness filter. This costs a bit more per-response reading on a page whose response count is small and bounded (one page load + a capped scroll loop), which is a fine trade for not hardcoding an unverified assumption.

## Verification (real network capture, not just source reading)

Captured HAR traffic from both page types against my own LinkedIn account:

**Company posts** (`linkedin.com/company/microsoft/posts/`):
- The initial page's own `text/html` response already contains 3 permalinks (confirms the listener must be live before navigation).
- Pagination on scroll goes through `voyager/api/graphql?...moduleKey:ORGANIZATION_MEMBER_FEED_DESKTOP...`, content-type `application/vnd.linkedin.normalized+json+2.1` — 10-11 unique post permalinks per call.

**Person recent-activity** (`linkedin.com/in/<user>/recent-activity/all/`):
- Same `voyager/api/graphql` architecture, keyed by `profileUrn` instead of `organizationalPageUrn`, same content-type. Confirmed a real permalink extracted correctly.

Neither matches `_FEED_RSC_MARKER` or any SDUI marker — confirming the content-type-based approach (rather than a guessed marker) was the right call here.

## Testing

- New unit tests for `_is_post_listing_page`, `_is_post_listing_response`, and `_append_captured_post_permalinks`.
- New integration-style test (`TestExtractPageCapturesCompanyPostPermalinks`) simulating a network response on a company posts page end-to-end through `_extract_page_once`, asserting the captured permalink survives into the final references alongside the DOM-derived ones.
- Existing `TestBuildFeedReferences` and `TestActivityFeedExtraction` suites pass unchanged (refactor preserves feed behaviour exactly).
- Full test suite: 2990 passed, 9 pre-existing failures unrelated to this change (confirmed identical failures on `main` before this diff — environment-specific bootstrap/daemon-election probes, not scraping-related).
- `ruff check`: no new findings beyond the existing baseline (confirmed via before/after diff).

Fixes #788.
