### PR TITLE
docs(readme): Reorder installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 
 [![uvx](https://img.shields.io/badge/uvx-Quick_Install-de5fe9?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDEiIGhlaWdodD0iNDEiIHZpZXdCb3g9IjAgMCA0MSA0MSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTS01LjI4NjE5ZS0wNiAwLjE2ODYyOUwwLjA4NDMwOTggMjAuMTY4NUwwLjE1MTc2MiAzNi4xNjgzQzAuMTYxMDc1IDM4LjM3NzQgMS45NTk0NyA0MC4xNjA3IDQuMTY4NTkgNDAuMTUxNEwyMC4xNjg0IDQwLjA4NEwzMC4xNjg0IDQwLjA0MThMMzEuMTg1MiA0MC4wMzc1QzMzLjM4NzcgNDAuMDI4MiAzNS4xNjgzIDM4LjIwMjYgMzUuMTY4MyAzNlYzNkwzNy4wMDAzIDM2TDM3LjAwMDMgMzkuOTk5Mkw0MC4xNjgzIDM5Ljk5OTZMMzkuOTk5NiAtOS45NDY1M2UtMDdMMjEuNTk5OCAwLjA3NzU2ODlMMjEuNjc3NCAxNi4wMTg1TDIxLjY3NzQgMjUuOTk5OEwyMC4wNzc0IDI1Ljk5OThMMTguMzk5OCAyNS45OTk4TDE4LjQ3NzQgMTYuMDMyTDE4LjM5OTggMC4wOTEwNTkzTC01LjI4NjE5ZS0wNiAwLjE2ODYyOVoiIGZpbGw9IiNERTVGRTkiLz4KPC9zdmc+Cg==)](#-uvx-setup-recommended---universal)
 [![Install MCP Bundle](https://img.shields.io/badge/Claude_Desktop_MCPB-d97757?style=for-the-badge&logo=anthropic)](#-claude-desktop-mcp-bundle-formerly-dxt)
+[![Codex Plugin](https://img.shields.io/badge/Codex-Plugin-24292f?style=for-the-badge&logo=openai&logoColor=white)](#codex-plugin)
 [![Docker](https://img.shields.io/badge/Docker-Universal_MCP-008fe2?style=for-the-badge&logo=docker&logoColor=008fe2)](#-docker-setup)
 [![Development](https://img.shields.io/badge/Development-Local-ffdc53?style=for-the-badge&logo=python&logoColor=ffdc53)](#-local-setup-develop--contribute)
 
@@ -61,31 +62,6 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 
 <br/>
 <br/>
-
-## Codex plugin
-
-This repository includes an opt-in Codex plugin that bundles the MCP server and
-its LinkedIn workflow guidance. Add the repository marketplace, then install the
-plugin:
-
-```bash
-codex plugin marketplace add stickerdaniel/linkedin-mcp-server
-codex plugin add linkedin-mcp-server@linkedin-mcp-server
-```
-
-The plugin pins the MCP package to the same version as the plugin release. It
-does not install by default or override the user's enabled state. The plugin can
-be disabled in Codex settings, and its bundled MCP server can be disabled
-independently in `~/.codex/config.toml`:
-
-```toml
-[plugins."linkedin-mcp-server".mcp_servers.linkedin]
-enabled = false
-```
-
-Installing or enabling the plugin does not open a browser or sign in. A
-LinkedIn data request may start the managed browser, import an existing local
-session, or require a visible login window.
 
 ## 🚀 uvx Setup (Recommended - Universal)
 
@@ -319,6 +295,31 @@ On startup, the MCP Bundle starts preparing the shared Patchright Chromium brows
 
 <br/>
 <br/>
+
+## Codex plugin
+
+This repository includes an opt-in Codex plugin that bundles the MCP server and
+its LinkedIn workflow guidance. Add the repository marketplace, then install the
+plugin:
+
+```bash
+codex plugin marketplace add stickerdaniel/linkedin-mcp-server
+codex plugin add linkedin-mcp-server@linkedin-mcp-server
+```
+
+The plugin pins the MCP package to the same version as the plugin release. It
+does not install by default or override the user's enabled state. The plugin can
+be disabled in Codex settings, and its bundled MCP server can be disabled
+independently in `~/.codex/config.toml`:
+
+```toml
+[plugins."linkedin-mcp-server".mcp_servers.linkedin]
+enabled = false
+```
+
+Installing or enabling the plugin does not open a browser or sign in. A
+LinkedIn data request may start the managed browser, import an existing local
+session, or require a visible login window.
 
 ## 🐳 Docker Setup
 


### PR DESCRIPTION
The detailed installation guide opened with the new Codex plugin even though the badges and repository usage point users to `uvx` and Claude Desktop first. That made the universal setup harder to find.

Order the full sections to match the installation paths users are most likely to need: `uvx`, Claude Desktop MCPB, Codex, Docker, then local development. Add the missing Codex badge in the same position. The existing instructions and caveats are unchanged.

README checks, documentation contracts, pre-commit hooks, and local anchor verification pass.

## Synthetic prompt

> Move the Codex plugin instructions below Claude Desktop so the README leads with uvx, then MCPB, then Codex. Add a matching Codex badge and preserve the existing setup text.

Generated with GPT-5.6 Sol
