### PR TITLE
fix(ci): Check attribution on bot-triggered runs

### DIFF
--- a/.github/workflows/check-attribution.yml
+++ b/.github/workflows/check-attribution.yml
@@ -21,7 +21,6 @@ env:
 
 jobs:
   check-bot-coauthors:
-    if: ${{ !endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0


### PR DESCRIPTION
Closes #897

The attribution check skipped every update triggered by a bot. A Cursor-triggered update could therefore bypass the check even though its committer address was already denied.

Run the existing identity checks regardless of the triggering actor. Dependabot and Renovate remain permitted by the existing identity list.

YAML and pre-commit checks pass; the existing matcher rejects the observed Cursor address and permits Dependabot and Renovate addresses.

## Synthetic prompt

> Remove the blanket bot-actor exemption from the attribution workflow without changing its identity rules. Verify that Cursor is rejected and maintenance bots remain allowed.

Generated with GPT-6 Astra + GPT-5.6 Sol
