### PR TITLE
chore(release): Bump version to 4.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-linkedin"
-version = "4.23.3"
+version = "4.24.0"
 description = "MCP server that gives AI assistants like Claude access to LinkedIn profiles, companies, and job postings through the user's own browser session."
 readme = "README.md"
 requires-python = ">=3.12.4,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-linkedin"
-version = "4.23.3"
+version = "4.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Advance the package from 4.23.3 to 4.24.0 so the accumulated features and fixes can be published through the existing release workflow. The workflow will synchronize the registry manifests, publish PyPI and container artifacts, and create the release tag after merge.

`uv lock --locked`, the full test suite, all pre-commit hooks, Ruff, and ty pass.

## Synthetic prompt

> Prepare the next minor release by bumping the project and lockfile version from 4.23.3 to 4.24.0 with the repository release tooling.

Generated with GPT-5.6 Sol
