### PR TITLE
fix(messaging): Pin verified composer

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -442,9 +442,9 @@ _MESSAGING_COMPOSE_SELECTOR = '[role="textbox"][contenteditable="true"]'
 # is then the only record that a message may already have left. Answering the
 # caller instead needs the tool to know its own deadline, which is issue #889.
 SEND_INTERRUPTED_WARNING = (
-    "Message submission was interrupted while in flight. Delivery is unknown; "
-    "check the conversation before retrying, as a retry may deliver the "
-    "message twice."
+    "Message submission was interrupted while in flight. The send outcome is "
+    "unknown; check the conversation before retrying, as a retry may deliver "
+    "the message twice."
 )
 
 _PROFILE_MESSAGE_TARGET_JS = r"""() => {
@@ -452,20 +452,42 @@ _PROFILE_MESSAGE_TARGET_JS = r"""() => {
         element &&
         (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
     );
+    const active = anchor =>
+        visible(anchor) &&
+        !anchor.hasAttribute('disabled') &&
+        (anchor.getAttribute('aria-disabled') || '').toLowerCase() !== 'true';
     const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
     const main = document.querySelector('main');
     if (!main) return null;
-    const scope = main.querySelector('section') || main.firstElementChild || main;
-    const composeHrefs = Array.from(
-        scope.querySelectorAll('a[href*="/messaging/compose/"]')
-    )
+
+    const candidates = Array.from(main.querySelectorAll('section'))
         .filter(visible)
-        .map(anchor => anchor.getAttribute('href') || anchor.href || '');
-    const heading = scope.querySelector('h1');
+        .map(section => {
+            const headings = Array.from(section.querySelectorAll('h1')).filter(
+                heading => visible(heading) && heading.closest('section') === section
+            );
+            const composeAnchors = Array.from(
+                section.querySelectorAll('a[href*="/messaging/compose/"]')
+            ).filter(
+                anchor => active(anchor) && anchor.closest('section') === section
+            );
+            return {section, headings, composeAnchors};
+        })
+        .filter(
+            candidate =>
+                candidate.headings.length === 1 &&
+                candidate.composeAnchors.length === 1
+        );
+    if (candidates.length !== 1) return null;
+
+    const candidate = candidates[0];
+    const anchor = candidate.composeAnchors[0];
     return {
         pageUrl: window.location.href,
-        displayName: normalize(heading?.innerText || heading?.textContent || ''),
-        composeHrefs,
+        displayName: normalize(
+            candidate.headings[0].innerText || candidate.headings[0].textContent || ''
+        ),
+        composeHrefs: [anchor.getAttribute('href') || anchor.href || ''],
     };
 }"""
 
@@ -497,11 +519,6 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
             ) {
                 return null;
             }
-            // Everything under /in/<slug>/ belongs to that member, so the
-            // canonical path is the identity. Measured on a live profile:
-            // four of its own anchors point at /overlay/... and
-            // /recent-activity/, and reading those as an unknown member let
-            // the recipient contradict themselves.
             const match = /^\/in\/([^/?#]+)(?:\/.*)?$/.exec(url.pathname);
             return match ? `/in/${match[1]}/` : null;
         } catch {
@@ -514,82 +531,84 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
         ).filter(visible);
         if (editors.length !== 1) return {status: 'ambiguous_editor'};
         const editor = editors[0];
-        const outsideEditor = element =>
-            element !== editor && !editor.contains(element);
-        const readIdentity = owner => ({
-            // Draft content is untrusted. Neither the editor nor anything
-            // inside it may authorize or contradict the outer recipient.
-            paths: Array.from(owner.querySelectorAll('a[href*="/in/"]'))
-                .filter(element => visible(element) && outsideEditor(element))
+        const localScopes = [];
+        let ancestor = editor.parentElement;
+        while (ancestor) {
+            if (ancestor.matches('form, dialog, [role="dialog"]')) {
+                localScopes.push(ancestor);
+            }
+            ancestor = ancestor.parentElement;
+        }
+        if (localScopes.length === 0) return {status: 'missing_owner'};
+
+        const outsideDraftAndHistory = element =>
+            element !== editor &&
+            !editor.contains(element) &&
+            !element.closest('[data-view-name="message-list-item"]');
+        const readIdentity = scope => ({
+            paths: Array.from(scope.querySelectorAll('a[href*="/in/"]'))
+                .filter(element => visible(element) && outsideDraftAndHistory(element))
                 .map(anchor => profilePath(anchor.getAttribute('href') || anchor.href || '')),
-            // Every identity attribute an element carries is read, never only
-            // the first one present: a matching data-profile-urn must not hide
-            // a contradicting data-recipient-urn on the same element. An
-            // absent attribute is skipped, while a present one that is empty
-            // or malformed normalizes to null and so fails closed.
             urns: [
-                ...(owner.matches('[data-profile-urn], [data-recipient-urn]')
-                    ? [owner]
+                ...(scope.matches('[data-profile-urn], [data-recipient-urn]')
+                    ? [scope]
                     : []),
-                ...owner.querySelectorAll(
-                    '[data-profile-urn], [data-recipient-urn]'
-                ),
-            ].filter(element => visible(element) && outsideEditor(element)).flatMap(
-                element => ['data-profile-urn', 'data-recipient-urn']
+                ...scope.querySelectorAll('[data-profile-urn], [data-recipient-urn]'),
+            ].filter(
+                element => visible(element) && outsideDraftAndHistory(element)
+            ).flatMap(element =>
+                ['data-profile-urn', 'data-recipient-urn']
                     .filter(name => element.hasAttribute(name))
                     .map(name => normalizeUrn(element.getAttribute(name)))
             ),
         });
-        // The walk climbs until a dialog closes it, and every identity it
-        // finds on the way has to agree with the target. That scope is
-        // deliberate and it is not free. A thread rendered inside the same
-        // section as the editor puts its message history in the walk, so a
-        // profile mention anyone can drop into a conversation refuses every
-        // later send to that person. The refusal is the safe half of the
-        // trade: adding identities can only ever make this stricter, so the
-        // recipient cannot use it to redirect a message. The unsafe half
-        // needs the real recipient to expose no identity at all in the whole
-        // chain while a mention of the target does, which no measurement has
-        // reached: the live compose surface has not been read yet, so what
-        // LinkedIn actually puts between the editor and its dialog is
-        // unknown. Narrowing the walk to the innermost owner would cut the
-        // false refusals and give up that asymmetry, which is a design
-        // decision and not a repair.
-        const identities = [];
-        let ancestor = editor.parentElement;
-        while (ancestor) {
-            if (ancestor.matches('dialog, [role="dialog"], form, section, article')) {
-                const identity = readIdentity(ancestor);
-                if (identity.paths.length + identity.urns.length > 0) {
-                    identities.push({owner: ancestor, ...identity});
-                }
-                if (ancestor.matches('dialog, [role="dialog"]')) break;
-            }
-            ancestor = ancestor.parentElement;
-        }
-        if (identities.length === 0) return {status: 'missing_recipient'};
-        const owner = identities[0].owner;
-        const paths = identities.flatMap(identity => identity.paths);
-        const urns = identities.flatMap(identity => identity.urns);
-        if (
-            paths.some(path => path !== target.profilePath) ||
-            urns.some(urn => urn !== target.profileUrn)
-        ) {
-            return {status: 'recipient_mismatch'};
-        }
 
-        const buttons = Array.from(
-            owner.querySelectorAll('button[type="submit"], button[data-control-name="send"]')
-        ).filter(visible);
+        const submitButtons = scope => Array.from(
+            scope.querySelectorAll(
+                'button[type="submit"], button[data-control-name="send"]'
+            )
+        ).filter(button =>
+            visible(button) &&
+            !button.closest('[data-view-name="message-list-item"]')
+        );
+        let localScope = null;
+        let identity = null;
+        let buttons = [];
+        let enterScope = null;
+        let enterIdentity = null;
+        for (const scope of localScopes) {
+            const candidate = readIdentity(scope);
+            if (candidate.paths.length + candidate.urns.length === 0) continue;
+            if (
+                candidate.paths.some(path => path !== target.profilePath) ||
+                candidate.urns.some(urn => urn !== target.profileUrn)
+            ) {
+                return {status: 'recipient_mismatch'};
+            }
+            if (!enterScope) {
+                enterScope = scope;
+                enterIdentity = candidate;
+            }
+            const candidateButtons = submitButtons(scope);
+            if (!localScope && candidateButtons.length > 0) {
+                localScope = scope;
+                identity = candidate;
+                buttons = candidateButtons;
+            }
+        }
+        localScope = localScope || enterScope;
+        identity = identity || enterIdentity;
+        if (!localScope || !identity) return {status: 'missing_recipient'};
+        const owner = localScopes.find(scope =>
+            scope.matches('dialog, [role="dialog"]')
+        ) || localScope;
         return {
             status: 'valid',
             editor,
+            localScope,
             owner,
             buttons,
             active: document.activeElement === editor,
-            // Reported, never required: the send path refuses a composer that
-            // already holds a draft, and the same routine runs again after
-            // typing, when the editor is of course no longer empty.
             empty: !(editor.innerText || '').replace(/\s+/g, ' ').trim(),
         };
     };
@@ -612,70 +631,226 @@ _MESSAGE_COMPOSER_OWNER_JS = (
     }"""
 )
 
-_MESSAGE_OCCURRENCES_JS = (
+_MESSAGE_CONFIRMATION_PREPARE_JS = (
     "(arg) => {"
     + _MESSAGE_COMPOSER_INSPECT_JS
     + r"""
-        const state = inspect(arg);
+        const composer = inspect(arg);
         if (
-            state.status !== 'valid' ||
+            composer.status !== 'valid' ||
             !arg.owner ||
-            state.owner !== arg.owner ||
+            composer.owner !== arg.owner ||
             !arg.owner.isConnected ||
-            !state.editor.isConnected ||
-            !arg.owner.contains(state.editor)
+            !composer.editor.isConnected ||
+            !arg.owner.contains(composer.editor)
         ) {
-            return {status: 'invalid'};
+            return null;
         }
 
-        const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
-        const textUnits = value => (value || '')
-            .split(/\r?\n/)
-            .map(normalize)
-            .filter(Boolean);
-        const expectedUnits = textUnits(arg.expected);
-        if (expectedUnits.length === 0) {
-            return {status: 'valid', count: 0};
-        }
-        const countIn = value => {
-            const renderedUnits = textUnits(value);
-            let count = 0;
-            for (
-                let index = 0;
-                index <= renderedUnits.length - expectedUnits.length;
-                index += 1
-            ) {
-                if (
-                    expectedUnits.every(
-                        (unit, offset) => renderedUnits[index + offset] === unit
-                    )
-                ) {
-                    count += 1;
+        const counter = (arg.owner.__linkedinMcpConfirmationCounter || 0) + 1;
+        arg.owner.__linkedinMcpConfirmationCounter = counter;
+        const token = String(counter);
+        const marker = document.createElement('span');
+        marker.hidden = true;
+        marker.setAttribute('data-linkedin-mcp-confirmation', token);
+        marker.setAttribute('data-linkedin-mcp-invalid', 'false');
+        arg.owner.appendChild(marker);
+        composer.editor.setAttribute('data-linkedin-mcp-editor', token);
+        const state = {
+            owner: arg.owner,
+            editor: composer.editor,
+            expected: arg.expected,
+            candidates: new Map(),
+            invalid: false,
+        };
+        const exactUnit = (node, requireVisible) => {
+            if (requireVisible && !visible(node)) return false;
+            const elements = [node, ...node.querySelectorAll('*')].filter(
+                element => !requireVisible || visible(element)
+            );
+            const matches = elements.filter(
+                element => (element.innerText || '') === state.expected
+            );
+            const smallest = matches.filter(
+                element => !matches.some(
+                    other => other !== element && element.contains(other)
+                )
+            );
+            return smallest.length === 1;
+        };
+        const remember = node => {
+            if (!(node instanceof Element)) return;
+            const items = [
+                ...(node.matches('[data-view-name="message-list-item"]')
+                    ? [node]
+                    : []),
+                ...node.querySelectorAll('[data-view-name="message-list-item"]'),
+            ];
+            for (const item of items) {
+                if (!state.candidates.has(item)) {
+                    item.setAttribute('data-linkedin-mcp-candidate', token);
+                    state.candidates.set(item, {
+                        transitioned: false,
+                        matched: false,
+                    });
                 }
             }
-            return count;
         };
-        const isVisible = element => !!(
-            element &&
-            (element.offsetWidth ||
-                element.offsetHeight ||
-                element.getClientRects().length)
-        );
-
-        let total = countIn(arg.owner.innerText);
-        for (const editor of arg.owner.querySelectorAll('[contenteditable]')) {
-            if (isVisible(editor)) total -= countIn(editor.innerText);
+        const refresh = () => {
+            for (const [node, candidate] of state.candidates) {
+                if (
+                    node.isConnected &&
+                    state.owner.contains(node) &&
+                    exactUnit(node, true)
+                ) {
+                    candidate.matched = true;
+                    node.setAttribute('data-linkedin-mcp-matched', token);
+                }
+                if (candidate.matched && !node.isConnected) {
+                    state.invalid = true;
+                    marker.setAttribute('data-linkedin-mcp-invalid', 'true');
+                }
+            }
+            if (
+                Array.from(state.candidates.values()).filter(
+                    candidate => candidate.matched
+                ).length > 1
+            ) {
+                state.invalid = true;
+                marker.setAttribute('data-linkedin-mcp-invalid', 'true');
+            }
+        };
+        state.observer = new MutationObserver(records => {
+            for (const record of records) {
+                if (record.type !== 'childList') continue;
+                for (const node of record.addedNodes) remember(node);
+                for (const removed of record.removedNodes) {
+                    if (!(removed instanceof Element)) continue;
+                    if (removed === state.editor || removed.contains(state.editor)) {
+                        state.invalid = true;
+                        marker.setAttribute('data-linkedin-mcp-invalid', 'true');
+                    }
+                    for (const [candidate] of state.candidates) {
+                        if (
+                            (removed === candidate || removed.contains(candidate)) &&
+                            exactUnit(candidate, false)
+                        ) {
+                            state.invalid = true;
+                            marker.setAttribute(
+                                'data-linkedin-mcp-invalid', 'true'
+                            );
+                        }
+                    }
+                }
+            }
+            for (const record of records) {
+                if (
+                    record.type !== 'attributes' ||
+                    !state.candidates.has(record.target)
+                ) {
+                    continue;
+                }
+                const before = (record.oldValue || '').trim();
+                const after = (
+                    record.target.getAttribute('data-event-urn') || ''
+                ).trim();
+                if (before && after && before !== after) {
+                    state.candidates.get(record.target).transitioned = true;
+                    record.target.setAttribute(
+                        'data-linkedin-mcp-transitioned', token
+                    );
+                }
+            }
+            refresh();
+        });
+        state.observer.observe(state.owner, {
+            attributes: true,
+            attributeFilter: ['data-event-urn'],
+            attributeOldValue: true,
+            childList: true,
+            subtree: true,
+        });
+        if (!arg.owner.__linkedinMcpConfirmations) {
+            arg.owner.__linkedinMcpConfirmations = new Map();
         }
-        return {status: 'valid', count: total > 0 ? total : 0};
+        arg.owner.__linkedinMcpConfirmations.set(token, state);
+        return token;
     }"""
 )
 
-_MESSAGE_OCCURRENCES_INCREASED_JS = (
+_MESSAGE_CONFIRMATION_READY_JS = (
     "(arg) => {"
-    f"const result = ({_MESSAGE_OCCURRENCES_JS})(arg);"
-    "return result.status === 'valid' && result.count > arg.previous;"
-    "}"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + r"""
+        if (!arg.owner?.isConnected) return false;
+        const markers = Array.from(
+            arg.owner.querySelectorAll('[data-linkedin-mcp-confirmation]')
+        ).filter(
+            marker => marker.getAttribute('data-linkedin-mcp-confirmation') === arg.token
+        );
+        if (
+            markers.length !== 1 ||
+            markers[0].getAttribute('data-linkedin-mcp-invalid') !== 'false'
+        ) {
+            return false;
+        }
+        const composer = inspect(arg);
+        if (
+            composer.status !== 'valid' ||
+            composer.owner !== arg.owner ||
+            composer.editor.getAttribute('data-linkedin-mcp-editor') !== arg.token
+        ) {
+            return false;
+        }
+        const exactVisibleUnit = node => {
+            if (!visible(node)) return false;
+            const elements = [node, ...node.querySelectorAll('*')].filter(visible);
+            const matches = elements.filter(
+                element => (element.innerText || '') === arg.expected
+            );
+            return matches.filter(
+                element => !matches.some(
+                    other => other !== element && element.contains(other)
+                )
+            ).length === 1;
+        };
+        const candidates = Array.from(
+            arg.owner.querySelectorAll('[data-linkedin-mcp-candidate]')
+        ).filter(node =>
+            node.getAttribute('data-linkedin-mcp-candidate') === arg.token &&
+            node.getAttribute('data-linkedin-mcp-matched') === arg.token &&
+            node.getAttribute('data-linkedin-mcp-transitioned') === arg.token &&
+            (node.getAttribute('data-event-urn') || '').trim() &&
+            exactVisibleUnit(node)
+        );
+        return candidates.length === 1;
+    }"""
 )
+
+_MESSAGE_CONFIRMATION_DISPOSE_JS = r"""arg => {
+    const confirmations = arg.owner?.__linkedinMcpConfirmations;
+    const state = confirmations?.get(arg.token);
+    if (state?.observer) state.observer.disconnect();
+    confirmations?.delete(arg.token);
+    for (const element of arg.owner?.querySelectorAll(
+        '[data-linkedin-mcp-candidate], [data-linkedin-mcp-editor], '
+        + '[data-linkedin-mcp-confirmation]'
+    ) || []) {
+        for (const attribute of [
+            'data-linkedin-mcp-candidate',
+            'data-linkedin-mcp-matched',
+            'data-linkedin-mcp-transitioned',
+            'data-linkedin-mcp-editor',
+        ]) {
+            if (element.getAttribute(attribute) === arg.token) {
+                element.removeAttribute(attribute);
+            }
+        }
+        if (element.getAttribute('data-linkedin-mcp-confirmation') === arg.token) {
+            element.remove();
+        }
+    }
+}"""
 
 _MESSAGE_COMPOSER_STATE_JS = (
     "(target) => {"
@@ -3338,7 +3513,7 @@ class LinkedInExtractor:
         return result if result in {"clicked", "enter"} else "invalid"
 
     async def _resolve_message_owner(self, target: _ProfileMessageTarget) -> Any | None:
-        """Hold the verified owner node across baseline and confirmation."""
+        """Hold the verified owner node across submission and confirmation."""
         owner = await self._page.evaluate_handle(
             _MESSAGE_COMPOSER_OWNER_JS,
             arg=self._message_target_argument(target),
@@ -3356,7 +3531,7 @@ class LinkedInExtractor:
         except Exception:
             logger.debug("Could not release message owner handle", exc_info=True)
 
-    def _message_occurrence_argument(
+    def _message_confirmation_argument(
         self,
         message: str,
         target: _ProfileMessageTarget,
@@ -3368,59 +3543,62 @@ class LinkedInExtractor:
             "owner": owner,
         }
 
-    async def _message_text_occurrences(
+    async def _prepare_message_confirmation(
         self,
         message: str,
         *,
         target: _ProfileMessageTarget,
         owner: Any,
-    ) -> int | None:
-        """Count message copies inside the pinned verified owner."""
-        result = await self._page.evaluate(
-            _MESSAGE_OCCURRENCES_JS,
-            self._message_occurrence_argument(message, target, owner),
+    ) -> str | None:
+        """Start the owner-scoped DOM observer immediately before submission."""
+        token = await self._page.evaluate(
+            _MESSAGE_CONFIRMATION_PREPARE_JS,
+            self._message_confirmation_argument(message, target, owner),
         )
-        if not isinstance(result, dict) or result.get("status") != "valid":
-            return None
-        count = result.get("count")
-        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
-            return None
-        return count
+        return token if isinstance(token, str) and token else None
 
-    async def _message_text_visible(
+    async def _message_send_confirmed(
         self,
         message: str,
         *,
         target: _ProfileMessageTarget,
         owner: Any,
-        previous_occurrences: int,
+        confirmation: str,
     ) -> bool:
-        """Wait for a new message copy inside the pinned verified owner.
+        """Wait for one message-list node to gain a different opaque event ID.
 
-        ``previous_occurrences`` is the baseline taken after typing and before
-        the send attempt, so the requirement is strictly more occurrences than
-        before: the typed text sitting in the composer cannot confirm itself,
-        and neither can an identical message already in the thread.
-
-        Uses the page-level default timeout (``BrowserConfig.default_timeout``).
-
-        Every failure answers "not observed" rather than raising, because this
-        runs only after a submission was attempted. An execution context that
-        dies mid-wait, which is what an SPA remount looks like from here, would
-        otherwise reach the caller as a plain tool error and invite the one
-        retry that delivers the message twice.
+        The observer accepts only a node inserted after it was installed whose
+        exact visible message unit equals the typed text. That same connected
+        node must then change from one non-empty ``data-event-urn`` value to a
+        different non-empty value. Every timeout, remount, replacement or
+        ambiguity answers "not observed" because submission already happened.
         """
-        argument = self._message_occurrence_argument(message, target, owner)
-        argument["previous"] = previous_occurrences
         try:
             await self._page.wait_for_function(
-                _MESSAGE_OCCURRENCES_INCREASED_JS,
-                arg=argument,
+                _MESSAGE_CONFIRMATION_READY_JS,
+                arg={
+                    **self._message_target_argument(target),
+                    "expected": message,
+                    "owner": owner,
+                    "token": confirmation,
+                },
             )
             return True
         except Exception:
-            logger.debug("Message delivery could not be confirmed", exc_info=True)
+            logger.debug("Message send could not be confirmed", exc_info=True)
             return False
+
+    async def _dispose_message_confirmation(
+        self, owner: Any, confirmation: str
+    ) -> None:
+        """Disconnect a request-local confirmation observer."""
+        try:
+            await self._page.evaluate(
+                _MESSAGE_CONFIRMATION_DISPOSE_JS,
+                {"owner": owner, "token": confirmation},
+            )
+        except Exception:
+            logger.debug("Could not disconnect message observer", exc_info=True)
 
     @staticmethod
     def _extract_thread_id(url: str) -> str | None:
@@ -5283,7 +5461,7 @@ class LinkedInExtractor:
             profile_urn: Optional profile URN (e.g. ACoAAB...) to verify against
                 the recipient resolved from the loaded profile snapshot.
         """
-        refusal = refuse_a_blank_message(linkedin_username, message)
+        refusal = refuse_an_invalid_message(linkedin_username, message)
         if refusal is not None:
             return refusal
         linkedin_username = normalize_person_identifier(linkedin_username)
@@ -5422,9 +5600,6 @@ class LinkedInExtractor:
                 )
             allow_enter = state.get("submitCount") == 0
 
-            # `keyboard.type()` maps newlines onto Enter, which can submit the
-            # first paragraph before the explicit submit path runs.
-            may_have_submitted = "\n" in message or "\r" in message
             await self._page.keyboard.type(message, delay=15)
             await asyncio.sleep(0.3)
             await asyncio.sleep(1.0)  # allow React to process keyboard input
@@ -5467,27 +5642,12 @@ class LinkedInExtractor:
                 )
 
             try:
-                # Baseline immediately before the send attempt: how often the
-                # message is already visible in the verified owner. The click
-                # below only tries to send; delivery is proven by this count
-                # growing, never by the text the editor still holds.
-                previous_occurrences = await self._message_text_occurrences(
+                confirmation = await self._prepare_message_confirmation(
                     message,
                     target=target,
                     owner=owner,
                 )
-                if previous_occurrences is None:
-                    if may_have_submitted:
-                        return self._message_action_result(
-                            self._page.url,
-                            "send_unconfirmed",
-                            "The message may already have been submitted before "
-                            "its verified composer owner disappeared. Check the "
-                            "conversation before retrying; retrying may deliver "
-                            "the message twice.",
-                            recipient_selected=recipient_selected,
-                            retry_safe=False,
-                        )
+                if confirmation is None:
                     return self._message_action_result(
                         self._page.url,
                         "recipient_resolution_failed",
@@ -5495,111 +5655,108 @@ class LinkedInExtractor:
                         recipient_selected=recipient_selected,
                     )
 
-                may_have_submitted_before_submit = may_have_submitted
                 try:
-                    # A click can dispatch before the evaluate call reports an
-                    # error, so an exception from this round trip is ambiguous.
-                    may_have_submitted = True
-                    submission = await self._submit_verified_message(
-                        target, allow_enter=allow_enter
-                    )
-                except Exception:
-                    logger.debug("Message submission did not complete", exc_info=True)
-                    return self._message_action_result(
-                        self._page.url,
-                        "send_unconfirmed",
-                        "The message submission was interrupted and LinkedIn did "
-                        "not confirm delivery. Check the conversation before "
-                        "retrying; retrying may deliver the message twice.",
-                        recipient_selected=recipient_selected,
-                        retry_safe=False,
-                    )
-
-                if submission == "enter":
-                    may_have_submitted = may_have_submitted_before_submit
-                    state = await self._read_message_composer_state(target)
-                    if (
-                        not allow_enter
-                        or not _message_page_url_is_safe(
-                            self._page.url, target.profile_urn
-                        )
-                        or state.get("status") != "valid"
-                        or state.get("active") is not True
-                        or state.get("submitCount") != 0
-                    ):
-                        submission = "invalid"
-                    else:
-                        # The read and the keypress are two round trips, so the
-                        # editor could in principle lose focus between them.
-                        # Nothing a caller or recipient controls reaches that
-                        # window, and closing it would need the keystroke and
-                        # check to be one operation, which no input API offers.
+                    may_have_submitted_before_submit = may_have_submitted
+                    try:
+                        # A click can dispatch before the evaluate call reports an
+                        # error, so an exception from this round trip is ambiguous.
                         may_have_submitted = True
-                        try:
-                            await self._page.keyboard.press("Enter")
-                        except Exception:
-                            logger.debug(
-                                "Message submission did not complete", exc_info=True
-                            )
-                            return self._message_action_result(
-                                self._page.url,
-                                "send_unconfirmed",
-                                "The message submission was interrupted and LinkedIn "
-                                "did not confirm delivery. Check the conversation "
-                                "before retrying; retrying may deliver the message "
-                                "twice.",
-                                recipient_selected=recipient_selected,
-                                retry_safe=False,
-                            )
-                elif submission != "clicked":
-                    may_have_submitted = may_have_submitted_before_submit
+                        submission = await self._submit_verified_message(
+                            target, allow_enter=allow_enter
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Message submission did not complete", exc_info=True
+                        )
+                        return self._message_action_result(
+                            self._page.url,
+                            "send_unconfirmed",
+                            "The message submission was interrupted and LinkedIn did "
+                            "not confirm the send. Check the conversation before "
+                            "retrying; retrying may deliver the message twice.",
+                            recipient_selected=recipient_selected,
+                            retry_safe=False,
+                        )
 
-                if submission not in {"clicked", "enter"}:
-                    return self._message_action_result(
-                        self._page.url,
-                        "send_unavailable",
-                        "The local submit path was missing, disabled, or ambiguous.",
-                        recipient_selected=recipient_selected,
-                        retry_safe=not may_have_submitted,
+                    if submission == "enter":
+                        may_have_submitted = may_have_submitted_before_submit
+                        state = await self._read_message_composer_state(target)
+                        if (
+                            not allow_enter
+                            or not _message_page_url_is_safe(
+                                self._page.url, target.profile_urn
+                            )
+                            or state.get("status") != "valid"
+                            or state.get("active") is not True
+                            or state.get("submitCount") != 0
+                        ):
+                            submission = "invalid"
+                        else:
+                            # The read and the keypress are two round trips, so the
+                            # editor could in principle lose focus between them.
+                            # Nothing a caller or recipient controls reaches that
+                            # window, and closing it would need the keystroke and
+                            # check to be one operation, which no input API offers.
+                            may_have_submitted = True
+                            try:
+                                await self._page.keyboard.press("Enter")
+                            except Exception:
+                                logger.debug(
+                                    "Message submission did not complete", exc_info=True
+                                )
+                                return self._message_action_result(
+                                    self._page.url,
+                                    "send_unconfirmed",
+                                    "The message submission was interrupted and "
+                                    "LinkedIn did not confirm the send. Check the "
+                                    "conversation before retrying; retrying may "
+                                    "deliver the message twice.",
+                                    recipient_selected=recipient_selected,
+                                    retry_safe=False,
+                                )
+                    elif submission != "clicked":
+                        may_have_submitted = may_have_submitted_before_submit
+
+                    if submission not in {"clicked", "enter"}:
+                        return self._message_action_result(
+                            self._page.url,
+                            "send_unavailable",
+                            "The local submit path was missing, disabled, or ambiguous.",
+                            recipient_selected=recipient_selected,
+                            retry_safe=not may_have_submitted,
+                        )
+
+                    confirmed = await self._message_send_confirmed(
+                        message,
+                        target=target,
+                        owner=owner,
+                        confirmation=confirmation,
                     )
+                    if not confirmed:
+                        return self._message_action_result(
+                            self._page.url,
+                            "send_unconfirmed",
+                            "The message was submitted but LinkedIn did not confirm "
+                            "the message-list transition in time. Check the "
+                            "conversation before retrying; retrying may deliver the "
+                            "message twice.",
+                            recipient_selected=recipient_selected,
+                            retry_safe=False,
+                        )
 
-                confirmed = await self._message_text_visible(
-                    message,
-                    target=target,
-                    owner=owner,
-                    previous_occurrences=previous_occurrences,
-                )
-
-                if not confirmed:
-                    # Submission already happened, so this is not evidence that
-                    # nothing was sent: a thread that renders the delivered bubble
-                    # slower than the page timeout arrives here having delivered.
-                    # Reporting a plain failure invites a retry, and a retry sends a
-                    # second real message to a real person, so the status says
-                    # unknown rather than no.
                     return self._message_action_result(
                         self._page.url,
-                        "send_unconfirmed",
-                        "The message was submitted but LinkedIn did not confirm "
-                        "delivery in time. Check the conversation before retrying; "
-                        "retrying may deliver the message twice.",
+                        "sent",
+                        "Message submitted and confirmed in the conversation UI.",
                         recipient_selected=recipient_selected,
+                        sent=True,
                         retry_safe=False,
                     )
-
-                return self._message_action_result(
-                    self._page.url,
-                    "sent",
-                    "Message sent.",
-                    recipient_selected=recipient_selected,
-                    sent=True,
-                    retry_safe=False,
-                )
+                finally:
+                    await self._dispose_message_confirmation(owner, confirmation)
             finally:
                 await self._dispose_message_owner(owner)
         except Exception:
-            # A newline can submit while typing. Later reads can therefore fail
-            # after a message may already have left, before a result says so.
             if not may_have_submitted:
                 # Nothing can have been submitted yet, so the error itself is
                 # the useful answer and the caller can retry on it.
@@ -5611,7 +5768,7 @@ class LinkedInExtractor:
                 self._page.url,
                 "send_unconfirmed",
                 "The message may already have been submitted when the send "
-                "failed, and LinkedIn did not confirm delivery. Check the "
+                "failed, and LinkedIn did not confirm the outcome. Check the "
                 "conversation before retrying; retrying may deliver the "
                 "message twice.",
                 recipient_selected=recipient_selected,
@@ -5623,10 +5780,8 @@ class LinkedInExtractor:
             # returns, so the answer the branch above gives cannot be given
             # here and the log line is all that is left.
             #
-            # Silent for an interruption while typing a message without a
-            # newline: nothing can have submitted yet, and a warning that
-            # cries duplicate delivery where none is possible is the kind
-            # that gets ignored when it is right.
+            # Silent before explicit submission: nothing can have left yet,
+            # and a warning about duplicate delivery would be false.
             if may_have_submitted:
                 logger.warning(SEND_INTERRUPTED_WARNING)
             raise
@@ -5741,24 +5896,22 @@ class LinkedInExtractor:
         return result
 
 
-def refuse_a_blank_message(
+def refuse_an_invalid_message(
     linkedin_username: str, message: str
 ) -> dict[str, Any] | None:
-    """The refusal for a whitespace-only message, or None if there is none.
-
-    Shared between the MCP tool and `LinkedInExtractor.send_message` so the
-    two cannot answer the same input differently. The tool calls it before
-    acquiring a session: the input is the caller's own and needs no browser
-    to judge, while acquiring one can spend a login attempt and answer with
-    an authentication error the caller then has to interpret instead.
-    """
-    if message.strip():
+    """Return the shared browser-free refusal for an unsafe message."""
+    reason = None
+    if not message.strip():
+        reason = "Message must contain non-whitespace characters."
+    elif any(ord(character) < 32 or ord(character) == 127 for character in message):
+        # `keyboard.type()` maps line breaks onto Enter, which can submit while
+        # text is still being entered. Reject every C0 control and DEL before a
+        # session is acquired so no input can reach that implicit submit path.
+        reason = "Message must not contain control characters or line breaks."
+    if reason is None:
         return None
-    # Not `message_unavailable`, which says the *recipient* exposes no
-    # Message action and tells a caller to give up on this person. A blank
-    # message is the caller's own input and the repair is theirs.
     return LinkedInExtractor._message_action_result(
         person_profile_url(normalize_person_identifier(linkedin_username), "/"),
         "invalid_message",
-        "Message must contain non-whitespace characters.",
+        reason,
     )

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -3868,7 +3868,7 @@ class LinkedInExtractor:
     async def _wait_for_message_surface(
         self, target: _ProfileMessageTarget
     ) -> Literal["composer"] | None:
-        """Wait for one editor with a matching local recipient identity."""
+        """Wait for one editor with no contradictory local recipient identity."""
         if await self._wait_for_message_composer(target):
             return "composer"
         return None
@@ -3910,7 +3910,7 @@ class LinkedInExtractor:
     async def _read_message_composer_state(
         self, target: _ProfileMessageTarget
     ) -> dict[str, Any]:
-        """Inspect the unique editor and recipient inside its semantic owner."""
+        """Inspect the unique editor and reject contradictory local identity."""
         state = await self._page.evaluate(
             _MESSAGE_COMPOSER_STATE_JS,
             self._message_target_argument(target),
@@ -3920,7 +3920,7 @@ class LinkedInExtractor:
     async def _focus_verified_message_editor(
         self, target: _ProfileMessageTarget
     ) -> bool:
-        """Focus the same local editor whose recipient identity was verified."""
+        """Focus the same editor after local contradiction checks."""
         focused = await self._page.evaluate(
             _MESSAGE_COMPOSER_FOCUS_JS,
             self._message_target_argument(target),
@@ -5971,7 +5971,10 @@ class LinkedInExtractor:
 
         Opens LinkedIn's profile-based compose flow. That may create a separate
         DM instead of replying in an existing recruiter/InMail or messaging
-        thread.
+        thread. Recipient authorization comes from the validated top-card action
+        carrying the target URN and the browser navigation it initiates. The exact
+        resulting route is pinned through every later operation; visible local
+        identities are optional corroboration, but any contradiction fails closed.
 
         Args:
             linkedin_username: LinkedIn username of the recipient.
@@ -6020,6 +6023,10 @@ class LinkedInExtractor:
                 "The supplied profile URN did not match the loaded profile.",
             )
 
+        # The validated top-card action and its browser navigation are the
+        # recipient boundary. LinkedIn may strip the query and expose no local
+        # identity, so capture the final route now and fail on any later change or
+        # visible contradiction. Do not replace this with a Voyager/private API.
         await self._navigate_to_page(target.compose_url)
         expected_route = self._page.url
         if not _message_page_url_is_safe(expected_route, target.profile_urn):

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -448,10 +448,15 @@ SEND_INTERRUPTED_WARNING = (
 )
 
 _PROFILE_MESSAGE_TARGET_JS = r"""() => {
-    const visible = element => !!(
-        element &&
-        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
-    );
+    const visible = element => {
+        const visibility = element && getComputedStyle(element).visibility;
+        return !!(
+            element &&
+            visibility !== 'hidden' &&
+            visibility !== 'collapse' &&
+            (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+        );
+    };
     const active = anchor =>
         visible(anchor) &&
         !anchor.hasAttribute('disabled') &&
@@ -483,10 +488,15 @@ _PROFILE_MESSAGE_TARGET_JS = r"""() => {
 }"""
 
 _MESSAGE_COMPOSER_INSPECT_JS = r"""
-    const visible = element => !!(
-        element &&
-        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
-    );
+    const visible = element => {
+        const visibility = element && getComputedStyle(element).visibility;
+        return !!(
+            element &&
+            visibility !== 'hidden' &&
+            visibility !== 'collapse' &&
+            (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+        );
+    };
     const normalizeUrn = value => {
         const text = (value || '').trim();
         const prefix = 'urn:li:fsd_profile:';
@@ -921,10 +931,15 @@ _MESSAGE_COMPOSER_FOCUS_JS = (
 )
 
 _MESSAGE_COMPOSER_PINNED_JS = r"""
-    const visible = element => !!(
-        element &&
-        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
-    );
+    const visible = element => {
+        const visibility = element && getComputedStyle(element).visibility;
+        return !!(
+            element &&
+            visibility !== 'hidden' &&
+            visibility !== 'collapse' &&
+            (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+        );
+    };
     const normalizeUrn = value => {
         const text = (value || '').trim();
         const prefix = 'urn:li:fsd_profile:';

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -691,13 +691,14 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
 """
 
 _MESSAGE_COMPOSER_OWNER_JS = (
-    "(target) => {"
+    "(arg) => {"
     + _MESSAGE_COMPOSER_INSPECT_JS
     + """
+        const target = arg.target;
         const state = inspect(target);
         if (
             state.status !== 'valid' ||
-            state.messageRoute === null ||
+            state.messageRoute !== arg.expectedRoute ||
             !state.owner.isConnected ||
             !state.editor.isConnected ||
             !state.owner.contains(state.editor) ||
@@ -720,7 +721,7 @@ _MESSAGE_COMPOSER_OWNER_JS = (
             localScope: state.localScope,
             profilePath: target.profilePath,
             profileUrn: target.profileUrn,
-            route: state.messageRoute,
+            route: arg.expectedRoute,
             ownedMessage: null,
         };
         return state.owner;
@@ -3997,11 +3998,19 @@ class LinkedInExtractor:
             logger.warning("Timed out clearing tool-owned message text")
         await anyio.lowlevel.checkpoint()
 
-    async def _resolve_message_owner(self, target: _ProfileMessageTarget) -> Any | None:
+    async def _resolve_message_owner(
+        self,
+        target: _ProfileMessageTarget,
+        *,
+        expected_route: str,
+    ) -> Any | None:
         """Hold the verified owner node across submission and confirmation."""
         owner = await self._page.evaluate_handle(
             _MESSAGE_COMPOSER_OWNER_JS,
-            arg=self._message_target_argument(target),
+            arg={
+                "target": self._message_target_argument(target),
+                "expectedRoute": expected_route,
+            },
         )
         if owner.as_element() is None:
             await self._dispose_message_owner(owner)
@@ -6084,7 +6093,8 @@ class LinkedInExtractor:
                 "The verified message composer changed before text entry.",
                 recipient_selected=recipient_selected,
             )
-        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+        expected_route = self._page.url
+        if not _message_page_url_is_safe(expected_route, target.profile_urn):
             return self._message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
@@ -6101,7 +6111,9 @@ class LinkedInExtractor:
 
         may_have_submitted = False
         try:
-            owner = await self._resolve_message_owner(target)
+            owner = await self._resolve_message_owner(
+                target, expected_route=expected_route
+            )
             if owner is None:
                 return self._message_action_result(
                     self._page.url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -6021,21 +6021,40 @@ class LinkedInExtractor:
             )
 
         await self._navigate_to_page(target.compose_url)
+        expected_route = self._page.url
+        if not _message_page_url_is_safe(expected_route, target.profile_urn):
+            return self._message_action_result(
+                expected_route,
+                "recipient_resolution_failed",
+                "LinkedIn opened an unexpected messaging URL.",
+            )
+
         await detect_rate_limit(self._page)
+        if self._page.url != expected_route:
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed while the composer was loading.",
+            )
 
         try:
             await self._page.wait_for_selector("main")
         except PlaywrightTimeoutError:
             logger.debug("Compose page did not fully load for %s", linkedin_username)
-
-        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+        if self._page.url != expected_route:
             return self._message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
-                "LinkedIn opened an unexpected messaging URL.",
+                "The messaging URL changed while the composer was loading.",
             )
 
         message_surface = await self._wait_for_message_surface(target)
+        if self._page.url != expected_route:
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed while the composer was loading.",
+            )
         logger.debug(
             "Message surface for %s was %s", linkedin_username, message_surface
         )
@@ -6047,6 +6066,12 @@ class LinkedInExtractor:
             )
 
         state = await self._read_message_composer_state(target)
+        if self._page.url != expected_route:
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed during recipient verification.",
+            )
         if state.get("status") != "valid":
             logger.debug(
                 "Message recipient verification for %s returned %s",
@@ -6068,7 +6093,7 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
 
-        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+        if self._page.url != expected_route:
             return self._message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
@@ -6076,6 +6101,13 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
         state = await self._read_message_composer_state(target)
+        if self._page.url != expected_route:
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed before text entry.",
+                recipient_selected=recipient_selected,
+            )
         if state.get("status") == "valid" and state.get("empty") is not True:
             # Text already in the editor belongs to whoever typed it. Clearing
             # it would trade a recipient leak for destroying their draft.
@@ -6091,14 +6123,6 @@ class LinkedInExtractor:
                 self._page.url,
                 "compose_interact_failed",
                 "The verified message composer changed before text entry.",
-                recipient_selected=recipient_selected,
-            )
-        expected_route = self._page.url
-        if not _message_page_url_is_safe(expected_route, target.profile_urn):
-            return self._message_action_result(
-                self._page.url,
-                "recipient_resolution_failed",
-                "The messaging URL changed before the composer could be pinned.",
                 recipient_selected=recipient_selected,
             )
         if state.get("submitCount") != 1:

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -462,30 +462,88 @@ _PROFILE_MESSAGE_TARGET_JS = r"""() => {
         !anchor.hasAttribute('disabled') &&
         (anchor.getAttribute('aria-disabled') || '').toLowerCase() !== 'true';
     const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
+    const validComposeHref = value => {
+        if (typeof value !== 'string' || /[\\\x00-\x1f\x7f]/.test(value)) {
+            return false;
+        }
+        try {
+            const url = new URL(value, window.location.href);
+            const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
+            if (
+                url.protocol !== 'https:' ||
+                !/(^|\.)linkedin\.com$/.test(hostname) ||
+                url.username ||
+                url.password ||
+                (url.port && url.port !== '443') ||
+                url.hash ||
+                url.pathname !== '/messaging/compose/'
+            ) {
+                return false;
+            }
+            const values = [
+                ...url.searchParams.getAll('recipient'),
+                ...url.searchParams.getAll('profileUrn'),
+            ];
+            const normalized = values.map(item => {
+                const text = item.trim();
+                const prefix = 'urn:li:fsd_profile:';
+                const identifier = text.startsWith(prefix)
+                    ? text.slice(prefix.length)
+                    : text;
+                return /^[A-Za-z0-9_-]+$/.test(identifier) ? identifier : null;
+            });
+            return normalized.length > 0 &&
+                normalized.every(item => item !== null && item === normalized[0]);
+        } catch {
+            return false;
+        }
+    };
     const main = document.querySelector('main');
-    if (!main) return null;
+    if (!main) return {status: 'unresolved'};
 
     const section = Array.from(main.children).find(
         element => element.matches('section') && visible(element)
     );
-    if (!section) return null;
+    if (!section) return {status: 'unresolved'};
     const headings = Array.from(section.querySelectorAll('h1')).filter(
         heading => visible(heading) && heading.closest('section') === section
     );
-    const composeAnchors = Array.from(
+    const visibleComposeAnchors = Array.from(
         section.querySelectorAll('a[href*="/messaging/compose/"]')
-    ).filter(anchor => active(anchor) && anchor.closest('section') === section);
-    if (headings.length !== 1 || composeAnchors.length !== 1) return null;
+    ).filter(anchor => visible(anchor) && anchor.closest('section') === section);
+    const composeAnchors = visibleComposeAnchors.filter(active);
+    if (
+        headings.length !== 1 ||
+        composeAnchors.length > 1 ||
+        (composeAnchors.length === 1 && visibleComposeAnchors.length !== 1)
+    ) {
+        return {status: 'unresolved'};
+    }
+    if (composeAnchors.length === 0) {
+        return visibleComposeAnchors.length === 0
+            ? {status: 'unavailable', pageUrl: window.location.href}
+            : {status: 'unresolved'};
+    }
 
     const anchor = composeAnchors[0];
+    const composeHref = anchor.getAttribute('href') || anchor.href || '';
+    if (!validComposeHref(composeHref)) return {status: 'unresolved'};
     return {
+        status: 'resolved',
         pageUrl: window.location.href,
         displayName: normalize(
             headings[0].innerText || headings[0].textContent || ''
         ),
-        composeHrefs: [anchor.getAttribute('href') || anchor.href || ''],
+        composeHrefs: [composeHref],
     };
 }"""
+
+_PROFILE_MESSAGE_TARGET_READY_JS = (
+    f"() => ({_PROFILE_MESSAGE_TARGET_JS})().status === 'resolved'"
+)
+_PROFILE_MESSAGE_TARGET_TIMEOUT_MS = 1_000
+_MESSAGE_SUBMIT_READY_TIMEOUT_MS = 1_000
+_MESSAGE_CLEANUP_TIMEOUT_SECONDS = 1.0
 
 _MESSAGE_COMPOSER_INSPECT_JS = r"""
     const visible = element => {
@@ -526,7 +584,7 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
             return null;
         }
     };
-    const messageUrlSafe = target => {
+    const messageRoute = target => {
         try {
             const url = new URL(window.location.href);
             const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
@@ -542,15 +600,17 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
                     /^\/messaging\/thread\/[A-Za-z0-9_=-]+\/$/.test(url.pathname)
                 )
             ) {
-                return false;
+                return null;
             }
             const values = [
                 ...url.searchParams.getAll('recipient'),
                 ...url.searchParams.getAll('profileUrn'),
             ];
-            return values.every(value => normalizeUrn(value) === target.profileUrn);
+            return values.every(value => normalizeUrn(value) === target.profileUrn)
+                ? url.href
+                : null;
         } catch {
-            return false;
+            return null;
         }
     };
     const inspect = target => {
@@ -625,7 +685,7 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
             buttons,
             active: document.activeElement === editor,
             empty: !(editor.innerText || '').replace(/\s+/g, ' ').trim(),
-            messageUrlSafe: messageUrlSafe(target),
+            messageRoute: messageRoute(target),
         };
     };
 """
@@ -637,7 +697,7 @@ _MESSAGE_COMPOSER_OWNER_JS = (
         const state = inspect(target);
         if (
             state.status !== 'valid' ||
-            state.messageUrlSafe !== true ||
+            state.messageRoute === null ||
             !state.owner.isConnected ||
             !state.editor.isConnected ||
             !state.owner.contains(state.editor) ||
@@ -649,9 +709,7 @@ _MESSAGE_COMPOSER_OWNER_JS = (
         if (
             !button.isConnected ||
             !state.localScope.contains(button) ||
-            (button.form !== null && !state.ancestorChain.includes(button.form)) ||
-            button.disabled ||
-            (button.getAttribute('aria-disabled') || '').toLowerCase() === 'true'
+            (button.form !== null && !state.ancestorChain.includes(button.form))
         ) {
             return null;
         }
@@ -662,6 +720,8 @@ _MESSAGE_COMPOSER_OWNER_JS = (
             localScope: state.localScope,
             profilePath: target.profilePath,
             profileUrn: target.profileUrn,
+            route: state.messageRoute,
+            ownedMessage: null,
         };
         return state.owner;
     }"""
@@ -675,7 +735,7 @@ _MESSAGE_CONFIRMATION_PREPARE_JS = (
         const pinned = arg.owner?.__linkedinMcpComposer;
         if (
             composer.status !== 'valid' ||
-            composer.messageUrlSafe !== true ||
+            composer.messageRoute !== pinned?.route ||
             !pinned ||
             composer.owner !== arg.owner ||
             composer.editor !== pinned.editor ||
@@ -686,10 +746,14 @@ _MESSAGE_CONFIRMATION_PREPARE_JS = (
             composer.localScope !== pinned.localScope ||
             composer.buttons.length !== 1 ||
             composer.buttons[0] !== pinned.button ||
+            pinned.button.disabled ||
+            (pinned.button.getAttribute('aria-disabled') || '').toLowerCase()
+                === 'true' ||
             !arg.owner.isConnected ||
             !pinned.editor.isConnected ||
             !arg.owner.contains(pinned.editor) ||
             document.activeElement !== pinned.editor ||
+            pinned.ownedMessage !== arg.expected ||
             (pinned.editor.innerText || pinned.editor.textContent || '') !== arg.expected
         ) {
             return null;
@@ -850,7 +914,7 @@ _MESSAGE_CONFIRMATION_READY_JS = (
         const composer = inspect(arg);
         if (
             composer.status !== 'valid' ||
-            composer.messageUrlSafe !== true ||
+            composer.messageRoute === null ||
             composer.owner !== arg.owner ||
             composer.buttons.length !== 1 ||
             composer.editor.getAttribute('data-linkedin-mcp-editor') !== arg.token
@@ -887,7 +951,6 @@ _MESSAGE_CONFIRMATION_DISPOSE_JS = r"""arg => {
     const state = confirmations?.get(arg.token);
     if (state?.observer) state.observer.disconnect();
     confirmations?.delete(arg.token);
-    if (arg.owner) delete arg.owner.__linkedinMcpComposer;
     for (const element of arg.owner?.querySelectorAll(
         '[data-linkedin-mcp-candidate], [data-linkedin-mcp-editor], '
         + '[data-linkedin-mcp-confirmation]'
@@ -905,6 +968,28 @@ _MESSAGE_CONFIRMATION_DISPOSE_JS = r"""arg => {
         if (element.getAttribute('data-linkedin-mcp-confirmation') === arg.token) {
             element.remove();
         }
+    }
+}"""
+
+_MESSAGE_COMPOSER_DISPOSE_JS = r"""owner => {
+    const confirmations = owner?.__linkedinMcpConfirmations;
+    for (const state of confirmations?.values() || []) {
+        if (state?.observer) state.observer.disconnect();
+    }
+    confirmations?.clear();
+    if (owner) {
+        delete owner.__linkedinMcpConfirmations;
+        delete owner.__linkedinMcpComposer;
+    }
+    for (const element of owner?.querySelectorAll(
+        '[data-linkedin-mcp-candidate], [data-linkedin-mcp-editor], '
+        + '[data-linkedin-mcp-confirmation]'
+    ) || []) {
+        element.removeAttribute('data-linkedin-mcp-candidate');
+        element.removeAttribute('data-linkedin-mcp-matched');
+        element.removeAttribute('data-linkedin-mcp-transitioned');
+        element.removeAttribute('data-linkedin-mcp-editor');
+        if (element.hasAttribute('data-linkedin-mcp-confirmation')) element.remove();
     }
 }"""
 
@@ -984,7 +1069,7 @@ _MESSAGE_COMPOSER_PINNED_JS = r"""
             return null;
         }
     };
-    const messageUrlSafe = target => {
+    const messageRoute = target => {
         try {
             const url = new URL(window.location.href);
             const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
@@ -1000,15 +1085,17 @@ _MESSAGE_COMPOSER_PINNED_JS = r"""
                     /^\/messaging\/thread\/[A-Za-z0-9_=-]+\/$/.test(url.pathname)
                 )
             ) {
-                return false;
+                return null;
             }
             const values = [
                 ...url.searchParams.getAll('recipient'),
                 ...url.searchParams.getAll('profileUrn'),
             ];
-            return values.every(value => normalizeUrn(value) === target.profileUrn);
+            return values.every(value => normalizeUrn(value) === target.profileUrn)
+                ? url.href
+                : null;
         } catch {
-            return false;
+            return null;
         }
     };
     const semanticAncestors = element => {
@@ -1050,13 +1137,13 @@ _MESSAGE_COMPOSER_PINNED_JS = r"""
             urns.some(urn => urn !== target.profileUrn)
         );
     };
-    const validatePinned = target => {
+    const validatePinned = (target, requireEnabled = true) => {
         const pinned = owner?.__linkedinMcpComposer;
         if (
             !pinned ||
             pinned.profilePath !== target.profilePath ||
             pinned.profileUrn !== target.profileUrn ||
-            !messageUrlSafe(target)
+            messageRoute(target) !== pinned.route
         ) {
             return null;
         }
@@ -1092,8 +1179,10 @@ _MESSAGE_COMPOSER_PINNED_JS = r"""
         if (
             buttons.length !== 1 ||
             buttons[0] !== button ||
-            button.disabled ||
-            (button.getAttribute('aria-disabled') || '').toLowerCase() === 'true'
+            (requireEnabled && (
+                button.disabled ||
+                (button.getAttribute('aria-disabled') || '').toLowerCase() === 'true'
+            ))
         ) {
             return null;
         }
@@ -1105,14 +1194,14 @@ _MESSAGE_COMPOSER_WRITE_JS = (
     "(owner, arg) => {"
     + _MESSAGE_COMPOSER_PINNED_JS
     + r"""
-        let pinned = validatePinned(arg);
+        let pinned = validatePinned(arg, false);
         if (!pinned) return 'invalid';
         const {editor} = pinned;
         if ((editor.innerText || '').replace(/\s+/g, ' ').trim()) {
             return 'occupied';
         }
         editor.focus();
-        pinned = validatePinned(arg);
+        pinned = validatePinned(arg, false);
         if (!pinned || document.activeElement !== editor) return 'invalid';
         if ((editor.innerText || '').replace(/\s+/g, ' ').trim()) {
             return 'occupied';
@@ -1120,15 +1209,20 @@ _MESSAGE_COMPOSER_WRITE_JS = (
         if (
             typeof document.queryCommandSupported !== 'function' ||
             !document.queryCommandSupported('insertText') ||
-            typeof document.execCommand !== 'function' ||
-            document.execCommand('insertText', false, arg.message) !== true
+            typeof document.execCommand !== 'function'
         ) {
             return 'unsupported';
         }
-        pinned = validatePinned(arg);
+        const inserted = document.execCommand('insertText', false, arg.message);
+        if ((editor.innerText || editor.textContent || '') === arg.message) {
+            pinned.ownedMessage = arg.message;
+        }
+        if (inserted !== true) return 'unsupported';
+        pinned = validatePinned(arg, false);
         if (
             !pinned ||
             document.activeElement !== editor ||
+            pinned.ownedMessage !== arg.message ||
             (editor.innerText || editor.textContent || '') !== arg.message
         ) {
             return 'invalid';
@@ -1136,6 +1230,61 @@ _MESSAGE_COMPOSER_WRITE_JS = (
         return 'written';
     }"""
 )
+
+_MESSAGE_COMPOSER_SUBMIT_READY_JS = (
+    "(owner, arg) => {"
+    + _MESSAGE_COMPOSER_PINNED_JS
+    + r"""
+        const pinned = validatePinned(arg, false);
+        if (
+            !pinned ||
+            document.activeElement !== pinned.editor ||
+            pinned.ownedMessage !== arg.message ||
+            (pinned.editor.innerText || pinned.editor.textContent || '') !== arg.message
+        ) {
+            return 'invalid';
+        }
+        return pinned.button.disabled ||
+            (pinned.button.getAttribute('aria-disabled') || '').toLowerCase() === 'true'
+            ? 'disabled'
+            : 'ready';
+    }"""
+)
+
+_MESSAGE_COMPOSER_CLEANUP_JS = r"""(owner, arg) => {
+    const pinned = owner?.__linkedinMcpComposer;
+    if (!pinned || pinned.ownedMessage !== arg.message) return false;
+    const {editor, ancestorChain} = pinned;
+    const currentChain = [];
+    let ancestor = editor?.parentElement;
+    while (ancestor) {
+        if (ancestor.matches('form, dialog, [role="dialog"]')) {
+            currentChain.push(ancestor);
+        }
+        ancestor = ancestor.parentElement;
+    }
+    if (
+        !owner.isConnected ||
+        !editor?.isConnected ||
+        !Array.isArray(ancestorChain) ||
+        currentChain.length !== ancestorChain.length ||
+        currentChain.some((scope, index) => scope !== ancestorChain[index]) ||
+        !currentChain.includes(owner) ||
+        !owner.contains(editor) ||
+        (editor.innerText || editor.textContent || '') !== arg.message
+    ) {
+        return false;
+    }
+    pinned.ownedMessage = null;
+    editor.replaceChildren();
+    editor.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        composed: true,
+        data: null,
+        inputType: 'deleteContentBackward',
+    }));
+    return true;
+}"""
 
 _MESSAGE_COMPOSER_SUBMIT_JS = (
     "(owner, arg) => {"
@@ -1145,6 +1294,7 @@ _MESSAGE_COMPOSER_SUBMIT_JS = (
         if (
             !pinned ||
             document.activeElement !== pinned.editor ||
+            pinned.ownedMessage !== arg.message ||
             (pinned.editor.innerText || pinned.editor.textContent || '') !== arg.message
         ) {
             return 'invalid';
@@ -1173,6 +1323,12 @@ class _ProfileMessageTarget:
     profile_urn: str
     compose_url: str
     display_name: str | None
+
+
+@dataclass(frozen=True)
+class _ProfileMessageTargetResolution:
+    status: Literal["resolved", "unavailable", "failed"]
+    target: _ProfileMessageTarget | None = None
 
 
 def _safe_linkedin_url(value: str, *, base: str | None = None) -> ParseResult | None:
@@ -3433,8 +3589,8 @@ class LinkedInExtractor:
 
     async def _extract_profile_urn(self) -> str | None:
         """Extract a profile URN only from one unambiguous top-card snapshot."""
-        target = await self._read_profile_message_target()
-        return target.profile_urn if target else None
+        resolution = await self._read_profile_message_target()
+        return resolution.target.profile_urn if resolution.target else None
 
     async def get_sidebar_profiles(self, username: str) -> dict[str, Any]:
         """Extract profile links from sidebar sections on a LinkedIn profile page.
@@ -3613,46 +3769,73 @@ class LinkedInExtractor:
             "sidebar_profiles": sidebar_profiles,
         }
 
-    async def _read_profile_message_target(self) -> _ProfileMessageTarget | None:
-        """Read profile identity, name, compose URL and URN in one DOM snapshot."""
-        data = await self._page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
+    async def _read_profile_message_target(self) -> _ProfileMessageTargetResolution:
+        """Resolve one recipient-specific top-card compose action after settling."""
+        try:
+            await self._page.wait_for_function(
+                _PROFILE_MESSAGE_TARGET_READY_JS,
+                timeout=_PROFILE_MESSAGE_TARGET_TIMEOUT_MS,
+            )
+        except PlaywrightTimeoutError:
+            pass
+        except Exception:
+            logger.debug("Could not wait for the profile Message action", exc_info=True)
+
+        try:
+            data = await self._page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
+        except Exception:
+            logger.debug("Could not inspect the profile Message action", exc_info=True)
+            return _ProfileMessageTargetResolution("failed")
         if not isinstance(data, dict):
-            return None
+            return _ProfileMessageTargetResolution("failed")
+        if data.get("status") == "unavailable":
+            page_url = data.get("pageUrl")
+            if (
+                not isinstance(page_url, str)
+                or _profile_path_from_url(page_url) is None
+            ):
+                return _ProfileMessageTargetResolution("failed")
+            return _ProfileMessageTargetResolution("unavailable")
+        if data.get("status") != "resolved":
+            return _ProfileMessageTargetResolution("failed")
 
         page_url = data.get("pageUrl")
         compose_hrefs = data.get("composeHrefs")
         if not isinstance(page_url, str) or not isinstance(compose_hrefs, list):
-            return None
+            return _ProfileMessageTargetResolution("failed")
         profile_path = _profile_path_from_url(page_url)
         if profile_path is None:
-            return None
+            return _ProfileMessageTargetResolution("failed")
         if len(compose_hrefs) != 1 or not isinstance(compose_hrefs[0], str):
-            return None
+            return _ProfileMessageTargetResolution("failed")
 
         parsed_compose = _safe_linkedin_url(compose_hrefs[0], base=page_url)
         if parsed_compose is None:
-            return None
+            return _ProfileMessageTargetResolution("failed")
         compose_url = parsed_compose.geturl()
         profile_urn = _profile_urn_from_compose_url(compose_url)
         if profile_urn is None:
-            return None
+            return _ProfileMessageTargetResolution("failed")
 
         display_name = data.get("displayName")
         if not isinstance(display_name, str) or not display_name.strip():
             display_name = None
         else:
             display_name = display_name.strip()
-        return _ProfileMessageTarget(
-            profile_path=profile_path,
-            profile_urn=profile_urn,
-            compose_url=compose_url,
-            display_name=display_name,
+        return _ProfileMessageTargetResolution(
+            "resolved",
+            _ProfileMessageTarget(
+                profile_path=profile_path,
+                profile_urn=profile_urn,
+                compose_url=compose_url,
+                display_name=display_name,
+            ),
         )
 
     async def _resolve_message_compose_href(self) -> str | None:
         """Return an unambiguous recipient-specific top-card compose URL."""
-        target = await self._read_profile_message_target()
-        return target.compose_url if target else None
+        resolution = await self._read_profile_message_target()
+        return resolution.target.compose_url if resolution.target else None
 
     async def _read_profile_display_name(self) -> str | None:
         """Read the visible profile name from the current person page."""
@@ -3757,6 +3940,35 @@ class LinkedInExtractor:
         )
         return result if result in {"written", "occupied", "unsupported"} else "invalid"
 
+    async def _wait_for_verified_submit(
+        self,
+        message: str,
+        *,
+        target: _ProfileMessageTarget,
+        owner: Any,
+    ) -> bool:
+        """Wait briefly for the exact pinned submit button to become active."""
+        deadline = time.monotonic() + _MESSAGE_SUBMIT_READY_TIMEOUT_MS / 1_000
+        argument = {**self._message_target_argument(target), "message": message}
+        while True:
+            try:
+                state = await owner.evaluate(
+                    _MESSAGE_COMPOSER_SUBMIT_READY_JS, argument
+                )
+                if state == "ready":
+                    return True
+                if state != "disabled":
+                    return False
+            except Exception:
+                logger.debug(
+                    "Could not wait for the pinned submit button", exc_info=True
+                )
+                return False
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            await asyncio.sleep(min(0.05, remaining))
+
     async def _submit_verified_message(
         self,
         message: str,
@@ -3771,6 +3983,20 @@ class LinkedInExtractor:
         )
         return "clicked" if result == "clicked" else "invalid"
 
+    @staticmethod
+    async def _cleanup_owned_message(message: str, owner: Any) -> None:
+        """Best-effort removal of text proven to belong to this tool call."""
+        with anyio.move_on_after(
+            _MESSAGE_CLEANUP_TIMEOUT_SECONDS, shield=True
+        ) as scope:
+            try:
+                await owner.evaluate(_MESSAGE_COMPOSER_CLEANUP_JS, {"message": message})
+            except Exception:
+                logger.debug("Could not clear tool-owned message text", exc_info=True)
+        if scope.cancel_called:
+            logger.warning("Timed out clearing tool-owned message text")
+        await anyio.lowlevel.checkpoint()
+
     async def _resolve_message_owner(self, target: _ProfileMessageTarget) -> Any | None:
         """Hold the verified owner node across submission and confirmation."""
         owner = await self._page.evaluate_handle(
@@ -3784,15 +4010,30 @@ class LinkedInExtractor:
 
     @staticmethod
     async def _dispose_message_owner(owner: Any) -> None:
-        """Release the pinned composer nodes without replacing their result."""
+        """Release all owner-scoped observers, pins, markers and handles."""
         try:
-            await owner.evaluate("owner => { delete owner.__linkedinMcpComposer; }")
-        except Exception:
-            logger.debug("Could not clear pinned message nodes", exc_info=True)
-        try:
-            await owner.dispose()
-        except Exception:
-            logger.debug("Could not release message owner handle", exc_info=True)
+            with anyio.move_on_after(
+                _MESSAGE_CLEANUP_TIMEOUT_SECONDS, shield=True
+            ) as dom_scope:
+                try:
+                    await owner.evaluate(_MESSAGE_COMPOSER_DISPOSE_JS)
+                except Exception:
+                    logger.debug("Could not clear pinned message nodes", exc_info=True)
+            if dom_scope.cancel_called:
+                logger.warning("Timed out clearing pinned message nodes")
+        finally:
+            with anyio.move_on_after(
+                _MESSAGE_CLEANUP_TIMEOUT_SECONDS, shield=True
+            ) as handle_scope:
+                try:
+                    await owner.dispose()
+                except Exception:
+                    logger.debug(
+                        "Could not release message owner handle", exc_info=True
+                    )
+            if handle_scope.cancel_called:
+                logger.warning("Timed out releasing message owner handle")
+        await anyio.lowlevel.checkpoint()
 
     def _message_confirmation_argument(
         self,
@@ -3855,13 +4096,19 @@ class LinkedInExtractor:
         self, owner: Any, confirmation: str
     ) -> None:
         """Disconnect a request-local confirmation observer."""
-        try:
-            await self._page.evaluate(
-                _MESSAGE_CONFIRMATION_DISPOSE_JS,
-                {"owner": owner, "token": confirmation},
-            )
-        except Exception:
-            logger.debug("Could not disconnect message observer", exc_info=True)
+        with anyio.move_on_after(
+            _MESSAGE_CLEANUP_TIMEOUT_SECONDS, shield=True
+        ) as scope:
+            try:
+                await self._page.evaluate(
+                    _MESSAGE_CONFIRMATION_DISPOSE_JS,
+                    {"owner": owner, "token": confirmation},
+                )
+            except Exception:
+                logger.debug("Could not disconnect message observer", exc_info=True)
+        if scope.cancel_called:
+            logger.warning("Timed out disconnecting message observer")
+        await anyio.lowlevel.checkpoint()
 
     @staticmethod
     def _extract_thread_id(url: str) -> str | None:
@@ -5738,14 +5985,22 @@ class LinkedInExtractor:
         except PlaywrightTimeoutError:
             logger.debug("Profile page did not load for %s", linkedin_username)
 
-        target = await self._read_profile_message_target()
-        if target is None:
+        resolution = await self._read_profile_message_target()
+        if resolution.status == "unavailable":
             return self._message_action_result(
                 profile_url,
                 "message_unavailable",
                 "LinkedIn did not expose a normal Message action for this profile. "
                 "Use connect_with_person first, then retry only after the connection "
                 "request is accepted.",
+            )
+        target = resolution.target
+        if target is None:
+            return self._message_action_result(
+                profile_url,
+                "recipient_resolution_failed",
+                "LinkedIn did not expose one unambiguous recipient-specific Message "
+                "action.",
             )
 
         supplied_urn = _normalize_profile_urn(profile_urn) if profile_urn else None
@@ -5836,11 +6091,11 @@ class LinkedInExtractor:
                 "The messaging URL changed before the composer could be pinned.",
                 recipient_selected=recipient_selected,
             )
-        if state.get("submitCount") != 1 or state.get("submitUsable") is not True:
+        if state.get("submitCount") != 1:
             return self._message_action_result(
                 self._page.url,
                 "send_unavailable",
-                "The local submit path was missing, disabled, or ambiguous.",
+                "The local submit path was missing or ambiguous.",
                 recipient_selected=recipient_selected,
             )
 
@@ -5881,6 +6136,19 @@ class LinkedInExtractor:
                         self._page.url,
                         "compose_interact_failed",
                         "The verified message editor could not accept the message.",
+                        recipient_selected=recipient_selected,
+                    )
+
+                if not await self._wait_for_verified_submit(
+                    message,
+                    target=target,
+                    owner=owner,
+                ):
+                    return self._message_action_result(
+                        self._page.url,
+                        "send_unavailable",
+                        "The pinned submit button did not become available without "
+                        "changing the verified composer.",
                         recipient_selected=recipient_selected,
                     )
 
@@ -5959,7 +6227,11 @@ class LinkedInExtractor:
                 finally:
                     await self._dispose_message_confirmation(owner, confirmation)
             finally:
-                await self._dispose_message_owner(owner)
+                try:
+                    if not may_have_submitted:
+                        await self._cleanup_owned_message(message, owner)
+                finally:
+                    await self._dispose_message_owner(owner)
         except Exception:
             if not may_have_submitted:
                 # Nothing can have been submitted yet, so the error itself is

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -11,7 +11,7 @@ import logging
 import re
 import time
 from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import parse_qs, quote_plus, urljoin, urlparse
+from urllib.parse import ParseResult, parse_qs, quote_plus, urljoin, urlparse
 
 import anyio
 import anyio.lowlevel
@@ -431,87 +431,13 @@ _DIALOG_PREMIUM_LINK_SELECTOR = (
 )
 _DIALOG_TEXTAREA_SELECTOR = '[role="dialog"] textarea, dialog textarea'
 
-_MESSAGING_COMPOSE_LINK_SELECTOR = 'main a[href*="/messaging/compose/"]'
-_MESSAGING_COMPOSE_SELECTOR = (
-    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"]'
-)
-_MESSAGING_COMPOSE_FALLBACK_SELECTORS = (
-    _MESSAGING_COMPOSE_SELECTOR,
-    'main div[role="textbox"][contenteditable="true"]',
-    'main [contenteditable="true"][aria-label*="message"]',
-)
-_MESSAGING_ENABLED_SEND_SELECTOR = (
-    'button[type="submit"]:not([disabled]), '
-    'button[aria-label*="Send"]:not([disabled]), '
-    'button[aria-label*="send"]:not([disabled])'
-)
-_MESSAGING_RECIPIENT_PICKER_SELECTOR = (
-    'input[placeholder*="Type a name"], '
-    'input[aria-label*="Type a name"], '
-    'input[placeholder*="multiple names"]'
-)
+_MESSAGING_COMPOSE_SELECTOR = '[role="textbox"][contenteditable="true"]'
 _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Close your draft conversation"], '
     'button[aria-label="Dismiss"], '
     'button[aria-label*="Dismiss"], '
     'button[aria-label*="Close"]'
 )
-
-# Counts visible occurrences of a message *outside* every open composer.
-# The composer holds the message before it is sent, so plain body text is no
-# evidence of delivery: a Send button whose handler does nothing leaves the
-# text standing in the editor and the page still "contains" it. Occurrences
-# inside visible contenteditable editors are therefore subtracted, and the
-# send path compares a baseline taken before the click with the count after
-# it. Visibility is pure geometry and the match is on normalized text, so no
-# LinkedIn class name or localized label enters the decision.
-#
-# Known limit (issue #888), and it scales with how short the message is: the count is taken
-# over the whole body, so any unrelated text arriving between the two reads can
-# raise it if the message occurs inside it. A messaging page updates presence
-# and timestamps on its own, so a one-character message can be confirmed by
-# something that has nothing to do with it. A sentence cannot. Scoping the
-# count to the thread would need a container selector, and every candidate
-# LinkedIn offers is a layout class name.
-_MESSAGE_OCCURRENCES_JS = r"""
-({ expected }) => {
-    const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
-    const needle = normalize(expected);
-    if (!needle) return 0;
-
-    const countIn = value => {
-        const haystack = normalize(value);
-        let count = 0;
-        let index = haystack.indexOf(needle);
-        while (index !== -1) {
-            count += 1;
-            index = haystack.indexOf(needle, index + needle.length);
-        }
-        return count;
-    };
-
-    const isVisible = element =>
-        !!(
-            element &&
-            (element.offsetWidth ||
-                element.offsetHeight ||
-                element.getClientRects().length)
-        );
-
-    let total = countIn(document.body?.innerText || '');
-    // Any element that declares contenteditable at all, not only the ones
-    // currently set to "true": a composer commonly goes read-only for the
-    // duration of an in-flight send while keeping its text on screen, and
-    // an occurrence subtracted at baseline must stay subtracted afterwards
-    // or the same unsent draft confirms itself.
-    for (const editor of document.querySelectorAll('[contenteditable]')) {
-        if (isVisible(editor)) {
-            total -= countIn(editor.innerText);
-        }
-    }
-    return total > 0 ? total : 0;
-}
-"""
 
 # A submission is in flight from the moment the send is dispatched until the
 # whole path has produced a result, cleanup included, and an interruption in
@@ -527,11 +453,404 @@ SEND_INTERRUPTED_WARNING = (
     "message twice."
 )
 
-# The post-send predicate is the same counting routine, so the baseline and
-# the confirmation can never disagree about what counts as an occurrence.
-_MESSAGE_OCCURRENCES_INCREASED_JS = (
-    f"(arg) => ({_MESSAGE_OCCURRENCES_JS})(arg) > arg.previous"
+_PROFILE_MESSAGE_TARGET_JS = r"""() => {
+    const visible = element => !!(
+        element &&
+        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+    );
+    const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
+    const main = document.querySelector('main');
+    if (!main) return null;
+    const scope = main.querySelector('section') || main.firstElementChild || main;
+    const composeHrefs = Array.from(
+        scope.querySelectorAll('a[href*="/messaging/compose/"]')
+    )
+        .filter(visible)
+        .map(anchor => anchor.getAttribute('href') || anchor.href || '');
+    const heading = scope.querySelector('h1');
+    return {
+        pageUrl: window.location.href,
+        displayName: normalize(heading?.innerText || heading?.textContent || ''),
+        composeHrefs,
+    };
+}"""
+
+_MESSAGE_COMPOSER_INSPECT_JS = r"""
+    const visible = element => !!(
+        element &&
+        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+    );
+    const normalizeUrn = value => {
+        const text = (value || '').trim();
+        const prefix = 'urn:li:fsd_profile:';
+        const identifier = text.startsWith(prefix) ? text.slice(prefix.length) : text;
+        return /^[A-Za-z0-9_-]+$/.test(identifier) ? identifier : null;
+    };
+    const profilePath = value => {
+        if (typeof value !== 'string' || /[\\\x00-\x1f\x7f]/.test(value)) {
+            return null;
+        }
+        try {
+            const url = new URL(value, window.location.href);
+            const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
+            if (
+                url.protocol !== 'https:' ||
+                !/(^|\.)linkedin\.com$/.test(hostname) ||
+                url.username ||
+                url.password ||
+                (url.port && url.port !== '443') ||
+                url.hash
+            ) {
+                return null;
+            }
+            // Everything under /in/<slug>/ belongs to that member, so the
+            // canonical path is the identity. Measured on a live profile:
+            // four of its own anchors point at /overlay/... and
+            // /recent-activity/, and reading those as an unknown member let
+            // the recipient contradict themselves.
+            const match = /^\/in\/([^/?#]+)(?:\/.*)?$/.exec(url.pathname);
+            return match ? `/in/${match[1]}/` : null;
+        } catch {
+            return null;
+        }
+    };
+    const inspect = target => {
+        const editors = Array.from(
+            document.querySelectorAll('[role="textbox"][contenteditable="true"]')
+        ).filter(visible);
+        if (editors.length !== 1) return {status: 'ambiguous_editor'};
+        const editor = editors[0];
+        const outsideEditor = element =>
+            element !== editor && !editor.contains(element);
+        const readIdentity = owner => ({
+            // Draft content is untrusted. Neither the editor nor anything
+            // inside it may authorize or contradict the outer recipient.
+            paths: Array.from(owner.querySelectorAll('a[href*="/in/"]'))
+                .filter(element => visible(element) && outsideEditor(element))
+                .map(anchor => profilePath(anchor.getAttribute('href') || anchor.href || '')),
+            // Every identity attribute an element carries is read, never only
+            // the first one present: a matching data-profile-urn must not hide
+            // a contradicting data-recipient-urn on the same element. An
+            // absent attribute is skipped, while a present one that is empty
+            // or malformed normalizes to null and so fails closed.
+            urns: [
+                ...(owner.matches('[data-profile-urn], [data-recipient-urn]')
+                    ? [owner]
+                    : []),
+                ...owner.querySelectorAll(
+                    '[data-profile-urn], [data-recipient-urn]'
+                ),
+            ].filter(element => visible(element) && outsideEditor(element)).flatMap(
+                element => ['data-profile-urn', 'data-recipient-urn']
+                    .filter(name => element.hasAttribute(name))
+                    .map(name => normalizeUrn(element.getAttribute(name)))
+            ),
+        });
+        // The walk climbs until a dialog closes it, and every identity it
+        // finds on the way has to agree with the target. That scope is
+        // deliberate and it is not free. A thread rendered inside the same
+        // section as the editor puts its message history in the walk, so a
+        // profile mention anyone can drop into a conversation refuses every
+        // later send to that person. The refusal is the safe half of the
+        // trade: adding identities can only ever make this stricter, so the
+        // recipient cannot use it to redirect a message. The unsafe half
+        // needs the real recipient to expose no identity at all in the whole
+        // chain while a mention of the target does, which no measurement has
+        // reached: the live compose surface has not been read yet, so what
+        // LinkedIn actually puts between the editor and its dialog is
+        // unknown. Narrowing the walk to the innermost owner would cut the
+        // false refusals and give up that asymmetry, which is a design
+        // decision and not a repair.
+        const identities = [];
+        let ancestor = editor.parentElement;
+        while (ancestor) {
+            if (ancestor.matches('dialog, [role="dialog"], form, section, article')) {
+                const identity = readIdentity(ancestor);
+                if (identity.paths.length + identity.urns.length > 0) {
+                    identities.push({owner: ancestor, ...identity});
+                }
+                if (ancestor.matches('dialog, [role="dialog"]')) break;
+            }
+            ancestor = ancestor.parentElement;
+        }
+        if (identities.length === 0) return {status: 'missing_recipient'};
+        const owner = identities[0].owner;
+        const paths = identities.flatMap(identity => identity.paths);
+        const urns = identities.flatMap(identity => identity.urns);
+        if (
+            paths.some(path => path !== target.profilePath) ||
+            urns.some(urn => urn !== target.profileUrn)
+        ) {
+            return {status: 'recipient_mismatch'};
+        }
+
+        const buttons = Array.from(
+            owner.querySelectorAll('button[type="submit"], button[data-control-name="send"]')
+        ).filter(visible);
+        return {
+            status: 'valid',
+            editor,
+            owner,
+            buttons,
+            active: document.activeElement === editor,
+            // Reported, never required: the send path refuses a composer that
+            // already holds a draft, and the same routine runs again after
+            // typing, when the editor is of course no longer empty.
+            empty: !(editor.innerText || '').replace(/\s+/g, ' ').trim(),
+        };
+    };
+"""
+
+_MESSAGE_COMPOSER_OWNER_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        const state = inspect(target);
+        if (
+            state.status !== 'valid' ||
+            !state.owner.isConnected ||
+            !state.editor.isConnected ||
+            !state.owner.contains(state.editor)
+        ) {
+            return null;
+        }
+        return state.owner;
+    }"""
 )
+
+# Baseline und Bestätigung bleiben an dieselbe konkrete Owner-Instanz gebunden.
+# Ein gleich identifizierter Ersatzknoten darf eine vorhandene Bubble daher
+# nicht als Zustellung des ursprünglichen Sends bestätigen.
+_MESSAGE_OCCURRENCES_JS = (
+    "(arg) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + r"""
+        const state = inspect(arg);
+        if (
+            state.status !== 'valid' ||
+            !arg.owner ||
+            state.owner !== arg.owner ||
+            !arg.owner.isConnected ||
+            !state.editor.isConnected ||
+            !arg.owner.contains(state.editor)
+        ) {
+            return {status: 'invalid'};
+        }
+
+        const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
+        const textUnits = value => (value || '')
+            .split(/\r?\n/)
+            .map(normalize)
+            .filter(Boolean);
+        const expectedUnits = textUnits(arg.expected);
+        if (expectedUnits.length === 0) {
+            return {status: 'valid', count: 0};
+        }
+        const countIn = value => {
+            const renderedUnits = textUnits(value);
+            let count = 0;
+            for (
+                let index = 0;
+                index <= renderedUnits.length - expectedUnits.length;
+                index += 1
+            ) {
+                if (
+                    expectedUnits.every(
+                        (unit, offset) => renderedUnits[index + offset] === unit
+                    )
+                ) {
+                    count += 1;
+                }
+            }
+            return count;
+        };
+        const isVisible = element => !!(
+            element &&
+            (element.offsetWidth ||
+                element.offsetHeight ||
+                element.getClientRects().length)
+        );
+
+        let total = countIn(arg.owner.innerText);
+        for (const editor of arg.owner.querySelectorAll('[contenteditable]')) {
+            if (isVisible(editor)) total -= countIn(editor.innerText);
+        }
+        return {status: 'valid', count: total > 0 ? total : 0};
+    }"""
+)
+
+_MESSAGE_OCCURRENCES_INCREASED_JS = (
+    "(arg) => {"
+    f"const result = ({_MESSAGE_OCCURRENCES_JS})(arg);"
+    "return result.status === 'valid' && result.count > arg.previous;"
+    "}"
+)
+
+_MESSAGE_COMPOSER_STATE_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        const state = inspect(target);
+        return {
+            status: state.status,
+            active: state.active === true,
+            empty: state.empty === true,
+            submitCount: state.buttons ? state.buttons.length : 0,
+        };
+    }"""
+)
+
+_MESSAGE_COMPOSER_READY_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        return inspect(target).status === 'valid';
+    }"""
+)
+
+_MESSAGE_COMPOSER_FOCUS_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        const state = inspect(target);
+        if (state.status !== 'valid') return false;
+        state.editor.focus();
+        return state.editor.isConnected && document.activeElement === state.editor;
+    }"""
+)
+
+_MESSAGE_COMPOSER_SUBMIT_JS = (
+    "(target) => {"
+    + _MESSAGE_COMPOSER_INSPECT_JS
+    + """
+        const state = inspect(target);
+        if (
+            state.status !== 'valid' ||
+            !state.editor.isConnected ||
+            document.activeElement !== state.editor
+        ) {
+            return 'invalid';
+        }
+        if (state.buttons.length === 0) {
+            return target.allowEnter === true ? 'enter' : 'invalid';
+        }
+        if (state.buttons.length !== 1) return 'invalid';
+        const button = state.buttons[0];
+        if (
+            !button.isConnected ||
+            button.disabled ||
+            button.getAttribute('aria-disabled') === 'true'
+        ) {
+            return 'invalid';
+        }
+        button.click();
+        return 'clicked';
+    }"""
+)
+
+_LINKEDIN_MESSAGE_HOST_RE = re.compile(r"^(?:[a-z0-9-]+\.)*linkedin\.com$")
+_PROFILE_PATH_RE = re.compile(r"^/in/[^/?#]+/$")
+# A thread id is base64url and keeps its padding literally. Measured live:
+# /messaging/thread/2-ZDBkMjZiY2Ut...XzEwMA==/ is what LinkedIn redirects an
+# existing conversation to, and rejecting it stopped every send to a member
+# the account had already written to. Only '=' is added: '%' would readmit an
+# encoded slash and let one path pose as another. The id identifies nobody on
+# its own, and the recipient is proven by the composer rather than this path.
+_MESSAGE_THREAD_PATH_RE = re.compile(r"^/messaging/thread/[A-Za-z0-9_=-]+/$")
+_PROFILE_URN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_PROFILE_URN_PREFIX = "urn:li:fsd_profile:"
+
+
+@dataclass(frozen=True)
+class _ProfileMessageTarget:
+    profile_path: str
+    profile_urn: str
+    compose_url: str
+    display_name: str | None
+
+
+def _safe_linkedin_url(value: str, *, base: str | None = None) -> ParseResult | None:
+    """Parse an HTTPS LinkedIn URL without credentials or an ambiguous origin."""
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or "\\" in value
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        return None
+    candidate = urljoin(base, value.strip()) if base else value.strip()
+    try:
+        parsed = urlparse(candidate)
+        port = parsed.port
+    except ValueError:
+        return None
+    hostname = (parsed.hostname or "").lower().removesuffix(".")
+    if (
+        parsed.scheme != "https"
+        or not _LINKEDIN_MESSAGE_HOST_RE.fullmatch(hostname)
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in (None, 443)
+        or parsed.fragment
+    ):
+        return None
+    return parsed
+
+
+def _normalize_profile_urn(value: str | None) -> str | None:
+    """Return the identifier carried by a profile URN or raw recipient value."""
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if candidate.startswith(_PROFILE_URN_PREFIX):
+        candidate = candidate[len(_PROFILE_URN_PREFIX) :]
+    return candidate if _PROFILE_URN_RE.fullmatch(candidate) else None
+
+
+def _profile_path_from_url(value: str) -> str | None:
+    parsed = _safe_linkedin_url(value)
+    if parsed is None or parsed.query or not _PROFILE_PATH_RE.fullmatch(parsed.path):
+        return None
+    try:
+        username = normalize_person_identifier(value)
+    except LinkedInScraperException:
+        return None
+    canonical_path = urlparse(person_profile_url(username, "/")).path
+    return parsed.path if parsed.path == canonical_path else None
+
+
+def _profile_urn_from_compose_url(value: str, *, base: str | None = None) -> str | None:
+    parsed = _safe_linkedin_url(value, base=base)
+    if parsed is None or parsed.path != "/messaging/compose/":
+        return None
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    identifiers: set[str] = set()
+    for key in ("recipient", "profileUrn"):
+        values = params.get(key, [])
+        normalized = [_normalize_profile_urn(item) for item in values]
+        if any(item is None for item in normalized):
+            return None
+        identifiers.update(item for item in normalized if item is not None)
+    if len(identifiers) != 1:
+        return None
+    return identifiers.pop()
+
+
+def _message_page_url_is_safe(value: str, profile_urn: str) -> bool:
+    parsed = _safe_linkedin_url(value)
+    if parsed is None:
+        return False
+
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    recipient_values = [
+        item for key in ("recipient", "profileUrn") for item in params.get(key, [])
+    ]
+    if parsed.path != "/messaging/compose/" and not _MESSAGE_THREAD_PATH_RE.fullmatch(
+        parsed.path
+    ):
+        return False
+    return all(_normalize_profile_urn(item) == profile_urn for item in recipient_values)
+
 
 # Shared JS function that walks up from any /messaging/compose/ anchor
 # inside <main> to find the smallest ancestor that satisfies the
@@ -2707,27 +3026,9 @@ class LinkedInExtractor:
         )
 
     async def _extract_profile_urn(self) -> str | None:
-        """Extract the recipient profile URN from the messaging compose link.
-
-        The compose button on a person's profile contains a recipient URN in its
-        href query string. This URN is more reliable than username for messaging.
-        Returns None when no compose button is present (e.g. not a 1st-degree
-        connection or viewing own profile).
-        """
-        href: str | None = await self._page.evaluate(
-            """() => {
-                const anchor = document.querySelector(
-                    'main a[href*="/messaging/compose/"]'
-                );
-                if (!anchor) return null;
-                return anchor.getAttribute('href') || anchor.href || null;
-            }"""
-        )
-        if not isinstance(href, str) or not href.strip():
-            return None
-        params = parse_qs(urlparse(href.strip()).query)
-        recipient = params.get("recipient", [None])[0]
-        return recipient if isinstance(recipient, str) and recipient else None
+        """Extract a profile URN only from one unambiguous top-card snapshot."""
+        target = await self._read_profile_message_target()
+        return target.profile_urn if target else None
 
     async def get_sidebar_profiles(self, username: str) -> dict[str, Any]:
         """Extract profile links from sidebar sections on a LinkedIn profile page.
@@ -2906,29 +3207,46 @@ class LinkedInExtractor:
             "sidebar_profiles": sidebar_profiles,
         }
 
-    async def _resolve_message_compose_href(self) -> str | None:
-        """Return the direct recipient-specific compose URL from a profile page."""
-        href = await self._page.evaluate(
-            """(selector) => {
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth ||
-                            element.offsetHeight ||
-                            element.getClientRects().length)
-                    );
-
-                const anchor = Array.from(
-                    document.querySelectorAll(selector)
-                ).find(isVisible);
-                if (!anchor) return null;
-                return anchor.getAttribute('href') || anchor.href || null;
-            }""",
-            _MESSAGING_COMPOSE_LINK_SELECTOR,
-        )
-        if not isinstance(href, str) or not href.strip():
+    async def _read_profile_message_target(self) -> _ProfileMessageTarget | None:
+        """Read profile identity, name, compose URL and URN in one DOM snapshot."""
+        data = await self._page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
+        if not isinstance(data, dict):
             return None
-        return urljoin("https://www.linkedin.com", href.strip())
+
+        page_url = data.get("pageUrl")
+        compose_hrefs = data.get("composeHrefs")
+        if not isinstance(page_url, str) or not isinstance(compose_hrefs, list):
+            return None
+        profile_path = _profile_path_from_url(page_url)
+        if profile_path is None:
+            return None
+        if len(compose_hrefs) != 1 or not isinstance(compose_hrefs[0], str):
+            return None
+
+        parsed_compose = _safe_linkedin_url(compose_hrefs[0], base=page_url)
+        if parsed_compose is None:
+            return None
+        compose_url = parsed_compose.geturl()
+        profile_urn = _profile_urn_from_compose_url(compose_url)
+        if profile_urn is None:
+            return None
+
+        display_name = data.get("displayName")
+        if not isinstance(display_name, str) or not display_name.strip():
+            display_name = None
+        else:
+            display_name = display_name.strip()
+        return _ProfileMessageTarget(
+            profile_path=profile_path,
+            profile_urn=profile_urn,
+            compose_url=compose_url,
+            display_name=display_name,
+        )
+
+    async def _resolve_message_compose_href(self) -> str | None:
+        """Return an unambiguous recipient-specific top-card compose URL."""
+        target = await self._read_profile_message_target()
+        return target.compose_url if target else None
 
     async def _read_profile_display_name(self) -> str | None:
         """Read the visible profile name from the current person page."""
@@ -2958,194 +3276,135 @@ class LinkedInExtractor:
         return display_name or None
 
     async def _wait_for_message_surface(
-        self,
-    ) -> Literal["composer", "recipient_picker"] | None:
-        """Wait for either the recipient picker or the real composer to appear.
-
-        The recipient-picker probe uses a short 2 s cap so we fall through
-        quickly to the composer check, which uses the page-level default
-        (``BrowserConfig.default_timeout``, configurable via ``--timeout``).
-        """
-        if await self._locator_is_visible(
-            _MESSAGING_RECIPIENT_PICKER_SELECTOR, timeout=2000
-        ):
-            return "recipient_picker"
-        if await self._wait_for_message_composer():
+        self, target: _ProfileMessageTarget
+    ) -> Literal["composer"] | None:
+        """Wait for one editor with a matching local recipient identity."""
+        if await self._wait_for_message_composer(target):
             return "composer"
         return None
 
-    async def _select_message_recipient(self, *candidates: str) -> bool:
-        """Select the intended recipient from LinkedIn's New message picker."""
-        normalized_candidates = [value.strip() for value in candidates if value.strip()]
-        if not normalized_candidates:
+    async def _wait_for_message_composer(self, target: _ProfileMessageTarget) -> bool:
+        """Wait for the complete verified LinkedIn composer state to settle."""
+        try:
+            await self._page.wait_for_function(
+                _MESSAGE_COMPOSER_READY_JS,
+                arg=self._message_target_argument(target),
+            )
+        except PlaywrightTimeoutError:
             return False
-
-        selected = await self._page.evaluate(
-            """({ candidates }) => {
-                const normalize = value =>
-                    (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
-                    );
-                const pickerInput = Array.from(document.querySelectorAll('input')).find(
-                    element =>
-                        isVisible(element) &&
-                        /type a name|multiple names/i.test(
-                            `${element.placeholder || ''} ${
-                                element.getAttribute('aria-label') || ''
-                            }`
-                        )
-                );
-                const pickerRoot =
-                    pickerInput?.closest('section, dialog, [role="dialog"], aside, div') ||
-                    document.body;
-                const rows = Array.from(
-                    pickerRoot.querySelectorAll(
-                        '[role="option"], [role="listitem"], li, button, a, div'
-                    )
-                ).filter(element => {
-                    if (!isVisible(element)) return false;
-                    const text = normalize(element.innerText || element.textContent);
-                    return text.length > 0 && text !== 'new message';
-                });
-
-                for (const candidate of candidates.map(normalize)) {
-                    const exact = rows.find(element =>
-                        normalize(element.innerText || element.textContent) === candidate
-                    );
-                    if (exact) {
-                        exact.click();
-                        return true;
-                    }
-                }
-
-                for (const candidate of candidates.map(normalize)) {
-                    const partial = rows.find(element =>
-                        normalize(element.innerText || element.textContent).includes(candidate)
-                    );
-                    if (partial) {
-                        partial.click();
-                        return true;
-                    }
-                }
-
-                return false;
-            }""",
-            {"candidates": normalized_candidates},
-        )
-        if selected:
-            await asyncio.sleep(0.75)
-        return bool(selected)
-
-    async def _wait_for_message_composer(self) -> bool:
-        """Wait for the usable LinkedIn message composer to appear."""
-        return await self._resolve_message_compose_box() is not None
+        except Exception:
+            logger.debug("Could not wait for the message editor", exc_info=True)
+            return False
+        return True
 
     async def _resolve_message_compose_box(self) -> Any | None:
-        """Resolve the visible compose box used for writing a LinkedIn message.
+        """Resolve the editor only when exactly one visible candidate exists."""
+        locator = self._page.locator(f"{_MESSAGING_COMPOSE_SELECTOR}:visible")
+        try:
+            if await locator.count() != 1:
+                return None
+        except Exception:
+            logger.debug("Could not count message editor candidates", exc_info=True)
+            return None
+        return locator.first
 
-        Uses the page-level default timeout (``BrowserConfig.default_timeout``)
-        so the ``--timeout`` CLI flag is respected.
-        """
-        for selector in _MESSAGING_COMPOSE_FALLBACK_SELECTORS:
-            locator = self._page.locator(selector)
-            candidate_count: int | None = None
-            try:
-                candidate_count = await locator.count()
-            except Exception:
-                logger.debug(
-                    "Could not count compose box candidates for selector %r",
-                    selector,
-                    exc_info=True,
-                )
+    @staticmethod
+    def _message_target_argument(
+        target: _ProfileMessageTarget,
+    ) -> dict[str, str | bool]:
+        return {
+            "profilePath": target.profile_path,
+            "profileUrn": target.profile_urn,
+        }
 
-            logger.debug(
-                "Message compose selector %r matched %s candidate(s)",
-                selector,
-                candidate_count if candidate_count is not None else "unknown",
-            )
-
-            # patchright quirk: locator.wait_for(state="visible") times out on
-            # the contenteditable compose div even though count() > 0 and the
-            # element is fully visible by every CSS/DOM criterion (display:block,
-            # visibility:visible, opacity:1, non-zero bbox, no inert ancestor).
-            # This appears to be a patchright bug with React-hydrated contenteditable
-            # elements in isolated worlds. Skip the actionability wait when count()
-            # already confirmed the element is present — downstream interactions
-            # use page.evaluate() which bypasses the same check.
-            if candidate_count and candidate_count > 0:
-                return locator.last
-
-            # Fallback: when count() raised an exception above (candidate_count
-            # is None), attempt the original wait_for path.  This is unlikely to
-            # succeed given the same patchright quirk, but preserves the prior
-            # behaviour for non-patchright drivers where wait_for works normally.
-            candidate = locator.last
-            try:
-                await candidate.wait_for(state="visible")
-                return candidate
-            except PlaywrightTimeoutError:
-                continue
-
-        return None
-
-    async def _compose_page_matches_recipient(self, *candidates: str) -> bool:
-        """Verify the compose page visibly identifies the intended recipient."""
-        normalized_candidates = [value.strip() for value in candidates if value.strip()]
-        if not normalized_candidates:
-            return False
-
-        matched = await self._page.evaluate(
-            """({ candidates }) => {
-                const normalize = value =>
-                    (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
-                const isVisible = element =>
-                    !!(
-                        element &&
-                        (element.offsetWidth ||
-                            element.offsetHeight ||
-                            element.getClientRects().length)
-                    );
-
-                const targetValues = candidates.map(normalize).filter(Boolean);
-                const root = document.querySelector('main') || document.body;
-                if (!root) return false;
-
-                const entries = Array.from(
-                    root.querySelectorAll(
-                        'button, [role="button"], a, span, div, li, p, h1, h2, h3'
-                    )
-                )
-                    .filter(isVisible)
-                    .map(element =>
-                        [
-                            normalize(element.innerText || element.textContent || ''),
-                            normalize(element.getAttribute('aria-label') || ''),
-                        ].filter(Boolean)
-                    )
-                    .flat();
-
-                return targetValues.some(candidate =>
-                    entries.some(entry => entry === candidate || entry.includes(candidate))
-                );
-            }""",
-            {"candidates": normalized_candidates},
+    async def _read_message_composer_state(
+        self, target: _ProfileMessageTarget
+    ) -> dict[str, Any]:
+        """Inspect the unique editor and recipient inside its semantic owner."""
+        state = await self._page.evaluate(
+            _MESSAGE_COMPOSER_STATE_JS,
+            self._message_target_argument(target),
         )
-        return bool(matched)
+        return state if isinstance(state, dict) else {"status": "invalid"}
 
-    async def _message_text_occurrences(self, message: str) -> int:
-        """Count visible occurrences of the message outside any open composer."""
-        occurrences = await self._page.evaluate(
-            _MESSAGE_OCCURRENCES_JS, {"expected": message}
+    async def _focus_verified_message_editor(
+        self, target: _ProfileMessageTarget
+    ) -> bool:
+        """Focus the same local editor whose recipient identity was verified."""
+        focused = await self._page.evaluate(
+            _MESSAGE_COMPOSER_FOCUS_JS,
+            self._message_target_argument(target),
         )
-        return int(occurrences or 0)
+        return focused is True
+
+    async def _submit_verified_message(
+        self, target: _ProfileMessageTarget, *, allow_enter: bool
+    ) -> str:
+        """Click one local submit button or authorize the strict Enter fallback."""
+        argument = self._message_target_argument(target)
+        argument["allowEnter"] = allow_enter
+        result = await self._page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, argument)
+        return result if result in {"clicked", "enter"} else "invalid"
+
+    async def _resolve_message_owner(self, target: _ProfileMessageTarget) -> Any | None:
+        """Hold the verified owner node across baseline and confirmation."""
+        owner = await self._page.evaluate_handle(
+            _MESSAGE_COMPOSER_OWNER_JS,
+            arg=self._message_target_argument(target),
+        )
+        if owner.as_element() is None:
+            await self._dispose_message_owner(owner)
+            return None
+        return owner
+
+    @staticmethod
+    async def _dispose_message_owner(owner: Any) -> None:
+        """Release a request-local owner handle without replacing its result."""
+        try:
+            await owner.dispose()
+        except Exception:
+            logger.debug("Could not release message owner handle", exc_info=True)
+
+    def _message_occurrence_argument(
+        self,
+        message: str,
+        target: _ProfileMessageTarget,
+        owner: Any,
+    ) -> dict[str, Any]:
+        return {
+            **self._message_target_argument(target),
+            "expected": message,
+            "owner": owner,
+        }
+
+    async def _message_text_occurrences(
+        self,
+        message: str,
+        *,
+        target: _ProfileMessageTarget,
+        owner: Any,
+    ) -> int | None:
+        """Count message copies inside the pinned verified owner."""
+        result = await self._page.evaluate(
+            _MESSAGE_OCCURRENCES_JS,
+            self._message_occurrence_argument(message, target, owner),
+        )
+        if not isinstance(result, dict) or result.get("status") != "valid":
+            return None
+        count = result.get("count")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            return None
+        return count
 
     async def _message_text_visible(
-        self, message: str, *, previous_occurrences: int
+        self,
+        message: str,
+        *,
+        target: _ProfileMessageTarget,
+        owner: Any,
+        previous_occurrences: int,
     ) -> bool:
-        """Wait until a *new* copy of the message appears outside the composer.
+        """Wait for a new message copy inside the pinned verified owner.
 
         ``previous_occurrences`` is the baseline taken after typing and before
         the send attempt, so the requirement is strictly more occurrences than
@@ -3160,10 +3419,12 @@ class LinkedInExtractor:
         otherwise reach the caller as a plain tool error and invite the one
         retry that delivers the message twice.
         """
+        argument = self._message_occurrence_argument(message, target, owner)
+        argument["previous"] = previous_occurrences
         try:
             await self._page.wait_for_function(
                 _MESSAGE_OCCURRENCES_INCREASED_JS,
-                arg={"expected": message, "previous": previous_occurrences},
+                arg=argument,
             )
             return True
         except Exception:
@@ -5038,8 +5299,8 @@ class LinkedInExtractor:
             linkedin_username: LinkedIn username of the recipient.
             message: The message text to send.
             confirm_send: Must be True to actually send (False does a dry run).
-            profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
-                compose URL directly, bypassing the Message-button lookup.
+            profile_urn: Optional profile URN (e.g. ACoAAB...) to verify against
+                the recipient resolved from the loaded profile snapshot.
         """
         refusal = refuse_a_blank_message(linkedin_username, message)
         if refusal is not None:
@@ -5056,31 +5317,23 @@ class LinkedInExtractor:
             logger.debug("Profile page did not load for %s", linkedin_username)
 
         await handle_modal_close(self._page)
-        display_name = await self._read_profile_display_name()
-        if profile_urn:
-            # Build the full compose URL that LinkedIn's own Message button
-            # generates. The minimal ?recipient=<URN> form works for established
-            # connections but shows a "Say hello" widget (no compose box) for new
-            # connections. Adding profileUrn + screenContext + interop=msgOverlay
-            # consistently opens the real composer regardless of connection age.
-            _encoded = quote_plus(f"urn:li:fsd_profile:{profile_urn}")
-            compose_url: str | None = (
-                f"https://www.linkedin.com/messaging/compose/"
-                f"?profileUrn={_encoded}"
-                f"&recipient={quote_plus(profile_urn)}"
-                f"&screenContext=NON_SELF_PROFILE_VIEW"
-                f"&interop=msgOverlay"
-            )
-        else:
-            compose_url = await self._resolve_message_compose_href()
-        if not compose_url:
+        target = await self._read_profile_message_target()
+        if target is None:
             return self._message_action_result(
                 profile_url,
                 "message_unavailable",
-                "LinkedIn did not expose a usable Message action for this profile.",
+                "LinkedIn did not expose one usable Message action for this profile.",
             )
 
-        await self._navigate_to_page(compose_url)
+        supplied_urn = _normalize_profile_urn(profile_urn) if profile_urn else None
+        if profile_urn is not None and supplied_urn != target.profile_urn:
+            return self._message_action_result(
+                profile_url,
+                "recipient_resolution_failed",
+                "The supplied profile URN did not match the loaded profile.",
+            )
+
+        await self._navigate_to_page(target.compose_url)
         await detect_rate_limit(self._page)
 
         try:
@@ -5089,72 +5342,42 @@ class LinkedInExtractor:
             logger.debug("Compose page did not fully load for %s", linkedin_username)
 
         await handle_modal_close(self._page)
-        message_surface = await self._wait_for_message_surface()
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "LinkedIn opened an unexpected messaging URL.",
+            )
+
+        message_surface = await self._wait_for_message_surface(target)
         logger.debug(
-            "Message surface for %s before hydration was %s",
-            linkedin_username,
-            message_surface,
+            "Message surface for %s was %s", linkedin_username, message_surface
         )
-
-        recipient_selected = False
-        if message_surface == "recipient_picker":
-            recipient_selected = await self._select_message_recipient(
-                display_name or "",
-                linkedin_username,
-            )
-            logger.debug(
-                "Recipient picker selection for %s returned %s",
-                linkedin_username,
-                recipient_selected,
-            )
-            if not recipient_selected:
-                await self._dismiss_message_ui()
-                return self._message_action_result(
-                    self._page.url,
-                    "recipient_resolution_failed",
-                    "LinkedIn opened a compose page, but the visible recipient did not match the requested profile.",
-                )
-            message_surface = await self._wait_for_message_surface()
-            logger.debug(
-                "Message surface for %s after recipient selection was %s",
-                linkedin_username,
-                message_surface,
-            )
-
-        compose_box = await self._resolve_message_compose_box()
-        if compose_box is None:
+        if message_surface != "composer":
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "composer_unavailable",
-                "LinkedIn did not expose a usable message composer.",
-                recipient_selected=recipient_selected,
+                "LinkedIn did not expose one usable message composer.",
             )
 
-        logger.debug(
-            "Message compose box resolved for %s after hydration",
-            linkedin_username,
-        )
-
-        if not await self._compose_page_matches_recipient(
-            display_name or "",
-            linkedin_username,
-        ):
+        state = await self._read_message_composer_state(target)
+        if state.get("status") != "valid":
             logger.debug(
-                "Recipient match still failed for %s after compose hydration",
+                "Message recipient verification for %s returned %s",
                 linkedin_username,
+                state.get("status"),
             )
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
-                "LinkedIn opened a compose page, but the visible recipient did not match the requested profile.",
-                recipient_selected=recipient_selected,
+                "The local composer did not identify exactly the requested profile.",
             )
         recipient_selected = True
 
         if not confirm_send:
-            await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "confirmation_required",
@@ -5162,37 +5385,21 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
 
-        # patchright quirk: compose_box.click() and press_sequentially() use
-        # actionability checks internally and hit the same wait_for timeout.
-        # Instead: focus via page.evaluate() (no actionability check) and type
-        # via page.keyboard.type() which operates on the active element directly
-        # and fires the real keydown/input/keyup events React needs to enable Send.
-        #
-        # DOM dependency: innerText extraction is not applicable here — we need
-        # to call .focus() on the element reference, which requires querySelector.
-        # Selectors use only role + contenteditable + aria-label (ARIA attributes,
-        # not layout class names) so they are stable across LinkedIn UI changes.
-        composer = await self._page.evaluate(
-            """() => {
-                const el = document.querySelector(
-                    'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
-                    + 'div[role="textbox"][contenteditable="true"]'
-                );
-                if (!el) return 'missing';
-                // Text already in the editor belongs to whoever typed it.
-                // Chromium leaves the caret at the start of a contenteditable
-                // after focus(), so typing here puts the message in front of
-                // that draft and LinkedIn delivers the two as one. Clearing
-                // it would destroy it, so refuse and leave it standing.
-                if ((el.innerText || '').replace(/\\s+/g, ' ').trim()) {
-                    return 'occupied';
-                }
-                el.focus();
-                return 'focused';
-            }"""
-        )
-        if composer == "occupied":
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
             await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed before the editor could be focused.",
+                recipient_selected=recipient_selected,
+            )
+        state = await self._read_message_composer_state(target)
+        if state.get("status") == "valid" and state.get("empty") is not True:
+            # Text already in the editor belongs to whoever typed it.
+            # Chromium leaves the caret at the start of a contenteditable
+            # after focus(), so the message would land in front of that draft
+            # and LinkedIn would deliver the two as one. Clearing it would
+            # trade the leak for destroying it, so refuse and leave it.
             return self._message_action_result(
                 self._page.url,
                 "composer_occupied",
@@ -5200,12 +5407,14 @@ class LinkedInExtractor:
                 "with the message. The draft was left untouched.",
                 recipient_selected=recipient_selected,
             )
-        if composer != "focused":
+        if state.get(
+            "status"
+        ) != "valid" or not await self._focus_verified_message_editor(target):
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "compose_interact_failed",
-                "Could not focus compose box via JavaScript.",
+                "The verified message editor could not be focused.",
                 recipient_selected=recipient_selected,
             )
         await asyncio.sleep(0.1)
@@ -5228,90 +5437,188 @@ class LinkedInExtractor:
         # this window for that reason: an interruption during
         # `_dismiss_message_ui` is as unreportable as one during the send.
         try:
+            if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+                await self._dismiss_message_ui()
+                return self._message_action_result(
+                    self._page.url,
+                    "recipient_resolution_failed",
+                    "The messaging URL changed before text entry.",
+                    recipient_selected=recipient_selected,
+                )
+            state = await self._read_message_composer_state(target)
+            if state.get("status") != "valid" or state.get("active") is not True:
+                await self._dismiss_message_ui()
+                return self._message_action_result(
+                    self._page.url,
+                    "compose_interact_failed",
+                    "The verified message editor changed before text entry.",
+                    recipient_selected=recipient_selected,
+                )
+            allow_enter = state.get("submitCount") == 0
+
             await self._page.keyboard.type(message, delay=15)
             await asyncio.sleep(0.3)
             await asyncio.sleep(1.0)  # allow React to process keyboard input
+            if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+                await self._dismiss_message_ui()
+                if may_have_submitted:
+                    return self._message_action_result(
+                        self._page.url,
+                        "send_unconfirmed",
+                        "The message may already have been submitted before the "
+                        "messaging URL changed. Check the conversation before "
+                        "retrying; retrying may deliver the message twice.",
+                        recipient_selected=recipient_selected,
+                        retry_safe=False,
+                    )
+                return self._message_action_result(
+                    self._page.url,
+                    "recipient_resolution_failed",
+                    "The messaging URL changed before submission.",
+                    recipient_selected=recipient_selected,
+                )
 
-            # Baseline immediately before the send attempt: how often the
-            # message is already visible outside the composer. The click below
-            # only tries to send; delivery is proven by this count growing,
-            # never by the text the composer still holds.
-            previous_occurrences = await self._message_text_occurrences(message)
+            owner = await self._resolve_message_owner(target)
+            if owner is None:
+                await self._dismiss_message_ui()
+                if may_have_submitted:
+                    return self._message_action_result(
+                        self._page.url,
+                        "send_unconfirmed",
+                        "The message may already have been submitted before the "
+                        "verified composer owner disappeared. Check the "
+                        "conversation before retrying; retrying may deliver "
+                        "the message twice.",
+                        recipient_selected=recipient_selected,
+                        retry_safe=False,
+                    )
+                return self._message_action_result(
+                    self._page.url,
+                    "recipient_resolution_failed",
+                    "The verified message composer changed before submission.",
+                    recipient_selected=recipient_selected,
+                )
 
-            # patchright actionability also blocks send_button.click(). Use JS
-            # click on any visible, enabled send button; fall back to Enter key
-            # which LinkedIn's composer also accepts for submission.
-            #
-            # DOM dependency: we need btn.click() on the element reference — not
-            # achievable via innerText or URL navigation. Selectors use only
-            # type, aria-label, and data attributes (no layout class names).
             try:
-                # The click is dispatched inside the call that may then fail,
-                # so the flag is set before it rather than after.
-                may_have_submitted = True
-                sent_via_js = await self._page.evaluate(
-                    """() => {
-                    const btn = Array.from(document.querySelectorAll(
-                        'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
-                        + 'button[data-control-name="send"]'
-                    )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
-                    if (!btn) return false;
-                    btn.click();
-                    return true;
-                }"""
+                # Baseline immediately before the send attempt: how often the
+                # message is already visible in the verified owner. The click
+                # below only tries to send; delivery is proven by this count
+                # growing, never by the text the editor still holds.
+                previous_occurrences = await self._message_text_occurrences(
+                    message,
+                    target=target,
+                    owner=owner,
                 )
-                if not sent_via_js:
-                    await self._page.keyboard.press("Enter")
-            except Exception:
-                # Both submissions dispatch their input event inside the very
-                # call that then fails, so a context that dies here says
-                # nothing about whether the message left: a send that navigates
-                # the page away looks exactly like one that never started.
-                # Letting the error out would reach the caller as a plain tool
-                # failure and invite the retry that delivers a second message
-                # to a real person.
-                logger.debug("Message submission did not complete", exc_info=True)
-                await self._dismiss_message_ui()
+                if previous_occurrences is None:
+                    await self._dismiss_message_ui()
+                    if may_have_submitted:
+                        return self._message_action_result(
+                            self._page.url,
+                            "send_unconfirmed",
+                            "The message may already have been submitted before "
+                            "its verified composer owner disappeared. Check the "
+                            "conversation before retrying; retrying may deliver "
+                            "the message twice.",
+                            recipient_selected=recipient_selected,
+                            retry_safe=False,
+                        )
+                    return self._message_action_result(
+                        self._page.url,
+                        "recipient_resolution_failed",
+                        "The verified message composer changed before submission.",
+                        recipient_selected=recipient_selected,
+                    )
+
+                try:
+                    # The click is dispatched inside the call that may then fail,
+                    # so the flag is set before it rather than after.
+                    may_have_submitted = True
+                    submission = await self._submit_verified_message(
+                        target, allow_enter=allow_enter
+                    )
+                    if submission == "enter":
+                        state = await self._read_message_composer_state(target)
+                        if (
+                            not allow_enter
+                            or not _message_page_url_is_safe(
+                                self._page.url, target.profile_urn
+                            )
+                            or state.get("status") != "valid"
+                            or state.get("active") is not True
+                            or state.get("submitCount") != 0
+                        ):
+                            submission = "invalid"
+                        else:
+                            # The read and the keypress are two round trips, so the
+                            # editor could in principle lose focus between them.
+                            # Nothing a caller or recipient controls reaches that
+                            # window, and closing it would need the keystroke and
+                            # check to be one operation, which no input API offers.
+                            await self._page.keyboard.press("Enter")
+                    if submission not in {"clicked", "enter"}:
+                        await self._dismiss_message_ui()
+                        return self._message_action_result(
+                            self._page.url,
+                            "send_unavailable",
+                            "The local submit path was missing, disabled, or ambiguous.",
+                            recipient_selected=recipient_selected,
+                            retry_safe=False,
+                        )
+                except Exception:
+                    # Both submissions dispatch their input event inside the very
+                    # call that then fails, so a context that dies here says
+                    # nothing about whether the message left: a send that navigates
+                    # the page away looks exactly like one that never started.
+                    # Letting the error out would reach the caller as a plain tool
+                    # failure and invite the retry that delivers a second message
+                    # to a real person.
+                    logger.debug("Message submission did not complete", exc_info=True)
+                    await self._dismiss_message_ui()
+                    return self._message_action_result(
+                        self._page.url,
+                        "send_unconfirmed",
+                        "The message submission was interrupted and LinkedIn did "
+                        "not confirm delivery. Check the conversation before "
+                        "retrying; retrying may deliver the message twice.",
+                        recipient_selected=recipient_selected,
+                        retry_safe=False,
+                    )
+
+                confirmed = await self._message_text_visible(
+                    message,
+                    target=target,
+                    owner=owner,
+                    previous_occurrences=previous_occurrences,
+                )
+
+                if not confirmed:
+                    await self._dismiss_message_ui()
+                    # Submission already happened, so this is not evidence that
+                    # nothing was sent: a thread that renders the delivered bubble
+                    # slower than the page timeout arrives here having delivered.
+                    # Reporting a plain failure invites a retry, and a retry sends a
+                    # second real message to a real person, so the status says
+                    # unknown rather than no.
+                    return self._message_action_result(
+                        self._page.url,
+                        "send_unconfirmed",
+                        "The message was submitted but LinkedIn did not confirm "
+                        "delivery in time. Check the conversation before retrying; "
+                        "retrying may deliver the message twice.",
+                        recipient_selected=recipient_selected,
+                        retry_safe=False,
+                    )
+
                 return self._message_action_result(
                     self._page.url,
-                    "send_unconfirmed",
-                    "The message submission was interrupted and LinkedIn did "
-                    "not confirm delivery. Check the conversation before "
-                    "retrying; retrying may deliver the message twice.",
+                    "sent",
+                    "Message sent.",
                     recipient_selected=recipient_selected,
+                    sent=True,
                     retry_safe=False,
                 )
-
-            confirmed = await self._message_text_visible(
-                message, previous_occurrences=previous_occurrences
-            )
-
-            if not confirmed:
-                await self._dismiss_message_ui()
-                # Submission already happened, so this is not evidence that
-                # nothing was sent: a thread that renders the delivered bubble
-                # slower than the page timeout arrives here having delivered.
-                # Reporting a plain failure invites a retry, and a retry sends a
-                # second real message to a real person, so the status says
-                # unknown rather than no.
-                return self._message_action_result(
-                    self._page.url,
-                    "send_unconfirmed",
-                    "The message was submitted but LinkedIn did not confirm "
-                    "delivery in time. Check the conversation before retrying; "
-                    "retrying may deliver the message twice.",
-                    recipient_selected=recipient_selected,
-                    retry_safe=False,
-                )
-
-            return self._message_action_result(
-                self._page.url,
-                "sent",
-                "Message sent.",
-                recipient_selected=recipient_selected,
-                sent=True,
-                retry_safe=False,
-            )
+            finally:
+                await self._dispose_message_owner(owner)
         except Exception:
             # Reached where a message may already be gone and no result says
             # so: an error while typing, which a newline has by then turned

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5302,7 +5302,9 @@ class LinkedInExtractor:
             return self._message_action_result(
                 profile_url,
                 "message_unavailable",
-                "LinkedIn did not expose one usable Message action for this profile.",
+                "LinkedIn did not expose a normal Message action for this profile. "
+                "Use connect_with_person first, then retry only after the connection "
+                "request is accepted.",
             )
 
         supplied_urn = _normalize_profile_urn(profile_urn) if profile_urn else None

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -514,15 +514,15 @@ _MESSAGE_OCCURRENCES_JS = r"""
 """
 
 # A submission is in flight from the moment the send is dispatched until the
-# confirmation answers, and a cancellation in that window cannot be reported:
-# FastMCP runs every tool inside `anyio.fail_after()`, so the deadline raises
-# `CancelledError` past `except Exception` and discards any result returned
-# from the cancelled scope. The caller gets a timeout that carries no
-# `retry_safe`, and this line is then the only record that a message may
-# already have left. Answering the caller instead needs the tool to know its
-# own deadline, which is issue #889.
-_SEND_CANCELLED_WARNING = (
-    "Message submission was cancelled while in flight. Delivery is unknown; "
+# whole path has produced a result, cleanup included, and an interruption in
+# that window cannot be reported. FastMCP runs every tool inside
+# `anyio.fail_after()`, so the deadline raises `CancelledError` past
+# `except Exception` and discards any result returned from the cancelled
+# scope. The caller gets a timeout that carries no `retry_safe`, and this line
+# is then the only record that a message may already have left. Answering the
+# caller instead needs the tool to know its own deadline, which is issue #889.
+_SEND_INTERRUPTED_WARNING = (
+    "Message submission was interrupted while in flight. Delivery is unknown; "
     "check the conversation before retrying, as a retry may deliver the "
     "message twice."
 )
@@ -5219,16 +5219,23 @@ class LinkedInExtractor:
         # the composer still holds.
         previous_occurrences = await self._message_text_occurrences(message)
 
-        # patchright actionability also blocks send_button.click(). Use JS click
-        # on any visible, enabled send button; fall back to Enter key which
-        # LinkedIn's composer also accepts for submission.
-        #
-        # DOM dependency: we need btn.click() on the element reference — not
-        # achievable via innerText or URL navigation. Selectors use only type,
-        # aria-label, and data attributes (no layout class names).
+        # Everything from here on runs with a submission dispatched or about to
+        # be, so any exit that carries no result leaves the caller unable to
+        # tell whether a message went out. The cleanup awaits between the
+        # branches below are inside this window for that reason: an
+        # interruption during `_dismiss_message_ui` is as unreportable as one
+        # during the send itself.
         try:
-            sent_via_js = await self._page.evaluate(
-                """() => {
+            # patchright actionability also blocks send_button.click(). Use JS
+            # click on any visible, enabled send button; fall back to Enter key
+            # which LinkedIn's composer also accepts for submission.
+            #
+            # DOM dependency: we need btn.click() on the element reference — not
+            # achievable via innerText or URL navigation. Selectors use only
+            # type, aria-label, and data attributes (no layout class names).
+            try:
+                sent_via_js = await self._page.evaluate(
+                    """() => {
                     const btn = Array.from(document.querySelectorAll(
                         'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
                         + 'button[data-control-name="send"]'
@@ -5237,71 +5244,69 @@ class LinkedInExtractor:
                     btn.click();
                     return true;
                 }"""
-            )
-            if not sent_via_js:
-                await self._page.keyboard.press("Enter")
-        except Exception:
-            # Both submissions dispatch their input event inside the very call
-            # that then fails, so a context that dies here says nothing about
-            # whether the message left: a send that navigates the page away
-            # looks exactly like one that never started. Letting the error out
-            # would reach the caller as a plain tool failure and invite the
-            # retry that delivers a second message to a real person.
-            logger.debug("Message submission did not complete", exc_info=True)
-            await self._dismiss_message_ui()
-            return self._message_action_result(
-                self._page.url,
-                "send_unconfirmed",
-                "The message submission was interrupted and LinkedIn did not "
-                "confirm delivery. Check the conversation before retrying; "
-                "retrying may deliver the message twice.",
-                recipient_selected=recipient_selected,
-                retry_safe=False,
-            )
-        except BaseException:
-            # Ordered after `except Exception`, so this is cancellation and
-            # not an ordinary failure. Re-raised rather than reported,
-            # because the cancelled scope discards a return value.
-            logger.warning(_SEND_CANCELLED_WARNING)
-            raise
+                )
+                if not sent_via_js:
+                    await self._page.keyboard.press("Enter")
+            except Exception:
+                # Both submissions dispatch their input event inside the very
+                # call that then fails, so a context that dies here says
+                # nothing about whether the message left: a send that navigates
+                # the page away looks exactly like one that never started.
+                # Letting the error out would reach the caller as a plain tool
+                # failure and invite the retry that delivers a second message
+                # to a real person.
+                logger.debug("Message submission did not complete", exc_info=True)
+                await self._dismiss_message_ui()
+                return self._message_action_result(
+                    self._page.url,
+                    "send_unconfirmed",
+                    "The message submission was interrupted and LinkedIn did "
+                    "not confirm delivery. Check the conversation before "
+                    "retrying; retrying may deliver the message twice.",
+                    recipient_selected=recipient_selected,
+                    retry_safe=False,
+                )
 
-        try:
             confirmed = await self._message_text_visible(
                 message, previous_occurrences=previous_occurrences
             )
-        except BaseException:
-            # `_message_text_visible` answers False for every failure it can
-            # observe, so only cancellation arrives here, and it arrives
-            # after a message may already have been delivered.
-            logger.warning(_SEND_CANCELLED_WARNING)
-            raise
 
-        if not confirmed:
-            await self._dismiss_message_ui()
-            # Submission already happened, so this is not evidence that
-            # nothing was sent: a thread that renders the delivered bubble
-            # slower than the page timeout arrives here having delivered.
-            # Reporting a plain failure invites a retry, and a retry sends a
-            # second real message to a real person, so the status says
-            # unknown rather than no.
+            if not confirmed:
+                await self._dismiss_message_ui()
+                # Submission already happened, so this is not evidence that
+                # nothing was sent: a thread that renders the delivered bubble
+                # slower than the page timeout arrives here having delivered.
+                # Reporting a plain failure invites a retry, and a retry sends a
+                # second real message to a real person, so the status says
+                # unknown rather than no.
+                return self._message_action_result(
+                    self._page.url,
+                    "send_unconfirmed",
+                    "The message was submitted but LinkedIn did not confirm "
+                    "delivery in time. Check the conversation before retrying; "
+                    "retrying may deliver the message twice.",
+                    recipient_selected=recipient_selected,
+                    retry_safe=False,
+                )
+
             return self._message_action_result(
                 self._page.url,
-                "send_unconfirmed",
-                "The message was submitted but LinkedIn did not confirm "
-                "delivery in time. Check the conversation before retrying; "
-                "retrying may deliver the message twice.",
+                "sent",
+                "Message sent.",
                 recipient_selected=recipient_selected,
+                sent=True,
                 retry_safe=False,
             )
-
-        return self._message_action_result(
-            self._page.url,
-            "sent",
-            "Message sent.",
-            recipient_selected=recipient_selected,
-            sent=True,
-            retry_safe=False,
-        )
+        except BaseException:
+            # Reached only where the window produced no result at all. An
+            # ordinary submission failure returns from the inner handler, and
+            # `_message_text_visible` answers False for every failure it can
+            # observe, so what arrives here is cancellation or the rare error
+            # escaping cleanup. Both leave the same question behind, and both
+            # are re-raised rather than reported, because a cancelled scope
+            # discards a return value.
+            logger.warning(_SEND_INTERRUPTED_WARNING)
+            raise
 
     async def _extract_root_content(
         self,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -465,6 +465,14 @@ _MESSAGING_CLOSE_SELECTOR = (
 # send path compares a baseline taken before the click with the count after
 # it. Visibility is pure geometry and the match is on normalized text, so no
 # LinkedIn class name or localized label enters the decision.
+#
+# Known limit, and it scales with how short the message is: the count is taken
+# over the whole body, so any unrelated text arriving between the two reads can
+# raise it if the message occurs inside it. A messaging page updates presence
+# and timestamps on its own, so a one-character message can be confirmed by
+# something that has nothing to do with it. A sentence cannot. Scoping the
+# count to the thread would need a container selector, and every candidate
+# LinkedIn offers is a layout class name.
 _MESSAGE_OCCURRENCES_JS = r"""
 ({ expected }) => {
     const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
@@ -491,7 +499,12 @@ _MESSAGE_OCCURRENCES_JS = r"""
         );
 
     let total = countIn(document.body?.innerText || '');
-    for (const editor of document.querySelectorAll('[contenteditable="true"]')) {
+    // Any element that declares contenteditable at all, not only the ones
+    // currently set to "true": a composer commonly goes read-only for the
+    // duration of an in-flight send while keeping its text on screen, and
+    // an occurrence subtracted at baseline must stay subtracted afterwards
+    // or the same unsent draft confirms itself.
+    for (const editor of document.querySelectorAll('[contenteditable]')) {
         if (isVisible(editor)) {
             total -= countIn(editor.innerText);
         }
@@ -5130,18 +5143,35 @@ class LinkedInExtractor:
         # to call .focus() on the element reference, which requires querySelector.
         # Selectors use only role + contenteditable + aria-label (ARIA attributes,
         # not layout class names) so they are stable across LinkedIn UI changes.
-        focused = await self._page.evaluate(
+        composer = await self._page.evaluate(
             """() => {
                 const el = document.querySelector(
                     'div[role="textbox"][contenteditable="true"][aria-label*="Write a message"],'
                     + 'div[role="textbox"][contenteditable="true"]'
                 );
-                if (!el) return false;
+                if (!el) return 'missing';
+                // Text already in the editor belongs to whoever typed it.
+                // Chromium leaves the caret at the start of a contenteditable
+                // after focus(), so typing here puts the message in front of
+                // that draft and LinkedIn delivers the two as one. Clearing
+                // it would destroy it, so refuse and leave it standing.
+                if ((el.innerText || '').replace(/\\s+/g, ' ').trim()) {
+                    return 'occupied';
+                }
                 el.focus();
-                return true;
+                return 'focused';
             }"""
         )
-        if not focused:
+        if composer == "occupied":
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "composer_occupied",
+                "The composer already holds a draft that would be sent along "
+                "with the message. The draft was left untouched.",
+                recipient_selected=recipient_selected,
+            )
+        if composer != "focused":
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
@@ -5185,10 +5215,18 @@ class LinkedInExtractor:
             message, previous_occurrences=previous_occurrences
         ):
             await self._dismiss_message_ui()
+            # Submission already happened, so this is not evidence that
+            # nothing was sent: a thread that renders the delivered bubble
+            # slower than the page timeout arrives here having delivered.
+            # Reporting a plain failure invites a retry, and a retry sends a
+            # second real message to a real person, so the status says
+            # unknown rather than no.
             return self._message_action_result(
                 self._page.url,
-                "send_unavailable",
-                "LinkedIn did not confirm that the message was sent.",
+                "send_unconfirmed",
+                "The message was submitted but LinkedIn did not confirm "
+                "delivery in time. Check the conversation before retrying; "
+                "retrying may deliver the message twice.",
                 recipient_selected=recipient_selected,
             )
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5041,17 +5041,11 @@ class LinkedInExtractor:
             profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
                 compose URL directly, bypassing the Message-button lookup.
         """
+        refusal = refuse_a_blank_message(linkedin_username, message)
+        if refusal is not None:
+            return refusal
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
-        if not message.strip():
-            # Not `message_unavailable`, which says the *recipient* exposes no
-            # Message action and tells a caller to give up on this person. A
-            # blank message is the caller's own input and the repair is theirs.
-            return self._message_action_result(
-                profile_url,
-                "invalid_message",
-                "Message must contain non-whitespace characters.",
-            )
 
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
@@ -5417,3 +5411,26 @@ class LinkedInExtractor:
             {"selectors": selectors},
         )
         return result
+
+
+def refuse_a_blank_message(
+    linkedin_username: str, message: str
+) -> dict[str, Any] | None:
+    """The refusal for a whitespace-only message, or None if there is none.
+
+    Shared between the MCP tool and `LinkedInExtractor.send_message` so the
+    two cannot answer the same input differently. The tool calls it before
+    acquiring a session: the input is the caller's own and needs no browser
+    to judge, while acquiring one can spend a login attempt and answer with
+    an authentication error the caller then has to interpret instead.
+    """
+    if message.strip():
+        return None
+    # Not `message_unavailable`, which says the *recipient* exposes no
+    # Message action and tells a caller to give up on this person. A blank
+    # message is the caller's own input and the repair is theirs.
+    return LinkedInExtractor._message_action_result(
+        person_profile_url(normalize_person_identifier(linkedin_username), "/"),
+        "invalid_message",
+        "Message must contain non-whitespace characters.",
+    )

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -1134,14 +1134,25 @@ class LinkedInExtractor:
         *,
         recipient_selected: bool = False,
         sent: bool = False,
+        retry_safe: bool = True,
     ) -> dict[str, Any]:
-        """Build a structured response for the send_message tool."""
+        """Build a structured response for the send_message tool.
+
+        ``sent`` answers whether delivery was proven, so it is false both
+        where nothing was submitted and where submission happened but
+        delivery could not be observed. A caller keying a retry on it alone
+        therefore re-sends a message that may already have arrived, which is
+        what ``retry_safe`` exists to say: it is false from the moment a
+        submission is attempted, and true only while nothing can have left
+        the composer.
+        """
         return {
             "url": url,
             "status": status,
             "message": message,
             "recipient_selected": recipient_selected,
             "sent": sent,
+            "retry_safe": retry_safe,
         }
 
     async def _log_navigation_failure(
@@ -3128,6 +3139,12 @@ class LinkedInExtractor:
         and neither can an identical message already in the thread.
 
         Uses the page-level default timeout (``BrowserConfig.default_timeout``).
+
+        Every failure answers "not observed" rather than raising, because this
+        runs only after a submission was attempted. An execution context that
+        dies mid-wait, which is what an SPA remount looks like from here, would
+        otherwise reach the caller as a plain tool error and invite the one
+        retry that delivers the message twice.
         """
         try:
             await self._page.wait_for_function(
@@ -3135,7 +3152,8 @@ class LinkedInExtractor:
                 arg={"expected": message, "previous": previous_occurrences},
             )
             return True
-        except PlaywrightTimeoutError:
+        except Exception:
+            logger.debug("Message delivery could not be confirmed", exc_info=True)
             return False
 
     async def _dismiss_message_ui(self) -> None:
@@ -5012,9 +5030,12 @@ class LinkedInExtractor:
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
         if not message.strip():
+            # Not `message_unavailable`, which says the *recipient* exposes no
+            # Message action and tells a caller to give up on this person. A
+            # blank message is the caller's own input and the repair is theirs.
             return self._message_action_result(
                 profile_url,
-                "message_unavailable",
+                "invalid_message",
                 "Message must contain non-whitespace characters.",
             )
 
@@ -5228,6 +5249,7 @@ class LinkedInExtractor:
                 "delivery in time. Check the conversation before retrying; "
                 "retrying may deliver the message twice.",
                 recipient_selected=recipient_selected,
+                retry_safe=False,
             )
 
         return self._message_action_result(
@@ -5236,6 +5258,7 @@ class LinkedInExtractor:
             "Message sent.",
             recipient_selected=recipient_selected,
             sent=True,
+            retry_safe=False,
         )
 
     async def _extract_root_content(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -457,6 +457,55 @@ _MESSAGING_CLOSE_SELECTOR = (
     'button[aria-label*="Close"]'
 )
 
+# Counts visible occurrences of a message *outside* every open composer.
+# The composer holds the message before it is sent, so plain body text is no
+# evidence of delivery: a Send button whose handler does nothing leaves the
+# text standing in the editor and the page still "contains" it. Occurrences
+# inside visible contenteditable editors are therefore subtracted, and the
+# send path compares a baseline taken before the click with the count after
+# it. Visibility is pure geometry and the match is on normalized text, so no
+# LinkedIn class name or localized label enters the decision.
+_MESSAGE_OCCURRENCES_JS = r"""
+({ expected }) => {
+    const normalize = value => (value || '').replace(/\s+/g, ' ').trim();
+    const needle = normalize(expected);
+    if (!needle) return 0;
+
+    const countIn = value => {
+        const haystack = normalize(value);
+        let count = 0;
+        let index = haystack.indexOf(needle);
+        while (index !== -1) {
+            count += 1;
+            index = haystack.indexOf(needle, index + needle.length);
+        }
+        return count;
+    };
+
+    const isVisible = element =>
+        !!(
+            element &&
+            (element.offsetWidth ||
+                element.offsetHeight ||
+                element.getClientRects().length)
+        );
+
+    let total = countIn(document.body?.innerText || '');
+    for (const editor of document.querySelectorAll('[contenteditable="true"]')) {
+        if (isVisible(editor)) {
+            total -= countIn(editor.innerText);
+        }
+    }
+    return total > 0 ? total : 0;
+}
+"""
+
+# The post-send predicate is the same counting routine, so the baseline and
+# the confirmation can never disagree about what counts as an occurrence.
+_MESSAGE_OCCURRENCES_INCREASED_JS = (
+    f"(arg) => ({_MESSAGE_OCCURRENCES_JS})(arg) > arg.previous"
+)
+
 # Shared JS function that walks up from any /messaging/compose/ anchor
 # inside <main> to find the smallest ancestor that satisfies the
 # action-root predicate (>=2 interactive children, >=1 button). This is
@@ -3048,20 +3097,29 @@ class LinkedInExtractor:
         )
         return bool(matched)
 
-    async def _message_text_visible(self, message: str) -> bool:
-        """Wait until the compose page visibly contains the just-sent message text.
+    async def _message_text_occurrences(self, message: str) -> int:
+        """Count visible occurrences of the message outside any open composer."""
+        occurrences = await self._page.evaluate(
+            _MESSAGE_OCCURRENCES_JS, {"expected": message}
+        )
+        return int(occurrences or 0)
+
+    async def _message_text_visible(
+        self, message: str, *, previous_occurrences: int
+    ) -> bool:
+        """Wait until a *new* copy of the message appears outside the composer.
+
+        ``previous_occurrences`` is the baseline taken after typing and before
+        the send attempt, so the requirement is strictly more occurrences than
+        before: the typed text sitting in the composer cannot confirm itself,
+        and neither can an identical message already in the thread.
 
         Uses the page-level default timeout (``BrowserConfig.default_timeout``).
         """
         try:
             await self._page.wait_for_function(
-                """({ expected }) => {
-                    const normalize = value =>
-                        (value || '').replace(/\\s+/g, ' ').trim();
-                    const bodyText = normalize(document.body?.innerText || '');
-                    return bodyText.includes(normalize(expected));
-                }""",
-                arg={"expected": message},
+                _MESSAGE_OCCURRENCES_INCREASED_JS,
+                arg={"expected": message, "previous": previous_occurrences},
             )
             return True
         except PlaywrightTimeoutError:
@@ -5087,6 +5145,13 @@ class LinkedInExtractor:
         await asyncio.sleep(0.1)
         await self._page.keyboard.type(message, delay=15)
         await asyncio.sleep(0.3)
+        await asyncio.sleep(1.0)  # allow React to process keyboard input
+
+        # Baseline immediately before the send attempt: how often the message
+        # is already visible outside the composer. The click below only tries
+        # to send; delivery is proven by this count growing, never by the text
+        # the composer still holds.
+        previous_occurrences = await self._message_text_occurrences(message)
 
         # patchright actionability also blocks send_button.click(). Use JS click
         # on any visible, enabled send button; fall back to Enter key which
@@ -5095,7 +5160,6 @@ class LinkedInExtractor:
         # DOM dependency: we need btn.click() on the element reference — not
         # achievable via innerText or URL navigation. Selectors use only type,
         # aria-label, and data attributes (no layout class names).
-        await asyncio.sleep(1.0)  # allow React to process keyboard input
         sent_via_js = await self._page.evaluate(
             """() => {
                 const btn = Array.from(document.querySelectorAll(
@@ -5110,7 +5174,9 @@ class LinkedInExtractor:
         if not sent_via_js:
             await self._page.keyboard.press("Enter")
 
-        if not await self._message_text_visible(message):
+        if not await self._message_text_visible(
+            message, previous_occurrences=previous_occurrences
+        ):
             await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -4998,6 +4998,13 @@ class LinkedInExtractor:
         """
         linkedin_username = normalize_person_identifier(linkedin_username)
         profile_url = person_profile_url(linkedin_username, "/")
+        if not message.strip():
+            return self._message_action_result(
+                profile_url,
+                "message_unavailable",
+                "Message must contain non-whitespace characters.",
+            )
+
         await self._navigate_to_page(profile_url)
         await detect_rate_limit(self._page)
 

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -466,7 +466,7 @@ _MESSAGING_CLOSE_SELECTOR = (
 # it. Visibility is pure geometry and the match is on normalized text, so no
 # LinkedIn class name or localized label enters the decision.
 #
-# Known limit, and it scales with how short the message is: the count is taken
+# Known limit (issue #888), and it scales with how short the message is: the count is taken
 # over the whole body, so any unrelated text arriving between the two reads can
 # raise it if the message occurs inside it. A messaging page updates presence
 # and timestamps on its own, so a one-character message can be confirmed by
@@ -512,6 +512,20 @@ _MESSAGE_OCCURRENCES_JS = r"""
     return total > 0 ? total : 0;
 }
 """
+
+# A submission is in flight from the moment the send is dispatched until the
+# confirmation answers, and a cancellation in that window cannot be reported:
+# FastMCP runs every tool inside `anyio.fail_after()`, so the deadline raises
+# `CancelledError` past `except Exception` and discards any result returned
+# from the cancelled scope. The caller gets a timeout that carries no
+# `retry_safe`, and this line is then the only record that a message may
+# already have left. Answering the caller instead needs the tool to know its
+# own deadline, which is issue #889.
+_SEND_CANCELLED_WARNING = (
+    "Message submission was cancelled while in flight. Delivery is unknown; "
+    "check the conversation before retrying, as a retry may deliver the "
+    "message twice."
+)
 
 # The post-send predicate is the same counting routine, so the baseline and
 # the confirmation can never disagree about what counts as an occurrence.
@@ -5250,10 +5264,25 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
                 retry_safe=False,
             )
+        except BaseException:
+            # Ordered after `except Exception`, so this is cancellation and
+            # not an ordinary failure. Re-raised rather than reported,
+            # because the cancelled scope discards a return value.
+            logger.warning(_SEND_CANCELLED_WARNING)
+            raise
 
-        if not await self._message_text_visible(
-            message, previous_occurrences=previous_occurrences
-        ):
+        try:
+            confirmed = await self._message_text_visible(
+                message, previous_occurrences=previous_occurrences
+            )
+        except BaseException:
+            # `_message_text_visible` answers False for every failure it can
+            # observe, so only cancellation arrives here, and it arrives
+            # after a message may already have been delivered.
+            logger.warning(_SEND_CANCELLED_WARNING)
+            raise
+
+        if not confirmed:
             await self._dismiss_message_ui()
             # Submission already happened, so this is not evidence that
             # nothing was sent: a thread that renders the delivered bubble

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -432,12 +432,6 @@ _DIALOG_PREMIUM_LINK_SELECTOR = (
 _DIALOG_TEXTAREA_SELECTOR = '[role="dialog"] textarea, dialog textarea'
 
 _MESSAGING_COMPOSE_SELECTOR = '[role="textbox"][contenteditable="true"]'
-_MESSAGING_CLOSE_SELECTOR = (
-    'button[aria-label*="Close your draft conversation"], '
-    'button[aria-label="Dismiss"], '
-    'button[aria-label*="Dismiss"], '
-    'button[aria-label*="Close"]'
-)
 
 # A submission is in flight from the moment the send is dispatched until the
 # whole path has produced a result, cleanup included, and an interruption in
@@ -618,9 +612,6 @@ _MESSAGE_COMPOSER_OWNER_JS = (
     }"""
 )
 
-# Baseline und Bestätigung bleiben an dieselbe konkrete Owner-Instanz gebunden.
-# Ein gleich identifizierter Ersatzknoten darf eine vorhandene Bubble daher
-# nicht als Zustellung des ursprünglichen Sends bestätigen.
 _MESSAGE_OCCURRENCES_JS = (
     "(arg) => {"
     + _MESSAGE_COMPOSER_INSPECT_JS
@@ -3431,16 +3422,6 @@ class LinkedInExtractor:
             logger.debug("Message delivery could not be confirmed", exc_info=True)
             return False
 
-    async def _dismiss_message_ui(self) -> None:
-        """Best-effort dismissal for the profile messaging UI."""
-        if not await self._locator_is_visible(_MESSAGING_CLOSE_SELECTOR, timeout=750):
-            return
-        try:
-            await self._click_first(_MESSAGING_CLOSE_SELECTOR, timeout=1500)
-            await asyncio.sleep(0.5)
-        except Exception:
-            logger.debug("Could not dismiss LinkedIn messaging UI", exc_info=True)
-
     @staticmethod
     def _extract_thread_id(url: str) -> str | None:
         """Parse a LinkedIn thread id from a messaging thread URL."""
@@ -5316,7 +5297,6 @@ class LinkedInExtractor:
         except PlaywrightTimeoutError:
             logger.debug("Profile page did not load for %s", linkedin_username)
 
-        await handle_modal_close(self._page)
         target = await self._read_profile_message_target()
         if target is None:
             return self._message_action_result(
@@ -5341,9 +5321,7 @@ class LinkedInExtractor:
         except PlaywrightTimeoutError:
             logger.debug("Compose page did not fully load for %s", linkedin_username)
 
-        await handle_modal_close(self._page)
         if not _message_page_url_is_safe(self._page.url, target.profile_urn):
-            await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
@@ -5355,7 +5333,6 @@ class LinkedInExtractor:
             "Message surface for %s was %s", linkedin_username, message_surface
         )
         if message_surface != "composer":
-            await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "composer_unavailable",
@@ -5369,7 +5346,6 @@ class LinkedInExtractor:
                 linkedin_username,
                 state.get("status"),
             )
-            await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
@@ -5386,7 +5362,6 @@ class LinkedInExtractor:
             )
 
         if not _message_page_url_is_safe(self._page.url, target.profile_urn):
-            await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
@@ -5410,7 +5385,6 @@ class LinkedInExtractor:
         if state.get(
             "status"
         ) != "valid" or not await self._focus_verified_message_editor(target):
-            await self._dismiss_message_ui()
             return self._message_action_result(
                 self._page.url,
                 "compose_interact_failed",
@@ -5419,26 +5393,9 @@ class LinkedInExtractor:
             )
         await asyncio.sleep(0.1)
 
-        # Typing is inside the window, and not as a precaution.
-        # `keyboard.type()` presses one key per character, and patchright maps
-        # "\n" and "\r" onto Enter through its alias table, which this
-        # composer submits on: the send below relies on that very behaviour.
-        # A message carrying a newline therefore delivers its first paragraph
-        # *during* typing, and typing is slow enough for that to matter — at
-        # 15ms per character a 20k-character message runs past the 180s tool
-        # deadline long before the send call is reached. Splitting the text so
-        # a newline cannot submit is issue #441 and a change of its own; until
-        # then the flag below is what keeps the interruption reportable.
-        may_have_submitted = "\n" in message or "\r" in message
-
-        # Everything from here on can leave a message delivered, so any exit
-        # that carries no result leaves the caller unable to tell whether one
-        # went out. The cleanup awaits between the branches below are inside
-        # this window for that reason: an interruption during
-        # `_dismiss_message_ui` is as unreportable as one during the send.
+        may_have_submitted = False
         try:
             if not _message_page_url_is_safe(self._page.url, target.profile_urn):
-                await self._dismiss_message_ui()
                 return self._message_action_result(
                     self._page.url,
                     "recipient_resolution_failed",
@@ -5446,8 +5403,15 @@ class LinkedInExtractor:
                     recipient_selected=recipient_selected,
                 )
             state = await self._read_message_composer_state(target)
+            if state.get("status") == "valid" and state.get("empty") is not True:
+                return self._message_action_result(
+                    self._page.url,
+                    "composer_occupied",
+                    "The composer already holds a draft that would be sent along "
+                    "with the message. The draft was left untouched.",
+                    recipient_selected=recipient_selected,
+                )
             if state.get("status") != "valid" or state.get("active") is not True:
-                await self._dismiss_message_ui()
                 return self._message_action_result(
                     self._page.url,
                     "compose_interact_failed",
@@ -5456,11 +5420,13 @@ class LinkedInExtractor:
                 )
             allow_enter = state.get("submitCount") == 0
 
+            # `keyboard.type()` maps newlines onto Enter, which can submit the
+            # first paragraph before the explicit submit path runs.
+            may_have_submitted = "\n" in message or "\r" in message
             await self._page.keyboard.type(message, delay=15)
             await asyncio.sleep(0.3)
             await asyncio.sleep(1.0)  # allow React to process keyboard input
             if not _message_page_url_is_safe(self._page.url, target.profile_urn):
-                await self._dismiss_message_ui()
                 if may_have_submitted:
                     return self._message_action_result(
                         self._page.url,
@@ -5480,7 +5446,6 @@ class LinkedInExtractor:
 
             owner = await self._resolve_message_owner(target)
             if owner is None:
-                await self._dismiss_message_ui()
                 if may_have_submitted:
                     return self._message_action_result(
                         self._page.url,
@@ -5510,7 +5475,6 @@ class LinkedInExtractor:
                     owner=owner,
                 )
                 if previous_occurrences is None:
-                    await self._dismiss_message_ui()
                     if may_have_submitted:
                         return self._message_action_result(
                             self._page.url,
@@ -5529,51 +5493,16 @@ class LinkedInExtractor:
                         recipient_selected=recipient_selected,
                     )
 
+                may_have_submitted_before_submit = may_have_submitted
                 try:
-                    # The click is dispatched inside the call that may then fail,
-                    # so the flag is set before it rather than after.
+                    # A click can dispatch before the evaluate call reports an
+                    # error, so an exception from this round trip is ambiguous.
                     may_have_submitted = True
                     submission = await self._submit_verified_message(
                         target, allow_enter=allow_enter
                     )
-                    if submission == "enter":
-                        state = await self._read_message_composer_state(target)
-                        if (
-                            not allow_enter
-                            or not _message_page_url_is_safe(
-                                self._page.url, target.profile_urn
-                            )
-                            or state.get("status") != "valid"
-                            or state.get("active") is not True
-                            or state.get("submitCount") != 0
-                        ):
-                            submission = "invalid"
-                        else:
-                            # The read and the keypress are two round trips, so the
-                            # editor could in principle lose focus between them.
-                            # Nothing a caller or recipient controls reaches that
-                            # window, and closing it would need the keystroke and
-                            # check to be one operation, which no input API offers.
-                            await self._page.keyboard.press("Enter")
-                    if submission not in {"clicked", "enter"}:
-                        await self._dismiss_message_ui()
-                        return self._message_action_result(
-                            self._page.url,
-                            "send_unavailable",
-                            "The local submit path was missing, disabled, or ambiguous.",
-                            recipient_selected=recipient_selected,
-                            retry_safe=False,
-                        )
                 except Exception:
-                    # Both submissions dispatch their input event inside the very
-                    # call that then fails, so a context that dies here says
-                    # nothing about whether the message left: a send that navigates
-                    # the page away looks exactly like one that never started.
-                    # Letting the error out would reach the caller as a plain tool
-                    # failure and invite the retry that delivers a second message
-                    # to a real person.
                     logger.debug("Message submission did not complete", exc_info=True)
-                    await self._dismiss_message_ui()
                     return self._message_action_result(
                         self._page.url,
                         "send_unconfirmed",
@@ -5584,6 +5513,54 @@ class LinkedInExtractor:
                         retry_safe=False,
                     )
 
+                if submission == "enter":
+                    may_have_submitted = may_have_submitted_before_submit
+                    state = await self._read_message_composer_state(target)
+                    if (
+                        not allow_enter
+                        or not _message_page_url_is_safe(
+                            self._page.url, target.profile_urn
+                        )
+                        or state.get("status") != "valid"
+                        or state.get("active") is not True
+                        or state.get("submitCount") != 0
+                    ):
+                        submission = "invalid"
+                    else:
+                        # The read and the keypress are two round trips, so the
+                        # editor could in principle lose focus between them.
+                        # Nothing a caller or recipient controls reaches that
+                        # window, and closing it would need the keystroke and
+                        # check to be one operation, which no input API offers.
+                        may_have_submitted = True
+                        try:
+                            await self._page.keyboard.press("Enter")
+                        except Exception:
+                            logger.debug(
+                                "Message submission did not complete", exc_info=True
+                            )
+                            return self._message_action_result(
+                                self._page.url,
+                                "send_unconfirmed",
+                                "The message submission was interrupted and LinkedIn "
+                                "did not confirm delivery. Check the conversation "
+                                "before retrying; retrying may deliver the message "
+                                "twice.",
+                                recipient_selected=recipient_selected,
+                                retry_safe=False,
+                            )
+                elif submission != "clicked":
+                    may_have_submitted = may_have_submitted_before_submit
+
+                if submission not in {"clicked", "enter"}:
+                    return self._message_action_result(
+                        self._page.url,
+                        "send_unavailable",
+                        "The local submit path was missing, disabled, or ambiguous.",
+                        recipient_selected=recipient_selected,
+                        retry_safe=not may_have_submitted,
+                    )
+
                 confirmed = await self._message_text_visible(
                     message,
                     target=target,
@@ -5592,7 +5569,6 @@ class LinkedInExtractor:
                 )
 
                 if not confirmed:
-                    await self._dismiss_message_ui()
                     # Submission already happened, so this is not evidence that
                     # nothing was sent: a thread that renders the delivered bubble
                     # slower than the page timeout arrives here having delivered.
@@ -5620,20 +5596,8 @@ class LinkedInExtractor:
             finally:
                 await self._dispose_message_owner(owner)
         except Exception:
-            # Reached where a message may already be gone and no result says
-            # so: an error while typing, which a newline has by then turned
-            # into a submission; one from the baseline read; or one from the
-            # cleanup call in a branch above, whose own guard does not cover
-            # the visibility probe it opens with. The inner handler covers the
-            # send call alone, and `_message_text_visible` answers False for
-            # every failure it can observe, so none of these three has an
-            # answer of its own. Letting the error out would reach the caller
-            # as a plain tool failure and invite the retry that delivers a
-            # second message to a real person.
-            #
-            # Cleanup is not attempted here. Its own failure is one of the
-            # ways into this handler, and a second attempt would replace the
-            # answer with the error it was raised for.
+            # A newline can submit while typing. Later reads can therefore fail
+            # after a message may already have left, before a result says so.
             if not may_have_submitted:
                 # Nothing can have been submitted yet, so the error itself is
                 # the useful answer and the caller can retry on it.

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5312,14 +5312,43 @@ class LinkedInExtractor:
                 sent=True,
                 retry_safe=False,
             )
+        except Exception:
+            # Reached where a message may already be gone and no result says
+            # so: an error while typing, which a newline has by then turned
+            # into a submission; one from the baseline read; or one from the
+            # cleanup call in a branch above, whose own guard does not cover
+            # the visibility probe it opens with. The inner handler covers the
+            # send call alone, and `_message_text_visible` answers False for
+            # every failure it can observe, so none of these three has an
+            # answer of its own. Letting the error out would reach the caller
+            # as a plain tool failure and invite the retry that delivers a
+            # second message to a real person.
+            #
+            # Cleanup is not attempted here. Its own failure is one of the
+            # ways into this handler, and a second attempt would replace the
+            # answer with the error it was raised for.
+            if not may_have_submitted:
+                # Nothing can have been submitted yet, so the error itself is
+                # the useful answer and the caller can retry on it.
+                raise
+            logger.debug(
+                "Message send failed after a possible submission", exc_info=True
+            )
+            return self._message_action_result(
+                self._page.url,
+                "send_unconfirmed",
+                "The message may already have been submitted when the send "
+                "failed, and LinkedIn did not confirm delivery. Check the "
+                "conversation before retrying; retrying may deliver the "
+                "message twice.",
+                recipient_selected=recipient_selected,
+                retry_safe=False,
+            )
         except BaseException:
-            # Reached only where the window produced no result at all. An
-            # ordinary submission failure returns from the inner handler, and
-            # `_message_text_visible` answers False for every failure it can
-            # observe, so what arrives here is cancellation or the rare error
-            # escaping cleanup. Both leave the same question behind, and both
-            # are re-raised rather than reported, because a cancelled scope
-            # discards a return value.
+            # Cancellation only. FastMCP runs the tool inside
+            # `anyio.fail_after()` and a cancelled scope discards whatever it
+            # returns, so the answer the branch above gives cannot be given
+            # here and the log line is all that is left.
             #
             # Silent for an interruption while typing a message without a
             # newline: nothing can have submitted yet, and a warning that

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -521,7 +521,7 @@ _MESSAGE_OCCURRENCES_JS = r"""
 # scope. The caller gets a timeout that carries no `retry_safe`, and this line
 # is then the only record that a message may already have left. Answering the
 # caller instead needs the tool to know its own deadline, which is issue #889.
-_SEND_INTERRUPTED_WARNING = (
+SEND_INTERRUPTED_WARNING = (
     "Message submission was interrupted while in flight. Delivery is unknown; "
     "check the conversation before retrying, as a retry may deliver the "
     "message twice."
@@ -5209,23 +5209,35 @@ class LinkedInExtractor:
                 recipient_selected=recipient_selected,
             )
         await asyncio.sleep(0.1)
-        await self._page.keyboard.type(message, delay=15)
-        await asyncio.sleep(0.3)
-        await asyncio.sleep(1.0)  # allow React to process keyboard input
 
-        # Baseline immediately before the send attempt: how often the message
-        # is already visible outside the composer. The click below only tries
-        # to send; delivery is proven by this count growing, never by the text
-        # the composer still holds.
-        previous_occurrences = await self._message_text_occurrences(message)
+        # Typing is inside the window, and not as a precaution.
+        # `keyboard.type()` presses one key per character, and patchright maps
+        # "\n" and "\r" onto Enter through its alias table, which this
+        # composer submits on: the send below relies on that very behaviour.
+        # A message carrying a newline therefore delivers its first paragraph
+        # *during* typing, and typing is slow enough for that to matter — at
+        # 15ms per character a 20k-character message runs past the 180s tool
+        # deadline long before the send call is reached. Splitting the text so
+        # a newline cannot submit is issue #441 and a change of its own; until
+        # then the flag below is what keeps the interruption reportable.
+        may_have_submitted = "\n" in message or "\r" in message
 
-        # Everything from here on runs with a submission dispatched or about to
-        # be, so any exit that carries no result leaves the caller unable to
-        # tell whether a message went out. The cleanup awaits between the
-        # branches below are inside this window for that reason: an
-        # interruption during `_dismiss_message_ui` is as unreportable as one
-        # during the send itself.
+        # Everything from here on can leave a message delivered, so any exit
+        # that carries no result leaves the caller unable to tell whether one
+        # went out. The cleanup awaits between the branches below are inside
+        # this window for that reason: an interruption during
+        # `_dismiss_message_ui` is as unreportable as one during the send.
         try:
+            await self._page.keyboard.type(message, delay=15)
+            await asyncio.sleep(0.3)
+            await asyncio.sleep(1.0)  # allow React to process keyboard input
+
+            # Baseline immediately before the send attempt: how often the
+            # message is already visible outside the composer. The click below
+            # only tries to send; delivery is proven by this count growing,
+            # never by the text the composer still holds.
+            previous_occurrences = await self._message_text_occurrences(message)
+
             # patchright actionability also blocks send_button.click(). Use JS
             # click on any visible, enabled send button; fall back to Enter key
             # which LinkedIn's composer also accepts for submission.
@@ -5234,6 +5246,9 @@ class LinkedInExtractor:
             # achievable via innerText or URL navigation. Selectors use only
             # type, aria-label, and data attributes (no layout class names).
             try:
+                # The click is dispatched inside the call that may then fail,
+                # so the flag is set before it rather than after.
+                may_have_submitted = True
                 sent_via_js = await self._page.evaluate(
                     """() => {
                     const btn = Array.from(document.querySelectorAll(
@@ -5305,7 +5320,13 @@ class LinkedInExtractor:
             # escaping cleanup. Both leave the same question behind, and both
             # are re-raised rather than reported, because a cancelled scope
             # discards a return value.
-            logger.warning(_SEND_INTERRUPTED_WARNING)
+            #
+            # Silent for an interruption while typing a message without a
+            # newline: nothing can have submitted yet, and a warning that
+            # cries duplicate delivery where none is possible is the kind
+            # that gets ignored when it is right.
+            if may_have_submitted:
+                logger.warning(SEND_INTERRUPTED_WARNING)
             raise
 
     async def _extract_root_content(

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -559,14 +559,18 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
         ).filter(visible);
         if (editors.length !== 1) return {status: 'ambiguous_editor'};
         const editor = editors[0];
-        const localScopes = [];
-        let ancestor = editor.parentElement;
-        while (ancestor) {
-            if (ancestor.matches('form, dialog, [role="dialog"]')) {
-                localScopes.push(ancestor);
+        const semanticAncestors = element => {
+            const scopes = [];
+            let ancestor = element.parentElement;
+            while (ancestor) {
+                if (ancestor.matches('form, dialog, [role="dialog"]')) {
+                    scopes.push(ancestor);
+                }
+                ancestor = ancestor.parentElement;
             }
-            ancestor = ancestor.parentElement;
-        }
+            return scopes;
+        };
+        const localScopes = semanticAncestors(editor);
         if (localScopes.length === 0) return {status: 'missing_owner'};
 
         const owner = localScopes.find(scope =>
@@ -576,15 +580,18 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
             element !== editor &&
             !editor.contains(element) &&
             !element.closest('[data-view-name="message-list-item"]');
-        const paths = Array.from(owner.querySelectorAll('a[href*="/in/"]'))
+        const identityElements = selector => Array.from(new Set(
+            localScopes.flatMap(scope => [
+                ...(scope.matches(selector) ? [scope] : []),
+                ...scope.querySelectorAll(selector),
+            ])
+        ));
+        const paths = identityElements('a[href*="/in/"]')
             .filter(element => visible(element) && outsideDraftAndHistory(element))
             .map(anchor => profilePath(anchor.getAttribute('href') || anchor.href || ''));
-        const urns = [
-            ...(owner.matches('[data-profile-urn], [data-recipient-urn]')
-                ? [owner]
-                : []),
-            ...owner.querySelectorAll('[data-profile-urn], [data-recipient-urn]'),
-        ].filter(
+        const urns = identityElements(
+            '[data-profile-urn], [data-recipient-urn]'
+        ).filter(
             element => visible(element) && outsideDraftAndHistory(element)
         ).flatMap(element =>
             ['data-profile-urn', 'data-recipient-urn']
@@ -612,6 +619,7 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
         return {
             status: 'valid',
             editor,
+            ancestorChain: localScopes,
             localScope,
             owner,
             buttons,
@@ -641,6 +649,7 @@ _MESSAGE_COMPOSER_OWNER_JS = (
         if (
             !button.isConnected ||
             !state.localScope.contains(button) ||
+            (button.form !== null && !state.ancestorChain.includes(button.form)) ||
             button.disabled ||
             (button.getAttribute('aria-disabled') || '').toLowerCase() === 'true'
         ) {
@@ -648,6 +657,7 @@ _MESSAGE_COMPOSER_OWNER_JS = (
         }
         state.owner.__linkedinMcpComposer = {
             editor: state.editor,
+            ancestorChain: state.ancestorChain,
             button,
             localScope: state.localScope,
             profilePath: target.profilePath,
@@ -669,6 +679,10 @@ _MESSAGE_CONFIRMATION_PREPARE_JS = (
             !pinned ||
             composer.owner !== arg.owner ||
             composer.editor !== pinned.editor ||
+            composer.ancestorChain.length !== pinned.ancestorChain.length ||
+            composer.ancestorChain.some(
+                (scope, index) => scope !== pinned.ancestorChain[index]
+            ) ||
             composer.localScope !== pinned.localScope ||
             composer.buttons.length !== 1 ||
             composer.buttons[0] !== pinned.button ||
@@ -694,9 +708,7 @@ _MESSAGE_CONFIRMATION_PREPARE_JS = (
             owner: arg.owner,
             editor: pinned.editor,
             expected: arg.expected,
-            baseline: new Set(
-                arg.owner.querySelectorAll('[data-view-name="message-list-item"]')
-            ),
+            baseline: new Set(),
             candidates: new Map(),
             invalid: false,
         };
@@ -801,6 +813,9 @@ _MESSAGE_CONFIRMATION_PREPARE_JS = (
             }
             refresh();
         });
+        state.baseline = new Set(
+            document.querySelectorAll('[data-view-name="message-list-item"]')
+        );
         state.observer.observe(state.owner, {
             attributes: true,
             attributeFilter: ['data-event-urn'],
@@ -996,6 +1011,45 @@ _MESSAGE_COMPOSER_PINNED_JS = r"""
             return false;
         }
     };
+    const semanticAncestors = element => {
+        const scopes = [];
+        let ancestor = element?.parentElement;
+        while (ancestor) {
+            if (ancestor.matches('form, dialog, [role="dialog"]')) {
+                scopes.push(ancestor);
+            }
+            ancestor = ancestor.parentElement;
+        }
+        return scopes;
+    };
+    const identitiesMatch = (scopes, editor, target) => {
+        const outsideDraftAndHistory = element =>
+            element !== editor &&
+            !editor.contains(element) &&
+            !element.closest('[data-view-name="message-list-item"]');
+        const identityElements = selector => Array.from(new Set(
+            scopes.flatMap(scope => [
+                ...(scope.matches(selector) ? [scope] : []),
+                ...scope.querySelectorAll(selector),
+            ])
+        ));
+        const paths = identityElements('a[href*="/in/"]')
+            .filter(element => visible(element) && outsideDraftAndHistory(element))
+            .map(anchor => profilePath(anchor.getAttribute('href') || anchor.href || ''));
+        const urns = identityElements(
+            '[data-profile-urn], [data-recipient-urn]'
+        ).filter(
+            element => visible(element) && outsideDraftAndHistory(element)
+        ).flatMap(element =>
+            ['data-profile-urn', 'data-recipient-urn']
+                .filter(name => element.hasAttribute(name))
+                .map(name => normalizeUrn(element.getAttribute(name)))
+        );
+        return !(
+            paths.some(path => path !== target.profilePath) ||
+            urns.some(urn => urn !== target.profileUrn)
+        );
+    };
     const validatePinned = target => {
         const pinned = owner?.__linkedinMcpComposer;
         if (
@@ -1006,43 +1060,26 @@ _MESSAGE_COMPOSER_PINNED_JS = r"""
         ) {
             return null;
         }
-        const {editor, button, localScope} = pinned;
+        const {editor, ancestorChain, button, localScope} = pinned;
+        const currentChain = semanticAncestors(editor);
         if (
             !owner.isConnected ||
             !editor?.isConnected ||
             !button?.isConnected ||
             !localScope?.isConnected ||
+            !Array.isArray(ancestorChain) ||
+            currentChain.length !== ancestorChain.length ||
+            currentChain.some((scope, index) => scope !== ancestorChain[index]) ||
+            !currentChain.includes(owner) ||
+            !currentChain.includes(localScope) ||
             !owner.contains(editor) ||
             !owner.contains(localScope) ||
             !localScope.contains(button) ||
+            (button.form !== null && !currentChain.includes(button.form)) ||
             !visible(editor) ||
             !visible(button) ||
-            !editor.matches('[role="textbox"][contenteditable="true"]')
-        ) {
-            return null;
-        }
-        const outsideDraftAndHistory = element =>
-            element !== editor &&
-            !editor.contains(element) &&
-            !element.closest('[data-view-name="message-list-item"]');
-        const paths = Array.from(owner.querySelectorAll('a[href*="/in/"]'))
-            .filter(element => visible(element) && outsideDraftAndHistory(element))
-            .map(anchor => profilePath(anchor.getAttribute('href') || anchor.href || ''));
-        const urns = [
-            ...(owner.matches('[data-profile-urn], [data-recipient-urn]')
-                ? [owner]
-                : []),
-            ...owner.querySelectorAll('[data-profile-urn], [data-recipient-urn]'),
-        ].filter(
-            element => visible(element) && outsideDraftAndHistory(element)
-        ).flatMap(element =>
-            ['data-profile-urn', 'data-recipient-urn']
-                .filter(name => element.hasAttribute(name))
-                .map(name => normalizeUrn(element.getAttribute(name)))
-        );
-        if (
-            paths.some(path => path !== target.profilePath) ||
-            urns.some(urn => urn !== target.profileUrn)
+            !editor.matches('[role="textbox"][contenteditable="true"]') ||
+            !identitiesMatch(currentChain, editor, target)
         ) {
             return null;
         }

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -5218,19 +5218,38 @@ class LinkedInExtractor:
         # DOM dependency: we need btn.click() on the element reference — not
         # achievable via innerText or URL navigation. Selectors use only type,
         # aria-label, and data attributes (no layout class names).
-        sent_via_js = await self._page.evaluate(
-            """() => {
-                const btn = Array.from(document.querySelectorAll(
-                    'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
-                    + 'button[data-control-name="send"]'
-                )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
-                if (!btn) return false;
-                btn.click();
-                return true;
-            }"""
-        )
-        if not sent_via_js:
-            await self._page.keyboard.press("Enter")
+        try:
+            sent_via_js = await self._page.evaluate(
+                """() => {
+                    const btn = Array.from(document.querySelectorAll(
+                        'button[type="submit"], button[aria-label*="Send"], button[aria-label*="send"],'
+                        + 'button[data-control-name="send"]'
+                    )).find(b => !b.disabled && (b.offsetWidth || b.offsetHeight || b.getClientRects().length));
+                    if (!btn) return false;
+                    btn.click();
+                    return true;
+                }"""
+            )
+            if not sent_via_js:
+                await self._page.keyboard.press("Enter")
+        except Exception:
+            # Both submissions dispatch their input event inside the very call
+            # that then fails, so a context that dies here says nothing about
+            # whether the message left: a send that navigates the page away
+            # looks exactly like one that never started. Letting the error out
+            # would reach the caller as a plain tool failure and invite the
+            # retry that delivers a second message to a real person.
+            logger.debug("Message submission did not complete", exc_info=True)
+            await self._dismiss_message_ui()
+            return self._message_action_result(
+                self._page.url,
+                "send_unconfirmed",
+                "The message submission was interrupted and LinkedIn did not "
+                "confirm delivery. Check the conversation before retrying; "
+                "retrying may deliver the message twice.",
+                recipient_selected=recipient_selected,
+                retry_safe=False,
+            )
 
         if not await self._message_text_visible(
             message, previous_occurrences=previous_occurrences

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -460,32 +460,23 @@ _PROFILE_MESSAGE_TARGET_JS = r"""() => {
     const main = document.querySelector('main');
     if (!main) return null;
 
-    const candidates = Array.from(main.querySelectorAll('section'))
-        .filter(visible)
-        .map(section => {
-            const headings = Array.from(section.querySelectorAll('h1')).filter(
-                heading => visible(heading) && heading.closest('section') === section
-            );
-            const composeAnchors = Array.from(
-                section.querySelectorAll('a[href*="/messaging/compose/"]')
-            ).filter(
-                anchor => active(anchor) && anchor.closest('section') === section
-            );
-            return {section, headings, composeAnchors};
-        })
-        .filter(
-            candidate =>
-                candidate.headings.length === 1 &&
-                candidate.composeAnchors.length === 1
-        );
-    if (candidates.length !== 1) return null;
+    const section = Array.from(main.children).find(
+        element => element.matches('section') && visible(element)
+    );
+    if (!section) return null;
+    const headings = Array.from(section.querySelectorAll('h1')).filter(
+        heading => visible(heading) && heading.closest('section') === section
+    );
+    const composeAnchors = Array.from(
+        section.querySelectorAll('a[href*="/messaging/compose/"]')
+    ).filter(anchor => active(anchor) && anchor.closest('section') === section);
+    if (headings.length !== 1 || composeAnchors.length !== 1) return null;
 
-    const candidate = candidates[0];
-    const anchor = candidate.composeAnchors[0];
+    const anchor = composeAnchors[0];
     return {
         pageUrl: window.location.href,
         displayName: normalize(
-            candidate.headings[0].innerText || candidate.headings[0].textContent || ''
+            headings[0].innerText || headings[0].textContent || ''
         ),
         composeHrefs: [anchor.getAttribute('href') || anchor.href || ''],
     };
@@ -525,6 +516,33 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
             return null;
         }
     };
+    const messageUrlSafe = target => {
+        try {
+            const url = new URL(window.location.href);
+            const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
+            if (
+                url.protocol !== 'https:' ||
+                !/(^|\.)linkedin\.com$/.test(hostname) ||
+                url.username ||
+                url.password ||
+                (url.port && url.port !== '443') ||
+                url.hash ||
+                !(
+                    url.pathname === '/messaging/compose/' ||
+                    /^\/messaging\/thread\/[A-Za-z0-9_=-]+\/$/.test(url.pathname)
+                )
+            ) {
+                return false;
+            }
+            const values = [
+                ...url.searchParams.getAll('recipient'),
+                ...url.searchParams.getAll('profileUrn'),
+            ];
+            return values.every(value => normalizeUrn(value) === target.profileUrn);
+        } catch {
+            return false;
+        }
+    };
     const inspect = target => {
         const editors = Array.from(
             document.querySelectorAll('[role="textbox"][contenteditable="true"]')
@@ -541,27 +559,34 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
         }
         if (localScopes.length === 0) return {status: 'missing_owner'};
 
+        const owner = localScopes.find(scope =>
+            scope.matches('dialog, [role="dialog"]')
+        ) || localScopes[0];
         const outsideDraftAndHistory = element =>
             element !== editor &&
             !editor.contains(element) &&
             !element.closest('[data-view-name="message-list-item"]');
-        const readIdentity = scope => ({
-            paths: Array.from(scope.querySelectorAll('a[href*="/in/"]'))
-                .filter(element => visible(element) && outsideDraftAndHistory(element))
-                .map(anchor => profilePath(anchor.getAttribute('href') || anchor.href || '')),
-            urns: [
-                ...(scope.matches('[data-profile-urn], [data-recipient-urn]')
-                    ? [scope]
-                    : []),
-                ...scope.querySelectorAll('[data-profile-urn], [data-recipient-urn]'),
-            ].filter(
-                element => visible(element) && outsideDraftAndHistory(element)
-            ).flatMap(element =>
-                ['data-profile-urn', 'data-recipient-urn']
-                    .filter(name => element.hasAttribute(name))
-                    .map(name => normalizeUrn(element.getAttribute(name)))
-            ),
-        });
+        const paths = Array.from(owner.querySelectorAll('a[href*="/in/"]'))
+            .filter(element => visible(element) && outsideDraftAndHistory(element))
+            .map(anchor => profilePath(anchor.getAttribute('href') || anchor.href || ''));
+        const urns = [
+            ...(owner.matches('[data-profile-urn], [data-recipient-urn]')
+                ? [owner]
+                : []),
+            ...owner.querySelectorAll('[data-profile-urn], [data-recipient-urn]'),
+        ].filter(
+            element => visible(element) && outsideDraftAndHistory(element)
+        ).flatMap(element =>
+            ['data-profile-urn', 'data-recipient-urn']
+                .filter(name => element.hasAttribute(name))
+                .map(name => normalizeUrn(element.getAttribute(name)))
+        );
+        if (
+            paths.some(path => path !== target.profilePath) ||
+            urns.some(urn => urn !== target.profileUrn)
+        ) {
+            return {status: 'recipient_mismatch'};
+        }
 
         const submitButtons = scope => Array.from(
             scope.querySelectorAll(
@@ -571,37 +596,9 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
             visible(button) &&
             !button.closest('[data-view-name="message-list-item"]')
         );
-        let localScope = null;
-        let identity = null;
-        let buttons = [];
-        let enterScope = null;
-        let enterIdentity = null;
-        for (const scope of localScopes) {
-            const candidate = readIdentity(scope);
-            if (candidate.paths.length + candidate.urns.length === 0) continue;
-            if (
-                candidate.paths.some(path => path !== target.profilePath) ||
-                candidate.urns.some(urn => urn !== target.profileUrn)
-            ) {
-                return {status: 'recipient_mismatch'};
-            }
-            if (!enterScope) {
-                enterScope = scope;
-                enterIdentity = candidate;
-            }
-            const candidateButtons = submitButtons(scope);
-            if (!localScope && candidateButtons.length > 0) {
-                localScope = scope;
-                identity = candidate;
-                buttons = candidateButtons;
-            }
-        }
-        localScope = localScope || enterScope;
-        identity = identity || enterIdentity;
-        if (!localScope || !identity) return {status: 'missing_recipient'};
-        const owner = localScopes.find(scope =>
-            scope.matches('dialog, [role="dialog"]')
-        ) || localScope;
+        const localScope = localScopes.find(scope => submitButtons(scope).length > 0)
+            || localScopes[0];
+        const buttons = submitButtons(localScope);
         return {
             status: 'valid',
             editor,
@@ -610,6 +607,7 @@ _MESSAGE_COMPOSER_INSPECT_JS = r"""
             buttons,
             active: document.activeElement === editor,
             empty: !(editor.innerText || '').replace(/\s+/g, ' ').trim(),
+            messageUrlSafe: messageUrlSafe(target),
         };
     };
 """
@@ -621,12 +619,30 @@ _MESSAGE_COMPOSER_OWNER_JS = (
         const state = inspect(target);
         if (
             state.status !== 'valid' ||
+            state.messageUrlSafe !== true ||
             !state.owner.isConnected ||
             !state.editor.isConnected ||
-            !state.owner.contains(state.editor)
+            !state.owner.contains(state.editor) ||
+            state.buttons.length !== 1
         ) {
             return null;
         }
+        const button = state.buttons[0];
+        if (
+            !button.isConnected ||
+            !state.localScope.contains(button) ||
+            button.disabled ||
+            (button.getAttribute('aria-disabled') || '').toLowerCase() === 'true'
+        ) {
+            return null;
+        }
+        state.owner.__linkedinMcpComposer = {
+            editor: state.editor,
+            button,
+            localScope: state.localScope,
+            profilePath: target.profilePath,
+            profileUrn: target.profileUrn,
+        };
         return state.owner;
     }"""
 )
@@ -636,13 +652,21 @@ _MESSAGE_CONFIRMATION_PREPARE_JS = (
     + _MESSAGE_COMPOSER_INSPECT_JS
     + r"""
         const composer = inspect(arg);
+        const pinned = arg.owner?.__linkedinMcpComposer;
         if (
             composer.status !== 'valid' ||
-            !arg.owner ||
+            composer.messageUrlSafe !== true ||
+            !pinned ||
             composer.owner !== arg.owner ||
+            composer.editor !== pinned.editor ||
+            composer.localScope !== pinned.localScope ||
+            composer.buttons.length !== 1 ||
+            composer.buttons[0] !== pinned.button ||
             !arg.owner.isConnected ||
-            !composer.editor.isConnected ||
-            !arg.owner.contains(composer.editor)
+            !pinned.editor.isConnected ||
+            !arg.owner.contains(pinned.editor) ||
+            document.activeElement !== pinned.editor ||
+            (pinned.editor.innerText || pinned.editor.textContent || '') !== arg.expected
         ) {
             return null;
         }
@@ -655,11 +679,14 @@ _MESSAGE_CONFIRMATION_PREPARE_JS = (
         marker.setAttribute('data-linkedin-mcp-confirmation', token);
         marker.setAttribute('data-linkedin-mcp-invalid', 'false');
         arg.owner.appendChild(marker);
-        composer.editor.setAttribute('data-linkedin-mcp-editor', token);
+        pinned.editor.setAttribute('data-linkedin-mcp-editor', token);
         const state = {
             owner: arg.owner,
-            editor: composer.editor,
+            editor: pinned.editor,
             expected: arg.expected,
+            baseline: new Set(
+                arg.owner.querySelectorAll('[data-view-name="message-list-item"]')
+            ),
             candidates: new Map(),
             invalid: false,
         };
@@ -687,6 +714,7 @@ _MESSAGE_CONFIRMATION_PREPARE_JS = (
                 ...node.querySelectorAll('[data-view-name="message-list-item"]'),
             ];
             for (const item of items) {
+                if (state.baseline.has(item)) continue;
                 if (!state.candidates.has(item)) {
                     item.setAttribute('data-linkedin-mcp-candidate', token);
                     state.candidates.set(item, {
@@ -797,7 +825,9 @@ _MESSAGE_CONFIRMATION_READY_JS = (
         const composer = inspect(arg);
         if (
             composer.status !== 'valid' ||
+            composer.messageUrlSafe !== true ||
             composer.owner !== arg.owner ||
+            composer.buttons.length !== 1 ||
             composer.editor.getAttribute('data-linkedin-mcp-editor') !== arg.token
         ) {
             return false;
@@ -832,6 +862,7 @@ _MESSAGE_CONFIRMATION_DISPOSE_JS = r"""arg => {
     const state = confirmations?.get(arg.token);
     if (state?.observer) state.observer.disconnect();
     confirmations?.delete(arg.token);
+    if (arg.owner) delete arg.owner.__linkedinMcpComposer;
     for (const element of arg.owner?.querySelectorAll(
         '[data-linkedin-mcp-candidate], [data-linkedin-mcp-editor], '
         + '[data-linkedin-mcp-confirmation]'
@@ -862,6 +893,10 @@ _MESSAGE_COMPOSER_STATE_JS = (
             active: state.active === true,
             empty: state.empty === true,
             submitCount: state.buttons ? state.buttons.length : 0,
+            submitUsable: state.buttons?.length === 1 &&
+                !state.buttons[0].disabled &&
+                (state.buttons[0].getAttribute('aria-disabled') || '').toLowerCase()
+                    !== 'true',
         };
     }"""
 )
@@ -885,31 +920,184 @@ _MESSAGE_COMPOSER_FOCUS_JS = (
     }"""
 )
 
-_MESSAGE_COMPOSER_SUBMIT_JS = (
-    "(target) => {"
-    + _MESSAGE_COMPOSER_INSPECT_JS
-    + """
-        const state = inspect(target);
+_MESSAGE_COMPOSER_PINNED_JS = r"""
+    const visible = element => !!(
+        element &&
+        (element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+    );
+    const normalizeUrn = value => {
+        const text = (value || '').trim();
+        const prefix = 'urn:li:fsd_profile:';
+        const identifier = text.startsWith(prefix) ? text.slice(prefix.length) : text;
+        return /^[A-Za-z0-9_-]+$/.test(identifier) ? identifier : null;
+    };
+    const profilePath = value => {
+        if (typeof value !== 'string' || /[\\\x00-\x1f\x7f]/.test(value)) {
+            return null;
+        }
+        try {
+            const url = new URL(value, window.location.href);
+            const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
+            if (
+                url.protocol !== 'https:' ||
+                !/(^|\.)linkedin\.com$/.test(hostname) ||
+                url.username ||
+                url.password ||
+                (url.port && url.port !== '443') ||
+                url.hash
+            ) {
+                return null;
+            }
+            const match = /^\/in\/([^/?#]+)(?:\/.*)?$/.exec(url.pathname);
+            return match ? `/in/${match[1]}/` : null;
+        } catch {
+            return null;
+        }
+    };
+    const messageUrlSafe = target => {
+        try {
+            const url = new URL(window.location.href);
+            const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
+            if (
+                url.protocol !== 'https:' ||
+                !/(^|\.)linkedin\.com$/.test(hostname) ||
+                url.username ||
+                url.password ||
+                (url.port && url.port !== '443') ||
+                url.hash ||
+                !(
+                    url.pathname === '/messaging/compose/' ||
+                    /^\/messaging\/thread\/[A-Za-z0-9_=-]+\/$/.test(url.pathname)
+                )
+            ) {
+                return false;
+            }
+            const values = [
+                ...url.searchParams.getAll('recipient'),
+                ...url.searchParams.getAll('profileUrn'),
+            ];
+            return values.every(value => normalizeUrn(value) === target.profileUrn);
+        } catch {
+            return false;
+        }
+    };
+    const validatePinned = target => {
+        const pinned = owner?.__linkedinMcpComposer;
         if (
-            state.status !== 'valid' ||
-            !state.editor.isConnected ||
-            document.activeElement !== state.editor
+            !pinned ||
+            pinned.profilePath !== target.profilePath ||
+            pinned.profileUrn !== target.profileUrn ||
+            !messageUrlSafe(target)
         ) {
-            return 'invalid';
+            return null;
         }
-        if (state.buttons.length === 0) {
-            return target.allowEnter === true ? 'enter' : 'invalid';
-        }
-        if (state.buttons.length !== 1) return 'invalid';
-        const button = state.buttons[0];
+        const {editor, button, localScope} = pinned;
         if (
-            !button.isConnected ||
+            !owner.isConnected ||
+            !editor?.isConnected ||
+            !button?.isConnected ||
+            !localScope?.isConnected ||
+            !owner.contains(editor) ||
+            !owner.contains(localScope) ||
+            !localScope.contains(button) ||
+            !visible(editor) ||
+            !visible(button) ||
+            !editor.matches('[role="textbox"][contenteditable="true"]')
+        ) {
+            return null;
+        }
+        const outsideDraftAndHistory = element =>
+            element !== editor &&
+            !editor.contains(element) &&
+            !element.closest('[data-view-name="message-list-item"]');
+        const paths = Array.from(owner.querySelectorAll('a[href*="/in/"]'))
+            .filter(element => visible(element) && outsideDraftAndHistory(element))
+            .map(anchor => profilePath(anchor.getAttribute('href') || anchor.href || ''));
+        const urns = [
+            ...(owner.matches('[data-profile-urn], [data-recipient-urn]')
+                ? [owner]
+                : []),
+            ...owner.querySelectorAll('[data-profile-urn], [data-recipient-urn]'),
+        ].filter(
+            element => visible(element) && outsideDraftAndHistory(element)
+        ).flatMap(element =>
+            ['data-profile-urn', 'data-recipient-urn']
+                .filter(name => element.hasAttribute(name))
+                .map(name => normalizeUrn(element.getAttribute(name)))
+        );
+        if (
+            paths.some(path => path !== target.profilePath) ||
+            urns.some(urn => urn !== target.profileUrn)
+        ) {
+            return null;
+        }
+        const buttons = Array.from(localScope.querySelectorAll(
+            'button[type="submit"], button[data-control-name="send"]'
+        )).filter(candidate =>
+            visible(candidate) &&
+            !candidate.closest('[data-view-name="message-list-item"]')
+        );
+        if (
+            buttons.length !== 1 ||
+            buttons[0] !== button ||
             button.disabled ||
-            button.getAttribute('aria-disabled') === 'true'
+            (button.getAttribute('aria-disabled') || '').toLowerCase() === 'true'
+        ) {
+            return null;
+        }
+        return pinned;
+    };
+"""
+
+_MESSAGE_COMPOSER_WRITE_JS = (
+    "(owner, arg) => {"
+    + _MESSAGE_COMPOSER_PINNED_JS
+    + r"""
+        let pinned = validatePinned(arg);
+        if (!pinned) return 'invalid';
+        const {editor} = pinned;
+        if ((editor.innerText || '').replace(/\s+/g, ' ').trim()) {
+            return 'occupied';
+        }
+        editor.focus();
+        pinned = validatePinned(arg);
+        if (!pinned || document.activeElement !== editor) return 'invalid';
+        if ((editor.innerText || '').replace(/\s+/g, ' ').trim()) {
+            return 'occupied';
+        }
+        if (
+            typeof document.queryCommandSupported !== 'function' ||
+            !document.queryCommandSupported('insertText') ||
+            typeof document.execCommand !== 'function' ||
+            document.execCommand('insertText', false, arg.message) !== true
+        ) {
+            return 'unsupported';
+        }
+        pinned = validatePinned(arg);
+        if (
+            !pinned ||
+            document.activeElement !== editor ||
+            (editor.innerText || editor.textContent || '') !== arg.message
         ) {
             return 'invalid';
         }
-        button.click();
+        return 'written';
+    }"""
+)
+
+_MESSAGE_COMPOSER_SUBMIT_JS = (
+    "(owner, arg) => {"
+    + _MESSAGE_COMPOSER_PINNED_JS
+    + r"""
+        const pinned = validatePinned(arg);
+        if (
+            !pinned ||
+            document.activeElement !== pinned.editor ||
+            (pinned.editor.innerText || pinned.editor.textContent || '') !== arg.message
+        ) {
+            return 'invalid';
+        }
+        pinned.button.click();
         return 'clicked';
     }"""
 )
@@ -1637,10 +1825,10 @@ class LinkedInExtractor:
     ) -> dict[str, Any]:
         """Build a structured response for the send_message tool.
 
-        ``sent`` answers whether delivery was proven, so it is false both
-        where nothing was submitted and where submission happened but
-        delivery could not be observed. A caller keying a retry on it alone
-        therefore re-sends a message that may already have arrived, which is
+        ``sent`` is true only when the narrowly defined message-list UI
+        transition was observed after submission. It does not prove delivery
+        or that the recipient read the message. A caller keying a retry on it
+        alone can re-send a message that may already have arrived, which is
         what ``retry_safe`` exists to say: it is false from the moment a
         submission is attempted, and true only while nothing can have left
         the composer.
@@ -3503,14 +3691,33 @@ class LinkedInExtractor:
         )
         return focused is True
 
-    async def _submit_verified_message(
-        self, target: _ProfileMessageTarget, *, allow_enter: bool
+    async def _write_verified_message(
+        self,
+        message: str,
+        *,
+        target: _ProfileMessageTarget,
+        owner: Any,
     ) -> str:
-        """Click one local submit button or authorize the strict Enter fallback."""
-        argument = self._message_target_argument(target)
-        argument["allowEnter"] = allow_enter
-        result = await self._page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, argument)
-        return result if result in {"clicked", "enter"} else "invalid"
+        """Insert text synchronously into the pinned local editor."""
+        result = await owner.evaluate(
+            _MESSAGE_COMPOSER_WRITE_JS,
+            {**self._message_target_argument(target), "message": message},
+        )
+        return result if result in {"written", "occupied", "unsupported"} else "invalid"
+
+    async def _submit_verified_message(
+        self,
+        message: str,
+        *,
+        target: _ProfileMessageTarget,
+        owner: Any,
+    ) -> str:
+        """Click the one active submit button pinned with the local editor."""
+        result = await owner.evaluate(
+            _MESSAGE_COMPOSER_SUBMIT_JS,
+            {**self._message_target_argument(target), "message": message},
+        )
+        return "clicked" if result == "clicked" else "invalid"
 
     async def _resolve_message_owner(self, target: _ProfileMessageTarget) -> Any | None:
         """Hold the verified owner node across submission and confirmation."""
@@ -3525,7 +3732,11 @@ class LinkedInExtractor:
 
     @staticmethod
     async def _dispose_message_owner(owner: Any) -> None:
-        """Release a request-local owner handle without replacing its result."""
+        """Release the pinned composer nodes without replacing their result."""
+        try:
+            await owner.evaluate("owner => { delete owner.__linkedinMcpComposer; }")
+        except Exception:
+            logger.debug("Could not clear pinned message nodes", exc_info=True)
         try:
             await owner.dispose()
         except Exception:
@@ -5545,16 +5756,13 @@ class LinkedInExtractor:
             return self._message_action_result(
                 self._page.url,
                 "recipient_resolution_failed",
-                "The messaging URL changed before the editor could be focused.",
+                "The messaging URL changed before text entry.",
                 recipient_selected=recipient_selected,
             )
         state = await self._read_message_composer_state(target)
         if state.get("status") == "valid" and state.get("empty") is not True:
-            # Text already in the editor belongs to whoever typed it.
-            # Chromium leaves the caret at the start of a contenteditable
-            # after focus(), so the message would land in front of that draft
-            # and LinkedIn would deliver the two as one. Clearing it would
-            # trade the leak for destroying it, so refuse and leave it.
+            # Text already in the editor belongs to whoever typed it. Clearing
+            # it would trade a recipient leak for destroying their draft.
             return self._message_action_result(
                 self._page.url,
                 "composer_occupied",
@@ -5562,86 +5770,68 @@ class LinkedInExtractor:
                 "with the message. The draft was left untouched.",
                 recipient_selected=recipient_selected,
             )
-        if state.get(
-            "status"
-        ) != "valid" or not await self._focus_verified_message_editor(target):
+        if state.get("status") != "valid":
             return self._message_action_result(
                 self._page.url,
                 "compose_interact_failed",
-                "The verified message editor could not be focused.",
+                "The verified message composer changed before text entry.",
                 recipient_selected=recipient_selected,
             )
-        await asyncio.sleep(0.1)
+        if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+            return self._message_action_result(
+                self._page.url,
+                "recipient_resolution_failed",
+                "The messaging URL changed before the composer could be pinned.",
+                recipient_selected=recipient_selected,
+            )
+        if state.get("submitCount") != 1 or state.get("submitUsable") is not True:
+            return self._message_action_result(
+                self._page.url,
+                "send_unavailable",
+                "The local submit path was missing, disabled, or ambiguous.",
+                recipient_selected=recipient_selected,
+            )
 
         may_have_submitted = False
         try:
-            if not _message_page_url_is_safe(self._page.url, target.profile_urn):
-                return self._message_action_result(
-                    self._page.url,
-                    "recipient_resolution_failed",
-                    "The messaging URL changed before text entry.",
-                    recipient_selected=recipient_selected,
-                )
-            state = await self._read_message_composer_state(target)
-            if state.get("status") == "valid" and state.get("empty") is not True:
-                return self._message_action_result(
-                    self._page.url,
-                    "composer_occupied",
-                    "The composer already holds a draft that would be sent along "
-                    "with the message. The draft was left untouched.",
-                    recipient_selected=recipient_selected,
-                )
-            if state.get("status") != "valid" or state.get("active") is not True:
-                return self._message_action_result(
-                    self._page.url,
-                    "compose_interact_failed",
-                    "The verified message editor changed before text entry.",
-                    recipient_selected=recipient_selected,
-                )
-            allow_enter = state.get("submitCount") == 0
-
-            await self._page.keyboard.type(message, delay=15)
-            await asyncio.sleep(0.3)
-            await asyncio.sleep(1.0)  # allow React to process keyboard input
-            if not _message_page_url_is_safe(self._page.url, target.profile_urn):
-                if may_have_submitted:
-                    return self._message_action_result(
-                        self._page.url,
-                        "send_unconfirmed",
-                        "The message may already have been submitted before the "
-                        "messaging URL changed. Check the conversation before "
-                        "retrying; retrying may deliver the message twice.",
-                        recipient_selected=recipient_selected,
-                        retry_safe=False,
-                    )
-                return self._message_action_result(
-                    self._page.url,
-                    "recipient_resolution_failed",
-                    "The messaging URL changed before submission.",
-                    recipient_selected=recipient_selected,
-                )
-
             owner = await self._resolve_message_owner(target)
             if owner is None:
-                if may_have_submitted:
-                    return self._message_action_result(
-                        self._page.url,
-                        "send_unconfirmed",
-                        "The message may already have been submitted before the "
-                        "verified composer owner disappeared. Check the "
-                        "conversation before retrying; retrying may deliver "
-                        "the message twice.",
-                        recipient_selected=recipient_selected,
-                        retry_safe=False,
-                    )
                 return self._message_action_result(
                     self._page.url,
                     "recipient_resolution_failed",
-                    "The verified message composer changed before submission.",
+                    "The verified message composer changed before text entry.",
                     recipient_selected=recipient_selected,
                 )
 
             try:
+                write_result = await self._write_verified_message(
+                    message,
+                    target=target,
+                    owner=owner,
+                )
+                if not _message_page_url_is_safe(self._page.url, target.profile_urn):
+                    return self._message_action_result(
+                        self._page.url,
+                        "recipient_resolution_failed",
+                        "The messaging URL changed during text entry.",
+                        recipient_selected=recipient_selected,
+                    )
+                if write_result == "occupied":
+                    return self._message_action_result(
+                        self._page.url,
+                        "composer_occupied",
+                        "The composer already holds a draft that would be sent along "
+                        "with the message. The draft was left untouched.",
+                        recipient_selected=recipient_selected,
+                    )
+                if write_result != "written":
+                    return self._message_action_result(
+                        self._page.url,
+                        "compose_interact_failed",
+                        "The verified message editor could not accept the message.",
+                        recipient_selected=recipient_selected,
+                    )
+
                 confirmation = await self._prepare_message_confirmation(
                     message,
                     target=target,
@@ -5656,13 +5846,14 @@ class LinkedInExtractor:
                     )
 
                 try:
-                    may_have_submitted_before_submit = may_have_submitted
                     try:
                         # A click can dispatch before the evaluate call reports an
                         # error, so an exception from this round trip is ambiguous.
                         may_have_submitted = True
                         submission = await self._submit_verified_message(
-                            target, allow_enter=allow_enter
+                            message,
+                            target=target,
+                            owner=owner,
                         )
                     except Exception:
                         logger.debug(
@@ -5678,52 +5869,13 @@ class LinkedInExtractor:
                             retry_safe=False,
                         )
 
-                    if submission == "enter":
-                        may_have_submitted = may_have_submitted_before_submit
-                        state = await self._read_message_composer_state(target)
-                        if (
-                            not allow_enter
-                            or not _message_page_url_is_safe(
-                                self._page.url, target.profile_urn
-                            )
-                            or state.get("status") != "valid"
-                            or state.get("active") is not True
-                            or state.get("submitCount") != 0
-                        ):
-                            submission = "invalid"
-                        else:
-                            # The read and the keypress are two round trips, so the
-                            # editor could in principle lose focus between them.
-                            # Nothing a caller or recipient controls reaches that
-                            # window, and closing it would need the keystroke and
-                            # check to be one operation, which no input API offers.
-                            may_have_submitted = True
-                            try:
-                                await self._page.keyboard.press("Enter")
-                            except Exception:
-                                logger.debug(
-                                    "Message submission did not complete", exc_info=True
-                                )
-                                return self._message_action_result(
-                                    self._page.url,
-                                    "send_unconfirmed",
-                                    "The message submission was interrupted and "
-                                    "LinkedIn did not confirm the send. Check the "
-                                    "conversation before retrying; retrying may "
-                                    "deliver the message twice.",
-                                    recipient_selected=recipient_selected,
-                                    retry_safe=False,
-                                )
-                    elif submission != "clicked":
-                        may_have_submitted = may_have_submitted_before_submit
-
-                    if submission not in {"clicked", "enter"}:
+                    if submission != "clicked":
+                        may_have_submitted = False
                         return self._message_action_result(
                             self._page.url,
                             "send_unavailable",
                             "The local submit path was missing, disabled, or ambiguous.",
                             recipient_selected=recipient_selected,
-                            retry_safe=not may_have_submitted,
                         )
 
                     confirmed = await self._message_send_confirmed(
@@ -5904,9 +6056,9 @@ def refuse_an_invalid_message(
     if not message.strip():
         reason = "Message must contain non-whitespace characters."
     elif any(ord(character) < 32 or ord(character) == 127 for character in message):
-        # `keyboard.type()` maps line breaks onto Enter, which can submit while
-        # text is still being entered. Reject every C0 control and DEL before a
-        # session is acquired so no input can reach that implicit submit path.
+        # Keep the browser-side insertion contract to plain message text.
+        # Reject every C0 control and DEL before a session is acquired so no
+        # control input can reach the contenteditable surface.
         reason = "Message must not contain control characters or line breaks."
     if reason is None:
         return None

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -251,7 +251,12 @@ def register_messaging_tools(
                 messages; use search_conversations as a fallback.
 
         Returns:
-            Dict with url, status, message, recipient_selected, and sent.
+            Dict with url, status, message, recipient_selected, sent, and
+            retry_safe. ``sent`` is true only where delivery was observed, so
+            it is false both where nothing was submitted and where the outcome
+            is unknown. ``retry_safe`` separates the two: it is false from the
+            moment a submission is attempted, and calling again while it is
+            false can deliver the message twice.
         """
         try:
             extractor = extractor or await get_ready_extractor(

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -240,19 +240,21 @@ def register_messaging_tools(
         existing thread; they do not send a reply. Until a thread-targeted send
         path is available, do not treat profile-based send_message as a reply.
 
-        The recipient must be directly messageable from the profile page. This is a
-        write operation when confirm_send is True.
+        The recipient must be directly messageable from the profile page. Nothing
+        is typed or submitted until the loaded profile and the open composer
+        identify the same person; on any disagreement the tool returns without
+        touching the editor. This is a write operation when confirm_send is True.
 
         Args:
             linkedin_username: LinkedIn username of the recipient; a full profile URL is accepted too
             message: The message text to send
             confirm_send: Must be True to send the message
             ctx: FastMCP context for progress reporting
-            profile_urn: Optional profile URN (e.g. ACoAAB...) to construct the
-                compose URL directly. Providing this bypasses the Message-button
-                lookup and is more reliable when available. Obtain via
-                get_person_profile. Note: inbox may not always show all
-                messages; use search_conversations as a fallback.
+            profile_urn: Optional profile URN (e.g. ACoAAB...) to verify against
+                the URN exposed by the loaded profile before opening its Message
+                action. It never bypasses recipient verification. Obtain via
+                get_person_profile. Note: inbox may not always show all messages;
+                use search_conversations as a fallback.
 
         Returns:
             Dict with url, status, message, recipient_selected, sent, and

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -240,10 +240,13 @@ def register_messaging_tools(
         existing thread; they do not send a reply. Until a thread-targeted send
         path is available, do not treat profile-based send_message as a reply.
 
-        The recipient must be directly messageable from the profile page. Nothing
-        is typed or submitted until the loaded profile and the open composer
-        identify the same person; on any disagreement the tool returns without
-        touching the editor. This is a write operation when confirm_send is True.
+        The recipient must be directly messageable from the profile page. If
+        LinkedIn does not expose a normal Message action, use connect_with_person
+        first, then retry send_message only after the connection request is
+        accepted. Nothing is typed or submitted until the loaded profile and the
+        open composer identify the same person; on any disagreement the tool
+        returns without touching the editor. This is a write operation when
+        confirm_send is True.
 
         Args:
             linkedin_username: LinkedIn username of the recipient; a full profile URL is accepted too

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -259,15 +259,18 @@ def register_messaging_tools(
             moment a submission is attempted, and calling again while it is
             false can deliver the message twice.
         """
-        # Answered before a session is acquired. Nothing about a blank message
-        # needs a browser, and acquiring one can spend a login attempt and
-        # come back as an authentication error instead of the refusal the
-        # caller can act on.
-        refusal = refuse_a_blank_message(linkedin_username, message)
-        if refusal is not None:
-            return refusal
-
         try:
+            # Answered before a session is acquired. Nothing about a blank
+            # message needs a browser, and acquiring one can spend a login
+            # attempt and come back as an authentication error instead of the
+            # refusal the caller can act on. Inside the `try` because building
+            # the refusal normalizes the recipient, and an unusable one raises
+            # `InvalidReferenceError`; outside, that error would skip
+            # `raise_tool_error` and reach the caller masked by
+            # `mask_error_details` instead of naming the correction.
+            refusal = refuse_a_blank_message(linkedin_username, message)
+            if refusal is not None:
+                return refusal
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="send_message"
             )

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -19,7 +19,7 @@ from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_er
 from linkedin_mcp_server.error_handler import raise_tool_error
 from linkedin_mcp_server.scraping.extractor import (
     SEND_INTERRUPTED_WARNING,
-    refuse_a_blank_message,
+    refuse_an_invalid_message,
 )
 
 logger = logging.getLogger(__name__)
@@ -261,22 +261,24 @@ def register_messaging_tools(
 
         Returns:
             Dict with url, status, message, recipient_selected, sent, and
-            retry_safe. ``sent`` is true only where delivery was observed, so
-            it is false both where nothing was submitted and where the outcome
-            is unknown. ``retry_safe`` separates the two: it is false from the
-            moment a submission is attempted, and calling again while it is
+            retry_safe. ``sent`` is true only after the submitted message's DOM
+            node gains a different opaque event ID; this does not claim delivery
+            or read status. It is false both where nothing was submitted and
+            where the outcome is unknown. ``retry_safe`` separates the two: it
+            is false from the moment a submission is attempted, and calling
+            again while it is
             false can deliver the message twice.
         """
         try:
-            # Answered before a session is acquired. Nothing about a blank
-            # message needs a browser, and acquiring one can spend a login
+            # Answered before a session is acquired. Caller-owned message
+            # validation needs no browser, and acquiring one can spend a login
             # attempt and come back as an authentication error instead of the
             # refusal the caller can act on. Inside the `try` because building
             # the refusal normalizes the recipient, and an unusable one raises
             # `InvalidReferenceError`; outside, that error would skip
             # `raise_tool_error` and reach the caller masked by
             # `mask_error_details` instead of naming the correction.
-            refusal = refuse_a_blank_message(linkedin_username, message)
+            refusal = refuse_an_invalid_message(linkedin_username, message)
             if refusal is not None:
                 return refusal
             extractor = extractor or await get_ready_extractor(
@@ -302,8 +304,8 @@ def register_messaging_tools(
             except BaseException:
                 # The send has already answered, and this notification is the
                 # last await inside FastMCP's `anyio.fail_after()`. A deadline
-                # landing here discards a result that may say a message was
-                # delivered, and nothing can hand it back afterwards, so the
+                # landing here discards a result that may say the send was
+                # confirmed, and nothing can hand it back afterwards, so the
                 # log line is all that is left. Quiet where the result says a
                 # retry is safe, because then there is nothing to warn about.
                 if result.get("retry_safe") is False:

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -243,14 +243,17 @@ def register_messaging_tools(
         The recipient must be directly messageable from the profile page. If
         LinkedIn does not expose a normal Message action, use connect_with_person
         first, then retry send_message only after the connection request is
-        accepted. Nothing is typed or submitted until the loaded profile and the
-        open composer identify the same person; on any disagreement the tool
-        returns without touching the editor. This is a write operation when
-        confirm_send is True.
+        accepted. Recipient authorization comes from validating one
+        recipient-specific Message action carrying the target URN, then following
+        its browser navigation and pinning the exact final route. Visible profile
+        links or recipient URNs in the composer are optional corroboration; any
+        contradiction fails closed. No Voyager or other private API is used. This
+        is a write operation when confirm_send is True.
 
         Args:
             linkedin_username: LinkedIn username of the recipient; a full profile URL is accepted too
-            message: The message text to send
+            message: Single-line message text to send. C0 control characters and
+                DEL are rejected, including CR, LF, and tab.
             confirm_send: Must be True to send the message
             ctx: FastMCP context for progress reporting
             profile_urn: Optional profile URN (e.g. ACoAAB...) to verify against

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -17,6 +17,7 @@ from linkedin_mcp_server.core.exceptions import (
 )
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
+from linkedin_mcp_server.scraping.extractor import refuse_a_blank_message
 
 logger = logging.getLogger(__name__)
 
@@ -258,6 +259,14 @@ def register_messaging_tools(
             moment a submission is attempted, and calling again while it is
             false can deliver the message twice.
         """
+        # Answered before a session is acquired. Nothing about a blank message
+        # needs a browser, and acquiring one can spend a login attempt and
+        # come back as an authentication error instead of the refusal the
+        # caller can act on.
+        refusal = refuse_a_blank_message(linkedin_username, message)
+        if refusal is not None:
+            return refusal
+
         try:
             extractor = extractor or await get_ready_extractor(
                 ctx, tool_name="send_message"

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -17,7 +17,10 @@ from linkedin_mcp_server.core.exceptions import (
 )
 from linkedin_mcp_server.dependencies import get_ready_extractor, handle_auth_error
 from linkedin_mcp_server.error_handler import raise_tool_error
-from linkedin_mcp_server.scraping.extractor import refuse_a_blank_message
+from linkedin_mcp_server.scraping.extractor import (
+    SEND_INTERRUPTED_WARNING,
+    refuse_a_blank_message,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -289,7 +292,18 @@ def register_messaging_tools(
                 profile_urn=profile_urn,
             )
 
-            await ctx.report_progress(progress=100, total=100, message="Complete")
+            try:
+                await ctx.report_progress(progress=100, total=100, message="Complete")
+            except BaseException:
+                # The send has already answered, and this notification is the
+                # last await inside FastMCP's `anyio.fail_after()`. A deadline
+                # landing here discards a result that may say a message was
+                # delivered, and nothing can hand it back afterwards, so the
+                # log line is all that is left. Quiet where the result says a
+                # retry is safe, because then there is nothing to warn about.
+                if result.get("retry_safe") is False:
+                    logger.warning(SEND_INTERRUPTED_WARNING)
+                raise
 
             return result
 

--- a/manifest.json
+++ b/manifest.json
@@ -109,7 +109,7 @@
     },
     {
       "name": "send_message",
-      "description": "Compose and send a new message to a LinkedIn user with explicit confirmation and optional profile URN support; profile-based targeting may create a separate DM instead of replying in an existing thread"
+      "description": "Compose and send a new message to a LinkedIn user with explicit confirmation and optional profile URN support; profile-based targeting may create a separate DM instead of replying in an existing thread, and when no normal Message action is exposed, use connect_with_person and retry after acceptance"
     },
     {
       "name": "get_feed",

--- a/manifest.json
+++ b/manifest.json
@@ -109,7 +109,7 @@
     },
     {
       "name": "send_message",
-      "description": "Compose and send a new message to a LinkedIn user with explicit confirmation and optional profile URN support; profile-based targeting may create a separate DM instead of replying in an existing thread, and when no normal Message action is exposed, use connect_with_person and retry after acceptance"
+      "description": "Compose and send a new single-line message without C0 or DEL control characters (including CR, LF, and tab) to a LinkedIn user with explicit confirmation and optional profile URN support; profile-based targeting may create a separate DM instead of replying in an existing thread, and when no normal Message action is exposed, use connect_with_person and retry after acceptance"
     },
     {
       "name": "get_feed",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -166,6 +166,14 @@ def test_every_declared_key_is_referenced(manifest: dict[str, Any]) -> None:
     )
 
 
+def test_send_message_documents_single_line_controls(manifest: dict[str, Any]) -> None:
+    tools = {tool["name"]: tool["description"] for tool in manifest["tools"]}
+    assert (
+        "single-line message without C0 or DEL control characters "
+        "(including CR, LF, and tab)"
+    ) in tools["send_message"]
+
+
 def test_no_default_is_itself_a_placeholder(manifest: dict[str, Any]) -> None:
     """A default that names another field only moves the problem.
 

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -254,7 +254,9 @@ class TestMessageComposerDom:
             ),
         )
         extractor = LinkedInExtractor(dom_page)
-        owner = await extractor._resolve_message_owner(_message_target())
+        owner = await extractor._resolve_message_owner(
+            _message_target(), expected_route=dom_page.url
+        )
 
         assert owner is not None
         assert owner.as_element() is not None
@@ -307,7 +309,9 @@ class TestMessageComposerDom:
         )
         extractor = LinkedInExtractor(dom_page)
 
-        owner = await extractor._resolve_message_owner(_message_target())
+        owner = await extractor._resolve_message_owner(
+            _message_target(), expected_route=dom_page.url
+        )
         assert owner is not None
         assert (
             await extractor._write_verified_message(
@@ -332,7 +336,9 @@ class TestMessageComposerDom:
         )
         extractor = LinkedInExtractor(dom_page)
 
-        owner = await extractor._resolve_message_owner(_message_target())
+        owner = await extractor._resolve_message_owner(
+            _message_target(), expected_route=dom_page.url
+        )
         assert owner is not None
         assert (
             await extractor._write_verified_message(
@@ -411,7 +417,9 @@ class TestMessageComposerDom:
         )
 
         extractor = LinkedInExtractor(dom_page)
-        owner = await extractor._resolve_message_owner(_message_target())
+        owner = await extractor._resolve_message_owner(
+            _message_target(), expected_route=dom_page.url
+        )
         assert owner is not None
         written = await extractor._write_verified_message(
             "Hello!", target=_message_target(), owner=owner
@@ -460,7 +468,9 @@ class TestMessageComposerDom:
             </body></html>""",
         )
         extractor = LinkedInExtractor(dom_page)
-        owner = await extractor._resolve_message_owner(_message_target())
+        owner = await extractor._resolve_message_owner(
+            _message_target(), expected_route=dom_page.url
+        )
         written = submitted = None
         if owner is not None:
             written = await extractor._write_verified_message(
@@ -630,7 +640,9 @@ class TestMessageComposerDom:
         )
 
         extractor = LinkedInExtractor(dom_page)
-        owner = await extractor._resolve_message_owner(_message_target())
+        owner = await extractor._resolve_message_owner(
+            _message_target(), expected_route=dom_page.url
+        )
         assert owner is not None
         written = await extractor._write_verified_message(
             "Hello!", target=_message_target(), owner=owner
@@ -662,7 +674,9 @@ class TestMessageComposerDom:
         )
 
         assert (
-            await LinkedInExtractor(dom_page)._resolve_message_owner(_message_target())
+            await LinkedInExtractor(dom_page)._resolve_message_owner(
+                _message_target(), expected_route=dom_page.url
+            )
             is None
         )
 
@@ -679,7 +693,9 @@ class TestMessageComposerDom:
         )
         extractor = LinkedInExtractor(dom_page)
 
-        owner = await extractor._resolve_message_owner(_message_target())
+        owner = await extractor._resolve_message_owner(
+            _message_target(), expected_route=dom_page.url
+        )
 
         assert owner is not None
         assert (
@@ -705,7 +721,9 @@ class TestMessageComposerDom:
             _composer(identity=identity, buttons='<button type="submit">Send</button>'),
         )
         extractor = LinkedInExtractor(dom_page)
-        owner = await extractor._resolve_message_owner(_message_target())
+        owner = await extractor._resolve_message_owner(
+            _message_target(), expected_route=dom_page.url
+        )
         assert owner is not None
         assert (
             await extractor._write_verified_message(
@@ -726,7 +744,9 @@ class TestMessageComposerDom:
             dom_page,
             _composer(identity=identity, buttons='<button type="submit">Send</button>'),
         )
-        owner = await extractor._resolve_message_owner(_message_target())
+        owner = await extractor._resolve_message_owner(
+            _message_target(), expected_route=dom_page.url
+        )
         assert owner is not None
         assert (
             await extractor._write_verified_message(
@@ -751,7 +771,9 @@ class TestMessageComposerDom:
             _composer(identity="", buttons='<button type="submit">Send</button>')
         )
         extractor = LinkedInExtractor(dom_page)
-        owner = await extractor._resolve_message_owner(_message_target())
+        owner = await extractor._resolve_message_owner(
+            _message_target(), expected_route=dom_page.url
+        )
 
         assert owner is not None
         assert (
@@ -790,7 +812,9 @@ class TestMessageComposerDom:
         await dom_page.locator("#foreign").focus()
 
         assert (
-            await LinkedInExtractor(dom_page)._resolve_message_owner(_message_target())
+            await LinkedInExtractor(dom_page)._resolve_message_owner(
+                _message_target(), expected_route=dom_page.url
+            )
             is None
         )
         assert await dom_page.evaluate("document.body.dataset.foreignKey") is None

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -291,6 +291,57 @@ class TestMessageComposerDom:
 
         assert state["status"] == "valid"
 
+    @pytest.mark.parametrize("visibility", ["hidden", "collapse"])
+    async def test_invisible_conflicts_do_not_block_url_pinned_composer(
+        self, dom_page, visibility
+    ):
+        await _set_composer_content(
+            dom_page,
+            _composer(
+                identity=(
+                    f'<div style="visibility:{visibility}" data-recipient-urn="OTHER">'
+                    '<a href="https://www.linkedin.com/in/bob/">Bob</a></div>'
+                ),
+                buttons='<button type="submit">Send</button>',
+            ),
+        )
+        extractor = LinkedInExtractor(dom_page)
+
+        owner = await extractor._resolve_message_owner(_message_target())
+        assert owner is not None
+        assert (
+            await extractor._write_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
+            == "written"
+        )
+        await extractor._dispose_message_owner(owner)
+
+    async def test_hidden_conflicts_do_not_override_visible_identity(self, dom_page):
+        await _set_composer_content(
+            dom_page,
+            _composer(
+                identity=(
+                    '<div style="visibility:hidden" data-recipient-urn="OTHER">'
+                    '<a href="https://www.linkedin.com/in/bob/">Bob</a></div>'
+                    '<div data-recipient-urn="ACoAAB">'
+                    '<a href="https://www.linkedin.com/in/testuser/">Test</a></div>'
+                ),
+                buttons='<button type="submit">Send</button>',
+            ),
+        )
+        extractor = LinkedInExtractor(dom_page)
+
+        owner = await extractor._resolve_message_owner(_message_target())
+        assert owner is not None
+        assert (
+            await extractor._write_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
+            == "written"
+        )
+        await extractor._dispose_message_owner(owner)
+
     async def test_second_urn_attribute_on_one_element_is_never_skipped(self, dom_page):
         conflicting = await _state(
             dom_page,

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -1,0 +1,546 @@
+"""Browser-DOM tests for local message-recipient verification.
+
+The unit suite mocks ``page.evaluate``, so these cases execute the extraction,
+focus, and submit JavaScript against synthetic Chromium DOMs. No LinkedIn page
+is loaded and no account action is performed.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.scraping.extractor import (
+    LinkedInExtractor,
+    _MESSAGE_COMPOSER_FOCUS_JS,
+    _MESSAGE_COMPOSER_STATE_JS,
+    _MESSAGE_COMPOSER_SUBMIT_JS,
+    _PROFILE_MESSAGE_TARGET_JS,
+    _ProfileMessageTarget,
+)
+
+pytestmark = [
+    pytest.mark.browser_dom,
+    pytest.mark.xdist_group("browser_runtime"),
+]
+
+TARGET = {"profilePath": "/in/testuser/", "profileUrn": "ACoAAB"}
+ENTER_TARGET = {**TARGET, "allowEnter": True}
+
+
+def _message_target() -> _ProfileMessageTarget:
+    return _ProfileMessageTarget(
+        profile_path=TARGET["profilePath"],
+        profile_urn=TARGET["profileUrn"],
+        compose_url="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+        display_name="Test User",
+    )
+
+
+@pytest.fixture
+async def dom_page():
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(
+                channel="chromium", headless=True
+            )
+            page = await browser.new_page()
+        except Exception as exc:
+            pytest.skip(f"chromium unavailable: {exc}")
+        try:
+            yield page
+        finally:
+            await browser.close()
+
+
+def _composer(*, identity: str, buttons: str = "", extra: str = "") -> str:
+    return f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+      <main>
+        <section role="dialog">
+          {identity}
+          <form>
+            <div role="textbox" contenteditable="true"
+                 style="display:block;width:200px;height:30px"></div>
+            {buttons}
+          </form>
+        </section>
+        {extra}
+      </main>
+    </body></html>
+    """
+
+
+async def _state(page, html: str) -> dict:
+    await page.set_content(html)
+    return await page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET)
+
+
+class TestMessageSurfaceDom:
+    async def test_waits_for_delayed_recipient_identity(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog">
+                <form>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                </form>
+              </section>
+            </body></html>"""
+        )
+        dom_page.set_default_timeout(1_000)
+        await dom_page.evaluate(
+            """() => setTimeout(() => {
+                document.querySelector('form').insertAdjacentHTML(
+                    'afterbegin',
+                    '<a href="https://www.linkedin.com/in/testuser/">Test</a>'
+                );
+            }, 250)"""
+        )
+        started = time.monotonic()
+
+        result = await LinkedInExtractor(dom_page)._wait_for_message_surface(
+            _message_target()
+        )
+
+        assert result == "composer"
+        assert time.monotonic() - started >= 0.2
+
+    async def test_waits_for_multiple_editors_to_settle(self, dom_page):
+        await dom_page.set_content(
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                extra=(
+                    '<div role="textbox" contenteditable="true" data-stale '
+                    'style="display:block;width:200px;height:30px"></div>'
+                ),
+            )
+        )
+        dom_page.set_default_timeout(1_000)
+        await dom_page.evaluate(
+            """() => setTimeout(() => {
+                document.querySelector('[data-stale]').remove();
+            }, 250)"""
+        )
+        started = time.monotonic()
+
+        result = await LinkedInExtractor(dom_page)._wait_for_message_surface(
+            _message_target()
+        )
+
+        assert result == "composer"
+        assert time.monotonic() - started >= 0.2
+
+    async def test_permanent_recipient_conflict_times_out(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog" data-recipient-urn="OTHER">
+                <form>
+                  <a href="https://www.linkedin.com/in/testuser/">Test</a>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                </form>
+              </section>
+            </body></html>"""
+        )
+        dom_page.set_default_timeout(350)
+        started = time.monotonic()
+
+        result = await LinkedInExtractor(dom_page)._wait_for_message_surface(
+            _message_target()
+        )
+
+        assert result is None
+        assert time.monotonic() - started >= 0.25
+        # `active` and `empty` both read false wherever the inspect never
+        # settled on an editor: they answer for one, and there is none.
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET) == {
+            "status": "recipient_mismatch",
+            "active": False,
+            "empty": False,
+            "submitCount": 0,
+        }
+
+
+class TestProfileMessageTargetDom:
+    async def test_snapshot_stays_inside_first_top_card(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body><main>
+              <section>
+                <h1>Test User</h1>
+                <a style="display:block" href="/messaging/compose/?recipient=ACoAAB">
+                  Nachricht
+                </a>
+              </section>
+              <section>
+                <a style="display:block" href="/messaging/compose/?recipient=OTHER">
+                  Sidebar
+                </a>
+              </section>
+            </main></body></html>
+            """
+        )
+
+        result = await dom_page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
+
+        assert result["displayName"] == "Test User"
+        assert result["composeHrefs"] == ["/messaging/compose/?recipient=ACoAAB"]
+
+
+class TestMessageComposerDom:
+    async def test_owner_handle_pins_one_dom_instance_and_disposes(self, dom_page):
+        await dom_page.set_content(
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>'
+            )
+        )
+        extractor = LinkedInExtractor(dom_page)
+        owner = await extractor._resolve_message_owner(_message_target())
+
+        assert owner is not None
+        assert owner.as_element() is not None
+        await dom_page.evaluate(
+            """() => {
+                const owner = document.querySelector('[role="dialog"]');
+                owner.replaceWith(owner.cloneNode(true));
+            }"""
+        )
+        assert await owner.evaluate("node => node.isConnected") is False
+        await extractor._dispose_message_owner(owner)
+        with pytest.raises(Exception, match="closed"):
+            await owner.evaluate("node => node.isConnected")
+
+    async def test_generic_data_urn_never_authorizes_recipient(self, dom_page):
+        state = await _state(
+            dom_page,
+            _composer(identity='<span data-urn="ACoAAB">unrelated generic data</span>'),
+        )
+
+        assert state["status"] == "missing_recipient"
+
+    async def test_native_dialog_accepts_explicit_recipient_urn(self, dom_page):
+        state = await _state(
+            dom_page,
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <dialog open>
+                <span data-recipient-urn="ACoAAB">Test</span>
+                <div role="textbox" contenteditable="true"
+                     style="display:block;width:200px;height:30px"></div>
+              </dialog>
+            </body></html>""",
+        )
+
+        assert state["status"] == "valid"
+
+    async def test_second_urn_attribute_on_one_element_is_never_skipped(self, dom_page):
+        conflicting = await _state(
+            dom_page,
+            _composer(
+                identity=(
+                    '<span data-profile-urn="ACoAAB" data-recipient-urn="OTHER">'
+                    "Test</span>"
+                )
+            ),
+        )
+        empty = await _state(
+            dom_page,
+            _composer(
+                identity=(
+                    '<span data-profile-urn="ACoAAB" data-recipient-urn="">Test</span>'
+                )
+            ),
+        )
+        consistent = await _state(
+            dom_page,
+            _composer(
+                identity=(
+                    '<span data-profile-urn="ACoAAB" '
+                    'data-recipient-urn="urn:li:fsd_profile:ACoAAB">Test</span>'
+                )
+            ),
+        )
+
+        assert conflicting["status"] == "recipient_mismatch"
+        assert empty["status"] == "recipient_mismatch"
+        assert consistent["status"] == "valid"
+
+    async def test_nested_owner_conflict_fails_closed(self, dom_page):
+        state = await _state(
+            dom_page,
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog" data-recipient-urn="OTHER">
+                <form>
+                  <a href="https://www.linkedin.com/in/testuser/">Test</a>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                  <button type="submit">Local</button>
+                </form>
+                <button type="submit" data-outer>Outer</button>
+              </section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "recipient_mismatch"
+        assert state["submitCount"] == 0
+
+    async def test_nested_consistent_identity_keeps_submit_local(self, dom_page):
+        await dom_page.set_content(
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog" data-recipient-urn="ACoAAB">
+                <form>
+                  <a href="https://www.linkedin.com/in/testuser/">Test</a>
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                  <button type="submit" onclick="event.preventDefault();
+                    this.setAttribute('data-clicked','yes')">Local</button>
+                </form>
+                <button type="submit" data-outer>Outer</button>
+              </section>
+            </body></html>"""
+        )
+
+        focused = await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET)
+        submitted = await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET)
+
+        assert focused is True
+        assert submitted == "clicked"
+        assert (
+            await dom_page.locator("form button").get_attribute("data-clicked") == "yes"
+        )
+        assert (
+            await dom_page.locator("[data-outer]").get_attribute("data-clicked") is None
+        )
+
+    async def test_profile_link_inside_editor_never_authorizes(self, dom_page):
+        """Draft content is not a recipient, however well-formed it looks."""
+        state = await _state(
+            dom_page,
+            """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog"><form>
+                <div role="textbox" contenteditable="true"
+                     style="display:block;width:200px;height:30px">
+                  <a href="https://www.linkedin.com/in/testuser/">Draft link</a>
+                </div>
+              </form></section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "missing_recipient"
+
+    @pytest.mark.parametrize("attribute", ["data-profile-urn", "data-recipient-urn"])
+    @pytest.mark.parametrize("location", ["editor", "descendant"])
+    async def test_recipient_urn_inside_editor_never_authorizes(
+        self, dom_page, attribute, location
+    ):
+        editor_attribute = f'{attribute}="ACoAAB"' if location == "editor" else ""
+        draft = (
+            f'<span {attribute}="ACoAAB">Draft identity</span>'
+            if location == "descendant"
+            else "Draft"
+        )
+        state = await _state(
+            dom_page,
+            f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog"><form>
+                <div role="textbox" contenteditable="true" {editor_attribute}
+                     style="display:block;width:200px;height:30px">{draft}</div>
+              </form></section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "missing_recipient"
+
+    @pytest.mark.parametrize(
+        "draft_identity",
+        [
+            '<a href="https://www.linkedin.com/in/testuser/">Matching draft</a>',
+            '<a href="https://www.linkedin.com/in/other/">Foreign draft</a>',
+            '<span data-profile-urn="ACoAAB">Matching draft</span>',
+            '<span data-profile-urn="OTHER">Foreign draft</span>',
+            '<span data-recipient-urn="ACoAAB">Matching draft</span>',
+            '<span data-recipient-urn="OTHER">Foreign draft</span>',
+        ],
+    )
+    async def test_outer_identity_ignores_draft_identity(
+        self, dom_page, draft_identity
+    ):
+        """The verdict comes from the recipient chip, never from the draft."""
+        state = await _state(
+            dom_page,
+            f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <section role="dialog"><form>
+                <a href="https://www.linkedin.com/in/testuser/">Recipient</a>
+                <div role="textbox" contenteditable="true"
+                     style="display:block;width:200px;height:30px">
+                  {draft_identity}
+                </div>
+              </form></section>
+            </body></html>""",
+        )
+
+        assert state["status"] == "valid"
+
+    async def test_name_only_or_global_identity_never_authorizes(self, dom_page):
+        html = _composer(
+            identity=(
+                "<span>Test User</span>"
+                '<span hidden data-profile-urn="ACoAAB">stale identity</span>'
+            ),
+            extra='<a href="https://www.linkedin.com/in/testuser/">Test User</a>',
+        )
+
+        state = await _state(dom_page, html)
+
+        assert state["status"] == "missing_recipient"
+
+    async def test_foreign_or_multiple_editor_fails_closed(self, dom_page):
+        foreign = await _state(
+            dom_page,
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/other/">Other</a>'
+            ),
+        )
+        multiple = await _state(
+            dom_page,
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                extra=(
+                    '<div role="textbox" contenteditable="true" '
+                    'style="display:block;width:200px;height:30px"></div>'
+                ),
+            ),
+        )
+
+        assert foreign["status"] == "recipient_mismatch"
+        assert multiple["status"] == "ambiguous_editor"
+
+    @pytest.mark.parametrize(
+        ("href", "expected"),
+        [
+            # Every shape below was read off one live profile page. Four of
+            # its 38 visible anchors point into the member's own subtree, and
+            # reading those as an unknown member made the recipient
+            # contradict themselves and stopped the send.
+            ("https://www.linkedin.com/in/testuser/overlay/contact-info/", "valid"),
+            ("https://www.linkedin.com/in/testuser/recent-activity/all/", "valid"),
+            ("https://www.linkedin.com/in/testuser", "valid"),
+            ("https://www.linkedin.com/in/testuser?miniProfileUrn=urn%3A", "valid"),
+            # A different member stays a different member in every shape.
+            ("https://www.linkedin.com/in/other/en/", "recipient_mismatch"),
+            ("https://www.linkedin.com/in/other", "recipient_mismatch"),
+            # An anchor that names nobody stays a contradiction rather than
+            # silence: a link the check cannot read is not evidence that the
+            # recipient is the requested one.
+            ("https://www.linkedin.com/in/", "recipient_mismatch"),
+            ("https://evil.example/in/testuser/", "recipient_mismatch"),
+        ],
+    )
+    async def test_subpaths_belong_to_the_member_they_sit_under(
+        self, dom_page, href, expected
+    ):
+        state = await _state(
+            dom_page, _composer(identity=f'<a href="{href}">Profile</a>')
+        )
+
+        assert state["status"] == expected
+
+    async def test_focus_and_single_submit_stay_local(self, dom_page):
+        await dom_page.set_content(
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                buttons=(
+                    '<button type="submit" onclick="event.preventDefault();'
+                    "this.setAttribute('data-clicked','yes')\">Senden</button>"
+                ),
+                extra=('<button type="submit" data-global="true">Global</button>'),
+            )
+        )
+
+        focused = await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET)
+        submitted = await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET)
+
+        assert focused is True
+        assert submitted == "clicked"
+        assert (
+            await dom_page.locator("form button").get_attribute("data-clicked") == "yes"
+        )
+        assert (
+            await dom_page.locator("[data-global]").get_attribute("data-clicked")
+            is None
+        )
+
+    async def test_ambiguous_disabled_and_changed_recipient_never_submit(
+        self, dom_page
+    ):
+        identity = '<a href="https://www.linkedin.com/in/testuser/">Test</a>'
+        await dom_page.set_content(
+            _composer(
+                identity=identity,
+                buttons='<button type="submit">A</button><button type="submit">B</button>',
+            )
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
+
+        await dom_page.set_content(
+            _composer(
+                identity=identity, buttons='<button type="submit" disabled>A</button>'
+            )
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
+
+        await dom_page.set_content(
+            _composer(
+                identity=identity,
+                buttons='<button type="submit" aria-disabled="true">A</button>',
+            )
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
+
+        await dom_page.set_content(
+            _composer(identity=identity, buttons='<button type="submit">stale</button>')
+        )
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        state = await dom_page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET)
+        await dom_page.locator("form button").evaluate("element => element.remove()")
+        submit_target = {**TARGET, "allowEnter": state["submitCount"] == 0}
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, submit_target)
+            == "invalid"
+        )
+
+        await dom_page.set_content(_composer(identity=identity))
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        await dom_page.locator('[role="dialog"] > a').evaluate(
+            "element => element.setAttribute('href', 'https://www.linkedin.com/in/other/')"
+        )
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
+            == "invalid"
+        )
+
+    async def test_enter_only_when_verified_editor_stays_active_without_buttons(
+        self, dom_page
+    ):
+        await dom_page.set_content(
+            _composer(
+                identity=(
+                    '<span data-profile-urn="urn:li:fsd_profile:ACoAAB">Test</span>'
+                )
+            )
+        )
+
+        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
+            == "enter"
+        )
+
+        await dom_page.evaluate("document.activeElement.blur()")
+        assert (
+            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
+            == "invalid"
+        )

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -430,6 +430,59 @@ class TestMessageComposerDom:
             await dom_page.locator("[data-outer]").get_attribute("data-clicked") is None
         )
 
+    @pytest.mark.parametrize(
+        ("recipient_urn", "button_form", "expected"),
+        [
+            ("OTHER", None, None),
+            ("ACoAAB", "foreign", None),
+            ("ACoAAB", None, ("written", "clicked", "ancestor")),
+        ],
+        ids=["foreign-ancestor", "foreign-form-owner", "matching-ancestor"],
+    )
+    async def test_entire_semantic_ancestor_chain_controls_submit(
+        self, dom_page, recipient_urn, button_form, expected
+    ):
+        form_attribute = f' form="{button_form}"' if button_form else ""
+        await _set_composer_content(
+            dom_page,
+            f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
+              <form id="ancestor" data-recipient-urn="{recipient_urn}"
+                    onsubmit="event.preventDefault();
+                      document.body.dataset.submitted=this.id">
+                <section role="dialog">
+                  <div role="textbox" contenteditable="true"
+                       style="display:block;width:200px;height:30px"></div>
+                  <button type="submit"{form_attribute}>Send</button>
+                </section>
+              </form>
+              <form id="foreign" onsubmit="event.preventDefault();
+                document.body.dataset.submitted=this.id"></form>
+            </body></html>""",
+        )
+        extractor = LinkedInExtractor(dom_page)
+        owner = await extractor._resolve_message_owner(_message_target())
+        written = submitted = None
+        if owner is not None:
+            written = await extractor._write_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
+            submitted = await extractor._submit_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
+            await extractor._dispose_message_owner(owner)
+
+        if expected is None:
+            assert owner is None
+            assert written is None
+            assert submitted is None
+            assert await dom_page.evaluate("document.body.dataset.submitted") is None
+        else:
+            assert (written, submitted) == expected[:2]
+            assert (
+                await dom_page.evaluate("document.body.dataset.submitted")
+                == expected[2]
+            )
+
     async def test_profile_link_inside_editor_never_authorizes(self, dom_page):
         """Draft content is not a recipient, however well-formed it looks."""
         state = await _state(

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -7,10 +7,12 @@ is loaded and no account action is performed.
 
 from __future__ import annotations
 
+import os
 import time
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from patchright.async_api import async_playwright
+from patchright.async_api import BrowserType, async_playwright
 
 from linkedin_mcp_server.scraping.extractor import (
     LinkedInExtractor,
@@ -39,8 +41,7 @@ def _message_target() -> _ProfileMessageTarget:
     )
 
 
-@pytest.fixture
-async def dom_page():
+async def _dom_page():
     async with async_playwright() as playwright:
         try:
             browser = await playwright.chromium.launch(
@@ -48,11 +49,55 @@ async def dom_page():
             )
             page = await browser.new_page()
         except Exception as exc:
+            if os.environ.get("CI"):
+                raise
             pytest.skip(f"chromium unavailable: {exc}")
         try:
             yield page
         finally:
             await browser.close()
+
+
+@pytest.fixture
+async def dom_page():
+    async for page in _dom_page():
+        yield page
+
+
+async def test_dom_page_launch_failure_raises_in_ci(monkeypatch):
+    monkeypatch.setenv("CI", "1")
+    fixture = _dom_page()
+    with (
+        patch.object(
+            BrowserType,
+            "launch",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("injected launch failure"),
+        ),
+        patch.object(
+            pytest,
+            "skip",
+            side_effect=AssertionError("CI launch failure was skipped"),
+        ) as skip,
+        pytest.raises(RuntimeError, match="injected launch failure"),
+    ):
+        await fixture.__anext__()
+    skip.assert_not_called()
+
+
+async def test_dom_page_launch_failure_skips_locally(monkeypatch):
+    monkeypatch.delenv("CI", raising=False)
+    fixture = _dom_page()
+    with (
+        patch.object(
+            BrowserType,
+            "launch",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("injected launch failure"),
+        ),
+        pytest.raises(pytest.skip.Exception, match="injected launch failure"),
+    ):
+        await fixture.__anext__()
 
 
 def _composer(*, identity: str, buttons: str = "", extra: str = "") -> str:

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -16,9 +16,7 @@ from patchright.async_api import BrowserType, async_playwright
 
 from linkedin_mcp_server.scraping.extractor import (
     LinkedInExtractor,
-    _MESSAGE_COMPOSER_FOCUS_JS,
     _MESSAGE_COMPOSER_STATE_JS,
-    _MESSAGE_COMPOSER_SUBMIT_JS,
     _PROFILE_MESSAGE_TARGET_JS,
     _ProfileMessageTarget,
 )
@@ -29,7 +27,6 @@ pytestmark = [
 ]
 
 TARGET = {"profilePath": "/in/testuser/", "profileUrn": "ACoAAB"}
-ENTER_TARGET = {**TARGET, "allowEnter": True}
 
 
 def _message_target() -> _ProfileMessageTarget:
@@ -52,6 +49,14 @@ async def _dom_page():
             if os.environ.get("CI"):
                 raise
             pytest.skip(f"chromium unavailable: {exc}")
+        await page.route(
+            "https://www.linkedin.com/**",
+            lambda route: route.fulfill(
+                status=200,
+                content_type="text/html",
+                body='<!DOCTYPE html><html><head><meta charset="utf-8"></head></html>',
+            ),
+        )
         try:
             yield page
         finally:
@@ -117,29 +122,31 @@ def _composer(*, identity: str, buttons: str = "", extra: str = "") -> str:
     """
 
 
-async def _state(page, html: str) -> dict:
+async def _set_composer_content(page, html: str) -> None:
+    await page.goto("https://www.linkedin.com/messaging/compose/?recipient=ACoAAB")
     await page.set_content(html)
+
+
+async def _state(page, html: str) -> dict:
+    await _set_composer_content(page, html)
     return await page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET)
 
 
 class TestMessageSurfaceDom:
-    async def test_waits_for_delayed_recipient_identity(self, dom_page):
-        await dom_page.set_content(
+    async def test_waits_for_delayed_editor(self, dom_page):
+        await _set_composer_content(
+            dom_page,
             """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
-              <section role="dialog">
-                <form>
-                  <div role="textbox" contenteditable="true"
-                       style="display:block;width:200px;height:30px"></div>
-                </form>
-              </section>
-            </body></html>"""
+              <section role="dialog"><form></form></section>
+            </body></html>""",
         )
         dom_page.set_default_timeout(1_000)
         await dom_page.evaluate(
             """() => setTimeout(() => {
                 document.querySelector('form').insertAdjacentHTML(
-                    'afterbegin',
-                    '<a href="https://www.linkedin.com/in/testuser/">Test</a>'
+                    'beforeend',
+                    '<div role="textbox" contenteditable="true" '
+                    + 'style="display:block;width:200px;height:30px"></div>'
                 );
             }, 250)"""
         )
@@ -153,14 +160,15 @@ class TestMessageSurfaceDom:
         assert time.monotonic() - started >= 0.2
 
     async def test_waits_for_multiple_editors_to_settle(self, dom_page):
-        await dom_page.set_content(
+        await _set_composer_content(
+            dom_page,
             _composer(
                 identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
                 extra=(
                     '<div role="textbox" contenteditable="true" data-stale '
                     'style="display:block;width:200px;height:30px"></div>'
                 ),
-            )
+            ),
         )
         dom_page.set_default_timeout(1_000)
         await dom_page.evaluate(
@@ -178,7 +186,8 @@ class TestMessageSurfaceDom:
         assert time.monotonic() - started >= 0.2
 
     async def test_permanent_recipient_conflict_times_out(self, dom_page):
-        await dom_page.set_content(
+        await _set_composer_content(
+            dom_page,
             """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
               <section role="dialog" data-recipient-urn="OTHER">
                 <form>
@@ -187,7 +196,7 @@ class TestMessageSurfaceDom:
                        style="display:block;width:200px;height:30px"></div>
                 </form>
               </section>
-            </body></html>"""
+            </body></html>""",
         )
         dom_page.set_default_timeout(350)
         started = time.monotonic()
@@ -205,12 +214,14 @@ class TestMessageSurfaceDom:
             "active": False,
             "empty": False,
             "submitCount": 0,
+            "submitUsable": False,
         }
 
 
 class TestProfileMessageTargetDom:
     async def test_snapshot_stays_inside_first_top_card(self, dom_page):
-        await dom_page.set_content(
+        await _set_composer_content(
+            dom_page,
             """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body><main>
               <section>
                 <h1>Test User</h1>
@@ -224,7 +235,7 @@ class TestProfileMessageTargetDom:
                 </a>
               </section>
             </main></body></html>
-            """
+            """,
         )
 
         result = await dom_page.evaluate(_PROFILE_MESSAGE_TARGET_JS)
@@ -235,10 +246,12 @@ class TestProfileMessageTargetDom:
 
 class TestMessageComposerDom:
     async def test_owner_handle_pins_one_dom_instance_and_disposes(self, dom_page):
-        await dom_page.set_content(
+        await _set_composer_content(
+            dom_page,
             _composer(
-                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>'
-            )
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                buttons='<button type="submit">Send</button>',
+            ),
         )
         extractor = LinkedInExtractor(dom_page)
         owner = await extractor._resolve_message_owner(_message_target())
@@ -262,7 +275,7 @@ class TestMessageComposerDom:
             _composer(identity='<span data-urn="ACoAAB">unrelated generic data</span>'),
         )
 
-        assert state["status"] == "missing_recipient"
+        assert state["status"] == "valid"
 
     async def test_native_dialog_accepts_explicit_recipient_urn(self, dom_page):
         state = await _state(
@@ -330,7 +343,8 @@ class TestMessageComposerDom:
         assert state["submitCount"] == 0
 
     async def test_nested_consistent_identity_keeps_submit_local(self, dom_page):
-        await dom_page.set_content(
+        await _set_composer_content(
+            dom_page,
             """<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>
               <section role="dialog" data-recipient-urn="ACoAAB">
                 <form>
@@ -342,13 +356,21 @@ class TestMessageComposerDom:
                 </form>
                 <button type="submit" data-outer>Outer</button>
               </section>
-            </body></html>"""
+            </body></html>""",
         )
 
-        focused = await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET)
-        submitted = await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET)
+        extractor = LinkedInExtractor(dom_page)
+        owner = await extractor._resolve_message_owner(_message_target())
+        assert owner is not None
+        written = await extractor._write_verified_message(
+            "Hello!", target=_message_target(), owner=owner
+        )
+        submitted = await extractor._submit_verified_message(
+            "Hello!", target=_message_target(), owner=owner
+        )
+        await extractor._dispose_message_owner(owner)
 
-        assert focused is True
+        assert written == "written"
         assert submitted == "clicked"
         assert (
             await dom_page.locator("form button").get_attribute("data-clicked") == "yes"
@@ -371,7 +393,7 @@ class TestMessageComposerDom:
             </body></html>""",
         )
 
-        assert state["status"] == "missing_recipient"
+        assert state["status"] == "valid"
 
     @pytest.mark.parametrize("attribute", ["data-profile-urn", "data-recipient-urn"])
     @pytest.mark.parametrize("location", ["editor", "descendant"])
@@ -394,7 +416,7 @@ class TestMessageComposerDom:
             </body></html>""",
         )
 
-        assert state["status"] == "missing_recipient"
+        assert state["status"] == "valid"
 
     @pytest.mark.parametrize(
         "draft_identity",
@@ -437,7 +459,7 @@ class TestMessageComposerDom:
 
         state = await _state(dom_page, html)
 
-        assert state["status"] == "missing_recipient"
+        assert state["status"] == "valid"
 
     async def test_foreign_or_multiple_editor_fails_closed(self, dom_page):
         foreign = await _state(
@@ -491,7 +513,8 @@ class TestMessageComposerDom:
         assert state["status"] == expected
 
     async def test_focus_and_single_submit_stay_local(self, dom_page):
-        await dom_page.set_content(
+        await _set_composer_content(
+            dom_page,
             _composer(
                 identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
                 buttons=(
@@ -499,13 +522,21 @@ class TestMessageComposerDom:
                     "this.setAttribute('data-clicked','yes')\">Senden</button>"
                 ),
                 extra=('<button type="submit" data-global="true">Global</button>'),
-            )
+            ),
         )
 
-        focused = await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET)
-        submitted = await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET)
+        extractor = LinkedInExtractor(dom_page)
+        owner = await extractor._resolve_message_owner(_message_target())
+        assert owner is not None
+        written = await extractor._write_verified_message(
+            "Hello!", target=_message_target(), owner=owner
+        )
+        submitted = await extractor._submit_verified_message(
+            "Hello!", target=_message_target(), owner=owner
+        )
+        await extractor._dispose_message_owner(owner)
 
-        assert focused is True
+        assert written == "written"
         assert submitted == "clicked"
         assert (
             await dom_page.locator("form button").get_attribute("data-clicked") == "yes"
@@ -515,77 +546,96 @@ class TestMessageComposerDom:
             is None
         )
 
-    async def test_ambiguous_disabled_and_changed_recipient_never_submit(
-        self, dom_page
+    @pytest.mark.parametrize(
+        "buttons",
+        [
+            '<button type="submit">A</button><button type="submit">B</button>',
+            '<button type="submit" disabled>A</button>',
+            '<button type="submit" aria-disabled="true">A</button>',
+        ],
+        ids=["ambiguous", "disabled", "aria-disabled"],
+    )
+    async def test_ambiguous_or_disabled_submit_is_never_pinned(
+        self, dom_page, buttons
     ):
-        identity = '<a href="https://www.linkedin.com/in/testuser/">Test</a>'
-        await dom_page.set_content(
+        await _set_composer_content(
+            dom_page,
             _composer(
-                identity=identity,
-                buttons='<button type="submit">A</button><button type="submit">B</button>',
-            )
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                buttons=buttons,
+            ),
         )
-        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
-        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
 
-        await dom_page.set_content(
-            _composer(
-                identity=identity, buttons='<button type="submit" disabled>A</button>'
-            )
-        )
-        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
-        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
-
-        await dom_page.set_content(
-            _composer(
-                identity=identity,
-                buttons='<button type="submit" aria-disabled="true">A</button>',
-            )
-        )
-        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
-        assert await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, TARGET) == "invalid"
-
-        await dom_page.set_content(
-            _composer(identity=identity, buttons='<button type="submit">stale</button>')
-        )
-        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
-        state = await dom_page.evaluate(_MESSAGE_COMPOSER_STATE_JS, TARGET)
-        await dom_page.locator("form button").evaluate("element => element.remove()")
-        submit_target = {**TARGET, "allowEnter": state["submitCount"] == 0}
         assert (
-            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, submit_target)
+            await LinkedInExtractor(dom_page)._resolve_message_owner(_message_target())
+            is None
+        )
+
+    async def test_removed_submit_or_changed_recipient_invalidates_pins(self, dom_page):
+        identity = '<a href="https://www.linkedin.com/in/testuser/">Test</a>'
+        await _set_composer_content(
+            dom_page,
+            _composer(identity=identity, buttons='<button type="submit">Send</button>'),
+        )
+        extractor = LinkedInExtractor(dom_page)
+        owner = await extractor._resolve_message_owner(_message_target())
+        assert owner is not None
+        assert (
+            await extractor._write_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
+            == "written"
+        )
+        await dom_page.locator("form button").evaluate("element => element.remove()")
+        assert (
+            await extractor._submit_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
             == "invalid"
         )
+        await extractor._dispose_message_owner(owner)
 
-        await dom_page.set_content(_composer(identity=identity))
-        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
+        await _set_composer_content(
+            dom_page,
+            _composer(identity=identity, buttons='<button type="submit">Send</button>'),
+        )
+        owner = await extractor._resolve_message_owner(_message_target())
+        assert owner is not None
+        assert (
+            await extractor._write_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
+            == "written"
+        )
         await dom_page.locator('[role="dialog"] > a').evaluate(
             "element => element.setAttribute('href', 'https://www.linkedin.com/in/other/')"
         )
         assert (
-            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
+            await extractor._submit_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
             == "invalid"
         )
+        await extractor._dispose_message_owner(owner)
 
-    async def test_enter_only_when_verified_editor_stays_active_without_buttons(
-        self, dom_page
-    ):
-        await dom_page.set_content(
+    async def test_missing_submit_never_falls_back_to_enter(self, dom_page):
+        await _set_composer_content(
+            dom_page,
             _composer(
                 identity=(
                     '<span data-profile-urn="urn:li:fsd_profile:ACoAAB">Test</span>'
-                )
-            )
+                ),
+                extra='<input id="foreign">',
+            ),
         )
+        await dom_page.locator("#foreign").evaluate(
+            "element => element.addEventListener('keydown', () => "
+            "document.body.dataset.foreignKey = 'true')"
+        )
+        await dom_page.locator("#foreign").focus()
 
-        assert await dom_page.evaluate(_MESSAGE_COMPOSER_FOCUS_JS, TARGET) is True
         assert (
-            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
-            == "enter"
+            await LinkedInExtractor(dom_page)._resolve_message_owner(_message_target())
+            is None
         )
-
-        await dom_page.evaluate("document.activeElement.blur()")
-        assert (
-            await dom_page.evaluate(_MESSAGE_COMPOSER_SUBMIT_JS, ENTER_TARGET)
-            == "invalid"
-        )
+        assert await dom_page.evaluate("document.body.dataset.foreignKey") is None

--- a/tests/test_message_recipient_dom.py
+++ b/tests/test_message_recipient_dom.py
@@ -650,23 +650,14 @@ class TestMessageComposerDom:
             is None
         )
 
-    @pytest.mark.parametrize(
-        "buttons",
-        [
-            '<button type="submit">A</button><button type="submit">B</button>',
-            '<button type="submit" disabled>A</button>',
-            '<button type="submit" aria-disabled="true">A</button>',
-        ],
-        ids=["ambiguous", "disabled", "aria-disabled"],
-    )
-    async def test_ambiguous_or_disabled_submit_is_never_pinned(
-        self, dom_page, buttons
-    ):
+    async def test_ambiguous_submit_is_never_pinned(self, dom_page):
         await _set_composer_content(
             dom_page,
             _composer(
                 identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
-                buttons=buttons,
+                buttons=(
+                    '<button type="submit">A</button><button type="submit">B</button>'
+                ),
             ),
         )
 
@@ -674,6 +665,38 @@ class TestMessageComposerDom:
             await LinkedInExtractor(dom_page)._resolve_message_owner(_message_target())
             is None
         )
+
+    @pytest.mark.parametrize("disabled_attribute", ["disabled", 'aria-disabled="true"'])
+    async def test_unique_disabled_submit_is_pinned_for_local_write(
+        self, dom_page, disabled_attribute
+    ):
+        await _set_composer_content(
+            dom_page,
+            _composer(
+                identity='<a href="https://www.linkedin.com/in/testuser/">Test</a>',
+                buttons=f'<button type="submit" {disabled_attribute}>A</button>',
+            ),
+        )
+        extractor = LinkedInExtractor(dom_page)
+
+        owner = await extractor._resolve_message_owner(_message_target())
+
+        assert owner is not None
+        assert (
+            await extractor._write_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
+            == "written"
+        )
+        assert (
+            await extractor._submit_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
+            == "invalid"
+        )
+        await extractor._cleanup_owned_message("Hello!", owner)
+        await extractor._dispose_message_owner(owner)
+        assert await dom_page.locator('[role="textbox"]').inner_text() == ""
 
     async def test_removed_submit_or_changed_recipient_invalidates_pins(self, dom_page):
         identity = '<a href="https://www.linkedin.com/in/testuser/">Test</a>'
@@ -721,6 +744,34 @@ class TestMessageComposerDom:
             == "invalid"
         )
         await extractor._dispose_message_owner(owner)
+
+    async def test_queryless_thread_route_is_pinned_exactly(self, dom_page):
+        await dom_page.goto("https://www.linkedin.com/messaging/thread/INITIAL/")
+        await dom_page.set_content(
+            _composer(identity="", buttons='<button type="submit">Send</button>')
+        )
+        extractor = LinkedInExtractor(dom_page)
+        owner = await extractor._resolve_message_owner(_message_target())
+
+        assert owner is not None
+        assert (
+            await extractor._write_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
+            == "written"
+        )
+        await dom_page.evaluate(
+            "history.replaceState({}, '', '/messaging/thread/OTHER/')"
+        )
+        assert (
+            await extractor._submit_verified_message(
+                "Hello!", target=_message_target(), owner=owner
+            )
+            == "invalid"
+        )
+        await extractor._cleanup_owned_message("Hello!", owner)
+        await extractor._dispose_message_owner(owner)
+        assert await dom_page.locator('[role="textbox"]').inner_text() == ""
 
     async def test_missing_submit_never_falls_back_to_enter(self, dom_page):
         await _set_composer_content(

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8452,12 +8452,15 @@ class TestSendMessage:
                 "testuser", message, confirm_send=True
             )
 
+        # Not `message_unavailable`: that status is about the recipient and
+        # tells a caller to move on, while this one is about their own input.
         assert result == {
             "url": "https://www.linkedin.com/in/testuser/",
-            "status": "message_unavailable",
+            "status": "invalid_message",
             "message": "Message must contain non-whitespace characters.",
             "recipient_selected": False,
             "sent": False,
+            "retry_safe": True,
         }
         navigate.assert_not_awaited()
         mock_page.evaluate.assert_not_awaited()
@@ -9015,9 +9018,11 @@ class TestSendMessageComposerInteraction:
             )
 
         # The click happened, so nothing here proves the message did not go
-        # out. Answering "not sent" would invite a retry that delivers twice.
+        # out. Answering "not sent" would invite a retry that delivers twice,
+        # which is what `retry_safe` says and `sent` cannot.
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
+        assert result["retry_safe"] is False
         visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
 
 
@@ -9069,14 +9074,21 @@ class TestMessageTextOccurrences:
         )
 
     async def test_other_confirmation_errors_do_not_confirm(self, mock_page):
-        """A broken confirmation surfaces as an error, never as a send."""
+        """A broken confirmation is an unknown, never a send and never an error.
+
+        This runs only after a submission was attempted, so letting the error
+        out would reach the caller as a plain tool failure and invite the one
+        retry that delivers the message a second time.
+        """
         extractor = LinkedInExtractor(mock_page)
         mock_page.wait_for_function = AsyncMock(
             side_effect=PatchrightError("execution context destroyed")
         )
 
-        with pytest.raises(PatchrightError):
+        assert (
             await extractor._message_text_visible("Hello!", previous_occurrences=0)
+            is False
+        )
 
 
 class TestBuildFeedReferences:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8620,6 +8620,65 @@ class TestSendMessage:
         keyboard.type.assert_not_called()
         keyboard.press.assert_not_called()
 
+    async def test_unavailable_message_action_returns_connection_handoff(
+        self, mock_page
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.keyboard = MagicMock(type=AsyncMock(), press=AsyncMock())
+
+        with (
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as navigate,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_read_profile_message_target",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(
+                extractor, "_wait_for_message_surface", new_callable=AsyncMock
+            ) as surface,
+            patch.object(
+                extractor, "_read_message_composer_state", new_callable=AsyncMock
+            ) as state,
+            patch.object(
+                extractor,
+                "_focus_verified_message_editor",
+                new_callable=AsyncMock,
+            ) as focus,
+            patch.object(
+                extractor, "_submit_verified_message", new_callable=AsyncMock
+            ) as submit,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result == {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "status": "message_unavailable",
+            "message": (
+                "LinkedIn did not expose a normal Message action for this profile. "
+                "Use connect_with_person first, then retry only after the connection "
+                "request is accepted."
+            ),
+            "recipient_selected": False,
+            "sent": False,
+            "retry_safe": True,
+        }
+        navigate.assert_awaited_once_with("https://www.linkedin.com/in/testuser/")
+        surface.assert_not_awaited()
+        state.assert_not_awaited()
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
+        mock_page.keyboard.press.assert_not_awaited()
+
     @staticmethod
     def _target():
         return extractor_module._ProfileMessageTarget(

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -9007,6 +9007,51 @@ class TestSendMessage:
         submit.assert_not_awaited()
         mock_page.keyboard.type.assert_not_awaited()
 
+    async def test_queryless_route_is_captured_before_owner_resolution(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        alice_route = "https://www.linkedin.com/messaging/thread/ALICE/"
+        bob_route = "https://www.linkedin.com/messaging/thread/BOB/"
+        mock_page.url = alice_route
+
+        async def switch_route(target, *, expected_route):
+            assert target == self._target()
+            assert expected_route == alice_route
+            mock_page.url = bob_route
+            return None
+
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6] as write,
+            patches[7] as submit,
+            patches[8],
+            patches[9],
+            patches[10],
+            patch.object(
+                extractor,
+                "_resolve_message_owner",
+                new_callable=AsyncMock,
+                side_effect=switch_route,
+            ) as resolve_owner,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "recipient_resolution_failed"
+        assert result["retry_safe"] is True
+        resolve_owner.assert_awaited_once_with(
+            self._target(), expected_route=alice_route
+        )
+        write.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
+        mock_page.keyboard.press.assert_not_awaited()
+
     async def test_rejects_contradictory_url_before_submission(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         patches = self._patch_to_composer(extractor, mock_page)
@@ -9613,11 +9658,24 @@ class TestMessageConfirmation:
         owner.as_element.return_value = owner
         mock_page.evaluate_handle = AsyncMock(return_value=owner)
 
-        assert await extractor._resolve_message_owner(target) is owner
+        expected_route = "https://www.linkedin.com/messaging/thread/ALICE/"
+
+        assert (
+            await extractor._resolve_message_owner(
+                target, expected_route=expected_route
+            )
+            is owner
+        )
 
         mock_page.evaluate_handle.assert_awaited_once_with(
             _MESSAGE_COMPOSER_OWNER_JS,
-            arg={"profilePath": target.profile_path, "profileUrn": target.profile_urn},
+            arg={
+                "target": {
+                    "profilePath": target.profile_path,
+                    "profileUrn": target.profile_urn,
+                },
+                "expectedRoute": expected_route,
+            },
         )
 
     async def test_invalid_owner_handle_is_released(self, mock_page):
@@ -9627,7 +9685,13 @@ class TestMessageConfirmation:
         owner.dispose = AsyncMock()
         mock_page.evaluate_handle = AsyncMock(return_value=owner)
 
-        assert await extractor._resolve_message_owner(target) is None
+        assert (
+            await extractor._resolve_message_owner(
+                target,
+                expected_route="https://www.linkedin.com/messaging/thread/ALICE/",
+            )
+            is None
+        )
         owner.dispose.assert_awaited_once_with()
 
     async def test_owner_disposal_error_is_suppressed(self, mock_page):

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8799,8 +8799,9 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), True (send button click)
-        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        # evaluate returns: 'focused' (empty composer, focused), then
+        # True (send button click)
+        mock_page.evaluate = AsyncMock(side_effect=["focused", True])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -8842,8 +8843,8 @@ class TestSendMessageComposerInteraction:
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns False (focus failed)
-        mock_page.evaluate = AsyncMock(return_value=False)
+        # evaluate returns 'missing' (no composer to focus)
+        mock_page.evaluate = AsyncMock(return_value="missing")
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -8872,8 +8873,8 @@ class TestSendMessageComposerInteraction:
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), False (no send button found)
-        mock_page.evaluate = AsyncMock(side_effect=[True, False])
+        # evaluate returns: 'focused', then False (no send button found)
+        mock_page.evaluate = AsyncMock(side_effect=["focused", False])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -8925,8 +8926,11 @@ class TestSendMessageComposerInteraction:
         mock_page.keyboard = mock_keyboard
 
         async def evaluate(*args, **kwargs):
-            steps.append("click" if steps else "focus")
-            return True
+            focusing = not steps
+            steps.append("focus" if focusing else "click")
+            # The focus call reports the composer state; the click reports
+            # whether a send button was found.
+            return "focused" if focusing else True
 
         async def occurrences(message):
             steps.append("baseline")
@@ -8971,15 +8975,15 @@ class TestSendMessageComposerInteraction:
         # The confirmation receives exactly the baseline taken before the click.
         assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
 
-    async def test_send_unavailable_when_click_adds_nothing(self, mock_page):
+    async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        # evaluate returns: True (focus), True (send button found and clicked)
-        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        # evaluate returns: 'focused', then True (send button found and clicked)
+        mock_page.evaluate = AsyncMock(side_effect=["focused", True])
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with (
@@ -9010,7 +9014,9 @@ class TestSendMessageComposerInteraction:
                 "testuser", "Hello!", confirm_send=True
             )
 
-        assert result["status"] == "send_unavailable"
+        # The click happened, so nothing here proves the message did not go
+        # out. Answering "not sent" would invite a retry that delivers twice.
+        assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -9169,6 +9169,87 @@ class TestSendMessageComposerInteraction:
         hit = any("retry may deliver the message twice" in w for w in warnings)
         assert hit is warns, warnings
 
+    @pytest.mark.parametrize(
+        "stage",
+        ["typing", "baseline", "cleanup"],
+        ids=["typing", "baseline", "cleanup"],
+    )
+    async def test_ordinary_error_after_a_possible_submission_still_answers(
+        self, mock_page, stage
+    ):
+        """An error a caller could retry on gets an answer, not a raise.
+
+        Three awaits inside the destructive window have no guard of their own.
+        Typing raises before the send call is reached, and a newline has by
+        then submitted a paragraph. The baseline read sits between the two.
+        And `_dismiss_message_ui` guards its click but not the visibility
+        probe it opens with, so a page that dies during cleanup escapes it.
+
+        All three reach the caller as a plain tool failure unless the window
+        answers, and a plain failure invites the retry that delivers a second
+        message to a real person.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(return_value="focused")
+        occurrences = AsyncMock(return_value=1)
+        visible = AsyncMock(return_value=False)
+        dismiss = AsyncMock()
+        if stage == "typing":
+            mock_keyboard.type = AsyncMock(side_effect=RuntimeError("page closed"))
+        elif stage == "baseline":
+            occurrences = AsyncMock(side_effect=RuntimeError("context destroyed"))
+        else:
+            # The send went out unconfirmed and cleanup then failed, which is
+            # the branch that was about to return `retry_safe=False`.
+            mock_page.evaluate = AsyncMock(side_effect=["focused", True])
+            dismiss = AsyncMock(side_effect=RuntimeError("page closed"))
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with ExitStack() as stack:
+            for entered in patches:
+                stack.enter_context(entered)
+            stack.enter_context(
+                patch.object(extractor, "_message_text_occurrences", occurrences)
+            )
+            stack.enter_context(
+                patch.object(extractor, "_message_text_visible", visible)
+            )
+            stack.enter_context(patch.object(extractor, "_dismiss_message_ui", dismiss))
+            result = await extractor.send_message(
+                "testuser", "First\nSecond", confirm_send=True
+            )
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+
+    async def test_an_error_before_anything_can_submit_is_raised(self, mock_page):
+        """Without a newline nothing has submitted yet, so the error is the answer.
+
+        The pair to the case above. Reporting `send_unconfirmed` here would
+        claim a duplicate-delivery risk that cannot exist and take the real
+        error away from a caller who can simply retry.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock(side_effect=RuntimeError("page closed"))
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(return_value="focused")
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            ExitStack() as stack,
+            pytest.raises(RuntimeError, match="page closed"),
+        ):
+            for entered in patches:
+                stack.enter_context(entered)
+            await extractor.send_message("testuser", "Single line", confirm_send=True)
+
     async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -9123,6 +9123,52 @@ class TestSendMessageComposerInteraction:
             warnings
         )
 
+    @pytest.mark.parametrize(
+        ("message", "warns"),
+        [("Hello\nthere!", True), ("Hello there!", False)],
+        ids=["newline", "single-line"],
+    )
+    async def test_cancellation_while_typing_warns_only_for_a_newline(
+        self, mock_page, caplog, message, warns
+    ):
+        """Typing can submit, so the window has to start before it.
+
+        ``keyboard.type()`` presses one key per character and patchright maps
+        ``"\n"`` onto Enter, which this composer submits on: the send path
+        relies on that very behaviour. A message carrying a newline therefore
+        delivers its first paragraph *while* it is being typed, long before
+        the send call, and typing is slow enough for the tool deadline to land
+        in there — at 15ms per character a 20k-character message runs past
+        180s on its own.
+
+        The single-line case is what makes this a test rather than a blanket
+        warning: nothing can have submitted yet, and a warning that cries
+        duplicate delivery where none is possible is the kind that gets
+        ignored when it is right.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(return_value="focused")
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            ExitStack() as stack,
+            caplog.at_level(
+                logging.WARNING, logger="linkedin_mcp_server.scraping.extractor"
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            for entered in patches:
+                stack.enter_context(entered)
+            await extractor.send_message("testuser", message, confirm_send=True)
+
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        hit = any("retry may deliver the message twice" in w for w in warnings)
+        assert hit is warns, warnings
+
     async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -30,6 +30,8 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _CONTENT_DATE_POSTED_MAP,
+    _MESSAGE_OCCURRENCES_INCREASED_JS,
+    _MESSAGE_OCCURRENCES_JS,
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
@@ -8787,6 +8789,12 @@ class TestSendMessageComposerInteraction:
             patches[9],
             patch.object(
                 extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
                 "_message_text_visible",
                 new_callable=AsyncMock,
                 return_value=True,
@@ -8854,6 +8862,12 @@ class TestSendMessageComposerInteraction:
             patches[9],
             patch.object(
                 extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
                 "_message_text_visible",
                 new_callable=AsyncMock,
                 return_value=True,
@@ -8866,6 +8880,170 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "sent"
         # Enter was pressed as fallback
         mock_keyboard.press.assert_awaited_once_with("Enter")
+
+    async def test_baseline_is_taken_after_typing_and_before_send(self, mock_page):
+        """The occurrence baseline is captured between typing and the click.
+
+        Taken any earlier it would miss what the composer already holds; taken
+        after the click it could already include the delivered message, and
+        the confirmation would compare that copy against itself.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        steps: list[str] = []
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock(
+            side_effect=lambda *args, **kwargs: steps.append("type")
+        )
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+
+        async def evaluate(*args, **kwargs):
+            steps.append("click" if steps else "focus")
+            return True
+
+        async def occurrences(message):
+            steps.append("baseline")
+            return 2
+
+        async def visible(message, *, previous_occurrences):
+            steps.append(f"confirm:{previous_occurrences}")
+            return True
+
+        mock_page.evaluate = AsyncMock(side_effect=evaluate)
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                side_effect=occurrences,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                side_effect=visible,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "sent"
+        # The confirmation receives exactly the baseline taken before the click.
+        assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
+
+    async def test_send_unavailable_when_click_adds_nothing(self, mock_page):
+        """A clicked Send button that changes nothing is not a sent message."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        # evaluate returns: True (focus), True (send button found and clicked)
+        mock_page.evaluate = AsyncMock(side_effect=[True, True])
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as visible,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert result["sent"] is False
+        visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
+
+
+class TestMessageTextOccurrences:
+    """Tests for the occurrence-based send confirmation (issue #866)."""
+
+    async def test_occurrences_run_the_shared_counting_routine(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=3)
+
+        assert await extractor._message_text_occurrences("Hello!") == 3
+
+        mock_page.evaluate.assert_awaited_once_with(
+            _MESSAGE_OCCURRENCES_JS, {"expected": "Hello!"}
+        )
+
+    async def test_missing_count_reads_as_zero(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.evaluate = AsyncMock(return_value=None)
+
+        assert await extractor._message_text_occurrences("Hello!") == 0
+
+    async def test_confirmation_waits_for_more_than_the_baseline(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(return_value=None)
+
+        assert (
+            await extractor._message_text_visible("Hello!", previous_occurrences=2)
+            is True
+        )
+
+        mock_page.wait_for_function.assert_awaited_once_with(
+            _MESSAGE_OCCURRENCES_INCREASED_JS,
+            arg={"expected": "Hello!", "previous": 2},
+        )
+        # Baseline and confirmation run one routine, so they cannot disagree
+        # about what counts as an occurrence.
+        assert _MESSAGE_OCCURRENCES_JS in _MESSAGE_OCCURRENCES_INCREASED_JS
+
+    async def test_confirmation_timeout_is_not_a_send(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PlaywrightTimeoutError("timeout")
+        )
+
+        assert (
+            await extractor._message_text_visible("Hello!", previous_occurrences=0)
+            is False
+        )
+
+    async def test_other_confirmation_errors_do_not_confirm(self, mock_page):
+        """A broken confirmation surfaces as an error, never as a send."""
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.wait_for_function = AsyncMock(
+            side_effect=PatchrightError("execution context destroyed")
+        )
+
+        with pytest.raises(PatchrightError):
+            await extractor._message_text_visible("Hello!", previous_occurrences=0)
 
 
 class TestBuildFeedReferences:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8721,12 +8721,20 @@ class TestSendMessage:
         )
 
     @staticmethod
-    def _patch_to_composer(extractor, mock_page, *, states=None, submission="clicked"):
+    def _patch_to_composer(
+        extractor,
+        mock_page,
+        *,
+        states=None,
+        submission="clicked",
+        write_result="written",
+    ):
         target = TestSendMessage._target()
         mock_page.url = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
         mock_page.keyboard = MagicMock(type=AsyncMock(), press=AsyncMock())
         owner = MagicMock()
         owner.as_element.return_value = owner
+        owner.evaluate = AsyncMock()
         owner.dispose = AsyncMock()
         mock_page.evaluate_handle = AsyncMock(return_value=owner)
 
@@ -8734,9 +8742,14 @@ class TestSendMessage:
         # state that says nothing about it means empty. A case about a draft
         # still standing in the editor says `"empty": False` and gets it.
         def with_empty(state):
-            if isinstance(state, dict) and "empty" not in state:
-                return {**state, "empty": True}
-            return state
+            if not isinstance(state, dict):
+                return state
+            return {
+                "empty": True,
+                "submitCount": 1,
+                "submitUsable": True,
+                **state,
+            }
 
         if callable(states):
             inner = states
@@ -8771,16 +8784,17 @@ class TestSendMessage:
                 side_effect=states or None,
                 return_value={
                     "status": "valid",
-                    "active": True,
+                    "active": False,
                     "empty": True,
-                    "submitCount": 0,
+                    "submitCount": 1,
+                    "submitUsable": True,
                 },
             ),
             patch.object(
                 extractor,
-                "_focus_verified_message_editor",
+                "_write_verified_message",
                 new_callable=AsyncMock,
-                return_value=True,
+                return_value=write_result,
             ),
             patch.object(
                 extractor,
@@ -8805,12 +8819,6 @@ class TestSendMessage:
                 return_value=True,
             ),
         )
-
-    def _patch_send_message_to_compose(self, extractor, mock_page):
-        keyboard = mock_page.keyboard
-        patches = self._patch_to_composer(extractor, mock_page)
-        mock_page.keyboard = keyboard
-        return (*patches[1:7], patches[8])
 
     async def test_dry_run_returns_before_focus_or_text_entry(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
@@ -8962,7 +8970,7 @@ class TestSendMessage:
             )
 
         assert result["status"] == "recipient_resolution_failed"
-        focus.assert_awaited_once()
+        focus.assert_not_awaited()
         submit.assert_not_awaited()
         mock_page.keyboard.type.assert_not_awaited()
 
@@ -8970,32 +8978,36 @@ class TestSendMessage:
         extractor = LinkedInExtractor(mock_page)
         patches = self._patch_to_composer(extractor, mock_page)
 
-        async def change_url_after_typing(_message, *, delay):
-            assert delay == 15
+        async def change_url_during_write(message, *, target, owner):
+            assert message == "Hello!"
+            assert target == self._target()
+            assert owner is mock_page.evaluate_handle.return_value
             mock_page.url = (
                 "https://www.linkedin.com/messaging/compose/"
                 "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AOTHER"
             )
+            return "invalid"
 
-        mock_page.keyboard.type.side_effect = change_url_after_typing
         with (
             patches[1],
             patches[2],
             patches[3],
             patches[4],
             patches[5],
-            patches[6],
+            patches[6] as write,
             patches[7] as submit,
             patches[8],
             patches[9],
             patches[10],
         ):
+            write.side_effect = change_url_during_write
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
         assert result["status"] == "recipient_resolution_failed"
-        mock_page.keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        write.assert_awaited_once()
+        mock_page.keyboard.type.assert_not_awaited()
         submit.assert_not_awaited()
         mock_page.keyboard.press.assert_not_awaited()
 
@@ -9075,8 +9087,8 @@ class TestSendMessage:
             states=[
                 {"status": "valid", "active": False},
                 {"status": "valid", "active": False},
-                {"status": "ambiguous_editor", "active": False},
             ],
+            write_result="invalid",
         )
         with (
             patches[1],
@@ -9133,7 +9145,7 @@ class TestSendMessage:
             patches[3],
             patches[4],
             patches[5],
-            patches[6],
+            patches[6] as write,
             patches[7],
             patches[8],
             patches[9],
@@ -9145,19 +9157,30 @@ class TestSendMessage:
 
         assert result["status"] == "send_unavailable"
         assert result["retry_safe"] is True
-        mock_page.keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        write.assert_awaited_once()
+        mock_page.keyboard.type.assert_not_awaited()
         mock_page.keyboard.press.assert_not_awaited()
 
-    async def test_removed_submit_candidate_cannot_switch_to_enter(self, mock_page):
+    @pytest.mark.parametrize(
+        ("submit_count", "submit_usable"),
+        [(0, False), (2, False), (1, False)],
+        ids=["missing", "ambiguous", "disabled"],
+    )
+    async def test_only_one_active_submit_path_can_send(
+        self, mock_page, submit_count, submit_usable
+    ):
         extractor = LinkedInExtractor(mock_page)
-        states = [
-            {"status": "valid", "active": False, "submitCount": 1},
-            {"status": "valid", "active": False, "submitCount": 1},
-            {"status": "valid", "active": True, "submitCount": 1},
-            {"status": "valid", "active": True, "submitCount": 0},
-        ]
         patches = self._patch_to_composer(
-            extractor, mock_page, states=states, submission="enter"
+            extractor,
+            mock_page,
+            states=[
+                {"status": "valid"},
+                {
+                    "status": "valid",
+                    "submitCount": submit_count,
+                    "submitUsable": submit_usable,
+                },
+            ],
         )
         with (
             patches[1],
@@ -9165,7 +9188,7 @@ class TestSendMessage:
             patches[3],
             patches[4],
             patches[5],
-            patches[6],
+            patches[6] as write,
             patches[7] as submit,
             patches[8],
             patches[9],
@@ -9177,78 +9200,9 @@ class TestSendMessage:
 
         assert result["status"] == "send_unavailable"
         assert result["retry_safe"] is True
-        submit.assert_awaited_once_with(self._target(), allow_enter=False)
+        write.assert_not_awaited()
+        submit.assert_not_awaited()
         mock_page.keyboard.press.assert_not_awaited()
-
-    async def test_enter_revalidates_active_editor_before_press(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        states = [
-            {"status": "valid", "active": False, "submitCount": 0},
-            {"status": "valid", "active": False, "submitCount": 0},
-            {"status": "valid", "active": True, "submitCount": 0},
-            {"status": "valid", "active": False, "submitCount": 0},
-        ]
-        patches = self._patch_to_composer(
-            extractor, mock_page, states=states, submission="enter"
-        )
-        with (
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-            patches[5] as state,
-            patches[6],
-            patches[7],
-            patches[8],
-            patches[9],
-            patches[10],
-        ):
-            result = await extractor.send_message(
-                "testuser", "Hello!", confirm_send=True
-            )
-
-        assert result["status"] == "send_unavailable"
-        assert result["retry_safe"] is True
-        assert state.await_count == 4
-        mock_page.keyboard.press.assert_not_awaited()
-
-    async def test_enter_requires_verified_zero_button_path(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        patches = self._patch_to_composer(extractor, mock_page, submission="enter")
-        mock_page.url = (
-            "https://www.linkedin.com/messaging/compose/"
-            "?recipient=ACoAAB&recipient=ACoAAB&"
-            "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
-        )
-        with (
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-            patches[5],
-            patches[6],
-            patches[7] as submit,
-            patches[8],
-            patch.object(
-                extractor,
-                "_prepare_message_confirmation",
-                new_callable=AsyncMock,
-                return_value=0,
-            ),
-            patch.object(
-                extractor,
-                "_message_send_confirmed",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-        ):
-            result = await extractor.send_message(
-                "testuser", "Hello!", confirm_send=True
-            )
-
-        assert result["status"] == "sent"
-        submit.assert_awaited_once_with(self._target(), allow_enter=True)
-        mock_page.keyboard.press.assert_awaited_once_with("Enter")
 
     async def test_observer_is_prepared_after_typing_and_before_submission(
         self, mock_page
@@ -9257,9 +9211,13 @@ class TestSendMessage:
         extractor = LinkedInExtractor(mock_page)
         steps: list[str] = []
         patches = self._patch_to_composer(extractor, mock_page)
-        mock_page.keyboard.type.side_effect = lambda *args, **kwargs: steps.append(
-            "type"
-        )
+
+        async def write(message, *, target, owner):
+            assert message == "Hello!"
+            assert target == self._target()
+            assert owner is mock_page.evaluate_handle.return_value
+            steps.append("write")
+            return "written"
 
         async def prepare(message, *, target, owner):
             assert message == "Hello!"
@@ -9268,7 +9226,10 @@ class TestSendMessage:
             steps.append("prepare")
             return "confirmation-token"
 
-        async def submit(target, *, allow_enter):
+        async def submit(message, *, target, owner):
+            assert message == "Hello!"
+            assert target == self._target()
+            assert owner is mock_page.evaluate_handle.return_value
             steps.append("submit")
             return "clicked"
 
@@ -9285,7 +9246,12 @@ class TestSendMessage:
             patches[3],
             patches[4],
             patches[5],
-            patches[6],
+            patch.object(
+                extractor,
+                "_write_verified_message",
+                new_callable=AsyncMock,
+                side_effect=write,
+            ),
             patch.object(
                 extractor,
                 "_submit_verified_message",
@@ -9312,55 +9278,31 @@ class TestSendMessage:
 
         assert result["status"] == "sent"
         assert steps == [
-            "type",
+            "write",
             "prepare",
             "submit",
             "confirm:confirmation-token",
         ]
 
-    @pytest.mark.parametrize(
-        "submit_effect",
-        [PatchrightError("execution context was destroyed"), "enter"],
-        ids=["click", "enter"],
-    )
-    async def test_interrupted_submission_is_not_a_failure(
-        self, mock_page, submit_effect
-    ):
-        """A submission that dies mid-call is an unknown, never a tool error.
-
-        Both paths dispatch their input event inside the call that then
-        fails, so the exception says nothing about whether the message left.
-        Letting it out would reach the caller as a plain failure and invite
-        the retry that delivers a second message to a real person.
-        """
+    async def test_interrupted_submission_is_not_a_failure(self, mock_page):
+        """A click round trip can fail after dispatching the local event."""
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock(
-            side_effect=PatchrightError("execution context was destroyed")
-        )
-        mock_page.keyboard = mock_keyboard
-        if isinstance(submit_effect, Exception):
-            mock_page.evaluate = AsyncMock(side_effect=submit_effect)
-        else:
-            mock_page.evaluate = AsyncMock(return_value=submit_effect)
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
         visible = AsyncMock()
 
-        with ExitStack() as stack:
-            for entered in patches:
-                stack.enter_context(entered)
-            stack.enter_context(
-                patch.object(
-                    extractor,
-                    "_prepare_message_confirmation",
-                    new_callable=AsyncMock,
-                    return_value=1,
-                )
-            )
-            stack.enter_context(
-                patch.object(extractor, "_message_send_confirmed", visible)
-            )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7] as submit,
+            patches[8],
+            patches[9],
+            patch.object(extractor, "_message_send_confirmed", visible),
+        ):
+            submit.side_effect = PatchrightError("execution context was destroyed")
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
@@ -9368,8 +9310,6 @@ class TestSendMessage:
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         assert result["retry_safe"] is False
-        # There is no page left to read, so the confirmation is never even
-        # attempted; the answer comes from the interruption itself.
         visible.assert_not_awaited()
 
     @pytest.mark.parametrize(
@@ -9381,41 +9321,32 @@ class TestSendMessage:
     ):
         """Cancellation in the destructive window leaves a warning behind."""
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        if stage == "dispatch":
-            mock_page.evaluate = AsyncMock(side_effect=asyncio.CancelledError())
-            visible_effect = AsyncMock()
-        elif stage == "confirmation":
-            mock_page.evaluate = AsyncMock(return_value="clicked")
-            visible_effect = AsyncMock(side_effect=asyncio.CancelledError())
-        else:
-            mock_page.evaluate = AsyncMock(return_value="clicked")
-            visible_effect = AsyncMock(return_value=True)
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
         if stage == "owner-cleanup":
             mock_page.evaluate_handle.return_value.dispose = AsyncMock(
                 side_effect=asyncio.CancelledError()
             )
 
         with (
-            ExitStack() as stack,
-            patch.object(
-                extractor,
-                "_prepare_message_confirmation",
-                new_callable=AsyncMock,
-                return_value=1,
-            ),
-            patch.object(extractor, "_message_send_confirmed", visible_effect),
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7] as submit,
+            patches[8],
+            patches[9],
+            patches[10] as confirmed,
             caplog.at_level(
                 logging.WARNING, logger="linkedin_mcp_server.scraping.extractor"
             ),
             pytest.raises(asyncio.CancelledError),
         ):
-            for entered in patches:
-                stack.enter_context(entered)
+            if stage == "dispatch":
+                submit.side_effect = asyncio.CancelledError()
+            elif stage == "confirmation":
+                confirmed.side_effect = asyncio.CancelledError()
             await extractor.send_message("testuser", "Hello!", confirm_send=True)
 
         # Cancellation has to keep propagating, or the surrounding scope
@@ -9426,25 +9357,28 @@ class TestSendMessage:
             warnings
         )
 
-    async def test_cancellation_while_typing_does_not_warn(self, mock_page, caplog):
+    async def test_cancellation_while_writing_does_not_warn(self, mock_page, caplog):
         """Validated text cannot submit before the explicit submit path."""
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock(side_effect=asyncio.CancelledError())
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        mock_page.evaluate = AsyncMock(return_value="focused")
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
 
         with (
-            ExitStack() as stack,
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6] as write,
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
             caplog.at_level(
                 logging.WARNING, logger="linkedin_mcp_server.scraping.extractor"
             ),
             pytest.raises(asyncio.CancelledError),
         ):
-            for entered in patches:
-                stack.enter_context(entered)
+            write.side_effect = asyncio.CancelledError()
             await extractor.send_message("testuser", "Hello there!", confirm_send=True)
 
         warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
@@ -9452,24 +9386,21 @@ class TestSendMessage:
 
     async def test_ordinary_error_after_dispatch_still_answers(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        mock_page.evaluate = AsyncMock(return_value="clicked")
-        prepare = AsyncMock(return_value="confirmation-token")
-        confirmed = AsyncMock(side_effect=RuntimeError("context destroyed"))
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
 
-        with ExitStack() as stack:
-            for entered in patches:
-                stack.enter_context(entered)
-            stack.enter_context(
-                patch.object(extractor, "_prepare_message_confirmation", prepare)
-            )
-            stack.enter_context(
-                patch.object(extractor, "_message_send_confirmed", confirmed)
-            )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10] as confirmed,
+        ):
+            confirmed.side_effect = RuntimeError("context destroyed")
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
@@ -9486,19 +9417,22 @@ class TestSendMessage:
         error away from a caller who can simply retry.
         """
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock(side_effect=RuntimeError("page closed"))
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        mock_page.evaluate = AsyncMock(return_value="focused")
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
 
         with (
-            ExitStack() as stack,
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6] as write,
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
             pytest.raises(RuntimeError, match="page closed"),
         ):
-            for entered in patches:
-                stack.enter_context(entered)
+            write.side_effect = RuntimeError("page closed")
             await extractor.send_message("testuser", "Single line", confirm_send=True)
 
     async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -31,6 +31,7 @@ from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     LinkedInExtractor,
     _CONTENT_DATE_POSTED_MAP,
+    _MESSAGE_COMPOSER_OWNER_JS,
     _MESSAGE_OCCURRENCES_INCREASED_JS,
     _MESSAGE_OCCURRENCES_JS,
     _RATE_LIMITED_MSG,
@@ -7624,35 +7625,186 @@ class TestGetSidebarProfiles:
         }
 
 
+class TestMessageTargetUrls:
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+                "ACoAAB",
+            ),
+            (
+                "https://de.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB",
+                "ACoAAB",
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=ACoAAB",
+                "ACoAAB",
+            ),
+            ("http://www.linkedin.com/messaging/compose/?recipient=ACoAAB", None),
+            ("https://evil.example/messaging/compose/?recipient=ACoAAB", None),
+            ("//evil.example/messaging/compose/?recipient=ACoAAB", None),
+            ("https://user@www.linkedin.com/messaging/compose/?recipient=ACoAAB", None),
+            ("https://www.linkedin.com:444/messaging/compose/?recipient=ACoAAB", None),
+            ("https://www.linkedin.com/jobs/?recipient=ACoAAB", None),
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB#draft",
+                None,
+            ),
+            ("https://www.linkedin.com/messaging/compose/?recipient=ACoAAB\n", None),
+            ("https://www.linkedin.com/messaging/compose/?recipient=", None),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=OTHER",
+                None,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AOTHER",
+                None,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/?profileUrn=malformed%3Aurn",
+                None,
+            ),
+        ],
+    )
+    def test_compose_url_requires_one_linkedin_recipient(self, url, expected):
+        assert extractor_module._profile_urn_from_compose_url(url) == expected
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://www.linkedin.com/in/testuser/", "/in/testuser/"),
+            ("https://de.linkedin.com/in/testuser/", "/in/testuser/"),
+            ("http://www.linkedin.com/in/testuser/", None),
+            ("https://evil.example/in/testuser/", None),
+            ("https://user@www.linkedin.com/in/testuser/", None),
+            ("https://www.linkedin.com:444/in/testuser/", None),
+            ("https://www.linkedin.com/in/testuser/edit/intro/", None),
+            ("https://www.linkedin.com/in/testuser%2Fedit/", None),
+            ("https://www.linkedin.com/in/testuser/?trk=profile", None),
+            ("https://www.linkedin.com/in/testuser/#details", None),
+        ],
+    )
+    def test_profile_url_requires_exact_linkedin_profile(self, url, expected):
+        assert extractor_module._profile_path_from_url(url) == expected
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://www.linkedin.com/messaging/compose/", True),
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+                True,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=ACoAAB&"
+                "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB",
+                True,
+            ),
+            ("https://de.linkedin.com/messaging/thread/2-abc/", True),
+            (
+                "https://www.linkedin.com/messaging/thread/2-abc/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB",
+                True,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/?recipient=OTHER",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=OTHER",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/compose/?profileUrn=",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/thread/2-abc/"
+                "?recipient=ACoAAB&recipient=OTHER",
+                False,
+            ),
+            (
+                "https://www.linkedin.com/messaging/thread/2-abc/?profileUrn=",
+                False,
+            ),
+            ("http://www.linkedin.com/messaging/compose/", False),
+            ("https://evil.example/messaging/compose/", False),
+            ("https://user@www.linkedin.com/messaging/thread/2-abc/", False),
+            ("https://www.linkedin.com:444/messaging/compose/", False),
+            ("https://www.linkedin.com/messaging/compose/#draft", False),
+            ("https://www.linkedin.com/messaging/thread/2-abc%2Fother/", False),
+            # Measured live: LinkedIn redirects an existing conversation to a
+            # padded base64url id, and the padding reaches the path unescaped.
+            (
+                "https://www.linkedin.com/messaging/thread/"
+                "2-ZDBkMjZiY2UtNjQwYi00NzczLWIxYWYtNTczZTZhZDkzMzQ4XzEwMA==/",
+                True,
+            ),
+            ("https://www.linkedin.com/feed/", False),
+        ],
+    )
+    def test_final_url_requires_safe_messaging_path(self, url, expected):
+        assert extractor_module._message_page_url_is_safe(url, "ACoAAB") is expected
+
+
 class TestExtractProfileUrn:
-    async def test_returns_urn_from_compose_href(self, mock_page):
-        """Extracts the recipient URN from the messaging compose link."""
+    async def test_returns_urn_from_atomic_top_card_snapshot(self, mock_page):
         mock_page.evaluate = AsyncMock(
-            return_value="/messaging/compose/?recipient=ACoAAB1IelEBLEkqTkNbZ-a1D8mq5R-6C1ihSEk&lipi=urn..."
+            return_value={
+                "pageUrl": "https://www.linkedin.com/in/testuser/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB&"
+                    "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+                ],
+            }
         )
 
-        extractor = LinkedInExtractor(mock_page)
-        result = await extractor._extract_profile_urn()
+        result = await LinkedInExtractor(mock_page)._extract_profile_urn()
 
-        assert result == "ACoAAB1IelEBLEkqTkNbZ-a1D8mq5R-6C1ihSEk"
-
-    async def test_returns_none_when_no_compose_button(self, mock_page):
-        """Returns None when no messaging compose link is found."""
-        mock_page.evaluate = AsyncMock(return_value=None)
-
-        extractor = LinkedInExtractor(mock_page)
-        result = await extractor._extract_profile_urn()
-
-        assert result is None
-
-    async def test_returns_none_when_no_recipient_param(self, mock_page):
-        """Returns None when the compose href has no recipient query param."""
-        mock_page.evaluate = AsyncMock(
-            return_value="/messaging/compose/?someOtherParam=value"
+        assert result == "ACoAAB"
+        mock_page.evaluate.assert_awaited_once_with(
+            extractor_module._PROFILE_MESSAGE_TARGET_JS
         )
 
-        extractor = LinkedInExtractor(mock_page)
-        result = await extractor._extract_profile_urn()
+    async def test_accepts_safe_final_vanity_redirect(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "pageUrl": "https://www.linkedin.com/in/canonical-user/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB&"
+                    "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+                ],
+            }
+        )
+
+        target = await LinkedInExtractor(mock_page)._read_profile_message_target()
+
+        assert target is not None
+        assert target.profile_path == "/in/canonical-user/"
+        assert target.profile_urn == "ACoAAB"
+
+    async def test_returns_none_for_ambiguous_top_card_links(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "pageUrl": "https://www.linkedin.com/in/testuser/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB",
+                    "/messaging/compose/?recipient=OTHER",
+                ],
+            }
+        )
+
+        result = await LinkedInExtractor(mock_page)._extract_profile_urn()
 
         assert result is None
 
@@ -8468,10 +8620,45 @@ class TestSendMessage:
         keyboard.type.assert_not_called()
         keyboard.press.assert_not_called()
 
-    async def test_dry_run_returns_confirmation_required(self, mock_page):
-        """send_message with confirm_send=False returns confirmation_required status."""
-        extractor = LinkedInExtractor(mock_page)
-        with (
+    @staticmethod
+    def _target():
+        return extractor_module._ProfileMessageTarget(
+            profile_path="/in/testuser/",
+            profile_urn="ACoAAB",
+            compose_url=(
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+            ),
+            display_name="Test User",
+        )
+
+    @staticmethod
+    def _patch_to_composer(extractor, mock_page, *, states=None, submission="clicked"):
+        target = TestSendMessage._target()
+        mock_page.url = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
+        mock_page.keyboard = MagicMock(type=AsyncMock(), press=AsyncMock())
+        owner = MagicMock()
+        owner.as_element.return_value = owner
+        owner.dispose = AsyncMock()
+        mock_page.evaluate_handle = AsyncMock(return_value=owner)
+
+        # An empty composer is the ordinary precondition for sending, so a
+        # state that says nothing about it means empty. A case about a draft
+        # still standing in the editor says `"empty": False` and gets it.
+        def with_empty(state):
+            if isinstance(state, dict) and "empty" not in state:
+                return {**state, "empty": True}
+            return state
+
+        if callable(states):
+            inner = states
+
+            async def states(*args, **kwargs):
+                return with_empty(await inner(*args, **kwargs))
+        elif states is not None:
+            states = [with_empty(state) for state in states]
+        return (
+            target,
             patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
@@ -8483,15 +8670,9 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_read_profile_display_name",
+                "_read_profile_message_target",
                 new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
+                return_value=target,
             ),
             patch.object(
                 extractor,
@@ -8501,34 +8682,86 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_resolve_message_compose_box",
+                "_read_message_composer_state",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                side_effect=states or None,
+                return_value={
+                    "status": "valid",
+                    "active": True,
+                    "empty": True,
+                    "submitCount": 0,
+                },
             ),
             patch.object(
                 extractor,
-                "_compose_page_matches_recipient",
+                "_focus_verified_message_editor",
                 new_callable=AsyncMock,
                 return_value=True,
             ),
             patch.object(
                 extractor,
-                "_dismiss_message_ui",
+                "_submit_verified_message",
+                new_callable=AsyncMock,
+                return_value=submission,
+            ),
+            patch.object(extractor, "_dismiss_message_ui", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        )
+
+    def _patch_send_message_to_compose(self, extractor, mock_page):
+        keyboard = mock_page.keyboard
+        patches = self._patch_to_composer(extractor, mock_page)
+        mock_page.keyboard = keyboard
+        return (*patches[1:8], *patches[9:11])
+
+    async def test_dry_run_returns_before_focus_or_text_entry(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9] as dismiss,
+            patches[10],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=False
             )
 
         assert result["status"] == "confirmation_required"
-        assert result["sent"] is False
+        assert result["recipient_selected"] is True
+        dismiss.assert_not_awaited()
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_message_unavailable_when_no_compose_href(self, mock_page):
-        """send_message returns message_unavailable when no compose URL found."""
+    async def test_rejects_supplied_urn_before_compose_navigation(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
+        target = self._target()
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(
+                extractor, "_navigate_to_page", new_callable=AsyncMock
+            ) as navigate,
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
@@ -8539,277 +8772,143 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_read_profile_display_name",
+                "_read_profile_message_target",
                 new_callable=AsyncMock,
-                return_value="Test User",
+                return_value=target,
             ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
+        ):
+            result = await extractor.send_message(
+                "testuser",
+                "Hello!",
+                confirm_send=True,
+                profile_urn="OTHER",
+            )
+
+        assert result["status"] == "recipient_resolution_failed"
+        navigate.assert_awaited_once_with("https://www.linkedin.com/in/testuser/")
+
+    async def test_rejects_foreign_url_recipient_after_navigation(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        mock_page.url = "https://www.linkedin.com/messaging/compose/?recipient=OTHER"
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5] as surface,
+            patches[6] as state,
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
-        assert result["status"] == "message_unavailable"
-        assert result["sent"] is False
+        assert result["status"] == "recipient_resolution_failed"
+        surface.assert_not_awaited()
+        state.assert_not_awaited()
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_uses_profile_urn_when_provided(self, mock_page):
-        """send_message builds compose URL from profile_urn without Message-button lookup."""
+    async def test_rejects_contradictory_url_before_focus(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
+
+        async def change_url_after_initial_state(_target):
+            mock_page.url = (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&recipient=OTHER"
+            )
+            return {"status": "valid", "active": False}
+
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=change_url_after_initial_state,
+        )
         with (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-            ),
-            patch.object(
-                extractor,
-                "_read_profile_display_name",
-                new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value=None,
-            ) as mock_resolve_href,
-            patch.object(
-                extractor,
-                "_wait_for_message_surface",
-                new_callable=AsyncMock,
-                return_value="composer",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_box",
-                new_callable=AsyncMock,
-                return_value=MagicMock(),
-            ),
-            patch.object(
-                extractor,
-                "_compose_page_matches_recipient",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch.object(
-                extractor,
-                "_dismiss_message_ui",
-                new_callable=AsyncMock,
-            ),
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6] as state,
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
-                "testuser",
-                "Hello!",
-                confirm_send=False,
-                profile_urn="ACoAAB1IelEB",
+                "testuser", "Hello!", confirm_send=True
             )
 
-        # _resolve_message_compose_href should NOT be called when profile_urn given
-        mock_resolve_href.assert_not_awaited()
-        assert result["status"] == "confirmation_required"
+        assert result["status"] == "recipient_resolution_failed"
+        state.assert_awaited_once()
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_profile_urn_compose_url_includes_full_params(self, mock_page):
-        """send_message with profile_urn builds URL with profileUrn, screenContext, interop."""
+    async def test_rejects_foreign_url_recipient_before_text_entry(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        navigate_calls = []
+        state_calls = 0
 
-        async def capture_navigate(url):
-            navigate_calls.append(url)
+        async def change_url_during_prefocus_state(_target):
+            nonlocal state_calls
+            state_calls += 1
+            if state_calls == 2:
+                mock_page.url = (
+                    "https://www.linkedin.com/messaging/compose/?recipient=OTHER"
+                )
+            return {"status": "valid", "active": state_calls > 1}
 
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=change_url_during_prefocus_state,
+        )
         with (
-            patch.object(
-                extractor,
-                "_navigate_to_page",
-                new_callable=AsyncMock,
-                side_effect=capture_navigate,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-            ),
-            patch.object(
-                extractor,
-                "_read_profile_display_name",
-                new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_wait_for_message_surface",
-                new_callable=AsyncMock,
-                return_value="composer",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_box",
-                new_callable=AsyncMock,
-                return_value=MagicMock(),
-            ),
-            patch.object(
-                extractor,
-                "_compose_page_matches_recipient",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch.object(
-                extractor,
-                "_dismiss_message_ui",
-                new_callable=AsyncMock,
-            ),
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
-            await extractor.send_message(
-                "testuser",
-                "Hello!",
-                confirm_send=False,
-                profile_urn="ACoAAB1IelEB",
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
             )
 
-        # Second navigate call is the compose URL (first is the profile page)
-        compose_url = navigate_calls[1]
-        assert "profileUrn=" in compose_url
-        assert "urn%3Ali%3Afsd_profile%3AACoAAB1IelEB" in compose_url
-        assert "recipient=ACoAAB1IelEB" in compose_url
-        assert "screenContext=NON_SELF_PROFILE_VIEW" in compose_url
-        assert "interop=msgOverlay" in compose_url
+        assert result["status"] == "recipient_resolution_failed"
+        focus.assert_awaited_once()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-
-class TestResolveMessageComposeBox:
-    async def test_returns_locator_when_count_positive(self, mock_page):
-        """_resolve_message_compose_box returns locator.last when count() > 0."""
+    async def test_rejects_contradictory_url_before_submission(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_locator = MagicMock()
-        mock_locator.count = AsyncMock(return_value=1)
-        sentinel = MagicMock(name="last_locator")
-        sentinel.wait_for = AsyncMock()
-        mock_locator.last = sentinel
-        mock_locator.wait_for = AsyncMock()
-        mock_page.locator = MagicMock(return_value=mock_locator)
+        patches = self._patch_to_composer(extractor, mock_page)
 
-        result = await extractor._resolve_message_compose_box()
+        async def change_url_after_typing(_message, *, delay):
+            assert delay == 15
+            mock_page.url = (
+                "https://www.linkedin.com/messaging/compose/"
+                "?recipient=ACoAAB&profileUrn=urn%3Ali%3Afsd_profile%3AOTHER"
+            )
 
-        assert result is sentinel
-        # wait_for should NOT be called on the early-return path
-        sentinel.wait_for.assert_not_called()
-        mock_locator.wait_for.assert_not_called()
-
-    async def test_returns_none_when_all_selectors_miss(self, mock_page):
-        """_resolve_message_compose_box returns None when no selector matches."""
-        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
-
-        extractor = LinkedInExtractor(mock_page)
-        mock_locator = MagicMock()
-        mock_locator.count = AsyncMock(return_value=0)
-        mock_locator.last = MagicMock()
-        mock_locator.last.wait_for = AsyncMock(
-            side_effect=PlaywrightTimeoutError("timeout")
-        )
-        mock_page.locator = MagicMock(return_value=mock_locator)
-
-        result = await extractor._resolve_message_compose_box()
-
-        assert result is None
-
-    async def test_falls_through_when_count_raises(self, mock_page):
-        """_resolve_message_compose_box handles count() exceptions gracefully."""
-        from patchright.async_api import TimeoutError as PlaywrightTimeoutError
-
-        extractor = LinkedInExtractor(mock_page)
-        mock_locator = MagicMock()
-        mock_locator.count = AsyncMock(side_effect=Exception("detached"))
-        mock_locator.last = MagicMock()
-        mock_locator.last.wait_for = AsyncMock(
-            side_effect=PlaywrightTimeoutError("timeout")
-        )
-        mock_page.locator = MagicMock(return_value=mock_locator)
-
-        result = await extractor._resolve_message_compose_box()
-
-        assert result is None
-
-
-class TestSendMessageComposerInteraction:
-    """Tests for the page.evaluate + keyboard.type send path (patchright workaround)."""
-
-    def _patch_send_message_to_compose(self, extractor, mock_page):
-        """Return a context manager that patches send_message up to the compose step."""
-        return (
-            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-            ),
-            patch.object(
-                extractor,
-                "_read_profile_display_name",
-                new_callable=AsyncMock,
-                return_value="Test User",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_href",
-                new_callable=AsyncMock,
-                return_value="https://www.linkedin.com/messaging/compose/?recipient=ACoAAB",
-            ),
-            patch.object(
-                extractor,
-                "_wait_for_message_surface",
-                new_callable=AsyncMock,
-                return_value="composer",
-            ),
-            patch.object(
-                extractor,
-                "_resolve_message_compose_box",
-                new_callable=AsyncMock,
-                return_value=MagicMock(),
-            ),
-            patch.object(
-                extractor,
-                "_compose_page_matches_recipient",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
-            patch.object(
-                extractor,
-                "_dismiss_message_ui",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        )
-
-    async def test_focus_and_type_via_evaluate_and_keyboard(self, mock_page):
-        """send_message uses page.evaluate to focus and page.keyboard.type to type."""
-        extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns: 'focused' (empty composer, focused), then
-        # True (send button click)
-        mock_page.evaluate = AsyncMock(side_effect=["focused", True])
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        mock_page.keyboard.type.side_effect = change_url_after_typing
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8817,72 +8916,106 @@ class TestSendMessageComposerInteraction:
             patches[5],
             patches[6],
             patches[7],
-            patches[8],
+            patches[8] as submit,
             patches[9],
-            patch.object(
-                extractor,
-                "_message_text_occurrences",
-                new_callable=AsyncMock,
-                return_value=0,
-            ),
-            patch.object(
-                extractor,
-                "_message_text_visible",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
-        assert result["status"] == "sent"
-        assert result["sent"] is True
-        # Verify keyboard.type was used (not press_sequentially)
-        mock_keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        assert result["status"] == "recipient_resolution_failed"
+        mock_page.keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        submit.assert_not_awaited()
+        mock_page.keyboard.press.assert_not_awaited()
 
-    async def test_compose_interact_failed_when_focus_fails(self, mock_page):
-        """send_message returns compose_interact_failed when JS focus fails."""
+    async def test_refuses_a_composer_that_already_holds_a_draft(self, mock_page):
+        """A draft in the editor is not ours to send, and not ours to clear."""
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns 'missing' (no composer to focus)
-        mock_page.evaluate = AsyncMock(return_value="missing")
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            # The recipient check first, then the read taken immediately
+            # before focus: that one still finds the author's draft.
+            states=[
+                {"status": "valid", "active": False},
+                {"status": "valid", "active": False, "empty": False},
+            ],
+        )
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
+            patches[7] as focus,
+            patches[8] as submit,
+            patches[9] as dismiss,
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "composer_occupied"
+        assert result["sent"] is False
+        dismiss.assert_not_awaited()
+        # Nothing is typed, nothing is submitted, and the draft is left where
+        # its author put it.
+        focus.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_rejects_recipient_change_before_focus(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=[
+                {"status": "valid", "active": False},
+                {"status": "recipient_mismatch", "active": False},
+            ],
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7] as focus,
             patches[8],
             patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
         assert result["status"] == "compose_interact_failed"
-        assert result["sent"] is False
+        focus.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
 
-    async def test_enter_fallback_when_send_button_not_found(self, mock_page):
-        """send_message falls back to Enter key when JS cannot find send button."""
+    async def test_rejects_editor_change_before_text_entry(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns: 'focused', then False (no send button found)
-        mock_page.evaluate = AsyncMock(side_effect=["focused", False])
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        patches = self._patch_to_composer(
+            extractor,
+            mock_page,
+            states=[
+                {"status": "valid", "active": False},
+                {"status": "valid", "active": False},
+                {"status": "ambiguous_editor", "active": False},
+            ],
+        )
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8892,6 +9025,164 @@ class TestSendMessageComposerInteraction:
             patches[7],
             patches[8],
             patches[9],
+            patches[10],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "compose_interact_failed"
+        mock_page.keyboard.type.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        ("message", "status", "retry_safe"),
+        [
+            ("Hello!", "recipient_resolution_failed", True),
+            ("First\nSecond", "send_unconfirmed", False),
+        ],
+        ids=["before-dispatch", "newline-may-have-submitted"],
+    )
+    async def test_missing_owner_preserves_retry_policy(
+        self, mock_page, message, status, retry_safe
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        owner = mock_page.evaluate_handle.return_value
+        owner.as_element.return_value = None
+        with ExitStack() as stack:
+            entered = [stack.enter_context(item) for item in patches[1:]]
+            result = await extractor.send_message(
+                "testuser", message, confirm_send=True
+            )
+
+        assert result["status"] == status
+        assert result["sent"] is False
+        assert result["retry_safe"] is retry_safe
+        entered[7].assert_not_awaited()
+        owner.dispose.assert_awaited_once_with()
+
+    async def test_rejects_ambiguous_submit_after_text_entry(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page, submission="invalid")
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        mock_page.keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_removed_submit_candidate_cannot_switch_to_enter(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        states = [
+            {"status": "valid", "active": False, "submitCount": 1},
+            {"status": "valid", "active": False, "submitCount": 1},
+            {"status": "valid", "active": True, "submitCount": 1},
+            {"status": "valid", "active": True, "submitCount": 0},
+        ]
+        patches = self._patch_to_composer(
+            extractor, mock_page, states=states, submission="enter"
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8] as submit,
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        submit.assert_awaited_once_with(self._target(), allow_enter=False)
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_enter_revalidates_active_editor_before_press(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        states = [
+            {"status": "valid", "active": False, "submitCount": 0},
+            {"status": "valid", "active": False, "submitCount": 0},
+            {"status": "valid", "active": True, "submitCount": 0},
+            {"status": "valid", "active": False, "submitCount": 0},
+        ]
+        patches = self._patch_to_composer(
+            extractor, mock_page, states=states, submission="enter"
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6] as state,
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patches[11],
+            patches[12],
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert state.await_count == 4
+        mock_page.keyboard.press.assert_not_awaited()
+
+    async def test_enter_requires_verified_zero_button_path(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page, submission="enter")
+        mock_page.url = (
+            "https://www.linkedin.com/messaging/compose/"
+            "?recipient=ACoAAB&recipient=ACoAAB&"
+            "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+        )
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8] as submit,
+            patches[9],
+            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -8910,45 +9201,42 @@ class TestSendMessageComposerInteraction:
             )
 
         assert result["status"] == "sent"
-        # Enter was pressed as fallback
-        mock_keyboard.press.assert_awaited_once_with("Enter")
+        submit.assert_awaited_once_with(self._target(), allow_enter=True)
+        mock_page.keyboard.press.assert_awaited_once_with("Enter")
 
-    async def test_baseline_is_taken_after_typing_and_before_send(self, mock_page):
-        """The occurrence baseline is captured between typing and the click.
+    async def test_baseline_is_taken_after_typing_and_before_submission(
+        self, mock_page
+    ):
+        """The occurrence baseline is captured between typing and submission.
 
-        Taken any earlier it would miss what the composer already holds; taken
-        after the click it could already include the delivered message, and
-        the confirmation would compare that copy against itself.
+        Taken any earlier it would miss what the verified composer already
+        holds; taken after submission it could already include the delivered
+        message, and the confirmation would compare that copy against itself.
         """
         extractor = LinkedInExtractor(mock_page)
         steps: list[str] = []
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock(
-            side_effect=lambda *args, **kwargs: steps.append("type")
+        patches = self._patch_to_composer(extractor, mock_page)
+        mock_page.keyboard.type.side_effect = lambda *args, **kwargs: steps.append(
+            "type"
         )
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
 
-        async def evaluate(*args, **kwargs):
-            focusing = not steps
-            steps.append("focus" if focusing else "click")
-            # The focus call reports the composer state; the click reports
-            # whether a send button was found.
-            return "focused" if focusing else True
-
-        async def occurrences(message):
+        async def occurrences(message, *, target, owner):
+            assert target == self._target()
+            assert owner is mock_page.evaluate_handle.return_value
             steps.append("baseline")
             return 2
 
-        async def visible(message, *, previous_occurrences):
+        async def submit(target, *, allow_enter):
+            steps.append("submit")
+            return "clicked"
+
+        async def visible(message, *, target, owner, previous_occurrences):
+            assert target == self._target()
+            assert owner is mock_page.evaluate_handle.return_value
             steps.append(f"confirm:{previous_occurrences}")
             return True
 
-        mock_page.evaluate = AsyncMock(side_effect=evaluate)
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -8956,8 +9244,14 @@ class TestSendMessageComposerInteraction:
             patches[5],
             patches[6],
             patches[7],
-            patches[8],
+            patch.object(
+                extractor,
+                "_submit_verified_message",
+                new_callable=AsyncMock,
+                side_effect=submit,
+            ),
             patches[9],
+            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -8976,19 +9270,16 @@ class TestSendMessageComposerInteraction:
             )
 
         assert result["status"] == "sent"
-        # The confirmation receives exactly the baseline taken before the click.
-        assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
+        # The confirmation receives exactly the baseline taken before submission.
+        assert steps == ["type", "baseline", "submit", "confirm:2"]
 
     @pytest.mark.parametrize(
-        "side_effect",
-        [
-            ["focused", PatchrightError("execution context was destroyed")],
-            ["focused", False],
-        ],
+        "submit_effect",
+        [PatchrightError("execution context was destroyed"), "enter"],
         ids=["click", "enter"],
     )
     async def test_interrupted_submission_is_not_a_failure(
-        self, mock_page, side_effect
+        self, mock_page, submit_effect
     ):
         """A submission that dies mid-call is an unknown, never a tool error.
 
@@ -9004,32 +9295,27 @@ class TestSendMessageComposerInteraction:
             side_effect=PatchrightError("execution context was destroyed")
         )
         mock_page.keyboard = mock_keyboard
-        mock_page.evaluate = AsyncMock(side_effect=side_effect)
+        if isinstance(submit_effect, Exception):
+            mock_page.evaluate = AsyncMock(side_effect=submit_effect)
+        else:
+            mock_page.evaluate = AsyncMock(return_value=submit_effect)
         patches = self._patch_send_message_to_compose(extractor, mock_page)
+        visible = AsyncMock()
 
-        with (
-            patches[0],
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-            patches[5],
-            patches[6],
-            patches[7],
-            patches[8],
-            patches[9],
-            patch.object(
-                extractor,
-                "_message_text_occurrences",
-                new_callable=AsyncMock,
-                return_value=1,
-            ),
-            patch.object(
-                extractor,
-                "_message_text_visible",
-                new_callable=AsyncMock,
-            ) as visible,
-        ):
+        with ExitStack() as stack:
+            for entered in patches:
+                stack.enter_context(entered)
+            stack.enter_context(
+                patch.object(
+                    extractor,
+                    "_message_text_occurrences",
+                    new_callable=AsyncMock,
+                    return_value=1,
+                )
+            )
+            stack.enter_context(
+                patch.object(extractor, "_message_text_visible", visible)
+            )
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
@@ -9042,7 +9328,14 @@ class TestSendMessageComposerInteraction:
         visible.assert_not_awaited()
 
     @pytest.mark.parametrize(
-        "stage", ["dispatch", "confirmation", "failed-cleanup", "unconfirmed-cleanup"]
+        "stage",
+        [
+            "dispatch",
+            "confirmation",
+            "failed-cleanup",
+            "unconfirmed-cleanup",
+            "owner-cleanup",
+        ],
     )
     async def test_cancellation_after_dispatch_is_logged(
         self, mock_page, caplog, stage
@@ -9068,29 +9361,34 @@ class TestSendMessageComposerInteraction:
         mock_page.keyboard = mock_keyboard
         dismiss_effect = None
         if stage == "dispatch":
-            mock_page.evaluate = AsyncMock(
-                side_effect=["focused", asyncio.CancelledError()]
-            )
+            mock_page.evaluate = AsyncMock(side_effect=asyncio.CancelledError())
             visible_effect = AsyncMock()
         elif stage == "confirmation":
-            mock_page.evaluate = AsyncMock(side_effect=["focused", True])
+            mock_page.evaluate = AsyncMock(return_value="clicked")
             visible_effect = AsyncMock(side_effect=asyncio.CancelledError())
         elif stage == "failed-cleanup":
             # The submission raised an ordinary error after dispatching its
             # input event, so the handler runs and is cancelled inside it.
             mock_page.evaluate = AsyncMock(
-                side_effect=["focused", RuntimeError("context destroyed")]
+                side_effect=RuntimeError("context destroyed")
             )
             visible_effect = AsyncMock()
             dismiss_effect = AsyncMock(side_effect=asyncio.CancelledError())
+        elif stage == "owner-cleanup":
+            mock_page.evaluate = AsyncMock(return_value="clicked")
+            visible_effect = AsyncMock(return_value=True)
         else:
             # The send went out and delivery was not observed, which is the
             # path that most needs the warning: the result it was about to
             # return is the one carrying `retry_safe=False`.
-            mock_page.evaluate = AsyncMock(side_effect=["focused", True])
+            mock_page.evaluate = AsyncMock(return_value="clicked")
             visible_effect = AsyncMock(return_value=False)
             dismiss_effect = AsyncMock(side_effect=asyncio.CancelledError())
         patches = self._patch_send_message_to_compose(extractor, mock_page)
+        if stage == "owner-cleanup":
+            mock_page.evaluate_handle.return_value.dispose = AsyncMock(
+                side_effect=asyncio.CancelledError()
+            )
         if dismiss_effect is not None:
             patches = [
                 *patches,
@@ -9205,7 +9503,7 @@ class TestSendMessageComposerInteraction:
         else:
             # The send went out unconfirmed and cleanup then failed, which is
             # the branch that was about to return `retry_safe=False`.
-            mock_page.evaluate = AsyncMock(side_effect=["focused", True])
+            mock_page.evaluate = AsyncMock(return_value="clicked")
             dismiss = AsyncMock(side_effect=RuntimeError("page closed"))
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
@@ -9253,16 +9551,8 @@ class TestSendMessageComposerInteraction:
     async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)
-        mock_keyboard = MagicMock()
-        mock_keyboard.type = AsyncMock()
-        mock_keyboard.press = AsyncMock()
-        mock_page.keyboard = mock_keyboard
-        # evaluate returns: 'focused', then True (send button found and clicked)
-        mock_page.evaluate = AsyncMock(side_effect=["focused", True])
-        patches = self._patch_send_message_to_compose(extractor, mock_page)
-
+        patches = self._patch_to_composer(extractor, mock_page)
         with (
-            patches[0],
             patches[1],
             patches[2],
             patches[3],
@@ -9272,6 +9562,7 @@ class TestSendMessageComposerInteraction:
             patches[7],
             patches[8],
             patches[9],
+            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -9295,70 +9586,165 @@ class TestSendMessageComposerInteraction:
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         assert result["retry_safe"] is False
-        visible.assert_awaited_once_with("Hello!", previous_occurrences=1)
+        visible.assert_awaited_once_with(
+            "Hello!",
+            target=self._target(),
+            owner=mock_page.evaluate_handle.return_value,
+            previous_occurrences=1,
+        )
+
+
+class TestResolveMessageComposeBox:
+    async def test_requires_exactly_one_visible_editor(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        locator = MagicMock(count=AsyncMock(return_value=2))
+        locator.first = MagicMock()
+        mock_page.locator.return_value = locator
+
+        assert await extractor._resolve_message_compose_box() is None
+
+        mock_page.locator.assert_called_once_with(
+            f"{extractor_module._MESSAGING_COMPOSE_SELECTOR}:visible"
+        )
 
 
 class TestMessageTextOccurrences:
-    """Tests for the occurrence-based send confirmation (issue #866)."""
+    """Tests for the owner-scoped send confirmation."""
 
-    async def test_occurrences_run_the_shared_counting_routine(self, mock_page):
+    @staticmethod
+    def _arguments():
+        target = TestSendMessage._target()
+        owner = MagicMock()
+        return target, owner
+
+    async def test_owner_handle_uses_the_shared_recipient_inspection(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_page.evaluate = AsyncMock(return_value=3)
+        target, owner = self._arguments()
+        owner.as_element.return_value = owner
+        mock_page.evaluate_handle = AsyncMock(return_value=owner)
 
-        assert await extractor._message_text_occurrences("Hello!") == 3
+        assert await extractor._resolve_message_owner(target) is owner
 
-        mock_page.evaluate.assert_awaited_once_with(
-            _MESSAGE_OCCURRENCES_JS, {"expected": "Hello!"}
+        mock_page.evaluate_handle.assert_awaited_once_with(
+            _MESSAGE_COMPOSER_OWNER_JS,
+            arg={"profilePath": target.profile_path, "profileUrn": target.profile_urn},
         )
 
-    async def test_missing_count_reads_as_zero(self, mock_page):
+    async def test_invalid_owner_handle_is_released(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
-        mock_page.evaluate = AsyncMock(return_value=None)
+        target, owner = self._arguments()
+        owner.as_element.return_value = None
+        owner.dispose = AsyncMock()
+        mock_page.evaluate_handle = AsyncMock(return_value=owner)
 
-        assert await extractor._message_text_occurrences("Hello!") == 0
+        assert await extractor._resolve_message_owner(target) is None
+        owner.dispose.assert_awaited_once_with()
+
+    async def test_owner_disposal_error_is_suppressed(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        owner = MagicMock(dispose=AsyncMock(side_effect=RuntimeError("closed")))
+
+        await extractor._dispose_message_owner(owner)
+
+        owner.dispose.assert_awaited_once_with()
+
+    async def test_occurrences_run_inside_the_target_owner(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        target, owner = self._arguments()
+        mock_page.evaluate = AsyncMock(return_value={"status": "valid", "count": 3})
+
+        assert (
+            await extractor._message_text_occurrences(
+                "Hello!", target=target, owner=owner
+            )
+            == 3
+        )
+
+        mock_page.evaluate.assert_awaited_once_with(
+            _MESSAGE_OCCURRENCES_JS,
+            {
+                "profilePath": target.profile_path,
+                "profileUrn": target.profile_urn,
+                "expected": "Hello!",
+                "owner": owner,
+            },
+        )
+
+    @pytest.mark.parametrize(
+        "result",
+        [None, {"status": "invalid"}, {"status": "valid", "count": None}],
+    )
+    async def test_invalid_baseline_is_distinct_from_zero(self, mock_page, result):
+        extractor = LinkedInExtractor(mock_page)
+        target, owner = self._arguments()
+        mock_page.evaluate = AsyncMock(return_value=result)
+
+        assert (
+            await extractor._message_text_occurrences(
+                "Hello!", target=target, owner=owner
+            )
+            is None
+        )
+
+    async def test_valid_zero_baseline_stays_zero(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        target, owner = self._arguments()
+        mock_page.evaluate = AsyncMock(return_value={"status": "valid", "count": 0})
+
+        assert (
+            await extractor._message_text_occurrences(
+                "Hello!", target=target, owner=owner
+            )
+            == 0
+        )
 
     async def test_confirmation_waits_for_more_than_the_baseline(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
+        target, owner = self._arguments()
         mock_page.wait_for_function = AsyncMock(return_value=None)
 
         assert (
-            await extractor._message_text_visible("Hello!", previous_occurrences=2)
+            await extractor._message_text_visible(
+                "Hello!",
+                target=target,
+                owner=owner,
+                previous_occurrences=2,
+            )
             is True
         )
 
         mock_page.wait_for_function.assert_awaited_once_with(
             _MESSAGE_OCCURRENCES_INCREASED_JS,
-            arg={"expected": "Hello!", "previous": 2},
+            arg={
+                "profilePath": target.profile_path,
+                "profileUrn": target.profile_urn,
+                "expected": "Hello!",
+                "owner": owner,
+                "previous": 2,
+            },
         )
-        # Baseline and confirmation run one routine, so they cannot disagree
-        # about what counts as an occurrence.
         assert _MESSAGE_OCCURRENCES_JS in _MESSAGE_OCCURRENCES_INCREASED_JS
 
-    async def test_confirmation_timeout_is_not_a_send(self, mock_page):
+    @pytest.mark.parametrize(
+        "error",
+        [
+            PlaywrightTimeoutError("timeout"),
+            PatchrightError("execution context destroyed"),
+        ],
+        ids=["timeout", "context-destroyed"],
+    )
+    async def test_confirmation_errors_do_not_confirm(self, mock_page, error):
         extractor = LinkedInExtractor(mock_page)
-        mock_page.wait_for_function = AsyncMock(
-            side_effect=PlaywrightTimeoutError("timeout")
-        )
+        target, owner = self._arguments()
+        mock_page.wait_for_function = AsyncMock(side_effect=error)
 
         assert (
-            await extractor._message_text_visible("Hello!", previous_occurrences=0)
-            is False
-        )
-
-    async def test_other_confirmation_errors_do_not_confirm(self, mock_page):
-        """A broken confirmation is an unknown, never a send and never an error.
-
-        This runs only after a submission was attempted, so letting the error
-        out would reach the caller as a plain tool failure and invite the one
-        retry that delivers the message a second time.
-        """
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.wait_for_function = AsyncMock(
-            side_effect=PatchrightError("execution context destroyed")
-        )
-
-        assert (
-            await extractor._message_text_visible("Hello!", previous_occurrences=0)
+            await extractor._message_text_visible(
+                "Hello!",
+                target=target,
+                owner=owner,
+                previous_occurrences=0,
+            )
             is False
         )
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -7759,6 +7759,7 @@ class TestExtractProfileUrn:
     async def test_returns_urn_from_atomic_top_card_snapshot(self, mock_page):
         mock_page.evaluate = AsyncMock(
             return_value={
+                "status": "resolved",
                 "pageUrl": "https://www.linkedin.com/in/testuser/",
                 "displayName": "Test User",
                 "composeHrefs": [
@@ -7778,6 +7779,7 @@ class TestExtractProfileUrn:
     async def test_accepts_safe_final_vanity_redirect(self, mock_page):
         mock_page.evaluate = AsyncMock(
             return_value={
+                "status": "resolved",
                 "pageUrl": "https://www.linkedin.com/in/canonical-user/",
                 "displayName": "Test User",
                 "composeHrefs": [
@@ -7787,15 +7789,17 @@ class TestExtractProfileUrn:
             }
         )
 
-        target = await LinkedInExtractor(mock_page)._read_profile_message_target()
+        resolution = await LinkedInExtractor(mock_page)._read_profile_message_target()
 
-        assert target is not None
-        assert target.profile_path == "/in/canonical-user/"
-        assert target.profile_urn == "ACoAAB"
+        assert resolution.status == "resolved"
+        assert resolution.target is not None
+        assert resolution.target.profile_path == "/in/canonical-user/"
+        assert resolution.target.profile_urn == "ACoAAB"
 
     async def test_returns_none_for_ambiguous_top_card_links(self, mock_page):
         mock_page.evaluate = AsyncMock(
             return_value={
+                "status": "resolved",
                 "pageUrl": "https://www.linkedin.com/in/testuser/",
                 "displayName": "Test User",
                 "composeHrefs": [
@@ -8667,7 +8671,9 @@ class TestSendMessage:
                 extractor,
                 "_read_profile_message_target",
                 new_callable=AsyncMock,
-                return_value=None,
+                return_value=extractor_module._ProfileMessageTargetResolution(
+                    "unavailable"
+                ),
             ),
             patch.object(
                 extractor, "_wait_for_message_surface", new_callable=AsyncMock
@@ -8708,6 +8714,29 @@ class TestSendMessage:
         mock_page.keyboard.type.assert_not_awaited()
         mock_page.keyboard.press.assert_not_awaited()
 
+    async def test_unresolved_profile_target_is_not_connection_handoff(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                extractor,
+                "_read_profile_message_target",
+                new_callable=AsyncMock,
+                return_value=extractor_module._ProfileMessageTargetResolution("failed"),
+            ),
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "recipient_resolution_failed"
+        assert "connect_with_person" not in result["message"]
+        assert result["retry_safe"] is True
+
     @staticmethod
     def _target():
         return extractor_module._ProfileMessageTarget(
@@ -8734,7 +8763,7 @@ class TestSendMessage:
         mock_page.keyboard = MagicMock(type=AsyncMock(), press=AsyncMock())
         owner = MagicMock()
         owner.as_element.return_value = owner
-        owner.evaluate = AsyncMock()
+        owner.evaluate = AsyncMock(return_value="ready")
         owner.dispose = AsyncMock()
         mock_page.evaluate_handle = AsyncMock(return_value=owner)
 
@@ -8769,7 +8798,9 @@ class TestSendMessage:
                 extractor,
                 "_read_profile_message_target",
                 new_callable=AsyncMock,
-                return_value=target,
+                return_value=extractor_module._ProfileMessageTargetResolution(
+                    "resolved", target
+                ),
             ),
             patch.object(
                 extractor,
@@ -8858,7 +8889,9 @@ class TestSendMessage:
                 extractor,
                 "_read_profile_message_target",
                 new_callable=AsyncMock,
-                return_value=target,
+                return_value=extractor_module._ProfileMessageTargetResolution(
+                    "resolved", target
+                ),
             ),
         ):
             result = await extractor.send_message(
@@ -9161,10 +9194,48 @@ class TestSendMessage:
         mock_page.keyboard.type.assert_not_awaited()
         mock_page.keyboard.press.assert_not_awaited()
 
+    async def test_disabled_pinned_submit_cleans_before_retryable_failure(
+        self, mock_page
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        owner = mock_page.evaluate_handle.return_value
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6] as write,
+            patches[7] as submit,
+            patches[8],
+            patches[9] as prepare,
+            patches[10],
+            patch.object(
+                extractor,
+                "_wait_for_verified_submit",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(
+                extractor, "_cleanup_owned_message", new_callable=AsyncMock
+            ) as cleanup,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unavailable"
+        assert result["retry_safe"] is True
+        write.assert_awaited_once()
+        prepare.assert_not_awaited()
+        submit.assert_not_awaited()
+        cleanup.assert_awaited_once_with("Hello!", owner)
+
     @pytest.mark.parametrize(
         ("submit_count", "submit_usable"),
-        [(0, False), (2, False), (1, False)],
-        ids=["missing", "ambiguous", "disabled"],
+        [(0, False), (2, False)],
+        ids=["missing", "ambiguous"],
     )
     async def test_only_one_active_submit_path_can_send(
         self, mock_page, submit_count, submit_usable
@@ -9408,6 +9479,40 @@ class TestSendMessage:
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         assert result["retry_safe"] is False
+
+    async def test_owner_cleanup_runs_when_confirmation_cleanup_fails(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        owner = mock_page.evaluate_handle.return_value
+
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10],
+            patch.object(
+                extractor,
+                "_dispose_message_confirmation",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("cleanup failed"),
+            ),
+            patch.object(
+                extractor, "_dispose_message_owner", new_callable=AsyncMock
+            ) as dispose_owner,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["retry_safe"] is False
+        dispose_owner.assert_awaited_once_with(owner)
 
     async def test_an_error_before_anything_can_submit_is_raised(self, mock_page):
         """Without a newline nothing has submitted yet, so the error is the answer.

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8664,10 +8664,6 @@ class TestSendMessage:
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
                 new_callable=AsyncMock,
             ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-            ),
             patch.object(
                 extractor,
                 "_read_profile_message_target",
@@ -8704,7 +8700,6 @@ class TestSendMessage:
                 new_callable=AsyncMock,
                 return_value=submission,
             ),
-            patch.object(extractor, "_dismiss_message_ui", new_callable=AsyncMock),
             patch(
                 "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
                 new_callable=AsyncMock,
@@ -8727,7 +8722,7 @@ class TestSendMessage:
         keyboard = mock_page.keyboard
         patches = self._patch_to_composer(extractor, mock_page)
         mock_page.keyboard = keyboard
-        return (*patches[1:8], *patches[9:11])
+        return (*patches[1:7], patches[8])
 
     async def test_dry_run_returns_before_focus_or_text_entry(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
@@ -8738,11 +8733,9 @@ class TestSendMessage:
             patches[3],
             patches[4],
             patches[5],
-            patches[6],
-            patches[7] as focus,
-            patches[8] as submit,
-            patches[9] as dismiss,
-            patches[10],
+            patches[6] as focus,
+            patches[7] as submit,
+            patches[8],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=False
@@ -8750,7 +8743,6 @@ class TestSendMessage:
 
         assert result["status"] == "confirmation_required"
         assert result["recipient_selected"] is True
-        dismiss.assert_not_awaited()
         focus.assert_not_awaited()
         submit.assert_not_awaited()
         mock_page.keyboard.type.assert_not_awaited()
@@ -8764,10 +8756,6 @@ class TestSendMessage:
             ) as navigate,
             patch(
                 "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
                 new_callable=AsyncMock,
             ),
             patch.object(
@@ -8795,15 +8783,13 @@ class TestSendMessage:
             patches[1],
             patches[2],
             patches[3],
-            patches[4],
-            patches[5] as surface,
-            patches[6] as state,
-            patches[7] as focus,
-            patches[8] as submit,
+            patches[4] as surface,
+            patches[5] as state,
+            patches[6] as focus,
+            patches[7] as submit,
+            patches[8],
             patches[9],
             patches[10],
-            patches[11],
-            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
@@ -8836,14 +8822,12 @@ class TestSendMessage:
             patches[2],
             patches[3],
             patches[4],
-            patches[5],
-            patches[6] as state,
-            patches[7] as focus,
-            patches[8] as submit,
+            patches[5] as state,
+            patches[6] as focus,
+            patches[7] as submit,
+            patches[8],
             patches[9],
             patches[10],
-            patches[11],
-            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
@@ -8879,13 +8863,11 @@ class TestSendMessage:
             patches[3],
             patches[4],
             patches[5],
-            patches[6],
-            patches[7] as focus,
-            patches[8] as submit,
+            patches[6] as focus,
+            patches[7] as submit,
+            patches[8],
             patches[9],
             patches[10],
-            patches[11],
-            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
@@ -8915,12 +8897,10 @@ class TestSendMessage:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
-            patches[8] as submit,
+            patches[7] as submit,
+            patches[8],
             patches[9],
             patches[10],
-            patches[11],
-            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
@@ -8950,13 +8930,11 @@ class TestSendMessage:
             patches[3],
             patches[4],
             patches[5],
-            patches[6],
-            patches[7] as focus,
-            patches[8] as submit,
-            patches[9] as dismiss,
+            patches[6] as focus,
+            patches[7] as submit,
+            patches[8],
+            patches[9],
             patches[10],
-            patches[11],
-            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
@@ -8964,7 +8942,6 @@ class TestSendMessage:
 
         assert result["status"] == "composer_occupied"
         assert result["sent"] is False
-        dismiss.assert_not_awaited()
         # Nothing is typed, nothing is submitted, and the draft is left where
         # its author put it.
         focus.assert_not_awaited()
@@ -8988,13 +8965,11 @@ class TestSendMessage:
             patches[3],
             patches[4],
             patches[5],
-            patches[6],
-            patches[7] as focus,
+            patches[6] as focus,
+            patches[7],
             patches[8],
             patches[9],
             patches[10],
-            patches[11],
-            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
@@ -9024,8 +8999,6 @@ class TestSendMessage:
             patches[6],
             patches[7],
             patches[8],
-            patches[9],
-            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -9070,10 +9043,17 @@ class TestSendMessage:
         assert result["status"] == status
         assert result["sent"] is False
         assert result["retry_safe"] is retry_safe
-        entered[7].assert_not_awaited()
+        entered[6].assert_not_awaited()
         owner.dispose.assert_awaited_once_with()
 
-    async def test_rejects_ambiguous_submit_after_text_entry(self, mock_page):
+    @pytest.mark.parametrize(
+        ("message", "retry_safe"),
+        [("Hello!", True), ("First\nSecond", False)],
+        ids=["single-line", "newline"],
+    )
+    async def test_rejects_ambiguous_submit_after_text_entry(
+        self, mock_page, message, retry_safe
+    ):
         extractor = LinkedInExtractor(mock_page)
         patches = self._patch_to_composer(extractor, mock_page, submission="invalid")
         with (
@@ -9087,15 +9067,14 @@ class TestSendMessage:
             patches[8],
             patches[9],
             patches[10],
-            patches[11],
-            patches[12],
         ):
             result = await extractor.send_message(
-                "testuser", "Hello!", confirm_send=True
+                "testuser", message, confirm_send=True
             )
 
         assert result["status"] == "send_unavailable"
-        mock_page.keyboard.type.assert_awaited_once_with("Hello!", delay=15)
+        assert result["retry_safe"] is retry_safe
+        mock_page.keyboard.type.assert_awaited_once_with(message, delay=15)
         mock_page.keyboard.press.assert_not_awaited()
 
     async def test_removed_submit_candidate_cannot_switch_to_enter(self, mock_page):
@@ -9116,22 +9095,28 @@ class TestSendMessage:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
-            patches[8] as submit,
+            patches[7] as submit,
+            patches[8],
             patches[9],
             patches[10],
-            patches[11],
-            patches[12],
         ):
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
             )
 
         assert result["status"] == "send_unavailable"
+        assert result["retry_safe"] is True
         submit.assert_awaited_once_with(self._target(), allow_enter=False)
         mock_page.keyboard.press.assert_not_awaited()
 
-    async def test_enter_revalidates_active_editor_before_press(self, mock_page):
+    @pytest.mark.parametrize(
+        ("message", "retry_safe"),
+        [("Hello!", True), ("First\nSecond", False)],
+        ids=["single-line", "newline"],
+    )
+    async def test_enter_revalidates_active_editor_before_press(
+        self, mock_page, message, retry_safe
+    ):
         extractor = LinkedInExtractor(mock_page)
         states = [
             {"status": "valid", "active": False, "submitCount": 0},
@@ -9147,20 +9132,19 @@ class TestSendMessage:
             patches[2],
             patches[3],
             patches[4],
-            patches[5],
-            patches[6] as state,
+            patches[5] as state,
+            patches[6],
             patches[7],
             patches[8],
             patches[9],
             patches[10],
-            patches[11],
-            patches[12],
         ):
             result = await extractor.send_message(
-                "testuser", "Hello!", confirm_send=True
+                "testuser", message, confirm_send=True
             )
 
         assert result["status"] == "send_unavailable"
+        assert result["retry_safe"] is retry_safe
         assert state.await_count == 4
         mock_page.keyboard.press.assert_not_awaited()
 
@@ -9179,10 +9163,8 @@ class TestSendMessage:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
-            patches[8] as submit,
-            patches[9],
-            patches[10],
+            patches[7] as submit,
+            patches[8],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -9243,15 +9225,13 @@ class TestSendMessage:
             patches[4],
             patches[5],
             patches[6],
-            patches[7],
             patch.object(
                 extractor,
                 "_submit_verified_message",
                 new_callable=AsyncMock,
                 side_effect=submit,
             ),
-            patches[9],
-            patches[10],
+            patches[8],
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -9329,71 +9309,31 @@ class TestSendMessage:
 
     @pytest.mark.parametrize(
         "stage",
-        [
-            "dispatch",
-            "confirmation",
-            "failed-cleanup",
-            "unconfirmed-cleanup",
-            "owner-cleanup",
-        ],
+        ["dispatch", "confirmation", "owner-cleanup"],
     )
     async def test_cancellation_after_dispatch_is_logged(
         self, mock_page, caplog, stage
     ):
-        """Cancellation in the destructive window leaves a warning behind.
-
-        FastMCP runs the tool inside ``anyio.fail_after()``, so the deadline
-        raises ``CancelledError`` past ``except Exception`` and discards
-        anything the cancelled scope returns. The caller therefore sees a
-        timeout carrying no ``retry_safe``, and this log line is the only
-        record that a message may already have left.
-
-        The window ends where a result exists, not where the send returns.
-        Both cleanup calls run after a submission was dispatched, and both
-        await: the one in the submission-failure handler and the one on the
-        unconfirmed path. Cancelled there, the message is exactly as
-        possibly-delivered as during the send itself.
-        """
+        """Cancellation in the destructive window leaves a warning behind."""
         extractor = LinkedInExtractor(mock_page)
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        dismiss_effect = None
         if stage == "dispatch":
             mock_page.evaluate = AsyncMock(side_effect=asyncio.CancelledError())
             visible_effect = AsyncMock()
         elif stage == "confirmation":
             mock_page.evaluate = AsyncMock(return_value="clicked")
             visible_effect = AsyncMock(side_effect=asyncio.CancelledError())
-        elif stage == "failed-cleanup":
-            # The submission raised an ordinary error after dispatching its
-            # input event, so the handler runs and is cancelled inside it.
-            mock_page.evaluate = AsyncMock(
-                side_effect=RuntimeError("context destroyed")
-            )
-            visible_effect = AsyncMock()
-            dismiss_effect = AsyncMock(side_effect=asyncio.CancelledError())
-        elif stage == "owner-cleanup":
+        else:
             mock_page.evaluate = AsyncMock(return_value="clicked")
             visible_effect = AsyncMock(return_value=True)
-        else:
-            # The send went out and delivery was not observed, which is the
-            # path that most needs the warning: the result it was about to
-            # return is the one carrying `retry_safe=False`.
-            mock_page.evaluate = AsyncMock(return_value="clicked")
-            visible_effect = AsyncMock(return_value=False)
-            dismiss_effect = AsyncMock(side_effect=asyncio.CancelledError())
         patches = self._patch_send_message_to_compose(extractor, mock_page)
         if stage == "owner-cleanup":
             mock_page.evaluate_handle.return_value.dispose = AsyncMock(
                 side_effect=asyncio.CancelledError()
             )
-        if dismiss_effect is not None:
-            patches = [
-                *patches,
-                patch.object(extractor, "_dismiss_message_ui", dismiss_effect),
-            ]
 
         with (
             ExitStack() as stack,
@@ -9467,26 +9407,11 @@ class TestSendMessage:
         hit = any("retry may deliver the message twice" in w for w in warnings)
         assert hit is warns, warnings
 
-    @pytest.mark.parametrize(
-        "stage",
-        ["typing", "baseline", "cleanup"],
-        ids=["typing", "baseline", "cleanup"],
-    )
+    @pytest.mark.parametrize("stage", ["typing", "baseline"])
     async def test_ordinary_error_after_a_possible_submission_still_answers(
         self, mock_page, stage
     ):
-        """An error a caller could retry on gets an answer, not a raise.
-
-        Three awaits inside the destructive window have no guard of their own.
-        Typing raises before the send call is reached, and a newline has by
-        then submitted a paragraph. The baseline read sits between the two.
-        And `_dismiss_message_ui` guards its click but not the visibility
-        probe it opens with, so a page that dies during cleanup escapes it.
-
-        All three reach the caller as a plain tool failure unless the window
-        answers, and a plain failure invites the retry that delivers a second
-        message to a real person.
-        """
+        """A newline keeps later typing and baseline failures non-retryable."""
         extractor = LinkedInExtractor(mock_page)
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
@@ -9495,16 +9420,10 @@ class TestSendMessage:
         mock_page.evaluate = AsyncMock(return_value="focused")
         occurrences = AsyncMock(return_value=1)
         visible = AsyncMock(return_value=False)
-        dismiss = AsyncMock()
         if stage == "typing":
             mock_keyboard.type = AsyncMock(side_effect=RuntimeError("page closed"))
-        elif stage == "baseline":
-            occurrences = AsyncMock(side_effect=RuntimeError("context destroyed"))
         else:
-            # The send went out unconfirmed and cleanup then failed, which is
-            # the branch that was about to return `retry_safe=False`.
-            mock_page.evaluate = AsyncMock(return_value="clicked")
-            dismiss = AsyncMock(side_effect=RuntimeError("page closed"))
+            occurrences = AsyncMock(side_effect=RuntimeError("context destroyed"))
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with ExitStack() as stack:
@@ -9516,7 +9435,6 @@ class TestSendMessage:
             stack.enter_context(
                 patch.object(extractor, "_message_text_visible", visible)
             )
-            stack.enter_context(patch.object(extractor, "_dismiss_message_ui", dismiss))
             result = await extractor.send_message(
                 "testuser", "First\nSecond", confirm_send=True
             )
@@ -9561,8 +9479,6 @@ class TestSendMessage:
             patches[6],
             patches[7],
             patches[8],
-            patches[9],
-            patches[10],
             patch.object(
                 extractor,
                 "_message_text_occurrences",

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -32,8 +32,9 @@ from linkedin_mcp_server.scraping.extractor import (
     LinkedInExtractor,
     _CONTENT_DATE_POSTED_MAP,
     _MESSAGE_COMPOSER_OWNER_JS,
-    _MESSAGE_OCCURRENCES_INCREASED_JS,
-    _MESSAGE_OCCURRENCES_JS,
+    _MESSAGE_CONFIRMATION_DISPOSE_JS,
+    _MESSAGE_CONFIRMATION_PREPARE_JS,
+    _MESSAGE_CONFIRMATION_READY_JS,
     _RATE_LIMITED_MSG,
     _build_feed_references,
     _truncate_linkedin_noise,
@@ -8620,6 +8621,34 @@ class TestSendMessage:
         keyboard.type.assert_not_called()
         keyboard.press.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "message",
+        ["First\nSecond", "First\rSecond", "First\tSecond", "First\x7fSecond"],
+        ids=["newline", "carriage-return", "tab", "del"],
+    )
+    async def test_control_message_is_rejected_before_browser_interaction(
+        self, mock_page, message
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        mock_page.keyboard = MagicMock(type=AsyncMock(), press=AsyncMock())
+
+        with patch.object(
+            extractor, "_navigate_to_page", new_callable=AsyncMock
+        ) as navigate:
+            result = await extractor.send_message(
+                "testuser", message, confirm_send=True
+            )
+
+        assert result["status"] == "invalid_message"
+        assert result["message"] == (
+            "Message must not contain control characters or line breaks."
+        )
+        assert result["retry_safe"] is True
+        navigate.assert_not_awaited()
+        mock_page.evaluate.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
+        mock_page.keyboard.press.assert_not_awaited()
+
     async def test_unavailable_message_action_returns_connection_handoff(
         self, mock_page
     ):
@@ -8765,13 +8794,13 @@ class TestSendMessage:
             ),
             patch.object(
                 extractor,
-                "_message_text_occurrences",
+                "_prepare_message_confirmation",
                 new_callable=AsyncMock,
-                return_value=0,
+                return_value="confirmation-token",
             ),
             patch.object(
                 extractor,
-                "_message_text_visible",
+                "_message_send_confirmed",
                 new_callable=AsyncMock,
                 return_value=True,
             ),
@@ -9060,13 +9089,13 @@ class TestSendMessage:
             patches[8],
             patch.object(
                 extractor,
-                "_message_text_occurrences",
+                "_prepare_message_confirmation",
                 new_callable=AsyncMock,
                 return_value=0,
             ),
             patch.object(
                 extractor,
-                "_message_text_visible",
+                "_message_send_confirmed",
                 new_callable=AsyncMock,
                 return_value=True,
             ),
@@ -9078,17 +9107,7 @@ class TestSendMessage:
         assert result["status"] == "compose_interact_failed"
         mock_page.keyboard.type.assert_not_awaited()
 
-    @pytest.mark.parametrize(
-        ("message", "status", "retry_safe"),
-        [
-            ("Hello!", "recipient_resolution_failed", True),
-            ("First\nSecond", "send_unconfirmed", False),
-        ],
-        ids=["before-dispatch", "newline-may-have-submitted"],
-    )
-    async def test_missing_owner_preserves_retry_policy(
-        self, mock_page, message, status, retry_safe
-    ):
+    async def test_missing_owner_is_retryable_before_dispatch(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         patches = self._patch_to_composer(extractor, mock_page)
         owner = mock_page.evaluate_handle.return_value
@@ -9096,23 +9115,16 @@ class TestSendMessage:
         with ExitStack() as stack:
             entered = [stack.enter_context(item) for item in patches[1:]]
             result = await extractor.send_message(
-                "testuser", message, confirm_send=True
+                "testuser", "Hello!", confirm_send=True
             )
 
-        assert result["status"] == status
+        assert result["status"] == "recipient_resolution_failed"
         assert result["sent"] is False
-        assert result["retry_safe"] is retry_safe
+        assert result["retry_safe"] is True
         entered[6].assert_not_awaited()
         owner.dispose.assert_awaited_once_with()
 
-    @pytest.mark.parametrize(
-        ("message", "retry_safe"),
-        [("Hello!", True), ("First\nSecond", False)],
-        ids=["single-line", "newline"],
-    )
-    async def test_rejects_ambiguous_submit_after_text_entry(
-        self, mock_page, message, retry_safe
-    ):
+    async def test_rejects_ambiguous_submit_after_text_entry(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         patches = self._patch_to_composer(extractor, mock_page, submission="invalid")
         with (
@@ -9128,12 +9140,12 @@ class TestSendMessage:
             patches[10],
         ):
             result = await extractor.send_message(
-                "testuser", message, confirm_send=True
+                "testuser", "Hello!", confirm_send=True
             )
 
         assert result["status"] == "send_unavailable"
-        assert result["retry_safe"] is retry_safe
-        mock_page.keyboard.type.assert_awaited_once_with(message, delay=15)
+        assert result["retry_safe"] is True
+        mock_page.keyboard.type.assert_awaited_once_with("Hello!", delay=15)
         mock_page.keyboard.press.assert_not_awaited()
 
     async def test_removed_submit_candidate_cannot_switch_to_enter(self, mock_page):
@@ -9168,14 +9180,7 @@ class TestSendMessage:
         submit.assert_awaited_once_with(self._target(), allow_enter=False)
         mock_page.keyboard.press.assert_not_awaited()
 
-    @pytest.mark.parametrize(
-        ("message", "retry_safe"),
-        [("Hello!", True), ("First\nSecond", False)],
-        ids=["single-line", "newline"],
-    )
-    async def test_enter_revalidates_active_editor_before_press(
-        self, mock_page, message, retry_safe
-    ):
+    async def test_enter_revalidates_active_editor_before_press(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         states = [
             {"status": "valid", "active": False, "submitCount": 0},
@@ -9199,11 +9204,11 @@ class TestSendMessage:
             patches[10],
         ):
             result = await extractor.send_message(
-                "testuser", message, confirm_send=True
+                "testuser", "Hello!", confirm_send=True
             )
 
         assert result["status"] == "send_unavailable"
-        assert result["retry_safe"] is retry_safe
+        assert result["retry_safe"] is True
         assert state.await_count == 4
         mock_page.keyboard.press.assert_not_awaited()
 
@@ -9226,13 +9231,13 @@ class TestSendMessage:
             patches[8],
             patch.object(
                 extractor,
-                "_message_text_occurrences",
+                "_prepare_message_confirmation",
                 new_callable=AsyncMock,
                 return_value=0,
             ),
             patch.object(
                 extractor,
-                "_message_text_visible",
+                "_message_send_confirmed",
                 new_callable=AsyncMock,
                 return_value=True,
             ),
@@ -9245,15 +9250,10 @@ class TestSendMessage:
         submit.assert_awaited_once_with(self._target(), allow_enter=True)
         mock_page.keyboard.press.assert_awaited_once_with("Enter")
 
-    async def test_baseline_is_taken_after_typing_and_before_submission(
+    async def test_observer_is_prepared_after_typing_and_before_submission(
         self, mock_page
     ):
-        """The occurrence baseline is captured between typing and submission.
-
-        Taken any earlier it would miss what the verified composer already
-        holds; taken after submission it could already include the delivered
-        message, and the confirmation would compare that copy against itself.
-        """
+        """The mutation observer starts immediately before the only submit."""
         extractor = LinkedInExtractor(mock_page)
         steps: list[str] = []
         patches = self._patch_to_composer(extractor, mock_page)
@@ -9261,20 +9261,22 @@ class TestSendMessage:
             "type"
         )
 
-        async def occurrences(message, *, target, owner):
+        async def prepare(message, *, target, owner):
+            assert message == "Hello!"
             assert target == self._target()
             assert owner is mock_page.evaluate_handle.return_value
-            steps.append("baseline")
-            return 2
+            steps.append("prepare")
+            return "confirmation-token"
 
         async def submit(target, *, allow_enter):
             steps.append("submit")
             return "clicked"
 
-        async def visible(message, *, target, owner, previous_occurrences):
+        async def confirmed(message, *, target, owner, confirmation):
+            assert message == "Hello!"
             assert target == self._target()
             assert owner is mock_page.evaluate_handle.return_value
-            steps.append(f"confirm:{previous_occurrences}")
+            steps.append(f"confirm:{confirmation}")
             return True
 
         with (
@@ -9293,15 +9295,15 @@ class TestSendMessage:
             patches[8],
             patch.object(
                 extractor,
-                "_message_text_occurrences",
+                "_prepare_message_confirmation",
                 new_callable=AsyncMock,
-                side_effect=occurrences,
+                side_effect=prepare,
             ),
             patch.object(
                 extractor,
-                "_message_text_visible",
+                "_message_send_confirmed",
                 new_callable=AsyncMock,
-                side_effect=visible,
+                side_effect=confirmed,
             ),
         ):
             result = await extractor.send_message(
@@ -9309,8 +9311,12 @@ class TestSendMessage:
             )
 
         assert result["status"] == "sent"
-        # The confirmation receives exactly the baseline taken before submission.
-        assert steps == ["type", "baseline", "submit", "confirm:2"]
+        assert steps == [
+            "type",
+            "prepare",
+            "submit",
+            "confirm:confirmation-token",
+        ]
 
     @pytest.mark.parametrize(
         "submit_effect",
@@ -9347,13 +9353,13 @@ class TestSendMessage:
             stack.enter_context(
                 patch.object(
                     extractor,
-                    "_message_text_occurrences",
+                    "_prepare_message_confirmation",
                     new_callable=AsyncMock,
                     return_value=1,
                 )
             )
             stack.enter_context(
-                patch.object(extractor, "_message_text_visible", visible)
+                patch.object(extractor, "_message_send_confirmed", visible)
             )
             result = await extractor.send_message(
                 "testuser", "Hello!", confirm_send=True
@@ -9398,11 +9404,11 @@ class TestSendMessage:
             ExitStack() as stack,
             patch.object(
                 extractor,
-                "_message_text_occurrences",
+                "_prepare_message_confirmation",
                 new_callable=AsyncMock,
                 return_value=1,
             ),
-            patch.object(extractor, "_message_text_visible", visible_effect),
+            patch.object(extractor, "_message_send_confirmed", visible_effect),
             caplog.at_level(
                 logging.WARNING, logger="linkedin_mcp_server.scraping.extractor"
             ),
@@ -9420,29 +9426,8 @@ class TestSendMessage:
             warnings
         )
 
-    @pytest.mark.parametrize(
-        ("message", "warns"),
-        [("Hello\nthere!", True), ("Hello there!", False)],
-        ids=["newline", "single-line"],
-    )
-    async def test_cancellation_while_typing_warns_only_for_a_newline(
-        self, mock_page, caplog, message, warns
-    ):
-        """Typing can submit, so the window has to start before it.
-
-        ``keyboard.type()`` presses one key per character and patchright maps
-        ``"\n"`` onto Enter, which this composer submits on: the send path
-        relies on that very behaviour. A message carrying a newline therefore
-        delivers its first paragraph *while* it is being typed, long before
-        the send call, and typing is slow enough for the tool deadline to land
-        in there — at 15ms per character a 20k-character message runs past
-        180s on its own.
-
-        The single-line case is what makes this a test rather than a blanket
-        warning: nothing can have submitted yet, and a warning that cries
-        duplicate delivery where none is possible is the kind that gets
-        ignored when it is right.
-        """
+    async def test_cancellation_while_typing_does_not_warn(self, mock_page, caplog):
+        """Validated text cannot submit before the explicit submit path."""
         extractor = LinkedInExtractor(mock_page)
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock(side_effect=asyncio.CancelledError())
@@ -9460,42 +9445,33 @@ class TestSendMessage:
         ):
             for entered in patches:
                 stack.enter_context(entered)
-            await extractor.send_message("testuser", message, confirm_send=True)
+            await extractor.send_message("testuser", "Hello there!", confirm_send=True)
 
         warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
-        hit = any("retry may deliver the message twice" in w for w in warnings)
-        assert hit is warns, warnings
+        assert not any("retry may deliver the message twice" in w for w in warnings)
 
-    @pytest.mark.parametrize("stage", ["typing", "baseline"])
-    async def test_ordinary_error_after_a_possible_submission_still_answers(
-        self, mock_page, stage
-    ):
-        """A newline keeps later typing and baseline failures non-retryable."""
+    async def test_ordinary_error_after_dispatch_still_answers(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
-        mock_page.evaluate = AsyncMock(return_value="focused")
-        occurrences = AsyncMock(return_value=1)
-        visible = AsyncMock(return_value=False)
-        if stage == "typing":
-            mock_keyboard.type = AsyncMock(side_effect=RuntimeError("page closed"))
-        else:
-            occurrences = AsyncMock(side_effect=RuntimeError("context destroyed"))
+        mock_page.evaluate = AsyncMock(return_value="clicked")
+        prepare = AsyncMock(return_value="confirmation-token")
+        confirmed = AsyncMock(side_effect=RuntimeError("context destroyed"))
         patches = self._patch_send_message_to_compose(extractor, mock_page)
 
         with ExitStack() as stack:
             for entered in patches:
                 stack.enter_context(entered)
             stack.enter_context(
-                patch.object(extractor, "_message_text_occurrences", occurrences)
+                patch.object(extractor, "_prepare_message_confirmation", prepare)
             )
             stack.enter_context(
-                patch.object(extractor, "_message_text_visible", visible)
+                patch.object(extractor, "_message_send_confirmed", confirmed)
             )
             result = await extractor.send_message(
-                "testuser", "First\nSecond", confirm_send=True
+                "testuser", "Hello!", confirm_send=True
             )
 
         assert result["status"] == "send_unconfirmed"
@@ -9540,13 +9516,13 @@ class TestSendMessage:
             patches[8],
             patch.object(
                 extractor,
-                "_message_text_occurrences",
+                "_prepare_message_confirmation",
                 new_callable=AsyncMock,
                 return_value=1,
             ),
             patch.object(
                 extractor,
-                "_message_text_visible",
+                "_message_send_confirmed",
                 new_callable=AsyncMock,
                 return_value=False,
             ) as visible,
@@ -9565,7 +9541,7 @@ class TestSendMessage:
             "Hello!",
             target=self._target(),
             owner=mock_page.evaluate_handle.return_value,
-            previous_occurrences=1,
+            confirmation=1,
         )
 
 
@@ -9583,8 +9559,8 @@ class TestResolveMessageComposeBox:
         )
 
 
-class TestMessageTextOccurrences:
-    """Tests for the owner-scoped send confirmation."""
+class TestMessageConfirmation:
+    """Tests for the owner-pinned message-list mutation contract."""
 
     @staticmethod
     def _arguments():
@@ -9623,20 +9599,19 @@ class TestMessageTextOccurrences:
 
         owner.dispose.assert_awaited_once_with()
 
-    async def test_occurrences_run_inside_the_target_owner(self, mock_page):
+    async def test_prepare_installs_observer_in_the_target_owner(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         target, owner = self._arguments()
-        mock_page.evaluate = AsyncMock(return_value={"status": "valid", "count": 3})
+        mock_page.evaluate = AsyncMock(return_value="confirmation-token")
 
         assert (
-            await extractor._message_text_occurrences(
+            await extractor._prepare_message_confirmation(
                 "Hello!", target=target, owner=owner
             )
-            == 3
+            == "confirmation-token"
         )
-
         mock_page.evaluate.assert_awaited_once_with(
-            _MESSAGE_OCCURRENCES_JS,
+            _MESSAGE_CONFIRMATION_PREPARE_JS,
             {
                 "profilePath": target.profile_path,
                 "profileUrn": target.profile_urn,
@@ -9645,60 +9620,43 @@ class TestMessageTextOccurrences:
             },
         )
 
-    @pytest.mark.parametrize(
-        "result",
-        [None, {"status": "invalid"}, {"status": "valid", "count": None}],
-    )
-    async def test_invalid_baseline_is_distinct_from_zero(self, mock_page, result):
+    @pytest.mark.parametrize("result", [None, "", 0, {"token": "wrong"}])
+    async def test_invalid_prepare_result_fails_closed(self, mock_page, result):
         extractor = LinkedInExtractor(mock_page)
         target, owner = self._arguments()
         mock_page.evaluate = AsyncMock(return_value=result)
 
         assert (
-            await extractor._message_text_occurrences(
+            await extractor._prepare_message_confirmation(
                 "Hello!", target=target, owner=owner
             )
             is None
         )
 
-    async def test_valid_zero_baseline_stays_zero(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        target, owner = self._arguments()
-        mock_page.evaluate = AsyncMock(return_value={"status": "valid", "count": 0})
-
-        assert (
-            await extractor._message_text_occurrences(
-                "Hello!", target=target, owner=owner
-            )
-            == 0
-        )
-
-    async def test_confirmation_waits_for_more_than_the_baseline(self, mock_page):
+    async def test_confirmation_waits_for_the_exact_token(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         target, owner = self._arguments()
         mock_page.wait_for_function = AsyncMock(return_value=None)
 
         assert (
-            await extractor._message_text_visible(
+            await extractor._message_send_confirmed(
                 "Hello!",
                 target=target,
                 owner=owner,
-                previous_occurrences=2,
+                confirmation="confirmation-token",
             )
             is True
         )
-
         mock_page.wait_for_function.assert_awaited_once_with(
-            _MESSAGE_OCCURRENCES_INCREASED_JS,
+            _MESSAGE_CONFIRMATION_READY_JS,
             arg={
                 "profilePath": target.profile_path,
                 "profileUrn": target.profile_urn,
                 "expected": "Hello!",
                 "owner": owner,
-                "previous": 2,
+                "token": "confirmation-token",
             },
         )
-        assert _MESSAGE_OCCURRENCES_JS in _MESSAGE_OCCURRENCES_INCREASED_JS
 
     @pytest.mark.parametrize(
         "error",
@@ -9714,13 +9672,25 @@ class TestMessageTextOccurrences:
         mock_page.wait_for_function = AsyncMock(side_effect=error)
 
         assert (
-            await extractor._message_text_visible(
+            await extractor._message_send_confirmed(
                 "Hello!",
                 target=target,
                 owner=owner,
-                previous_occurrences=0,
+                confirmation="confirmation-token",
             )
             is False
+        )
+
+    async def test_dispose_disconnects_the_owner_token(self, mock_page):
+        extractor = LinkedInExtractor(mock_page)
+        _target, owner = self._arguments()
+        mock_page.evaluate = AsyncMock()
+
+        await extractor._dispose_message_confirmation(owner, "confirmation-token")
+
+        mock_page.evaluate.assert_awaited_once_with(
+            _MESSAGE_CONFIRMATION_DISPOSE_JS,
+            {"owner": owner, "token": "confirmation-token"},
         )
 
 

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,5 +1,6 @@
 """Tests for the LinkedInExtractor scraping engine."""
 
+from contextlib import ExitStack
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -9040,7 +9041,9 @@ class TestSendMessageComposerInteraction:
         # attempted; the answer comes from the interruption itself.
         visible.assert_not_awaited()
 
-    @pytest.mark.parametrize("stage", ["dispatch", "confirmation"])
+    @pytest.mark.parametrize(
+        "stage", ["dispatch", "confirmation", "failed-cleanup", "unconfirmed-cleanup"]
+    )
     async def test_cancellation_after_dispatch_is_logged(
         self, mock_page, caplog, stage
     ):
@@ -9051,33 +9054,51 @@ class TestSendMessageComposerInteraction:
         anything the cancelled scope returns. The caller therefore sees a
         timeout carrying no ``retry_safe``, and this log line is the only
         record that a message may already have left.
+
+        The window ends where a result exists, not where the send returns.
+        Both cleanup calls run after a submission was dispatched, and both
+        await: the one in the submission-failure handler and the one on the
+        unconfirmed path. Cancelled there, the message is exactly as
+        possibly-delivered as during the send itself.
         """
         extractor = LinkedInExtractor(mock_page)
         mock_keyboard = MagicMock()
         mock_keyboard.type = AsyncMock()
         mock_keyboard.press = AsyncMock()
         mock_page.keyboard = mock_keyboard
+        dismiss_effect = None
         if stage == "dispatch":
             mock_page.evaluate = AsyncMock(
                 side_effect=["focused", asyncio.CancelledError()]
             )
             visible_effect = AsyncMock()
-        else:
+        elif stage == "confirmation":
             mock_page.evaluate = AsyncMock(side_effect=["focused", True])
             visible_effect = AsyncMock(side_effect=asyncio.CancelledError())
+        elif stage == "failed-cleanup":
+            # The submission raised an ordinary error after dispatching its
+            # input event, so the handler runs and is cancelled inside it.
+            mock_page.evaluate = AsyncMock(
+                side_effect=["focused", RuntimeError("context destroyed")]
+            )
+            visible_effect = AsyncMock()
+            dismiss_effect = AsyncMock(side_effect=asyncio.CancelledError())
+        else:
+            # The send went out and delivery was not observed, which is the
+            # path that most needs the warning: the result it was about to
+            # return is the one carrying `retry_safe=False`.
+            mock_page.evaluate = AsyncMock(side_effect=["focused", True])
+            visible_effect = AsyncMock(return_value=False)
+            dismiss_effect = AsyncMock(side_effect=asyncio.CancelledError())
         patches = self._patch_send_message_to_compose(extractor, mock_page)
+        if dismiss_effect is not None:
+            patches = [
+                *patches,
+                patch.object(extractor, "_dismiss_message_ui", dismiss_effect),
+            ]
 
         with (
-            patches[0],
-            patches[1],
-            patches[2],
-            patches[3],
-            patches[4],
-            patches[5],
-            patches[6],
-            patches[7],
-            patches[8],
-            patches[9],
+            ExitStack() as stack,
             patch.object(
                 extractor,
                 "_message_text_occurrences",
@@ -9090,6 +9111,8 @@ class TestSendMessageComposerInteraction:
             ),
             pytest.raises(asyncio.CancelledError),
         ):
+            for entered in patches:
+                stack.enter_context(entered)
             await extractor.send_message("testuser", "Hello!", confirm_send=True)
 
         # Cancellation has to keep propagating, or the surrounding scope

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8437,6 +8437,33 @@ class TestSearchConversations:
 
 
 class TestSendMessage:
+    @pytest.mark.parametrize("message", ["", " \t\n"], ids=["empty", "whitespace"])
+    async def test_blank_message_is_rejected_before_browser_interaction(
+        self, mock_page, message
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        keyboard = MagicMock()
+        mock_page.keyboard = keyboard
+
+        with patch.object(
+            extractor, "_navigate_to_page", new_callable=AsyncMock
+        ) as navigate:
+            result = await extractor.send_message(
+                "testuser", message, confirm_send=True
+            )
+
+        assert result == {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "status": "message_unavailable",
+            "message": "Message must contain non-whitespace characters.",
+            "recipient_selected": False,
+            "sent": False,
+        }
+        navigate.assert_not_awaited()
+        mock_page.evaluate.assert_not_awaited()
+        keyboard.type.assert_not_called()
+        keyboard.press.assert_not_called()
+
     async def test_dry_run_returns_confirmation_required(self, mock_page):
         """send_message with confirm_send=False returns confirmation_required status."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -8978,6 +8978,68 @@ class TestSendMessageComposerInteraction:
         # The confirmation receives exactly the baseline taken before the click.
         assert steps == ["focus", "type", "baseline", "click", "confirm:2"]
 
+    @pytest.mark.parametrize(
+        "side_effect",
+        [
+            ["focused", PatchrightError("execution context was destroyed")],
+            ["focused", False],
+        ],
+        ids=["click", "enter"],
+    )
+    async def test_interrupted_submission_is_not_a_failure(
+        self, mock_page, side_effect
+    ):
+        """A submission that dies mid-call is an unknown, never a tool error.
+
+        Both paths dispatch their input event inside the call that then
+        fails, so the exception says nothing about whether the message left.
+        Letting it out would reach the caller as a plain failure and invite
+        the retry that delivers a second message to a real person.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock(
+            side_effect=PatchrightError("execution context was destroyed")
+        )
+        mock_page.keyboard = mock_keyboard
+        mock_page.evaluate = AsyncMock(side_effect=side_effect)
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch.object(
+                extractor,
+                "_message_text_visible",
+                new_callable=AsyncMock,
+            ) as visible,
+        ):
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        # There is no page left to read, so the confirmation is never even
+        # attempted; the answer comes from the interruption itself.
+        visible.assert_not_awaited()
+
     async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -9007,6 +9007,45 @@ class TestSendMessage:
         submit.assert_not_awaited()
         mock_page.keyboard.type.assert_not_awaited()
 
+    async def test_queryless_route_switch_during_surface_wait_fails_closed(
+        self, mock_page
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+        alice_route = "https://www.linkedin.com/messaging/thread/ALICE/"
+        bob_route = "https://www.linkedin.com/messaging/thread/BOB/"
+        mock_page.url = alice_route
+
+        async def switch_route(_target):
+            mock_page.url = bob_route
+            return "composer"
+
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4] as surface,
+            patches[5] as state,
+            patches[6] as write,
+            patches[7] as submit,
+            patches[8],
+            patches[9],
+            patches[10],
+        ):
+            surface.side_effect = switch_route
+            result = await extractor.send_message(
+                "testuser", "Hello!", confirm_send=True
+            )
+
+        assert result["status"] == "recipient_resolution_failed"
+        assert result["retry_safe"] is True
+        assert result["url"] == bob_route
+        state.assert_not_awaited()
+        write.assert_not_awaited()
+        submit.assert_not_awaited()
+        mock_page.keyboard.type.assert_not_awaited()
+        mock_page.keyboard.press.assert_not_awaited()
+
     async def test_queryless_route_is_captured_before_owner_resolution(self, mock_page):
         extractor = LinkedInExtractor(mock_page)
         patches = self._patch_to_composer(extractor, mock_page)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -9040,6 +9040,66 @@ class TestSendMessageComposerInteraction:
         # attempted; the answer comes from the interruption itself.
         visible.assert_not_awaited()
 
+    @pytest.mark.parametrize("stage", ["dispatch", "confirmation"])
+    async def test_cancellation_after_dispatch_is_logged(
+        self, mock_page, caplog, stage
+    ):
+        """Cancellation in the destructive window leaves a warning behind.
+
+        FastMCP runs the tool inside ``anyio.fail_after()``, so the deadline
+        raises ``CancelledError`` past ``except Exception`` and discards
+        anything the cancelled scope returns. The caller therefore sees a
+        timeout carrying no ``retry_safe``, and this log line is the only
+        record that a message may already have left.
+        """
+        extractor = LinkedInExtractor(mock_page)
+        mock_keyboard = MagicMock()
+        mock_keyboard.type = AsyncMock()
+        mock_keyboard.press = AsyncMock()
+        mock_page.keyboard = mock_keyboard
+        if stage == "dispatch":
+            mock_page.evaluate = AsyncMock(
+                side_effect=["focused", asyncio.CancelledError()]
+            )
+            visible_effect = AsyncMock()
+        else:
+            mock_page.evaluate = AsyncMock(side_effect=["focused", True])
+            visible_effect = AsyncMock(side_effect=asyncio.CancelledError())
+        patches = self._patch_send_message_to_compose(extractor, mock_page)
+
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patch.object(
+                extractor,
+                "_message_text_occurrences",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch.object(extractor, "_message_text_visible", visible_effect),
+            caplog.at_level(
+                logging.WARNING, logger="linkedin_mcp_server.scraping.extractor"
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await extractor.send_message("testuser", "Hello!", confirm_send=True)
+
+        # Cancellation has to keep propagating, or the surrounding scope
+        # never unwinds. The warning names the duplicate-delivery risk that
+        # the discarded result can no longer report.
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("retry may deliver the message twice" in w for w in warnings), (
+            warnings
+        )
+
     async def test_send_unconfirmed_when_click_adds_nothing(self, mock_page):
         """A clicked Send button that changes nothing is not a sent message."""
         extractor = LinkedInExtractor(mock_page)

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -115,7 +115,7 @@ async def dom_page():
             await browser.close()
 
 
-async def send(page, html: str) -> dict:
+async def send(page, html: str, *, message: str = MESSAGE) -> dict:
     """Run the real send path against `html`, mocking discovery only."""
     await page.set_content(html)
     extractor = LinkedInExtractor(page)
@@ -134,7 +134,7 @@ async def send(page, html: str) -> dict:
             return_value=COMPOSE_URL,
         ),
     ):
-        return await extractor.send_message("fadi-eliwi", MESSAGE, confirm_send=True)
+        return await extractor.send_message("fadi-eliwi", message, confirm_send=True)
 
 
 async def text_of(page, selector: str) -> str:
@@ -142,6 +142,23 @@ async def text_of(page, selector: str) -> str:
 
 
 class TestSendConfirmationAgainstRealDom:
+    @pytest.mark.parametrize("message", ["", " \t\n"], ids=["empty", "whitespace"])
+    async def test_blank_message_leaves_existing_draft_untouched(
+        self, dom_page, message
+    ):
+        draft = "Confidential draft"
+        result = await send(
+            dom_page,
+            compose_page(DELIVERING_SEND_JS, draft=draft),
+            message=message,
+        )
+
+        assert result["status"] == "message_unavailable"
+        assert result["sent"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await text_of(dom_page, "#composer") == draft
+        assert await dom_page.locator("#thread .msg").count() == 1
+
     async def test_ineffective_send_is_not_confirmed(self, dom_page):
         # The reported failure: Send is clicked, the handler does nothing,
         # and the message stays in the composer next to an identical earlier

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -48,6 +48,17 @@ NOOP_SEND_JS = """
   });
 """
 
+# Goes read-only for the duration of an in-flight send and delivers nothing,
+# which is what a React composer commonly does while it waits. The text stays
+# on screen the whole time, so an occurrence subtracted at baseline has to
+# stay subtracted or this no-op confirms itself.
+READONLY_NOOP_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    document.getElementById('composer').setAttribute('contenteditable', 'false');
+  });
+"""
+
 # Moves the composer's text into the thread as a plain, non-editable entry,
 # which is what a delivered message looks like to the page.
 DELIVERING_SEND_JS = """
@@ -159,14 +170,44 @@ class TestSendConfirmationAgainstRealDom:
         assert await text_of(dom_page, "#composer") == draft
         assert await dom_page.locator("#thread .msg").count() == 1
 
+    async def test_existing_draft_is_never_sent_along(self, dom_page):
+        # Measured, and the reason this fixture carries a draft at all:
+        # `element.focus()` leaves the caret at the *start* of a
+        # contenteditable in Chromium, so a typed message lands in front of
+        # whatever the composer already held and LinkedIn delivers the two as
+        # one. The draft is the user's text and nobody asked for it to be
+        # sent, so the send refuses here. Clearing it instead would trade the
+        # leak for destroying it.
+        result = await send(dom_page, compose_page(DELIVERING_SEND_JS, draft=DRAFT))
+
+        assert result["status"] == "composer_occupied"
+        assert result["sent"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await text_of(dom_page, "#composer") == DRAFT.strip()
+        assert await dom_page.locator("#thread .msg").count() == 1
+
     async def test_ineffective_send_is_not_confirmed(self, dom_page):
         # The reported failure: Send is clicked, the handler does nothing,
         # and the message stays in the composer next to an identical earlier
-        # copy in the thread. Neither is evidence of delivery.
+        # copy in the thread. Neither is evidence of delivery. The click did
+        # happen, though, so the answer is "unknown" rather than "not sent".
         result = await send(dom_page, compose_page(NOOP_SEND_JS))
 
         assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
-        assert result["status"] == "send_unavailable"
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert await text_of(dom_page, "#composer") == MESSAGE
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_composer_going_read_only_does_not_confirm(self, dom_page):
+        # The same no-op, except the composer stops being editable while it
+        # waits. Counting only `[contenteditable="true"]` would stop
+        # subtracting the unsent text at exactly that moment and read its
+        # own draft as a delivery.
+        result = await send(dom_page, compose_page(READONLY_NOOP_SEND_JS))
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         assert await text_of(dom_page, "#composer") == MESSAGE
         assert await dom_page.locator("#thread .msg").count() == 1
@@ -175,18 +216,11 @@ class TestSendConfirmationAgainstRealDom:
         # Same page, same earlier copy, but the Send handler moves the text
         # into the thread. The count outside the composer grows, so this one
         # confirms where the ineffective click above did not.
-        result = await send(dom_page, compose_page(DELIVERING_SEND_JS, draft=DRAFT))
+        result = await send(dom_page, compose_page(DELIVERING_SEND_JS))
 
         assert result["status"] == "sent"
         assert result["sent"] is True
         assert await text_of(dom_page, "#composer") == ""
         entries = dom_page.locator("#thread .msg")
         assert await entries.count() == 2
-        # Measured, and the reason this fixture carries a draft at all:
-        # `element.focus()` leaves the caret at the *start* of a
-        # contenteditable in Chromium, so the typed message lands in front of
-        # whatever the composer already held. The delivered entry therefore
-        # reads message-then-draft. The confirmation is unaffected — it counts
-        # the message as a substring — but a composer with an unsent draft
-        # sends the two in that order.
-        assert (await entries.last.inner_text()).strip() == f"{MESSAGE}{DRAFT}".strip()
+        assert (await entries.last.inner_text()).strip() == MESSAGE

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -18,6 +18,7 @@ whether or not the send succeeds.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -56,6 +57,18 @@ READONLY_NOOP_SEND_JS = """
   document.getElementById('send').addEventListener('click', () => {
     document.body.setAttribute('data-clicked', 'true');
     document.getElementById('composer').setAttribute('contenteditable', 'false');
+  });
+"""
+
+# Clears the composer and delivers nothing, which is what an optimistic
+# reset followed by a failed submission leaves behind. This is the case that
+# separates "a new occurrence appeared" from "the editor went empty": a
+# confirmation that subtracted the draft only while the editor held text
+# would read the clearance itself as the delivery.
+CLEARING_NOOP_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    document.getElementById('composer').textContent = '';
   });
 """
 
@@ -116,6 +129,12 @@ async def dom_page():
             browser = await p.chromium.launch(channel="chromium", headless=True)
             page = await browser.new_page()
         except Exception as exc:  # browser binary missing
+            if os.environ.get("CI"):
+                # CI installs chromium before this suite runs, so a launch
+                # that fails there is a broken environment rather than an
+                # absent browser. Skipping would take every case in this file
+                # out of CI while the run stayed green.
+                raise
             pytest.skip(f"chromium unavailable: {exc}")
         # The confirmation waits on the page-level default, so a failed send
         # has to give up quickly here.
@@ -217,6 +236,22 @@ class TestSendConfirmationAgainstRealDom:
         # The click happened, so a retry can deliver the message twice.
         assert result["retry_safe"] is False
         assert await text_of(dom_page, "#composer") == MESSAGE
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_a_cleared_composer_alone_does_not_confirm(self, dom_page):
+        # The composer empties and nothing arrives in the thread. The count
+        # outside every editor is the same before and after, so this stays
+        # unconfirmed. Reading the clearance as delivery is the mistake this
+        # case exists to catch: an implementation that stopped subtracting
+        # the draft once the editor went empty would pass every other case
+        # in this file and confirm here.
+        result = await send(dom_page, compose_page(CLEARING_NOOP_SEND_JS))
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert await text_of(dom_page, "#composer") == ""
         assert await dom_page.locator("#thread .msg").count() == 1
 
     async def test_delivered_message_is_confirmed(self, dom_page):

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -1,0 +1,175 @@
+# tests/test_send_message_confirmation_dom.py
+"""Browser-DOM tests for the send_message post-send confirmation (issue #866).
+
+The unit suite mocks ``page.evaluate``, so none of what decides "sent" ever
+runs there: the JS focus, the keyboard typing into a contenteditable, the
+Send click and the occurrence count taken across the resulting DOM. These
+cases drive the production ``send_message`` path in headless chromium and
+replace navigation and recipient discovery only, so every step the
+confirmation depends on executes unchanged. Skipped automatically when
+chromium is not installed; run locally after
+``uv run patchright install chromium --no-shell``.
+
+Both fixtures place an identical earlier message in the thread, which is
+what made "the text is somewhere on the page" worthless as evidence: the
+composer holds the message before it is sent, and the earlier copy holds it
+whether or not the send succeeds.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from patchright.async_api import async_playwright
+
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+
+#: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
+#: worker so browser startups cannot compete with the DOM cases' wall-clock
+#: timers.
+#: Without that distribution mode the group mark is inert.
+pytestmark = [
+    pytest.mark.browser_dom,
+    pytest.mark.xdist_group("browser_runtime"),
+]
+
+DISPLAY_NAME = "Fadi Al Eliwi"
+MESSAGE = "UNDELIVERED SENTINEL"
+DRAFT = "Draft: "
+COMPOSE_URL = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
+
+# Records the click as a body attribute and does nothing else: the button is
+# visible and enabled, so the production JS click path succeeds while the
+# message never leaves the composer.
+NOOP_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+  });
+"""
+
+# Moves the composer's text into the thread as a plain, non-editable entry,
+# which is what a delivered message looks like to the page.
+DELIVERING_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    const composer = document.getElementById('composer');
+    const text = composer.innerText;
+    if (!text.trim()) return;
+    const entry = document.createElement('div');
+    entry.className = 'msg';
+    entry.textContent = text;
+    document.getElementById('thread').appendChild(entry);
+    composer.textContent = '';
+  });
+"""
+
+
+def compose_page(send_js: str, *, draft: str = "") -> str:
+    """A compose surface holding one earlier copy of the same message."""
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Messaging</title></head>
+  <body>
+    <main>
+      <h2 id="recipient">{DISPLAY_NAME}</h2>
+      <div id="thread">
+        <div class="msg">{MESSAGE}</div>
+      </div>
+      <div id="composer" role="textbox" contenteditable="true"
+        aria-label="Write a message…">{draft}</div>
+      <button id="send" type="submit">Send</button>
+    </main>
+    <script>{send_js}</script>
+  </body>
+</html>
+"""
+
+
+@pytest.fixture
+async def dom_page():
+    """Real chromium page, or skip when no browser is installed.
+
+    Only launch/setup is guarded by the skip — the ``yield`` is outside it
+    so an assertion failure or JS error in a test body is never swallowed
+    into a skip.
+
+    ``channel="chromium"`` names the browser this project installs. Without
+    it Playwright picks the *binary* from the ``headless`` flag alone and
+    asks for ``chromium-headless-shell``, which nothing here installs since
+    the setup moved to ``--no-shell``: the launch would fail and every case
+    in this file would skip itself, silently, wherever the real browser is.
+    """
+    async with async_playwright() as p:
+        try:
+            browser = await p.chromium.launch(channel="chromium", headless=True)
+            page = await browser.new_page()
+        except Exception as exc:  # browser binary missing
+            pytest.skip(f"chromium unavailable: {exc}")
+        # The confirmation waits on the page-level default, so a failed send
+        # has to give up quickly here.
+        page.set_default_timeout(1500)
+        try:
+            yield page
+        finally:
+            await browser.close()
+
+
+async def send(page, html: str) -> dict:
+    """Run the real send path against `html`, mocking discovery only."""
+    await page.set_content(html)
+    extractor = LinkedInExtractor(page)
+    with (
+        patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+        patch.object(
+            extractor,
+            "_read_profile_display_name",
+            new_callable=AsyncMock,
+            return_value=DISPLAY_NAME,
+        ),
+        patch.object(
+            extractor,
+            "_resolve_message_compose_href",
+            new_callable=AsyncMock,
+            return_value=COMPOSE_URL,
+        ),
+    ):
+        return await extractor.send_message("fadi-eliwi", MESSAGE, confirm_send=True)
+
+
+async def text_of(page, selector: str) -> str:
+    return (await page.locator(selector).inner_text()).strip()
+
+
+class TestSendConfirmationAgainstRealDom:
+    async def test_ineffective_send_is_not_confirmed(self, dom_page):
+        # The reported failure: Send is clicked, the handler does nothing,
+        # and the message stays in the composer next to an identical earlier
+        # copy in the thread. Neither is evidence of delivery.
+        result = await send(dom_page, compose_page(NOOP_SEND_JS))
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unavailable"
+        assert result["sent"] is False
+        assert await text_of(dom_page, "#composer") == MESSAGE
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_delivered_message_is_confirmed(self, dom_page):
+        # Same page, same earlier copy, but the Send handler moves the text
+        # into the thread. The count outside the composer grows, so this one
+        # confirms where the ineffective click above did not.
+        result = await send(dom_page, compose_page(DELIVERING_SEND_JS, draft=DRAFT))
+
+        assert result["status"] == "sent"
+        assert result["sent"] is True
+        assert await text_of(dom_page, "#composer") == ""
+        entries = dom_page.locator("#thread .msg")
+        assert await entries.count() == 2
+        # Measured, and the reason this fixture carries a draft at all:
+        # `element.focus()` leaves the caret at the *start* of a
+        # contenteditable in Chromium, so the typed message lands in front of
+        # whatever the composer already held. The delivered entry therefore
+        # reads message-then-draft. The confirmation is unaffected — it counts
+        # the message as a substring — but a composer with an unsent draft
+        # sends the two in that order.
+        assert (await entries.last.inner_text()).strip() == f"{MESSAGE}{DRAFT}".strip()

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -164,8 +164,9 @@ class TestSendConfirmationAgainstRealDom:
             message=message,
         )
 
-        assert result["status"] == "message_unavailable"
+        assert result["status"] == "invalid_message"
         assert result["sent"] is False
+        assert result["retry_safe"] is True
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
         assert await text_of(dom_page, "#composer") == draft
         assert await dom_page.locator("#thread .msg").count() == 1
@@ -182,6 +183,8 @@ class TestSendConfirmationAgainstRealDom:
 
         assert result["status"] == "composer_occupied"
         assert result["sent"] is False
+        # Nothing was submitted, so calling again cannot deliver twice.
+        assert result["retry_safe"] is True
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
         assert await text_of(dom_page, "#composer") == DRAFT.strip()
         assert await dom_page.locator("#thread .msg").count() == 1
@@ -196,6 +199,8 @@ class TestSendConfirmationAgainstRealDom:
         assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
+        # The click happened, so a retry can deliver the message twice.
+        assert result["retry_safe"] is False
         assert await text_of(dom_page, "#composer") == MESSAGE
         assert await dom_page.locator("#thread .msg").count() == 1
 
@@ -209,6 +214,8 @@ class TestSendConfirmationAgainstRealDom:
         assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
+        # The click happened, so a retry can deliver the message twice.
+        assert result["retry_safe"] is False
         assert await text_of(dom_page, "#composer") == MESSAGE
         assert await dom_page.locator("#thread .msg").count() == 1
 
@@ -220,6 +227,7 @@ class TestSendConfirmationAgainstRealDom:
 
         assert result["status"] == "sent"
         assert result["sent"] is True
+        assert result["retry_safe"] is False
         assert await text_of(dom_page, "#composer") == ""
         entries = dom_page.locator("#thread .msg")
         assert await entries.count() == 2

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -6,7 +6,9 @@ runs there: the JS focus, the keyboard typing into a contenteditable, the
 Send click and the occurrence count taken across the resulting DOM. These
 cases drive the production ``send_message`` path in headless chromium and
 replace navigation and recipient discovery only, so every step the
-confirmation depends on executes unchanged. Skipped automatically when
+confirmation depends on executes unchanged: recipient verification reads
+this page's own identity and submission clicks this page's own button.
+Skipped automatically when
 chromium is not installed; run locally after
 ``uv run patchright install chromium --no-shell``.
 
@@ -24,7 +26,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from patchright.async_api import async_playwright
 
-from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+from linkedin_mcp_server.scraping.extractor import (
+    LinkedInExtractor,
+    _ProfileMessageTarget,
+)
 
 #: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
 #: worker so browser startups cannot compete with the DOM cases' wall-clock
@@ -39,6 +44,13 @@ DISPLAY_NAME = "Fadi Al Eliwi"
 MESSAGE = "UNDELIVERED SENTINEL"
 DRAFT = "Draft: "
 COMPOSE_URL = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
+PROFILE_PATH = "/in/fadi-eliwi/"
+TARGET = _ProfileMessageTarget(
+    profile_path=PROFILE_PATH,
+    profile_urn="ACoAAB",
+    compose_url=COMPOSE_URL,
+    display_name=DISPLAY_NAME,
+)
 
 # Records the click as a body attribute and does nothing else: the button is
 # visible and enabled, so the production JS click path succeeds while the
@@ -88,21 +100,87 @@ DELIVERING_SEND_JS = """
   });
 """
 
+FOREIGN_DELIVERING_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    const composer = document.getElementById('composer');
+    const text = composer.innerText;
+    if (!text.trim()) return;
+    const entry = document.createElement('div');
+    entry.className = 'msg';
+    entry.textContent = text;
+    document.getElementById('foreign-thread').appendChild(entry);
+    composer.textContent = '';
+  });
+"""
+
+REMOVING_OWNER_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    const text = document.getElementById('composer').innerText;
+    const entry = document.createElement('div');
+    entry.className = 'msg';
+    entry.textContent = text;
+    document.getElementById('outside').appendChild(entry);
+    document.getElementById('conversation').remove();
+  });
+"""
+
+REPLACING_OWNER_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    const owner = document.getElementById('conversation');
+    const replacement = owner.cloneNode(true);
+    const composer = replacement.querySelector('#composer');
+    const entry = document.createElement('div');
+    entry.className = 'msg';
+    entry.textContent = composer.innerText;
+    replacement.querySelector('#thread').appendChild(entry);
+    composer.textContent = '';
+    owner.replaceWith(replacement);
+  });
+"""
+
+STATUS_GROWTH_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    document.getElementById('conversation').insertAdjacentHTML(
+      'beforeend', '<span>available</span>');
+  });
+"""
+
+CLEARING_STATUS_GROWTH_SEND_JS = """
+  document.getElementById('send').addEventListener('click', () => {
+    document.body.setAttribute('data-clicked', 'true');
+    document.getElementById('composer').textContent = '';
+    document.getElementById('conversation').insertAdjacentHTML(
+      'beforeend', '<span>available</span>');
+  });
+"""
+
 
 def compose_page(send_js: str, *, draft: str = "") -> str:
-    """A compose surface holding one earlier copy of the same message."""
+    """A compose surface holding one earlier copy of the same message.
+
+    The recipient link sits beside the editor rather than inside it, which is
+    what lets the production verification resolve an identity at all: draft
+    content never authorizes anyone.
+    """
     return f"""<!DOCTYPE html>
 <html lang="en">
   <head><meta charset="utf-8"><title>Messaging</title></head>
   <body>
     <main>
-      <h2 id="recipient">{DISPLAY_NAME}</h2>
-      <div id="thread">
-        <div class="msg">{MESSAGE}</div>
-      </div>
-      <div id="composer" role="textbox" contenteditable="true"
-        aria-label="Write a message…">{draft}</div>
-      <button id="send" type="submit">Send</button>
+      <section id="conversation">
+        <a id="recipient" href="https://www.linkedin.com{PROFILE_PATH}">
+          {DISPLAY_NAME}</a>
+        <div id="thread">
+          <div class="msg">{MESSAGE}</div>
+        </div>
+        <div id="composer" role="textbox" contenteditable="true"
+          aria-label="Write a message…">{draft}</div>
+        <button id="send" type="submit">Send</button>
+      </section>
     </main>
     <script>{send_js}</script>
   </body>
@@ -145,26 +223,34 @@ async def dom_page():
             await browser.close()
 
 
-async def send(page, html: str, *, message: str = MESSAGE) -> dict:
-    """Run the real send path against `html`, mocking discovery only."""
+async def send(
+    page, html: str, *, message: str = MESSAGE, confirm_send: bool = True
+) -> dict:
+    """Run the real send path against `html`, mocking discovery only.
+
+    Only the two steps that need a live LinkedIn are replaced: reading the
+    target off a profile page, and the messaging-URL guard, which cannot pass
+    for the ``about:blank`` a ``set_content`` page reports. Both have their own
+    unit tests. Everything the confirmation rests on runs here for real.
+    """
     await page.set_content(html)
     extractor = LinkedInExtractor(page)
     with (
         patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
         patch.object(
             extractor,
-            "_read_profile_display_name",
+            "_read_profile_message_target",
             new_callable=AsyncMock,
-            return_value=DISPLAY_NAME,
+            return_value=TARGET,
         ),
-        patch.object(
-            extractor,
-            "_resolve_message_compose_href",
-            new_callable=AsyncMock,
-            return_value=COMPOSE_URL,
+        patch(
+            "linkedin_mcp_server.scraping.extractor._message_page_url_is_safe",
+            return_value=True,
         ),
     ):
-        return await extractor.send_message("fadi-eliwi", message, confirm_send=True)
+        return await extractor.send_message(
+            "fadi-eliwi", message, confirm_send=confirm_send
+        )
 
 
 async def text_of(page, selector: str) -> str:
@@ -190,6 +276,22 @@ class TestSendConfirmationAgainstRealDom:
         assert await text_of(dom_page, "#composer") == draft
         assert await dom_page.locator("#thread .msg").count() == 1
 
+    async def test_foreign_recipient_never_reaches_the_composer(self, dom_page):
+        # Issue #861: the composer belongs to someone else. Nothing may be
+        # typed and nothing may be clicked, so the message the caller wrote
+        # cannot reach a person they never named.
+        page = compose_page(DELIVERING_SEND_JS).replace(
+            f'href="https://www.linkedin.com{PROFILE_PATH}"',
+            'href="https://www.linkedin.com/in/someone-else/"',
+        )
+        result = await send(dom_page, page)
+
+        assert result["sent"] is False
+        assert result["status"] == "composer_unavailable"
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await text_of(dom_page, "#composer") == ""
+        assert await dom_page.locator("#thread .msg").count() == 1
+
     async def test_existing_draft_is_never_sent_along(self, dom_page):
         # Measured, and the reason this fixture carries a draft at all:
         # `element.focus()` leaves the caret at the *start* of a
@@ -207,6 +309,37 @@ class TestSendConfirmationAgainstRealDom:
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
         assert await text_of(dom_page, "#composer") == DRAFT.strip()
         assert await dom_page.locator("#thread .msg").count() == 1
+
+    @pytest.mark.parametrize(
+        ("confirm_send", "status"),
+        [(True, "composer_occupied"), (False, "confirmation_required")],
+        ids=["occupied", "dry-run"],
+    )
+    async def test_draft_refusal_never_closes_the_composer(
+        self, dom_page, confirm_send, status
+    ):
+        draft = "Private draft"
+        page = compose_page("", draft=draft).replace(
+            "</section>",
+            """<button aria-label="Close your draft conversation"
+              onclick="document.body.dataset.closed = String(
+                Number(document.body.dataset.closed || 0) + 1);
+                document.getElementById('composer').remove()">Close</button>
+              </section>""",
+        )
+
+        result = await send(dom_page, page, confirm_send=confirm_send)
+
+        observed = await dom_page.evaluate(
+            """() => ({
+                draft: document.getElementById('composer')?.innerText ?? null,
+                closed: document.body.dataset.closed ?? null,
+            })"""
+        )
+        assert result["status"] == status
+        assert result["sent"] is False
+        assert result["retry_safe"] is True
+        assert observed == {"draft": draft, "closed": None}
 
     async def test_ineffective_send_is_not_confirmed(self, dom_page):
         # The reported failure: Send is clicked, the handler does nothing,
@@ -253,6 +386,105 @@ class TestSendConfirmationAgainstRealDom:
         assert result["retry_safe"] is False
         assert await text_of(dom_page, "#composer") == ""
         assert await dom_page.locator("#thread .msg").count() == 1
+
+    @pytest.mark.parametrize(
+        "send_js",
+        [STATUS_GROWTH_SEND_JS, CLEARING_STATUS_GROWTH_SEND_JS],
+        ids=["draft-remains", "draft-cleared"],
+    )
+    async def test_status_substring_growth_is_not_confirmed(self, dom_page, send_js):
+        result = await send(dom_page, compose_page(send_js), message="a")
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert await text_of(dom_page, "#thread") == MESSAGE
+        assert await text_of(dom_page, "#conversation span") == "available"
+
+    async def test_delivered_short_message_is_confirmed(self, dom_page):
+        result = await send(dom_page, compose_page(DELIVERING_SEND_JS), message="a")
+
+        assert result["status"] == "sent"
+        assert result["sent"] is True
+        assert result["retry_safe"] is False
+        entries = dom_page.locator("#thread .msg")
+        assert await entries.count() == 2
+        assert (await entries.last.inner_text()).strip() == "a"
+
+    async def test_multiline_whitespace_units_are_normalized(self, dom_page):
+        await dom_page.set_content(compose_page(""))
+        await dom_page.evaluate(
+            """() => {
+                const entry = document.createElement('div');
+                entry.innerHTML = 'First<br>Second';
+                document.getElementById('thread').appendChild(entry);
+            }"""
+        )
+        extractor = LinkedInExtractor(dom_page)
+        owner = await extractor._resolve_message_owner(TARGET)
+        assert owner is not None
+        try:
+            count = await extractor._message_text_occurrences(
+                "  First \n  Second  ", target=TARGET, owner=owner
+            )
+        finally:
+            await extractor._dispose_message_owner(owner)
+
+        assert count == 1
+
+    async def test_foreign_thread_growth_is_not_confirmed(self, dom_page):
+        console_errors: list[str] = []
+        dom_page.on(
+            "console",
+            lambda message: (
+                console_errors.append(message.text) if message.type == "error" else None
+            ),
+        )
+        page = compose_page(FOREIGN_DELIVERING_SEND_JS).replace(
+            "</main>",
+            '<aside id="foreign-thread"></aside></main>',
+        )
+        result = await send(dom_page, page)
+
+        assert console_errors == []
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert await text_of(dom_page, "#composer") == ""
+        assert await dom_page.locator("#thread .msg").count() == 1
+        entries = dom_page.locator("#foreign-thread .msg")
+        assert await entries.count() == 1
+        assert (await entries.last.inner_text()).strip() == MESSAGE
+
+    async def test_removed_owner_with_matching_text_is_not_confirmed(self, dom_page):
+        page = compose_page(REMOVING_OWNER_SEND_JS).replace(
+            "</main>",
+            '<aside id="outside"></aside></main>',
+        )
+        result = await send(dom_page, page)
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert await dom_page.locator("#conversation").count() == 0
+        assert await text_of(dom_page, "#outside .msg") == MESSAGE
+
+    async def test_replacement_owner_with_copied_bubble_is_not_confirmed(
+        self, dom_page
+    ):
+        result = await send(dom_page, compose_page(REPLACING_OWNER_SEND_JS))
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert await text_of(dom_page, "#composer") == ""
+        entries = dom_page.locator("#thread .msg")
+        assert await entries.count() == 2
+        assert (await entries.last.inner_text()).strip() == MESSAGE
 
     async def test_delivered_message_is_confirmed(self, dom_page):
         # Same page, same earlier copy, but the Send handler moves the text

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -503,6 +503,57 @@ class TestComposerRecipientDom:
         assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
         assert (await dom_page.locator("#composer").inner_text()).strip() == MESSAGE
 
+    async def test_queryless_route_switch_before_owner_resolution_fails_closed(
+        self, dom_page
+    ):
+        alice_route = "https://www.linkedin.com/messaging/thread/ALICE/"
+        bob_route = "https://www.linkedin.com/messaging/thread/BOB/"
+        await dom_page.goto(alice_route)
+        await dom_page.set_content(compose_page(NOOP_SEND_JS))
+        await dom_page.evaluate(
+            """() => {
+                window.__originalComposer = document.getElementById('composer');
+                window.__originalSend = document.getElementById('send');
+            }"""
+        )
+        extractor = LinkedInExtractor(dom_page)
+        resolve_owner = extractor._resolve_message_owner
+
+        async def switch_route(target, *, expected_route):
+            assert target == TARGET
+            assert expected_route == alice_route
+            await dom_page.evaluate(
+                "history.replaceState({}, '', '/messaging/thread/BOB/')"
+            )
+            return await resolve_owner(target, expected_route=expected_route)
+
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(
+                extractor,
+                "_read_profile_message_target",
+                new_callable=AsyncMock,
+                return_value=_ProfileMessageTargetResolution("resolved", TARGET),
+            ),
+            patch.object(extractor, "_resolve_message_owner", side_effect=switch_route),
+        ):
+            result = await extractor.send_message(
+                "fadi-eliwi", MESSAGE, confirm_send=True
+            )
+
+        assert result["status"] == "recipient_resolution_failed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is True
+        assert dom_page.url == bob_route
+        assert await dom_page.evaluate(
+            """() => (
+                document.getElementById('composer') === window.__originalComposer &&
+                document.getElementById('send') === window.__originalSend
+            )"""
+        )
+        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+
     async def test_foreign_history_identity_does_not_reject_local_target(
         self, dom_page
     ):
@@ -937,8 +988,8 @@ class TestSendConfirmationDom:
         resolve_owner = extractor._resolve_message_owner
         captured = {}
 
-        async def capture_owner(target):
-            owner = await resolve_owner(target)
+        async def capture_owner(target, *, expected_route):
+            owner = await resolve_owner(target, expected_route=expected_route)
             captured["owner"] = owner
             return owner
 

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -365,6 +365,22 @@ class TestProfileMessageTargetDom:
 
         assert await read_profile_target(dom_page, html) is None
 
+    async def test_visibility_hidden_card_does_not_precede_visible_card(self, dom_page):
+        html = profile_page(
+            '<section style="visibility:hidden"><h1>Bob</h1>'
+            '<a href="/messaging/compose/?recipient=BOB">message</a></section>',
+            other=(
+                f'<section><h1>Alice</h1><a href="{COMPOSE_URL}">message</a></section>'
+            ),
+        )
+
+        target = await read_profile_target(dom_page, html)
+
+        assert target is not None
+        assert target.display_name == "Alice"
+        assert target.profile_urn == "ACoAAB"
+        assert target.compose_url == COMPOSE_URL
+
     async def test_later_sections_never_compete_with_first_top_card(self, dom_page):
         card = (
             "<section>"

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -1,21 +1,9 @@
 # tests/test_send_message_confirmation_dom.py
-"""Browser-DOM tests for the send_message post-send confirmation (issue #866).
+"""Browser-DOM tests for the send_message safety contract (issue #866).
 
-The unit suite mocks ``page.evaluate``, so none of what decides "sent" ever
-runs there: the JS focus, the keyboard typing into a contenteditable, the
-Send click and the occurrence count taken across the resulting DOM. These
-cases drive the production ``send_message`` path in headless chromium and
-replace navigation and recipient discovery only, so every step the
-confirmation depends on executes unchanged: recipient verification reads
-this page's own identity and submission clicks this page's own button.
-Skipped automatically when
-chromium is not installed; run locally after
-``uv run patchright install chromium --no-shell``.
-
-Both fixtures place an identical earlier message in the thread, which is
-what made "the text is somewhere on the page" worthless as evidence: the
-composer holds the message before it is sent, and the earlier copy holds it
-whether or not the send succeeds.
+The unit suite mocks ``page.evaluate``, so recipient scoping, focus, submission,
+and mutation observation need a real DOM. These tests run the production
+JavaScript in headless Chromium without making a LinkedIn request or write.
 """
 
 from __future__ import annotations
@@ -31,10 +19,6 @@ from linkedin_mcp_server.scraping.extractor import (
     _ProfileMessageTarget,
 )
 
-#: CI uses ``--dist loadgroup``. Keep every test that launches Chromium on one
-#: worker so browser startups cannot compete with the DOM cases' wall-clock
-#: timers.
-#: Without that distribution mode the group mark is inert.
 pytestmark = [
     pytest.mark.browser_dom,
     pytest.mark.xdist_group("browser_runtime"),
@@ -42,7 +26,6 @@ pytestmark = [
 
 DISPLAY_NAME = "Fadi Al Eliwi"
 MESSAGE = "UNDELIVERED SENTINEL"
-DRAFT = "Draft: "
 COMPOSE_URL = "https://www.linkedin.com/messaging/compose/?recipient=ACoAAB"
 PROFILE_PATH = "/in/fadi-eliwi/"
 TARGET = _ProfileMessageTarget(
@@ -52,171 +35,221 @@ TARGET = _ProfileMessageTarget(
     display_name=DISPLAY_NAME,
 )
 
-# Records the click as a body attribute and does nothing else: the button is
-# visible and enabled, so the production JS click path succeeds while the
-# message never leaves the composer.
 NOOP_SEND_JS = """
-  document.getElementById('send').addEventListener('click', () => {
-    document.body.setAttribute('data-clicked', 'true');
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
   });
 """
 
-# Goes read-only for the duration of an in-flight send and delivers nothing,
-# which is what a React composer commonly does while it waits. The text stays
-# on screen the whole time, so an occurrence subtracted at baseline has to
-# stay subtracted or this no-op confirms itself.
-READONLY_NOOP_SEND_JS = """
-  document.getElementById('send').addEventListener('click', () => {
-    document.body.setAttribute('data-clicked', 'true');
-    document.getElementById('composer').setAttribute('contenteditable', 'false');
-  });
-"""
-
-# Clears the composer and delivers nothing, which is what an optimistic
-# reset followed by a failed submission leaves behind. This is the case that
-# separates "a new occurrence appeared" from "the editor went empty": a
-# confirmation that subtracted the draft only while the editor held text
-# would read the clearance itself as the delivery.
 CLEARING_NOOP_SEND_JS = """
-  document.getElementById('send').addEventListener('click', () => {
-    document.body.setAttribute('data-clicked', 'true');
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
     document.getElementById('composer').textContent = '';
   });
 """
 
-# Moves the composer's text into the thread as a plain, non-editable entry,
-# which is what a delivered message looks like to the page.
-DELIVERING_SEND_JS = """
-  document.getElementById('send').addEventListener('click', () => {
-    document.body.setAttribute('data-clicked', 'true');
+READONLY_NOOP_SEND_JS = """
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
+    document.getElementById('composer').setAttribute('contenteditable', 'false');
+  });
+"""
+
+FIXED_ID_BUBBLE_JS = """
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
     const composer = document.getElementById('composer');
-    const text = composer.innerText;
-    if (!text.trim()) return;
-    const entry = document.createElement('div');
-    entry.className = 'msg';
-    entry.textContent = text;
+    const entry = messageItem(composer.innerText, 'local-only');
     document.getElementById('thread').appendChild(entry);
     composer.textContent = '';
   });
 """
 
-FOREIGN_DELIVERING_SEND_JS = """
-  document.getElementById('send').addEventListener('click', () => {
-    document.body.setAttribute('data-clicked', 'true');
+ID_TRANSITION_SEND_JS = """
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = String(
+      Number(document.body.dataset.clicked || 0) + 1);
     const composer = document.getElementById('composer');
-    const text = composer.innerText;
-    if (!text.trim()) return;
-    const entry = document.createElement('div');
-    entry.className = 'msg';
-    entry.textContent = text;
-    document.getElementById('foreign-thread').appendChild(entry);
+    const entry = messageItem(composer.innerText, 'client-opaque-id');
+    document.getElementById('thread').appendChild(entry);
+    setTimeout(() => {
+      entry.setAttribute('data-event-urn', 'server-opaque-id');
+    }, 0);
     composer.textContent = '';
   });
 """
 
-REMOVING_OWNER_SEND_JS = """
-  document.getElementById('send').addEventListener('click', () => {
-    document.body.setAttribute('data-clicked', 'true');
-    const text = document.getElementById('composer').innerText;
-    const entry = document.createElement('div');
-    entry.className = 'msg';
-    entry.textContent = text;
-    document.getElementById('outside').appendChild(entry);
-    document.getElementById('conversation').remove();
+REPLACED_NODE_SEND_JS = """
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
+    const composer = document.getElementById('composer');
+    const entry = messageItem(composer.innerText, 'client-opaque-id');
+    document.getElementById('thread').appendChild(entry);
+    const replacement = entry.cloneNode(true);
+    replacement.setAttribute('data-event-urn', 'server-opaque-id');
+    entry.replaceWith(replacement);
+    composer.textContent = '';
   });
 """
 
-REPLACING_OWNER_SEND_JS = """
+MULTIPLE_CANDIDATES_SEND_JS = """
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
+    const composer = document.getElementById('composer');
+    for (const suffix of ['one', 'two']) {
+      const entry = messageItem(composer.innerText, `client-${suffix}`);
+      document.getElementById('thread').appendChild(entry);
+      entry.setAttribute('data-event-urn', `server-${suffix}`);
+    }
+    composer.textContent = '';
+  });
+"""
+
+DIFFERENT_TEXT_SEND_JS = """
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
+    const entry = messageItem('different text', 'client-opaque-id');
+    document.getElementById('thread').appendChild(entry);
+    entry.setAttribute('data-event-urn', 'server-opaque-id');
+    document.getElementById('composer').textContent = '';
+  });
+"""
+
+OUTSIDE_OWNER_SEND_JS = """
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
+    const composer = document.getElementById('composer');
+    const entry = messageItem(composer.innerText, 'client-opaque-id');
+    document.getElementById('outside').appendChild(entry);
+    setTimeout(() => {
+      entry.setAttribute('data-event-urn', 'server-opaque-id');
+    }, 0);
+    composer.textContent = '';
+  });
+"""
+
+REPLACED_EDITOR_SEND_JS = (
+    ID_TRANSITION_SEND_JS
+    + """
   document.getElementById('send').addEventListener('click', () => {
-    document.body.setAttribute('data-clicked', 'true');
+    const editor = document.getElementById('composer');
+    editor.replaceWith(editor.cloneNode(true));
+  });
+"""
+)
+
+REPLACED_OWNER_SEND_JS = """
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
     const owner = document.getElementById('conversation');
     const replacement = owner.cloneNode(true);
     const composer = replacement.querySelector('#composer');
-    const entry = document.createElement('div');
-    entry.className = 'msg';
-    entry.textContent = composer.innerText;
+    const entry = messageItem(composer.innerText, 'client-opaque-id');
     replacement.querySelector('#thread').appendChild(entry);
+    entry.setAttribute('data-event-urn', 'server-opaque-id');
     composer.textContent = '';
     owner.replaceWith(replacement);
   });
 """
 
-STATUS_GROWTH_SEND_JS = """
-  document.getElementById('send').addEventListener('click', () => {
-    document.body.setAttribute('data-clicked', 'true');
-    document.getElementById('conversation').insertAdjacentHTML(
-      'beforeend', '<span>available</span>');
-  });
-"""
 
-CLEARING_STATUS_GROWTH_SEND_JS = """
-  document.getElementById('send').addEventListener('click', () => {
-    document.body.setAttribute('data-clicked', 'true');
-    document.getElementById('composer').textContent = '';
-    document.getElementById('conversation').insertAdjacentHTML(
-      'beforeend', '<span>available</span>');
-  });
-"""
-
-
-def compose_page(send_js: str, *, draft: str = "") -> str:
-    """A compose surface holding one earlier copy of the same message.
-
-    The recipient link sits beside the editor rather than inside it, which is
-    what lets the production verification resolve an identity at all: draft
-    content never authorizes anyone.
+def history_item(path: str, *, hidden: bool = False) -> str:
+    style = ' style="display:none"' if hidden else ""
+    return f"""
+      <div data-view-name="message-list-item" data-event-urn="history-id"{style}>
+        <a href="https://www.linkedin.com{path}">Mentioned profile</a>
+      </div>
     """
+
+
+def compose_page(
+    send_js: str,
+    *,
+    recipient_path: str | None = PROFILE_PATH,
+    recipient_urn: str = "ACoAAB",
+    recipient_hidden: bool = False,
+    history_html: str = "",
+    draft: str = "",
+) -> str:
+    hidden = ' style="display:none"' if recipient_hidden else ""
+    recipient = ""
+    if recipient_path is not None:
+        recipient = f"""
+          <div id="recipient" data-profile-urn="{recipient_urn}"{hidden}>
+            <a href="https://www.linkedin.com{recipient_path}">{DISPLAY_NAME}</a>
+          </div>
+        """
     return f"""<!DOCTYPE html>
 <html lang="en">
   <head><meta charset="utf-8"><title>Messaging</title></head>
   <body>
     <main>
-      <section id="conversation">
-        <a id="recipient" href="https://www.linkedin.com{PROFILE_PATH}">
-          {DISPLAY_NAME}</a>
+      <section id="conversation" role="dialog">
         <div id="thread">
-          <div class="msg">{MESSAGE}</div>
+          <div class="msg" data-view-name="message-list-item"
+               data-event-urn="existing-message-id">
+            <span class="message-unit">{MESSAGE}</span>
+          </div>
+          {history_html}
         </div>
-        <div id="composer" role="textbox" contenteditable="true"
-          aria-label="Write a message…">{draft}</div>
-        <button id="send" type="submit">Send</button>
+        <form id="composer-scope" onsubmit="return false">
+          {recipient}
+          <div id="composer" role="textbox" contenteditable="true">{draft}</div>
+          <button id="send" type="submit">Send</button>
+        </form>
       </section>
     </main>
-    <script>{send_js}</script>
+    <script>
+      function messageItem(text, eventUrn) {{
+        const entry = document.createElement('div');
+        entry.className = 'msg';
+        entry.dataset.viewName = 'message-list-item';
+        entry.dataset.eventUrn = eventUrn;
+        const unit = document.createElement('span');
+        unit.className = 'message-unit';
+        unit.textContent = text;
+        entry.appendChild(unit);
+        return entry;
+      }}
+      {send_js}
+    </script>
   </body>
+</html>
+"""
+
+
+def profile_page(top_card: str, *, other: str = "") -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Profile</title></head>
+  <body><main>{top_card}{other}</main></body>
 </html>
 """
 
 
 @pytest.fixture
 async def dom_page():
-    """Real chromium page, or skip when no browser is installed.
-
-    Only launch/setup is guarded by the skip — the ``yield`` is outside it
-    so an assertion failure or JS error in a test body is never swallowed
-    into a skip.
-
-    ``channel="chromium"`` names the browser this project installs. Without
-    it Playwright picks the *binary* from the ``headless`` flag alone and
-    asks for ``chromium-headless-shell``, which nothing here installs since
-    the setup moved to ``--no-shell``: the launch would fail and every case
-    in this file would skip itself, silently, wherever the real browser is.
-    """
-    async with async_playwright() as p:
+    async with async_playwright() as playwright:
         try:
-            browser = await p.chromium.launch(channel="chromium", headless=True)
+            browser = await playwright.chromium.launch(
+                channel="chromium", headless=True
+            )
             page = await browser.new_page()
-        except Exception as exc:  # browser binary missing
+        except Exception as exc:
             if os.environ.get("CI"):
-                # CI installs chromium before this suite runs, so a launch
-                # that fails there is a broken environment rather than an
-                # absent browser. Skipping would take every case in this file
-                # out of CI while the run stayed green.
                 raise
             pytest.skip(f"chromium unavailable: {exc}")
-        # The confirmation waits on the page-level default, so a failed send
-        # has to give up quickly here.
-        page.set_default_timeout(1500)
+        page.set_default_timeout(600)
         try:
             yield page
         finally:
@@ -226,13 +259,6 @@ async def dom_page():
 async def send(
     page, html: str, *, message: str = MESSAGE, confirm_send: bool = True
 ) -> dict:
-    """Run the real send path against `html`, mocking discovery only.
-
-    Only the two steps that need a live LinkedIn are replaced: reading the
-    target off a profile page, and the messaging-URL guard, which cannot pass
-    for the ``about:blank`` a ``set_content`` page reports. Both have their own
-    unit tests. Everything the confirmation rests on runs here for real.
-    """
     await page.set_content(html)
     extractor = LinkedInExtractor(page)
     with (
@@ -253,356 +279,306 @@ async def send(
         )
 
 
-async def text_of(page, selector: str) -> str:
-    return (await page.locator(selector).inner_text()).strip()
+async def read_profile_target(page, html: str) -> _ProfileMessageTarget | None:
+    async def fulfill(route):
+        await route.fulfill(status=200, content_type="text/html", body=html)
+
+    await page.route("https://www.linkedin.com/**", fulfill)
+    await page.goto(f"https://www.linkedin.com{PROFILE_PATH}")
+    return await LinkedInExtractor(page)._read_profile_message_target()
 
 
-class TestSendConfirmationAgainstRealDom:
-    @pytest.mark.parametrize("message", ["", " \t\n"], ids=["empty", "whitespace"])
-    async def test_blank_message_leaves_existing_draft_untouched(
-        self, dom_page, message
-    ):
-        draft = "Confidential draft"
+class TestProfileMessageTargetDom:
+    async def test_history_only_compose_link_does_not_authorize_profile(self, dom_page):
+        html = profile_page(
+            f"<section><h1>{DISPLAY_NAME}</h1></section>",
+            other=(
+                '<section data-view-name="message-list-item">'
+                f'<a href="{COMPOSE_URL}">history</a></section>'
+            ),
+        )
+
+        assert await read_profile_target(dom_page, html) is None
+
+    async def test_foreign_history_link_does_not_reject_top_card_target(self, dom_page):
+        html = profile_page(
+            '<section id="top-card">'
+            f'<h1>{DISPLAY_NAME}</h1><a href="{COMPOSE_URL}">message</a>'
+            "</section>",
+            other=(
+                '<section><a href="/messaging/compose/?recipient=OTHER">'
+                "history</a></section>"
+            ),
+        )
+
+        target = await read_profile_target(dom_page, html)
+
+        assert target is not None
+        assert target.profile_path == PROFILE_PATH
+        assert target.profile_urn == "ACoAAB"
+        assert target.compose_url == COMPOSE_URL
+
+    async def test_hidden_top_card_identity_does_not_authorize_profile(self, dom_page):
+        html = profile_page(
+            "<section>"
+            f"<h1>{DISPLAY_NAME}</h1>"
+            f'<a style="display:none" href="{COMPOSE_URL}">message</a>'
+            "</section>"
+        )
+
+        assert await read_profile_target(dom_page, html) is None
+
+    async def test_multiple_visible_top_cards_fail_closed(self, dom_page):
+        card = (
+            "<section>"
+            f'<h1>{DISPLAY_NAME}</h1><a href="{COMPOSE_URL}">message</a>'
+            "</section>"
+        )
+
+        assert (
+            await read_profile_target(dom_page, profile_page(card, other=card)) is None
+        )
+
+
+class TestComposerRecipientDom:
+    async def test_target_identity_only_in_history_does_not_authorize(self, dom_page):
         result = await send(
             dom_page,
-            compose_page(DELIVERING_SEND_JS, draft=draft),
-            message=message,
+            compose_page(
+                NOOP_SEND_JS,
+                recipient_path=None,
+                history_html=history_item(PROFILE_PATH),
+            ),
         )
 
-        assert result["status"] == "invalid_message"
+        assert result["status"] == "composer_unavailable"
         assert result["sent"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
+
+    async def test_foreign_history_identity_does_not_reject_local_target(
+        self, dom_page
+    ):
+        result = await send(
+            dom_page,
+            compose_page(
+                NOOP_SEND_JS,
+                history_html=history_item("/in/someone-else/"),
+            ),
+        )
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+
+    async def test_foreign_local_identity_cannot_use_matching_history(self, dom_page):
+        result = await send(
+            dom_page,
+            compose_page(
+                NOOP_SEND_JS,
+                recipient_path="/in/someone-else/",
+                recipient_urn="OTHER",
+                history_html=history_item(PROFILE_PATH),
+            ),
+        )
+
+        assert result["status"] == "composer_unavailable"
+        assert result["sent"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+
+    async def test_hidden_local_identity_fails_closed(self, dom_page):
+        result = await send(
+            dom_page,
+            compose_page(NOOP_SEND_JS, recipient_hidden=True),
+        )
+
+        assert result["status"] == "composer_unavailable"
+        assert result["sent"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+
+    async def test_dry_run_ends_before_focus_or_entry(self, dom_page):
+        html = compose_page(
+            """
+              document.getElementById('composer').addEventListener('focus', () => {
+                document.body.dataset.focused = 'true';
+              });
+            """
+        )
+
+        result = await send(dom_page, html, confirm_send=False)
+
+        assert result["status"] == "confirmation_required"
+        assert result["recipient_selected"] is True
+        assert await dom_page.evaluate("document.body.dataset.focused") is None
+        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
+
+    async def test_existing_draft_is_left_untouched(self, dom_page):
+        result = await send(
+            dom_page,
+            compose_page(ID_TRANSITION_SEND_JS, draft="Private draft"),
+        )
+
+        assert result["status"] == "composer_occupied"
         assert result["retry_safe"] is True
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
-        assert await text_of(dom_page, "#composer") == draft
-        assert await dom_page.locator("#thread .msg").count() == 1
-
-    async def test_foreign_recipient_never_reaches_the_composer(self, dom_page):
-        # Issue #861: the composer belongs to someone else. Nothing may be
-        # typed and nothing may be clicked, so the message the caller wrote
-        # cannot reach a person they never named.
-        draft = "Private foreign draft"
-        page = (
-            compose_page(DELIVERING_SEND_JS, draft=draft)
-            .replace(
-                f'href="https://www.linkedin.com{PROFILE_PATH}"',
-                'href="https://www.linkedin.com/in/someone-else/"',
-            )
-            .replace(
-                "</section>",
-                """<button aria-label="Close your draft conversation"
-              onclick="document.body.dataset.closed = String(
-                Number(document.body.dataset.closed || 0) + 1);
-                document.getElementById('composer').remove()">Close</button>
-              </section>""",
-            )
+        assert (await dom_page.locator("#composer").inner_text()).strip() == (
+            "Private draft"
         )
-        result = await send(dom_page, page)
 
-        observed = await dom_page.evaluate(
-            """() => ({
-                draft: document.getElementById('composer')?.innerText ?? null,
-                closed: Number(document.body.dataset.closed || 0),
-            })"""
-        )
-        assert result["sent"] is False
-        assert result["status"] == "composer_unavailable"
-        assert await dom_page.evaluate("document.body.dataset.clicked") is None
-        assert observed == {"draft": draft, "closed": 0}
-        assert await dom_page.locator("#thread .msg").count() == 1
-
-    async def test_focus_restored_draft_is_left_untouched(self, dom_page):
-        draft = "Confidential restored draft"
-        page = compose_page(
-            DELIVERING_SEND_JS
-            + f"""
+    async def test_draft_restored_on_focus_is_left_untouched(self, dom_page):
+        restored = "Confidential restored draft"
+        html = compose_page(
+            f"""
               document.getElementById('composer').addEventListener('focus', () => {{
-                document.getElementById('composer').textContent = '{draft}';
+                document.getElementById('composer').textContent = '{restored}';
               }});
             """
-        ).replace(
-            "</section>",
-            """<button aria-label="Close your draft conversation"
-              onclick="document.body.dataset.closed = String(
-                Number(document.body.dataset.closed || 0) + 1);
-                document.getElementById('composer').remove()">Close</button>
-              </section>""",
         )
 
-        result = await send(dom_page, page)
+        result = await send(dom_page, html)
 
-        observed = await dom_page.evaluate(
-            """() => ({
-                draft: document.getElementById('composer')?.innerText ?? null,
-                closed: Number(document.body.dataset.closed || 0),
-                clicked: document.body.dataset.clicked ?? null,
-            })"""
-        )
         assert result["status"] == "composer_occupied"
         assert result["sent"] is False
         assert result["retry_safe"] is True
-        assert observed == {"draft": draft, "closed": 0, "clicked": None}
-        assert await dom_page.locator("#thread .msg").count() == 1
-
-    async def test_state_error_before_newline_typing_is_retryable(self, dom_page):
-        original = LinkedInExtractor._read_message_composer_state
-        calls = 0
-
-        async def fail_last_pretyping_read(extractor, target):
-            nonlocal calls
-            calls += 1
-            if calls == 3:
-                raise RuntimeError("synthetic pre-typing state failure")
-            return await original(extractor, target)
-
-        with (
-            patch.object(
-                LinkedInExtractor,
-                "_read_message_composer_state",
-                autospec=True,
-                side_effect=fail_last_pretyping_read,
-            ),
-            pytest.raises(RuntimeError, match="pre-typing state failure"),
-        ):
-            await send(dom_page, compose_page(""), message="First\nSecond")
-
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
-        assert await text_of(dom_page, "#composer") == ""
+        assert (await dom_page.locator("#composer").inner_text()).strip() == restored
 
     @pytest.mark.parametrize(
-        ("button_html", "case"),
+        "button_html",
         [
-            ('<button id="send" type="submit" disabled>Send</button>', "disabled"),
+            '<button id="send" type="submit" disabled>Send</button>',
             (
                 '<button id="send" type="submit">Send</button>'
-                '<button type="submit">Other</button>',
-                "ambiguous",
+                '<button type="submit">Other</button>'
             ),
         ],
-        ids=lambda value: value if value in {"disabled", "ambiguous"} else None,
+        ids=["disabled", "ambiguous"],
     )
-    @pytest.mark.parametrize(
-        ("message", "retry_safe"),
-        [("Single line", True), ("First\nSecond", False)],
-        ids=["single-line", "newline"],
-    )
-    async def test_blocked_submit_preserves_retry_policy(
-        self, dom_page, button_html, case, message, retry_safe
+    async def test_disabled_or_ambiguous_submit_never_dispatches(
+        self, dom_page, button_html
     ):
-        page = compose_page("").replace(
+        html = compose_page(NOOP_SEND_JS).replace(
             '<button id="send" type="submit">Send</button>', button_html
         )
 
-        result = await send(dom_page, page, message=message)
+        result = await send(dom_page, html)
 
-        assert result["status"] == "send_unavailable", case
+        assert result["status"] == "send_unavailable"
         assert result["sent"] is False
-        assert result["retry_safe"] is retry_safe
-        assert await dom_page.evaluate("document.body.dataset.clicked") is None
-
-    async def test_existing_draft_is_never_sent_along(self, dom_page):
-        # Measured, and the reason this fixture carries a draft at all:
-        # `element.focus()` leaves the caret at the *start* of a
-        # contenteditable in Chromium, so a typed message lands in front of
-        # whatever the composer already held and LinkedIn delivers the two as
-        # one. The draft is the user's text and nobody asked for it to be
-        # sent, so the send refuses here. Clearing it instead would trade the
-        # leak for destroying it.
-        result = await send(dom_page, compose_page(DELIVERING_SEND_JS, draft=DRAFT))
-
-        assert result["status"] == "composer_occupied"
-        assert result["sent"] is False
-        # Nothing was submitted, so calling again cannot deliver twice.
         assert result["retry_safe"] is True
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
-        assert await text_of(dom_page, "#composer") == DRAFT.strip()
-        assert await dom_page.locator("#thread .msg").count() == 1
 
+
+class TestSendConfirmationDom:
     @pytest.mark.parametrize(
-        ("confirm_send", "status"),
-        [(True, "composer_occupied"), (False, "confirmation_required")],
-        ids=["occupied", "dry-run"],
+        "message",
+        ["First\nSecond", "First\rSecond", "First\tSecond", "First\x7fSecond"],
+        ids=["newline", "carriage-return", "tab", "del"],
     )
-    async def test_draft_refusal_never_closes_the_composer(
-        self, dom_page, confirm_send, status
+    async def test_control_characters_are_rejected_before_dom_interaction(
+        self, dom_page, message
     ):
-        draft = "Private draft"
-        page = compose_page("", draft=draft).replace(
-            "</section>",
-            """<button aria-label="Close your draft conversation"
-              onclick="document.body.dataset.closed = String(
-                Number(document.body.dataset.closed || 0) + 1);
-                document.getElementById('composer').remove()">Close</button>
-              </section>""",
+        result = await send(
+            dom_page, compose_page(ID_TRANSITION_SEND_JS), message=message
         )
 
-        result = await send(dom_page, page, confirm_send=confirm_send)
-
-        observed = await dom_page.evaluate(
-            """() => ({
-                draft: document.getElementById('composer')?.innerText ?? null,
-                closed: document.body.dataset.closed ?? null,
-            })"""
+        assert result["status"] == "invalid_message"
+        assert result["message"] == (
+            "Message must not contain control characters or line breaks."
         )
-        assert result["status"] == status
-        assert result["sent"] is False
         assert result["retry_safe"] is True
-        assert observed == {"draft": draft, "closed": None}
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
 
-    async def test_ineffective_send_is_not_confirmed(self, dom_page):
-        # The reported failure: Send is clicked, the handler does nothing,
-        # and the message stays in the composer next to an identical earlier
-        # copy in the thread. Neither is evidence of delivery. The click did
-        # happen, though, so the answer is "unknown" rather than "not sent".
+    async def test_local_bubble_without_id_transition_is_not_confirmed(self, dom_page):
+        result = await send(dom_page, compose_page(FIXED_ID_BUBBLE_JS))
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert await dom_page.locator("#thread .msg").count() == 2
+
+    async def test_same_node_opaque_id_transition_confirms_once(self, dom_page):
+        result = await send(dom_page, compose_page(ID_TRANSITION_SEND_JS))
+
+        assert result["status"] == "sent"
+        assert result["sent"] is True
+        assert result["retry_safe"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "1"
+        entries = dom_page.locator("#thread .msg")
+        assert await entries.count() == 2
+        assert await entries.last.get_attribute("data-event-urn") == "server-opaque-id"
+        assert (await entries.last.locator(".message-unit").inner_text()) == MESSAGE
+
+    async def test_replaced_candidate_node_is_not_confirmed(self, dom_page):
+        result = await send(dom_page, compose_page(REPLACED_NODE_SEND_JS))
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+
+    async def test_multiple_matching_candidates_are_not_confirmed(self, dom_page):
+        result = await send(dom_page, compose_page(MULTIPLE_CANDIDATES_SEND_JS))
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert await dom_page.locator("#thread .msg").count() == 3
+
+    async def test_different_visible_message_unit_is_not_confirmed(self, dom_page):
+        result = await send(dom_page, compose_page(DIFFERENT_TEXT_SEND_JS))
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+
+    async def test_no_dom_mutation_is_not_confirmed(self, dom_page):
         result = await send(dom_page, compose_page(NOOP_SEND_JS))
 
-        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
-        assert result["status"] == "send_unconfirmed"
-        assert result["sent"] is False
-        # The click happened, so a retry can deliver the message twice.
-        assert result["retry_safe"] is False
-        assert await text_of(dom_page, "#composer") == MESSAGE
-        assert await dom_page.locator("#thread .msg").count() == 1
-
-    async def test_composer_going_read_only_does_not_confirm(self, dom_page):
-        # The same no-op, except the composer stops being editable while it
-        # waits. Counting only `[contenteditable="true"]` would stop
-        # subtracting the unsent text at exactly that moment and read its
-        # own draft as a delivery.
-        result = await send(dom_page, compose_page(READONLY_NOOP_SEND_JS))
-
-        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
-        assert result["status"] == "send_unconfirmed"
-        assert result["sent"] is False
-        # The click happened, so a retry can deliver the message twice.
-        assert result["retry_safe"] is False
-        assert await text_of(dom_page, "#composer") == MESSAGE
-        assert await dom_page.locator("#thread .msg").count() == 1
-
-    async def test_a_cleared_composer_alone_does_not_confirm(self, dom_page):
-        # The composer empties and nothing arrives in the thread. The count
-        # outside every editor is the same before and after, so this stays
-        # unconfirmed. Reading the clearance as delivery is the mistake this
-        # case exists to catch: an implementation that stopped subtracting
-        # the draft once the editor went empty would pass every other case
-        # in this file and confirm here.
-        result = await send(dom_page, compose_page(CLEARING_NOOP_SEND_JS))
-
-        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         assert result["retry_safe"] is False
-        assert await text_of(dom_page, "#composer") == ""
-        assert await dom_page.locator("#thread .msg").count() == 1
+        assert (await dom_page.locator("#composer").inner_text()).strip() == MESSAGE
 
     @pytest.mark.parametrize(
         "send_js",
-        [STATUS_GROWTH_SEND_JS, CLEARING_STATUS_GROWTH_SEND_JS],
-        ids=["draft-remains", "draft-cleared"],
+        [CLEARING_NOOP_SEND_JS, READONLY_NOOP_SEND_JS],
+        ids=["cleared", "read-only"],
     )
-    async def test_status_substring_growth_is_not_confirmed(self, dom_page, send_js):
-        result = await send(dom_page, compose_page(send_js), message="a")
-
-        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
-        assert result["status"] == "send_unconfirmed"
-        assert result["sent"] is False
-        assert result["retry_safe"] is False
-        assert await text_of(dom_page, "#thread") == MESSAGE
-        assert await text_of(dom_page, "#conversation span") == "available"
-
-    async def test_delivered_short_message_is_confirmed(self, dom_page):
-        result = await send(dom_page, compose_page(DELIVERING_SEND_JS), message="a")
-
-        assert result["status"] == "sent"
-        assert result["sent"] is True
-        assert result["retry_safe"] is False
-        entries = dom_page.locator("#thread .msg")
-        assert await entries.count() == 2
-        assert (await entries.last.inner_text()).strip() == "a"
-
-    async def test_multiline_whitespace_units_are_normalized(self, dom_page):
-        await dom_page.set_content(compose_page(""))
-        await dom_page.evaluate(
-            """() => {
-                const entry = document.createElement('div');
-                entry.innerHTML = 'First<br>Second';
-                document.getElementById('thread').appendChild(entry);
-            }"""
-        )
-        extractor = LinkedInExtractor(dom_page)
-        owner = await extractor._resolve_message_owner(TARGET)
-        assert owner is not None
-        try:
-            count = await extractor._message_text_occurrences(
-                "  First \n  Second  ", target=TARGET, owner=owner
-            )
-        finally:
-            await extractor._dispose_message_owner(owner)
-
-        assert count == 1
-
-    async def test_foreign_thread_growth_is_not_confirmed(self, dom_page):
-        console_errors: list[str] = []
-        dom_page.on(
-            "console",
-            lambda message: (
-                console_errors.append(message.text) if message.type == "error" else None
-            ),
-        )
-        page = compose_page(FOREIGN_DELIVERING_SEND_JS).replace(
-            "</main>",
-            '<aside id="foreign-thread"></aside></main>',
-        )
-        result = await send(dom_page, page)
-
-        assert console_errors == []
-        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
-        assert result["status"] == "send_unconfirmed"
-        assert result["sent"] is False
-        assert result["retry_safe"] is False
-        assert await text_of(dom_page, "#composer") == ""
-        assert await dom_page.locator("#thread .msg").count() == 1
-        entries = dom_page.locator("#foreign-thread .msg")
-        assert await entries.count() == 1
-        assert (await entries.last.inner_text()).strip() == MESSAGE
-
-    async def test_removed_owner_with_matching_text_is_not_confirmed(self, dom_page):
-        page = compose_page(REMOVING_OWNER_SEND_JS).replace(
-            "</main>",
-            '<aside id="outside"></aside></main>',
-        )
-        result = await send(dom_page, page)
-
-        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
-        assert result["status"] == "send_unconfirmed"
-        assert result["sent"] is False
-        assert result["retry_safe"] is False
-        assert await dom_page.locator("#conversation").count() == 0
-        assert await text_of(dom_page, "#outside .msg") == MESSAGE
-
-    async def test_replacement_owner_with_copied_bubble_is_not_confirmed(
-        self, dom_page
+    async def test_local_composer_state_change_alone_is_not_confirmed(
+        self, dom_page, send_js
     ):
-        result = await send(dom_page, compose_page(REPLACING_OWNER_SEND_JS))
+        result = await send(dom_page, compose_page(send_js))
 
-        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         assert result["retry_safe"] is False
-        assert await text_of(dom_page, "#composer") == ""
-        entries = dom_page.locator("#thread .msg")
-        assert await entries.count() == 2
-        assert (await entries.last.inner_text()).strip() == MESSAGE
+        assert await dom_page.locator("#thread .msg").count() == 1
 
-    async def test_delivered_message_is_confirmed(self, dom_page):
-        # Same page, same earlier copy, but the Send handler moves the text
-        # into the thread. The count outside the composer grows, so this one
-        # confirms where the ineffective click above did not.
-        result = await send(dom_page, compose_page(DELIVERING_SEND_JS))
+    async def test_matching_bubble_outside_owner_is_not_confirmed(self, dom_page):
+        html = compose_page(OUTSIDE_OWNER_SEND_JS).replace(
+            "</section>", '</section><aside id="outside"></aside>'
+        )
 
-        assert result["status"] == "sent"
-        assert result["sent"] is True
+        result = await send(dom_page, html)
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
         assert result["retry_safe"] is False
-        assert await text_of(dom_page, "#composer") == ""
-        entries = dom_page.locator("#thread .msg")
-        assert await entries.count() == 2
-        assert (await entries.last.inner_text()).strip() == MESSAGE
+        assert await dom_page.locator("#outside .msg").count() == 1
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_editor_replacement_after_submit_is_not_confirmed(self, dom_page):
+        result = await send(dom_page, compose_page(REPLACED_EDITOR_SEND_JS))
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+
+    async def test_owner_replacement_after_submit_is_not_confirmed(self, dom_page):
+        result = await send(dom_page, compose_page(REPLACED_OWNER_SEND_JS))
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -84,6 +84,20 @@ ID_TRANSITION_SEND_JS = """
   });
 """
 
+REPARENTED_BASELINE_SEND_JS = """
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
+    const composer = document.getElementById('composer');
+    const entry = document.querySelector('#thread [data-view-name="message-list-item"]');
+    entry.remove();
+    entry.querySelector('.message-unit').textContent = composer.innerText;
+    document.getElementById('thread').appendChild(entry);
+    entry.setAttribute('data-event-urn', 'server-reparented-id');
+    composer.textContent = '';
+  });
+"""
+
 REPLACED_NODE_SEND_JS = """
   document.getElementById('send').addEventListener('click', event => {
     event.preventDefault();
@@ -175,7 +189,7 @@ def history_item(path: str, *, hidden: bool = False) -> str:
 def compose_page(
     send_js: str,
     *,
-    recipient_path: str | None = PROFILE_PATH,
+    recipient_path: str | None = None,
     recipient_urn: str = "ACoAAB",
     recipient_hidden: bool = False,
     history_html: str = "",
@@ -204,7 +218,8 @@ def compose_page(
         </div>
         <form id="composer-scope" onsubmit="return false">
           {recipient}
-          <div id="composer" role="textbox" contenteditable="true">{draft}</div>
+          <div id="composer" role="textbox" contenteditable="true"
+               style="display:block;width:200px;height:30px">{draft}</div>
           <button id="send" type="submit">Send</button>
         </form>
       </section>
@@ -250,6 +265,14 @@ async def dom_page():
                 raise
             pytest.skip(f"chromium unavailable: {exc}")
         page.set_default_timeout(600)
+        await page.route(
+            "https://www.linkedin.com/**",
+            lambda route: route.fulfill(
+                status=200,
+                content_type="text/html",
+                body='<!DOCTYPE html><html><head><meta charset="utf-8"></head></html>',
+            ),
+        )
         try:
             yield page
         finally:
@@ -259,6 +282,7 @@ async def dom_page():
 async def send(
     page, html: str, *, message: str = MESSAGE, confirm_send: bool = True
 ) -> dict:
+    await page.goto(COMPOSE_URL)
     await page.set_content(html)
     extractor = LinkedInExtractor(page)
     with (
@@ -318,6 +342,19 @@ class TestProfileMessageTargetDom:
         assert target.profile_urn == "ACoAAB"
         assert target.compose_url == COMPOSE_URL
 
+    async def test_later_bob_card_cannot_supply_alices_missing_action(self, dom_page):
+        html = profile_page(
+            '<section id="alice"><h1>Alice</h1></section>',
+            other=(
+                '<section id="bob"><h1>Bob</h1>'
+                '<a href="/messaging/compose/?recipient=BOB">message</a></section>'
+            ),
+        )
+        extractor = LinkedInExtractor(dom_page)
+
+        assert await read_profile_target(dom_page, html) is None
+        assert await extractor._extract_profile_urn() is None
+
     async def test_hidden_top_card_identity_does_not_authorize_profile(self, dom_page):
         html = profile_page(
             "<section>"
@@ -328,33 +365,35 @@ class TestProfileMessageTargetDom:
 
         assert await read_profile_target(dom_page, html) is None
 
-    async def test_multiple_visible_top_cards_fail_closed(self, dom_page):
+    async def test_later_sections_never_compete_with_first_top_card(self, dom_page):
         card = (
             "<section>"
             f'<h1>{DISPLAY_NAME}</h1><a href="{COMPOSE_URL}">message</a>'
             "</section>"
         )
 
-        assert (
-            await read_profile_target(dom_page, profile_page(card, other=card)) is None
-        )
+        target = await read_profile_target(dom_page, profile_page(card, other=card))
+
+        assert target is not None
+        assert target.profile_urn == "ACoAAB"
 
 
 class TestComposerRecipientDom:
-    async def test_target_identity_only_in_history_does_not_authorize(self, dom_page):
+    async def test_missing_local_identity_uses_profile_and_url_authority(
+        self, dom_page
+    ):
         result = await send(
             dom_page,
             compose_page(
                 NOOP_SEND_JS,
-                recipient_path=None,
                 history_html=history_item(PROFILE_PATH),
             ),
         )
 
-        assert result["status"] == "composer_unavailable"
+        assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
-        assert await dom_page.evaluate("document.body.dataset.clicked") is None
-        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert (await dom_page.locator("#composer").inner_text()).strip() == MESSAGE
 
     async def test_foreign_history_identity_does_not_reject_local_target(
         self, dom_page
@@ -389,12 +428,16 @@ class TestComposerRecipientDom:
     async def test_hidden_local_identity_fails_closed(self, dom_page):
         result = await send(
             dom_page,
-            compose_page(NOOP_SEND_JS, recipient_hidden=True),
+            compose_page(
+                NOOP_SEND_JS,
+                recipient_path=PROFILE_PATH,
+                recipient_hidden=True,
+            ),
         )
 
-        assert result["status"] == "composer_unavailable"
+        assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
-        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
 
     async def test_dry_run_ends_before_focus_or_entry(self, dom_page):
         html = compose_page(
@@ -442,6 +485,40 @@ class TestComposerRecipientDom:
         assert result["retry_safe"] is True
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
         assert (await dom_page.locator("#composer").inner_text()).strip() == restored
+
+    async def test_focus_switch_cannot_redirect_text_to_foreign_editor(self, dom_page):
+        html = compose_page(
+            """
+              document.body.insertAdjacentHTML('beforeend', '<input id="foreign">');
+              document.getElementById('composer').addEventListener('focus', () => {
+                document.getElementById('foreign').focus();
+              });
+            """
+        )
+
+        result = await send(dom_page, html)
+
+        assert result["status"] == "compose_interact_failed"
+        assert await dom_page.locator("#composer").inner_text() == ""
+        assert await dom_page.locator("#foreign").input_value() == ""
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+
+    async def test_input_focus_switch_keeps_full_text_in_pinned_editor(self, dom_page):
+        html = compose_page(
+            """
+              document.body.insertAdjacentHTML('beforeend', '<input id="foreign">');
+              document.getElementById('composer').addEventListener('input', () => {
+                document.getElementById('foreign').focus();
+              });
+            """
+        )
+
+        result = await send(dom_page, html)
+
+        assert result["status"] == "compose_interact_failed"
+        assert await dom_page.locator("#composer").inner_text() == MESSAGE
+        assert await dom_page.locator("#foreign").input_value() == ""
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
 
     @pytest.mark.parametrize(
         "button_html",
@@ -510,6 +587,19 @@ class TestSendConfirmationDom:
         assert await entries.count() == 2
         assert await entries.last.get_attribute("data-event-urn") == "server-opaque-id"
         assert (await entries.last.locator(".message-unit").inner_text()) == MESSAGE
+
+    async def test_reparented_baseline_node_is_never_confirmed(self, dom_page):
+        result = await send(dom_page, compose_page(REPARENTED_BASELINE_SEND_JS))
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert await dom_page.locator("#thread .msg").count() == 1
+        assert (
+            await dom_page.locator("#thread .msg").get_attribute("data-event-urn")
+            == "server-reparented-id"
+        )
 
     async def test_replaced_candidate_node_is_not_confirmed(self, dom_page):
         result = await send(dom_page, compose_page(REPLACED_NODE_SEND_JS))

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -503,6 +503,50 @@ class TestComposerRecipientDom:
         assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
         assert (await dom_page.locator("#composer").inner_text()).strip() == MESSAGE
 
+    async def test_queryless_route_switch_before_second_state_fails_closed(
+        self, dom_page
+    ):
+        alice_route = "https://www.linkedin.com/messaging/thread/ALICE/"
+        bob_route = "https://www.linkedin.com/messaging/thread/BOB/"
+        await dom_page.goto(alice_route)
+        await dom_page.set_content(compose_page(NOOP_SEND_JS))
+        extractor = LinkedInExtractor(dom_page)
+        read_state = extractor._read_message_composer_state
+        state_reads = 0
+
+        async def switch_route(target):
+            nonlocal state_reads
+            state_reads += 1
+            if state_reads == 2:
+                await dom_page.evaluate(
+                    "history.replaceState({}, '', '/messaging/thread/BOB/')"
+                )
+            return await read_state(target)
+
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(
+                extractor,
+                "_read_profile_message_target",
+                new_callable=AsyncMock,
+                return_value=_ProfileMessageTargetResolution("resolved", TARGET),
+            ),
+            patch.object(
+                extractor, "_read_message_composer_state", side_effect=switch_route
+            ),
+        ):
+            result = await extractor.send_message(
+                "fadi-eliwi", MESSAGE, confirm_send=True
+            )
+
+        assert result["status"] == "recipient_resolution_failed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is True
+        assert state_reads == 2
+        assert dom_page.url == bob_route
+        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+
     async def test_queryless_route_switch_before_owner_resolution_fails_closed(
         self, dom_page
     ):

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -9,14 +9,17 @@ JavaScript in headless Chromium without making a LinkedIn request or write.
 from __future__ import annotations
 
 import os
+import time
 from unittest.mock import AsyncMock, patch
 
+import anyio
 import pytest
 from patchright.async_api import async_playwright
 
 from linkedin_mcp_server.scraping.extractor import (
     LinkedInExtractor,
     _ProfileMessageTarget,
+    _ProfileMessageTargetResolution,
 )
 
 pytestmark = [
@@ -303,7 +306,7 @@ async def send(
             extractor,
             "_read_profile_message_target",
             new_callable=AsyncMock,
-            return_value=TARGET,
+            return_value=_ProfileMessageTargetResolution("resolved", TARGET),
         ),
         patch(
             "linkedin_mcp_server.scraping.extractor._message_page_url_is_safe",
@@ -315,7 +318,7 @@ async def send(
         )
 
 
-async def read_profile_target(page, html: str) -> _ProfileMessageTarget | None:
+async def read_profile_target(page, html: str) -> _ProfileMessageTargetResolution:
     async def fulfill(route):
         await route.fulfill(status=200, content_type="text/html", body=html)
 
@@ -325,7 +328,7 @@ async def read_profile_target(page, html: str) -> _ProfileMessageTarget | None:
 
 
 class TestProfileMessageTargetDom:
-    async def test_history_only_compose_link_does_not_authorize_profile(self, dom_page):
+    async def test_history_only_compose_link_proves_action_absence(self, dom_page):
         html = profile_page(
             f"<section><h1>{DISPLAY_NAME}</h1></section>",
             other=(
@@ -334,7 +337,10 @@ class TestProfileMessageTargetDom:
             ),
         )
 
-        assert await read_profile_target(dom_page, html) is None
+        resolution = await read_profile_target(dom_page, html)
+
+        assert resolution.status == "unavailable"
+        assert resolution.target is None
 
     async def test_foreign_history_link_does_not_reject_top_card_target(self, dom_page):
         html = profile_page(
@@ -347,8 +353,10 @@ class TestProfileMessageTargetDom:
             ),
         )
 
-        target = await read_profile_target(dom_page, html)
+        resolution = await read_profile_target(dom_page, html)
+        target = resolution.target
 
+        assert resolution.status == "resolved"
         assert target is not None
         assert target.profile_path == PROFILE_PATH
         assert target.profile_urn == "ACoAAB"
@@ -364,10 +372,12 @@ class TestProfileMessageTargetDom:
         )
         extractor = LinkedInExtractor(dom_page)
 
-        assert await read_profile_target(dom_page, html) is None
+        resolution = await read_profile_target(dom_page, html)
+
+        assert resolution.status == "unavailable"
         assert await extractor._extract_profile_urn() is None
 
-    async def test_hidden_top_card_identity_does_not_authorize_profile(self, dom_page):
+    async def test_hidden_top_card_action_proves_action_absence(self, dom_page):
         html = profile_page(
             "<section>"
             f"<h1>{DISPLAY_NAME}</h1>"
@@ -375,7 +385,9 @@ class TestProfileMessageTargetDom:
             "</section>"
         )
 
-        assert await read_profile_target(dom_page, html) is None
+        resolution = await read_profile_target(dom_page, html)
+
+        assert resolution.status == "unavailable"
 
     async def test_visibility_hidden_card_does_not_precede_visible_card(self, dom_page):
         html = profile_page(
@@ -386,8 +398,10 @@ class TestProfileMessageTargetDom:
             ),
         )
 
-        target = await read_profile_target(dom_page, html)
+        resolution = await read_profile_target(dom_page, html)
+        target = resolution.target
 
+        assert resolution.status == "resolved"
         assert target is not None
         assert target.display_name == "Alice"
         assert target.profile_urn == "ACoAAB"
@@ -400,10 +414,76 @@ class TestProfileMessageTargetDom:
             "</section>"
         )
 
-        target = await read_profile_target(dom_page, profile_page(card, other=card))
+        resolution = await read_profile_target(dom_page, profile_page(card, other=card))
 
-        assert target is not None
-        assert target.profile_urn == "ACoAAB"
+        assert resolution.status == "resolved"
+        assert resolution.target is not None
+        assert resolution.target.profile_urn == "ACoAAB"
+
+    async def test_waits_for_delayed_profile_message_action(self, dom_page):
+        html = profile_page(f'<section id="top"><h1>{DISPLAY_NAME}</h1></section>')
+
+        async def fulfill(route):
+            await route.fulfill(status=200, content_type="text/html", body=html)
+
+        await dom_page.route("https://www.linkedin.com/**", fulfill)
+        await dom_page.goto(f"https://www.linkedin.com{PROFILE_PATH}")
+        await dom_page.evaluate(
+            f"""() => setTimeout(() => {{
+                document.getElementById('top').insertAdjacentHTML(
+                    'beforeend', '<a href="{COMPOSE_URL}">message</a>'
+                );
+            }}, 200)"""
+        )
+        started = time.monotonic()
+
+        resolution = await LinkedInExtractor(dom_page)._read_profile_message_target()
+
+        assert resolution.status == "resolved"
+        assert resolution.target is not None
+        assert resolution.target.profile_urn == "ACoAAB"
+        assert time.monotonic() - started >= 0.15
+
+    @pytest.mark.parametrize(
+        "top_card",
+        [
+            "<div>still loading</div>",
+            f"<section><h1>{DISPLAY_NAME}</h1><h1>Other</h1></section>",
+            (
+                f"<section><h1>{DISPLAY_NAME}</h1>"
+                f'<a href="{COMPOSE_URL}">one</a>'
+                '<a href="/messaging/compose/?recipient=OTHER">two</a></section>'
+            ),
+            (
+                f"<section><h1>{DISPLAY_NAME}</h1>"
+                f'<a aria-disabled="true" href="{COMPOSE_URL}">message</a></section>'
+            ),
+            (
+                f"<section><h1>{DISPLAY_NAME}</h1>"
+                '<a href="/messaging/compose/?recipient=">message</a></section>'
+            ),
+            (
+                f"<section><h1>{DISPLAY_NAME}</h1>"
+                '<a href="https://evil.example/messaging/compose/?recipient=ACoAAB">'
+                "message</a></section>"
+            ),
+        ],
+        ids=[
+            "missing-section",
+            "ambiguous-headings",
+            "ambiguous-actions",
+            "disabled-action",
+            "malformed-recipient",
+            "unsafe-url",
+        ],
+    )
+    async def test_ambiguous_or_invalid_target_is_not_action_absence(
+        self, dom_page, top_card
+    ):
+        resolution = await read_profile_target(dom_page, profile_page(top_card))
+
+        assert resolution.status == "failed"
+        assert resolution.target is None
 
 
 class TestComposerRecipientDom:
@@ -531,7 +611,7 @@ class TestComposerRecipientDom:
         assert await dom_page.locator("#foreign").input_value() == ""
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
 
-    async def test_input_focus_switch_keeps_full_text_in_pinned_editor(self, dom_page):
+    async def test_input_focus_switch_cleans_exact_owned_text(self, dom_page):
         html = compose_page(
             """
               document.body.insertAdjacentHTML('beforeend', '<input id="foreign">');
@@ -544,26 +624,41 @@ class TestComposerRecipientDom:
         result = await send(dom_page, html)
 
         assert result["status"] == "compose_interact_failed"
-        assert await dom_page.locator("#composer").inner_text() == MESSAGE
+        assert await dom_page.locator("#composer").inner_text() == ""
         assert await dom_page.locator("#foreign").input_value() == ""
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
 
-    @pytest.mark.parametrize(
-        "button_html",
-        [
+    async def test_disabled_submit_enables_after_local_input_and_sends(self, dom_page):
+        html = compose_page(
+            ID_TRANSITION_SEND_JS
+            + """
+              document.getElementById('composer').addEventListener('input', () => {
+                document.getElementById('send').disabled = false;
+              });
+            """
+        ).replace(
+            '<button id="send" type="submit">Send</button>',
             '<button id="send" type="submit" disabled>Send</button>',
-            (
-                '<button id="send" type="submit">Send</button>'
-                '<button type="submit">Other</button>'
-            ),
-        ],
-        ids=["disabled", "ambiguous"],
-    )
-    async def test_disabled_or_ambiguous_submit_never_dispatches(
-        self, dom_page, button_html
-    ):
-        html = compose_page(NOOP_SEND_JS).replace(
-            '<button id="send" type="submit">Send</button>', button_html
+        )
+
+        result = await send(dom_page, html)
+
+        assert result["status"] == "sent"
+        assert result["sent"] is True
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "1"
+
+    async def test_permanently_disabled_submit_cleans_exact_owned_text(self, dom_page):
+        html = compose_page(
+            NOOP_SEND_JS
+            + """
+              document.getElementById('composer').addEventListener('input', () => {
+                document.body.dataset.inputCount = String(
+                  Number(document.body.dataset.inputCount || 0) + 1);
+              });
+            """
+        ).replace(
+            '<button id="send" type="submit">Send</button>',
+            '<button id="send" type="submit" disabled>Send</button>',
         )
 
         result = await send(dom_page, html)
@@ -572,6 +667,110 @@ class TestComposerRecipientDom:
         assert result["sent"] is False
         assert result["retry_safe"] is True
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await dom_page.evaluate("document.body.dataset.inputCount") == "2"
+        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
+
+    @pytest.mark.parametrize(
+        "button_change",
+        [
+            "send.replaceWith(send.cloneNode(true));",
+            "send.insertAdjacentHTML('afterend', '<button type=submit>Other</button>');",
+        ],
+        ids=["replaced", "ambiguous"],
+    )
+    async def test_submit_change_after_insertion_cleans_without_click(
+        self, dom_page, button_change
+    ):
+        html = compose_page(
+            NOOP_SEND_JS
+            + f"""
+              document.getElementById('composer').addEventListener('input', () => {{
+                const send = document.getElementById('send');
+                if (document.getElementById('composer').innerText) {{
+                  {button_change}
+                }}
+              }});
+            """
+        )
+
+        result = await send(dom_page, html)
+
+        assert result["status"] == "compose_interact_failed"
+        assert result["retry_safe"] is True
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
+
+    async def test_ambiguous_submit_never_dispatches(self, dom_page):
+        html = compose_page(NOOP_SEND_JS).replace(
+            '<button id="send" type="submit">Send</button>',
+            (
+                '<button id="send" type="submit">Send</button>'
+                '<button type="submit">Other</button>'
+            ),
+        )
+
+        result = await send(dom_page, html)
+
+        assert result["status"] == "send_unavailable"
+        assert result["sent"] is False
+        assert result["retry_safe"] is True
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
+
+    async def test_route_change_on_focus_invalidates_pinned_owner(self, dom_page):
+        html = compose_page(
+            """
+              document.getElementById('composer').addEventListener('focus', () => {
+                history.replaceState({}, '', '/messaging/thread/OTHER/');
+              });
+            """
+        )
+
+        result = await send(dom_page, html)
+
+        assert result["status"] == "compose_interact_failed"
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
+
+    async def test_route_change_after_insertion_cleans_owned_text(self, dom_page):
+        html = compose_page(
+            """
+              document.getElementById('composer').addEventListener('input', () => {
+                if (document.getElementById('composer').innerText) {
+                  history.replaceState({}, '', '/messaging/thread/OTHER/');
+                }
+              });
+            """
+        )
+
+        result = await send(dom_page, html)
+
+        assert result["status"] == "compose_interact_failed"
+        assert result["retry_safe"] is True
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert (await dom_page.locator("#composer").inner_text()).strip() == ""
+
+    async def test_modified_inserted_text_is_preserved_on_route_failure(self, dom_page):
+        html = compose_page(
+            """
+              document.getElementById('composer').addEventListener('input', () => {
+                const editor = document.getElementById('composer');
+                if (editor.innerText === 'UNDELIVERED SENTINEL') {
+                  editor.textContent += ' user edit';
+                  history.replaceState({}, '', '/messaging/thread/OTHER/');
+                }
+              });
+            """
+        )
+
+        result = await send(dom_page, html)
+
+        assert result["status"] == "compose_interact_failed"
+        assert result["retry_safe"] is True
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await dom_page.locator("#composer").inner_text() == (
+            MESSAGE + " user edit"
+        )
 
 
 class TestSendConfirmationDom:
@@ -728,3 +927,71 @@ class TestSendConfirmationDom:
         assert result["status"] == "send_unconfirmed"
         assert result["sent"] is False
         assert result["retry_safe"] is False
+
+    async def test_cancelled_confirmation_cleans_observer_pins_and_handle(
+        self, dom_page
+    ):
+        await dom_page.goto(COMPOSE_URL)
+        await dom_page.set_content(compose_page(NOOP_SEND_JS))
+        extractor = LinkedInExtractor(dom_page)
+        resolve_owner = extractor._resolve_message_owner
+        captured = {}
+
+        async def capture_owner(target):
+            owner = await resolve_owner(target)
+            captured["owner"] = owner
+            return owner
+
+        async def wait_for_confirmation(*_args, **_kwargs):
+            await anyio.sleep_forever()
+
+        with (
+            patch.object(extractor, "_navigate_to_page", new_callable=AsyncMock),
+            patch.object(
+                extractor,
+                "_read_profile_message_target",
+                new_callable=AsyncMock,
+                return_value=_ProfileMessageTargetResolution("resolved", TARGET),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.extractor._message_page_url_is_safe",
+                return_value=True,
+            ),
+            patch.object(
+                extractor, "_resolve_message_owner", side_effect=capture_owner
+            ),
+            patch.object(
+                extractor,
+                "_message_send_confirmed",
+                side_effect=wait_for_confirmation,
+            ),
+            pytest.raises(TimeoutError),
+        ):
+            with anyio.fail_after(0.5):
+                await extractor.send_message("fadi-eliwi", MESSAGE, confirm_send=True)
+
+        cleanup_state = await dom_page.evaluate(
+            """() => {
+                const owner = document.getElementById('conversation');
+                return {
+                    hasComposer: Object.hasOwn(owner, '__linkedinMcpComposer'),
+                    hasConfirmations: Object.hasOwn(
+                        owner, '__linkedinMcpConfirmations'
+                    ),
+                    markers: owner.querySelectorAll(
+                        '[data-linkedin-mcp-candidate], '
+                        + '[data-linkedin-mcp-editor], '
+                        + '[data-linkedin-mcp-confirmation]'
+                    ).length,
+                };
+            }"""
+        )
+        assert cleanup_state == {
+            "hasComposer": False,
+            "hasConfirmations": False,
+            "markers": 0,
+        }
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert (await dom_page.locator("#composer").inner_text()).strip() == MESSAGE
+        with pytest.raises(Exception, match="closed"):
+            await captured["owner"].evaluate("owner => owner.isConnected")

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -98,6 +98,18 @@ REPARENTED_BASELINE_SEND_JS = """
   });
 """
 
+GLOBAL_BASELINE_REPARENT_SEND_JS = """
+  document.getElementById('send').addEventListener('click', event => {
+    event.preventDefault();
+    document.body.dataset.clicked = 'true';
+    const composer = document.getElementById('composer');
+    const entry = document.querySelector('#outside [data-view-name="message-list-item"]');
+    document.getElementById('thread').appendChild(entry);
+    entry.setAttribute('data-event-urn', 'server-reparented-id');
+    composer.textContent = '';
+  });
+"""
+
 REPLACED_NODE_SEND_JS = """
   document.getElementById('send').addEventListener('click', event => {
     event.preventDefault();
@@ -614,6 +626,34 @@ class TestSendConfirmationDom:
         assert await dom_page.locator("#thread .msg").count() == 1
         assert (
             await dom_page.locator("#thread .msg").get_attribute("data-event-urn")
+            == "server-reparented-id"
+        )
+
+    async def test_global_baseline_node_reparented_into_owner_is_never_confirmed(
+        self, dom_page
+    ):
+        outside = f"""
+          <aside id="outside">
+            <div class="msg" data-view-name="message-list-item"
+                 data-event-urn="outside-history-id">
+              <span class="message-unit">{MESSAGE}</span>
+            </div>
+          </aside>
+        """
+        html = compose_page(GLOBAL_BASELINE_REPARENT_SEND_JS).replace(
+            "</section>", f"</section>{outside}"
+        )
+
+        result = await send(dom_page, html)
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert await dom_page.evaluate("document.body.dataset.clicked") == "true"
+        assert await dom_page.locator("#outside .msg").count() == 0
+        assert await dom_page.locator("#thread .msg").count() == 2
+        assert (
+            await dom_page.locator("#thread .msg").last.get_attribute("data-event-urn")
             == "server-reparented-id"
         )
 

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -280,17 +280,124 @@ class TestSendConfirmationAgainstRealDom:
         # Issue #861: the composer belongs to someone else. Nothing may be
         # typed and nothing may be clicked, so the message the caller wrote
         # cannot reach a person they never named.
-        page = compose_page(DELIVERING_SEND_JS).replace(
-            f'href="https://www.linkedin.com{PROFILE_PATH}"',
-            'href="https://www.linkedin.com/in/someone-else/"',
+        draft = "Private foreign draft"
+        page = (
+            compose_page(DELIVERING_SEND_JS, draft=draft)
+            .replace(
+                f'href="https://www.linkedin.com{PROFILE_PATH}"',
+                'href="https://www.linkedin.com/in/someone-else/"',
+            )
+            .replace(
+                "</section>",
+                """<button aria-label="Close your draft conversation"
+              onclick="document.body.dataset.closed = String(
+                Number(document.body.dataset.closed || 0) + 1);
+                document.getElementById('composer').remove()">Close</button>
+              </section>""",
+            )
         )
         result = await send(dom_page, page)
 
+        observed = await dom_page.evaluate(
+            """() => ({
+                draft: document.getElementById('composer')?.innerText ?? null,
+                closed: Number(document.body.dataset.closed || 0),
+            })"""
+        )
         assert result["sent"] is False
         assert result["status"] == "composer_unavailable"
         assert await dom_page.evaluate("document.body.dataset.clicked") is None
-        assert await text_of(dom_page, "#composer") == ""
+        assert observed == {"draft": draft, "closed": 0}
         assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_focus_restored_draft_is_left_untouched(self, dom_page):
+        draft = "Confidential restored draft"
+        page = compose_page(
+            DELIVERING_SEND_JS
+            + f"""
+              document.getElementById('composer').addEventListener('focus', () => {{
+                document.getElementById('composer').textContent = '{draft}';
+              }});
+            """
+        ).replace(
+            "</section>",
+            """<button aria-label="Close your draft conversation"
+              onclick="document.body.dataset.closed = String(
+                Number(document.body.dataset.closed || 0) + 1);
+                document.getElementById('composer').remove()">Close</button>
+              </section>""",
+        )
+
+        result = await send(dom_page, page)
+
+        observed = await dom_page.evaluate(
+            """() => ({
+                draft: document.getElementById('composer')?.innerText ?? null,
+                closed: Number(document.body.dataset.closed || 0),
+                clicked: document.body.dataset.clicked ?? null,
+            })"""
+        )
+        assert result["status"] == "composer_occupied"
+        assert result["sent"] is False
+        assert result["retry_safe"] is True
+        assert observed == {"draft": draft, "closed": 0, "clicked": None}
+        assert await dom_page.locator("#thread .msg").count() == 1
+
+    async def test_state_error_before_newline_typing_is_retryable(self, dom_page):
+        original = LinkedInExtractor._read_message_composer_state
+        calls = 0
+
+        async def fail_last_pretyping_read(extractor, target):
+            nonlocal calls
+            calls += 1
+            if calls == 3:
+                raise RuntimeError("synthetic pre-typing state failure")
+            return await original(extractor, target)
+
+        with (
+            patch.object(
+                LinkedInExtractor,
+                "_read_message_composer_state",
+                autospec=True,
+                side_effect=fail_last_pretyping_read,
+            ),
+            pytest.raises(RuntimeError, match="pre-typing state failure"),
+        ):
+            await send(dom_page, compose_page(""), message="First\nSecond")
+
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
+        assert await text_of(dom_page, "#composer") == ""
+
+    @pytest.mark.parametrize(
+        ("button_html", "case"),
+        [
+            ('<button id="send" type="submit" disabled>Send</button>', "disabled"),
+            (
+                '<button id="send" type="submit">Send</button>'
+                '<button type="submit">Other</button>',
+                "ambiguous",
+            ),
+        ],
+        ids=lambda value: value if value in {"disabled", "ambiguous"} else None,
+    )
+    @pytest.mark.parametrize(
+        ("message", "retry_safe"),
+        [("Single line", True), ("First\nSecond", False)],
+        ids=["single-line", "newline"],
+    )
+    async def test_blocked_submit_preserves_retry_policy(
+        self, dom_page, button_html, case, message, retry_safe
+    ):
+        page = compose_page("").replace(
+            '<button id="send" type="submit">Send</button>', button_html
+        )
+
+        result = await send(dom_page, page, message=message)
+
+        assert result["status"] == "send_unavailable", case
+        assert result["sent"] is False
+        assert result["retry_safe"] is retry_safe
+        assert await dom_page.evaluate("document.body.dataset.clicked") is None
 
     async def test_existing_draft_is_never_sent_along(self, dom_page):
         # Measured, and the reason this fixture carries a draft at all:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1035,6 +1035,33 @@ class TestMessagingTools:
         assert result["url"] == "https://www.linkedin.com/in/testuser/"
 
     @pytest.mark.parametrize(
+        "message",
+        ["First\nSecond", "First\rSecond", "First\tSecond", "First\x7fSecond"],
+        ids=["newline", "carriage-return", "tab", "del"],
+    )
+    async def test_send_message_refuses_controls_before_a_session(
+        self, mock_context, message
+    ):
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "send_message")
+        with patch(
+            "linkedin_mcp_server.tools.messaging.get_ready_extractor",
+            new_callable=AsyncMock,
+        ) as ready:
+            result = await tool_fn("testuser", message, True, mock_context)
+
+        ready.assert_not_awaited()
+        assert result["status"] == "invalid_message"
+        assert result["message"] == (
+            "Message must not contain control characters or line breaks."
+        )
+        assert result["retry_safe"] is True
+
+    @pytest.mark.parametrize(
         "username",
         ["", "me", "https://www.linkedin.com/company/microsoft/"],
         ids=["empty", "self-alias", "not-a-person"],

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1060,12 +1060,16 @@ class TestMessagingTools:
         assert str(excinfo.value) == str(cause) != ""
 
     @pytest.mark.parametrize(
-        ("retry_safe", "warns"),
-        [(False, True), (True, False)],
-        ids=["submitted", "retry-safe"],
+        ("result", "warns"),
+        [
+            ({"status": "sent", "sent": True, "retry_safe": False}, True),
+            ({"status": "send_unconfirmed", "sent": False, "retry_safe": False}, True),
+            ({"status": "composer_occupied", "sent": False, "retry_safe": True}, False),
+        ],
+        ids=["sent", "unconfirmed", "refused"],
     )
     async def test_cancelled_completion_notification_warns(
-        self, mock_context, caplog, retry_safe, warns
+        self, mock_context, caplog, result, warns
     ):
         """The last await can discard an answer that says a message went out.
 
@@ -1076,18 +1080,21 @@ class TestMessagingTools:
         the log line is then the only record.
 
         Silent where the result says a retry is safe: nothing was submitted,
-        so there is no duplicate delivery to warn about.
+        so there is no duplicate delivery to warn about. That is `retry_safe`
+        and not the status, which is why a confirmed send is parametrized
+        here alongside an unconfirmed one.
         """
         from linkedin_mcp_server.scraping.extractor import SEND_INTERRUPTED_WARNING
         from linkedin_mcp_server.tools.messaging import register_messaging_tools
 
         mock_extractor = _make_mock_extractor({})
+        # Only shapes the extractor can actually return. A confirmed send is
+        # the one that most needs the warning and the one an implementation
+        # keyed on `status == "send_unconfirmed"` would silently drop.
         mock_extractor.send_message = AsyncMock(
             return_value={
                 "url": "https://www.linkedin.com/messaging/compose/",
-                "status": "send_unconfirmed" if retry_safe is False else "sent",
-                "sent": False,
-                "retry_safe": retry_safe,
+                **result,
             }
         )
         # Only the completion notification is cancelled; the one before the

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -988,6 +988,22 @@ class TestMessagingTools:
             "testuser", "Hello!", confirm_send=True, profile_urn=None
         )
 
+    async def test_send_message_description_explains_connection_handoff(self):
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool = await mcp.get_tool("send_message")
+        assert tool is not None
+        assert tool.description is not None
+        description = " ".join(tool.description.split())
+        assert (
+            "If LinkedIn does not expose a normal Message action, use "
+            "connect_with_person first, then retry send_message only after the "
+            "connection request is accepted."
+        ) in description
+
     @pytest.mark.parametrize("message", ["", "   \t\n"], ids=["empty", "whitespace"])
     async def test_send_message_refuses_blank_before_a_session(
         self, mock_context, message

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1017,6 +1017,47 @@ class TestMessagingTools:
         assert result["retry_safe"] is True
         assert result["url"] == "https://www.linkedin.com/in/testuser/"
 
+    @pytest.mark.parametrize(
+        "username",
+        ["", "me", "https://www.linkedin.com/company/microsoft/"],
+        ids=["empty", "self-alias", "not-a-person"],
+    )
+    async def test_blank_message_with_an_unusable_recipient_is_mapped(
+        self, mock_context, username
+    ):
+        """A recipient the refusal cannot name still reaches the error mapping.
+
+        Building the refusal normalizes the recipient, so a username that
+        cannot become a profile URL raises `InvalidReferenceError` from inside
+        the guard. Raised past `raise_tool_error` it would arrive at the caller
+        as a generic masked error (`mask_error_details=True` in `server.py`),
+        which drops the one sentence that says what to correct.
+        """
+        from fastmcp.exceptions import ToolError
+
+        from linkedin_mcp_server.core.exceptions import InvalidReferenceError
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "send_message")
+        with (
+            patch(
+                "linkedin_mcp_server.tools.messaging.get_ready_extractor",
+                new_callable=AsyncMock,
+            ) as ready,
+            pytest.raises(ToolError) as excinfo,
+        ):
+            await tool_fn(username, "", True, mock_context)
+
+        ready.assert_not_awaited()
+        # A ToolError is what `mask_error_details` lets through, so the
+        # correction the message names reaches the caller intact.
+        cause = excinfo.value.__cause__
+        assert isinstance(cause, InvalidReferenceError)
+        assert str(excinfo.value) == str(cause) != ""
+
     async def test_send_message_with_profile_urn(self, mock_context):
         expected = {
             "url": "https://www.linkedin.com/messaging/thread/abc123/",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1004,6 +1004,20 @@ class TestMessagingTools:
             "connection request is accepted."
         ) in description
 
+    async def test_send_message_schema_explains_single_line_controls(self):
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool = await mcp.get_tool("send_message")
+        assert tool is not None
+        message_schema = tool.parameters["properties"]["message"]
+        assert " ".join(message_schema["description"].split()) == (
+            "Single-line message text to send. C0 control characters and DEL are "
+            "rejected, including CR, LF, and tab."
+        )
+
     @pytest.mark.parametrize("message", ["", "   \t\n"], ids=["empty", "whitespace"])
     async def test_send_message_refuses_blank_before_a_session(
         self, mock_context, message
@@ -1036,8 +1050,8 @@ class TestMessagingTools:
 
     @pytest.mark.parametrize(
         "message",
-        ["First\nSecond", "First\rSecond", "First\tSecond", "First\x7fSecond"],
-        ids=["newline", "carriage-return", "tab", "del"],
+        [f"First{chr(codepoint)}Second" for codepoint in (*range(32), 127)],
+        ids=[f"U+{codepoint:04X}" for codepoint in (*range(32), 127)],
     )
     async def test_send_message_refuses_controls_before_a_session(
         self, mock_context, message

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -987,6 +987,36 @@ class TestMessagingTools:
             "testuser", "Hello!", confirm_send=True, profile_urn=None
         )
 
+    @pytest.mark.parametrize("message", ["", "   \t\n"], ids=["empty", "whitespace"])
+    async def test_send_message_refuses_blank_before_a_session(
+        self, mock_context, message
+    ):
+        """A blank message is answered without acquiring a browser session.
+
+        The extractor keeps the same guard, but it only runs once a session
+        exists. Reaching it means `get_ready_extractor` has already had the
+        chance to spend a login attempt and answer with an authentication
+        error, which is not the refusal the caller can act on.
+        """
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+
+        tool_fn = await get_tool_fn(mcp, "send_message")
+        with patch(
+            "linkedin_mcp_server.tools.messaging.get_ready_extractor",
+            new_callable=AsyncMock,
+        ) as ready:
+            result = await tool_fn("testuser", message, True, mock_context)
+
+        ready.assert_not_awaited()
+        assert result["status"] == "invalid_message"
+        assert result["sent"] is False
+        # Nothing was submitted, so calling again cannot deliver twice.
+        assert result["retry_safe"] is True
+        assert result["url"] == "https://www.linkedin.com/in/testuser/"
+
     async def test_send_message_with_profile_urn(self, mock_context):
         expected = {
             "url": "https://www.linkedin.com/messaging/thread/abc123/",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from types import SimpleNamespace
 from typing import Any, Callable, Coroutine, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1057,6 +1058,64 @@ class TestMessagingTools:
         cause = excinfo.value.__cause__
         assert isinstance(cause, InvalidReferenceError)
         assert str(excinfo.value) == str(cause) != ""
+
+    @pytest.mark.parametrize(
+        ("retry_safe", "warns"),
+        [(False, True), (True, False)],
+        ids=["submitted", "retry-safe"],
+    )
+    async def test_cancelled_completion_notification_warns(
+        self, mock_context, caplog, retry_safe, warns
+    ):
+        """The last await can discard an answer that says a message went out.
+
+        `ctx.report_progress` is the final await inside FastMCP's
+        `anyio.fail_after()`, so a deadline landing there raises
+        `CancelledError` past `except Exception` and throws away the result
+        the send already produced. Nothing can hand it back afterwards, and
+        the log line is then the only record.
+
+        Silent where the result says a retry is safe: nothing was submitted,
+        so there is no duplicate delivery to warn about.
+        """
+        from linkedin_mcp_server.scraping.extractor import SEND_INTERRUPTED_WARNING
+        from linkedin_mcp_server.tools.messaging import register_messaging_tools
+
+        mock_extractor = _make_mock_extractor({})
+        mock_extractor.send_message = AsyncMock(
+            return_value={
+                "url": "https://www.linkedin.com/messaging/compose/",
+                "status": "send_unconfirmed" if retry_safe is False else "sent",
+                "sent": False,
+                "retry_safe": retry_safe,
+            }
+        )
+        # Only the completion notification is cancelled; the one before the
+        # send has to pass or the send never runs.
+        mock_context.report_progress = AsyncMock(
+            side_effect=[None, asyncio.CancelledError()]
+        )
+
+        mcp = FastMCP("test")
+        register_messaging_tools(mcp)
+        tool_fn = await get_tool_fn(mcp, "send_message")
+
+        with (
+            patch(
+                "linkedin_mcp_server.tools.messaging.get_ready_extractor",
+                new_callable=AsyncMock,
+                return_value=mock_extractor,
+            ),
+            caplog.at_level(
+                logging.WARNING, logger="linkedin_mcp_server.tools.messaging"
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await tool_fn("testuser", "Hello!", True, mock_context)
+
+        mock_extractor.send_message.assert_awaited_once()
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert (SEND_INTERRUPTED_WARNING in warnings) is warns, warnings
 
     async def test_send_message_with_profile_urn(self, mock_context):
         expected = {


### PR DESCRIPTION
Closes #861. Closes #866. Closes #888.

Recipient checks could diverge from the editor, submit button, owner, and evidence used for the write after changes.

This PR pins one composer and its ancestor chain. It writes only to that editor, uses one submit button, preserves drafts, and confirms only a new message node whose opaque event ID changes on the same node. Old, moved, replaced, foreign, or duplicate candidates fail closed. Missing Message actions tell callers to connect first and retry after acceptance. No Voyager or private API transport is used.

Verification: 3,408 tests passed sequentially. Pre-commit and 164 focused tests passed. No live message was sent.

## Synthetic prompt

> Bind recipient verification, editing, submission, and evidence to one composer. Fail closed on identity or DOM changes, preserve drafts and retry safety, and guide connection handoff when messaging is unavailable.

Generated with GPT-5.6 Sol + GPT-6 Astra
