### PR TITLE
docs(readme): Align installation headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ On startup, the MCP Bundle starts preparing the shared Patchright Chromium brows
 <br/>
 <br/>
 
-## Codex plugin
+## 🧩 Codex plugin
 
 This repository includes an opt-in Codex plugin that bundles the MCP server and
 its LinkedIn workflow guidance. Add the repository marketplace, then install the
@@ -320,6 +320,9 @@ enabled = false
 Installing or enabling the plugin does not open a browser or sign in. A
 LinkedIn data request may start the managed browser, import an existing local
 session, or require a visible login window.
+
+<br/>
+<br/>
 
 ## 🐳 Docker Setup
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This MCP server is **free** and **open source**, supported by [**Unipile**](http
 
 [![uvx](https://img.shields.io/badge/uvx-Quick_Install-de5fe9?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDEiIGhlaWdodD0iNDEiIHZpZXdCb3g9IjAgMCA0MSA0MSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTS01LjI4NjE5ZS0wNiAwLjE2ODYyOUwwLjA4NDMwOTggMjAuMTY4NUwwLjE1MTc2MiAzNi4xNjgzQzAuMTYxMDc1IDM4LjM3NzQgMS45NTk0NyA0MC4xNjA3IDQuMTY4NTkgNDAuMTUxNEwyMC4xNjg0IDQwLjA4NEwzMC4xNjg0IDQwLjA0MThMMzEuMTg1MiA0MC4wMzc1QzMzLjM4NzcgNDAuMDI4MiAzNS4xNjgzIDM4LjIwMjYgMzUuMTY4MyAzNlYzNkwzNy4wMDAzIDM2TDM3LjAwMDMgMzkuOTk5Mkw0MC4xNjgzIDM5Ljk5OTZMMzkuOTk5NiAtOS45NDY1M2UtMDdMMjEuNTk5OCAwLjA3NzU2ODlMMjEuNjc3NCAxNi4wMTg1TDIxLjY3NzQgMjUuOTk5OEwyMC4wNzc0IDI1Ljk5OThMMTguMzk5OCAyNS45OTk4TDE4LjQ3NzQgMTYuMDMyTDE4LjM5OTggMC4wOTEwNTkzTC01LjI4NjE5ZS0wNiAwLjE2ODYyOVoiIGZpbGw9IiNERTVGRTkiLz4KPC9zdmc+Cg==)](#-uvx-setup-recommended---universal)
 [![Install MCP Bundle](https://img.shields.io/badge/Claude_Desktop_MCPB-d97757?style=for-the-badge&logo=anthropic)](#-claude-desktop-mcp-bundle-formerly-dxt)
-[![Codex Plugin](https://img.shields.io/badge/Codex-Plugin-24292f?style=for-the-badge&logo=openai&logoColor=white)](#codex-plugin)
+[![Codex Plugin](https://img.shields.io/badge/Codex-Plugin-24292f?style=for-the-badge&logo=openai&logoColor=white)](#-codex-plugin)
 [![Docker](https://img.shields.io/badge/Docker-Universal_MCP-008fe2?style=for-the-badge&logo=docker&logoColor=008fe2)](#-docker-setup)
 [![Development](https://img.shields.io/badge/Development-Local-ffdc53?style=for-the-badge&logo=python&logoColor=ffdc53)](#-local-setup-develop--contribute)
 


### PR DESCRIPTION
Closes #906

The Codex plugin heading lacked the icon used by the surrounding installation sections, and Docker Setup started immediately after the Codex text. This made the rendered README look uneven.

The Codex heading now uses the puzzle-piece icon to represent a plugin, and Docker Setup has the same section spacing as the other installation methods.

Verified with the README consumer tests and pre-commit checks.

## Synthetic prompt

> Add a fitting icon to the Codex plugin heading and match the surrounding installation-section spacing before Docker Setup without changing the existing instructions.

Generated with GPT-5.6 Sol high
