### PR TITLE
ci(pr): Validate pull request titles

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,6 +12,9 @@ changelog:
     authors:
       - renovate[bot]
   categories:
+    - title: "⚠️ Breaking Changes"
+      labels:
+        - breaking-change
     - title: "🚀 Features"
       labels:
         - enhancement

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,19 +1,30 @@
-name: PR Title
+name: Validate PR title
 
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
+  # SHA-like fork branch names can suppress pull_request_target. An exact
+  # comment on a PR reruns this trusted default-branch workflow as a fallback.
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
+  pull-requests: read
+  statuses: write
 
 concurrency:
-  group: pr-title-${{ github.event.pull_request.number }}
+  group: pr-title-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   check:
-    name: PR Title
+    name: Check current PR title
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/check-pr-title')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the trusted workflow revision
@@ -22,7 +33,72 @@ jobs:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
-      - name: Validate pull request title
+      - name: Fetch current pull request
+        id: pr
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: python3 scripts/check_pr_title.py
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          PR_JSON="$RUNNER_TEMP/pull-request.json"
+          gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "$PR_JSON"
+          HEAD_SHA=$(python3 - "$PR_JSON" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          try:
+              data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+              head_sha = data["head"]["sha"]
+          except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError):
+              raise SystemExit("Unable to read current pull request data.") from None
+          if not isinstance(head_sha, str) or re.fullmatch(r"[0-9a-f]{40}", head_sha) is None:
+              raise SystemExit("Unable to read current pull request data.")
+          print(head_sha)
+          PY
+          )
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Publish pending PR Title status
+        id: pending
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state=pending \
+            -f context="PR Title" \
+            -f description="Checking pull request title" \
+            -f target_url="$TARGET_URL"
+
+      - name: Validate current pull request title
+        id: validate
+        run: python3 scripts/check_pr_title.py --pr-json "$RUNNER_TEMP/pull-request.json"
+
+      - name: Publish final PR Title status
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          PENDING_OUTCOME: ${{ steps.pending.outcome }}
+          VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
+          TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          STATE=failure
+          DESCRIPTION="PR title validation failed"
+          if [ "$PENDING_OUTCOME" = success ] && [ "$VALIDATION_OUTCOME" = success ]; then
+            STATE=success
+            DESCRIPTION="PR title is valid"
+          fi
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state="$STATE" \
+            -f context="PR Title" \
+            -f description="$DESCRIPTION" \
+            -f target_url="$TARGET_URL"

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,28 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the trusted workflow revision
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Validate pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 scripts/check_pr_title.py

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,7 +1,8 @@
 name: PR Title
 
 # GitHub suppresses pull_request_target for SHA-like source branch names.
-# Rename the source branch to resume this required check and Label PR.
+# Renaming a head branch closes its pull request. Open a replacement pull
+# request from a non-SHA-like source branch so this check and Label PR can run.
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,30 +1,22 @@
-name: Validate PR title
+name: PR Title
 
+# GitHub suppresses pull_request_target for SHA-like source branch names.
+# Rename the source branch to resume this required check and Label PR.
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
-  # SHA-like fork branch names can suppress pull_request_target. An exact
-  # comment on a PR reruns this trusted default-branch workflow as a fallback.
-  issue_comment:
-    types: [created]
 
 permissions:
   contents: read
   pull-requests: read
-  statuses: write
 
 concurrency:
-  group: pr-title-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: pr-title-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   check:
-    name: Check current PR title
-    if: >-
-      github.event_name == 'pull_request_target' ||
-      (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      github.event.comment.body == '/check-pr-title')
+    name: PR Title
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the trusted workflow revision
@@ -34,71 +26,14 @@ jobs:
           persist-credentials: false
 
       - name: Fetch current pull request
-        id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          PR_JSON="$RUNNER_TEMP/pull-request.json"
           gh api --method GET \
-            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "$PR_JSON"
-          HEAD_SHA=$(python3 - "$PR_JSON" <<'PY'
-          import json
-          import re
-          import sys
-          from pathlib import Path
-
-          try:
-              data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-              head_sha = data["head"]["sha"]
-          except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError):
-              raise SystemExit("Unable to read current pull request data.") from None
-          if not isinstance(head_sha, str) or re.fullmatch(r"[0-9a-f]{40}", head_sha) is None:
-              raise SystemExit("Unable to read current pull request data.")
-          print(head_sha)
-          PY
-          )
-          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-
-      - name: Publish pending PR Title status
-        id: pending
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-          TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          gh api --method POST \
-            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
-            -f state=pending \
-            -f context="PR Title" \
-            -f description="Checking pull request title" \
-            -f target_url="$TARGET_URL"
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            > "$RUNNER_TEMP/pull-request.json"
 
       - name: Validate current pull request title
-        id: validate
         run: python3 scripts/check_pr_title.py --pr-json "$RUNNER_TEMP/pull-request.json"
-
-      - name: Publish final PR Title status
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-          PENDING_OUTCOME: ${{ steps.pending.outcome }}
-          VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
-          TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          STATE=failure
-          DESCRIPTION="PR title validation failed"
-          if [ "$PENDING_OUTCOME" = success ] && [ "$VALIDATION_OUTCOME" = success ]; then
-            STATE=success
-            DESCRIPTION="PR title is valid"
-          fi
-          gh api --method POST \
-            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
-            -f state="$STATE" \
-            -f context="PR Title" \
-            -f description="$DESCRIPTION" \
-            -f target_url="$TARGET_URL"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -10,9 +10,9 @@ on:
 # from the conventional-commit type in the PR title so the filtering works
 # without anyone remembering to label by hand.
 # pull_request_target is required so PRs from forks get a writable token.
-# It is safe here only because this job never checks out the PR branch and
-# never runs its code: current API data is matched against a fixed case list,
-# so an untrusted title can at worst yield no label.
+# It is safe here only because the job checks out the trusted workflow revision,
+# never the PR branch, and matches current API data against a fixed case list.
+# An untrusted title can at worst yield no label.
 concurrency:
   group: label-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -21,8 +21,15 @@ jobs:
   label:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
+      - name: Checkout the trusted workflow revision
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
       - name: Apply label for the current conventional-commit type
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,6 +42,11 @@ jobs:
           ATTACHED_DERIVED="$RUNNER_TEMP/attached-derived-labels.txt"
 
           gh api --method GET "repos/${REPO}/pulls/${PR_NUMBER}" > "$PR_JSON"
+          TITLE_VALID=true
+          if ! python3 scripts/check_pr_title.py --pr-json "$PR_JSON" >/dev/null; then
+            TITLE_VALID=false
+          fi
+
           gh api --method GET --paginate --slurp \
             "repos/${REPO}/issues/${PR_NUMBER}/labels?per_page=100" > "$LABELS_JSON"
 
@@ -78,9 +90,11 @@ jobs:
           # The title stays in a variable, so a crafted value cannot inject shell.
           TYPE=""
           BREAKING=""
-          if [[ "$PR_TITLE" =~ ^([a-z]+)(\([^()]+\))?(!)?:\ [^[:space:]] ]]; then
-            TYPE="${BASH_REMATCH[1]}"
-            BREAKING="${BASH_REMATCH[3]-}"
+          if [ "$TITLE_VALID" = true ]; then
+            if [[ "$PR_TITLE" =~ ^([a-z]+)(\([^()]+\))?(!)?:\ [^[:space:]] ]]; then
+              TYPE="${BASH_REMATCH[1]}"
+              BREAKING="${BASH_REMATCH[3]-}"
+            fi
           fi
 
           if [ "$BREAKING" = "!" ]; then
@@ -96,7 +110,9 @@ jobs:
             esac
           fi
 
-          if [ -n "$LABEL" ]; then
+          if [ "$TITLE_VALID" != true ]; then
+            echo "Title is invalid; clearing derived labels."
+          elif [ -n "$LABEL" ]; then
             echo "Title type '$TYPE' -> label '$LABEL'"
           else
             echo "No conventional-commit type in title; clearing derived labels."

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -43,7 +43,14 @@ jobs:
           import sys
           from pathlib import Path
 
-          derived = {"enhancement", "bug", "documentation", "refactoring", "chore"}
+          derived = {
+              "breaking-change",
+              "enhancement",
+              "bug",
+              "documentation",
+              "refactoring",
+              "chore",
+          }
           try:
               pr = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
               label_pages = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
@@ -70,18 +77,24 @@ jobs:
           # Match only a type at the exact start of a structurally valid prefix.
           # The title stays in a variable, so a crafted value cannot inject shell.
           TYPE=""
-          if [[ "$PR_TITLE" =~ ^([a-z]+)(\([^()]+\))?!?:\ [^[:space:]] ]]; then
+          BREAKING=""
+          if [[ "$PR_TITLE" =~ ^([a-z]+)(\([^()]+\))?(!)?:\ [^[:space:]] ]]; then
             TYPE="${BASH_REMATCH[1]}"
+            BREAKING="${BASH_REMATCH[3]-}"
           fi
 
-          case "$TYPE" in
-            feat)           LABEL="enhancement" ;;
-            fix)            LABEL="bug" ;;
-            docs)           LABEL="documentation" ;;
-            refactor)       LABEL="refactoring" ;;
-            chore|ci|style|test|perf) LABEL="chore" ;;
-            *)              LABEL="" ;;
-          esac
+          if [ "$BREAKING" = "!" ]; then
+            LABEL="breaking-change"
+          else
+            case "$TYPE" in
+              feat)           LABEL="enhancement" ;;
+              fix)            LABEL="bug" ;;
+              docs)           LABEL="documentation" ;;
+              refactor)       LABEL="refactoring" ;;
+              chore|ci|style|test|perf) LABEL="chore" ;;
+              *)              LABEL="" ;;
+            esac
+          fi
 
           if [ -n "$LABEL" ]; then
             echo "Title type '$TYPE' -> label '$LABEL'"
@@ -96,7 +109,7 @@ jobs:
           # Idempotency is explicit: only attached stale derived labels are
           # removed, and the desired label is added only when it is absent.
           # Labels outside this fixed derived set are untouched.
-          for stale in enhancement bug documentation refactoring chore; do
+          for stale in breaking-change enhancement bug documentation refactoring chore; do
             [ "$stale" = "$LABEL" ] && continue
             if is_attached "$stale"; then
               gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$stale"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -26,17 +26,19 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          # Read the type from the title via a parameter expansion rather than
-          # interpolating it into a pattern, so a crafted title cannot inject.
-          TYPE="${PR_TITLE%%[(:]*}"
-          TYPE="${TYPE// /}"
+          # Match only a type at the exact start of a structurally valid prefix.
+          # The title stays in a variable, so a crafted value cannot inject shell.
+          TYPE=""
+          if [[ "$PR_TITLE" =~ ^([a-z]+)(\([^()]+\))?!?:\ [^[:space:]] ]]; then
+            TYPE="${BASH_REMATCH[1]}"
+          fi
 
           case "$TYPE" in
             feat)           LABEL="enhancement" ;;
             fix)            LABEL="bug" ;;
             docs)           LABEL="documentation" ;;
             refactor)       LABEL="refactoring" ;;
-            chore|ci|style|test|build|perf) LABEL="chore" ;;
+            chore|ci|style|test|perf) LABEL="chore" ;;
             *)              LABEL="" ;;
           esac
 

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -11,21 +11,62 @@ on:
 # without anyone remembering to label by hand.
 # pull_request_target is required so PRs from forks get a writable token.
 # It is safe here only because this job never checks out the PR branch and
-# never runs its code: the title is read into a variable and matched against
-# a fixed case list, so an untrusted title can at worst yield no label.
+# never runs its code: current API data is matched against a fixed case list,
+# so an untrusted title can at worst yield no label.
+concurrency:
+  group: label-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   label:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - name: Apply label for the conventional-commit type
+      - name: Apply label for the current conventional-commit type
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
+          PR_JSON="$RUNNER_TEMP/pull-request.json"
+          LABELS_JSON="$RUNNER_TEMP/pull-request-labels.json"
+          ATTACHED_DERIVED="$RUNNER_TEMP/attached-derived-labels.txt"
+
+          gh api --method GET "repos/${REPO}/pulls/${PR_NUMBER}" > "$PR_JSON"
+          gh api --method GET --paginate --slurp \
+            "repos/${REPO}/issues/${PR_NUMBER}/labels?per_page=100" > "$LABELS_JSON"
+
+          PR_TITLE=$(python3 - "$PR_JSON" "$LABELS_JSON" "$ATTACHED_DERIVED" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          derived = {"enhancement", "bug", "documentation", "refactoring", "chore"}
+          try:
+              pr = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+              label_pages = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+              if not isinstance(pr, dict) or not isinstance(label_pages, list):
+                  raise TypeError
+              if any(not isinstance(page, list) for page in label_pages):
+                  raise TypeError
+              title = pr["title"]
+              attached = {
+                  label["name"]
+                  for page in label_pages
+                  for label in page
+                  if isinstance(label, dict) and label.get("name") in derived
+              }
+          except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError):
+              raise SystemExit("Unable to read current pull request data.") from None
+          if not isinstance(title, str):
+              raise SystemExit("Unable to read current pull request data.")
+          Path(sys.argv[3]).write_text("\n".join(sorted(attached)), encoding="utf-8")
+          print(title)
+          PY
+          )
+
           # Match only a type at the exact start of a structurally valid prefix.
           # The title stays in a variable, so a crafted value cannot inject shell.
           TYPE=""
@@ -48,17 +89,20 @@ jobs:
             echo "No conventional-commit type in title; clearing derived labels."
           fi
 
-          # The cleanup runs even when the title yields no label: retitling away
-          # from docs: must not leave the documentation label attached, and one
-          # excluded label is enough to drop the PR from the release notes. The
-          # title is the single source of truth for these five, so any other one
-          # is cleared even if set by hand; labels outside this set
-          # (skip-changelog, upstream, ...) are untouched.
+          is_attached() {
+            grep -Fxq "$1" "$ATTACHED_DERIVED"
+          }
+
+          # Idempotency is explicit: only attached stale derived labels are
+          # removed, and the desired label is added only when it is absent.
+          # Labels outside this fixed derived set are untouched.
           for stale in enhancement bug documentation refactoring chore; do
             [ "$stale" = "$LABEL" ] && continue
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$stale" 2>/dev/null || true
+            if is_attached "$stale"; then
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$stale"
+            fi
           done
 
-          if [ -n "$LABEL" ]; then
+          if [ -n "$LABEL" ] && ! is_attached "$LABEL"; then
             gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,7 +363,8 @@ jobs:
                 "strict": true,
                 "checks": [
                   {"context": "lint-and-check", "app_id": 15368},
-                  {"context": "test", "app_id": 15368}
+                  {"context": "test", "app_id": 15368},
+                  {"context": "PR Title", "app_id": 15368}
                 ]
               },
               "enforce_admins": true,

--- a/scripts/check_pr_title.py
+++ b/scripts/check_pr_title.py
@@ -1,0 +1,111 @@
+"""Validate pull request titles for the required conventional-commit shape."""
+
+from __future__ import annotations
+
+import os
+import re
+
+ALLOWED_TYPES = (
+    "feat",
+    "fix",
+    "docs",
+    "style",
+    "refactor",
+    "test",
+    "chore",
+    "perf",
+    "ci",
+)
+
+MISSING_TITLE = "PR title is missing."
+UNSAFE_CHARACTER = "PR title contains an unsafe character."
+INVALID_SHAPE = "PR title must use an accepted conventional-commit shape."
+UNSUPPORTED_TYPE = "PR title uses an unsupported type."
+INVALID_SCOPE = "PR title has an invalid scope."
+INVALID_SUBJECT = "PR title has an invalid subject."
+FINAL_PERIOD = "PR title subject must not end with an ASCII period."
+
+HINT = (
+    "Expected: type: subject, type(scope): subject, type!: subject, or "
+    "type(scope)!: subject. Allowed types: " + ", ".join(ALLOWED_TYPES) + "."
+)
+
+_TITLE = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^()]*)\))?(?P<breaking>!)?: "
+    r"(?P<subject>.*)$"
+)
+_BOUNDARY_WHITESPACE = {
+    0x0020,
+    0x00A0,
+    0x1680,
+    *range(0x2000, 0x200B),
+    0x202F,
+    0x205F,
+    0x3000,
+}
+_BIDI_FORMATTING = {
+    0x061C,
+    0x200E,
+    0x200F,
+    *range(0x202A, 0x202F),
+    *range(0x2066, 0x206A),
+}
+
+
+def _is_unsafe(character: str) -> bool:
+    codepoint = ord(character)
+    return (
+        codepoint <= 0x001F
+        or 0x007F <= codepoint <= 0x009F
+        or codepoint in {0x2028, 0x2029, 0xFEFF, 0xFFFD}
+        or codepoint in _BIDI_FORMATTING
+    )
+
+
+def _has_boundary_whitespace(value: str) -> bool:
+    return bool(value) and (
+        ord(value[0]) in _BOUNDARY_WHITESPACE
+        or ord(value[-1]) in _BOUNDARY_WHITESPACE
+        or _is_unsafe(value[0])
+        or _is_unsafe(value[-1])
+    )
+
+
+def validate_title(title: str) -> str | None:
+    """Return a fixed diagnostic for an invalid title, or ``None``."""
+    if any(_is_unsafe(character) for character in title):
+        return UNSAFE_CHARACTER
+
+    match = _TITLE.fullmatch(title)
+    if match is None:
+        return INVALID_SHAPE
+
+    if match["type"] not in ALLOWED_TYPES:
+        return UNSUPPORTED_TYPE
+
+    scope = match["scope"]
+    if scope is not None and (not scope or _has_boundary_whitespace(scope)):
+        return INVALID_SCOPE
+
+    subject = match["subject"]
+    if not subject or _has_boundary_whitespace(subject):
+        return INVALID_SUBJECT
+    if subject.endswith("."):
+        return FINAL_PERIOD
+
+    return None
+
+
+def main() -> int:
+    title = os.environ.get("PR_TITLE")
+    diagnostic = MISSING_TITLE if not title else validate_title(title)
+    if diagnostic is None:
+        return 0
+
+    print(f"::error::{diagnostic}")
+    print(HINT)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_pr_title.py
+++ b/scripts/check_pr_title.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import argparse
+import json
 import os
 import re
+from pathlib import Path
 
 ALLOWED_TYPES = (
     "feat",
@@ -18,6 +21,7 @@ ALLOWED_TYPES = (
 )
 
 MISSING_TITLE = "PR title is missing."
+INVALID_PR_DATA = "Unable to read current pull request data."
 UNSAFE_CHARACTER = "PR title contains an unsafe character."
 INVALID_SHAPE = "PR title must use an accepted conventional-commit shape."
 UNSUPPORTED_TYPE = "PR title uses an unsupported type."
@@ -57,7 +61,7 @@ def _is_unsafe(character: str) -> bool:
     return (
         codepoint <= 0x001F
         or 0x007F <= codepoint <= 0x009F
-        or codepoint in {0x2028, 0x2029, 0xFEFF, 0xFFFD}
+        or codepoint in {0x200B, 0x2028, 0x2029, 0xFEFF, 0xFFFD}
         or codepoint in _BIDI_FORMATTING
     )
 
@@ -96,9 +100,35 @@ def validate_title(title: str) -> str | None:
     return None
 
 
+def _load_pr_title(path: Path) -> str | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(data, dict):
+        return None
+    title = data.get("title")
+    if not isinstance(title, str) or not title:
+        return None
+    return title
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pr-json", type=Path)
+    return parser.parse_args()
+
+
 def main() -> int:
-    title = os.environ.get("PR_TITLE")
-    diagnostic = MISSING_TITLE if not title else validate_title(title)
+    args = _parse_args()
+    if args.pr_json is not None:
+        title = _load_pr_title(args.pr_json)
+        diagnostic = INVALID_PR_DATA if title is None else validate_title(title)
+    else:
+        title = os.environ.get("PR_TITLE")
+        diagnostic = MISSING_TITLE if not title else validate_title(title)
+
     if diagnostic is None:
         return 0
 

--- a/scripts/check_pr_title.py
+++ b/scripts/check_pr_title.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import re
+import unicodedata
 from pathlib import Path
 
 ALLOWED_TYPES = (
@@ -38,15 +39,6 @@ _TITLE = re.compile(
     r"^(?P<type>[a-z]+)(?:\((?P<scope>[^()]*)\))?(?P<breaking>!)?: "
     r"(?P<subject>.*)$"
 )
-_BOUNDARY_WHITESPACE = {
-    0x0020,
-    0x00A0,
-    0x1680,
-    *range(0x2000, 0x200B),
-    0x202F,
-    0x205F,
-    0x3000,
-}
 _BIDI_FORMATTING = {
     0x061C,
     0x200E,
@@ -61,17 +53,27 @@ def _is_unsafe(character: str) -> bool:
     return (
         codepoint <= 0x001F
         or 0x007F <= codepoint <= 0x009F
-        or codepoint in {0x200B, 0x2028, 0x2029, 0xFEFF, 0xFFFD}
+        or codepoint in {0x200B, 0x2028, 0x2029, 0x2060, 0xFEFF, 0xFFFD}
         or codepoint in _BIDI_FORMATTING
     )
 
 
-def _has_boundary_whitespace(value: str) -> bool:
-    return bool(value) and (
-        ord(value[0]) in _BOUNDARY_WHITESPACE
-        or ord(value[-1]) in _BOUNDARY_WHITESPACE
-        or _is_unsafe(value[0])
-        or _is_unsafe(value[-1])
+def _is_substantive(character: str) -> bool:
+    return unicodedata.category(character)[0] not in {"C", "M", "Z"}
+
+
+def _last_substantive(value: str) -> str | None:
+    return next(
+        (character for character in reversed(value) if _is_substantive(character)),
+        None,
+    )
+
+
+def _has_invalid_boundary(value: str) -> bool:
+    return bool(value) and any(
+        unicodedata.category(character) == "Cf"
+        or unicodedata.category(character).startswith("Z")
+        for character in (value[0], value[-1])
     )
 
 
@@ -88,14 +90,19 @@ def validate_title(title: str) -> str | None:
         return UNSUPPORTED_TYPE
 
     scope = match["scope"]
-    if scope is not None and (not scope or _has_boundary_whitespace(scope)):
+    if scope is not None and (
+        _last_substantive(scope) is None or _has_invalid_boundary(scope)
+    ):
         return INVALID_SCOPE
 
     subject = match["subject"]
-    if not subject or _has_boundary_whitespace(subject):
+    last_substantive = _last_substantive(subject)
+    if last_substantive is None:
         return INVALID_SUBJECT
-    if subject.endswith("."):
+    if last_substantive == ".":
         return FINAL_PERIOD
+    if _has_invalid_boundary(subject):
+        return INVALID_SUBJECT
 
     return None
 

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -1435,7 +1435,7 @@ if len(sys.argv) >= 4:
         time.sleep(0.01)
     # Timed out without ``go``: the parent is failing the barrier and will
     # kill frontends. Entering obtain_owner here can spawn a detached owner
-    # that fixture cleanup then misses (#881 / Greptile).
+    # that fixture cleanup then misses (#881).
     if not go.exists():
         raise SystemExit("launch barrier timed out waiting for go signal")
 auth_root = profile.parent

--- a/tests/test_pr_title.py
+++ b/tests/test_pr_title.py
@@ -139,6 +139,7 @@ def test_subject_boundary_whitespace_is_rejected(space: str) -> None:
         "‮",
         "⁦",
         "⁩",
+        "\N{WORD JOINER}",
         "﻿",
         "�",
     ],
@@ -177,6 +178,61 @@ def test_zero_width_space_cli_input_is_rejected(title: str) -> None:
 
 def test_unsafe_character_precedes_other_diagnostics() -> None:
     assert validate_title("build: Invalid.\n") == UNSAFE_CHARACTER
+
+
+def test_word_joiner_is_globally_unsafe() -> None:
+    assert validate_title("fix: Before\N{WORD JOINER}after") == UNSAFE_CHARACTER
+
+
+@pytest.mark.parametrize(
+    "character",
+    ["\N{SOFT HYPHEN}", "\N{ZERO WIDTH JOINER}"],
+)
+def test_format_characters_at_boundaries_are_rejected(character: str) -> None:
+    assert validate_title(f"fix({character}scope): Keep boundaries") == INVALID_SCOPE
+    assert validate_title(f"fix(scope{character}): Keep boundaries") == INVALID_SCOPE
+    assert validate_title(f"fix: {character}Keep boundaries") == INVALID_SUBJECT
+    assert validate_title(f"fix: Keep boundaries{character}") == INVALID_SUBJECT
+
+
+@pytest.mark.parametrize(
+    ("title", "diagnostic"),
+    [
+        ("fix(\N{COMBINING ACUTE ACCENT}): Subject", INVALID_SCOPE),
+        ("fix: \N{COMBINING ACUTE ACCENT}", INVALID_SUBJECT),
+    ],
+)
+def test_scope_and_subject_require_substantive_content(
+    title: str, diagnostic: str
+) -> None:
+    assert validate_title(title) == diagnostic
+
+
+@pytest.mark.parametrize(
+    "trailing",
+    ["\N{SOFT HYPHEN}", "\N{COMBINING ACUTE ACCENT}"],
+)
+def test_final_period_uses_last_substantive_codepoint(trailing: str) -> None:
+    assert validate_title(f"fix: Do not hide.{trailing}") == FINAL_PERIOD
+
+
+def test_decomposed_accents_are_accepted() -> None:
+    assert (
+        validate_title(
+            "fix(cafe\N{COMBINING ACUTE ACCENT}): "
+            "Handle resume\N{COMBINING ACUTE ACCENT}"
+        )
+        is None
+    )
+
+
+def test_internal_emoji_zwj_sequence_is_accepted() -> None:
+    assert (
+        validate_title(
+            "fix: Support \N{WOMAN}\N{ZERO WIDTH JOINER}\N{PERSONAL COMPUTER} profiles"
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(
@@ -297,29 +353,27 @@ def test_cli_rejects_missing_pr_json_file(tmp_path: Path) -> None:
     assert "missing.json" not in result.stdout + result.stderr
 
 
-def test_pr_title_workflow_runs_only_trusted_validator() -> None:
+def test_pr_title_workflow_is_automatic_required_check() -> None:
     workflow = _CHECK_WORKFLOW.read_text(encoding="utf-8")
 
-    assert workflow.startswith("name: Validate PR title\n")
-    assert "pull_request_target:" in workflow
-    assert "types: [opened, edited, reopened, synchronize]" in workflow
-    assert "issue_comment:" in workflow
-    assert "types: [created]" in workflow
+    assert workflow.startswith("name: PR Title\n")
+    assert workflow.count("name: PR Title") == 2
+    assert workflow.count("pull_request_target:") == 1
+    assert workflow.count("types: [opened, edited, reopened, synchronize]") == 1
+    assert "issue_comment:" not in workflow
+    assert "types: [created]" not in workflow
+    assert "workflow_dispatch:" not in workflow
     assert "contents: read" in workflow
     assert "pull-requests: read" in workflow
-    assert "statuses: write" in workflow
     assert "pull-requests: write" not in workflow
-    assert (
-        "group: pr-title-${{ github.event.pull_request.number || "
-        "github.event.issue.number }}" in workflow
-    )
+    assert "group: pr-title-${{ github.event.pull_request.number }}" in workflow
     assert "cancel-in-progress: true" in workflow
-    assert "name: PR Title" not in workflow
-    assert "name: Check current PR title" in workflow
     assert _CHECKOUT in workflow
     assert "ref: ${{ github.workflow_sha }}" in workflow
     assert "persist-credentials: false" in workflow
     assert "github.event.pull_request.head" not in workflow
+    assert "github.head_ref" not in workflow
+    assert "refs/pull/" not in workflow
     assert "uv " not in workflow
     assert "pip " not in workflow
 
@@ -327,51 +381,44 @@ def test_pr_title_workflow_runs_only_trusted_validator() -> None:
 def test_pr_title_workflow_fetches_current_api_data() -> None:
     workflow = _CHECK_WORKFLOW.read_text(encoding="utf-8")
 
-    assert 'PR_JSON="$RUNNER_TEMP/pull-request.json"' in workflow
-    assert '"repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "$PR_JSON"' in workflow
+    assert "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in workflow
+    assert "PR_NUMBER: ${{ github.event.pull_request.number }}" in workflow
+    assert '"repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"' in workflow
+    assert '> "$RUNNER_TEMP/pull-request.json"' in workflow
     assert (
         'python3 scripts/check_pr_title.py --pr-json "$RUNNER_TEMP/pull-request.json"'
         in workflow
     )
     assert "PR_TITLE: ${{ github.event.pull_request.title }}" not in workflow
     assert "github.event.pull_request.title" not in workflow
-    assert "Unable to read current pull request data." in workflow
 
     validator_step = workflow.split(
         "- name: Validate current pull request title", maxsplit=1
-    )[1].split("- name: Publish final PR Title status", maxsplit=1)[0]
+    )[1]
     assert "GH_TOKEN" not in validator_step
+    assert "secrets.GITHUB_TOKEN" not in validator_step
 
 
-def test_pr_title_workflow_publishes_required_status() -> None:
+def test_pr_title_workflow_has_no_fallback_or_status_layer() -> None:
     workflow = _CHECK_WORKFLOW.read_text(encoding="utf-8")
 
-    assert workflow.count('"repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}"') == 2
-    assert workflow.count('-f context="PR Title"') == 2
-    assert "-f state=pending" in workflow
-    assert "STATE=success" in workflow
-    assert "STATE=failure" in workflow
-    assert "if: always()" in workflow
-    assert workflow.count("GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}") == 3
-    assert (
-        workflow.count(
-            "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        )
-        == 2
-    )
+    assert "issue_comment:" not in workflow
+    assert "github.event.comment" not in workflow
+    assert "/check-pr-title" not in workflow
+    assert "statuses: write" not in workflow
+    assert "/statuses/" not in workflow
+    assert "HEAD_SHA" not in workflow
+    assert "head_sha" not in workflow
+    assert '["head"]["sha"]' not in workflow
+    assert "Publish pending PR Title status" not in workflow
+    assert "Publish final PR Title status" not in workflow
 
 
-def test_pr_title_comment_fallback_is_exact_and_pr_only() -> None:
+def test_pr_title_workflow_documents_sha_like_branch_recovery() -> None:
     workflow = _CHECK_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "github.event_name == 'pull_request_target' ||" in workflow
-    assert "github.event_name == 'issue_comment'" in workflow
-    assert "github.event.issue.pull_request &&" in workflow
-    assert "github.event.comment.body == '/check-pr-title'" in workflow
-    assert "contains(github.event.comment.body" not in workflow
-    assert "startsWith(github.event.comment.body" not in workflow
-    assert "github.event.comment.body }}" not in workflow
-    assert "SHA-like fork branch names" in workflow
+    assert "suppresses pull_request_target for SHA-like source branch names" in workflow
+    assert "Rename the source branch" in workflow
 
 
 def test_label_workflow_matches_breaking_marker_without_normalizing() -> None:

--- a/tests/test_pr_title.py
+++ b/tests/test_pr_title.py
@@ -1,0 +1,255 @@
+"""Contracts for pull request title validation and its workflows."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, cast
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check_pr_title.py"
+_SPEC = importlib.util.spec_from_file_location("check_pr_title", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_VALIDATOR = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_VALIDATOR)
+
+ALLOWED_TYPES = cast(tuple[str, ...], _VALIDATOR.ALLOWED_TYPES)
+FINAL_PERIOD = cast(str, _VALIDATOR.FINAL_PERIOD)
+INVALID_SCOPE = cast(str, _VALIDATOR.INVALID_SCOPE)
+INVALID_SHAPE = cast(str, _VALIDATOR.INVALID_SHAPE)
+INVALID_SUBJECT = cast(str, _VALIDATOR.INVALID_SUBJECT)
+UNSAFE_CHARACTER = cast(str, _VALIDATOR.UNSAFE_CHARACTER)
+UNSUPPORTED_TYPE = cast(str, _VALIDATOR.UNSUPPORTED_TYPE)
+validate_title = cast(Callable[[str], str | None], _VALIDATOR.validate_title)
+
+_CHECK_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "check-pr-title.yml"
+_LABEL_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "label-pr.yml"
+_RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
+_CHECKOUT = "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803"
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "feat: Add title validation",
+        "fix(parser): Reject an invalid title",
+        "docs!: Rewrite the guide",
+        "refactor(release workflow)!: Restore required checks",
+    ],
+)
+def test_accepted_shapes(title: str) -> None:
+    assert validate_title(title) is None
+
+
+@pytest.mark.parametrize("type_name", ALLOWED_TYPES)
+def test_every_allowed_type_is_accepted(type_name: str) -> None:
+    assert validate_title(f"{type_name}: Accept this title") is None
+
+
+def test_build_type_is_rejected() -> None:
+    assert validate_title("build: Package the release") == UNSUPPORTED_TYPE
+
+
+@pytest.mark.parametrize(
+    ("title", "diagnostic"),
+    [
+        ("fix:Add spacing", INVALID_SHAPE),
+        ("fix:  Add spacing", INVALID_SUBJECT),
+        ("fix : Add spacing", INVALID_SHAPE),
+        (" fix: Add spacing", INVALID_SHAPE),
+        ("fix(scope) : Add spacing", INVALID_SHAPE),
+        ("fix(scope)! : Add spacing", INVALID_SHAPE),
+        ("fix(scope)!!: Add spacing", INVALID_SHAPE),
+        ("fix!!: Add spacing", INVALID_SHAPE),
+        ("fix!extra: Add spacing", INVALID_SHAPE),
+        ("fix(): Add spacing", INVALID_SCOPE),
+        ("fix( scope): Add spacing", INVALID_SCOPE),
+        ("fix(scope ): Add spacing", INVALID_SCOPE),
+        ("fix: ", INVALID_SUBJECT),
+        ("fix:  ", INVALID_SUBJECT),
+        ("fix: Add spacing ", INVALID_SUBJECT),
+        ("fix: Add spacing.", FINAL_PERIOD),
+    ],
+)
+def test_invalid_structure_has_deterministic_diagnostics(
+    title: str, diagnostic: str
+) -> None:
+    assert validate_title(title) == diagnostic
+
+
+@pytest.mark.parametrize(
+    "space",
+    [
+        " ",
+        " ",
+        " ",
+        " ",
+        " ",
+        " ",
+        " ",
+        " ",
+        "　",
+    ],
+)
+def test_scope_boundary_whitespace_is_rejected(space: str) -> None:
+    assert validate_title(f"fix({space}scope): Keep boundaries") == INVALID_SCOPE
+    assert validate_title(f"fix(scope{space}): Keep boundaries") == INVALID_SCOPE
+
+
+@pytest.mark.parametrize(
+    "space",
+    [
+        " ",
+        " ",
+        " ",
+        " ",
+        " ",
+        " ",
+        " ",
+        " ",
+        "　",
+    ],
+)
+def test_subject_boundary_whitespace_is_rejected(space: str) -> None:
+    assert validate_title(f"fix: {space}Keep boundaries") == INVALID_SUBJECT
+    assert validate_title(f"fix: Keep boundaries{space}") == INVALID_SUBJECT
+
+
+@pytest.mark.parametrize(
+    "character",
+    [
+        "\x00",
+        "\x1f",
+        "\x7f",
+        "\x80",
+        "\x9f",
+        "؜",
+        "‎",
+        "‏",
+        " ",
+        " ",
+        "‪",
+        "‮",
+        "⁦",
+        "⁩",
+        "﻿",
+        "�",
+    ],
+)
+def test_unsafe_characters_are_rejected_anywhere(character: str) -> None:
+    assert validate_title(f"fix: Before{character}after") == UNSAFE_CHARACTER
+
+
+def test_unsafe_character_precedes_other_diagnostics() -> None:
+    assert validate_title("build: Invalid.\n") == UNSAFE_CHARACTER
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "feat(HTTP/API v2): Preserve internal punctuation",
+        "fix: Handle déjà vu safely",
+        "docs: Explain 日本語 titles",
+        "test: Permit commas, semicolons; and question marks?",
+        "chore: Permit a Unicode full stop。",
+        "perf(scope! #42): Permit punctuation in scope",
+    ],
+)
+def test_unicode_and_internal_punctuation_are_accepted(title: str) -> None:
+    assert validate_title(title) is None
+
+
+def _run_cli(title: str | None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if title is None:
+        env.pop("PR_TITLE", None)
+    else:
+        env["PR_TITLE"] = title
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "build: payload%0A::warning::leaked",
+        "build: ::warning:: forged annotation",
+        "fix: actual\rcontrol",
+        "fix: actual\ncontrol",
+    ],
+)
+def test_invalid_cli_input_emits_one_safe_error_annotation(title: str) -> None:
+    result = _run_cli(title)
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0
+    assert sum(line.startswith("::error::") for line in output.splitlines()) == 1
+    assert "Expected: type: subject" in output
+    assert title not in output
+    assert "::warning::" not in output
+
+
+def test_missing_cli_title_emits_one_error_annotation() -> None:
+    result = _run_cli(None)
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0
+    assert sum(line.startswith("::error::") for line in output.splitlines()) == 1
+    assert "::error::PR title is missing." in output
+
+
+def test_valid_cli_title_exits_without_output() -> None:
+    result = _run_cli("fix(cli): Accept safe input")
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_pr_title_workflow_runs_only_trusted_validator() -> None:
+    workflow = _CHECK_WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow.startswith("name: PR Title\n")
+    assert "pull_request_target:" in workflow
+    assert "types: [opened, edited, reopened, synchronize]" in workflow
+    assert "contents: read" in workflow
+    assert "pull-requests: write" not in workflow
+    assert "statuses: write" not in workflow
+    assert "group: pr-title-${{ github.event.pull_request.number }}" in workflow
+    assert "cancel-in-progress: true" in workflow
+    assert workflow.count("name: PR Title") == 2
+    assert _CHECKOUT in workflow
+    assert "ref: ${{ github.workflow_sha }}" in workflow
+    assert "persist-credentials: false" in workflow
+    assert "PR_TITLE: ${{ github.event.pull_request.title }}" in workflow
+    assert "python3 scripts/check_pr_title.py" in workflow
+    assert "github.event.pull_request.head" not in workflow
+    assert "uv " not in workflow
+    assert "pip " not in workflow
+
+
+def test_label_workflow_matches_breaking_marker_without_normalizing() -> None:
+    workflow = _LABEL_WORKFLOW.read_text(encoding="utf-8")
+
+    assert '[[ "$PR_TITLE" =~ ^([a-z]+)(\\([^()]+\\))?!?:\\ [^[:space:]] ]]' in workflow
+    assert 'TYPE="${BASH_REMATCH[1]}"' in workflow
+    assert 'TYPE="${TYPE// /}"' not in workflow
+    assert "|build|" not in workflow
+    assert 'test|perf) LABEL="chore"' in workflow
+
+
+def test_release_restores_pr_title_required_check() -> None:
+    workflow = _RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert '{"context": "PR Title", "app_id": 15368}' in workflow

--- a/tests/test_pr_title.py
+++ b/tests/test_pr_title.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import subprocess
 import sys
@@ -20,6 +21,7 @@ _SPEC.loader.exec_module(_VALIDATOR)
 
 ALLOWED_TYPES = cast(tuple[str, ...], _VALIDATOR.ALLOWED_TYPES)
 FINAL_PERIOD = cast(str, _VALIDATOR.FINAL_PERIOD)
+INVALID_PR_DATA = cast(str, _VALIDATOR.INVALID_PR_DATA)
 INVALID_SCOPE = cast(str, _VALIDATOR.INVALID_SCOPE)
 INVALID_SHAPE = cast(str, _VALIDATOR.INVALID_SHAPE)
 INVALID_SUBJECT = cast(str, _VALIDATOR.INVALID_SUBJECT)
@@ -145,6 +147,34 @@ def test_unsafe_characters_are_rejected_anywhere(character: str) -> None:
     assert validate_title(f"fix: Before{character}after") == UNSAFE_CHARACTER
 
 
+@pytest.mark.parametrize(
+    "title",
+    [
+        "fix: ​",
+        "fix(​): Subject",
+        "fix: Subject.​",
+    ],
+)
+def test_zero_width_space_is_rejected_anywhere(title: str) -> None:
+    assert validate_title(title) == UNSAFE_CHARACTER
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "fix: ​",
+        "fix(​): Subject",
+        "fix: Subject.​",
+    ],
+)
+def test_zero_width_space_cli_input_is_rejected(title: str) -> None:
+    result = _run_cli(title)
+
+    assert result.returncode != 0
+    assert f"::error::{UNSAFE_CHARACTER}" in result.stdout
+    assert title not in result.stdout + result.stderr
+
+
 def test_unsafe_character_precedes_other_diagnostics() -> None:
     assert validate_title("build: Invalid.\n") == UNSAFE_CHARACTER
 
@@ -164,14 +194,19 @@ def test_unicode_and_internal_punctuation_are_accepted(title: str) -> None:
     assert validate_title(title) is None
 
 
-def _run_cli(title: str | None) -> subprocess.CompletedProcess[str]:
+def _run_cli(
+    title: str | None, pr_json: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     if title is None:
         env.pop("PR_TITLE", None)
     else:
         env["PR_TITLE"] = title
+    command = [sys.executable, str(_SCRIPT)]
+    if pr_json is not None:
+        command.extend(["--pr-json", str(pr_json)])
     return subprocess.run(
-        [sys.executable, str(_SCRIPT)],
+        command,
         cwd=_REPO_ROOT,
         env=env,
         capture_output=True,
@@ -217,26 +252,126 @@ def test_valid_cli_title_exits_without_output() -> None:
     assert result.stderr == ""
 
 
+def test_cli_reads_current_title_from_pr_json(tmp_path: Path) -> None:
+    pr_json = tmp_path / "pull-request.json"
+    pr_json.write_text(
+        json.dumps({"title": "fix(cli): Read current API data"}), encoding="utf-8"
+    )
+
+    result = _run_cli("build: Ignore stale event data", pr_json)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "{",
+        "{}",
+        '{"title": null}',
+        "[]",
+    ],
+)
+def test_cli_rejects_missing_or_malformed_pr_json(
+    tmp_path: Path, contents: str
+) -> None:
+    pr_json = tmp_path / "pull-request.json"
+    pr_json.write_text(contents, encoding="utf-8")
+
+    result = _run_cli("fix: Stale event title", pr_json)
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0
+    assert output.count(f"::error::{INVALID_PR_DATA}") == 1
+    assert contents not in output
+    assert "Stale event title" not in output
+
+
+def test_cli_rejects_missing_pr_json_file(tmp_path: Path) -> None:
+    result = _run_cli("fix: Stale event title", tmp_path / "missing.json")
+
+    assert result.returncode != 0
+    assert f"::error::{INVALID_PR_DATA}" in result.stdout
+    assert "missing.json" not in result.stdout + result.stderr
+
+
 def test_pr_title_workflow_runs_only_trusted_validator() -> None:
     workflow = _CHECK_WORKFLOW.read_text(encoding="utf-8")
 
-    assert workflow.startswith("name: PR Title\n")
+    assert workflow.startswith("name: Validate PR title\n")
     assert "pull_request_target:" in workflow
     assert "types: [opened, edited, reopened, synchronize]" in workflow
+    assert "issue_comment:" in workflow
+    assert "types: [created]" in workflow
     assert "contents: read" in workflow
+    assert "pull-requests: read" in workflow
+    assert "statuses: write" in workflow
     assert "pull-requests: write" not in workflow
-    assert "statuses: write" not in workflow
-    assert "group: pr-title-${{ github.event.pull_request.number }}" in workflow
+    assert (
+        "group: pr-title-${{ github.event.pull_request.number || "
+        "github.event.issue.number }}" in workflow
+    )
     assert "cancel-in-progress: true" in workflow
-    assert workflow.count("name: PR Title") == 2
+    assert "name: PR Title" not in workflow
+    assert "name: Check current PR title" in workflow
     assert _CHECKOUT in workflow
     assert "ref: ${{ github.workflow_sha }}" in workflow
     assert "persist-credentials: false" in workflow
-    assert "PR_TITLE: ${{ github.event.pull_request.title }}" in workflow
-    assert "python3 scripts/check_pr_title.py" in workflow
     assert "github.event.pull_request.head" not in workflow
     assert "uv " not in workflow
     assert "pip " not in workflow
+
+
+def test_pr_title_workflow_fetches_current_api_data() -> None:
+    workflow = _CHECK_WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'PR_JSON="$RUNNER_TEMP/pull-request.json"' in workflow
+    assert '"repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "$PR_JSON"' in workflow
+    assert (
+        'python3 scripts/check_pr_title.py --pr-json "$RUNNER_TEMP/pull-request.json"'
+        in workflow
+    )
+    assert "PR_TITLE: ${{ github.event.pull_request.title }}" not in workflow
+    assert "github.event.pull_request.title" not in workflow
+    assert "Unable to read current pull request data." in workflow
+
+    validator_step = workflow.split(
+        "- name: Validate current pull request title", maxsplit=1
+    )[1].split("- name: Publish final PR Title status", maxsplit=1)[0]
+    assert "GH_TOKEN" not in validator_step
+
+
+def test_pr_title_workflow_publishes_required_status() -> None:
+    workflow = _CHECK_WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow.count('"repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}"') == 2
+    assert workflow.count('-f context="PR Title"') == 2
+    assert "-f state=pending" in workflow
+    assert "STATE=success" in workflow
+    assert "STATE=failure" in workflow
+    assert "if: always()" in workflow
+    assert workflow.count("GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}") == 3
+    assert (
+        workflow.count(
+            "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        )
+        == 2
+    )
+
+
+def test_pr_title_comment_fallback_is_exact_and_pr_only() -> None:
+    workflow = _CHECK_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "github.event_name == 'pull_request_target' ||" in workflow
+    assert "github.event_name == 'issue_comment'" in workflow
+    assert "github.event.issue.pull_request &&" in workflow
+    assert "github.event.comment.body == '/check-pr-title'" in workflow
+    assert "contains(github.event.comment.body" not in workflow
+    assert "startsWith(github.event.comment.body" not in workflow
+    assert "github.event.comment.body }}" not in workflow
+    assert "SHA-like fork branch names" in workflow
 
 
 def test_label_workflow_matches_breaking_marker_without_normalizing() -> None:
@@ -247,6 +382,35 @@ def test_label_workflow_matches_breaking_marker_without_normalizing() -> None:
     assert 'TYPE="${TYPE// /}"' not in workflow
     assert "|build|" not in workflow
     assert 'test|perf) LABEL="chore"' in workflow
+
+
+def test_label_workflow_uses_current_title_and_per_pr_concurrency() -> None:
+    workflow = _LABEL_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "group: label-pr-${{ github.event.pull_request.number }}" in workflow
+    assert "cancel-in-progress: true" in workflow
+    assert "set -euo pipefail" in workflow
+    assert '"repos/${REPO}/pulls/${PR_NUMBER}" > "$PR_JSON"' in workflow
+    assert "--paginate --slurp" in workflow
+    assert (
+        '"repos/${REPO}/issues/${PR_NUMBER}/labels?per_page=100" > "$LABELS_JSON"'
+        in workflow
+    )
+    assert "< <(" not in workflow
+    assert "PR_TITLE: ${{ github.event.pull_request.title }}" not in workflow
+    assert "github.event.pull_request.title" not in workflow
+
+
+def test_label_workflow_removes_only_attached_stale_labels() -> None:
+    workflow = _LABEL_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "ATTACHED_DERIVED=" in workflow
+    assert 'if is_attached "$stale"; then' in workflow
+    assert '[ -n "$LABEL" ] && ! is_attached "$LABEL"' in workflow
+    assert '--remove-label "$stale"' in workflow
+    assert "|| true" not in workflow
+    assert "2>/dev/null" not in workflow
+    assert "Labels outside this fixed derived set are untouched." in workflow
 
 
 def test_release_restores_pr_title_required_check() -> None:

--- a/tests/test_pr_title.py
+++ b/tests/test_pr_title.py
@@ -602,13 +602,49 @@ def test_pr_title_label_release_lifecycle(
     assert rerun_calls == []
 
 
-def test_label_workflow_uses_current_title_and_per_pr_concurrency() -> None:
+@pytest.mark.parametrize(
+    "title",
+    [
+        "fix: Subject.",
+        "build: Unsupported",
+        "fix: \N{NO-BREAK SPACE}Boundary",
+        "fix: Invisible\N{ZERO WIDTH SPACE}",
+        "fix: First line\nsecond line",
+        "fix: Before\rAfter",
+    ],
+)
+def test_invalid_pr_title_label_lifecycle(tmp_path: Path, title: str) -> None:
+    assert validate_title(title) is not None
+    attached = _DERIVED_LABELS | {"triage"}
+
+    result, final_labels, calls = _run_label_workflow(tmp_path, title, attached)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "::error::" not in result.stdout + result.stderr
+    assert "Title is invalid; clearing derived labels." in result.stdout
+    assert final_labels == {"triage"}
+    assert {call[-1] for call in calls} == _DERIVED_LABELS
+    assert all("--remove-label" in call for call in calls)
+
+
+def test_label_workflow_uses_trusted_validator_and_current_title() -> None:
     workflow = _LABEL_WORKFLOW.read_text(encoding="utf-8")
 
     assert "group: label-pr-${{ github.event.pull_request.number }}" in workflow
     assert "cancel-in-progress: true" in workflow
     assert "set -euo pipefail" in workflow
+    assert "      contents: read\n      pull-requests: write\n" in workflow
+    assert "contents: write" not in workflow
+    assert _CHECKOUT in workflow
+    assert "ref: ${{ github.workflow_sha }}" in workflow
+    assert "persist-credentials: false" in workflow
+    assert "github.event.pull_request.head" not in workflow
+    assert "github.head_ref" not in workflow
+    assert "refs/pull/" not in workflow
     assert '"repos/${REPO}/pulls/${PR_NUMBER}" > "$PR_JSON"' in workflow
+    assert (
+        'python3 scripts/check_pr_title.py --pr-json "$PR_JSON" >/dev/null' in workflow
+    )
     assert "--paginate --slurp" in workflow
     assert (
         '"repos/${REPO}/issues/${PR_NUMBER}/labels?per_page=100" > "$LABELS_JSON"'

--- a/tests/test_pr_title.py
+++ b/tests/test_pr_title.py
@@ -31,8 +31,17 @@ validate_title = cast(Callable[[str], str | None], _VALIDATOR.validate_title)
 
 _CHECK_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "check-pr-title.yml"
 _LABEL_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "label-pr.yml"
+_RELEASE_CONFIG = _REPO_ROOT / ".github" / "release.yml"
 _RELEASE_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release.yml"
 _CHECKOUT = "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803"
+_DERIVED_LABELS = {
+    "breaking-change",
+    "enhancement",
+    "bug",
+    "documentation",
+    "refactoring",
+    "chore",
+}
 
 
 @pytest.mark.parametrize(
@@ -271,6 +280,120 @@ def _run_cli(
     )
 
 
+def _label_workflow_script() -> str:
+    lines = _LABEL_WORKFLOW.read_text(encoding="utf-8").splitlines()
+    start = lines.index("        run: |") + 1
+    script: list[str] = []
+    for line in lines[start:]:
+        if line and not line.startswith("          "):
+            break
+        script.append(line[10:] if line else "")
+    return "\n".join(script)
+
+
+def _run_label_workflow(
+    tmp_path: Path, title: str, attached: set[str]
+) -> tuple[subprocess.CompletedProcess[str], set[str], list[list[str]]]:
+    state_path = tmp_path / "labels.json"
+    calls_path = tmp_path / "calls.jsonl"
+    state_path.write_text(
+        json.dumps({"title": title, "labels": sorted(attached)}), encoding="utf-8"
+    )
+    bin_path = tmp_path / "bin"
+    bin_path.mkdir()
+    gh_path = bin_path / "gh"
+    gh_path.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+state_path = Path(os.environ["FAKE_GH_STATE"])
+calls_path = Path(os.environ["FAKE_GH_CALLS"])
+state = json.loads(state_path.read_text(encoding="utf-8"))
+args = sys.argv[1:]
+if args[:3] == ["api", "--method", "GET"]:
+    endpoint = args[-1]
+    if "/pulls/" in endpoint:
+        print(json.dumps({"title": state["title"]}))
+    elif "/issues/" in endpoint:
+        print(json.dumps([[{"name": label} for label in state["labels"]]]))
+    else:
+        raise SystemExit(f"Unexpected API endpoint: {endpoint}")
+elif args[:2] == ["pr", "edit"]:
+    if "--add-label" in args:
+        flag = "--add-label"
+        state["labels"].append(args[args.index(flag) + 1])
+    elif "--remove-label" in args:
+        flag = "--remove-label"
+        state["labels"].remove(args[args.index(flag) + 1])
+    else:
+        raise SystemExit(f"Unexpected edit: {args}")
+    state["labels"].sort()
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    with calls_path.open("a", encoding="utf-8") as calls:
+        calls.write(json.dumps(args) + "\\n")
+else:
+    raise SystemExit(f"Unexpected gh invocation: {args}")
+""",
+        encoding="utf-8",
+    )
+    gh_path.chmod(0o755)
+    env = os.environ.copy()
+    env.update(
+        {
+            "FAKE_GH_CALLS": str(calls_path),
+            "FAKE_GH_STATE": str(state_path),
+            "GH_TOKEN": "fixed-test-token",
+            "PATH": f"{bin_path}{os.pathsep}{env['PATH']}",
+            "PR_NUMBER": "900",
+            "REPO": "stickerdaniel/linkedin-mcp-server",
+            "RUNNER_TEMP": str(tmp_path),
+        }
+    )
+    result = subprocess.run(
+        ["bash", "-c", _label_workflow_script()],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    calls = (
+        [
+            json.loads(line)
+            for line in calls_path.read_text(encoding="utf-8").splitlines()
+        ]
+        if calls_path.exists()
+        else []
+    )
+    return result, set(state["labels"]), calls
+
+
+def _release_category(label: str) -> str | None:
+    release = _RELEASE_CONFIG.read_text(encoding="utf-8")
+    exclude, categories = release.split("  categories:\n", maxsplit=1)
+    excluded = {
+        line.removeprefix("      - ")
+        for line in exclude.splitlines()
+        if line.startswith("      - ")
+    }
+    if label in excluded:
+        return None
+
+    current_title: str | None = None
+    for line in categories.splitlines():
+        if line.startswith("    - title: "):
+            current_title = json.loads(line.removeprefix("    - title: "))
+        elif line.startswith("        - ") and current_title is not None:
+            category_label = line.removeprefix("        - ").strip('"')
+            if category_label in {label, "*"}:
+                return current_title
+    return None
+
+
 @pytest.mark.parametrize(
     "title",
     [
@@ -418,17 +541,65 @@ def test_pr_title_workflow_documents_sha_like_branch_recovery() -> None:
     workflow = _CHECK_WORKFLOW.read_text(encoding="utf-8")
 
     assert "suppresses pull_request_target for SHA-like source branch names" in workflow
-    assert "Rename the source branch" in workflow
+    assert "Renaming a head branch closes its pull request" in workflow
+    assert "Open a replacement pull" in workflow
+    assert "request from a non-SHA-like source branch" in workflow
+    assert "resume this required check" not in workflow
+    assert "Rename the source branch" not in workflow
 
 
 def test_label_workflow_matches_breaking_marker_without_normalizing() -> None:
     workflow = _LABEL_WORKFLOW.read_text(encoding="utf-8")
 
-    assert '[[ "$PR_TITLE" =~ ^([a-z]+)(\\([^()]+\\))?!?:\\ [^[:space:]] ]]' in workflow
+    assert (
+        '[[ "$PR_TITLE" =~ ^([a-z]+)(\\([^()]+\\))?(!)?:\\ [^[:space:]] ]]' in workflow
+    )
     assert 'TYPE="${BASH_REMATCH[1]}"' in workflow
+    assert 'BREAKING="${BASH_REMATCH[3]-}"' in workflow
+    assert 'if [ "$BREAKING" = "!" ]; then' in workflow
+    assert 'LABEL="breaking-change"' in workflow
     assert 'TYPE="${TYPE// /}"' not in workflow
     assert "|build|" not in workflow
     assert 'test|perf) LABEL="chore"' in workflow
+
+
+@pytest.mark.parametrize(
+    ("title", "expected_label", "expected_category"),
+    [
+        ("refactor: Keep internals tidy", "refactoring", None),
+        (
+            "refactor(config)!: Change configuration",
+            "breaking-change",
+            "⚠️ Breaking Changes",
+        ),
+        ("feat!: Replace the public contract", "breaking-change", "⚠️ Breaking Changes"),
+    ],
+)
+def test_pr_title_label_release_lifecycle(
+    tmp_path: Path,
+    title: str,
+    expected_label: str,
+    expected_category: str | None,
+) -> None:
+    assert validate_title(title) is None
+    attached = (_DERIVED_LABELS - {expected_label}) | {"triage"}
+
+    result, final_labels, calls = _run_label_workflow(tmp_path, title, attached)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert final_labels == {expected_label, "triage"}
+    assert _release_category(expected_label) == expected_category
+    edited_labels = {call[-1] for call in calls}
+    assert edited_labels == _DERIVED_LABELS
+
+    idempotent_path = tmp_path / "idempotent"
+    idempotent_path.mkdir()
+    rerun, rerun_labels, rerun_calls = _run_label_workflow(
+        idempotent_path, title, final_labels
+    )
+    assert rerun.returncode == 0, rerun.stdout + rerun.stderr
+    assert rerun_labels == final_labels
+    assert rerun_calls == []
 
 
 def test_label_workflow_uses_current_title_and_per_pr_concurrency() -> None:
@@ -451,6 +622,11 @@ def test_label_workflow_uses_current_title_and_per_pr_concurrency() -> None:
 def test_label_workflow_removes_only_attached_stale_labels() -> None:
     workflow = _LABEL_WORKFLOW.read_text(encoding="utf-8")
 
+    assert '"breaking-change",' in workflow
+    assert (
+        "for stale in breaking-change enhancement bug documentation refactoring chore;"
+        in workflow
+    )
     assert "ATTACHED_DERIVED=" in workflow
     assert 'if is_attached "$stale"; then' in workflow
     assert '[ -n "$LABEL" ] && ! is_attached "$LABEL"' in workflow
@@ -458,6 +634,18 @@ def test_label_workflow_removes_only_attached_stale_labels() -> None:
     assert "|| true" not in workflow
     assert "2>/dev/null" not in workflow
     assert "Labels outside this fixed derived set are untouched." in workflow
+
+
+def test_release_notes_put_breaking_changes_first() -> None:
+    release = _RELEASE_CONFIG.read_text(encoding="utf-8")
+    exclude, categories = release.split("  categories:\n", maxsplit=1)
+
+    assert "breaking-change" not in exclude
+    assert categories.startswith(
+        '    - title: "⚠️ Breaking Changes"\n      labels:\n        - breaking-change\n'
+    )
+    assert _release_category("breaking-change") == "⚠️ Breaking Changes"
+    assert _release_category("refactoring") is None
 
 
 def test_release_restores_pr_title_required_check() -> None:


### PR DESCRIPTION
Closes #899.

Pull request titles become squash-merge subjects, but malformed titles were only caught during review. This could leave inconsistent history or require late manual correction.

Validate the documented Conventional Commit shapes from the trusted workflow revision on every title-changing PR event. The check returns fixed diagnostics without reproducing untrusted input. The label workflow now understands breaking markers, and release protection restoration preserves the new context. Imperative mood, capitalization, and length remain review guidance.

The validator suite, Ruff, ty, YAML checks, and all pre-commit hooks pass. An unrelated daemon FIFO timing test failed in the combined run and passed immediately in isolation.

## Synthetic prompt

> Add a fork-safe Conventional Commit PR-title check with precise diagnostics and regression tests. Align PR labeling and release branch-protection restoration, without enforcing judgement-based title rules.

Generated with GPT-6 Astra + GPT-5.6 Sol
