### PR TITLE
fix(scraping): Fail closed on unseen patch shapes

### DIFF
--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -751,6 +751,36 @@ def _setattr_arguments(node: ast.Call) -> tuple[ast.expr | None, ast.expr | None
 _MONKEYPATCH_NAMES = frozenset({"monkeypatch", "MonkeyPatch"})
 
 
+_MonkeyPatchState = tuple[set[str], set[str]]
+
+
+@dataclass(slots=True)
+class _FlowResult:
+    normal: list[_MonkeyPatchState] = field(default_factory=list)
+    breaks: list[_MonkeyPatchState] = field(default_factory=list)
+    continues: list[_MonkeyPatchState] = field(default_factory=list)
+    returns: list[_MonkeyPatchState] = field(default_factory=list)
+    exceptional: list[_MonkeyPatchState] = field(default_factory=list)
+
+    def extend(self, other: _FlowResult) -> None:
+        self.normal.extend(other.normal)
+        self.breaks.extend(other.breaks)
+        self.continues.extend(other.continues)
+        self.returns.extend(other.returns)
+        self.exceptional.extend(other.exceptional)
+
+
+@dataclass(slots=True)
+class _ClosureCell:
+    aliases: set[str]
+
+
+@dataclass(slots=True)
+class _DeferredFunction:
+    node: ast.FunctionDef | ast.AsyncFunctionDef
+    cell: _ClosureCell
+
+
 def _mentions_monkeypatch(expression: ast.expr) -> bool:
     return any(
         (isinstance(item, ast.Name) and item.id in _MONKEYPATCH_NAMES)
@@ -776,7 +806,9 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         self.aliases = {"monkeypatch"}
         self.closure_aliases = set(self.aliases)
         self.scope_kinds = ["module"]
-        self.loop_break_states: list[list[tuple[set[str], set[str]]]] = []
+        self.cells = [_ClosureCell(set(self.closure_aliases))]
+        self.deferred: list[_DeferredFunction] = []
+        self.deferred_ids: set[int] = set()
 
     @staticmethod
     def _key(expression: ast.expr) -> str:
@@ -833,40 +865,67 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
             set().union(*(state[1] for state in states)),
         )
 
-    def _visit_suite(
-        self, statements: list[ast.stmt]
-    ) -> list[tuple[set[str], set[str]]]:
-        states = [self._state()]
+    def _visit_suite(self, statements: list[ast.stmt]) -> _FlowResult:
+        result = _FlowResult()
+        active = True
         for statement in statements:
-            self.visit(statement)
-            states.append(self._state())
-        return states
+            if not active:
+                break
+            prefix = self._state()
+            flowed = self.visit(statement)
+            result.exceptional.append(prefix)
+            if not isinstance(flowed, _FlowResult):
+                continue
+            result.breaks.extend(flowed.breaks)
+            result.continues.extend(flowed.continues)
+            result.returns.extend(flowed.returns)
+            result.exceptional.extend(flowed.exceptional)
+            if flowed.normal:
+                self._restore(self._merge(flowed.normal))
+            else:
+                active = False
+        if active:
+            result.normal.append(self._state())
+        return result
 
     def _visit_branches(
         self,
-        initial: tuple[set[str], set[str]],
+        initial: _MonkeyPatchState,
         suites: list[list[ast.stmt]],
         *,
         include_initial: bool = False,
-    ) -> None:
-        states = [initial] if include_initial else []
+    ) -> _FlowResult:
+        result = _FlowResult(normal=[initial] if include_initial else [])
         for suite in suites:
             self._restore(initial)
-            self._visit_suite(suite)
-            states.append(self._state())
-        self._restore(self._merge(states))
+            result.extend(self._visit_suite(suite))
+        if result.normal:
+            self._restore(self._merge(result.normal))
+        return result
 
-    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+    def _visit_function_expressions(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
         for decorator in node.decorator_list:
             self.visit(decorator)
-        for default in [*node.args.defaults, *node.args.kw_defaults]:
-            if default is not None:
-                self.visit(default)
+        for expression in _signature_expressions(node.args):
+            self.visit(expression)
+        if node.returns is not None:
+            self.visit(node.returns)
 
+    def _defer_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._visit_function_expressions(node)
+        if id(node) not in self.deferred_ids:
+            self.deferred_ids.add(id(node))
+            self.deferred.append(_DeferredFunction(node, self.cells[-1]))
+        self._unbind({node.name})
+
+    def _evaluate_function(self, item: _DeferredFunction) -> None:
+        node = item.node
         collector = _scope_collector(self.path, node.body)
         parameters = _argument_names(node.args)
         local_bindings = collector.bindings - collector.globals - collector.nonlocals
-        inherited = self.closure_aliases - local_bindings - parameters
+        inherited = item.cell.aliases - local_bindings - parameters
         for argument in [
             *node.args.posonlyargs,
             *node.args.args,
@@ -880,21 +939,42 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
             ):
                 inherited.add(argument.arg)
 
-        previous = (self.aliases, self.closure_aliases)
-        self.aliases = inherited
+        previous = self._state()
+        self.aliases = set(inherited)
         self.closure_aliases = set(inherited)
+        cell = _ClosureCell(set(inherited))
+        self.cells.append(cell)
         self.scope_kinds.append("function")
-        for statement in node.body:
-            self.visit(statement)
+        flow = self._visit_suite(node.body)
+        endings = [*flow.normal, *flow.breaks, *flow.continues, *flow.returns]
+        if endings:
+            cell.aliases = set(self._merge(endings)[1])
         self.scope_kinds.pop()
-        self.aliases, self.closure_aliases = previous
-        self._unbind({node.name})
+        self.cells.pop()
+        self._restore(previous)
+        self._drain_deferred(cell)
+
+    def _drain_deferred(self, cell: _ClosureCell) -> None:
+        while True:
+            pending = [item for item in self.deferred if item.cell is cell]
+            if not pending:
+                return
+            self.deferred = [item for item in self.deferred if item.cell is not cell]
+            for item in pending:
+                self._evaluate_function(item)
+
+    def visit_Module(self, node: ast.Module) -> Any:
+        flow = self._visit_suite(node.body)
+        endings = list(flow.normal)
+        if endings:
+            self.cells[-1].aliases = set(self._merge(endings)[1])
+        self._drain_deferred(self.cells[-1])
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> Any:
-        self._visit_function(node)
+        self._defer_function(node)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
-        self._visit_function(node)
+        self._defer_function(node)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> Any:
         for decorator in node.decorator_list:
@@ -904,8 +984,7 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         previous = (self.aliases, self.closure_aliases)
         self.aliases = set(self.closure_aliases)
         self.scope_kinds.append("class")
-        for statement in node.body:
-            self.visit(statement)
+        self._visit_suite(node.body)
         self.scope_kinds.pop()
         self.aliases, self.closure_aliases = previous
         self._unbind({node.name})
@@ -944,96 +1023,154 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
     def visit_If(self, node: ast.If) -> Any:
         self.visit(node.test)
         initial = self._state()
-        self._visit_branches(
+        return self._visit_branches(
             initial,
             [node.body, node.orelse],
             include_initial=not node.orelse,
         )
 
-    def _visit_try(self, node: ast.Try | ast.TryStar) -> None:
+    def _visit_try(self, node: ast.Try | ast.TryStar) -> _FlowResult:
         initial = self._state()
         self._restore(initial)
-        body_states = self._visit_suite(node.body)
-        normal = self._state()
-        self._visit_suite(node.orelse)
-        continuing = [self._state()]
-        exception_entry = self._merge(body_states)
+        body = self._visit_suite(node.body)
+        result = _FlowResult(
+            breaks=list(body.breaks),
+            continues=list(body.continues),
+            returns=list(body.returns),
+            exceptional=list(body.exceptional),
+        )
 
+        if body.normal:
+            self._restore(self._merge(body.normal))
+            result.extend(self._visit_suite(node.orelse))
+
+        handler_entry = self._merge(body.exceptional)
         for handler in node.handlers:
-            self._restore(exception_entry)
+            self._restore(handler_entry)
             if handler.type is not None:
                 self.visit(handler.type)
             if handler.name is not None:
                 self._bind(ast.Name(id=handler.name, ctx=ast.Store()), False)
-            self._visit_suite(handler.body)
-            if handler.name is not None:
-                self._unbind({handler.name})
-            continuing.append(self._state())
+            handled = self._visit_suite(handler.body)
+            for states in (
+                handled.normal,
+                handled.breaks,
+                handled.continues,
+                handled.returns,
+                handled.exceptional,
+            ):
+                for index, state in enumerate(states):
+                    self._restore(state)
+                    if handler.name is not None:
+                        self._unbind({handler.name})
+                    states[index] = self._state()
+            result.extend(handled)
 
-        merged = self._merge(continuing)
         if not node.finalbody:
-            self._restore(merged)
-            return
+            if result.normal:
+                self._restore(self._merge(result.normal))
+            return result
 
-        self._restore(merged)
-        self._visit_suite(node.finalbody)
-        continuation = self._state()
-        exceptional = self._merge([exception_entry, normal])
-        self._restore(exceptional)
-        self._visit_suite(node.finalbody)
-        self._restore(continuation)
+        finished = _FlowResult()
+        for states, continuation in (
+            (result.normal, "normal"),
+            (result.breaks, "break"),
+            (result.continues, "continue"),
+            (result.returns, "return"),
+            (result.exceptional, "exceptional"),
+        ):
+            if not states:
+                continue
+            self._restore(self._merge(states))
+            final = self._visit_suite(node.finalbody)
+            finished.breaks.extend(final.breaks)
+            finished.continues.extend(final.continues)
+            finished.returns.extend(final.returns)
+            finished.exceptional.extend(final.exceptional)
+            if continuation == "normal":
+                finished.normal.extend(final.normal)
+            elif continuation == "break":
+                finished.breaks.extend(final.normal)
+            elif continuation == "continue":
+                finished.continues.extend(final.normal)
+            elif continuation == "return":
+                finished.returns.extend(final.normal)
+            else:
+                finished.exceptional.extend(final.normal)
+        if finished.normal:
+            self._restore(self._merge(finished.normal))
+        return finished
 
     def visit_Try(self, node: ast.Try) -> Any:
-        self._visit_try(node)
+        return self._visit_try(node)
 
     def visit_TryStar(self, node: ast.TryStar) -> Any:
-        self._visit_try(node)
+        return self._visit_try(node)
 
     def _visit_loop(
         self,
         node: ast.For | ast.AsyncFor | ast.While,
-        initial: tuple[set[str], set[str]],
-    ) -> None:
+        initial: _MonkeyPatchState,
+    ) -> _FlowResult:
         head = initial
-        self.loop_break_states.append([])
+        body = _FlowResult()
         while True:
             self._restore(head)
             if isinstance(node, ast.While):
                 self.visit(node.test)
-                iteration = self._state()
             else:
                 self._bind(node.target, False)
-                iteration = self._state()
-            self._visit_suite(node.body)
-            widened = self._merge([initial, iteration, self._state()])
+            body = self._visit_suite(node.body)
+            widened = self._merge([initial, *body.normal, *body.continues])
             if widened == head:
                 break
             head = widened
 
-        breaks = self.loop_break_states.pop()
         self._restore(head)
         if isinstance(node, ast.While):
             self.visit(node.test)
-        self._visit_suite(node.orelse)
-        exits = [self._state(), *breaks]
-        self._restore(self._merge(exits))
+        no_break = self._visit_suite(node.orelse)
+        normal = [*no_break.normal, *body.breaks]
+        if normal:
+            self._restore(self._merge(normal))
+        return _FlowResult(
+            normal=normal,
+            breaks=no_break.breaks,
+            continues=no_break.continues,
+            returns=[*body.returns, *no_break.returns],
+            exceptional=[*body.exceptional, *no_break.exceptional],
+        )
 
     def visit_Break(self, node: ast.Break) -> Any:
-        if self.loop_break_states:
-            self.loop_break_states[-1].append(self._state())
+        return _FlowResult(breaks=[self._state()])
 
-    def _visit_for(self, node: ast.For | ast.AsyncFor) -> None:
+    def visit_Continue(self, node: ast.Continue) -> Any:
+        return _FlowResult(continues=[self._state()])
+
+    def visit_Raise(self, node: ast.Raise) -> Any:
+        if node.exc is not None:
+            self.visit(node.exc)
+        if node.cause is not None:
+            self.visit(node.cause)
+        return _FlowResult(exceptional=[self._state()])
+
+    def visit_Return(self, node: ast.Return) -> Any:
+        if node.value is not None:
+            self.visit(node.value)
+        return _FlowResult(returns=[self._state()])
+
+    def _visit_for(self, node: ast.For | ast.AsyncFor) -> _FlowResult:
         self.visit(node.iter)
-        self._visit_loop(node, self._state())
+        return self._visit_loop(node, self._state())
 
     def visit_For(self, node: ast.For) -> Any:
-        self._visit_for(node)
+        return self._visit_for(node)
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> Any:
-        self._visit_for(node)
+        return self._visit_for(node)
 
     def visit_While(self, node: ast.While) -> Any:
-        self._visit_loop(node, self._state())
+        return self._visit_loop(node, self._state())
 
     @staticmethod
     def _match_names(pattern: ast.pattern) -> set[str]:
@@ -1063,36 +1200,36 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         self.visit(node.subject)
         initial = self._state()
         authority = self._is_authority(node.subject)
-        states: list[tuple[set[str], set[str]]] = []
+        result = _FlowResult()
         for case in node.cases:
             self._restore(initial)
             for name in self._match_names(case.pattern):
                 self._bind(ast.Name(id=name, ctx=ast.Store()), authority)
             if case.guard is not None:
                 self.visit(case.guard)
-            self._visit_suite(case.body)
-            states.append(self._state())
+            result.extend(self._visit_suite(case.body))
         if not node.cases or not self._is_catch_all(node.cases[-1]):
-            states.append(initial)
-        self._restore(self._merge(states))
+            result.normal.append(initial)
+        if result.normal:
+            self._restore(self._merge(result.normal))
+        return result
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> Any:
         self.visit(node.value)
         self._bind(node.target, self._is_authority(node.value))
 
-    def _visit_with(self, node: ast.With | ast.AsyncWith) -> None:
+    def _visit_with(self, node: ast.With | ast.AsyncWith) -> _FlowResult:
         for item in node.items:
             self.visit(item.context_expr)
             if item.optional_vars is not None:
                 self._bind(item.optional_vars, self._is_authority(item.context_expr))
-        for statement in node.body:
-            self.visit(statement)
+        return self._visit_suite(node.body)
 
     def visit_With(self, node: ast.With) -> Any:
-        self._visit_with(node)
+        return self._visit_with(node)
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> Any:
-        self._visit_with(node)
+        return self._visit_with(node)
 
     def visit_Call(self, node: ast.Call) -> Any:
         if (

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -149,34 +149,37 @@ _IMPORT_OWNERS = {
     ),
 }
 
-# `_content` and `_capture` are the facade's own wiring rather than a
-# collaborator a test could build for itself: reaching them is how a workflow
-# still living on the facade gets its capture stubbed, so the seam closes with
-# the last workflow that still asks the facade for it, not with the module that
-# owns the class and not with the facade. Measured over every reach-through in
-# the tree: all 19 `_capture` sites sit in `scrape_person` tests, which move at
-# stage 6, and the 14 `_content` sites spread over `scrape_company` (8),
-# `_extract_search_page`, `search_jobs`, `_extract_saved_jobs_page` (9) and
-# `get_inbox`, `get_conversation`, `search_conversations` (11). Pinning either
-# at the facade's own stage 14 would leave a stale reach-through unflagged for
-# the rest of the migration. `_session` and `_navigator` carry no such consumer
-# and stay pinned to their own stage.
+# Facade wiring a test reaches but never owns. These carry no consumer of their
+# own, so each one closes with the module that owns it.
 _INSTANCE_ATTRIBUTE_OWNERS = {
     "_page": ("facade.LinkedInExtractor._page", 14),
     "_session": ("session.ScrapingSession", 3),
     "_navigator": ("navigation.PageNavigator", 3),
-    "_content": ("facade.LinkedInExtractor._content", 11),
-    "_capture": ("facade.LinkedInExtractor._capture", 6),
     "_scroll_seconds": ("facade.LinkedInExtractor._scroll_seconds", 14),
 }
 
-# The collaborator behind each of those two attributes. A patch routed through
-# the attribute lands on the collaborator's own method, so the seam records the
-# collaborator as its owner while the stage stays the attribute's: what expires
-# is the reach-through, not the method.
+# `_content` and `_capture` are the facade's own wiring rather than a
+# collaborator a test could build for itself: reaching one is how a workflow
+# still living on the facade gets its reader stubbed. Each entry names the
+# collaborator the reach-through lands on and the facade binding the
+# reach-through itself consumes.
+#
+# Both the reach-through and the patch it carries expire with the workflow the
+# *call site* drives, never with a flat per-attribute maximum: the moment
+# `scrape_company` owns its own reader, a `_content` stub inside a
+# `scrape_company` test intercepts nothing, while a `get_inbox` test reaching
+# the same attribute is still live. Measured over every reach-through in the
+# tree: all 19 `_capture` sites drive `scrape_person` (6), and the 14 `_content`
+# sites split across `scrape_company` (8), `_extract_search_page` and
+# `search_jobs` (9) and `get_inbox`, `get_conversation`,
+# `search_conversations` (11). A single pin at 11 left the one stage-8 and the
+# four stage-9 reach-throughs unflagged for three and two stages; a pin at the
+# facade's own stage 14 would leave every one of them unflagged for the rest of
+# the migration. The stage therefore comes from `_callers`, exactly as a
+# boundary patch's does.
 _FACADE_COLLABORATORS = {
-    "_content": "content.PageContentReader",
-    "_capture": "capture.SectionCapture",
+    "_content": ("content.PageContentReader", "facade.LinkedInExtractor._content"),
+    "_capture": ("capture.SectionCapture", "facade.LinkedInExtractor._capture"),
 }
 
 _MODULE_ATTRIBUTE_OWNERS = {
@@ -628,6 +631,7 @@ class _ScopeFrame:
     closure_class_names: set[str]
     closure_instance_names: set[str]
     ambiguous_names: set[str] = field(default_factory=set)
+    collaborator_aliases: dict[str, str] = field(default_factory=dict)
 
 
 def _extractor_bindings(
@@ -667,6 +671,59 @@ def _extractor_bindings(
                 target.id for target in targets if isinstance(target, ast.Name)
             )
     return bindings
+
+
+def _patch_object_arguments(node: ast.Call) -> tuple[ast.expr | None, ast.expr | None]:
+    """Read ``patch.object``'s target and attribute across its call shapes.
+
+    ``mock`` accepts both by keyword, and an arity gate counting positional
+    arguments alone answers "not a patch" to the keyword form, to ``*args`` and
+    to a call missing its attribute. Returning ``None`` for either end tells the
+    caller to refuse rather than to skip.
+    """
+
+    if any(keyword.arg is None for keyword in node.keywords):
+        return (None, None)
+    keywords = {keyword.arg: keyword.value for keyword in node.keywords}
+    target = node.args[0] if node.args else keywords.get("target")
+    attribute = node.args[1] if len(node.args) > 1 else keywords.get("attribute")
+    return (target, attribute)
+
+
+def _collaborator_aliases(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    facade_names: set[str],
+) -> dict[str, str]:
+    """Map local names bound to a facade collaborator attribute.
+
+    ``cap = extractor._capture`` followed by ``patch.object(cap, ...)`` is the
+    same reach-through written over two statements, and without the alias the
+    patch lands on a bare local the reader cannot place. Collected over the
+    whole body like ``_extractor_bindings``, so a rebinding later in the
+    function is not tracked; the map is only ever consulted after every other
+    binding kind has been ruled out.
+    """
+
+    aliases: dict[str, str] = {}
+    for statement in node.body:
+        for item in (statement, *_walk_scope(statement)):
+            if not isinstance(item, (ast.Assign, ast.AnnAssign)):
+                continue
+            value = item.value
+            if not (
+                isinstance(value, ast.Attribute)
+                and isinstance(value.value, ast.Name)
+                and value.value.id in facade_names
+                and value.attr in _FACADE_COLLABORATORS
+            ):
+                continue
+            targets = item.targets if isinstance(item, ast.Assign) else [item.target]
+            aliases.update(
+                (target.id, value.attr)
+                for target in targets
+                if isinstance(target, ast.Name)
+            )
+    return aliases
 
 
 class _CalledMethodCollector(ast.NodeVisitor):
@@ -1079,7 +1136,14 @@ _COLLABORATOR_METHODS: dict[tuple[Path, str], frozenset[str]] = {}
 
 
 def collaborator_methods(owner: str, package: Path = PACKAGE) -> frozenset[str]:
-    """Read the method names of a facade collaborator named ``module.Class``."""
+    """Read the method names of a facade collaborator named ``module.Class``.
+
+    Only the class body is read, so a member reached through a base class or
+    produced by a decorator is not here and its patch is refused. That is the
+    acceptable direction: a loud refusal names the site and asks for the table
+    to be widened, while accepting an unknown name would let a patch that
+    intercepts nothing through.
+    """
 
     cached = _COLLABORATOR_METHODS.get((package, owner))
     if cached is not None:
@@ -1097,7 +1161,10 @@ def collaborator_methods(owner: str, package: Path = PACKAGE) -> frozenset[str]:
             )
             _COLLABORATOR_METHODS[package, owner] = methods
             return methods
-    raise AssertionError(f"{class_name} not found in scraping/{module}.py")
+    raise UnresolvedSeamError(
+        f"{class_name} not found in scraping/{module}.py: "
+        "rename the entry in _FACADE_COLLABORATORS"
+    )
 
 
 class Scanner(ast.NodeVisitor):
@@ -1252,6 +1319,9 @@ class Scanner(ast.NodeVisitor):
                 closure_module_names=set(module_names),
                 closure_class_names=set(class_names),
                 closure_instance_names=set(instance_names),
+                collaborator_aliases=_collaborator_aliases(
+                    node, instance_names | class_names
+                ),
             )
         )
         for statement in node.body:
@@ -1406,6 +1476,7 @@ class Scanner(ast.NodeVisitor):
             closure_class_names=set(frame.closure_class_names),
             closure_instance_names=set(frame.closure_instance_names),
             ambiguous_names=set(frame.ambiguous_names),
+            collaborator_aliases=dict(frame.collaborator_aliases),
         )
 
     def _visit_class_suite(self, statements: list[ast.stmt]) -> None:
@@ -1801,6 +1872,10 @@ class Scanner(ast.NodeVisitor):
     def _direct_facade_attribute(self, node: ast.Attribute, name: str) -> None:
         if not name.startswith("_"):
             return
+        collaborator = _FACADE_COLLABORATORS.get(name)
+        if collaborator is not None:
+            self._add_contextual("private_facade_access", node, name, collaborator[1])
+            return
         owner_stage = (
             _PRIVATE_OWNERS.get(name)
             or _WORKFLOW_OWNERS.get(name)
@@ -1869,11 +1944,85 @@ class Scanner(ast.NodeVisitor):
             and function.attr == "object"
             and isinstance(function.value, ast.Name)
             and function.value.id == "patch"
-            and len(node.args) >= 2
         ):
-            self._suppress_module_attributes(node.args[0])
-            self._patch_object(node, node.args[0], node.args[1])
+            target, attribute = _patch_object_arguments(node)
+            if target is None or attribute is None:
+                # An arity or keyword shape the reader cannot take apart hides
+                # both ends of the patch. Skipping it on a failed arity gate is
+                # indistinguishable from a patch that intercepts nothing, so
+                # the call names itself instead.
+                self._error(
+                    node, ast.unparse(node), "unresolved patch.object arguments"
+                )
+            else:
+                self._suppress_module_attributes(target)
+                self._patch_object(node, target, attribute)
+
+        if (isinstance(function, ast.Name) and function.id == "setattr") or (
+            isinstance(function, ast.Attribute) and function.attr == "setattr"
+        ):
+            self._setattr_call(node)
         self.generic_visit(node)
+
+    def _setattr_call(self, node: ast.Call) -> None:
+        """Inventory ``setattr`` and ``monkeypatch.setattr`` replacements.
+
+        The method name is matched on its own rather than against a receiver
+        named ``monkeypatch``, because the fixture is routinely bound to
+        another name and a receiver test would skip exactly the sites this
+        exists to see. Everything it resolves to is a foreign object unless the
+        target reaches the extractor, so the breadth costs nothing.
+        """
+
+        if not node.args:
+            return
+        target = node.args[0]
+        if (
+            isinstance(target, ast.Constant)
+            and isinstance(target.value, str)
+            and target.value.startswith(EXTRACTOR_MODULE + ".")
+        ):
+            self._string_patch(node, target.value)
+            return
+        if len(node.args) < 2:
+            return
+        attribute = node.args[1]
+        if not (
+            isinstance(attribute, ast.Constant) and isinstance(attribute.value, str)
+        ):
+            self._refuse_unresolved_target(node, target, "setattr")
+            return
+        self._suppress_module_attributes(target)
+        self._replacement(node, target, attribute.value, "setattr")
+
+    def visit_Assign(self, node: ast.Assign) -> Any:
+        for target in node.targets:
+            if isinstance(target, ast.Attribute):
+                self._assigned_replacement(node, target)
+        self.generic_visit(node)
+
+    def _assigned_replacement(self, node: ast.Assign, target: ast.Attribute) -> None:
+        """Inventory ``owner.name = replacement`` one level below the facade.
+
+        An attribute assigned on the facade itself is already on the record
+        through ``visit_Attribute``, which sees the replaced name directly. One
+        level deeper that attribute is the reach-through and never the replaced
+        member, so the collaborator's own name goes unchecked unless it is
+        resolved here.
+        """
+
+        owner = target.value
+        if isinstance(owner, ast.Name) and (
+            owner.id in self.frames[-1].instance_names
+            or owner.id in self.class_names
+            or owner.id in self.module_names
+        ):
+            return
+        collaborator = self._collaborator_reach(owner)
+        if collaborator is not None:
+            self._collaborator_patch(node, collaborator, target.attr)
+            return
+        self._refuse_unresolved_target(node, owner, "attribute assignment")
 
     def _string_patch(self, node: ast.Call, value: str) -> None:
         target = value.removeprefix(EXTRACTOR_MODULE + ".")
@@ -1915,7 +2064,15 @@ class Scanner(ast.NodeVisitor):
         ):
             self._error(node, ast.unparse(target), "dynamic patch.object attribute")
             return
-        name = attribute.value
+        self._replacement(node, target, attribute.value, "patch.object")
+
+    def _replacement(
+        self, node: ast.expr | ast.stmt, target: ast.expr, name: str, form: str
+    ) -> None:
+        # A walrus names the same object it evaluates to, so the binding is
+        # irrelevant to what the patch reaches.
+        while isinstance(target, ast.NamedExpr):
+            target = target.value
         if (
             isinstance(target, ast.Name)
             and target.id in self.frames[-1].ambiguous_names
@@ -2026,29 +2183,99 @@ class Scanner(ast.NodeVisitor):
             )
             return
 
+        collaborator = self._collaborator_reach(target)
+        if collaborator is not None:
+            self._collaborator_patch(node, collaborator, name)
+            return
+
+        self._refuse_unresolved_target(node, target, form)
+
+    def _collaborator_reach(self, target: ast.expr) -> str | None:
+        """Name the facade attribute a replacement target reaches through."""
+
         if (
             isinstance(target, ast.Attribute)
             and isinstance(target.value, ast.Name)
-            and (target.value.id in bindings or target.value.id in self.class_names)
+            and (
+                target.value.id in self.frames[-1].instance_names
+                or target.value.id in self.class_names
+            )
         ):
-            self._collaborator_patch(node, target.attr, name)
-            return
+            return target.attr
+        if isinstance(target, ast.Name):
+            for frame in reversed(self.frames):
+                alias = frame.collaborator_aliases.get(target.id)
+                if alias is not None:
+                    return alias
+        return None
 
-    def _collaborator_patch(self, node: ast.Call, attribute: str, name: str) -> None:
-        owner = _FACADE_COLLABORATORS.get(attribute)
-        owner_stage = _INSTANCE_ATTRIBUTE_OWNERS.get(attribute)
+    def _reaches_the_extractor(self, target: ast.expr) -> bool:
+        """Answer whether an unreduced target still names the extractor.
+
+        A refusal has to be narrower than "could not resolve", or every
+        ``patch.object`` in the tree that replaces a member of some foreign
+        object becomes an error. Two signals survive a shape the reader cannot
+        reduce: a name it already knows is the extractor module, the facade
+        class or a facade instance, and a facade wiring attribute anywhere in
+        the expression. Measured over every site that falls through today:
+        neither fires on any of the 137, and between them they catch the
+        chained, ``getattr``-routed and ``self``-rooted reach-throughs.
+        """
+
+        frame = self.frames[-1]
+        known = (
+            frame.module_names
+            | frame.class_names
+            | frame.instance_names
+            | frame.ambiguous_names
+        )
+        wiring = set(_FACADE_COLLABORATORS) | set(_INSTANCE_ATTRIBUTE_OWNERS)
+        return any(
+            (isinstance(item, ast.Name) and item.id in known)
+            or (isinstance(item, ast.Attribute) and item.attr in wiring)
+            for item in ast.walk(target)
+        )
+
+    def _refuse_unresolved_target(
+        self, node: ast.expr | ast.stmt, target: ast.expr, form: str
+    ) -> None:
+        if not self._reaches_the_extractor(target):
+            return
+        self._error(node, ast.unparse(target), f"unresolved {form} target")
+
+    def _collaborator_patch(
+        self, node: ast.expr | ast.stmt, attribute: str, name: str
+    ) -> None:
+        collaborator = _FACADE_COLLABORATORS.get(attribute)
         patch_target = f"{attribute}.{name}"
-        if owner is None or owner_stage is None:
+        if collaborator is None:
             self._error(node, patch_target, "unknown facade collaborator patch")
             return
-        if name not in collaborator_methods(owner):
+        owner, _ = collaborator
+        try:
+            methods = collaborator_methods(owner)
+        except UnresolvedSeamError as error:
+            self._error(node, patch_target, str(error))
+            return
+        if name not in methods:
             self._error(node, patch_target, f"unknown {owner} patch")
             return
-        _, stage = owner_stage
-        if name.startswith("_"):
-            self._add("private_patch_object", node, name, owner, stage)
+        callers = self._callers(name)
+        if not callers:
+            self._error(node, patch_target, "collaborator patch has no caller workflow")
             return
-        self._add("public_patch_object", node, name, f"{owner} dependency", stage)
+        for caller_owner, stage in callers:
+            if name.startswith("_"):
+                # A private member is owned where it is defined, so the owner
+                # stays the collaborator and only the stage follows the caller.
+                self._add("private_patch_object", node, name, owner, stage)
+                continue
+            # A public member *is* the collaborator rather than a dependency of
+            # it, so the owner names the workflow consuming it, matching every
+            # other `public_patch_object` entry.
+            self._add(
+                "public_patch_object", node, name, f"{caller_owner} dependency", stage
+            )
 
 
 def scan_source(

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -739,8 +739,8 @@ def _setattr_arguments(node: ast.Call) -> tuple[ast.expr | None, ast.expr | None
 
 
 # The fixture's own name, and the class a private context is opened from. A
-# binding reading from either holds the same object, which is the whole signal
-# `_monkeypatch_names` follows.
+# binding reading from either holds the same object, which is the authority the
+# use-site collector follows.
 _MONKEYPATCH_NAMES = frozenset({"monkeypatch", "MonkeyPatch"})
 
 
@@ -752,52 +752,191 @@ def _mentions_monkeypatch(expression: ast.expr) -> bool:
     )
 
 
-def _monkeypatch_names(tree: ast.Module) -> set[str]:
-    """Name every local in one file that plausibly holds a pytest fixture.
+class _MonkeyPatchCallCollector(ast.NodeVisitor):
+    """Locate unreadable ``setattr`` calls on a live pytest patcher binding.
 
-    ``with pytest.MonkeyPatch.context() as patching`` and a parameter annotated
-    ``pytest.MonkeyPatch`` are the fixture under another name, which is why a
-    receiver test spelled ``monkeypatch`` alone would not find them. Read over
-    the whole module rather than per scope, and kept for a name a later
-    statement reuses for something else: this set only ever decides whether an
-    unreadable ``setattr`` is loud, so a name too many costs a refusal that
-    names its site and a name too few costs a silent skip. The bare end of an
-    attribute target joins it for the same reason, because ``self.patcher``
-    reads back through ``patcher``.
+    Receiver authority follows lexical scopes and statement order. That keeps
+    an alias in the scope where it was established, retires it when the same
+    target is rebound, and still lets an unshadowed outer alias reach a nested
+    function. Calls with readable targets do not need this evidence: the
+    extractor reachability checks scope those independently.
     """
 
-    names = {"monkeypatch"}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.withitem):
-            if isinstance(node.optional_vars, ast.Name) and _mentions_monkeypatch(
-                node.context_expr
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.calls: set[int] = set()
+        self.aliases = {"monkeypatch"}
+        self.closure_aliases = set(self.aliases)
+        self.scope_kinds = ["module"]
+
+    @staticmethod
+    def _key(expression: ast.expr) -> str:
+        if isinstance(expression, (ast.Name, ast.Attribute)):
+            return ast.unparse(expression)
+        return ""
+
+    @staticmethod
+    def _targets(target: ast.expr) -> set[str]:
+        if isinstance(target, (ast.Tuple, ast.List)):
+            return {
+                name
+                for item in target.elts
+                if (name := _MonkeyPatchCallCollector._key(item))
+            }
+        name = _MonkeyPatchCallCollector._key(target)
+        return {name} if name else set()
+
+    def _is_authority(self, expression: ast.expr) -> bool:
+        return any(
+            (isinstance(item, ast.expr) and self._key(item) in self.aliases)
+            or (isinstance(item, ast.Name) and item.id == "MonkeyPatch")
+            or (isinstance(item, ast.Attribute) and item.attr == "MonkeyPatch")
+            for item in ast.walk(expression)
+        )
+
+    def _bind(self, target: ast.expr, authority: bool) -> None:
+        names = self._targets(target)
+        self.aliases.difference_update(names)
+        if authority and isinstance(target, (ast.Name, ast.Attribute)):
+            self.aliases.update(names)
+        if self.scope_kinds[-1] != "class":
+            self.closure_aliases.difference_update(names)
+            self.closure_aliases.update(self.aliases & names)
+
+    def _unbind(self, names: set[str]) -> None:
+        self.aliases.difference_update(names)
+        if self.scope_kinds[-1] != "class":
+            self.closure_aliases.difference_update(names)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in [*node.args.defaults, *node.args.kw_defaults]:
+            if default is not None:
+                self.visit(default)
+
+        collector = _scope_collector(self.path, node.body)
+        parameters = _argument_names(node.args)
+        local_bindings = collector.bindings - collector.globals - collector.nonlocals
+        inherited = self.closure_aliases - local_bindings - parameters
+        for argument in [
+            *node.args.posonlyargs,
+            *node.args.args,
+            *node.args.kwonlyargs,
+            *([node.args.vararg] if node.args.vararg else []),
+            *([node.args.kwarg] if node.args.kwarg else []),
+        ]:
+            if argument.arg == "monkeypatch" or (
+                argument.annotation is not None
+                and _mentions_monkeypatch(argument.annotation)
             ):
-                names.add(node.optional_vars.id)
-        elif isinstance(node, ast.Assign) and _mentions_monkeypatch(node.value):
-            names.update(_bound_name(target) for target in node.targets)
-        elif isinstance(node, ast.AnnAssign):
-            if _mentions_monkeypatch(node.annotation) or (
-                node.value is not None and _mentions_monkeypatch(node.value)
-            ):
-                names.add(_bound_name(node.target))
-        elif (
-            isinstance(node, ast.arg)
-            and node.annotation is not None
-            and _mentions_monkeypatch(node.annotation)
+                inherited.add(argument.arg)
+
+        previous = (self.aliases, self.closure_aliases)
+        self.aliases = inherited
+        self.closure_aliases = set(inherited)
+        self.scope_kinds.append("function")
+        for statement in node.body:
+            self.visit(statement)
+        self.scope_kinds.pop()
+        self.aliases, self.closure_aliases = previous
+        self._unbind({node.name})
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> Any:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
+        self._visit_function(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> Any:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        previous = (self.aliases, self.closure_aliases)
+        self.aliases = set(self.closure_aliases)
+        self.scope_kinds.append("class")
+        for statement in node.body:
+            self.visit(statement)
+        self.scope_kinds.pop()
+        self.aliases, self.closure_aliases = previous
+        self._unbind({node.name})
+
+    def visit_Assign(self, node: ast.Assign) -> Any:
+        self.visit(node.value)
+        authority = self._is_authority(node.value)
+        for target in node.targets:
+            self._bind(target, authority)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> Any:
+        if node.value is not None:
+            self.visit(node.value)
+        self._bind(
+            node.target,
+            _mentions_monkeypatch(node.annotation)
+            or (node.value is not None and self._is_authority(node.value)),
+        )
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> Any:
+        self.visit(node.value)
+        self._bind(node.target, False)
+
+    def visit_Delete(self, node: ast.Delete) -> Any:
+        for target in node.targets:
+            self._bind(target, False)
+
+    def visit_Import(self, node: ast.Import) -> Any:
+        self._unbind(
+            {alias.asname or alias.name.split(".", 1)[0] for alias in node.names}
+        )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> Any:
+        self._unbind({alias.asname or alias.name for alias in node.names})
+
+    def _visit_for(self, node: ast.For | ast.AsyncFor) -> None:
+        self.visit(node.iter)
+        self._bind(node.target, False)
+        for statement in [*node.body, *node.orelse]:
+            self.visit(statement)
+
+    def visit_For(self, node: ast.For) -> Any:
+        self._visit_for(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> Any:
+        self._visit_for(node)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> Any:
+        self.visit(node.value)
+        self._bind(node.target, self._is_authority(node.value))
+
+    def _visit_with(self, node: ast.With | ast.AsyncWith) -> None:
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self._bind(item.optional_vars, self._is_authority(item.context_expr))
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_With(self, node: ast.With) -> Any:
+        self._visit_with(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> Any:
+        self._visit_with(node)
+
+    def visit_Call(self, node: ast.Call) -> Any:
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "setattr"
+            and self._is_authority(node.func.value)
         ):
-            names.add(node.arg)
-    names.discard("")
-    return names
+            self.calls.add(id(node))
+        self.generic_visit(node)
 
 
-def _bound_name(target: ast.expr) -> str:
-    """Name what one assignment target binds, or nothing for a shape without one."""
-
-    if isinstance(target, ast.Name):
-        return target.id
-    if isinstance(target, ast.Attribute):
-        return target.attr
-    return ""
+def _monkeypatch_calls(path: Path, tree: ast.Module) -> set[int]:
+    collector = _MonkeyPatchCallCollector(path)
+    collector.visit(tree)
+    return collector.calls
 
 
 class _CollaboratorAliasCollector:
@@ -1545,14 +1684,14 @@ class Scanner(ast.NodeVisitor):
         class_names: set[str],
         facade_publics: frozenset[str],
         facade_privates: frozenset[str],
-        monkeypatch_names: set[str],
+        monkeypatch_calls: set[int],
     ):
         self.path = path
         self.root_module_names = module_names
         self.root_class_names = class_names
         self.facade_publics = facade_publics
         self.facade_privates = facade_privates
-        self.monkeypatch_names = monkeypatch_names
+        self.monkeypatch_calls = monkeypatch_calls
         self.functions: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
         self.frames = [
             _ScopeFrame(
@@ -2387,31 +2526,17 @@ class Scanner(ast.NodeVisitor):
         against the docstring above: matching the method name alone is what
         keeps an aliased fixture inventoried, and it is free only while a
         readable target does the scoping. With the target gone the receiver has
-        to answer instead, so ``_monkeypatch_names`` stands in for it, widened
-        past the fixture's own name for exactly the aliases that docstring
-        warns about.
+        to answer instead, so the use-site collector proves that its binding is
+        still authoritative in this lexical scope.
         """
 
         function = node.func
-        if isinstance(function, ast.Attribute) and not self._monkeypatch_receiver(
-            function.value
+        if (
+            isinstance(function, ast.Attribute)
+            and id(node) not in self.monkeypatch_calls
         ):
             return
         self._error(node, ast.unparse(node), "unresolved setattr arguments")
-
-    def _monkeypatch_receiver(self, receiver: ast.expr) -> bool:
-        """Answer whether a ``.setattr`` receiver plausibly holds the fixture.
-
-        A mention anywhere in the receiver is enough: ``self.patcher`` reaches
-        the same object as the bare local, and the attribute name is all of it
-        there is to recognise.
-        """
-
-        return any(
-            (isinstance(item, ast.Name) and item.id in self.monkeypatch_names)
-            or (isinstance(item, ast.Attribute) and item.attr in self.monkeypatch_names)
-            for item in ast.walk(receiver)
-        )
 
     def visit_Assign(self, node: ast.Assign) -> Any:
         for target in node.targets:
@@ -2755,7 +2880,7 @@ def scan_source(
         class_names,
         facade_publics,
         facade_privates,
-        _monkeypatch_names(tree),
+        _monkeypatch_calls(path, tree),
     )
     scanner.visit(tree)
     if scanner.errors:

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -787,6 +787,73 @@ class _ClosureCell:
 class _DeferredFunction:
     node: ast.FunctionDef | ast.AsyncFunctionDef
     cell: _ClosureCell
+    exception_shadowed: set[str]
+    builtins_aliases: set[str]
+
+
+class _BuiltinsAliasCollector(ast.NodeVisitor):
+    """Find scope-local names that can only denote the builtins module."""
+
+    def __init__(self) -> None:
+        self.candidates: set[str] = set()
+        self.invalid: set[str] = set()
+
+    def visit_Name(self, node: ast.Name) -> Any:
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.invalid.add(node.id)
+
+    def visit_Import(self, node: ast.Import) -> Any:
+        for alias in node.names:
+            name = alias.asname or alias.name.split(".", 1)[0]
+            if alias.name == "builtins":
+                self.candidates.add(name)
+            else:
+                self.invalid.add(name)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> Any:
+        self.invalid.update(alias.asname or alias.name for alias in node.names)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> Any:
+        self.invalid.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
+        self.invalid.add(node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> Any:
+        self.invalid.add(node.name)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> Any:
+        if node.name:
+            self.invalid.add(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchAs(self, node: ast.MatchAs) -> Any:
+        if node.name:
+            self.invalid.add(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchStar(self, node: ast.MatchStar) -> Any:
+        if node.name:
+            self.invalid.add(node.name)
+
+    def visit_MatchMapping(self, node: ast.MatchMapping) -> Any:
+        if node.rest:
+            self.invalid.add(node.rest)
+        self.generic_visit(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> Any:
+        return None
+
+    @property
+    def aliases(self) -> set[str]:
+        return self.candidates - self.invalid
+
+
+def _trusted_builtins_aliases(statements: list[ast.stmt]) -> set[str]:
+    collector = _BuiltinsAliasCollector()
+    for statement in statements:
+        collector.visit(statement)
+    return collector.aliases
 
 
 def _mentions_monkeypatch(expression: ast.expr) -> bool:
@@ -797,28 +864,25 @@ def _mentions_monkeypatch(expression: ast.expr) -> bool:
     )
 
 
-def _exception_type_name(expression: ast.expr) -> str | None:
-    if isinstance(expression, ast.Name):
-        return expression.id
-    if isinstance(expression, ast.Attribute):
-        return expression.attr
-    return None
-
-
-def _non_raising_binding_value(value: ast.expr) -> bool:
-    if isinstance(value, (ast.Name, ast.Constant)):
+def _non_raising_binding_value(value: ast.expr, safe_names: set[str]) -> bool:
+    if isinstance(value, ast.Constant):
         return True
+    if isinstance(value, ast.Name):
+        return value.id in safe_names
     if isinstance(value, (ast.Tuple, ast.List)):
         return all(
-            not isinstance(item, ast.Starred) and _non_raising_binding_value(item)
+            not isinstance(item, ast.Starred)
+            and _non_raising_binding_value(item, safe_names)
             for item in value.elts
         )
     return False
 
 
-def _non_raising_assignment(target: ast.expr, value: ast.expr) -> bool:
+def _non_raising_assignment(
+    target: ast.expr, value: ast.expr, safe_names: set[str]
+) -> bool:
     if isinstance(target, ast.Name):
-        return _non_raising_binding_value(value)
+        return _non_raising_binding_value(value, safe_names)
     if not (
         isinstance(target, (ast.Tuple, ast.List))
         and isinstance(value, (ast.Tuple, ast.List))
@@ -828,70 +892,28 @@ def _non_raising_assignment(target: ast.expr, value: ast.expr) -> bool:
     ):
         return False
     return all(
-        _non_raising_assignment(target_item, value_item)
+        _non_raising_assignment(target_item, value_item, safe_names)
         for target_item, value_item in zip(target.elts, value.elts, strict=True)
     )
 
 
-def _may_raise_implicitly(statement: ast.stmt) -> bool:
+def _may_raise_implicitly(statement: ast.stmt, safe_names: set[str]) -> bool:
     if isinstance(statement, (ast.Raise, ast.Pass, ast.Break, ast.Continue)):
         return False
     if isinstance(statement, ast.Assign):
         return not all(
-            _non_raising_assignment(target, statement.value)
+            _non_raising_assignment(target, statement.value, safe_names)
             for target in statement.targets
         )
     if isinstance(statement, ast.AnnAssign):
         return not (
             isinstance(statement.target, ast.Name)
-            and (statement.value is None or _non_raising_binding_value(statement.value))
+            and (
+                statement.value is None
+                or _non_raising_binding_value(statement.value, safe_names)
+            )
         )
     return True
-
-
-def _handler_match(handler: ast.ExceptHandler, kind: str | None) -> bool | None:
-    """Return whether one bounded exception kind reaches ``handler``.
-
-    ``None`` means both outcomes remain possible. Explicit built-in raises can be
-    compared through Python's real exception hierarchy; project-local exception
-    classes stay conservative unless the spelling matches. A bare handler and
-    ``BaseException`` cover every raisable value, while ``Exception`` deliberately
-    leaves the non-``Exception`` branch of an unknown kind alive.
-    """
-
-    if handler.type is None:
-        return True
-    candidates = (
-        handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
-    )
-    answers: list[bool | None] = []
-    for candidate in candidates:
-        candidate_name = _exception_type_name(candidate)
-        if candidate_name == "BaseException":
-            answers.append(True)
-            continue
-        if kind is None or candidate_name is None:
-            answers.append(None)
-            continue
-        if candidate_name == kind:
-            answers.append(True)
-            continue
-        raised_type = getattr(builtins, kind, None)
-        handled_type = getattr(builtins, candidate_name, None)
-        if (
-            isinstance(raised_type, type)
-            and issubclass(raised_type, BaseException)
-            and isinstance(handled_type, type)
-            and issubclass(handled_type, BaseException)
-        ):
-            answers.append(issubclass(raised_type, handled_type))
-        else:
-            answers.append(False if raised_type is not None else None)
-    if any(answer is True for answer in answers):
-        return True
-    if all(answer is False for answer in answers):
-        return False
-    return None
 
 
 class _MonkeyPatchCallCollector(ast.NodeVisitor):
@@ -914,12 +936,75 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         self.cells = [_ClosureCell(set(self.closure_aliases))]
         self.deferred: list[_DeferredFunction] = []
         self.deferred_ids: set[int] = set()
+        self.exception_shadowed = [set[str]()]
+        self.builtins_aliases = [set[str]()]
+        self.safe_names = [set[str]()]
 
     @staticmethod
     def _key(expression: ast.expr) -> str:
-        if isinstance(expression, (ast.Name, ast.Attribute)):
+        if isinstance(expression, (ast.Name, ast.Attribute, ast.Subscript)):
             return ast.unparse(expression)
         return ""
+
+    def _exception_identity(self, expression: ast.expr) -> str | None:
+        """Return a built-in exception name only when its identity is lexical fact."""
+
+        if isinstance(expression, ast.Name):
+            name = expression.id
+            if name in self.exception_shadowed[-1]:
+                return None
+        elif (
+            isinstance(expression, ast.Attribute)
+            and isinstance(expression.value, ast.Name)
+            and expression.value.id in self.builtins_aliases[-1]
+        ):
+            name = expression.attr
+        else:
+            return None
+        value = getattr(builtins, name, None)
+        if isinstance(value, type) and issubclass(value, BaseException):
+            return name
+        return None
+
+    def _raised_identity(self, node: ast.Raise) -> str | None:
+        if node.exc is None:
+            return None
+        expression = node.exc.func if isinstance(node.exc, ast.Call) else node.exc
+        return self._exception_identity(expression)
+
+    def _non_raising_raise_expression(self, expression: ast.expr) -> bool:
+        if self._exception_identity(expression) is not None:
+            return True
+        if not isinstance(expression, ast.Call):
+            return isinstance(expression, ast.Constant)
+        if self._exception_identity(expression.func) is None:
+            return False
+        return (
+            not any(keyword.arg is None for keyword in expression.keywords)
+            and all(isinstance(argument, ast.Constant) for argument in expression.args)
+            and all(
+                isinstance(keyword.value, ast.Constant)
+                for keyword in expression.keywords
+            )
+        )
+
+    def _handler_match(
+        self, handler: ast.ExceptHandler, kind: str | None
+    ) -> bool | None:
+        if handler.type is None:
+            return True
+        candidates = (
+            handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+        )
+        identities = [self._exception_identity(candidate) for candidate in candidates]
+        known_identities = [identity for identity in identities if identity is not None]
+        if kind is None or len(known_identities) != len(identities):
+            return None
+        raised_type = getattr(builtins, kind)
+        return any(
+            issubclass(raised_type, getattr(builtins, identity))
+            for identity in known_identities
+        )
 
     @staticmethod
     def _targets(target: ast.expr) -> set[str]:
@@ -1004,7 +1089,7 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
                 break
             prefix = self._state()
             flowed = self.visit(statement)
-            if _may_raise_implicitly(statement):
+            if _may_raise_implicitly(statement, self.safe_names[-1]):
                 result.exceptional.append(_ExceptionalState(prefix, None))
             if not isinstance(flowed, _FlowResult):
                 continue
@@ -1049,7 +1134,14 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         self._visit_function_expressions(node)
         if id(node) not in self.deferred_ids:
             self.deferred_ids.add(id(node))
-            self.deferred.append(_DeferredFunction(node, self.cells[-1]))
+            self.deferred.append(
+                _DeferredFunction(
+                    node,
+                    self.cells[-1],
+                    set(self.exception_shadowed[-1]),
+                    set(self.builtins_aliases[-1]),
+                )
+            )
         self._unbind({node.name})
 
     def _evaluate_function(self, item: _DeferredFunction) -> None:
@@ -1077,10 +1169,20 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         cell = _ClosureCell(set(inherited))
         self.cells.append(cell)
         self.scope_kinds.append("function")
+        local_bindings = local_bindings | parameters
+        local_builtins_aliases = _trusted_builtins_aliases(node.body)
+        self.exception_shadowed.append(item.exception_shadowed | local_bindings)
+        self.builtins_aliases.append(
+            (item.builtins_aliases - local_bindings) | local_builtins_aliases
+        )
+        self.safe_names.append(set(parameters))
         flow = self._visit_suite(node.body)
         endings = [*flow.normal, *flow.breaks, *flow.continues, *flow.returns]
         if endings:
             cell.aliases = set(self._merge(endings)[1])
+        self.safe_names.pop()
+        self.builtins_aliases.pop()
+        self.exception_shadowed.pop()
         self.scope_kinds.pop()
         self.cells.pop()
         self._restore(previous)
@@ -1096,6 +1198,9 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
                 self._evaluate_function(item)
 
     def visit_Module(self, node: ast.Module) -> Any:
+        collector = _scope_collector(self.path, node.body)
+        self.exception_shadowed[-1] = set(collector.bindings)
+        self.builtins_aliases[-1] = _trusted_builtins_aliases(node.body)
         flow = self._visit_suite(node.body)
         endings = list(flow.normal)
         if endings:
@@ -1184,11 +1289,15 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
             handler_inputs: list[_ExceptionalState] = []
             still_unmatched: list[_ExceptionalState] = []
             for exceptional in unmatched:
-                match = _handler_match(handler, exceptional.kind)
+                match = self._handler_match(handler, exceptional.kind)
                 if match is not False:
                     handler_inputs.append(exceptional)
-                if match is not True:
+                if isinstance(node, ast.TryStar) or match is not True:
                     still_unmatched.append(exceptional)
+            # ``except*`` handlers split an exception group instead of selecting
+            # one exclusive branch. Keep every original group path available to
+            # later handlers and to ``finally``; the AST does not prove which
+            # subgroups were consumed.
             unmatched = still_unmatched
             if not handler_inputs:
                 continue
@@ -1312,13 +1421,19 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         return _FlowResult(continues=[self._state()])
 
     def visit_Raise(self, node: ast.Raise) -> Any:
+        prefix = self._state()
+        may_fail_before_raise = (
+            node.exc is not None and not self._non_raising_raise_expression(node.exc)
+        )
         if node.exc is not None:
             self.visit(node.exc)
         if node.cause is not None:
+            may_fail_before_raise = True
             self.visit(node.cause)
-        return _FlowResult(
-            exceptional=[_ExceptionalState(self._state(), _raised_exception_name(node))]
-        )
+        exceptional = [_ExceptionalState(self._state(), self._raised_identity(node))]
+        if may_fail_before_raise:
+            exceptional.insert(0, _ExceptionalState(prefix, None))
+        return _FlowResult(exceptional=exceptional)
 
     def visit_Return(self, node: ast.Return) -> Any:
         if node.value is not None:

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -738,6 +738,68 @@ def _setattr_arguments(node: ast.Call) -> tuple[ast.expr | None, ast.expr | None
     return (target, name)
 
 
+# The fixture's own name, and the class a private context is opened from. A
+# binding reading from either holds the same object, which is the whole signal
+# `_monkeypatch_names` follows.
+_MONKEYPATCH_NAMES = frozenset({"monkeypatch", "MonkeyPatch"})
+
+
+def _mentions_monkeypatch(expression: ast.expr) -> bool:
+    return any(
+        (isinstance(item, ast.Name) and item.id in _MONKEYPATCH_NAMES)
+        or (isinstance(item, ast.Attribute) and item.attr in _MONKEYPATCH_NAMES)
+        for item in ast.walk(expression)
+    )
+
+
+def _monkeypatch_names(tree: ast.Module) -> set[str]:
+    """Name every local in one file that plausibly holds a pytest fixture.
+
+    ``with pytest.MonkeyPatch.context() as patching`` and a parameter annotated
+    ``pytest.MonkeyPatch`` are the fixture under another name, which is why a
+    receiver test spelled ``monkeypatch`` alone would not find them. Read over
+    the whole module rather than per scope, and kept for a name a later
+    statement reuses for something else: this set only ever decides whether an
+    unreadable ``setattr`` is loud, so a name too many costs a refusal that
+    names its site and a name too few costs a silent skip. The bare end of an
+    attribute target joins it for the same reason, because ``self.patcher``
+    reads back through ``patcher``.
+    """
+
+    names = {"monkeypatch"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.withitem):
+            if isinstance(node.optional_vars, ast.Name) and _mentions_monkeypatch(
+                node.context_expr
+            ):
+                names.add(node.optional_vars.id)
+        elif isinstance(node, ast.Assign) and _mentions_monkeypatch(node.value):
+            names.update(_bound_name(target) for target in node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            if _mentions_monkeypatch(node.annotation) or (
+                node.value is not None and _mentions_monkeypatch(node.value)
+            ):
+                names.add(_bound_name(node.target))
+        elif (
+            isinstance(node, ast.arg)
+            and node.annotation is not None
+            and _mentions_monkeypatch(node.annotation)
+        ):
+            names.add(node.arg)
+    names.discard("")
+    return names
+
+
+def _bound_name(target: ast.expr) -> str:
+    """Name what one assignment target binds, or nothing for a shape without one."""
+
+    if isinstance(target, ast.Name):
+        return target.id
+    if isinstance(target, ast.Attribute):
+        return target.attr
+    return ""
+
+
 class _CollaboratorAliasCollector:
     """Answer each use of a local name bound to a facade collaborator.
 
@@ -1483,12 +1545,14 @@ class Scanner(ast.NodeVisitor):
         class_names: set[str],
         facade_publics: frozenset[str],
         facade_privates: frozenset[str],
+        monkeypatch_names: set[str],
     ):
         self.path = path
         self.root_module_names = module_names
         self.root_class_names = class_names
         self.facade_publics = facade_publics
         self.facade_privates = facade_privates
+        self.monkeypatch_names = monkeypatch_names
         self.functions: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
         self.frames = [
             _ScopeFrame(
@@ -2282,17 +2346,14 @@ class Scanner(ast.NodeVisitor):
         named ``monkeypatch``, because the fixture is routinely bound to
         another name and a receiver test would skip exactly the sites this
         exists to see. Everything it resolves to is a foreign object unless the
-        target reaches the extractor, so the breadth costs nothing.
+        target reaches the extractor, so the breadth costs nothing. It costs
+        something only where there is no target left to scope, which is what
+        ``_refuse_unreadable_setattr`` answers for.
         """
 
         target, name = _setattr_arguments(node)
         if target is None:
-            # Neither end of the replacement is readable, so there is nothing
-            # to scope against the extractor and a skip would be
-            # indistinguishable from a patch that intercepts nothing. Measured
-            # over every `setattr` site in the tree: none reaches this, the
-            # same answer the `patch.object` refusal got.
-            self._error(node, ast.unparse(node), "unresolved setattr arguments")
+            self._refuse_unreadable_setattr(node)
             return
         if (
             isinstance(target, ast.Constant)
@@ -2308,6 +2369,49 @@ class Scanner(ast.NodeVisitor):
             return
         self._suppress_module_attributes(target)
         self._replacement(node, target, name.value, "setattr")
+
+    def _refuse_unreadable_setattr(self, node: ast.Call) -> None:
+        """Refuse a ``setattr`` whose call shape hides both of its ends.
+
+        There is no target to scope against the extractor, and a skip reads the
+        same as a patch that intercepts nothing, so the refusal has to be loud
+        where the call could plausibly land on the extractor. Every other
+        refusal here is narrowed by ``_reaches_the_extractor``; a blanket one
+        answers the same way for a foreign ``helper.setattr(*arguments)``
+        anywhere in the tree, and one false failure blocks every later stage.
+
+        The receiver is the only signal the shape leaves. A bare name is the
+        builtin, which takes any object including the extractor, so it stays
+        loud. A method belongs to whatever the receiver holds, and only a
+        pytest fixture patches the extractor through one. That is the trade-off
+        against the docstring above: matching the method name alone is what
+        keeps an aliased fixture inventoried, and it is free only while a
+        readable target does the scoping. With the target gone the receiver has
+        to answer instead, so ``_monkeypatch_names`` stands in for it, widened
+        past the fixture's own name for exactly the aliases that docstring
+        warns about.
+        """
+
+        function = node.func
+        if isinstance(function, ast.Attribute) and not self._monkeypatch_receiver(
+            function.value
+        ):
+            return
+        self._error(node, ast.unparse(node), "unresolved setattr arguments")
+
+    def _monkeypatch_receiver(self, receiver: ast.expr) -> bool:
+        """Answer whether a ``.setattr`` receiver plausibly holds the fixture.
+
+        A mention anywhere in the receiver is enough: ``self.patcher`` reaches
+        the same object as the bare local, and the attribute name is all of it
+        there is to recognise.
+        """
+
+        return any(
+            (isinstance(item, ast.Name) and item.id in self.monkeypatch_names)
+            or (isinstance(item, ast.Attribute) and item.attr in self.monkeypatch_names)
+            for item in ast.walk(receiver)
+        )
 
     def visit_Assign(self, node: ast.Assign) -> Any:
         for target in node.targets:
@@ -2651,6 +2755,7 @@ def scan_source(
         class_names,
         facade_publics,
         facade_privates,
+        _monkeypatch_names(tree),
     )
     scanner.visit(tree)
     if scanner.errors:

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -752,7 +752,7 @@ def _setattr_arguments(node: ast.Call) -> tuple[ast.expr | None, ast.expr | None
 _MONKEYPATCH_NAMES = frozenset({"monkeypatch", "MonkeyPatch"})
 
 
-_MonkeyPatchState = tuple[set[str], set[str]]
+_MonkeyPatchState = tuple[set[str], set[str], set[str]]
 
 
 @dataclass(slots=True)
@@ -760,6 +760,7 @@ class _ExceptionalState:
     state: _MonkeyPatchState
     # ``None`` is an exception whose runtime kind cannot be bounded from the AST.
     kind: str | None
+    is_group: bool
 
 
 @dataclass(slots=True)
@@ -788,72 +789,6 @@ class _DeferredFunction:
     node: ast.FunctionDef | ast.AsyncFunctionDef
     cell: _ClosureCell
     exception_shadowed: set[str]
-    builtins_aliases: set[str]
-
-
-class _BuiltinsAliasCollector(ast.NodeVisitor):
-    """Find scope-local names that can only denote the builtins module."""
-
-    def __init__(self) -> None:
-        self.candidates: set[str] = set()
-        self.invalid: set[str] = set()
-
-    def visit_Name(self, node: ast.Name) -> Any:
-        if isinstance(node.ctx, (ast.Store, ast.Del)):
-            self.invalid.add(node.id)
-
-    def visit_Import(self, node: ast.Import) -> Any:
-        for alias in node.names:
-            name = alias.asname or alias.name.split(".", 1)[0]
-            if alias.name == "builtins":
-                self.candidates.add(name)
-            else:
-                self.invalid.add(name)
-
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> Any:
-        self.invalid.update(alias.asname or alias.name for alias in node.names)
-
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> Any:
-        self.invalid.add(node.name)
-
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
-        self.invalid.add(node.name)
-
-    def visit_ClassDef(self, node: ast.ClassDef) -> Any:
-        self.invalid.add(node.name)
-
-    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> Any:
-        if node.name:
-            self.invalid.add(node.name)
-        self.generic_visit(node)
-
-    def visit_MatchAs(self, node: ast.MatchAs) -> Any:
-        if node.name:
-            self.invalid.add(node.name)
-        self.generic_visit(node)
-
-    def visit_MatchStar(self, node: ast.MatchStar) -> Any:
-        if node.name:
-            self.invalid.add(node.name)
-
-    def visit_MatchMapping(self, node: ast.MatchMapping) -> Any:
-        if node.rest:
-            self.invalid.add(node.rest)
-        self.generic_visit(node)
-
-    def visit_Lambda(self, node: ast.Lambda) -> Any:
-        return None
-
-    @property
-    def aliases(self) -> set[str]:
-        return self.candidates - self.invalid
-
-
-def _trusted_builtins_aliases(statements: list[ast.stmt]) -> set[str]:
-    collector = _BuiltinsAliasCollector()
-    for statement in statements:
-        collector.visit(statement)
-    return collector.aliases
 
 
 def _mentions_monkeypatch(expression: ast.expr) -> bool:
@@ -937,29 +872,21 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         self.deferred: list[_DeferredFunction] = []
         self.deferred_ids: set[int] = set()
         self.exception_shadowed = [set[str]()]
-        self.builtins_aliases = [set[str]()]
-        self.safe_names = [set[str]()]
+        self.safe_names = set[str]()
 
     @staticmethod
     def _key(expression: ast.expr) -> str:
-        if isinstance(expression, (ast.Name, ast.Attribute, ast.Subscript)):
+        if isinstance(expression, (ast.Name, ast.Attribute)):
             return ast.unparse(expression)
         return ""
 
     def _exception_identity(self, expression: ast.expr) -> str | None:
         """Return a built-in exception name only when its identity is lexical fact."""
 
-        if isinstance(expression, ast.Name):
-            name = expression.id
-            if name in self.exception_shadowed[-1]:
-                return None
-        elif (
-            isinstance(expression, ast.Attribute)
-            and isinstance(expression.value, ast.Name)
-            and expression.value.id in self.builtins_aliases[-1]
-        ):
-            name = expression.attr
-        else:
+        if not isinstance(expression, ast.Name):
+            return None
+        name = expression.id
+        if name in self.exception_shadowed[-1]:
             return None
         value = getattr(builtins, name, None)
         if isinstance(value, type) and issubclass(value, BaseException):
@@ -972,21 +899,59 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         expression = node.exc.func if isinstance(node.exc, ast.Call) else node.exc
         return self._exception_identity(expression)
 
-    def _non_raising_raise_expression(self, expression: ast.expr) -> bool:
+    def _raise_argument_is_safe(self, expression: ast.expr) -> bool:
+        if isinstance(expression, ast.Constant):
+            return True
+        if isinstance(expression, ast.Name):
+            return expression.id in self.safe_names
+        if isinstance(expression, (ast.Tuple, ast.List)):
+            return all(
+                not isinstance(item, ast.Starred) and self._raise_argument_is_safe(item)
+                for item in expression.elts
+            )
+        if not isinstance(expression, ast.Call):
+            return False
+        return (
+            self._exception_identity(expression.func) is not None
+            and not expression.keywords
+            and all(
+                not isinstance(argument, ast.Starred)
+                and self._raise_argument_is_safe(argument)
+                for argument in expression.args
+            )
+        )
+
+    def _raise_evaluation_is_safe(self, expression: ast.expr) -> bool:
         if self._exception_identity(expression) is not None:
             return True
         if not isinstance(expression, ast.Call):
             return isinstance(expression, ast.Constant)
         if self._exception_identity(expression.func) is None:
             return False
-        return (
-            not any(keyword.arg is None for keyword in expression.keywords)
-            and all(isinstance(argument, ast.Constant) for argument in expression.args)
-            and all(
-                isinstance(keyword.value, ast.Constant)
-                for keyword in expression.keywords
-            )
+        return all(
+            not isinstance(argument, ast.Starred)
+            and self._raise_argument_is_safe(argument)
+            for argument in expression.args
+        ) and all(
+            keyword.arg is not None and self._raise_argument_is_safe(keyword.value)
+            for keyword in expression.keywords
         )
+
+    def _raised_states(
+        self, node: ast.Raise, prefix: _MonkeyPatchState
+    ) -> list[_ExceptionalState]:
+        kind = self._raised_identity(node)
+        is_group = kind in {"BaseExceptionGroup", "ExceptionGroup"}
+        if not isinstance(node.exc, ast.Call) or kind is None:
+            return [_ExceptionalState(self._state(), kind, is_group)]
+        if node.exc.keywords:
+            if any(keyword.arg is None for keyword in node.exc.keywords):
+                return [
+                    _ExceptionalState(prefix, None, False),
+                    _ExceptionalState(prefix, None, True),
+                ]
+            return [_ExceptionalState(prefix, "TypeError", False)]
+        return [_ExceptionalState(self._state(), kind, is_group)]
 
     def _handler_match(
         self, handler: ast.ExceptHandler, kind: str | None
@@ -998,12 +963,29 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         )
         identities = [self._exception_identity(candidate) for candidate in candidates]
         known_identities = [identity for identity in identities if identity is not None]
-        if kind is None or len(known_identities) != len(identities):
+        if len(known_identities) != len(identities):
+            return None
+        if "BaseException" in known_identities:
+            return True
+        if kind is None:
             return None
         raised_type = getattr(builtins, kind)
         return any(
             issubclass(raised_type, getattr(builtins, identity))
             for identity in known_identities
+        )
+
+    def _handler_is_base_exception(self, handler: ast.ExceptHandler) -> bool:
+        candidates = (
+            handler.type.elts
+            if isinstance(handler.type, ast.Tuple)
+            else [handler.type]
+            if handler.type is not None
+            else []
+        )
+        return any(
+            self._exception_identity(candidate) == "BaseException"
+            for candidate in candidates
         )
 
     @staticmethod
@@ -1065,20 +1047,20 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         if self.scope_kinds[-1] != "class":
             self.closure_aliases.difference_update(names)
 
-    def _state(self) -> tuple[set[str], set[str]]:
-        return (set(self.aliases), set(self.closure_aliases))
+    def _state(self) -> _MonkeyPatchState:
+        return (set(self.aliases), set(self.closure_aliases), set(self.safe_names))
 
-    def _restore(self, state: tuple[set[str], set[str]]) -> None:
+    def _restore(self, state: _MonkeyPatchState) -> None:
         self.aliases = set(state[0])
         self.closure_aliases = set(state[1])
+        self.safe_names = set(state[2])
 
     @staticmethod
-    def _merge(
-        states: list[tuple[set[str], set[str]]],
-    ) -> tuple[set[str], set[str]]:
+    def _merge(states: list[_MonkeyPatchState]) -> _MonkeyPatchState:
         return (
             set().union(*(state[0] for state in states)),
             set().union(*(state[1] for state in states)),
+            set.intersection(*(state[2] for state in states)),
         )
 
     def _visit_suite(self, statements: list[ast.stmt]) -> _FlowResult:
@@ -1089,8 +1071,13 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
                 break
             prefix = self._state()
             flowed = self.visit(statement)
-            if _may_raise_implicitly(statement, self.safe_names[-1]):
-                result.exceptional.append(_ExceptionalState(prefix, None))
+            if _may_raise_implicitly(statement, self.safe_names):
+                result.exceptional.extend(
+                    (
+                        _ExceptionalState(prefix, None, False),
+                        _ExceptionalState(prefix, None, True),
+                    )
+                )
             if not isinstance(flowed, _FlowResult):
                 continue
             result.breaks.extend(flowed.breaks)
@@ -1139,7 +1126,6 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
                     node,
                     self.cells[-1],
                     set(self.exception_shadowed[-1]),
-                    set(self.builtins_aliases[-1]),
                 )
             )
         self._unbind({node.name})
@@ -1170,18 +1156,12 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         self.cells.append(cell)
         self.scope_kinds.append("function")
         local_bindings = local_bindings | parameters
-        local_builtins_aliases = _trusted_builtins_aliases(node.body)
         self.exception_shadowed.append(item.exception_shadowed | local_bindings)
-        self.builtins_aliases.append(
-            (item.builtins_aliases - local_bindings) | local_builtins_aliases
-        )
-        self.safe_names.append(set(parameters))
+        self.safe_names = set(parameters)
         flow = self._visit_suite(node.body)
         endings = [*flow.normal, *flow.breaks, *flow.continues, *flow.returns]
         if endings:
             cell.aliases = set(self._merge(endings)[1])
-        self.safe_names.pop()
-        self.builtins_aliases.pop()
         self.exception_shadowed.pop()
         self.scope_kinds.pop()
         self.cells.pop()
@@ -1200,7 +1180,6 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
     def visit_Module(self, node: ast.Module) -> Any:
         collector = _scope_collector(self.path, node.body)
         self.exception_shadowed[-1] = set(collector.bindings)
-        self.builtins_aliases[-1] = _trusted_builtins_aliases(node.body)
         flow = self._visit_suite(node.body)
         endings = list(flow.normal)
         if endings:
@@ -1218,18 +1197,41 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
             self.visit(decorator)
         for base in node.bases:
             self.visit(base)
-        previous = (self.aliases, self.closure_aliases)
+        previous = self._state()
         self.aliases = set(self.closure_aliases)
+        collector = _scope_collector(self.path, node.body)
+        self.exception_shadowed.append(self.exception_shadowed[-1] | collector.bindings)
         self.scope_kinds.append("class")
         self._visit_suite(node.body)
         self.scope_kinds.pop()
-        self.aliases, self.closure_aliases = previous
+        self.exception_shadowed.pop()
+        self._restore(previous)
         self._unbind({node.name})
+
+    @staticmethod
+    def _bound_names(target: ast.expr) -> set[str]:
+        if isinstance(target, ast.Name):
+            return {target.id}
+        if isinstance(target, (ast.Tuple, ast.List)):
+            return set().union(
+                *(_MonkeyPatchCallCollector._bound_names(item) for item in target.elts)
+            )
+        if isinstance(target, ast.Starred):
+            return _MonkeyPatchCallCollector._bound_names(target.value)
+        return set()
+
+    def _update_safe_assignment(self, target: ast.expr, value: ast.expr) -> None:
+        names = self._bound_names(target)
+        safe = _non_raising_assignment(target, value, self.safe_names)
+        self.safe_names.difference_update(names)
+        if safe:
+            self.safe_names.update(names)
 
     def visit_Assign(self, node: ast.Assign) -> Any:
         self.visit(node.value)
         for target in node.targets:
             self._bind_assignment(target, node.value)
+            self._update_safe_assignment(target, node.value)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> Any:
         if node.value is not None:
@@ -1239,22 +1241,33 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
             _mentions_monkeypatch(node.annotation)
             or (node.value is not None and self._is_authority(node.value)),
         )
+        names = self._bound_names(node.target)
+        safe = node.value is not None and _non_raising_assignment(
+            node.target, node.value, self.safe_names
+        )
+        self.safe_names.difference_update(names)
+        if safe:
+            self.safe_names.update(names)
 
     def visit_AugAssign(self, node: ast.AugAssign) -> Any:
         self.visit(node.value)
         self._bind(node.target, False)
+        self.safe_names.difference_update(self._bound_names(node.target))
 
     def visit_Delete(self, node: ast.Delete) -> Any:
         for target in node.targets:
             self._bind(target, False)
+            self.safe_names.difference_update(self._bound_names(target))
 
     def visit_Import(self, node: ast.Import) -> Any:
-        self._unbind(
-            {alias.asname or alias.name.split(".", 1)[0] for alias in node.names}
-        )
+        names = {alias.asname or alias.name.split(".", 1)[0] for alias in node.names}
+        self._unbind(names)
+        self.safe_names.update(names)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> Any:
-        self._unbind({alias.asname or alias.name for alias in node.names})
+        names = {alias.asname or alias.name for alias in node.names}
+        self._unbind(names)
+        self.safe_names.update(names)
 
     def visit_If(self, node: ast.If) -> Any:
         self.visit(node.test)
@@ -1290,14 +1303,19 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
             still_unmatched: list[_ExceptionalState] = []
             for exceptional in unmatched:
                 match = self._handler_match(handler, exceptional.kind)
-                if match is not False:
-                    handler_inputs.append(exceptional)
-                if isinstance(node, ast.TryStar) or match is not True:
-                    still_unmatched.append(exceptional)
-            # ``except*`` handlers split an exception group instead of selecting
-            # one exclusive branch. Keep every original group path available to
-            # later handlers and to ``finally``; the AST does not prove which
-            # subgroups were consumed.
+                if isinstance(node, ast.TryStar) and exceptional.is_group:
+                    # A named group says nothing about its members. Only an
+                    # unshadowed BaseException proves that every member is taken.
+                    if match is True and self._handler_is_base_exception(handler):
+                        handler_inputs.append(exceptional)
+                    else:
+                        handler_inputs.append(exceptional)
+                        still_unmatched.append(exceptional)
+                else:
+                    if match is not False:
+                        handler_inputs.append(exceptional)
+                    if match is not True:
+                        still_unmatched.append(exceptional)
             unmatched = still_unmatched
             if not handler_inputs:
                 continue
@@ -1365,10 +1383,13 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
             finished.continues.extend(final.continues)
             finished.returns.extend(final.returns)
             finished.exceptional.extend(final.exceptional)
-            kinds = {exceptional.kind for exceptional in result.exceptional}
+            kinds = {
+                (exceptional.kind, exceptional.is_group)
+                for exceptional in result.exceptional
+            }
             for state in final.normal:
                 finished.exceptional.extend(
-                    _ExceptionalState(state, kind) for kind in kinds
+                    _ExceptionalState(state, kind, is_group) for kind, is_group in kinds
                 )
         if finished.normal:
             self._restore(self._merge(finished.normal))
@@ -1423,16 +1444,19 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
     def visit_Raise(self, node: ast.Raise) -> Any:
         prefix = self._state()
         may_fail_before_raise = (
-            node.exc is not None and not self._non_raising_raise_expression(node.exc)
+            node.exc is not None and not self._raise_evaluation_is_safe(node.exc)
         )
         if node.exc is not None:
             self.visit(node.exc)
         if node.cause is not None:
             may_fail_before_raise = True
             self.visit(node.cause)
-        exceptional = [_ExceptionalState(self._state(), self._raised_identity(node))]
+        exceptional = self._raised_states(node, prefix)
         if may_fail_before_raise:
-            exceptional.insert(0, _ExceptionalState(prefix, None))
+            exceptional[0:0] = (
+                _ExceptionalState(prefix, None, False),
+                _ExceptionalState(prefix, None, True),
+            )
         return _FlowResult(exceptional=exceptional)
 
     def visit_Return(self, node: ast.Return) -> Any:
@@ -3120,6 +3144,11 @@ class Scanner(ast.NodeVisitor):
         """
 
         function = node.func
+        if isinstance(function, ast.Attribute) and any(
+            isinstance(item, ast.Subscript) for item in ast.walk(function.value)
+        ):
+            self._error(node, ast.unparse(node), "unresolved setattr arguments")
+            return
         if (
             isinstance(function, ast.Attribute)
             and id(node) not in self.monkeypatch_calls

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -534,6 +534,27 @@ def _argument_names(arguments: ast.arguments) -> set[str]:
     return names
 
 
+def _signature_expressions(arguments: ast.arguments) -> list[ast.expr]:
+    """Read the expressions a signature evaluates in its enclosing scope."""
+
+    annotated = [
+        *arguments.posonlyargs,
+        *arguments.args,
+        *arguments.kwonlyargs,
+        *([arguments.vararg] if arguments.vararg else []),
+        *([arguments.kwarg] if arguments.kwarg else []),
+    ]
+    return [
+        *(
+            argument.annotation
+            for argument in annotated
+            if argument.annotation is not None
+        ),
+        *arguments.defaults,
+        *(default for default in arguments.kw_defaults if default is not None),
+    ]
+
+
 def _scope_collector(path: Path, statements: list[ast.stmt]) -> _LocalBindingCollector:
     collector = _LocalBindingCollector(path)
     for statement in statements:
@@ -631,7 +652,12 @@ class _ScopeFrame:
     closure_class_names: set[str]
     closure_instance_names: set[str]
     ambiguous_names: set[str] = field(default_factory=set)
-    collaborator_aliases: dict[str, str] = field(default_factory=dict)
+    # Keyed by the identity of the ``ast.Name`` that uses the alias, not by the
+    # name: one local can hold the collaborator over part of a function and
+    # something else over the rest, and the scanner reaches those uses in an
+    # order of its own.
+    collaborator_aliases: dict[int, str] = field(default_factory=dict)
+    ambiguous_aliases: set[int] = field(default_factory=set)
 
 
 def _extractor_bindings(
@@ -690,40 +716,322 @@ def _patch_object_arguments(node: ast.Call) -> tuple[ast.expr | None, ast.expr |
     return (target, attribute)
 
 
-def _collaborator_aliases(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
-    facade_names: set[str],
-) -> dict[str, str]:
-    """Map local names bound to a facade collaborator attribute.
+def _setattr_arguments(node: ast.Call) -> tuple[ast.expr | None, ast.expr | None]:
+    """Read ``setattr``'s target and member name across its call shapes.
+
+    ``monkeypatch.setattr`` names ``target``, ``name`` and ``value``, so a gate
+    counting positional arguments answers "not a patch" to the keyword form,
+    exactly the defect ``_patch_object_arguments`` exists to close. Returning
+    ``None`` for the target tells the caller to refuse rather than to skip; a
+    missing name is left to the caller because the two-argument
+    ``setattr("dotted.path", value)`` form carries its member inside the
+    target and never has one.
+    """
+
+    if any(keyword.arg is None for keyword in node.keywords) or any(
+        isinstance(argument, ast.Starred) for argument in node.args
+    ):
+        return (None, None)
+    keywords = {keyword.arg: keyword.value for keyword in node.keywords}
+    target = node.args[0] if node.args else keywords.get("target")
+    name = node.args[1] if len(node.args) > 1 else keywords.get("name")
+    return (target, name)
+
+
+class _CollaboratorAliasCollector:
+    """Answer each use of a local name bound to a facade collaborator.
 
     ``cap = extractor._capture`` followed by ``patch.object(cap, ...)`` is the
     same reach-through written over two statements, and without the alias the
-    patch lands on a bare local the reader cannot place. Collected over the
-    whole body like ``_extractor_bindings``, so a rebinding later in the
-    function is not tracked; the map is only ever consulted after every other
-    binding kind has been ruled out.
+    patch lands on a bare local the reader cannot place. Read in source order
+    with the branch merging the class suites already use, because a map
+    collected over the whole body at once keeps answering ``_capture`` for a
+    ``cap`` that a later statement rebound. That error runs the other way from
+    the fail-open holes: it reports a foreign object as a collaborator seam, or
+    refuses it as an unknown one, and a false failure here blocks every later
+    stage. Where a rebinding depends on a branch no single answer fits, so the
+    name becomes ambiguous rather than keeping the stale one.
     """
 
-    aliases: dict[str, str] = {}
-    for statement in node.body:
-        for item in (statement, *_walk_scope(statement)):
-            if not isinstance(item, (ast.Assign, ast.AnnAssign)):
-                continue
-            value = item.value
-            if not (
-                isinstance(value, ast.Attribute)
-                and isinstance(value.value, ast.Name)
-                and value.value.id in facade_names
-                and value.attr in _FACADE_COLLABORATORS
+    def __init__(self, path: Path, facade_names: set[str]) -> None:
+        self.path = path
+        self.facade_names = facade_names
+        self.aliases: dict[str, str] = {}
+        self.ambiguous: set[str] = set()
+        self.resolved: dict[int, str] = {}
+        self.unresolved: set[int] = set()
+
+    def _state(self) -> tuple[dict[str, str], set[str]]:
+        return (dict(self.aliases), set(self.ambiguous))
+
+    def _restore(self, state: tuple[dict[str, str], set[str]]) -> None:
+        self.aliases = dict(state[0])
+        self.ambiguous = set(state[1])
+
+    def _merge(self, states: list[tuple[dict[str, str], set[str]]]) -> None:
+        names = set().union(*(set(state[0]) | state[1] for state in states))
+        self.aliases = {}
+        self.ambiguous = set()
+        for name in names:
+            answers = {state[0].get(name) for state in states}
+            answer = next(iter(answers))
+            if (
+                len(answers) == 1
+                and answer is not None
+                and not any(name in state[1] for state in states)
             ):
+                self.aliases[name] = answer
+            else:
+                self.ambiguous.add(name)
+
+    def _forget(self, names: set[str]) -> None:
+        for name in names:
+            self.aliases.pop(name, None)
+            self.ambiguous.discard(name)
+
+    def _bind_target(self, target: ast.expr) -> None:
+        self._forget(
+            {
+                item.id
+                for item in ast.walk(target)
+                if isinstance(item, ast.Name) and isinstance(item.ctx, ast.Store)
+            }
+        )
+
+    def _collaborator_attribute(self, value: ast.expr | None) -> str | None:
+        # A walrus names the same object it evaluates to, so the binding it
+        # makes on the way past does not change what the outer name receives.
+        while isinstance(value, ast.NamedExpr):
+            value = value.value
+        if (
+            isinstance(value, ast.Attribute)
+            and isinstance(value.value, ast.Name)
+            and value.value.id in self.facade_names
+            and value.attr in _FACADE_COLLABORATORS
+        ):
+            return value.attr
+        return None
+
+    def _assign(self, name: str, value: ast.expr | None) -> None:
+        attribute = self._collaborator_attribute(value)
+        if attribute is None:
+            self._forget({name})
+            return
+        self.ambiguous.discard(name)
+        self.aliases[name] = attribute
+
+    @staticmethod
+    def _nested_scope_names(node: ast.AST) -> set[str]:
+        """Name what an expression binds in a scope of its own."""
+
+        names: set[str] = set()
+        for item in ast.walk(node):
+            if isinstance(item, ast.Lambda):
+                names.update(_argument_names(item.args))
+            elif isinstance(
+                item, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)
+            ):
+                for generator in item.generators:
+                    names.update(
+                        target.id
+                        for target in ast.walk(generator.target)
+                        if isinstance(target, ast.Name)
+                    )
+        return names
+
+    def _record(self, node: ast.AST | None) -> None:
+        """Answer every name read inside one expression from the state so far.
+
+        The last answer wins, so a second reading of a loop body overwrites the
+        first rather than leaving both on the record.
+        """
+
+        if node is None:
+            return
+        shadowed = self._nested_scope_names(node)
+        for item in ast.walk(node):
+            if not (isinstance(item, ast.Name) and isinstance(item.ctx, ast.Load)):
                 continue
-            targets = item.targets if isinstance(item, ast.Assign) else [item.target]
-            aliases.update(
-                (target.id, value.attr)
-                for target in targets
-                if isinstance(target, ast.Name)
-            )
-    return aliases
+            alias = None if item.id in shadowed else self.aliases.get(item.id)
+            if alias is not None:
+                self.resolved[id(item)] = alias
+                self.unresolved.discard(id(item))
+                continue
+            self.resolved.pop(id(item), None)
+            if item.id in self.ambiguous and item.id not in shadowed:
+                self.unresolved.add(id(item))
+            else:
+                self.unresolved.discard(id(item))
+        for item in ast.walk(node):
+            if isinstance(item, ast.NamedExpr) and isinstance(item.target, ast.Name):
+                self._assign(item.target.id, item.value)
+
+    def _bind(self, statement: ast.stmt) -> None:
+        collector = _LocalBindingCollector(self.path)
+        collector.visit(statement)
+        # A walrus binds while the statement's own expressions are read, so
+        # `_record` has already answered it; forgetting it again here would
+        # retire the alias it just made.
+        walrus = {
+            item.target.id
+            for item in ast.walk(statement)
+            if isinstance(item, ast.NamedExpr) and isinstance(item.target, ast.Name)
+        }
+        self._forget(
+            (collector.bindings | collector.globals | collector.nonlocals) - walrus
+        )
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            return
+        targets = (
+            statement.targets
+            if isinstance(statement, ast.Assign)
+            else [statement.target]
+        )
+        for target in targets:
+            if isinstance(target, ast.Name):
+                self._assign(target.id, statement.value)
+
+    def visit_body(self, statements: list[ast.stmt]) -> None:
+        for statement in statements:
+            self.visit(statement)
+
+    def visit(self, statement: ast.stmt) -> None:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            self._visit_function(statement)
+        elif isinstance(statement, ast.ClassDef):
+            self._visit_class(statement)
+        elif isinstance(statement, ast.If):
+            self._visit_if(statement)
+        elif isinstance(statement, (ast.Try, ast.TryStar)):
+            self._visit_try(statement)
+        elif isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):
+            self._visit_loop(statement)
+        elif isinstance(statement, ast.Match):
+            self._visit_match(statement)
+        elif isinstance(statement, (ast.With, ast.AsyncWith)):
+            self._visit_with(statement)
+        else:
+            self._record(statement)
+            self._bind(statement)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        for expression in (
+            *node.decorator_list,
+            *_signature_expressions(node.args),
+            node.returns,
+        ):
+            self._record(expression)
+        # A closure is read against the bindings its definition saw, the same
+        # snapshot the scanner's own frames take.
+        state = self._state()
+        self._forget(_function_shadowed_names(self.path, node))
+        self.visit_body(node.body)
+        self._restore(state)
+        self._forget({node.name})
+
+    def _visit_class(self, node: ast.ClassDef) -> None:
+        for expression in (
+            *node.decorator_list,
+            *node.bases,
+            *(keyword.value for keyword in node.keywords),
+        ):
+            self._record(expression)
+        state = self._state()
+        self.visit_body(node.body)
+        self._restore(state)
+        self._forget({node.name})
+
+    def _visit_if(self, node: ast.If) -> None:
+        self._record(node.test)
+        if isinstance(node.test, ast.Constant) and isinstance(node.test.value, bool):
+            self.visit_body(node.body if node.test.value else node.orelse)
+            return
+        before = self._state()
+        states: list[tuple[dict[str, str], set[str]]] = []
+        for statements in (node.body, node.orelse):
+            self._restore(before)
+            self.visit_body(statements)
+            states.append(self._state())
+        self._merge(states)
+
+    def _visit_handler(self, handler: ast.ExceptHandler) -> None:
+        self._record(handler.type)
+        if handler.name:
+            self._forget({handler.name})
+        self.visit_body(handler.body)
+        if handler.name:
+            self._forget({handler.name})
+
+    def _visit_try(self, node: ast.Try | ast.TryStar) -> None:
+        outcome, handler_index = _static_try_outcome(node)
+        before = self._state()
+        if outcome == "normal":
+            self.visit_body(node.body)
+            self.visit_body(node.orelse)
+        elif outcome == "handler" and handler_index is not None:
+            self.visit_body(node.body)
+            self._visit_handler(node.handlers[handler_index])
+        else:
+            states: list[tuple[dict[str, str], set[str]]] = []
+            self.visit_body(node.body)
+            self.visit_body(node.orelse)
+            states.append(self._state())
+            for handler in node.handlers:
+                self._restore(before)
+                self._visit_handler(handler)
+                states.append(self._state())
+            self._merge(states)
+        self.visit_body(node.finalbody)
+
+    def _visit_loop(self, node: ast.For | ast.AsyncFor | ast.While) -> None:
+        # The body may run zero times or many, so its second reading starts
+        # from the entry state merged with whatever one iteration leaves. A
+        # single replay reaches the fixed point: a name the two readings
+        # disagree on is already ambiguous, and ambiguity is the top here.
+        if isinstance(node, ast.While):
+            self._record(node.test)
+        else:
+            self._record(node.iter)
+            self._bind_target(node.target)
+        entry = self._state()
+        self.visit_body(node.body)
+        self._merge([self._state(), entry])
+        replayed = self._state()
+        self.visit_body(node.body)
+        self._merge([self._state(), replayed])
+        self.visit_body(node.orelse)
+
+    def _visit_match(self, node: ast.Match) -> None:
+        self._record(node.subject)
+        before = self._state()
+        # No case has to match, so falling through is one of the outcomes.
+        states = [before]
+        for case in node.cases:
+            self._restore(before)
+            self._forget(_pattern_names(case.pattern))
+            self._record(case.guard)
+            self.visit_body(case.body)
+            states.append(self._state())
+        self._merge(states)
+
+    def _visit_with(self, node: ast.With | ast.AsyncWith) -> None:
+        for item in node.items:
+            self._record(item.context_expr)
+            if item.optional_vars is not None:
+                self._bind_target(item.optional_vars)
+        self.visit_body(node.body)
+
+
+def _collaborator_aliases(
+    path: Path,
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    facade_names: set[str],
+) -> tuple[dict[int, str], set[int]]:
+    """Resolve every use of a local name bound to a facade collaborator."""
+
+    collector = _CollaboratorAliasCollector(path, facade_names)
+    collector.visit_body(node.body)
+    return (collector.resolved, collector.unresolved)
 
 
 class _CalledMethodCollector(ast.NodeVisitor):
@@ -1309,6 +1617,9 @@ class Scanner(ast.NodeVisitor):
             _EXPLICIT_INSTANCE_BINDINGS.get((self.relative_path, node.name), ())
         )
         instance_names.difference_update(collector.globals)
+        aliases, ambiguous_aliases = _collaborator_aliases(
+            self.path, node, instance_names | class_names
+        )
         self.functions.append(node)
         self.frames.append(
             _ScopeFrame(
@@ -1319,9 +1630,8 @@ class Scanner(ast.NodeVisitor):
                 closure_module_names=set(module_names),
                 closure_class_names=set(class_names),
                 closure_instance_names=set(instance_names),
-                collaborator_aliases=_collaborator_aliases(
-                    node, instance_names | class_names
-                ),
+                collaborator_aliases=aliases,
+                ambiguous_aliases=ambiguous_aliases,
             )
         )
         for statement in node.body:
@@ -1477,6 +1787,7 @@ class Scanner(ast.NodeVisitor):
             closure_instance_names=set(frame.closure_instance_names),
             ambiguous_names=set(frame.ambiguous_names),
             collaborator_aliases=dict(frame.collaborator_aliases),
+            ambiguous_aliases=set(frame.ambiguous_aliases),
         )
 
     def _visit_class_suite(self, statements: list[ast.stmt]) -> None:
@@ -1974,26 +2285,29 @@ class Scanner(ast.NodeVisitor):
         target reaches the extractor, so the breadth costs nothing.
         """
 
-        if not node.args:
+        target, name = _setattr_arguments(node)
+        if target is None:
+            # Neither end of the replacement is readable, so there is nothing
+            # to scope against the extractor and a skip would be
+            # indistinguishable from a patch that intercepts nothing. Measured
+            # over every `setattr` site in the tree: none reaches this, the
+            # same answer the `patch.object` refusal got.
+            self._error(node, ast.unparse(node), "unresolved setattr arguments")
             return
-        target = node.args[0]
         if (
             isinstance(target, ast.Constant)
             and isinstance(target.value, str)
             and target.value.startswith(EXTRACTOR_MODULE + ".")
         ):
+            # A dotted import string holds the member name itself, so this
+            # resolves whether or not the call passed a separate one.
             self._string_patch(node, target.value)
             return
-        if len(node.args) < 2:
-            return
-        attribute = node.args[1]
-        if not (
-            isinstance(attribute, ast.Constant) and isinstance(attribute.value, str)
-        ):
+        if not (isinstance(name, ast.Constant) and isinstance(name.value, str)):
             self._refuse_unresolved_target(node, target, "setattr")
             return
         self._suppress_module_attributes(target)
-        self._replacement(node, target, attribute.value, "setattr")
+        self._replacement(node, target, name.value, "setattr")
 
     def visit_Assign(self, node: ast.Assign) -> Any:
         for target in node.targets:
@@ -2001,7 +2315,19 @@ class Scanner(ast.NodeVisitor):
                 self._assigned_replacement(node, target)
         self.generic_visit(node)
 
-    def _assigned_replacement(self, node: ast.Assign, target: ast.Attribute) -> None:
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> Any:
+        # `owner.name: T = replacement` replaces the member exactly as the
+        # unannotated form does, and skipping it left the member name
+        # uninventoried while the reach-through above it was recorded. The
+        # annotation-only `owner.name: T` binds nothing, so it replaces
+        # nothing and must not be read as a patch.
+        if node.value is not None and isinstance(node.target, ast.Attribute):
+            self._assigned_replacement(node, node.target)
+        self.generic_visit(node)
+
+    def _assigned_replacement(
+        self, node: ast.Assign | ast.AnnAssign, target: ast.Attribute
+    ) -> None:
         """Inventory ``owner.name = replacement`` one level below the facade.
 
         An attribute assigned on the facade itself is already on the record
@@ -2017,6 +2343,13 @@ class Scanner(ast.NodeVisitor):
             or owner.id in self.class_names
             or owner.id in self.module_names
         ):
+            return
+        if self._ambiguous_collaborator_alias(owner):
+            self._error(
+                node,
+                ast.unparse(owner),
+                "ambiguous collaborator alias after conditional control flow",
+            )
             return
         collaborator = self._collaborator_reach(owner)
         if collaborator is not None:
@@ -2081,6 +2414,13 @@ class Scanner(ast.NodeVisitor):
                 node,
                 target.id,
                 "ambiguous extractor binding after conditional class control flow",
+            )
+            return
+        if self._ambiguous_collaborator_alias(target):
+            self._error(
+                node,
+                ast.unparse(target),
+                "ambiguous collaborator alias after conditional control flow",
             )
             return
         bindings = self.frames[-1].instance_names
@@ -2204,10 +2544,23 @@ class Scanner(ast.NodeVisitor):
             return target.attr
         if isinstance(target, ast.Name):
             for frame in reversed(self.frames):
-                alias = frame.collaborator_aliases.get(target.id)
+                alias = frame.collaborator_aliases.get(id(target))
                 if alias is not None:
                     return alias
         return None
+
+    def _ambiguous_collaborator_alias(self, target: ast.expr) -> bool:
+        """Answer whether a local's collaborator binding depends on a branch.
+
+        A name that held the collaborator down one path and something else down
+        another fits no single answer, so resolving it either way would invent
+        one. Only a name already bound to a collaborator somewhere reaches this,
+        which is why the refusal needs no further scoping.
+        """
+
+        if not isinstance(target, ast.Name):
+            return False
+        return any(id(target) in frame.ambiguous_aliases for frame in self.frames)
 
     def _reaches_the_extractor(self, target: ast.expr) -> bool:
         """Answer whether an unreduced target still names the extractor.

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -725,16 +725,23 @@ def _setattr_arguments(node: ast.Call) -> tuple[ast.expr | None, ast.expr | None
     ``None`` for the target tells the caller to refuse rather than to skip; a
     missing name is left to the caller because the two-argument
     ``setattr("dotted.path", value)`` form carries its member inside the
-    target and never has one.
+    target and never has one. A star after a readable first argument can hide
+    the member and value, but it cannot hide which object receives the patch.
     """
 
-    if any(keyword.arg is None for keyword in node.keywords) or any(
-        isinstance(argument, ast.Starred) for argument in node.args
-    ):
+    if any(keyword.arg is None for keyword in node.keywords):
         return (None, None)
     keywords = {keyword.arg: keyword.value for keyword in node.keywords}
-    target = node.args[0] if node.args else keywords.get("target")
-    name = node.args[1] if len(node.args) > 1 else keywords.get("name")
+    first = node.args[0] if node.args else None
+    target = first if first is not None and not isinstance(first, ast.Starred) else None
+    if not node.args:
+        target = keywords.get("target")
+    second = node.args[1] if len(node.args) > 1 else None
+    name = (
+        second if second is not None and not isinstance(second, ast.Starred) else None
+    )
+    if len(node.args) < 2:
+        name = keywords.get("name")
     return (target, name)
 
 
@@ -755,11 +762,12 @@ def _mentions_monkeypatch(expression: ast.expr) -> bool:
 class _MonkeyPatchCallCollector(ast.NodeVisitor):
     """Locate unreadable ``setattr`` calls on a live pytest patcher binding.
 
-    Receiver authority follows lexical scopes and statement order. That keeps
-    an alias in the scope where it was established, retires it when the same
-    target is rebound, and still lets an unshadowed outer alias reach a nested
-    function. Calls with readable targets do not need this evidence: the
-    extractor reachability checks scope those independently.
+    Receiver authority follows lexical scopes and reachable control-flow paths.
+    Branches start from the same incoming state and merge by union, so one live
+    path retains fail-closed authority while rebinding on every path retires it.
+    The closure state is merged alongside the current scope without turning a
+    class local into a method closure. Calls with readable targets do not need
+    this evidence: extractor reachability scopes those independently.
     """
 
     def __init__(self, path: Path) -> None:
@@ -768,6 +776,7 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         self.aliases = {"monkeypatch"}
         self.closure_aliases = set(self.aliases)
         self.scope_kinds = ["module"]
+        self.loop_break_states: list[list[tuple[set[str], set[str]]]] = []
 
     @staticmethod
     def _key(expression: ast.expr) -> str:
@@ -807,6 +816,45 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
         self.aliases.difference_update(names)
         if self.scope_kinds[-1] != "class":
             self.closure_aliases.difference_update(names)
+
+    def _state(self) -> tuple[set[str], set[str]]:
+        return (set(self.aliases), set(self.closure_aliases))
+
+    def _restore(self, state: tuple[set[str], set[str]]) -> None:
+        self.aliases = set(state[0])
+        self.closure_aliases = set(state[1])
+
+    @staticmethod
+    def _merge(
+        states: list[tuple[set[str], set[str]]],
+    ) -> tuple[set[str], set[str]]:
+        return (
+            set().union(*(state[0] for state in states)),
+            set().union(*(state[1] for state in states)),
+        )
+
+    def _visit_suite(
+        self, statements: list[ast.stmt]
+    ) -> list[tuple[set[str], set[str]]]:
+        states = [self._state()]
+        for statement in statements:
+            self.visit(statement)
+            states.append(self._state())
+        return states
+
+    def _visit_branches(
+        self,
+        initial: tuple[set[str], set[str]],
+        suites: list[list[ast.stmt]],
+        *,
+        include_initial: bool = False,
+    ) -> None:
+        states = [initial] if include_initial else []
+        for suite in suites:
+            self._restore(initial)
+            self._visit_suite(suite)
+            states.append(self._state())
+        self._restore(self._merge(states))
 
     def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         for decorator in node.decorator_list:
@@ -893,17 +941,140 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
     def visit_ImportFrom(self, node: ast.ImportFrom) -> Any:
         self._unbind({alias.asname or alias.name for alias in node.names})
 
+    def visit_If(self, node: ast.If) -> Any:
+        self.visit(node.test)
+        initial = self._state()
+        self._visit_branches(
+            initial,
+            [node.body, node.orelse],
+            include_initial=not node.orelse,
+        )
+
+    def _visit_try(self, node: ast.Try | ast.TryStar) -> None:
+        initial = self._state()
+        self._restore(initial)
+        body_states = self._visit_suite(node.body)
+        normal = self._state()
+        self._visit_suite(node.orelse)
+        continuing = [self._state()]
+        exception_entry = self._merge(body_states)
+
+        for handler in node.handlers:
+            self._restore(exception_entry)
+            if handler.type is not None:
+                self.visit(handler.type)
+            if handler.name is not None:
+                self._bind(ast.Name(id=handler.name, ctx=ast.Store()), False)
+            self._visit_suite(handler.body)
+            if handler.name is not None:
+                self._unbind({handler.name})
+            continuing.append(self._state())
+
+        merged = self._merge(continuing)
+        if not node.finalbody:
+            self._restore(merged)
+            return
+
+        self._restore(merged)
+        self._visit_suite(node.finalbody)
+        continuation = self._state()
+        exceptional = self._merge([exception_entry, normal])
+        self._restore(exceptional)
+        self._visit_suite(node.finalbody)
+        self._restore(continuation)
+
+    def visit_Try(self, node: ast.Try) -> Any:
+        self._visit_try(node)
+
+    def visit_TryStar(self, node: ast.TryStar) -> Any:
+        self._visit_try(node)
+
+    def _visit_loop(
+        self,
+        node: ast.For | ast.AsyncFor | ast.While,
+        initial: tuple[set[str], set[str]],
+    ) -> None:
+        head = initial
+        self.loop_break_states.append([])
+        while True:
+            self._restore(head)
+            if isinstance(node, ast.While):
+                self.visit(node.test)
+                iteration = self._state()
+            else:
+                self._bind(node.target, False)
+                iteration = self._state()
+            self._visit_suite(node.body)
+            widened = self._merge([initial, iteration, self._state()])
+            if widened == head:
+                break
+            head = widened
+
+        breaks = self.loop_break_states.pop()
+        self._restore(head)
+        if isinstance(node, ast.While):
+            self.visit(node.test)
+        self._visit_suite(node.orelse)
+        exits = [self._state(), *breaks]
+        self._restore(self._merge(exits))
+
+    def visit_Break(self, node: ast.Break) -> Any:
+        if self.loop_break_states:
+            self.loop_break_states[-1].append(self._state())
+
     def _visit_for(self, node: ast.For | ast.AsyncFor) -> None:
         self.visit(node.iter)
-        self._bind(node.target, False)
-        for statement in [*node.body, *node.orelse]:
-            self.visit(statement)
+        self._visit_loop(node, self._state())
 
     def visit_For(self, node: ast.For) -> Any:
         self._visit_for(node)
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> Any:
         self._visit_for(node)
+
+    def visit_While(self, node: ast.While) -> Any:
+        self._visit_loop(node, self._state())
+
+    @staticmethod
+    def _match_names(pattern: ast.pattern) -> set[str]:
+        names: set[str] = set()
+        for item in ast.walk(pattern):
+            if isinstance(item, ast.MatchAs) and item.name is not None:
+                names.add(item.name)
+            elif isinstance(item, ast.MatchStar) and item.name is not None:
+                names.add(item.name)
+            elif isinstance(item, ast.MatchMapping) and item.rest is not None:
+                names.add(item.rest)
+        return names
+
+    @classmethod
+    def _is_irrefutable(cls, pattern: ast.pattern) -> bool:
+        if isinstance(pattern, ast.MatchAs):
+            return pattern.pattern is None or cls._is_irrefutable(pattern.pattern)
+        if isinstance(pattern, ast.MatchOr):
+            return any(cls._is_irrefutable(item) for item in pattern.patterns)
+        return False
+
+    @classmethod
+    def _is_catch_all(cls, case: ast.match_case) -> bool:
+        return case.guard is None and cls._is_irrefutable(case.pattern)
+
+    def visit_Match(self, node: ast.Match) -> Any:
+        self.visit(node.subject)
+        initial = self._state()
+        authority = self._is_authority(node.subject)
+        states: list[tuple[set[str], set[str]]] = []
+        for case in node.cases:
+            self._restore(initial)
+            for name in self._match_names(case.pattern):
+                self._bind(ast.Name(id=name, ctx=ast.Store()), authority)
+            if case.guard is not None:
+                self.visit(case.guard)
+            self._visit_suite(case.body)
+            states.append(self._state())
+        if not node.cases or not self._is_catch_all(node.cases[-1]):
+            states.append(initial)
+        self._restore(self._merge(states))
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> Any:
         self.visit(node.value)

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import argparse
 import ast
+import builtins
 import json
 import sys
 
@@ -755,12 +756,19 @@ _MonkeyPatchState = tuple[set[str], set[str]]
 
 
 @dataclass(slots=True)
+class _ExceptionalState:
+    state: _MonkeyPatchState
+    # ``None`` is an exception whose runtime kind cannot be bounded from the AST.
+    kind: str | None
+
+
+@dataclass(slots=True)
 class _FlowResult:
     normal: list[_MonkeyPatchState] = field(default_factory=list)
     breaks: list[_MonkeyPatchState] = field(default_factory=list)
     continues: list[_MonkeyPatchState] = field(default_factory=list)
     returns: list[_MonkeyPatchState] = field(default_factory=list)
-    exceptional: list[_MonkeyPatchState] = field(default_factory=list)
+    exceptional: list[_ExceptionalState] = field(default_factory=list)
 
     def extend(self, other: _FlowResult) -> None:
         self.normal.extend(other.normal)
@@ -787,6 +795,103 @@ def _mentions_monkeypatch(expression: ast.expr) -> bool:
         or (isinstance(item, ast.Attribute) and item.attr in _MONKEYPATCH_NAMES)
         for item in ast.walk(expression)
     )
+
+
+def _exception_type_name(expression: ast.expr) -> str | None:
+    if isinstance(expression, ast.Name):
+        return expression.id
+    if isinstance(expression, ast.Attribute):
+        return expression.attr
+    return None
+
+
+def _non_raising_binding_value(value: ast.expr) -> bool:
+    if isinstance(value, (ast.Name, ast.Constant)):
+        return True
+    if isinstance(value, (ast.Tuple, ast.List)):
+        return all(
+            not isinstance(item, ast.Starred) and _non_raising_binding_value(item)
+            for item in value.elts
+        )
+    return False
+
+
+def _non_raising_assignment(target: ast.expr, value: ast.expr) -> bool:
+    if isinstance(target, ast.Name):
+        return _non_raising_binding_value(value)
+    if not (
+        isinstance(target, (ast.Tuple, ast.List))
+        and isinstance(value, (ast.Tuple, ast.List))
+        and len(target.elts) == len(value.elts)
+        and not any(isinstance(item, ast.Starred) for item in target.elts)
+        and not any(isinstance(item, ast.Starred) for item in value.elts)
+    ):
+        return False
+    return all(
+        _non_raising_assignment(target_item, value_item)
+        for target_item, value_item in zip(target.elts, value.elts, strict=True)
+    )
+
+
+def _may_raise_implicitly(statement: ast.stmt) -> bool:
+    if isinstance(statement, (ast.Raise, ast.Pass, ast.Break, ast.Continue)):
+        return False
+    if isinstance(statement, ast.Assign):
+        return not all(
+            _non_raising_assignment(target, statement.value)
+            for target in statement.targets
+        )
+    if isinstance(statement, ast.AnnAssign):
+        return not (
+            isinstance(statement.target, ast.Name)
+            and (statement.value is None or _non_raising_binding_value(statement.value))
+        )
+    return True
+
+
+def _handler_match(handler: ast.ExceptHandler, kind: str | None) -> bool | None:
+    """Return whether one bounded exception kind reaches ``handler``.
+
+    ``None`` means both outcomes remain possible. Explicit built-in raises can be
+    compared through Python's real exception hierarchy; project-local exception
+    classes stay conservative unless the spelling matches. A bare handler and
+    ``BaseException`` cover every raisable value, while ``Exception`` deliberately
+    leaves the non-``Exception`` branch of an unknown kind alive.
+    """
+
+    if handler.type is None:
+        return True
+    candidates = (
+        handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+    )
+    answers: list[bool | None] = []
+    for candidate in candidates:
+        candidate_name = _exception_type_name(candidate)
+        if candidate_name == "BaseException":
+            answers.append(True)
+            continue
+        if kind is None or candidate_name is None:
+            answers.append(None)
+            continue
+        if candidate_name == kind:
+            answers.append(True)
+            continue
+        raised_type = getattr(builtins, kind, None)
+        handled_type = getattr(builtins, candidate_name, None)
+        if (
+            isinstance(raised_type, type)
+            and issubclass(raised_type, BaseException)
+            and isinstance(handled_type, type)
+            and issubclass(handled_type, BaseException)
+        ):
+            answers.append(issubclass(raised_type, handled_type))
+        else:
+            answers.append(False if raised_type is not None else None)
+    if any(answer is True for answer in answers):
+        return True
+    if all(answer is False for answer in answers):
+        return False
+    return None
 
 
 class _MonkeyPatchCallCollector(ast.NodeVisitor):
@@ -819,11 +924,11 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
     @staticmethod
     def _targets(target: ast.expr) -> set[str]:
         if isinstance(target, (ast.Tuple, ast.List)):
-            return {
-                name
-                for item in target.elts
-                if (name := _MonkeyPatchCallCollector._key(item))
-            }
+            return set().union(
+                *(_MonkeyPatchCallCollector._targets(item) for item in target.elts)
+            )
+        if isinstance(target, ast.Starred):
+            return _MonkeyPatchCallCollector._targets(target.value)
         name = _MonkeyPatchCallCollector._key(target)
         return {name} if name else set()
 
@@ -838,11 +943,37 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
     def _bind(self, target: ast.expr, authority: bool) -> None:
         names = self._targets(target)
         self.aliases.difference_update(names)
-        if authority and isinstance(target, (ast.Name, ast.Attribute)):
+        if authority:
             self.aliases.update(names)
         if self.scope_kinds[-1] != "class":
             self.closure_aliases.difference_update(names)
             self.closure_aliases.update(self.aliases & names)
+
+    def _bind_assignment(self, target: ast.expr, value: ast.expr) -> None:
+        """Pair destructuring targets with their corresponding RHS values.
+
+        Exact tuple/list shapes retain element-level authority. Stars, arity
+        mismatches, and opaque RHS values cannot be paired, so every target that
+        could receive the authoritative value remains possible rather than
+        silently losing it. The exact case is what keeps unrelated siblings
+        definitely non-authoritative.
+        """
+
+        if isinstance(target, (ast.Tuple, ast.List)) and isinstance(
+            value, (ast.Tuple, ast.List)
+        ):
+            pairable = (
+                len(target.elts) == len(value.elts)
+                and not any(isinstance(item, ast.Starred) for item in target.elts)
+                and not any(isinstance(item, ast.Starred) for item in value.elts)
+            )
+            if pairable:
+                for target_item, value_item in zip(
+                    target.elts, value.elts, strict=True
+                ):
+                    self._bind_assignment(target_item, value_item)
+                return
+        self._bind(target, self._is_authority(value))
 
     def _unbind(self, names: set[str]) -> None:
         self.aliases.difference_update(names)
@@ -873,7 +1004,8 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
                 break
             prefix = self._state()
             flowed = self.visit(statement)
-            result.exceptional.append(prefix)
+            if _may_raise_implicitly(statement):
+                result.exceptional.append(_ExceptionalState(prefix, None))
             if not isinstance(flowed, _FlowResult):
                 continue
             result.breaks.extend(flowed.breaks)
@@ -991,9 +1123,8 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign) -> Any:
         self.visit(node.value)
-        authority = self._is_authority(node.value)
         for target in node.targets:
-            self._bind(target, authority)
+            self._bind_assignment(target, node.value)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> Any:
         if node.value is not None:
@@ -1037,16 +1168,32 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
             breaks=list(body.breaks),
             continues=list(body.continues),
             returns=list(body.returns),
-            exceptional=list(body.exceptional),
         )
 
         if body.normal:
             self._restore(self._merge(body.normal))
             result.extend(self._visit_suite(node.orelse))
 
-        handler_entry = self._merge(body.exceptional)
+        # Route each exceptional path through handlers in source order. A known
+        # matching kind is consumed and therefore cannot also enter ``finally``
+        # as the original exception. Unknown relationships branch conservatively:
+        # the handler may run, while the still-unmatched branch reaches the next
+        # handler (or finally).
+        unmatched = list(body.exceptional)
         for handler in node.handlers:
-            self._restore(handler_entry)
+            handler_inputs: list[_ExceptionalState] = []
+            still_unmatched: list[_ExceptionalState] = []
+            for exceptional in unmatched:
+                match = _handler_match(handler, exceptional.kind)
+                if match is not False:
+                    handler_inputs.append(exceptional)
+                if match is not True:
+                    still_unmatched.append(exceptional)
+            unmatched = still_unmatched
+            if not handler_inputs:
+                continue
+
+            self._restore(self._merge([item.state for item in handler_inputs]))
             if handler.type is not None:
                 self.visit(handler.type)
             if handler.name is not None:
@@ -1057,14 +1204,19 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
                 handled.breaks,
                 handled.continues,
                 handled.returns,
-                handled.exceptional,
             ):
                 for index, state in enumerate(states):
                     self._restore(state)
                     if handler.name is not None:
                         self._unbind({handler.name})
                     states[index] = self._state()
+            for exceptional in handled.exceptional:
+                self._restore(exceptional.state)
+                if handler.name is not None:
+                    self._unbind({handler.name})
+                exceptional.state = self._state()
             result.extend(handled)
+        result.exceptional.extend(unmatched)
 
         if not node.finalbody:
             if result.normal:
@@ -1077,7 +1229,6 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
             (result.breaks, "break"),
             (result.continues, "continue"),
             (result.returns, "return"),
-            (result.exceptional, "exceptional"),
         ):
             if not states:
                 continue
@@ -1093,10 +1244,23 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
                 finished.breaks.extend(final.normal)
             elif continuation == "continue":
                 finished.continues.extend(final.normal)
-            elif continuation == "return":
-                finished.returns.extend(final.normal)
             else:
-                finished.exceptional.extend(final.normal)
+                finished.returns.extend(final.normal)
+
+        if result.exceptional:
+            self._restore(
+                self._merge([exceptional.state for exceptional in result.exceptional])
+            )
+            final = self._visit_suite(node.finalbody)
+            finished.breaks.extend(final.breaks)
+            finished.continues.extend(final.continues)
+            finished.returns.extend(final.returns)
+            finished.exceptional.extend(final.exceptional)
+            kinds = {exceptional.kind for exceptional in result.exceptional}
+            for state in final.normal:
+                finished.exceptional.extend(
+                    _ExceptionalState(state, kind) for kind in kinds
+                )
         if finished.normal:
             self._restore(self._merge(finished.normal))
         return finished
@@ -1152,7 +1316,9 @@ class _MonkeyPatchCallCollector(ast.NodeVisitor):
             self.visit(node.exc)
         if node.cause is not None:
             self.visit(node.cause)
-        return _FlowResult(exceptional=[self._state()])
+        return _FlowResult(
+            exceptional=[_ExceptionalState(self._state(), _raised_exception_name(node))]
+        )
 
     def visit_Return(self, node: ast.Return) -> Any:
         if node.value is not None:

--- a/tests/fixtures/scraping-policy/migration-manifest.json
+++ b/tests/fixtures/scraping-policy/migration-manifest.json
@@ -1110,15 +1110,15 @@
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
       "line": 629,
-      "migration_stage": 11,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "job_pages.JobPageReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 630,
-      "migration_stage": 11,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -1331,7 +1331,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 921,
       "migration_stage": 6,
@@ -1363,7 +1363,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 948,
       "migration_stage": 6,
@@ -1395,7 +1395,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 983,
       "migration_stage": 6,
@@ -1435,7 +1435,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1029,
       "migration_stage": 6,
@@ -1499,7 +1499,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1109,
       "migration_stage": 6,
@@ -1531,7 +1531,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1153,
       "migration_stage": 6,
@@ -1563,7 +1563,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1195,
       "migration_stage": 6,
@@ -1595,7 +1595,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1221,
       "migration_stage": 6,
@@ -1627,7 +1627,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1247,
       "migration_stage": 6,
@@ -1659,7 +1659,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1273,
       "migration_stage": 6,
@@ -1691,7 +1691,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 1299,
       "migration_stage": 6,
@@ -2299,7 +2299,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 2292,
       "migration_stage": 6,
@@ -2339,7 +2339,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 2333,
       "migration_stage": 6,
@@ -2371,7 +2371,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 2378,
       "migration_stage": 6,
@@ -2427,7 +2427,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 2442,
       "migration_stage": 6,
@@ -2510,15 +2510,15 @@
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
       "line": 2582,
-      "migration_stage": 11,
+      "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "company.CompanyScraper -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 2583,
-      "migration_stage": 11,
+      "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -2678,15 +2678,15 @@
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
       "line": 2860,
-      "migration_stage": 11,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "jobs.JobScraper -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 2861,
-      "migration_stage": 11,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -2830,15 +2830,15 @@
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
       "line": 3113,
-      "migration_stage": 11,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "jobs.JobScraper -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 3114,
-      "migration_stage": 11,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -3878,15 +3878,15 @@
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
       "line": 4547,
-      "migration_stage": 11,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "job_pages.JobPageReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 4548,
-      "migration_stage": 11,
+      "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_content"
     },
@@ -4531,7 +4531,7 @@
       "target": "_extract_overlay"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 5506,
       "migration_stage": 6,
@@ -4595,7 +4595,7 @@
       "target": "_extract_loaded_section"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 5618,
       "migration_stage": 6,
@@ -4635,7 +4635,7 @@
       "target": "_extract_loaded_section"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 5655,
       "migration_stage": 6,
@@ -4659,7 +4659,7 @@
       "target": "_extract_loaded_section"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._capture",
+      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
       "kind": "private_facade_access",
       "line": 5677,
       "migration_stage": 6,
@@ -4939,7 +4939,7 @@
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6254,
       "migration_stage": 11,
@@ -5011,7 +5011,7 @@
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6301,
       "migration_stage": 11,
@@ -5075,7 +5075,7 @@
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6353,
       "migration_stage": 11,
@@ -5147,7 +5147,7 @@
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6406,
       "migration_stage": 11,
@@ -5211,7 +5211,7 @@
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6452,
       "migration_stage": 11,
@@ -5283,7 +5283,7 @@
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6507,
       "migration_stage": 11,
@@ -5363,7 +5363,7 @@
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6565,
       "migration_stage": 11,
@@ -5667,7 +5667,7 @@
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6861,
       "migration_stage": 11,
@@ -5731,7 +5731,7 @@
       "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._content",
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
       "line": 6921,
       "migration_stage": 11,

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import json
 import logging
+import re
 import subprocess
 import sys
 
@@ -1645,6 +1646,14 @@ async def test_shape(page, replacement, monkeypatch, arguments, pair, thing, fla
             r"monkeypatch\.setattr\(\*\*arguments\): unresolved setattr arguments",
         ),
         (
+            "setattr(*arguments)",
+            r"setattr\(\*arguments\): unresolved setattr arguments",
+        ),
+        (
+            "setattr(**arguments)",
+            r"setattr\(\*\*arguments\): unresolved setattr arguments",
+        ),
+        (
             "monkeypatch.setattr(extractor._capture)",
             r"extractor\._capture: unresolved setattr target",
         ),
@@ -1667,6 +1676,84 @@ def test_unresolvable_replacement_targets_name_their_call_site(statement, messag
         migration.UnresolvedSeamError, match=rf"synthetic_inventory\.py:7 .*{message}"
     ):
         _scan_synthetic(_reach_through(statement))
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "helper.setattr(*arguments)",
+        "helper.setattr(**arguments)",
+        "helper.setattr()",
+        "self.helper.setattr(*arguments)",
+        "helpers[0].setattr(*arguments)",
+    ],
+)
+def test_a_foreign_setattr_receiver_keeps_its_dynamic_shape(statement):
+    # `setattr` is an ordinary method name and the tree holds about 1873 calls
+    # to one. Refusing every dynamic shape ahead of any scoping fails the
+    # checker on a receiver that cannot reach the extractor at all, and this
+    # guard gates every remaining stage of the decomposition. Nothing is
+    # recorded either, because nothing was resolved.
+    seams = _scan_synthetic(_reach_through(statement))
+
+    assert not [seam for seam in seams if seam.kind.endswith("_patch_object")]
+
+
+def _fixture_alias(binding: str, call: str) -> str:
+    """A workflow test that patches through a fixture under another name."""
+
+    return f"""
+import pytest
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+
+async def test_shape(page, arguments{binding}):
+    extractor = LinkedInExtractor(page)
+    {call}
+    await extractor.scrape_person("ada")
+"""
+
+
+@pytest.mark.parametrize(
+    ("binding", "call", "line", "receiver"),
+    [
+        ("", "monkeypatch.setattr(*arguments)", 7, "monkeypatch"),
+        (
+            "",
+            "with pytest.MonkeyPatch.context() as patching:\n"
+            "        patching.setattr(*arguments)",
+            8,
+            "patching",
+        ),
+        (
+            ", patcher: pytest.MonkeyPatch",
+            "patcher.setattr(*arguments)",
+            7,
+            "patcher",
+        ),
+        ("", "mp = monkeypatch\n    mp.setattr(*arguments)", 8, "mp"),
+        (
+            "",
+            "self.patcher = pytest.MonkeyPatch()\n    self.patcher.setattr(*arguments)",
+            8,
+            "self.patcher",
+        ),
+    ],
+)
+def test_an_unreadable_setattr_through_the_fixture_names_its_call_site(
+    binding, call, line, receiver
+):
+    # The fixture is the one receiver whose `setattr` routinely lands on the
+    # extractor, and it is routinely bound to another name: a private context
+    # manager, an annotated parameter, a plain alias. Testing the receiver
+    # against the literal `monkeypatch` would skip exactly those, so the names
+    # the fixture is bound to in the file are collected first.
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=rf"synthetic_inventory\.py:{line} "
+        rf"{re.escape(receiver)}\.setattr\(\*arguments\): "
+        r"unresolved setattr arguments",
+    ):
+        _scan_synthetic(_fixture_alias(binding, call))
 
 
 @pytest.mark.parametrize(

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1685,7 +1685,6 @@ def test_unresolvable_replacement_targets_name_their_call_site(statement, messag
         "helper.setattr(**arguments)",
         "helper.setattr()",
         "self.helper.setattr(*arguments)",
-        "helpers[0].setattr(*arguments)",
     ],
 )
 def test_a_foreign_setattr_receiver_keeps_its_dynamic_shape(statement):
@@ -1788,24 +1787,39 @@ def test_unpairable_destructuring_without_authority_stays_non_authoritative():
     assert _scan_synthetic(source) == []
 
 
-def test_destructuring_preserves_subscript_receiver_authority():
-    _assert_authoritative_receiver(
-        "slots[0], other = monkeypatch, helper", receiver="slots[0]"
-    )
+@pytest.mark.parametrize(
+    "statements",
+    [
+        "slots[0] = monkeypatch\n    slots[0] = helper",
+        "slots[0] = monkeypatch\n    alias = slots",
+        "slots[0] = monkeypatch\n    slots = value",
+        "slots[0], slots[1] = helper, monkeypatch",
+    ],
+)
+def test_subscript_receivers_fail_closed_without_textual_authority(statements):
+    receiver = "alias[0]" if "alias = slots" in statements else "slots[0]"
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=rf"{re.escape(receiver)}\.setattr\(\*arguments\): "
+        r"unresolved setattr arguments",
+    ):
+        _scan_synthetic(_receiver_flow(statements, receiver=receiver))
 
 
-def test_starred_destructuring_preserves_possible_subscript_authority():
-    _assert_authoritative_receiver(
-        "slots[0], *slots[1] = (monkeypatch, helper)", receiver="slots[0]"
-    )
+def test_subscript_receiver_in_a_closure_fails_closed():
+    source = """
+async def test_outer(monkeypatch, helper, arguments, slots):
+    slots[0] = helper
 
+    async def test_inner():
+        slots[0].setattr(*arguments)
+"""
 
-def test_exact_destructuring_keeps_unrelated_subscript_non_authoritative():
-    source = _receiver_flow(
-        "slots[0], slots[1] = helper, monkeypatch", receiver="slots[0]"
-    )
-
-    assert _scan_synthetic(source) == []
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"slots\[0\]\.setattr\(\*arguments\): unresolved setattr arguments",
+    ):
+        _scan_synthetic(source)
 
 
 def test_a_context_alias_does_not_leak_into_a_sibling_scope():
@@ -2092,8 +2106,8 @@ def test_finally_ignores_definitely_retired_else_and_handler_states(suite):
     assert _scan_synthetic(_receiver_flow(statements)) == []
 
 
-def test_trystar_keeps_later_authoritative_group_handlers_reachable():
-    _assert_authoritative_receiver(
+def test_trystar_consumes_a_known_lone_exception_at_the_first_match():
+    source = _receiver_flow(
         "patch = helper\n"
         "    try:\n"
         "        raise RuntimeError\n"
@@ -2104,6 +2118,82 @@ def test_trystar_keeps_later_authoritative_group_handlers_reachable():
         "    finally:\n"
         "        patch.setattr(*arguments)"
     )
+
+    assert _scan_synthetic(source) == []
+
+
+def test_trystar_keeps_group_member_matching_unknown():
+    _assert_authoritative_receiver(
+        "patch = helper\n"
+        "    try:\n"
+        '        raise ExceptionGroup("group", [RuntimeError()])\n'
+        "    except* RuntimeError:\n"
+        "        patch = helper\n"
+        "    except* Exception:\n"
+        "        patch = monkeypatch\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+def test_trystar_does_not_match_members_from_the_group_class_identity():
+    _assert_authoritative_receiver(
+        "patch = helper\n"
+        "    try:\n"
+        '        raise BaseExceptionGroup("group", [RuntimeError()])\n'
+        "    except* BaseExceptionGroup:\n"
+        "        patch = helper\n"
+        "    except* BaseException:\n"
+        "        patch = monkeypatch\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+def test_trystar_routes_only_remaining_lone_exceptions_to_later_handlers():
+    source = _receiver_flow(
+        "patch = helper\n"
+        "    try:\n"
+        "        raise RuntimeError\n"
+        "    except* TypeError:\n"
+        "        patch = monkeypatch\n"
+        "    except* RuntimeError:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+def test_trystar_unknown_groups_retain_handled_and_unmatched_paths():
+    _assert_authoritative_receiver(
+        "patch = helper\n"
+        "    try:\n"
+        "        raise error\n"
+        "    except* RuntimeError:\n"
+        "        patch = helper\n"
+        "    except* Exception:\n"
+        "        patch = monkeypatch\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+def test_trystar_base_exception_consumes_unknown_ordinary_exceptions():
+    source = _receiver_flow(
+        "patch = helper\n"
+        "    try:\n"
+        "        raise error\n"
+        "    except* BaseException:\n"
+        "        patch = helper\n"
+        "    except* Exception:\n"
+        "        patch = monkeypatch\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
 
 
 def test_trystar_without_any_authoritative_path_stays_non_authoritative():
@@ -2198,6 +2288,88 @@ def test_matching_handlers_consume_a_known_raise_before_finally(handler):
     assert _scan_synthetic(source) == []
 
 
+def test_builtin_exception_keyword_call_retains_its_type_error_prefix():
+    source = _receiver_flow(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        '        raise RuntimeError(message="failure")\n'
+        "    except TypeError:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+def test_bound_parameter_in_exception_call_creates_no_impossible_prefix():
+    source = _receiver_flow(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        "        raise RuntimeError(arguments)\n"
+        "    except RuntimeError:\n"
+        "        patch = helper\n"
+        "    except TypeError:\n"
+        "        patch = monkeypatch\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+@pytest.mark.parametrize(
+    "binding",
+    [
+        "message = arguments",
+        "import types as message",
+        "message = helper\n    message = arguments",
+    ],
+)
+def test_safe_name_bindings_survive_sequential_assignment_and_import(binding):
+    source = _receiver_flow(
+        f"patch = monkeypatch\n    {binding}\n"
+        "    try:\n"
+        "        raise RuntimeError(message)\n"
+        "    except RuntimeError:\n"
+        "        patch = helper\n"
+        "    except (NameError, TypeError):\n"
+        "        patch = monkeypatch\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+def test_deleted_safe_name_restores_the_evaluation_prefix():
+    _assert_authoritative_receiver(
+        "patch = monkeypatch\n"
+        "    message = arguments\n"
+        "    del message\n"
+        "    try:\n"
+        "        raise RuntimeError(message)\n"
+        "    except RuntimeError:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+def test_safe_name_branch_merges_by_intersection():
+    _assert_authoritative_receiver(
+        "patch = monkeypatch\n"
+        "    if flag:\n"
+        "        message = arguments\n"
+        "    try:\n"
+        "        raise RuntimeError(message)\n"
+        "    except RuntimeError:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
 def test_an_unmatched_known_raise_still_reaches_finally():
     _assert_authoritative_receiver(
         "patch = monkeypatch\n"
@@ -2279,8 +2451,8 @@ def test_a_bare_handler_consumes_an_unknown_exception_kind():
     assert _scan_synthetic(source) == []
 
 
-def test_named_catch_all_retains_an_unknown_exception_identity():
-    _assert_authoritative_receiver(
+def test_unshadowed_base_exception_consumes_an_unknown_ordinary_exception():
+    source = _receiver_flow(
         "patch = monkeypatch\n"
         "    try:\n"
         "        raise error\n"
@@ -2289,6 +2461,8 @@ def test_named_catch_all_retains_an_unknown_exception_identity():
         "    finally:\n"
         "        patch.setattr(*arguments)"
     )
+
+    assert _scan_synthetic(source) == []
 
 
 @pytest.mark.parametrize(
@@ -2314,21 +2488,52 @@ def test_uncertain_exception_spelling_does_not_consume_known_raise(
     )
 
 
-def test_explicit_unshadowed_builtins_qualification_consumes_known_raise():
+def test_class_local_exception_shadow_prevents_builtin_matching():
     source = """
-import builtins
-
 async def test_shape(monkeypatch, helper, arguments):
+    class Scope:
+        patch = monkeypatch
+        Exception = Sibling
+        try:
+            raise RuntimeError
+        except Exception:
+            patch = helper
+        finally:
+            patch.setattr(*arguments)
+"""
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"patch\.setattr\(\*arguments\): unresolved setattr arguments",
+    ):
+        _scan_synthetic(source)
+
+
+@pytest.mark.parametrize(
+    "import_statement",
+    [
+        "import builtins as bi",
+        "if flag:\n        import builtins as bi",
+    ],
+)
+def test_qualified_builtin_exception_identities_stay_unknown(import_statement):
+    source = f"""
+async def test_shape(monkeypatch, helper, arguments, flag):
     patch = monkeypatch
+    {import_statement}
     try:
-        raise builtins.RuntimeError
-    except builtins.Exception:
+        raise RuntimeError
+    except bi.Exception:
         patch = helper
     finally:
         patch.setattr(*arguments)
 """
 
-    assert _scan_synthetic(source) == []
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"patch\.setattr\(\*arguments\): unresolved setattr arguments",
+    ):
+        _scan_synthetic(source)
 
 
 def test_a_loop_retains_the_zero_iteration_receiver_path():

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1585,7 +1585,7 @@ def _reach_through(statement: str) -> str:
 from unittest.mock import patch
 from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
 
-async def test_shape(page, replacement, monkeypatch, arguments, pair, thing):
+async def test_shape(page, replacement, monkeypatch, arguments, pair, thing, flag):
     extractor = LinkedInExtractor(page)
     {statement}
     await extractor.scrape_person("ada")
@@ -1628,13 +1628,41 @@ async def test_shape(page, replacement, monkeypatch, arguments, pair, thing):
             "extractor._capture._reader.made_up = replacement",
             r"extractor\._capture\._reader: unresolved attribute assignment target",
         ),
+        (
+            "extractor._capture._reader.made_up: object = replacement",
+            r"extractor\._capture\._reader: unresolved attribute assignment target",
+        ),
+        (
+            "monkeypatch.setattr()",
+            r"monkeypatch\.setattr\(\): unresolved setattr arguments",
+        ),
+        (
+            "monkeypatch.setattr(*arguments)",
+            r"monkeypatch\.setattr\(\*arguments\): unresolved setattr arguments",
+        ),
+        (
+            "monkeypatch.setattr(**arguments)",
+            r"monkeypatch\.setattr\(\*\*arguments\): unresolved setattr arguments",
+        ),
+        (
+            "monkeypatch.setattr(extractor._capture)",
+            r"extractor\._capture: unresolved setattr target",
+        ),
+        (
+            "monkeypatch.setattr(target=extractor._capture, value=replacement)",
+            r"extractor\._capture: unresolved setattr target",
+        ),
     ],
 )
 def test_unresolvable_replacement_targets_name_their_call_site(statement, message):
     # Each of these replaces a name on something the reader cannot reduce to a
-    # collaborator, so nothing proves the patch intercepts the implementation.
-    # A chain of `if ...: return` blocks that simply ends answers "not a seam"
-    # to exactly that, which is indistinguishable from a foreign object.
+    # collaborator, or hides both ends of the replacement behind a shape it
+    # cannot take apart, so nothing proves the patch intercepts the
+    # implementation. A chain of `if ...: return` blocks that simply ends
+    # answers "not a seam" to exactly that, which is indistinguishable from a
+    # foreign object. The `setattr` arity gates were the last two such chains:
+    # both the keyword form and a call short of its member name walked past
+    # them without a word.
     with pytest.raises(
         migration.UnresolvedSeamError, match=rf"synthetic_inventory\.py:7 .*{message}"
     ):
@@ -1647,20 +1675,31 @@ def test_unresolvable_replacement_targets_name_their_call_site(statement, messag
         ('cap = extractor._capture\n    patch.object(cap, "{name}", replacement)', 8),
         ('patch.object(cap := extractor._capture, "{name}", replacement)', 7),
         (
+            '(cap := extractor._capture)\n    patch.object(cap, "{name}", replacement)',
+            8,
+        ),
+        (
             "patch.object(target=extractor._capture, "
             'attribute="{name}", new=replacement)',
             7,
         ),
         ('monkeypatch.setattr(extractor._capture, "{name}", replacement)', 7),
+        (
+            "monkeypatch.setattr(target=extractor._capture, "
+            'name="{name}", value=replacement)',
+            7,
+        ),
         ('setattr(extractor._capture, "{name}", replacement)', 7),
         ("extractor._capture.{name} = replacement", 7),
+        ("extractor._capture.{name}: object = replacement", 7),
     ],
 )
 def test_every_reach_through_shape_lands_on_the_collaborator(statement, line):
-    # An alias, a walrus, the keyword form and all three `setattr` spellings
-    # reach the same collaborator as `patch.object(extractor._capture, ...)`.
-    # A shape that produced no seam also produced no error, so a name that has
-    # never existed on `SectionCapture` read as a passing test.
+    # An alias, a walrus, both keyword forms, all three `setattr` spellings and
+    # an assignment with or without an annotation reach the same collaborator
+    # as `patch.object(extractor._capture, ...)`. A shape that produced no seam
+    # also produced no error, so a name that has never existed on
+    # `SectionCapture` read as a passing test.
     seams = _scan_synthetic(_reach_through(statement.format(name="_extract_overlay")))
 
     assert [
@@ -1675,6 +1714,99 @@ def test_every_reach_through_shape_lands_on_the_collaborator(statement, line):
         r"unknown capture\.SectionCapture patch",
     ):
         _scan_synthetic(_reach_through(statement.format(name="made_up")))
+
+
+def test_an_annotation_without_a_value_replaces_nothing():
+    # `owner.name: T` declares a type and assigns nothing, so there is no
+    # replacement to record and no member to validate. Reading it as a patch
+    # would refuse a name the file never claims exists, while the reach-through
+    # above it stays on the record either way.
+    seams = _scan_synthetic(_reach_through("extractor._capture.made_up: object"))
+
+    assert not [seam for seam in seams if seam.kind.endswith("_patch_object")]
+    assert [seam.target for seam in seams if seam.kind == "private_facade_access"] == [
+        "_capture"
+    ]
+
+
+@pytest.mark.parametrize(
+    "rebinding",
+    [
+        "cap = thing",
+        "cap, pair = thing",
+        "cap += thing",
+        "(cap := thing)",
+        "for cap in thing:\n        pass",
+        "with thing as cap:\n        pass",
+    ],
+)
+def test_a_rebound_alias_stops_naming_the_collaborator(rebinding):
+    # `cap` holds the reach-through only until the next binding, whichever
+    # spelling makes it. A map collected over the whole function keeps
+    # answering `_capture` for every later use, which books a patch on a
+    # foreign object as a `SectionCapture` seam and refuses an unknown member
+    # of it by name. That is the safer direction of the two, and still wrong:
+    # one false failure here blocks every stage behind it.
+    seams = _scan_synthetic(
+        _reach_through(
+            "cap = extractor._capture\n"
+            f"    {rebinding}\n"
+            '    patch.object(cap, "_extract_overlay", replacement)'
+        )
+    )
+
+    assert not [seam for seam in seams if seam.kind.endswith("_patch_object")]
+
+
+def test_an_alias_bound_after_a_foreign_one_still_resolves():
+    # The retirement has to follow the order the statements are written in
+    # rather than switch the alias off, or the shape that motivated the alias
+    # stops resolving along with the stale answer.
+    seams = _scan_synthetic(
+        _reach_through(
+            "cap = thing\n"
+            "    cap = extractor._capture\n"
+            '    patch.object(cap, "_extract_overlay", replacement)'
+        )
+    )
+
+    assert [
+        (seam.kind, seam.target, seam.canonical_owner, seam.migration_stage)
+        for seam in seams
+        if seam.kind.endswith("_patch_object")
+    ] == [("private_patch_object", "_extract_overlay", "capture.SectionCapture", 6)]
+
+
+@pytest.mark.parametrize(
+    ("statement", "line"),
+    [
+        (
+            "cap = extractor._capture\n"
+            "    if flag:\n"
+            "        cap = thing\n"
+            '    patch.object(cap, "_extract_overlay", replacement)',
+            10,
+        ),
+        (
+            "for item in thing:\n"
+            '        patch.object(cap, "_extract_overlay", replacement)\n'
+            "        cap = extractor._capture",
+            8,
+        ),
+    ],
+)
+def test_a_conditionally_rebound_alias_names_its_call_site(statement, line):
+    # No single answer fits a name that held the collaborator down one path and
+    # something else down another, and a loop body is the same question asked
+    # about its own previous iteration. Keeping the stale answer or dropping it
+    # both invent one, so the call site is named instead, the way every other
+    # ambiguous binding in this scanner is.
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=rf"synthetic_inventory\.py:{line} cap: "
+        r"ambiguous collaborator alias after conditional control flow",
+    ):
+        _scan_synthetic(_reach_through(statement))
 
 
 def test_a_foreign_collaborator_of_its_own_stays_out_of_the_inventory():

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1500,6 +1500,11 @@ async def test_reach_through(page, replacement):
         patch.object(extractor._content, "_extract_root_content", replacement),
     ):
         await extractor.scrape_person("ada")
+
+async def test_company_reach_through(page, replacement):
+    extractor = LinkedInExtractor(page)
+    with patch.object(extractor._content, "_extract_root_content", replacement):
+        await extractor.scrape_company("acme")
 """
     )
 
@@ -1509,22 +1514,39 @@ async def test_reach_through(page, replacement):
         if seam.kind.endswith("_patch_object")
     ] == [
         ("private_patch_object", "_extract_overlay", "capture.SectionCapture", 6),
-        ("public_patch_object", "extract_page", "capture.SectionCapture dependency", 6),
+        # `extract_page` is not a dependency of `SectionCapture`, it *is*
+        # `SectionCapture`, so the owner names the workflow consuming it the
+        # way every other public entry does.
+        ("public_patch_object", "extract_page", "person.PersonScraper dependency", 6),
         (
             "private_patch_object",
             "_extract_root_content",
             "content.PageContentReader",
-            11,
+            6,
+        ),
+        (
+            "private_patch_object",
+            "_extract_root_content",
+            "content.PageContentReader",
+            8,
         ),
     ]
-    # The reach-through itself stays on the record next to the patch it
-    # carries, and both expire with the last workflow that still asks the
-    # facade for the collaborator.
-    assert {
-        (seam.target, seam.migration_stage)
+    # The reach-through stays on the record next to the patch it carries, and
+    # both expire with the workflow this call site drives. The same `_content`
+    # attribute therefore closes at 6 in the first test and at 8 in the second:
+    # once `scrape_person` owns its own reader, the stub in that test
+    # intercepts nothing while the `scrape_company` one is still live. A flat
+    # per-attribute maximum answered 11 for both.
+    assert [
+        (seam.target, seam.canonical_owner, seam.migration_stage)
         for seam in seams
         if seam.kind == "private_facade_access"
-    } == {("_capture", 6), ("_content", 11)}
+    ] == [
+        ("_capture", "person.PersonScraper -> facade.LinkedInExtractor._capture", 6),
+        ("_capture", "person.PersonScraper -> facade.LinkedInExtractor._capture", 6),
+        ("_content", "person.PersonScraper -> facade.LinkedInExtractor._content", 6),
+        ("_content", "company.CompanyScraper -> facade.LinkedInExtractor._content", 8),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -1554,6 +1576,140 @@ async def test_typo(page):
         migration.UnresolvedSeamError, match=rf"synthetic_inventory\.py:7 .*{message}"
     ):
         _scan_synthetic(source)
+
+
+def _reach_through(statement: str) -> str:
+    """A workflow test whose single statement is the shape under test."""
+
+    return f"""
+from unittest.mock import patch
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+
+async def test_shape(page, replacement, monkeypatch, arguments, pair, thing):
+    extractor = LinkedInExtractor(page)
+    {statement}
+    await extractor.scrape_person("ada")
+"""
+
+
+@pytest.mark.parametrize(
+    ("statement", "message"),
+    [
+        (
+            'patch.object(self.extractor._capture, "made_up", replacement)',
+            r"self\.extractor\._capture: unresolved patch\.object target",
+        ),
+        (
+            'patch.object(extractor._capture._reader, "made_up", replacement)',
+            r"extractor\._capture\._reader: unresolved patch\.object target",
+        ),
+        (
+            'patch.object(getattr(extractor, "_capture"), "made_up", replacement)',
+            r"getattr\(extractor, '_capture'\): unresolved patch\.object target",
+        ),
+        (
+            "patch.object(*arguments)",
+            r"patch\.object\(\*arguments\): unresolved patch\.object arguments",
+        ),
+        (
+            "patch.object(extractor._capture)",
+            r"patch\.object\(extractor\._capture\): "
+            r"unresolved patch\.object arguments",
+        ),
+        (
+            "patch.object(*pair, replacement)",
+            r"\*pair: dynamic patch\.object attribute",
+        ),
+        (
+            'monkeypatch.setattr(extractor._capture._reader, "made_up", replacement)',
+            r"extractor\._capture\._reader: unresolved setattr target",
+        ),
+        (
+            "extractor._capture._reader.made_up = replacement",
+            r"extractor\._capture\._reader: unresolved attribute assignment target",
+        ),
+    ],
+)
+def test_unresolvable_replacement_targets_name_their_call_site(statement, message):
+    # Each of these replaces a name on something the reader cannot reduce to a
+    # collaborator, so nothing proves the patch intercepts the implementation.
+    # A chain of `if ...: return` blocks that simply ends answers "not a seam"
+    # to exactly that, which is indistinguishable from a foreign object.
+    with pytest.raises(
+        migration.UnresolvedSeamError, match=rf"synthetic_inventory\.py:7 .*{message}"
+    ):
+        _scan_synthetic(_reach_through(statement))
+
+
+@pytest.mark.parametrize(
+    ("statement", "line"),
+    [
+        ('cap = extractor._capture\n    patch.object(cap, "{name}", replacement)', 8),
+        ('patch.object(cap := extractor._capture, "{name}", replacement)', 7),
+        (
+            "patch.object(target=extractor._capture, "
+            'attribute="{name}", new=replacement)',
+            7,
+        ),
+        ('monkeypatch.setattr(extractor._capture, "{name}", replacement)', 7),
+        ('setattr(extractor._capture, "{name}", replacement)', 7),
+        ("extractor._capture.{name} = replacement", 7),
+    ],
+)
+def test_every_reach_through_shape_lands_on_the_collaborator(statement, line):
+    # An alias, a walrus, the keyword form and all three `setattr` spellings
+    # reach the same collaborator as `patch.object(extractor._capture, ...)`.
+    # A shape that produced no seam also produced no error, so a name that has
+    # never existed on `SectionCapture` read as a passing test.
+    seams = _scan_synthetic(_reach_through(statement.format(name="_extract_overlay")))
+
+    assert [
+        (seam.kind, seam.target, seam.canonical_owner, seam.migration_stage)
+        for seam in seams
+        if seam.kind.endswith("_patch_object")
+    ] == [("private_patch_object", "_extract_overlay", "capture.SectionCapture", 6)]
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=rf"synthetic_inventory\.py:{line} _capture\.made_up: "
+        r"unknown capture\.SectionCapture patch",
+    ):
+        _scan_synthetic(_reach_through(statement.format(name="made_up")))
+
+
+def test_a_foreign_collaborator_of_its_own_stays_out_of_the_inventory():
+    # The refusal has to stop at objects the reader knows nothing about, or it
+    # refuses the migration's own target state: `tests/scraping/test_feed.py`
+    # builds a `FeedScraper` and stubs `_extract_feed_body` on it, which is the
+    # identical shape and is exactly what stage 5 produced. Nothing in the
+    # expression names the extractor, so there is no reach-through to record.
+    seams = _scan_synthetic(
+        _reach_through('patch.object(thing, "_extract_overlay", replacement)')
+    )
+
+    assert not [seam for seam in seams if seam.kind.endswith("_patch_object")]
+
+
+def test_a_renamed_collaborator_class_names_its_call_site(monkeypatch):
+    # A rename used to reach `collaborator_methods`' bare `AssertionError`,
+    # which leaves the scan with a traceback and no location instead of a
+    # diagnostic naming the patch that can no longer be resolved.
+    monkeypatch.setitem(
+        migration._FACADE_COLLABORATORS,
+        "_capture",
+        ("capture.RenamedSectionCapture", "facade.LinkedInExtractor._capture"),
+    )
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"synthetic_inventory\.py:7 _capture\._extract_overlay: "
+        r"RenamedSectionCapture not found in scraping/capture\.py",
+    ):
+        _scan_synthetic(
+            _reach_through(
+                'patch.object(extractor._capture, "_extract_overlay", replacement)'
+            )
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1788,6 +1788,26 @@ def test_unpairable_destructuring_without_authority_stays_non_authoritative():
     assert _scan_synthetic(source) == []
 
 
+def test_destructuring_preserves_subscript_receiver_authority():
+    _assert_authoritative_receiver(
+        "slots[0], other = monkeypatch, helper", receiver="slots[0]"
+    )
+
+
+def test_starred_destructuring_preserves_possible_subscript_authority():
+    _assert_authoritative_receiver(
+        "slots[0], *slots[1] = (monkeypatch, helper)", receiver="slots[0]"
+    )
+
+
+def test_exact_destructuring_keeps_unrelated_subscript_non_authoritative():
+    source = _receiver_flow(
+        "slots[0], slots[1] = helper, monkeypatch", receiver="slots[0]"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
 def test_a_context_alias_does_not_leak_into_a_sibling_scope():
     source = """
 import pytest
@@ -2072,6 +2092,52 @@ def test_finally_ignores_definitely_retired_else_and_handler_states(suite):
     assert _scan_synthetic(_receiver_flow(statements)) == []
 
 
+def test_trystar_keeps_later_authoritative_group_handlers_reachable():
+    _assert_authoritative_receiver(
+        "patch = helper\n"
+        "    try:\n"
+        "        raise RuntimeError\n"
+        "    except* RuntimeError:\n"
+        "        patch = helper\n"
+        "    except* Exception:\n"
+        "        patch = monkeypatch\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+def test_trystar_without_any_authoritative_path_stays_non_authoritative():
+    source = _receiver_flow(
+        "patch = helper\n"
+        "    try:\n"
+        "        raise RuntimeError\n"
+        "    except* RuntimeError:\n"
+        "        patch = helper\n"
+        "    except* Exception:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+def test_ordinary_try_handlers_remain_exclusive_after_a_known_match():
+    source = _receiver_flow(
+        "patch = helper\n"
+        "    try:\n"
+        "        raise RuntimeError\n"
+        "    except RuntimeError:\n"
+        "        patch = helper\n"
+        "    except Exception:\n"
+        "        patch = monkeypatch\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
 def test_a_handled_raise_that_completes_does_not_poison_finally():
     # Greptile's reproducer: retaining the original RuntimeError beside the
     # handler result makes finally merge an impossible authoritative state. The
@@ -2088,6 +2154,32 @@ def test_a_handled_raise_that_completes_does_not_poison_finally():
     )
 
     assert _scan_synthetic(source) == []
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "result = local_before_assignment\n"
+        "local_before_assignment = helper\n"
+        "patch = helper",
+        "result = operation()\npatch = helper",
+        "result = consume(local_before_assignment)\n"
+        "local_before_assignment = helper\n"
+        "patch = helper",
+        "left, right = value\npatch = helper",
+        "raise RuntimeError(local_before_assignment)\nlocal_before_assignment = helper",
+    ],
+)
+def test_expression_evaluation_prefixes_still_reach_finally(operation):
+    _assert_authoritative_receiver(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        f"        {operation.replace(chr(10), chr(10) + '        ')}\n"
+        "    except RuntimeError:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
 
 
 @pytest.mark.parametrize("handler", ["RuntimeError", "Exception", "BaseException", ""])
@@ -2173,18 +2265,68 @@ def test_an_unknown_exception_keeps_the_non_exception_branch_alive():
     )
 
 
-@pytest.mark.parametrize("handler", ["BaseException", ""])
-def test_catch_all_handlers_consume_unknown_exception_kinds(handler):
-    clause = f"except {handler}:" if handler else "except:"
+def test_a_bare_handler_consumes_an_unknown_exception_kind():
     source = _receiver_flow(
         "patch = monkeypatch\n"
         "    try:\n"
         "        raise error\n"
-        f"    {clause}\n"
+        "    except:\n"
         "        patch = helper\n"
         "    finally:\n"
         "        patch.setattr(*arguments)"
     )
+
+    assert _scan_synthetic(source) == []
+
+
+def test_named_catch_all_retains_an_unknown_exception_identity():
+    _assert_authoritative_receiver(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        "        raise error\n"
+        "    except BaseException:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+@pytest.mark.parametrize(
+    "declaration, handler",
+    [
+        ("Exception = custom_exception", "Exception"),
+        ("", "errors.Exception"),
+    ],
+)
+def test_uncertain_exception_spelling_does_not_consume_known_raise(
+    declaration, handler
+):
+    prefix = "patch = monkeypatch\n"
+    if declaration:
+        prefix += f"    {declaration}\n"
+    _assert_authoritative_receiver(
+        prefix + "    try:\n"
+        "        raise RuntimeError\n"
+        f"    except {handler}:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+def test_explicit_unshadowed_builtins_qualification_consumes_known_raise():
+    source = """
+import builtins
+
+async def test_shape(monkeypatch, helper, arguments):
+    patch = monkeypatch
+    try:
+        raise builtins.RuntimeError
+    except builtins.Exception:
+        patch = helper
+    finally:
+        patch.setattr(*arguments)
+"""
 
     assert _scan_synthetic(source) == []
 

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1840,6 +1840,215 @@ def test_rebinding_receiver_does_not_hide_extractor_reachability():
         _scan_synthetic(source)
 
 
+@pytest.mark.parametrize("receiver", ["monkeypatch", "helper"])
+def test_a_readable_setattr_target_survives_a_later_star(receiver):
+    source = _reach_through(f"{receiver}.setattr(extractor, *arguments)")
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"synthetic_inventory\.py:7 extractor: unresolved setattr target",
+    ):
+        _scan_synthetic(source)
+
+
+def _receiver_flow(statements: str, receiver: str = "patch") -> str:
+    return f"""
+async def test_shape(monkeypatch, helper, arguments, flag, value):
+    {statements}
+    {receiver}.setattr(*arguments)
+"""
+
+
+def _assert_authoritative_receiver(statements: str, receiver: str = "patch") -> None:
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=rf"{re.escape(receiver)}\.setattr\(\*arguments\): "
+        r"unresolved setattr arguments",
+    ):
+        _scan_synthetic(_receiver_flow(statements, receiver))
+
+
+@pytest.mark.parametrize(
+    "branches",
+    [
+        "if flag:\n        patch = monkeypatch\n    else:\n        patch = helper",
+        "if flag:\n        patch = helper\n    else:\n        patch = monkeypatch",
+    ],
+)
+def test_if_branches_merge_receiver_authority_in_either_order(branches):
+    _assert_authoritative_receiver(f"patch = helper\n    {branches}")
+
+
+@pytest.mark.parametrize(
+    "branches",
+    [
+        "if flag:\n        patch = monkeypatch\n    else:\n        copy = patch",
+        "if flag:\n        copy = patch\n    else:\n        patch = monkeypatch",
+    ],
+)
+def test_if_branches_do_not_share_impossible_alias_states(branches):
+    source = _receiver_flow(
+        f"patch = helper\n    copy = helper\n    {branches}", "copy"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+@pytest.mark.parametrize(
+    "statements",
+    [
+        "patch = helper\n"
+        "    try:\n"
+        "        patch = monkeypatch\n"
+        "    except Exception:\n"
+        "        patch = helper\n"
+        "    else:\n"
+        "        pass\n"
+        "    finally:\n"
+        "        pass",
+        "patch = helper\n"
+        "    try:\n"
+        "        patch = helper\n"
+        "    except Exception:\n"
+        "        patch = monkeypatch\n"
+        "    else:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        pass",
+    ],
+)
+def test_try_paths_merge_receiver_authority(statements):
+    _assert_authoritative_receiver(statements)
+
+
+def test_try_finally_rebinding_retires_receiver_authority_on_every_path():
+    source = _receiver_flow(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        "        patch = monkeypatch\n"
+        "    except Exception:\n"
+        "        patch = monkeypatch\n"
+        "    else:\n"
+        "        patch = monkeypatch\n"
+        "    finally:\n"
+        "        patch = helper"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+def test_a_loop_retains_the_zero_iteration_receiver_path():
+    _assert_authoritative_receiver(
+        "patch = monkeypatch\n    for item in value:\n        patch = helper"
+    )
+
+
+def test_a_loop_revisits_calls_before_a_later_authority_assignment():
+    source = """
+async def test_shape(monkeypatch, helper, arguments, value):
+    patch = helper
+    for item in value:
+        patch.setattr(*arguments)
+        patch = monkeypatch
+"""
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"patch\.setattr\(\*arguments\): unresolved setattr arguments",
+    ):
+        _scan_synthetic(source)
+
+
+def test_a_loop_else_rebinding_retires_receiver_authority_without_a_break():
+    source = _receiver_flow(
+        "patch = monkeypatch\n"
+        "    for item in value:\n"
+        "        patch = helper\n"
+        "    else:\n"
+        "        patch = helper"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+@pytest.mark.parametrize(
+    "cases",
+    [
+        "case True:\n            patch = monkeypatch\n"
+        "        case False:\n            patch = helper",
+        "case True:\n            patch = helper\n"
+        "        case False:\n            patch = monkeypatch",
+    ],
+)
+def test_match_cases_merge_receiver_authority_in_either_order(cases):
+    _assert_authoritative_receiver(f"patch = helper\n    match flag:\n        {cases}")
+
+
+@pytest.mark.parametrize("catch_all", ["_", "ignored"])
+def test_exhaustive_match_rebinding_retires_receiver_authority(catch_all):
+    source = _receiver_flow(
+        "patch = monkeypatch\n"
+        "    match flag:\n"
+        "        case True:\n"
+        "            patch = helper\n"
+        f"        case {catch_all}:\n"
+        "            patch = helper"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+def test_a_conditional_receiver_merge_reaches_a_nested_closure():
+    source = """
+async def test_outer(monkeypatch, helper, arguments, flag):
+    patch = helper
+    if flag:
+        patch = monkeypatch
+
+    async def test_inner():
+        patch.setattr(*arguments)
+"""
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"patch\.setattr\(\*arguments\): unresolved setattr arguments",
+    ):
+        _scan_synthetic(source)
+
+
+def test_a_class_local_receiver_does_not_become_a_method_closure():
+    source = """
+import pytest
+
+class Scope:
+    patch = pytest.MonkeyPatch()
+
+    def method(self, arguments):
+        patch.setattr(*arguments)
+"""
+
+    assert _scan_synthetic(source) == []
+
+
+def test_a_method_still_closes_over_an_enclosing_function_receiver():
+    source = """
+async def test_outer(monkeypatch, arguments):
+    patch = monkeypatch
+
+    class Scope:
+        patch = object()
+
+        def method(self):
+            patch.setattr(*arguments)
+"""
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"patch\.setattr\(\*arguments\): unresolved setattr arguments",
+    ):
+        _scan_synthetic(source)
+
+
 @pytest.mark.parametrize(
     ("statement", "line"),
     [

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1756,6 +1756,38 @@ def test_an_unreadable_setattr_through_the_fixture_names_its_call_site(
         _scan_synthetic(_fixture_alias(binding, call))
 
 
+@pytest.mark.parametrize(
+    "binding",
+    [
+        "patch, other = monkeypatch, helper",
+        "[patch, other] = [monkeypatch, helper]",
+        "(first, [patch, other]) = (value, [monkeypatch, helper])",
+        "other, patch = helper, monkeypatch",
+    ],
+)
+def test_destructuring_preserves_the_corresponding_patcher_authority(binding):
+    # Mutating assignment handling back to one authority bit for the whole RHS
+    # either drops `patch` or blesses its unrelated sibling. The call is the
+    # observable authority check, not merely a count of names visited.
+    _assert_authoritative_receiver(binding)
+
+
+def test_exact_destructuring_keeps_an_unrelated_target_non_authoritative():
+    source = _receiver_flow("patch, other = helper, monkeypatch", receiver="patch")
+
+    assert _scan_synthetic(source) == []
+
+
+def test_unpairable_starred_destructuring_keeps_possible_authority():
+    _assert_authoritative_receiver("patch, *other = (monkeypatch, helper)")
+
+
+def test_unpairable_destructuring_without_authority_stays_non_authoritative():
+    source = _receiver_flow("patch, *other = (helper, value)")
+
+    assert _scan_synthetic(source) == []
+
+
 def test_a_context_alias_does_not_leak_into_a_sibling_scope():
     source = """
 import pytest
@@ -1953,6 +1985,7 @@ def test_if_branches_do_not_share_impossible_alias_states(branches):
         "patch = helper\n"
         "    try:\n"
         "        patch = helper\n"
+        "        value()\n"
         "    except Exception:\n"
         "        patch = monkeypatch\n"
         "    else:\n"
@@ -2037,6 +2070,123 @@ def test_finally_ignores_definitely_retired_else_and_handler_states(suite):
             "        patch.setattr(*arguments)"
         )
     assert _scan_synthetic(_receiver_flow(statements)) == []
+
+
+def test_a_handled_raise_that_completes_does_not_poison_finally():
+    # Greptile's reproducer: retaining the original RuntimeError beside the
+    # handler result makes finally merge an impossible authoritative state. The
+    # mutation that seeds `result.exceptional` directly from the try body makes
+    # this fail again.
+    source = _receiver_flow(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        "        raise RuntimeError\n"
+        "    except RuntimeError:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+@pytest.mark.parametrize("handler", ["RuntimeError", "Exception", "BaseException", ""])
+def test_matching_handlers_consume_a_known_raise_before_finally(handler):
+    clause = f"except {handler}:" if handler else "except:"
+    source = _receiver_flow(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        "        raise RuntimeError\n"
+        f"    {clause}\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+def test_an_unmatched_known_raise_still_reaches_finally():
+    _assert_authoritative_receiver(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except TypeError:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+def test_a_bare_reraise_from_a_handler_still_reaches_finally():
+    _assert_authoritative_receiver(
+        "patch = helper\n"
+        "    try:\n"
+        "        raise RuntimeError\n"
+        "    except RuntimeError:\n"
+        "        patch = monkeypatch\n"
+        "        raise\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+def test_a_later_matching_handler_receives_the_known_raise():
+    _assert_authoritative_receiver(
+        "patch = helper\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except TypeError:\n"
+        "        patch = helper\n"
+        "    except Exception:\n"
+        "        patch = monkeypatch\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+def test_a_nonmatching_handler_prefix_does_not_survive_a_later_match():
+    source = _receiver_flow(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except TypeError:\n"
+        "        patch = monkeypatch\n"
+        "    except Exception:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+def test_an_unknown_exception_keeps_the_non_exception_branch_alive():
+    _assert_authoritative_receiver(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        "        raise error\n"
+        "    except Exception:\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+
+@pytest.mark.parametrize("handler", ["BaseException", ""])
+def test_catch_all_handlers_consume_unknown_exception_kinds(handler):
+    clause = f"except {handler}:" if handler else "except:"
+    source = _receiver_flow(
+        "patch = monkeypatch\n"
+        "    try:\n"
+        "        raise error\n"
+        f"    {clause}\n"
+        "        patch = helper\n"
+        "    finally:\n"
+        "        patch.setattr(*arguments)"
+    )
+
+    assert _scan_synthetic(source) == []
 
 
 def test_a_loop_retains_the_zero_iteration_receiver_path():

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1810,6 +1810,50 @@ async def test_outer(monkeypatch, arguments):
         _scan_synthetic(source)
 
 
+@pytest.mark.parametrize(
+    "nested",
+    [
+        "async def inner():\n        patch.setattr(*arguments)",
+        "class Holder:\n        def method(self):\n            patch.setattr(*arguments)",
+    ],
+)
+def test_nested_bodies_use_authority_assigned_after_their_definition(nested):
+    source = f"""
+async def outer(monkeypatch, helper, arguments):
+    patch = helper
+
+    {nested}
+
+    patch = monkeypatch
+"""
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"patch\.setattr\(\*arguments\): unresolved setattr arguments",
+    ):
+        _scan_synthetic(source)
+
+
+@pytest.mark.parametrize(
+    "nested",
+    [
+        "async def inner():\n        patch.setattr(*arguments)",
+        "class Holder:\n        def method(self):\n            patch.setattr(*arguments)",
+    ],
+)
+def test_nested_bodies_drop_authority_retired_after_their_definition(nested):
+    source = f"""
+async def outer(monkeypatch, helper, arguments):
+    patch = monkeypatch
+
+    {nested}
+
+    patch = helper
+"""
+
+    assert _scan_synthetic(source) == []
+
+
 def test_a_live_context_alias_remains_authoritative():
     source = """
 import pytest
@@ -1937,6 +1981,64 @@ def test_try_finally_rebinding_retires_receiver_authority_on_every_path():
     assert _scan_synthetic(source) == []
 
 
+@pytest.mark.parametrize("suite", ["else", "handler"])
+def test_finally_sees_authority_before_else_and_handler_raises(suite):
+    if suite == "else":
+        statements = (
+            "patch = helper\n"
+            "    try:\n"
+            "        pass\n"
+            "    except Exception:\n"
+            "        pass\n"
+            "    else:\n"
+            "        patch = monkeypatch\n"
+            "        raise RuntimeError\n"
+            "    finally:\n"
+            "        patch.setattr(*arguments)"
+        )
+    else:
+        statements = (
+            "patch = helper\n"
+            "    try:\n"
+            "        raise RuntimeError\n"
+            "    except RuntimeError:\n"
+            "        patch = monkeypatch\n"
+            "        raise ValueError\n"
+            "    finally:\n"
+            "        patch.setattr(*arguments)"
+        )
+    _assert_authoritative_receiver(statements)
+
+
+@pytest.mark.parametrize("suite", ["else", "handler"])
+def test_finally_ignores_definitely_retired_else_and_handler_states(suite):
+    if suite == "else":
+        statements = (
+            "patch = helper\n"
+            "    try:\n"
+            "        pass\n"
+            "    except Exception:\n"
+            "        pass\n"
+            "    else:\n"
+            "        patch = helper\n"
+            "        raise RuntimeError\n"
+            "    finally:\n"
+            "        patch.setattr(*arguments)"
+        )
+    else:
+        statements = (
+            "patch = helper\n"
+            "    try:\n"
+            "        raise RuntimeError\n"
+            "    except RuntimeError:\n"
+            "        patch = helper\n"
+            "        raise ValueError\n"
+            "    finally:\n"
+            "        patch.setattr(*arguments)"
+        )
+    assert _scan_synthetic(_receiver_flow(statements)) == []
+
+
 def test_a_loop_retains_the_zero_iteration_receiver_path():
     _assert_authoritative_receiver(
         "patch = monkeypatch\n    for item in value:\n        patch = helper"
@@ -1965,6 +2067,35 @@ def test_a_loop_else_rebinding_retires_receiver_authority_without_a_break():
         "    for item in value:\n"
         "        patch = helper\n"
         "    else:\n"
+        "        patch = helper"
+    )
+
+    assert _scan_synthetic(source) == []
+
+
+@pytest.mark.parametrize("transfer", ["break", "continue"])
+def test_loop_transfers_keep_their_exact_authoritative_source(transfer):
+    _assert_authoritative_receiver(
+        "patch = helper\n"
+        "    for item in value:\n"
+        "        if flag:\n"
+        "            patch = monkeypatch\n"
+        f"            {transfer}\n"
+        "            patch = helper\n"
+        "        patch = helper"
+    )
+
+
+@pytest.mark.parametrize("transfer", ["break", "continue"])
+def test_loop_transfers_keep_definitely_retired_source_states(transfer):
+    source = _receiver_flow(
+        "patch = helper\n"
+        "    for item in value:\n"
+        "        if flag:\n"
+        "            patch = monkeypatch\n"
+        "            patch = helper\n"
+        f"            {transfer}\n"
+        "            patch = monkeypatch\n"
         "        patch = helper"
     )
 

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1745,8 +1745,8 @@ def test_an_unreadable_setattr_through_the_fixture_names_its_call_site(
     # The fixture is the one receiver whose `setattr` routinely lands on the
     # extractor, and it is routinely bound to another name: a private context
     # manager, an annotated parameter, a plain alias. Testing the receiver
-    # against the literal `monkeypatch` would skip exactly those, so the names
-    # the fixture is bound to in the file are collected first.
+    # against the literal `monkeypatch` would skip exactly those, so the live
+    # bindings at each call site are resolved first.
     with pytest.raises(
         migration.UnresolvedSeamError,
         match=rf"synthetic_inventory\.py:{line} "
@@ -1754,6 +1754,90 @@ def test_an_unreadable_setattr_through_the_fixture_names_its_call_site(
         r"unresolved setattr arguments",
     ):
         _scan_synthetic(_fixture_alias(binding, call))
+
+
+def test_a_context_alias_does_not_leak_into_a_sibling_scope():
+    source = """
+import pytest
+
+async def test_first():
+    with pytest.MonkeyPatch.context() as patch:
+        pass
+
+async def test_second(arguments):
+    patch.setattr(*arguments)
+"""
+
+    assert _scan_synthetic(source) == []
+
+
+def test_a_rebound_monkeypatch_alias_loses_receiver_authority():
+    source = """
+async def test_shape(monkeypatch, helper, arguments):
+    patch = monkeypatch
+    patch = helper
+    patch.setattr(*arguments)
+"""
+
+    assert _scan_synthetic(source) == []
+
+
+def test_a_nested_scope_can_shadow_an_outer_monkeypatch_alias():
+    source = """
+async def test_outer(monkeypatch, helper, arguments):
+    patch = monkeypatch
+
+    async def test_inner(patch=helper):
+        patch.setattr(*arguments)
+"""
+
+    assert _scan_synthetic(source) == []
+
+
+def test_a_nested_scope_inherits_a_live_monkeypatch_alias():
+    source = """
+async def test_outer(monkeypatch, arguments):
+    patch = monkeypatch
+
+    async def test_inner():
+        patch.setattr(*arguments)
+"""
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"patch\.setattr\(\*arguments\): unresolved setattr arguments",
+    ):
+        _scan_synthetic(source)
+
+
+def test_a_live_context_alias_remains_authoritative():
+    source = """
+import pytest
+
+async def test_shape(arguments):
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(*arguments)
+"""
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"patch\.setattr\(\*arguments\): unresolved setattr arguments",
+    ):
+        _scan_synthetic(source)
+
+
+def test_rebinding_receiver_does_not_hide_extractor_reachability():
+    source = _reach_through(
+        "patch = monkeypatch\n"
+        "    patch = helper\n"
+        '    patch.setattr(extractor._capture, "made_up", replacement)'
+    )
+
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"_capture\.made_up: unknown capture\.SectionCapture patch",
+    ):
+        _scan_synthetic(source)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Part of #853. Stacked on #915.

`scripts/check_scraping_migration_manifest.py` exists so a test patch that no longer intercepts the implementation cannot land silently. Review found it was not fail-closed. `_patch_object` ended without a terminal error, so nine target shapes fell through recording nothing: `self.extractor._capture`, a local alias, a walrus, `getattr`, a chained attribute, and the keyword and starred argument forms. `setattr` appeared nowhere in the file, despite being named in the plan, so `monkeypatch.setattr` and direct assignment through a collaborator were invisible too.

This adds those shapes and a terminal refusal naming the call site, models all three assignment spellings, corrects five stale `_content` stage pins from a flat maximum to each site's own workflow, and fixes the `public_patch_object` owner string. Refusal is scoped to targets that reach the extractor; a blanket refusal was measured first and fired on 79 of 137 legitimate sites.

Verification: eleven mutations each fail their test and pass once restored. Both checkers, Ruff, `ty`, pre-commit, and the full suite succeed. No production file changed.

## Synthetic prompt

> Make the scraping migration checker fail closed: refuse every unresolved patch target with its call site, model setattr and assignment, and derive stage pins per call site.

Generated with Claude Opus 5 + GPT-6 Astra
