### PR TITLE
ci: Add pull request title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,24 @@
+name: PR title
+
+on:
+  pull_request:
+    # `edited` is what makes a retitle re-run the check. Without it a fixed
+    # title stays red until the next push.
+    types: [opened, edited, reopened, synchronize]
+
+# Read-only status check. No pull_request_target and no write token: the title
+# comes from the event payload, and the only code executed is from the PR
+# checkout under the default fork-safe permissions.
+permissions:
+  contents: read
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Validate pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 scripts/validate_pr_title.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,7 +244,8 @@ for that.
 ## Commit Messages
 
 - Follow conventional commits: `type(scope): subject`
-- Types: feat, fix, docs, style, refactor, test, chore, perf, ci
+- Types: feat, fix, docs, style, refactor, test, chore, perf, ci, build
+  (`build` is for Renovate titles and matches `label-pr.yml`)
 - Keep subject <50 chars, imperative mood
 
 ## Development Workflow

--- a/scripts/validate_pr_title.py
+++ b/scripts/validate_pr_title.py
@@ -2,8 +2,9 @@
 """Validate a GitHub pull request title as a Conventional Commit subject.
 
 PRs in this repository are squash-merged, so the title becomes the permanent
-commit subject on ``main``. Types match ``AGENTS.md`` / ``CLAUDE.md``, plus
-``build`` so Renovate and the label workflow stay aligned.
+commit subject on ``main``. Allowed types match ``AGENTS.md`` / ``CLAUDE.md``
+and ``label-pr.yml`` (including ``build`` for Renovate). Subject length is
+capped under 50 characters; imperative mood remains human guidance.
 """
 
 from __future__ import annotations
@@ -13,7 +14,7 @@ import os
 import re
 import sys
 
-# Keep in sync with label-pr.yml's case list and AGENTS.md commit types.
+# Keep in sync with label-pr.yml's case list and AGENTS.md / CLAUDE.md.
 CONVENTIONAL_TYPES = frozenset(
     {
         "feat",
@@ -28,6 +29,9 @@ CONVENTIONAL_TYPES = frozenset(
         "build",
     }
 )
+
+# AGENTS.md / CLAUDE.md: keep subject <50 chars (the text after ": ").
+_MAX_SUBJECT_LEN = 49
 
 _TITLE_RE = re.compile(
     r"^(?P<type>[a-z]+)"
@@ -94,6 +98,13 @@ def validate_pr_title(title: str) -> str | None:
         return (
             "PR title subject is empty after ': '. "
             f"Add an imperative summary, e.g. {_EXAMPLE!r}."
+        )
+    # Imperative mood is documented guidance, not enforced here: a reliable
+    # check needs NLP and would reject valid titles. Length is mechanical.
+    if len(subject) > _MAX_SUBJECT_LEN:
+        return (
+            f"PR title subject is {len(subject)} characters; keep it under 50 "
+            f"(got {subject!r}). Shorten it, e.g. {_EXAMPLE!r}."
         )
     return None
 

--- a/scripts/validate_pr_title.py
+++ b/scripts/validate_pr_title.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Validate a GitHub pull request title as a Conventional Commit subject.
+
+PRs in this repository are squash-merged, so the title becomes the permanent
+commit subject on ``main``. Types match ``AGENTS.md`` / ``CLAUDE.md``, plus
+``build`` so Renovate and the label workflow stay aligned.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+# Keep in sync with label-pr.yml's case list and AGENTS.md commit types.
+CONVENTIONAL_TYPES = frozenset(
+    {
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "test",
+        "chore",
+        "perf",
+        "ci",
+        "build",
+    }
+)
+
+_TITLE_RE = re.compile(
+    r"^(?P<type>[a-z]+)"
+    r"(?:\((?P<scope>[a-z0-9][a-z0-9._/-]*)\))?"
+    r"(?P<breaking>!)?"
+    r": "
+    r"(?P<subject>.+)$"
+)
+
+_EXAMPLE = "feat(server): Add optional minimum tool interval"
+
+
+def validate_pr_title(title: str) -> str | None:
+    """Return ``None`` when *title* is valid, else a precise correction message."""
+    cleaned = title.strip()
+    if not cleaned:
+        return (
+            f"PR title is empty. Use a Conventional Commit subject, e.g. {_EXAMPLE!r}."
+        )
+    if "\n" in cleaned or "\r" in cleaned:
+        return (
+            "PR title must be a single line. "
+            f"Use a Conventional Commit subject, e.g. {_EXAMPLE!r}."
+        )
+
+    match = _TITLE_RE.match(cleaned)
+    if match is None:
+        bare = re.fullmatch(
+            r"(?P<type>[a-z]+)"
+            r"(?:\((?P<scope>[a-z0-9][a-z0-9._/-]*)\))?"
+            r"(?P<breaking>!)?"
+            r":?",
+            cleaned,
+        )
+        if bare is not None and bare.group("type") in CONVENTIONAL_TYPES:
+            return (
+                "PR title subject is empty after the type. "
+                f"Add an imperative summary, e.g. {_EXAMPLE!r}."
+            )
+        if ": " not in cleaned:
+            return (
+                "PR title is missing the ': ' separator after the type. "
+                f"Expected type(optional-scope): subject, e.g. {_EXAMPLE!r}."
+            )
+        type_part = cleaned.split(": ", 1)[0]
+        if "(" in type_part and not re.search(r"\([a-z0-9][a-z0-9._/-]*\)", type_part):
+            return (
+                "PR title has an invalid scope. Use lowercase letters, digits, "
+                f". _ / - inside parentheses, e.g. {_EXAMPLE!r}."
+            )
+        return (
+            "PR title is not a Conventional Commit subject. "
+            f"Expected type(optional-scope): subject, e.g. {_EXAMPLE!r}."
+        )
+    commit_type = match.group("type")
+    subject = match.group("subject")
+    if commit_type not in CONVENTIONAL_TYPES:
+        allowed = ", ".join(sorted(CONVENTIONAL_TYPES))
+        return (
+            f"Unknown type {commit_type!r}. Allowed types: {allowed}. "
+            f"Example: {_EXAMPLE!r}."
+        )
+    if not subject.strip():
+        return (
+            "PR title subject is empty after ': '. "
+            f"Add an imperative summary, e.g. {_EXAMPLE!r}."
+        )
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a pull request title as a Conventional Commit subject."
+    )
+    parser.add_argument(
+        "title",
+        nargs="?",
+        default=None,
+        help="Title to validate (default: $PR_TITLE)",
+    )
+    args = parser.parse_args(argv)
+    title = args.title if args.title is not None else os.environ.get("PR_TITLE", "")
+    error = validate_pr_title(title)
+    if error is None:
+        print(f"PR title ok: {title.strip()}")
+        return 0
+    print(f"::error::{error}")
+    print(error, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pr_title.py
+++ b/tests/test_pr_title.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 
 import pytest
 
-_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "validate_pr_title.py"
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _ROOT / "scripts" / "validate_pr_title.py"
+_LABEL_PR = _ROOT / ".github" / "workflows" / "label-pr.yml"
 
 
 def _load():
@@ -83,21 +86,38 @@ class TestValidatePrTitle:
         assert error is not None
         assert "scope" in error.lower() or "Conventional Commit" in error
 
-    def test_label_workflow_types_are_covered(self):
-        """label-pr.yml maps these types; the validator must accept them all."""
-        for commit_type in (
-            "feat",
-            "fix",
-            "docs",
-            "refactor",
-            "chore",
-            "ci",
-            "style",
-            "test",
-            "build",
-            "perf",
+    def test_rejects_long_subject(self):
+        subject = "A" * 50
+        error = validate_pr_title(f"feat: {subject}")
+        assert error is not None
+        assert "under 50" in error
+        assert validate_pr_title(f"feat: {'A' * 49}") is None
+
+    def test_label_workflow_types_match_validator(self):
+        """Fail if CONVENTIONAL_TYPES drifts from label-pr.yml's case list."""
+        text = _LABEL_PR.read_text(encoding="utf-8")
+        case_block = re.search(
+            r'case "\$TYPE" in\n(?P<body>.*?)\n\s*esac',
+            text,
+            flags=re.DOTALL,
+        )
+        assert case_block is not None, "label-pr.yml TYPE case block not found"
+        label_types: set[str] = set()
+        for arm in re.finditer(
+            r"^\s*(?P<names>[a-z|]+)\)",
+            case_block.group("body"),
+            flags=re.MULTILINE,
         ):
-            assert commit_type in CONVENTIONAL_TYPES
+            names = arm.group("names")
+            if names == "*":
+                continue
+            label_types.update(names.split("|"))
+        assert label_types, "no conventional types parsed from label-pr.yml"
+        assert CONVENTIONAL_TYPES == frozenset(label_types), (
+            f"validator types {sorted(CONVENTIONAL_TYPES)} != "
+            f"label-pr.yml types {sorted(label_types)}"
+        )
+        for commit_type in sorted(label_types):
             assert validate_pr_title(f"{commit_type}: Subject") is None
 
 

--- a/tests/test_pr_title.py
+++ b/tests/test_pr_title.py
@@ -1,0 +1,114 @@
+"""Regression tests for the Conventional Commit PR-title validator."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "validate_pr_title.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("validate_pr_title", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load()
+validate_pr_title = _mod.validate_pr_title
+CONVENTIONAL_TYPES = _mod.CONVENTIONAL_TYPES
+main = _mod.main
+
+
+class TestValidatePrTitle:
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "feat(server): Add optional minimum tool interval",
+            "fix: Cap search pages by remaining budget",
+            "docs(messaging): Clarify send_message is compose-oriented",
+            "test(daemon): Harden Windows election timing flakes",
+            "chore(deps): update dependency patchright to v1.2.3",
+            "ci: Add pull request title check",
+            "build(deps): bump actions/checkout",
+            "feat(api)!: Rename the public tool surface",
+            "fix!: Refuse a browser older than the profile",
+            "refactor(scraping): Extract search URL grammar",
+            "perf(daemon): Reduce election stampede retries",
+            "style: Apply ruff-format to interval clamp",
+        ],
+    )
+    def test_accepts_valid_titles(self, title: str):
+        assert validate_pr_title(title) is None
+
+    def test_accepts_surrounding_whitespace(self):
+        assert validate_pr_title("  feat: Add foo  ") is None
+
+    def test_rejects_empty(self):
+        error = validate_pr_title("")
+        assert error is not None
+        assert "empty" in error.lower()
+
+    def test_rejects_multiline(self):
+        error = validate_pr_title("feat: Add foo\nmore")
+        assert error is not None
+        assert "single line" in error.lower()
+
+    def test_rejects_missing_separator(self):
+        error = validate_pr_title("feat Add foo")
+        assert error is not None
+        assert "': '" in error
+
+    def test_rejects_unknown_type(self):
+        error = validate_pr_title("wip: temporary")
+        assert error is not None
+        assert "Unknown type 'wip'" in error
+        for allowed in CONVENTIONAL_TYPES:
+            assert allowed in error
+
+    def test_rejects_empty_subject(self):
+        error = validate_pr_title("feat:   ")
+        assert error is not None
+        assert "subject is empty" in error.lower()
+        error = validate_pr_title("fix(jobs):")
+        assert error is not None
+        assert "subject is empty" in error.lower()
+
+    def test_rejects_empty_scope_parens(self):
+        error = validate_pr_title("feat(): Add foo")
+        assert error is not None
+        assert "scope" in error.lower() or "Conventional Commit" in error
+
+    def test_label_workflow_types_are_covered(self):
+        """label-pr.yml maps these types; the validator must accept them all."""
+        for commit_type in (
+            "feat",
+            "fix",
+            "docs",
+            "refactor",
+            "chore",
+            "ci",
+            "style",
+            "test",
+            "build",
+            "perf",
+        ):
+            assert commit_type in CONVENTIONAL_TYPES
+            assert validate_pr_title(f"{commit_type}: Subject") is None
+
+
+class TestMain:
+    def test_main_reads_env(self, monkeypatch, capsys):
+        monkeypatch.setenv("PR_TITLE", "feat: Add foo")
+        assert main([]) == 0
+        assert "PR title ok" in capsys.readouterr().out
+
+    def test_main_fails_on_invalid(self, monkeypatch, capsys):
+        monkeypatch.setenv("PR_TITLE", "not a title")
+        assert main([]) == 1
+        err = capsys.readouterr().err
+        assert err


### PR DESCRIPTION
## Summary
- Add `scripts/validate_pr_title.py` that accepts Conventional Commit types (aligned with `AGENTS.md` and `label-pr.yml`, including `build` for Renovate), optional scopes, and `!` breaking markers, with precise correction messages on failure.
- Enforce subject length under 50 characters (imperative mood stays documented guidance).
- Add focused regression tests in `tests/test_pr_title.py`, including a sync check against `label-pr.yml`.
- Add a read-only `pull_request` workflow (including `edited`) that validates the event title without `pull_request_target` or write permissions.

Closes #899

## Notes for maintainers
After a live valid/invalid title event on this check, add **PR title / pr-title** to branch protection on `main` (the issue called this out; workflows cannot edit that setting).

## Test plan
- [x] `uv run pytest tests/test_pr_title.py`
- [x] `python3 scripts/validate_pr_title.py "ci: Add pull request title check"`
- [x] Mutation: dropping `build` from `CONVENTIONAL_TYPES` fails the label-pr sync test
- [x] CI `PR title` check green on this PR
- [ ] Optional: retitle temporarily to something invalid and confirm the check fails, then restore

## Synthetic prompt

> Add a repository-owned Conventional Commit PR-title validator with regression tests and a fork-safe GitHub Actions workflow that re-runs when the title is edited. Do not use third-party title actions or pull_request_target. Align allowed types with AGENTS.md and label-pr.yml (including build). Report precise corrections on invalid titles. Keep Renovate-style chore(deps) titles valid. Enforce subject length under 50; leave imperative mood as human guidance. Sync the type set against label-pr.yml in tests.

Generated with Composer