### PR TITLE
refactor(scraping): Extract person workflow

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -69,6 +69,8 @@ from linkedin_mcp_server.scraping.job_policy import (
     same_job_search,
 )
 from linkedin_mcp_server.scraping.navigation import PageNavigator
+from linkedin_mcp_server.scraping.person import NAV_DELAY, PersonScraper
+from linkedin_mcp_server.scraping.profile_page import ProfilePageReader
 from linkedin_mcp_server.scraping.session import ScrapingSession
 from linkedin_mcp_server.scraping.link_metadata import (
     Reference,
@@ -79,7 +81,6 @@ from linkedin_mcp_server.scraping.search_urls import (
     build_company_search_url,
     build_content_search_url,
     build_job_search_url,
-    build_people_search_url,
 )
 from linkedin_mcp_server.scraping.text import (
     filter_linkedin_noise_lines,
@@ -88,15 +89,12 @@ from linkedin_mcp_server.scraping.text import (
     truncate_linkedin_noise,
 )
 
-from .fields import COMPANY_SECTIONS, PERSON_SECTIONS
+from .fields import COMPANY_SECTIONS
 
 if TYPE_CHECKING:
     from linkedin_mcp_server.callbacks import ProgressCallback
 
 logger = logging.getLogger(__name__)
-
-# Pacing between page navigations
-_NAV_DELAY = 2.0
 
 # The id is the trailing run of digits, and LinkedIn serves the same job under
 # both `/jobs/view/1967281839/` and `/jobs/view/<title>-at-<company>-1967281839/`.
@@ -1376,6 +1374,15 @@ class LinkedInExtractor:
         self._content = PageContentReader(self._session)
         self._capture = SectionCapture(self._session, self._navigator, self._content)
         self._feed = FeedScraper(self._session, self._navigator, self._content)
+        # Late-bound on purpose: the top-card read the URN comes from still
+        # lives here until the message sender owns it, and a bound method
+        # captured now would not see a replacement installed on this instance.
+        self._profile_page = ProfilePageReader(
+            self._session, lambda: self._read_profile_message_target()
+        )
+        self._person = PersonScraper(
+            self._session, self._navigator, self._capture, self._profile_page
+        )
         self._page = page
         # What the sidebar scroll spent on the page being read, so that a
         # multi-page search charges its scroll budget for scrolling alone.
@@ -1689,145 +1696,15 @@ class LinkedInExtractor:
         main_profile_already_loaded: bool = False,
         allow_self_alias: bool = False,
     ) -> dict[str, Any]:
-        """Scrape a person profile with configurable sections.
-
-        When ``main_profile_already_loaded`` is True and ``self._page`` is on
-        the exact profile root for ``username``, the ``main_profile`` section
-        is extracted from the current page without re-navigating. Falls back
-        to ``extract_page`` if the URL drifts or the reuse path returns the
-        soft-rate-limit sentinel (preserving the retry semantics of
-        ``extract_page``).
-
-        Returns:
-            {url, sections: {name: text}, profile_urn?: str}
-        """
-        requested = requested | {"main_profile"}
-        username = normalize_person_identifier(
-            username, allow_self_alias=allow_self_alias
+        """Scrape a person profile with configurable sections."""
+        return await self._person.scrape_person(
+            username,
+            requested,
+            callbacks,
+            max_scrolls,
+            main_profile_already_loaded=main_profile_already_loaded,
+            allow_self_alias=allow_self_alias,
         )
-        base_url = person_profile_url(username)
-        sections: dict[str, str] = {}
-        references: dict[str, list[Reference]] = {}
-        section_errors: dict[str, dict[str, Any]] = {}
-        profile_urn: str | None = None
-        rate_limited = False
-
-        requested_ordered = [
-            (name, suffix, is_overlay)
-            for name, (suffix, is_overlay) in PERSON_SECTIONS.items()
-            if name in requested
-        ]
-        total = len(requested_ordered)
-
-        if callbacks:
-            await callbacks.on_start("person profile", base_url)
-
-        try:
-            for i, (section_name, suffix, is_overlay) in enumerate(requested_ordered):
-                if i > 0:
-                    await asyncio.sleep(_NAV_DELAY)
-
-                url = base_url + suffix
-                try:
-                    can_reuse_main = (
-                        section_name == "main_profile"
-                        and main_profile_already_loaded
-                        and urlparse(self._page.url).path.rstrip("/")
-                        == urlparse(base_url).path.rstrip("/")
-                    )
-                    if can_reuse_main:
-                        extracted = await self._capture._extract_loaded_section(
-                            url,
-                            section_name=section_name,
-                            max_scrolls=max_scrolls,
-                        )
-                        if extracted.text == RATE_LIMITED_SECTION_TEXT:
-                            logger.info(
-                                "Reuse path soft-rate-limited; falling back "
-                                "to extract_page for retry parity"
-                            )
-                            extracted = await self.extract_page(
-                                url,
-                                section_name=section_name,
-                                max_scrolls=max_scrolls,
-                            )
-                    elif is_overlay:
-                        extracted = await self._capture._extract_overlay(
-                            url, section_name=section_name
-                        )
-                    else:
-                        extracted = await self.extract_page(
-                            url,
-                            section_name=section_name,
-                            max_scrolls=max_scrolls,
-                        )
-
-                    if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
-                        sections[section_name] = extracted.text
-                        if extracted.references:
-                            references[section_name] = extracted.references
-                    elif extracted.text == RATE_LIMITED_SECTION_TEXT:
-                        section_errors[section_name] = rate_limited_section_error()
-                        # Stop rather than walk the remaining sections. Each one
-                        # is another navigation, and LinkedIn has just said it
-                        # wants fewer of them. Whatever was gathered before this
-                        # point is kept and returned.
-                        rate_limited = True
-                    elif extracted.error:
-                        section_errors[section_name] = extracted.error
-
-                    # Skipped once the section came back empty: there is no
-                    # content to read a URN from, and a failure here lands in
-                    # the handler below, which would overwrite the entry just
-                    # recorded with a generic diagnostic — losing the one
-                    # finding this section had.
-                    if (
-                        section_name == "main_profile"
-                        and profile_urn is None
-                        and not rate_limited
-                    ):
-                        profile_urn = await self._extract_profile_urn()
-                except LinkedInScraperException:
-                    raise
-                except Exception as e:
-                    logger.warning("Error scraping section %s: %s", section_name, e)
-                    section_errors[section_name] = build_issue_diagnostics(
-                        e,
-                        context="scrape_person",
-                        target_url=url,
-                        section_name=section_name,
-                    )
-
-                # "Scraped" = processed/attempted, not necessarily successful.
-                # Per-section failures are captured in section_errors.
-                if callbacks:
-                    percent = round((i + 1) / total * 95)
-                    await callbacks.on_progress(
-                        f"Scraped {section_name} ({i + 1}/{total})", percent
-                    )
-
-                if rate_limited:
-                    break
-        except LinkedInScraperException as e:
-            if callbacks:
-                await callbacks.on_error(e)
-            raise
-
-        result: dict[str, Any] = {
-            "url": f"{base_url}/",
-            "sections": sections,
-        }
-        if profile_urn:
-            result["profile_urn"] = profile_urn
-        if references:
-            result["references"] = references
-        if section_errors:
-            result["section_errors"] = section_errors
-
-        if callbacks:
-            await callbacks.on_complete("person profile", result)
-
-        return result
 
     async def get_my_profile(
         self,
@@ -1835,32 +1712,8 @@ class LinkedInExtractor:
         callbacks: ProgressCallback | None = None,
         max_scrolls: int | None = None,
     ) -> dict[str, Any]:
-        """Scrape the authenticated user's own LinkedIn profile.
-
-        Navigates to /in/me/ and resolves the redirect to obtain the real
-        username before scraping, so result["url"] reflects the actual profile
-        URL rather than /in/me/.
-
-        Returns:
-            {url, sections: {name: text}}
-        """
-        await self._navigator._navigate_to_page("https://www.linkedin.com/in/me/")
-        real_url = self._page.url  # post-redirect, e.g. /in/johndoe/
-        match = re.search(r"/in/([^/?#]+)", real_url)
-        username = match.group(1) if match else "me"
-        logger.debug("get_my_profile resolved username=%r from %s", username, real_url)
-
-        return await self.scrape_person(
-            username,
-            sections if sections is not None else {"main_profile"},
-            callbacks=callbacks,
-            max_scrolls=max_scrolls,
-            main_profile_already_loaded=True,
-            # The redirect is what resolves the alias. When it has not, this is
-            # still the tool the user asked for, so "me" stays usable here and
-            # nowhere else.
-            allow_self_alias=True,
-        )
+        """Scrape the authenticated user's own LinkedIn profile."""
+        return await self._person.get_my_profile(sections, callbacks, max_scrolls)
 
     async def _read_action_signals(self, username: str) -> ActionSignals:
         """Read locale-independent structural signals for a profile's
@@ -2272,187 +2125,9 @@ class LinkedInExtractor:
             profile=verified_text or page_text,
         )
 
-    async def _extract_profile_urn(self) -> str | None:
-        """Extract a profile URN only from one unambiguous top-card snapshot."""
-        resolution = await self._read_profile_message_target()
-        return resolution.target.profile_urn if resolution.target else None
-
     async def get_sidebar_profiles(self, username: str) -> dict[str, Any]:
-        """Extract profile links from sidebar sections on a LinkedIn profile page.
-
-        Scrapes "More profiles for you", "Explore premium profiles", and
-        "People you may know" sidebar sections. Follows each "Show all" link to
-        collect the full list; skips any section whose "Show all" URL contains or
-        redirects to /premium.
-
-        Returns:
-            Dict with url and sidebar_profiles mapping section key to list of
-            /in/username/ paths. Sections absent from the page are omitted.
-        """
-        username = normalize_person_identifier(username)
-        url = person_profile_url(username, "/")
-        await self._navigator._navigate_to_page(url)
-        await detect_rate_limit(self._page)
-
-        try:
-            await self._page.wait_for_selector("main", timeout=5000)
-        except PlaywrightTimeoutError:
-            logger.debug("No <main> element found on %s", url)
-
-        await handle_modal_close(self._page)
-
-        sidebar_data: dict[str, Any] = await self._page.evaluate(
-            """() => {
-                const SIDEBAR_SECTIONS = [
-                    "More profiles for you",
-                    "Explore premium profiles",
-                    "People you may know"
-                ];
-                const normalize = text => (text || '').replace(/\\s+/g, ' ').trim();
-                const slugify = text => text.toLowerCase().replace(/\\s+/g, '_');
-                const extractProfilePath = href => {
-                    if (!href) return null;
-                    const idx = href.indexOf('/in/');
-                    if (idx === -1) return null;
-                    const rest = href.slice(idx + 4);
-                    const end = rest.search(/[/?#]/);
-                    const username = end === -1 ? rest : rest.slice(0, end);
-                    return username ? '/in/' + username + '/' : null;
-                };
-
-                const sections = {};
-                const showAllUrls = {};
-
-                const headings = Array.from(document.querySelectorAll('h1, h2, h3'));
-                for (const heading of headings) {
-                    const headingText = normalize(
-                        heading.innerText || heading.textContent
-                    );
-                    if (!SIDEBAR_SECTIONS.includes(headingText)) continue;
-
-                    const sectionKey = slugify(headingText);
-
-                    // Walk up to find a section/aside container (max 5 levels)
-                    let container = heading.parentElement;
-                    let foundSection = false;
-                    for (let depth = 0; container && depth < 5; depth++) {
-                        const tag = container.tagName.toLowerCase();
-                        if (tag === 'section' || tag === 'aside') { foundSection = true; break; }
-                        container = container.parentElement;
-                    }
-                    if (!container || !foundSection) continue;
-
-                    // Collect /in/ profile links, deduplicated
-                    const seen = new Set();
-                    const profileLinks = [];
-                    for (const a of container.querySelectorAll('a[href*="/in/"]')) {
-                        const path = extractProfilePath(a.getAttribute('href'));
-                        if (path && !seen.has(path)) {
-                            seen.add(path);
-                            profileLinks.push(path);
-                        }
-                    }
-
-                    // Find "Show all" / "See all" anchor within container
-                    let showAll = null;
-                    for (const a of container.querySelectorAll('a')) {
-                        const text = normalize(
-                            a.innerText || a.textContent
-                        ).toLowerCase();
-                        if (text.startsWith('show all') || text.startsWith('see all')) {
-                            showAll = a.href || a.getAttribute('href');
-                            break;
-                        }
-                    }
-
-                    sections[sectionKey] = profileLinks;
-                    if (showAll) showAllUrls[sectionKey] = showAll;
-                }
-
-                return { sections, showAllUrls };
-            }"""
-        )
-
-        sidebar_profiles: dict[str, list[str]] = dict(sidebar_data.get("sections", {}))
-        show_all_urls: dict[str, str] = dict(sidebar_data.get("showAllUrls", {}))
-
-        first_show_all = True
-        for section_key, show_all_url in show_all_urls.items():
-            if "/premium" in show_all_url:
-                continue
-
-            if not first_show_all:
-                await asyncio.sleep(_NAV_DELAY)
-            first_show_all = False
-
-            try:
-                await self._navigator._navigate_to_page(show_all_url)
-            except LinkedInScraperException:
-                raise
-            except Exception:
-                logger.debug(
-                    "Failed to navigate to Show all for section %s: %s",
-                    section_key,
-                    show_all_url,
-                )
-                continue
-
-            if "/premium" in self._page.url:
-                logger.debug(
-                    "Show all for section %s redirected to premium, skipping",
-                    section_key,
-                )
-                continue
-
-            await detect_rate_limit(self._page)
-
-            try:
-                await self._page.wait_for_selector("main")
-            except PlaywrightTimeoutError:
-                logger.debug("No <main> on Show all page for section %s", section_key)
-
-            await handle_modal_close(self._page)
-
-            expanded_links: list[str] = await self._page.evaluate(
-                """() => {
-                    const extractProfilePath = href => {
-                        if (!href) return null;
-                        const idx = href.indexOf('/in/');
-                        if (idx === -1) return null;
-                        const rest = href.slice(idx + 4);
-                        const end = rest.search(/[/?#]/);
-                        const username = end === -1 ? rest : rest.slice(0, end);
-                        return username ? '/in/' + username + '/' : null;
-                    };
-                    const seen = new Set();
-                    const links = [];
-                    for (const a of document.querySelectorAll(
-                        'main a[href*="/in/"]'
-                    )) {
-                        const path = extractProfilePath(a.getAttribute('href'));
-                        if (path && !seen.has(path)) {
-                            seen.add(path);
-                            links.push(path);
-                        }
-                    }
-                    return links;
-                }"""
-            )
-
-            # Merge: sidebar links first, then show_all expansion, deduped
-            existing = sidebar_profiles.get(section_key, [])
-            seen_paths: set[str] = set(existing)
-            merged = list(existing)
-            for link in expanded_links:
-                if link not in seen_paths:
-                    seen_paths.add(link)
-                    merged.append(link)
-            sidebar_profiles[section_key] = merged
-
-        return {
-            "url": url,
-            "sidebar_profiles": sidebar_profiles,
-        }
+        """Extract profile links from sidebar sections on a profile page."""
+        return await self._person.get_sidebar_profiles(username)
 
     async def _read_profile_message_target(self) -> _ProfileMessageTargetResolution:
         """Resolve one recipient-specific top-card compose action after settling."""
@@ -2521,33 +2196,6 @@ class LinkedInExtractor:
         """Return an unambiguous recipient-specific top-card compose URL."""
         resolution = await self._read_profile_message_target()
         return resolution.target.compose_url if resolution.target else None
-
-    async def _read_profile_display_name(self) -> str | None:
-        """Read the visible profile name from the current person page."""
-        display_name = await self._page.evaluate(
-            """() => {
-                const heading = document.querySelector('main h1');
-                const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
-                if (heading) {
-                    const headingText = normalize(
-                        heading.innerText || heading.textContent || ''
-                    );
-                    if (headingText) return headingText;
-                }
-
-                const main = document.querySelector('main');
-                if (!main) return '';
-                const lines = (main.innerText || '')
-                    .split('\\n')
-                    .map(normalize)
-                    .filter(Boolean);
-                return lines[0] || '';
-            }"""
-        )
-        if not isinstance(display_name, str):
-            return None
-        display_name = display_name.strip()
-        return display_name or None
 
     async def _wait_for_message_surface(
         self, target: _ProfileMessageTarget
@@ -2904,7 +2552,7 @@ class LinkedInExtractor:
             logger.debug("Profile page did not load for %s", linkedin_username)
 
         await handle_modal_close(self._page)
-        display_name = await self._read_profile_display_name()
+        display_name = await self._profile_page._read_profile_display_name()
         if not display_name:
             raise LinkedInScraperException(
                 f"Could not resolve a display name for {linkedin_username}."
@@ -2960,7 +2608,7 @@ class LinkedInExtractor:
         try:
             for i, (section_name, suffix, is_overlay) in enumerate(requested_ordered):
                 if i > 0:
-                    await asyncio.sleep(_NAV_DELAY)
+                    await asyncio.sleep(NAV_DELAY)
 
                 url = base_url + suffix
                 try:
@@ -3407,22 +3055,22 @@ class LinkedInExtractor:
                 break
 
             elapsed = time.monotonic() - started
-            if page_num > 0 and elapsed + _NAV_DELAY + slowest_page > budget:
+            if page_num > 0 and elapsed + NAV_DELAY + slowest_page > budget:
                 logger.debug(
                     "Stopping after %d pages: %.1fs spent, another page costs "
                     "up to %.1fs and the budget is %.1fs",
                     page_num,
                     elapsed,
-                    _NAV_DELAY + slowest_page,
+                    NAV_DELAY + slowest_page,
                     budget,
                 )
                 break
 
             if page_num > 0:
-                await asyncio.sleep(_NAV_DELAY)
+                await asyncio.sleep(NAV_DELAY)
 
             # Started after the delay, because the prediction above adds
-            # `_NAV_DELAY` to `slowest_page` itself. Timing from before the
+            # `NAV_DELAY` to `slowest_page` itself. Timing from before the
             # sleep folds it into every page after the first and then charges
             # it a second time, which stops a page early for every two seconds
             # of delay the run has already paid for.
@@ -3852,7 +3500,7 @@ class LinkedInExtractor:
                 break
 
             if page_num > 0:
-                await asyncio.sleep(_NAV_DELAY)
+                await asyncio.sleep(NAV_DELAY)
 
             url = (
                 base_url
@@ -4010,57 +3658,13 @@ class LinkedInExtractor:
         network: list[str] | None = None,
         current_company: str | None = None,
     ) -> dict[str, Any]:
-        """Search for people and extract the results page.
-
-        Args:
-            keywords: Free-text query ("software engineer", "recruiter at Google").
-            location: Optional location filter ("New York", "Remote").
-            network: Optional connection-degree filter. Each element is one of
-                ``"F"`` (1st-degree), ``"S"`` (2nd-degree), ``"O"`` (3rd-degree
-                and beyond). Example: ``["F"]`` to only return 1st-degree
-                connections. Invalid tokens raise ``ValueError``.
-            current_company: Optional current-employer filter. LinkedIn's
-                ``currentCompany`` facet only filters on the numeric company
-                URN id (e.g. ``"1115"`` for SAP); plain company names are
-                accepted by the URL but ignored by LinkedIn and return the
-                unfiltered result set. Look up a company's URN via
-                ``get_company_profile`` -- it is exposed under
-                ``references["about"]``.
-
-        Returns:
-            {url, sections: {name: text}}
-        """
-        # Builds before it navigates, and the builder refuses a filter
-        # LinkedIn would swallow, so an invalid token costs no page load.
-        url = build_people_search_url(
+        """Search for people and extract the results page."""
+        return await self._person.search_people(
             keywords,
             location=location,
             network=network,
             current_company=current_company,
         )
-        extracted = await self.extract_page(url, section_name="search_results")
-
-        sections: dict[str, str] = {}
-        references: dict[str, list[Reference]] = {}
-        section_errors: dict[str, dict[str, Any]] = {}
-        if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
-            sections["search_results"] = extracted.text
-            if extracted.references:
-                references["search_results"] = extracted.references
-        elif extracted.text == RATE_LIMITED_SECTION_TEXT:
-            section_errors["search_results"] = rate_limited_section_error()
-        elif extracted.error:
-            section_errors["search_results"] = extracted.error
-
-        result: dict[str, Any] = {
-            "url": url,
-            "sections": sections,
-        }
-        if references:
-            result["references"] = references
-        if section_errors:
-            result["section_errors"] = section_errors
-        return result
 
     async def search_companies(
         self,

--- a/linkedin_mcp_server/scraping/person.py
+++ b/linkedin_mcp_server/scraping/person.py
@@ -1,0 +1,509 @@
+"""Person profile, own-profile, sidebar and people-search workflows."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
+
+import logging
+import re
+
+from patchright.async_api import TimeoutError as PlaywrightTimeoutError
+
+from linkedin_mcp_server.core.exceptions import LinkedInScraperException
+from linkedin_mcp_server.error_diagnostics import build_issue_diagnostics
+from linkedin_mcp_server.scraping.capture import SectionCapture
+from linkedin_mcp_server.scraping.contracts import (
+    RATE_LIMITED_SECTION_TEXT,
+    rate_limited_section_error,
+)
+from linkedin_mcp_server.scraping.fields import PERSON_SECTIONS
+from linkedin_mcp_server.scraping.identifiers import (
+    normalize_person_identifier,
+    person_profile_url,
+)
+from linkedin_mcp_server.scraping.link_metadata import Reference
+from linkedin_mcp_server.scraping.navigation import PageNavigator
+from linkedin_mcp_server.scraping.profile_page import ProfilePageReader
+from linkedin_mcp_server.scraping.search_urls import build_people_search_url
+from linkedin_mcp_server.scraping.session import ScrapingSession
+from linkedin_mcp_server.scraping.text import SIDEBAR_CHROME_EN
+
+if TYPE_CHECKING:
+    from linkedin_mcp_server.callbacks import ProgressCallback
+
+logger = logging.getLogger(__name__)
+
+# Pacing between page navigations. Owned here rather than copied, because the
+# company and job walks that still sit on the facade pace themselves the same
+# way: two constants would let one relocation give two workflows different
+# policies without anything failing.
+NAV_DELAY = 2.0
+
+
+def _js_literal(value: str, quote: str) -> str:
+    """Quote one locale-table label for the program below.
+
+    Both quoting styles already occur in that program, and reproducing each
+    exactly is what keeps it the byte-identical program the policy traces
+    fingerprint. Escaping is deliberately absent: the table holds visible
+    LinkedIn labels, and a label carrying a quote or a backslash would be a
+    reason to stop matching on text here, not a reason to escape it.
+    """
+    return f"{quote}{value}{quote}"
+
+
+# The sidebar headings and the "Show all" control are the one place this
+# workflow reads visible text to classify anything, and the strings come from
+# the explicit `en-US` table in `text.py` rather than from a copy here. Two
+# substitutions instead of a literal, so changing the table changes the
+# program and nothing has to remember to change both.
+_SIDEBAR_PROFILES_JS = """() => {
+                const SIDEBAR_SECTIONS = [
+                    __SECTION_HEADINGS__
+                ];
+                const normalize = text => (text || '').replace(/\\s+/g, ' ').trim();
+                const slugify = text => text.toLowerCase().replace(/\\s+/g, '_');
+                const extractProfilePath = href => {
+                    if (!href) return null;
+                    const idx = href.indexOf('/in/');
+                    if (idx === -1) return null;
+                    const rest = href.slice(idx + 4);
+                    const end = rest.search(/[/?#]/);
+                    const username = end === -1 ? rest : rest.slice(0, end);
+                    return username ? '/in/' + username + '/' : null;
+                };
+
+                const sections = {};
+                const showAllUrls = {};
+
+                const headings = Array.from(document.querySelectorAll('h1, h2, h3'));
+                for (const heading of headings) {
+                    const headingText = normalize(
+                        heading.innerText || heading.textContent
+                    );
+                    if (!SIDEBAR_SECTIONS.includes(headingText)) continue;
+
+                    const sectionKey = slugify(headingText);
+
+                    // Walk up to find a section/aside container (max 5 levels)
+                    let container = heading.parentElement;
+                    let foundSection = false;
+                    for (let depth = 0; container && depth < 5; depth++) {
+                        const tag = container.tagName.toLowerCase();
+                        if (tag === 'section' || tag === 'aside') { foundSection = true; break; }
+                        container = container.parentElement;
+                    }
+                    if (!container || !foundSection) continue;
+
+                    // Collect /in/ profile links, deduplicated
+                    const seen = new Set();
+                    const profileLinks = [];
+                    for (const a of container.querySelectorAll('a[href*="/in/"]')) {
+                        const path = extractProfilePath(a.getAttribute('href'));
+                        if (path && !seen.has(path)) {
+                            seen.add(path);
+                            profileLinks.push(path);
+                        }
+                    }
+
+                    // Find "Show all" / "See all" anchor within container
+                    let showAll = null;
+                    for (const a of container.querySelectorAll('a')) {
+                        const text = normalize(
+                            a.innerText || a.textContent
+                        ).toLowerCase();
+                        if (__SHOW_ALL_TEST__) {
+                            showAll = a.href || a.getAttribute('href');
+                            break;
+                        }
+                    }
+
+                    sections[sectionKey] = profileLinks;
+                    if (showAll) showAllUrls[sectionKey] = showAll;
+                }
+
+                return { sections, showAllUrls };
+            }""".replace(
+    "__SECTION_HEADINGS__",
+    ",\n".join(
+        _js_literal(heading, '"') for heading in SIDEBAR_CHROME_EN.section_headings
+    ),
+).replace(
+    "__SHOW_ALL_TEST__",
+    " || ".join(
+        f"text.startsWith({_js_literal(prefix, chr(39))})"
+        for prefix in SIDEBAR_CHROME_EN.show_all_prefixes
+    ),
+)
+
+_SIDEBAR_EXPANDED_PROFILES_JS = """() => {
+                    const extractProfilePath = href => {
+                        if (!href) return null;
+                        const idx = href.indexOf('/in/');
+                        if (idx === -1) return null;
+                        const rest = href.slice(idx + 4);
+                        const end = rest.search(/[/?#]/);
+                        const username = end === -1 ? rest : rest.slice(0, end);
+                        return username ? '/in/' + username + '/' : null;
+                    };
+                    const seen = new Set();
+                    const links = [];
+                    for (const a of document.querySelectorAll(
+                        'main a[href*="/in/"]'
+                    )) {
+                        const path = extractProfilePath(a.getAttribute('href'));
+                        if (path && !seen.has(path)) {
+                            seen.add(path);
+                            links.push(path);
+                        }
+                    }
+                    return links;
+                }"""
+
+
+class PersonScraper:
+    """Own every workflow whose subject is one LinkedIn member."""
+
+    def __init__(
+        self,
+        session: ScrapingSession,
+        navigator: PageNavigator,
+        capture: SectionCapture,
+        profile_page: ProfilePageReader,
+    ):
+        self._session = session
+        self._navigator = navigator
+        self._capture = capture
+        self._profile_page = profile_page
+
+    async def scrape_person(
+        self,
+        username: str,
+        requested: set[str],
+        callbacks: ProgressCallback | None = None,
+        max_scrolls: int | None = None,
+        *,
+        main_profile_already_loaded: bool = False,
+        allow_self_alias: bool = False,
+    ) -> dict[str, Any]:
+        """Scrape a person profile with configurable sections.
+
+        When ``main_profile_already_loaded`` is True and the bound page is on
+        the exact profile root for ``username``, the ``main_profile`` section
+        is extracted from the current page without re-navigating. Falls back
+        to ``extract_page`` if the URL drifts or the reuse path returns the
+        soft-rate-limit sentinel (preserving the retry semantics of
+        ``extract_page``).
+
+        Returns:
+            {url, sections: {name: text}, profile_urn?: str}
+        """
+        requested = requested | {"main_profile"}
+        username = normalize_person_identifier(
+            username, allow_self_alias=allow_self_alias
+        )
+        base_url = person_profile_url(username)
+        sections: dict[str, str] = {}
+        references: dict[str, list[Reference]] = {}
+        section_errors: dict[str, dict[str, Any]] = {}
+        profile_urn: str | None = None
+        rate_limited = False
+
+        requested_ordered = [
+            (name, suffix, is_overlay)
+            for name, (suffix, is_overlay) in PERSON_SECTIONS.items()
+            if name in requested
+        ]
+        total = len(requested_ordered)
+
+        if callbacks:
+            await callbacks.on_start("person profile", base_url)
+
+        try:
+            for i, (section_name, suffix, is_overlay) in enumerate(requested_ordered):
+                if i > 0:
+                    await self._session.delay(NAV_DELAY)
+
+                url = base_url + suffix
+                try:
+                    can_reuse_main = (
+                        section_name == "main_profile"
+                        and main_profile_already_loaded
+                        and urlparse(self._session.page.url).path.rstrip("/")
+                        == urlparse(base_url).path.rstrip("/")
+                    )
+                    if can_reuse_main:
+                        extracted = await self._capture._extract_loaded_section(
+                            url,
+                            section_name=section_name,
+                            max_scrolls=max_scrolls,
+                        )
+                        if extracted.text == RATE_LIMITED_SECTION_TEXT:
+                            logger.info(
+                                "Reuse path soft-rate-limited; falling back "
+                                "to extract_page for retry parity"
+                            )
+                            extracted = await self._capture.extract_page(
+                                url,
+                                section_name=section_name,
+                                max_scrolls=max_scrolls,
+                            )
+                    elif is_overlay:
+                        extracted = await self._capture._extract_overlay(
+                            url, section_name=section_name
+                        )
+                    else:
+                        extracted = await self._capture.extract_page(
+                            url,
+                            section_name=section_name,
+                            max_scrolls=max_scrolls,
+                        )
+
+                    if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
+                        sections[section_name] = extracted.text
+                        if extracted.references:
+                            references[section_name] = extracted.references
+                    elif extracted.text == RATE_LIMITED_SECTION_TEXT:
+                        section_errors[section_name] = rate_limited_section_error()
+                        # Stop rather than walk the remaining sections. Each one
+                        # is another navigation, and LinkedIn has just said it
+                        # wants fewer of them. Whatever was gathered before this
+                        # point is kept and returned.
+                        rate_limited = True
+                    elif extracted.error:
+                        section_errors[section_name] = extracted.error
+
+                    # Skipped once the section came back empty: there is no
+                    # content to read a URN from, and a failure here lands in
+                    # the handler below, which would overwrite the entry just
+                    # recorded with a generic diagnostic — losing the one
+                    # finding this section had.
+                    if (
+                        section_name == "main_profile"
+                        and profile_urn is None
+                        and not rate_limited
+                    ):
+                        profile_urn = await self._profile_page._extract_profile_urn()
+                except LinkedInScraperException:
+                    raise
+                except Exception as e:
+                    logger.warning("Error scraping section %s: %s", section_name, e)
+                    section_errors[section_name] = build_issue_diagnostics(
+                        e,
+                        context="scrape_person",
+                        target_url=url,
+                        section_name=section_name,
+                    )
+
+                # "Scraped" = processed/attempted, not necessarily successful.
+                # Per-section failures are captured in section_errors.
+                if callbacks:
+                    percent = round((i + 1) / total * 95)
+                    await callbacks.on_progress(
+                        f"Scraped {section_name} ({i + 1}/{total})", percent
+                    )
+
+                if rate_limited:
+                    break
+        except LinkedInScraperException as e:
+            if callbacks:
+                await callbacks.on_error(e)
+            raise
+
+        result: dict[str, Any] = {
+            "url": f"{base_url}/",
+            "sections": sections,
+        }
+        if profile_urn:
+            result["profile_urn"] = profile_urn
+        if references:
+            result["references"] = references
+        if section_errors:
+            result["section_errors"] = section_errors
+
+        if callbacks:
+            await callbacks.on_complete("person profile", result)
+
+        return result
+
+    async def get_my_profile(
+        self,
+        sections: set[str] | None = None,
+        callbacks: ProgressCallback | None = None,
+        max_scrolls: int | None = None,
+    ) -> dict[str, Any]:
+        """Scrape the authenticated user's own LinkedIn profile.
+
+        Navigates to /in/me/ and resolves the redirect to obtain the real
+        username before scraping, so result["url"] reflects the actual profile
+        URL rather than /in/me/.
+
+        Returns:
+            {url, sections: {name: text}}
+        """
+        await self._navigator._navigate_to_page("https://www.linkedin.com/in/me/")
+        real_url = self._session.page.url  # post-redirect, e.g. /in/johndoe/
+        match = re.search(r"/in/([^/?#]+)", real_url)
+        username = match.group(1) if match else "me"
+        logger.debug("get_my_profile resolved username=%r from %s", username, real_url)
+
+        return await self.scrape_person(
+            username,
+            sections if sections is not None else {"main_profile"},
+            callbacks=callbacks,
+            max_scrolls=max_scrolls,
+            main_profile_already_loaded=True,
+            # The redirect is what resolves the alias. When it has not, this is
+            # still the tool the user asked for, so "me" stays usable here and
+            # nowhere else.
+            allow_self_alias=True,
+        )
+
+    async def get_sidebar_profiles(self, username: str) -> dict[str, Any]:
+        """Extract profile links from sidebar sections on a LinkedIn profile page.
+
+        Scrapes "More profiles for you", "Explore premium profiles", and
+        "People you may know" sidebar sections. Follows each "Show all" link to
+        collect the full list; skips any section whose "Show all" URL contains or
+        redirects to /premium.
+
+        Returns:
+            Dict with url and sidebar_profiles mapping section key to list of
+            /in/username/ paths. Sections absent from the page are omitted.
+        """
+        username = normalize_person_identifier(username)
+        url = person_profile_url(username, "/")
+        await self._navigator._navigate_to_page(url)
+        await self._session.check_rate_limit()
+
+        try:
+            await self._session.page.wait_for_selector("main", timeout=5000)
+        except PlaywrightTimeoutError:
+            logger.debug("No <main> element found on %s", url)
+
+        await self._session.dismiss_modal()
+
+        sidebar_data: dict[str, Any] = await self._session.page.evaluate(
+            _SIDEBAR_PROFILES_JS
+        )
+
+        sidebar_profiles: dict[str, list[str]] = dict(sidebar_data.get("sections", {}))
+        show_all_urls: dict[str, str] = dict(sidebar_data.get("showAllUrls", {}))
+
+        first_show_all = True
+        for section_key, show_all_url in show_all_urls.items():
+            if "/premium" in show_all_url:
+                continue
+
+            if not first_show_all:
+                await self._session.delay(NAV_DELAY)
+            first_show_all = False
+
+            try:
+                await self._navigator._navigate_to_page(show_all_url)
+            except LinkedInScraperException:
+                raise
+            except Exception:
+                logger.debug(
+                    "Failed to navigate to Show all for section %s: %s",
+                    section_key,
+                    show_all_url,
+                )
+                continue
+
+            if "/premium" in self._session.page.url:
+                logger.debug(
+                    "Show all for section %s redirected to premium, skipping",
+                    section_key,
+                )
+                continue
+
+            await self._session.check_rate_limit()
+
+            try:
+                await self._session.page.wait_for_selector("main")
+            except PlaywrightTimeoutError:
+                logger.debug("No <main> on Show all page for section %s", section_key)
+
+            await self._session.dismiss_modal()
+
+            expanded_links: list[str] = await self._session.page.evaluate(
+                _SIDEBAR_EXPANDED_PROFILES_JS
+            )
+
+            # Merge: sidebar links first, then show_all expansion, deduped
+            existing = sidebar_profiles.get(section_key, [])
+            seen_paths: set[str] = set(existing)
+            merged = list(existing)
+            for link in expanded_links:
+                if link not in seen_paths:
+                    seen_paths.add(link)
+                    merged.append(link)
+            sidebar_profiles[section_key] = merged
+
+        return {
+            "url": url,
+            "sidebar_profiles": sidebar_profiles,
+        }
+
+    async def search_people(
+        self,
+        keywords: str,
+        location: str | None = None,
+        network: list[str] | None = None,
+        current_company: str | None = None,
+    ) -> dict[str, Any]:
+        """Search for people and extract the results page.
+
+        Args:
+            keywords: Free-text query ("software engineer", "recruiter at Google").
+            location: Optional location filter ("New York", "Remote").
+            network: Optional connection-degree filter. Each element is one of
+                ``"F"`` (1st-degree), ``"S"`` (2nd-degree), ``"O"`` (3rd-degree
+                and beyond). Example: ``["F"]`` to only return 1st-degree
+                connections. Invalid tokens raise ``ValueError``. The container
+                shape is repaired at the MCP tool boundary, so the list arrives
+                here already normalized.
+            current_company: Optional current-employer filter. LinkedIn's
+                ``currentCompany`` facet only filters on the numeric company
+                URN id (e.g. ``"1115"`` for SAP); plain company names are
+                accepted by the URL but ignored by LinkedIn and return the
+                unfiltered result set. Look up a company's URN via
+                ``get_company_profile`` -- it is exposed under
+                ``references["about"]``.
+
+        Returns:
+            {url, sections: {name: text}}
+        """
+        # Builds before it navigates, and the builder refuses a filter
+        # LinkedIn would swallow, so an invalid token costs no page load.
+        url = build_people_search_url(
+            keywords,
+            location=location,
+            network=network,
+            current_company=current_company,
+        )
+        extracted = await self._capture.extract_page(url, section_name="search_results")
+
+        sections: dict[str, str] = {}
+        references: dict[str, list[Reference]] = {}
+        section_errors: dict[str, dict[str, Any]] = {}
+        if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
+            sections["search_results"] = extracted.text
+            if extracted.references:
+                references["search_results"] = extracted.references
+        elif extracted.text == RATE_LIMITED_SECTION_TEXT:
+            section_errors["search_results"] = rate_limited_section_error()
+        elif extracted.error:
+            section_errors["search_results"] = extracted.error
+
+        result: dict[str, Any] = {
+            "url": url,
+            "sections": sections,
+        }
+        if references:
+            result["references"] = references
+        if section_errors:
+            result["section_errors"] = section_errors
+        return result

--- a/linkedin_mcp_server/scraping/person.py
+++ b/linkedin_mcp_server/scraping/person.py
@@ -45,12 +45,30 @@ def _js_literal(value: str, quote: str) -> str:
     """Quote one locale-table label for the program below.
 
     Both quoting styles already occur in that program, and reproducing each
-    exactly is what keeps it the byte-identical program the policy traces
-    fingerprint. Escaping is deliberately absent: the table holds visible
-    LinkedIn labels, and a label carrying a quote or a backslash would be a
-    reason to stop matching on text here, not a reason to escape it.
+    exactly is what keeps it the byte-identical program the inlined original
+    was. Escaping is deliberately absent: the table holds visible LinkedIn
+    labels, and a label carrying a quote or a backslash would be a reason to
+    stop matching on text here, not a reason to escape it.
+
+    So the label that cannot be quoted is refused instead, and at import,
+    because the alternative is a `SyntaxError` raised out of `page.evaluate`
+    under an unguarded call — reachable only against live LinkedIn, and only
+    once the table grows the locale this exists to accept.
     """
+    if quote in value or "\\" in value:
+        raise ValueError(
+            f"sidebar chrome label {value!r} cannot be quoted with {quote!r}: "
+            "a label carrying a quote or a backslash is a reason to stop "
+            "matching on text, not a reason to escape it"
+        )
     return f"{quote}{value}{quote}"
+
+
+# The template indents the first heading and the join has to carry the rest,
+# or headings two and three land at column zero. Only whitespace, and the
+# `program_digest` the policy traces fingerprint strips it either way, which
+# is exactly why nothing would have said so.
+_HEADING_INDENT = " " * 20
 
 
 # The sidebar headings and the "Show all" control are the one place this
@@ -126,7 +144,7 @@ _SIDEBAR_PROFILES_JS = """() => {
                 return { sections, showAllUrls };
             }""".replace(
     "__SECTION_HEADINGS__",
-    ",\n".join(
+    f",\n{_HEADING_INDENT}".join(
         _js_literal(heading, '"') for heading in SIDEBAR_CHROME_EN.section_headings
     ),
 ).replace(

--- a/linkedin_mcp_server/scraping/profile_page.py
+++ b/linkedin_mcp_server/scraping/profile_page.py
@@ -1,0 +1,74 @@
+"""Identity a loaded person page states about itself."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+from linkedin_mcp_server.scraping.session import ScrapingSession
+
+
+class MessageTarget(Protocol):
+    """The recipient identity a top-card compose action carries."""
+
+    @property
+    def profile_urn(self) -> str: ...
+
+
+class MessageTargetResolution(Protocol):
+    """One attempt at reading that identity off the current page."""
+
+    @property
+    def target(self) -> MessageTarget | None: ...
+
+
+# The URN is read out of the same atomic top-card snapshot the messaging
+# workflow resolves its recipient from, and that read still belongs to the
+# facade until the message sender owns it. Taking it as a callable keeps the
+# borrow explicit and one-directional: this module never learns what the
+# facade is, and the day the sender owns the read, only the wiring moves.
+ReadMessageTarget = Callable[[], Awaitable[MessageTargetResolution]]
+
+
+class ProfilePageReader:
+    """Read the profile URN and display name off the bound person page."""
+
+    def __init__(
+        self,
+        session: ScrapingSession,
+        read_message_target: ReadMessageTarget,
+    ):
+        self._session = session
+        self._read_message_target = read_message_target
+
+    async def _extract_profile_urn(self) -> str | None:
+        """Extract a profile URN only from one unambiguous top-card snapshot."""
+        resolution = await self._read_message_target()
+        return resolution.target.profile_urn if resolution.target else None
+
+    async def _read_profile_display_name(self) -> str | None:
+        """Read the visible profile name from the current person page."""
+        display_name = await self._session.page.evaluate(
+            """() => {
+                const heading = document.querySelector('main h1');
+                const normalize = value => (value || '').replace(/\\s+/g, ' ').trim();
+                if (heading) {
+                    const headingText = normalize(
+                        heading.innerText || heading.textContent || ''
+                    );
+                    if (headingText) return headingText;
+                }
+
+                const main = document.querySelector('main');
+                if (!main) return '';
+                const lines = (main.innerText || '')
+                    .split('\\n')
+                    .map(normalize)
+                    .filter(Boolean);
+                return lines[0] || '';
+            }"""
+        )
+        if not isinstance(display_name, str):
+            return None
+        display_name = display_name.strip()
+        return display_name or None

--- a/linkedin_mcp_server/scraping/text.py
+++ b/linkedin_mcp_server/scraping/text.py
@@ -172,3 +172,41 @@ def strip_conversation_chrome(text: str, locale: str = "en") -> str:
                 break
 
     return "\n".join(lines[start:end]).strip()
+
+
+# Sidebar recommendation headings on a person page, and the control that opens
+# the full list behind one. Neither carries a URL, an attribute or a structural
+# count separating it from any other heading or anchor in the same container,
+# so both are matched on visible strings — guarded by an explicit per-locale
+# table (CLAUDE.md → Scraping Rules) exactly like the messaging chrome above.
+# This is the only place the strings are written down; `person.py` builds its
+# extraction program from this table rather than repeating them.
+@dataclass(frozen=True)
+class SidebarChromeTable:
+    # Headings of the recommendation sections worth collecting, matched whole
+    # against a normalized `h1`/`h2`/`h3`. A heading outside the table is left
+    # alone rather than guessed at.
+    section_headings: tuple[str, ...]
+    # Prefixes of the anchor that expands a section to its full list, matched
+    # against lowercased anchor text. LinkedIn labels that control either way
+    # depending on the surface, so both spellings are listed.
+    show_all_prefixes: tuple[str, ...]
+
+
+_SIDEBAR_CHROME_STRINGS: dict[str, SidebarChromeTable] = {
+    "en": SidebarChromeTable(
+        section_headings=(
+            "More profiles for you",
+            "Explore premium profiles",
+            "People you may know",
+        ),
+        show_all_prefixes=("show all", "see all"),
+    ),
+}
+
+# BrowserManager forces the context locale to en-US (core/browser.py), so this
+# is the entry a running server reads, and the dictionary above is what makes
+# that dependency visible instead of implicit. A locale with no entry would
+# collect nothing here, which is why the sidebar is the one workflow whose
+# coverage has to be stated per locale rather than assumed.
+SIDEBAR_CHROME_EN = _SIDEBAR_CHROME_STRINGS["en"]

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -159,10 +159,10 @@ _INSTANCE_ATTRIBUTE_OWNERS = {
     "_scroll_seconds": ("facade.LinkedInExtractor._scroll_seconds", 14),
 }
 
-# `_content` and `_capture` are the facade's own wiring rather than a
-# collaborator a test could build for itself: reaching one is how a workflow
-# still living on the facade gets its reader stubbed. Each entry names the
-# collaborator the reach-through lands on and the facade binding the
+# `_content`, `_capture` and `_profile_page` are the facade's own wiring rather
+# than a collaborator a test could build for itself: reaching one is how a
+# workflow still living on the facade gets its reader stubbed. Each entry names
+# the collaborator the reach-through lands on and the facade binding the
 # reach-through itself consumes.
 #
 # Both the reach-through and the patch it carries expire with the workflow the
@@ -170,17 +170,27 @@ _INSTANCE_ATTRIBUTE_OWNERS = {
 # `scrape_company` owns its own reader, a `_content` stub inside a
 # `scrape_company` test intercepts nothing, while a `get_inbox` test reaching
 # the same attribute is still live. Measured over every reach-through in the
-# tree: all 19 `_capture` sites drive `scrape_person` (6), and the 14 `_content`
-# sites split across `scrape_company` (8), `_extract_search_page` and
-# `search_jobs` (9) and `get_inbox`, `get_conversation`,
-# `search_conversations` (11). A single pin at 11 left the one stage-8 and the
-# four stage-9 reach-throughs unflagged for three and two stages; a pin at the
-# facade's own stage 14 would leave every one of them unflagged for the rest of
-# the migration. The stage therefore comes from `_callers`, exactly as a
-# boundary patch's does.
+# tree at stage 6: the 14 `_content` sites split across `scrape_company` (8),
+# `_extract_search_page` and `search_jobs` (9) and `get_inbox`,
+# `get_conversation`, `search_conversations` (11), and the four
+# `_profile_page` sites all drive `get_conversation` (11). A single pin at 11
+# left the one stage-8 and the four stage-9 reach-throughs unflagged for three
+# and two stages; a pin at the facade's own stage 14 would leave every one of
+# them unflagged for the rest of the migration. The stage therefore comes from
+# `_callers`, exactly as a boundary patch's does.
+#
+# `_capture` carries no site of its own any more: all 19 were `scrape_person`
+# tests and retired with stage 6. The entry stays because the workflows that
+# still call `self._capture` from the facade are stages 8 to 12, and removing
+# it would turn the next such reach-through into an unresolved seam rather
+# than a dated one.
 _FACADE_COLLABORATORS = {
     "_content": ("content.PageContentReader", "facade.LinkedInExtractor._content"),
     "_capture": ("capture.SectionCapture", "facade.LinkedInExtractor._capture"),
+    "_profile_page": (
+        "profile_page.ProfilePageReader",
+        "facade.LinkedInExtractor._profile_page",
+    ),
 }
 
 _MODULE_ATTRIBUTE_OWNERS = {
@@ -241,22 +251,15 @@ _EXPLICIT_INSTANCE_BINDINGS = {
     ("tests/test_scraping.py", "_patch_to_composer"): ("extractor",),
 }
 
+# Helpers in an owner's own test module that build the migrated collaborator
+# instead of the facade. Keyed by file and function so a rename becomes a
+# refusal rather than a silent exemption, which is the direction this table
+# has to fail in: it only ever narrows the refusal, never the inventory.
+_OWNER_FACTORIES: dict[str, tuple[str, ...]] = {
+    "tests/scraping/test_person.py": ("_scraper",),
+}
+
 _EXPLICIT_CALLER_CONTEXTS: dict[tuple[str, str, str], tuple[str, ...]] = {
-    (
-        "tests/test_scraping.py",
-        "_calls",
-        "extract_page",
-    ): (
-        "scrape_person",
-        "connect_with_person",
-        "get_sidebar_profiles",
-        "_open_conversation_by_username",
-        "send_message",
-        "scrape_company",
-        "get_company_employees",
-        "scrape_job",
-        "get_conversation",
-    ),
     (
         "tests/scraping/policy_scenarios.py",
         "boundaries",
@@ -287,7 +290,6 @@ _EXPLICIT_CALLER_CONTEXTS: dict[tuple[str, str, str], tuple[str, ...]] = {
         "boundaries",
         "detect_rate_limit",
     ): (
-        "get_sidebar_profiles",
         "_extract_search_page_once",
         "_extract_saved_jobs_page_once",
         "_resolve_conversation_thread_urls",
@@ -302,7 +304,6 @@ _EXPLICIT_CALLER_CONTEXTS: dict[tuple[str, str, str], tuple[str, ...]] = {
         "boundaries",
         "handle_modal_close",
     ): (
-        "get_sidebar_profiles",
         "_extract_search_page_once",
         "_extract_saved_jobs_page_once",
         "_resolve_conversation_thread_urls",
@@ -327,7 +328,6 @@ _EXPLICIT_CALLER_CONTEXTS: dict[tuple[str, str, str], tuple[str, ...]] = {
         "boundaries",
         "build_issue_diagnostics",
     ): (
-        "scrape_person",
         "scrape_company",
         "_extract_search_page",
         "search_jobs",
@@ -659,6 +659,43 @@ class _ScopeFrame:
     # order of its own.
     collaborator_aliases: dict[int, str] = field(default_factory=dict)
     ambiguous_aliases: set[int] = field(default_factory=set)
+    owner_names: set[str] = field(default_factory=set)
+    closure_owner_names: set[str] = field(default_factory=set)
+
+
+def _owner_factory_bindings(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    factories: tuple[str, ...],
+) -> set[str]:
+    """Collect local names bound to a migrated owner rather than the facade.
+
+    A relocated owner wires itself the way the facade does, so its instance
+    carries the same attribute names — `_capture`, `_session`,
+    `_profile_page`. Without this, the wiring signal in
+    `_reaches_the_extractor` reads `scraper._capture` in an owner test as a
+    facade reach-through nobody declared and refuses a patch that never goes
+    near the facade.
+    """
+
+    if not factories:
+        return set()
+    bindings: set[str] = set()
+    for statement in node.body:
+        for item in (statement, *_walk_scope(statement)):
+            if not isinstance(item, (ast.Assign, ast.AnnAssign)):
+                continue
+            value = item.value
+            if not (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Name)
+                and value.func.id in factories
+            ):
+                continue
+            targets = item.targets if isinstance(item, ast.Assign) else [item.target]
+            bindings.update(
+                target.id for target in targets if isinstance(target, ast.Name)
+            )
+    return bindings
 
 
 def _extractor_bindings(
@@ -2436,6 +2473,12 @@ class Scanner(ast.NodeVisitor):
         aliases, ambiguous_aliases = _collaborator_aliases(
             self.path, node, instance_names | class_names
         )
+        owner_names = parent.closure_owner_names - _function_shadowed_names(
+            self.path, node
+        )
+        owner_names.update(
+            _owner_factory_bindings(node, _OWNER_FACTORIES.get(self.relative_path, ()))
+        )
         self.functions.append(node)
         self.frames.append(
             _ScopeFrame(
@@ -2448,6 +2491,8 @@ class Scanner(ast.NodeVisitor):
                 closure_instance_names=set(instance_names),
                 collaborator_aliases=aliases,
                 ambiguous_aliases=ambiguous_aliases,
+                owner_names=owner_names,
+                closure_owner_names=set(owner_names),
             )
         )
         for statement in node.body:
@@ -2604,6 +2649,8 @@ class Scanner(ast.NodeVisitor):
             ambiguous_names=set(frame.ambiguous_names),
             collaborator_aliases=dict(frame.collaborator_aliases),
             ambiguous_aliases=set(frame.ambiguous_aliases),
+            owner_names=set(frame.owner_names),
+            closure_owner_names=set(frame.closure_owner_names),
         )
 
     def _visit_class_suite(self, statements: list[ast.stmt]) -> None:
@@ -2719,6 +2766,8 @@ class Scanner(ast.NodeVisitor):
             closure_module_names=set(parent.closure_module_names),
             closure_class_names=set(parent.closure_class_names),
             closure_instance_names=set(parent.closure_instance_names),
+            owner_names=set(parent.closure_owner_names),
+            closure_owner_names=set(parent.closure_owner_names),
         )
         self.frames.append(frame)
         self._visit_class_suite(node.body)
@@ -2746,9 +2795,12 @@ class Scanner(ast.NodeVisitor):
         )
         local_bindings = collector.bindings - collector.globals - collector.nonlocals
         instance_names = parent.closure_instance_names - local_bindings - parameters
+        owner_names = parent.closure_owner_names - local_bindings - parameters
         self.frames.append(
             _ScopeFrame(
                 kind="function",
+                owner_names=owner_names,
+                closure_owner_names=set(owner_names),
                 module_names=module_names,
                 class_names=class_names,
                 instance_names=instance_names,
@@ -2779,6 +2831,7 @@ class Scanner(ast.NodeVisitor):
         module_names = set(parent.closure_module_names)
         class_names = set(parent.closure_class_names)
         instance_names = set(parent.closure_instance_names)
+        owner_names = set(parent.closure_owner_names)
         frame = _ScopeFrame(
             kind="comprehension",
             module_names=module_names,
@@ -2787,6 +2840,8 @@ class Scanner(ast.NodeVisitor):
             closure_module_names=module_names,
             closure_class_names=class_names,
             closure_instance_names=instance_names,
+            owner_names=owner_names,
+            closure_owner_names=owner_names,
         )
         self.frames.append(frame)
         for generator in (first, *remaining):
@@ -2797,6 +2852,7 @@ class Scanner(ast.NodeVisitor):
             frame.module_names.difference_update(targets)
             frame.class_names.difference_update(targets)
             frame.instance_names.difference_update(targets)
+            frame.owner_names.difference_update(targets)
             for condition in generator.ifs:
                 self.visit(condition)
         for value in values:
@@ -3420,6 +3476,14 @@ class Scanner(ast.NodeVisitor):
         the expression. Measured over every site that falls through today:
         neither fires on any of the 137, and between them they catch the
         chained, ``getattr``-routed and ``self``-rooted reach-throughs.
+
+        The wiring signal has one exception, and it is not optional: a
+        relocated owner wires itself exactly as the facade does, so an owner
+        test's ``scraper._capture`` carries a wiring name while naming no
+        facade at all. Names bound through ``_OWNER_FACTORIES`` are therefore
+        excluded from that signal — from that signal only, and only as the
+        immediate receiver, so ``self._capture`` and every unreducible shape
+        still refuse.
         """
 
         frame = self.frames[-1]
@@ -3430,9 +3494,18 @@ class Scanner(ast.NodeVisitor):
             | frame.ambiguous_names
         )
         wiring = set(_FACADE_COLLABORATORS) | set(_INSTANCE_ATTRIBUTE_OWNERS)
+
+        def names_the_facades_wiring(item: ast.AST) -> bool:
+            if not isinstance(item, ast.Attribute) or item.attr not in wiring:
+                return False
+            receiver = item.value
+            return not (
+                isinstance(receiver, ast.Name) and receiver.id in frame.owner_names
+            )
+
         return any(
             (isinstance(item, ast.Name) and item.id in known)
-            or (isinstance(item, ast.Attribute) and item.attr in wiring)
+            or names_the_facades_wiring(item)
             for item in ast.walk(target)
         )
 

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -698,6 +698,73 @@ def _owner_factory_bindings(
     return bindings
 
 
+class _NonFactoryBindingCollector(_LocalBindingCollector):
+    """Collect a scope's bindings except the ones an owner factory assigns."""
+
+    def __init__(self, path: Path | None, factories: tuple[str, ...]) -> None:
+        super().__init__(path)
+        self.factories = factories
+
+    def _binds_an_owner(self, value: ast.expr | None) -> bool:
+        return (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id in self.factories
+        )
+
+    def visit_Assign(self, node: ast.Assign) -> Any:
+        if not self._binds_an_owner(node.value):
+            self.generic_visit(node)
+            return
+        self.visit(node.value)
+        for target in node.targets:
+            if not isinstance(target, ast.Name):
+                self.visit(target)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> Any:
+        if not self._binds_an_owner(node.value):
+            self.generic_visit(node)
+            return
+        if node.value is not None:
+            self.visit(node.value)
+        if not isinstance(node.target, ast.Name):
+            self.visit(node.target)
+
+
+def _rebound_owner_names(
+    path: Path,
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    factories: tuple[str, ...],
+) -> set[str]:
+    """Collect names the scope also binds through anything but a factory call.
+
+    `_owner_factory_bindings` reads assignment targets and never takes a name
+    back, so a name the factory binds once and a `for`, a `with`, an `except`
+    or an unpack binds again keeps the owner exemption for every use of it.
+    None of those forms is a facade binding either, so `_extractor_bindings`
+    never saw them and the wiring signal in `_reaches_the_extractor` was the
+    only guard left standing over `scraper._capture`.
+
+    Whether the rebinding runs is not asked, the way `_function_shadowed_names`
+    does not ask: a name bound both ways fits no single answer, and the
+    exemption only ever narrows a refusal, so it is the side that gives way.
+    Parameters, `global` and `nonlocal` names count as other forms too — each
+    one says the name is not this scope's to answer for.
+    """
+
+    if not factories:
+        return set()
+    collector = _NonFactoryBindingCollector(path, factories)
+    for statement in node.body:
+        collector.visit(statement)
+    return (
+        collector.bindings
+        | collector.globals
+        | collector.nonlocals
+        | _argument_names(node.args)
+    )
+
+
 def _extractor_bindings(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
     annotation_aliases: set[str],
@@ -2473,12 +2540,12 @@ class Scanner(ast.NodeVisitor):
         aliases, ambiguous_aliases = _collaborator_aliases(
             self.path, node, instance_names | class_names
         )
+        factories = _OWNER_FACTORIES.get(self.relative_path, ())
         owner_names = parent.closure_owner_names - _function_shadowed_names(
             self.path, node
         )
-        owner_names.update(
-            _owner_factory_bindings(node, _OWNER_FACTORIES.get(self.relative_path, ()))
-        )
+        owner_names.update(_owner_factory_bindings(node, factories))
+        owner_names.difference_update(_rebound_owner_names(self.path, node, factories))
         self.functions.append(node)
         self.frames.append(
             _ScopeFrame(
@@ -3483,7 +3550,10 @@ class Scanner(ast.NodeVisitor):
         facade at all. Names bound through ``_OWNER_FACTORIES`` are therefore
         excluded from that signal — from that signal only, and only as the
         immediate receiver, so ``self._capture`` and every unreducible shape
-        still refuse.
+        still refuse. A name the scope also binds some other way loses the
+        exemption in ``_rebound_owner_names``: ``for``, ``with`` and
+        ``except`` targets are no facade binding either, so this signal is the
+        only one that ever sees them.
         """
 
         frame = self.frames[-1]

--- a/tests/fixtures/scraping-policy/migration-manifest.json
+++ b/tests/fixtures/scraping-policy/migration-manifest.json
@@ -61,7 +61,7 @@
     {
       "canonical_owner": "facade.LinkedInExtractor",
       "kind": "direct_import",
-      "line": 30,
+      "line": 31,
       "migration_stage": 14,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "LinkedInExtractor"
@@ -69,7 +69,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "module_attribute",
-      "line": 116,
+      "line": 117,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_to_bottom"
@@ -77,23 +77,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "module_attribute",
-      "line": 117,
+      "line": 118,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_job_sidebar"
     },
     {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "boundary_patch_object",
-      "line": 189,
-      "migration_stage": 6,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "detect_rate_limit"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 189,
+      "line": 190,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -101,7 +93,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 189,
+      "line": 190,
       "migration_stage": 11,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
@@ -109,23 +101,15 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "boundary_patch_object",
-      "line": 189,
+      "line": 190,
       "migration_stage": 12,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "detect_rate_limit"
     },
     {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "boundary_patch_object",
-      "line": 191,
-      "migration_stage": 6,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "handle_modal_close"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 191,
+      "line": 192,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -133,7 +117,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 191,
+      "line": 192,
       "migration_stage": 11,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -141,7 +125,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.dismiss_modal",
       "kind": "boundary_patch_object",
-      "line": 191,
+      "line": 192,
       "migration_stage": 12,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "handle_modal_close"
@@ -149,7 +133,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
       "kind": "boundary_patch_object",
-      "line": 193,
+      "line": 194,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_to_bottom"
@@ -157,23 +141,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
       "kind": "boundary_patch_object",
-      "line": 195,
+      "line": 196,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "scroll_job_sidebar"
     },
     {
-      "canonical_owner": "person.PersonScraper -> error_diagnostics.build_issue_diagnostics",
-      "kind": "boundary_patch_object",
-      "line": 198,
-      "migration_stage": 6,
-      "path": "tests/scraping/policy_scenarios.py",
-      "target": "build_issue_diagnostics"
-    },
-    {
       "canonical_owner": "company.CompanyScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 198,
+      "line": 200,
       "migration_stage": 8,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -181,7 +157,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 198,
+      "line": 200,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -189,7 +165,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> error_diagnostics.build_issue_diagnostics",
       "kind": "boundary_patch_object",
-      "line": 198,
+      "line": 200,
       "migration_stage": 9,
       "path": "tests/scraping/policy_scenarios.py",
       "target": "build_issue_diagnostics"
@@ -269,26 +245,50 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 258,
+      "line": 259,
       "migration_stage": 8,
       "path": "tests/scraping/test_policy_traces.py",
       "target": "search_companies"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 276,
-      "migration_stage": 6,
-      "path": "tests/scraping/test_policy_traces.py",
-      "target": "scrape_person"
     },
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 292,
+      "line": 293,
       "migration_stage": 8,
       "path": "tests/scraping/test_policy_traces.py",
       "target": "search_companies"
+    },
+    {
+      "canonical_owner": "owner-local scraping modules",
+      "kind": "module_alias",
+      "line": 7,
+      "migration_stage": 14,
+      "path": "tests/scraping/test_profile_page.py",
+      "target": "extractor_module"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor",
+      "kind": "direct_import",
+      "line": 8,
+      "migration_stage": 14,
+      "path": "tests/scraping/test_profile_page.py",
+      "target": "LinkedInExtractor"
+    },
+    {
+      "canonical_owner": "message_sender.MessageSender",
+      "kind": "private_facade_access",
+      "line": 21,
+      "migration_stage": 12,
+      "path": "tests/scraping/test_profile_page.py",
+      "target": "_read_profile_message_target"
+    },
+    {
+      "canonical_owner": "message_sender.PROFILE_MESSAGE_TARGET_JS",
+      "kind": "module_attribute",
+      "line": 43,
+      "migration_stage": 12,
+      "path": "tests/scraping/test_profile_page.py",
+      "target": "_PROFILE_MESSAGE_TARGET_JS"
     },
     {
       "canonical_owner": "connection_actions.ACTION_SIGNALS_JS",
@@ -661,7 +661,7 @@
     {
       "canonical_owner": "owner-local scraping modules",
       "kind": "module_alias",
-      "line": 26,
+      "line": 25,
       "migration_stage": 14,
       "path": "tests/test_scraping.py",
       "target": "extractor_module"
@@ -1315,489 +1315,97 @@
       "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "person.PersonScraper dependency",
+      "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 914,
-      "migration_stage": 6,
+      "line": 1073,
+      "migration_stage": 7,
       "path": "tests/test_scraping.py",
-      "target": "extract_page"
+      "target": "scrape_person"
     },
     {
-      "canonical_owner": "capture.SectionCapture",
+      "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 920,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 921,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 926,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 941,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 947,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 948,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 953,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 976,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 982,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 983,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 988,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1005,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1022,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1028,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 1029,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1034,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "company.CompanyScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1053,
-      "migration_stage": 8,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1059,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
       "line": 1078,
-      "migration_stage": 6,
+      "migration_stage": 7,
       "path": "tests/test_scraping.py",
-      "target": "extract_page"
+      "target": "_read_action_signals"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1087,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1102,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
+      "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1108,
-      "migration_stage": 6,
+      "line": 1089,
+      "migration_stage": 7,
       "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
+      "target": "_dialog_is_open"
     },
     {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 1109,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1114,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1146,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
+      "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1152,
-      "migration_stage": 6,
+      "line": 1095,
+      "migration_stage": 7,
       "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
+      "target": "_click_dialog_primary_button"
     },
     {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
+      "canonical_owner": "connection_actions.ConnectionActions dependency",
+      "kind": "public_patch_object",
+      "line": 1116,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "scrape_person"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 1119,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_read_action_signals"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 1126,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_dialog_is_open"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 1129,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_click_dialog_primary_button"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
       "line": 1153,
-      "migration_stage": 6,
+      "migration_stage": 7,
       "path": "tests/test_scraping.py",
-      "target": "_capture"
+      "target": "_get_premium_upsell_message"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1158,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1188,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
+      "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1194,
-      "migration_stage": 6,
+      "line": 1186,
+      "migration_stage": 7,
       "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
+      "target": "_dialog_is_open"
     },
     {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
+      "line": 1189,
+      "migration_stage": 7,
+      "path": "tests/test_scraping.py",
+      "target": "_get_premium_upsell_message"
+    },
+    {
+      "canonical_owner": "connection_actions.ConnectionActions",
+      "kind": "private_patch_object",
       "line": 1195,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1200,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1214,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1220,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 1221,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1226,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1240,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1246,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 1247,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1252,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1266,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1272,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 1273,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1278,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 1292,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 1298,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 1299,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 1304,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 1483,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "scrape_person"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 1488,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_read_action_signals"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 1499,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_dialog_is_open"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 1505,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_click_dialog_primary_button"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 1526,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "scrape_person"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 1529,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_read_action_signals"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 1536,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_dialog_is_open"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 1539,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_click_dialog_primary_button"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_facade_access",
-      "line": 1563,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_get_premium_upsell_message"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 1596,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_dialog_is_open"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 1599,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "_get_premium_upsell_message"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions",
-      "kind": "private_patch_object",
-      "line": 1605,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -1805,7 +1413,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 1609,
+      "line": 1199,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -1813,7 +1421,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1657,
+      "line": 1247,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -1821,7 +1429,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1665,
+      "line": 1255,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_fill_dialog_textarea"
@@ -1829,7 +1437,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1671,
+      "line": 1261,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -1837,7 +1445,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1677,
+      "line": 1267,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -1845,7 +1453,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1683,
+      "line": 1273,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -1853,7 +1461,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 1687,
+      "line": 1277,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -1861,7 +1469,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1699,
+      "line": 1289,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -1869,7 +1477,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1700,
+      "line": 1290,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -1877,7 +1485,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1707,
+      "line": 1297,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -1885,7 +1493,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1710,
+      "line": 1300,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -1893,7 +1501,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1722,
+      "line": 1312,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -1901,7 +1509,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1723,
+      "line": 1313,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -1909,7 +1517,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1740,
+      "line": 1330,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -1917,7 +1525,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1741,
+      "line": 1331,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -1925,7 +1533,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1763,
+      "line": 1353,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -1933,7 +1541,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1768,
+      "line": 1358,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -1941,7 +1549,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1781,
+      "line": 1371,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -1949,7 +1557,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1790,
+      "line": 1380,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -1957,7 +1565,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1796,
+      "line": 1386,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_dialog_primary_button"
@@ -1965,7 +1573,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1821,
+      "line": 1411,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -1973,7 +1581,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1822,
+      "line": 1412,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -1981,7 +1589,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1832,
+      "line": 1422,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -1989,7 +1597,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1841,
+      "line": 1431,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -1997,7 +1605,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1862,
+      "line": 1452,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2005,7 +1613,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1863,
+      "line": 1453,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2013,7 +1621,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1872,
+      "line": 1462,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2021,7 +1629,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1881,
+      "line": 1471,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_probe_invite_note_limit"
@@ -2029,7 +1637,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1887,
+      "line": 1477,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2037,7 +1645,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1910,
+      "line": 1500,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2045,7 +1653,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1911,
+      "line": 1501,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2053,7 +1661,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1917,
+      "line": 1507,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_open_more_menu"
@@ -2061,7 +1669,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1926,
+      "line": 1516,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2069,7 +1677,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1944,
+      "line": 1534,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2077,7 +1685,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1945,
+      "line": 1535,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2085,7 +1693,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1954,
+      "line": 1544,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2093,7 +1701,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 1972,
+      "line": 1562,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2101,7 +1709,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1977,
+      "line": 1567,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2109,7 +1717,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1986,
+      "line": 1576,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2117,7 +1725,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 1997,
+      "line": 1587,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
@@ -2125,7 +1733,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2017,
+      "line": 1607,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2133,7 +1741,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2022,
+      "line": 1612,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2141,7 +1749,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2028,
+      "line": 1618,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2149,7 +1757,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2034,
+      "line": 1624,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "click_button_by_text"
@@ -2157,7 +1765,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2059,
+      "line": 1649,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2165,7 +1773,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2069,
+      "line": 1659,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2173,7 +1781,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2075,
+      "line": 1665,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2181,7 +1789,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2081,
+      "line": 1671,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2189,7 +1797,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2106,
+      "line": 1696,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2197,7 +1805,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2111,
+      "line": 1701,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2205,7 +1813,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2121,
+      "line": 1711,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_click_incoming_accept"
@@ -2213,7 +1821,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2127,
+      "line": 1717,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2221,7 +1829,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2143,
+      "line": 1733,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2229,7 +1837,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2144,
+      "line": 1734,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -2237,7 +1845,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2151,
+      "line": 1741,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2245,7 +1853,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2154,
+      "line": 1744,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dismiss_dialog"
@@ -2253,7 +1861,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 2164,
+      "line": 1754,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -2261,7 +1869,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2237,
+      "line": 1827,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_dialog_is_open"
@@ -2269,7 +1877,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 2240,
+      "line": 1830,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_get_premium_upsell_message"
@@ -2277,175 +1885,15 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_facade_access",
-      "line": 2251,
+      "line": 1841,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_submit_invite_dialog"
     },
     {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 2264,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 2291,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 2292,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 2297,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 2323,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> error_diagnostics.build_issue_diagnostics",
-      "kind": "string_patch",
-      "line": 2328,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 2332,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 2333,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 2338,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 2368,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 2377,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 2378,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 2383,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 2406,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 2412,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_profile_urn"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 2418,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 2432,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 2441,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 2442,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 2447,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 2463,
+      "line": 1858,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2453,7 +1901,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2469,
+      "line": 1864,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2461,7 +1909,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 2485,
+      "line": 1884,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2469,7 +1917,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2491,
+      "line": 1890,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2477,7 +1925,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 2506,
+      "line": 1906,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2485,7 +1933,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2512,
+      "line": 1912,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2493,7 +1941,7 @@
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 2533,
+      "line": 1927,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2501,7 +1949,23 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2542,
+      "line": 1933,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "company.CompanyScraper dependency",
+      "kind": "public_patch_object",
+      "line": 1954,
+      "migration_stage": 8,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 1963,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2509,7 +1973,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 2582,
+      "line": 2003,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -2517,7 +1981,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
-      "line": 2583,
+      "line": 2004,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "_content"
@@ -2525,7 +1989,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 2588,
+      "line": 2009,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -2533,7 +1997,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 2592,
+      "line": 2013,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -2541,7 +2005,7 @@
     {
       "canonical_owner": "company.CompanyScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 2596,
+      "line": 2017,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -2549,7 +2013,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2601,
+      "line": 2022,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2557,7 +2021,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 2622,
+      "line": 2043,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2565,7 +2029,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 2637,
+      "line": 2058,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2573,7 +2037,7 @@
     {
       "canonical_owner": "jobs.JobScraper dependency",
       "kind": "public_patch_object",
-      "line": 2652,
+      "line": 2073,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -2581,7 +2045,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2698,
+      "line": 2119,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -2589,10 +2053,378 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2704,
+      "line": 2125,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2131,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2137,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2150,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2159,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2165,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2171,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2201,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2206,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2212,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2218,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 2281,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 2282,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_content"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2287,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2293,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 2299,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 2304,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 2308,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2378,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2384,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2390,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2396,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2415,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2421,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2427,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2433,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2465,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2466,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2472,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2478,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 2534,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 2535,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_content"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2540,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2546,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 2552,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 2557,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 2561,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2566,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2591,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2596,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2602,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2608,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 2632,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2648,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2657,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2663,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2669,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -2600,28 +2432,12 @@
       "line": 2710,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 2716,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 2729,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2738,
+      "line": 2711,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -2629,7 +2445,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2744,
+      "line": 2717,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -2637,7 +2453,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 2750,
+      "line": 2723,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2645,7 +2461,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2780,
+      "line": 2749,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -2653,7 +2469,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2785,
+      "line": 2758,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -2661,7 +2477,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2791,
+      "line": 2764,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -2669,95 +2485,71 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
+      "line": 2770,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 2797,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2808,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2814,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 2820,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "content.PageContentReader",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2843,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 2854,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
       "line": 2860,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_get_total_search_pages"
     },
     {
-      "canonical_owner": "jobs.JobScraper -> facade.LinkedInExtractor._content",
-      "kind": "private_facade_access",
-      "line": 2861,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_content"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
       "line": 2866,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 2872,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 2878,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 2883,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 2887,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 2957,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 2963,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 2969,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 2975,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2765,7 +2557,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 2994,
+      "line": 2898,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -2773,7 +2565,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3000,
+      "line": 2903,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -2781,7 +2573,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3006,
+      "line": 2909,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -2789,7 +2581,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3012,
+      "line": 2915,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -2797,7 +2589,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3044,
+      "line": 2939,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -2805,7 +2597,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3045,
+      "line": 2948,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -2813,7 +2605,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3051,
+      "line": 2954,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -2821,95 +2613,111 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3057,
+      "line": 2960,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "content.PageContentReader",
+      "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3113,
+      "line": 3018,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
+      "target": "_extract_search_page"
     },
     {
-      "canonical_owner": "jobs.JobScraper -> facade.LinkedInExtractor._content",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3019,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3025,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3031,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3065,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3071,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3077,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3083,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "facade.LinkedInExtractor._scroll_seconds",
       "kind": "private_facade_access",
-      "line": 3114,
+      "line": 3123,
+      "migration_stage": 14,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_seconds"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
+      "kind": "module_rebind_patch",
+      "line": 3134,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_content"
+      "target": "time"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3119,
+      "line": 3135,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
+      "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3125,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 3131,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
       "line": 3136,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 3140,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3145,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3170,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3175,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3181,
+      "line": 3142,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -2917,23 +2725,23 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3187,
+      "line": 3148,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 3211,
+      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
+      "kind": "module_rebind_patch",
+      "line": 3192,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
+      "target": "time"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3227,
+      "line": 3193,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -2941,7 +2749,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3236,
+      "line": 3194,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -2949,7 +2757,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3242,
+      "line": 3200,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -2957,15 +2765,23 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3248,
+      "line": 3206,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
+      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
+      "kind": "module_rebind_patch",
+      "line": 3256,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "time"
+    },
+    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3289,
+      "line": 3257,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -2973,7 +2789,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3290,
+      "line": 3258,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -2981,7 +2797,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3296,
+      "line": 3264,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -2989,15 +2805,23 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3302,
+      "line": 3270,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
+      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
+      "kind": "module_rebind_patch",
+      "line": 3316,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "time"
+    },
+    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3328,
+      "line": 3317,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3005,7 +2829,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3337,
+      "line": 3318,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3013,7 +2837,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3343,
+      "line": 3324,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3021,7 +2845,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3349,
+      "line": 3330,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3029,7 +2853,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3376,
+      "line": 3347,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3037,7 +2861,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3387,
+      "line": 3353,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3045,7 +2869,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3393,
+      "line": 3359,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3053,7 +2877,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3399,
+      "line": 3365,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3061,7 +2885,39 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3422,
+      "line": 3379,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3385,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3391,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3397,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3425,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3093,7 +2949,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3477,
+      "line": 3461,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3101,7 +2957,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3482,
+      "line": 3466,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3109,7 +2965,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3488,
+      "line": 3472,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3117,7 +2973,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3494,
+      "line": 3478,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3125,7 +2981,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3518,
+      "line": 3500,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3133,7 +2989,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3527,
+      "line": 3509,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3141,7 +2997,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3533,
+      "line": 3515,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3149,15 +3005,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
+      "line": 3521,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 3539,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3597,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3165,7 +3021,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3598,
+      "line": 3550,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3173,7 +3029,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3604,
+      "line": 3556,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3181,7 +3037,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3610,
+      "line": 3562,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3189,7 +3045,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3644,
+      "line": 3601,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3197,7 +3053,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3650,
+      "line": 3606,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3205,7 +3061,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3656,
+      "line": 3612,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3213,31 +3069,103 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3662,
+      "line": 3618,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "facade.LinkedInExtractor._scroll_seconds",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3635,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3645,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3651,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3657,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 3678,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 3682,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 3687,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_facade_access",
-      "line": 3702,
-      "migration_stage": 14,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_seconds"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 3713,
+      "line": 3693,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "time"
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 3724,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 3728,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "kind": "string_patch",
+      "line": 3733,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3714,
+      "kind": "private_facade_access",
+      "line": 3739,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3245,39 +3173,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3715,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3721,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3727,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 3771,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "time"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3772,
+      "line": 3755,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3285,7 +3181,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3773,
+      "line": 3764,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3293,7 +3189,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3779,
+      "line": 3770,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3301,31 +3197,55 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3785,
+      "line": 3776,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
-      "kind": "module_rebind_patch",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3797,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_search_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3806,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 3812,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_search_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 3818,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
       "line": 3835,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "time"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3836,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3837,
+      "line": 3841,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3333,7 +3253,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3843,
+      "line": 3847,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_search_pages"
@@ -3341,23 +3261,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3849,
+      "line": 3853,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "jobs.JobScraper -> owner-local time module binding",
-      "kind": "module_rebind_patch",
-      "line": 3895,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "time"
-    },
-    {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3896,
+      "line": 3869,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3365,23 +3277,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3897,
+      "line": 3878,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3903,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3909,
+      "line": 3884,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3389,7 +3293,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3926,
+      "line": 3904,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_search_page"
@@ -3397,103 +3301,111 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 3932,
+      "line": 3913,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3938,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 3944,
+      "line": 3919,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 3958,
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 3955,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 3959,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
       "line": 3964,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
+      "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 3970,
+      "line": 3968,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_extract_root_content"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 3976,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4004,
+      "canonical_owner": "job_pages.JobPageReader -> facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 3969,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_content"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4012,
+      "kind": "private_facade_access",
+      "line": 3979,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
+      "target": "_extract_saved_jobs_page"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 4014,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
       "line": 4018,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4024,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4040,
+      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
+      "kind": "string_patch",
+      "line": 4023,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_facade_access",
+      "line": 4033,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4045,
+      "line": 4061,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4067,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3501,47 +3413,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4051,
+      "line": 4073,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_get_total_list_pages"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4057,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
       "line": 4079,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4088,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4094,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4100,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3549,15 +3429,15 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4118,
+      "line": 4101,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_extract_saved_jobs_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4129,
+      "line": 4107,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3565,18 +3445,58 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4135,
+      "line": 4113,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_get_total_list_pages"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4141,
+      "line": 4119,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4136,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4145,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4151,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4157,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4173,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
@@ -3584,28 +3504,20 @@
       "line": 4180,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4185,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4191,
+      "line": 4186,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_get_total_list_pages"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4197,
+      "line": 4192,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -3616,12 +3528,12 @@
       "line": 4214,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
+      "target": "_extract_saved_jobs_page"
     },
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4224,
+      "line": 4217,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -3629,527 +3541,79 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4230,
+      "line": 4223,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
+      "target": "_get_total_list_pages"
     },
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4236,
+      "line": 4229,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4247,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_saved_jobs_page"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4252,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_job_ids"
+    },
+    {
+      "canonical_owner": "job_pages.JobPageReader",
+      "kind": "private_patch_object",
+      "line": 4258,
+      "migration_stage": 9,
+      "path": "tests/test_scraping.py",
+      "target": "_get_total_list_pages"
+    },
+    {
+      "canonical_owner": "global imported object, unaffected by relocation",
+      "kind": "imported_module_patch",
+      "line": 4264,
+      "migration_stage": null,
+      "path": "tests/test_scraping.py",
+      "target": "asyncio.sleep"
+    },
+    {
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 4257,
+      "line": 4290,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 4261,
+      "line": 4294,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 4266,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 4272,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 4303,
+      "line": 4339,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
     },
     {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
+      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 4307,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_job_sidebar",
-      "kind": "string_patch",
-      "line": 4312,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_job_sidebar"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 4318,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4334,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
       "line": 4343,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4349,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4355,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4376,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4385,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4391,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4397,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4414,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4420,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4426,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_search_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4432,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4448,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4457,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4463,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4483,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_search_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4492,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4498,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 4534,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 4538,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 4543,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 4547,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> facade.LinkedInExtractor._content",
-      "kind": "private_facade_access",
-      "line": 4548,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_content"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 4558,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 4593,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 4597,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader -> session.ScrapingSession.scroll_body",
-      "kind": "string_patch",
-      "line": 4602,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_facade_access",
-      "line": 4612,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4640,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4646,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4652,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4658,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4680,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4686,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4692,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4698,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4715,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4724,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4730,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4736,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4752,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4759,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4765,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4771,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4793,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4796,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4802,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4808,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4826,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_saved_jobs_page"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4831,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_job_ids"
-    },
-    {
-      "canonical_owner": "job_pages.JobPageReader",
-      "kind": "private_patch_object",
-      "line": 4837,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "_get_total_list_pages"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 4843,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 4869,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 4873,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 4918,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 4922,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4157,7 +3621,7 @@
     {
       "canonical_owner": "jobs.JobScraper -> session.ScrapingSession.scroll_body",
       "kind": "string_patch",
-      "line": 4927,
+      "line": 4348,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.scroll_to_bottom"
@@ -4165,7 +3629,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4946,
+      "line": 4367,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4173,7 +3637,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4952,
+      "line": 4373,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4181,7 +3645,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4958,
+      "line": 4379,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4189,7 +3653,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4973,
+      "line": 4394,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4197,7 +3661,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 4979,
+      "line": 4400,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4205,7 +3669,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 4985,
+      "line": 4406,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4213,7 +3677,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5006,
+      "line": 4427,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4221,7 +3685,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5015,
+      "line": 4436,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4229,7 +3693,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5021,
+      "line": 4442,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4237,7 +3701,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5027,
+      "line": 4448,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4245,7 +3709,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5048,
+      "line": 4469,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4253,7 +3717,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5053,
+      "line": 4474,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4261,7 +3725,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5059,
+      "line": 4480,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4269,7 +3733,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5065,
+      "line": 4486,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4277,7 +3741,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5088,
+      "line": 4509,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4285,7 +3749,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5094,
+      "line": 4515,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4293,7 +3757,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5100,
+      "line": 4521,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4301,7 +3765,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5106,
+      "line": 4527,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4309,7 +3773,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5130,
+      "line": 4551,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4317,7 +3781,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5136,
+      "line": 4557,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4325,7 +3789,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5142,
+      "line": 4563,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4333,7 +3797,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5148,
+      "line": 4569,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4341,7 +3805,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5168,
+      "line": 4589,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4349,7 +3813,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5174,
+      "line": 4595,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4357,7 +3821,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5180,
+      "line": 4601,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4365,7 +3829,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5186,
+      "line": 4607,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -4373,7 +3837,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5209,
+      "line": 4630,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_saved_jobs_page"
@@ -4381,7 +3845,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5215,
+      "line": 4636,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_extract_job_ids"
@@ -4389,7 +3853,7 @@
     {
       "canonical_owner": "job_pages.JobPageReader",
       "kind": "private_patch_object",
-      "line": 5221,
+      "line": 4642,
       "migration_stage": 9,
       "path": "tests/test_scraping.py",
       "target": "_get_total_list_pages"
@@ -4397,295 +3861,63 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5227,
+      "line": 4648,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
     },
     {
-      "canonical_owner": "person.PersonScraper dependency",
+      "canonical_owner": "posts.PostSearch dependency",
       "kind": "public_patch_object",
-      "line": 5259,
-      "migration_stage": 6,
+      "line": 4699,
+      "migration_stage": 10,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "posts.PostSearch dependency",
+      "kind": "public_patch_object",
+      "line": 4717,
+      "migration_stage": 10,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "posts.PostSearch dependency",
+      "kind": "public_patch_object",
+      "line": 4731,
+      "migration_stage": 10,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "posts.PostSearch dependency",
+      "kind": "public_patch_object",
+      "line": 4752,
+      "migration_stage": 10,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "posts.PostSearch dependency",
+      "kind": "public_patch_object",
+      "line": 4766,
+      "migration_stage": 10,
+      "path": "tests/test_scraping.py",
+      "target": "extract_page"
+    },
+    {
+      "canonical_owner": "posts.PostSearch dependency",
+      "kind": "public_patch_object",
+      "line": 4779,
+      "migration_stage": 10,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
     },
     {
       "canonical_owner": "company.CompanyScraper dependency",
       "kind": "public_patch_object",
-      "line": 5259,
-      "migration_stage": 8,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5274,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5296,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5308,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5320,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5355,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5367,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 5390,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 5408,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 5422,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 5443,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 5457,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "posts.PostSearch dependency",
-      "kind": "public_patch_object",
-      "line": 5470,
-      "migration_stage": 10,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5499,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 5505,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_overlay"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 5506,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5511,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5542,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5548,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5566,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5572,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5600,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "scrape_person"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 5617,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_loaded_section"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 5618,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5623,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5629,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5648,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 5654,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_loaded_section"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 5655,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5659,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "capture.SectionCapture",
-      "kind": "private_patch_object",
-      "line": 5676,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_loaded_section"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> facade.LinkedInExtractor._capture",
-      "kind": "private_facade_access",
-      "line": 5677,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_capture"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5682,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5688,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "company.CompanyScraper dependency",
-      "kind": "public_patch_object",
-      "line": 5714,
+      "line": 4808,
       "migration_stage": 8,
       "path": "tests/test_scraping.py",
       "target": "extract_page"
@@ -4693,135 +3925,15 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 5720,
+      "line": 4814,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5770,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5774,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5779,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5831,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5835,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5861,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5865,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> owner-local logger binding",
-      "kind": "imported_module_patch",
-      "line": 5870,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "logger.debug"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5899,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5903,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5937,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5941,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 5946,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 5966,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "person.PersonScraper -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 5970,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
     },
     {
       "canonical_owner": "message_sender.profile_urn_from_compose_url",
       "kind": "module_attribute",
-      "line": 6031,
+      "line": 4888,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_profile_urn_from_compose_url"
@@ -4829,7 +3941,7 @@
     {
       "canonical_owner": "message_sender.profile_path_from_url",
       "kind": "module_attribute",
-      "line": 6049,
+      "line": 4906,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_profile_path_from_url"
@@ -4837,71 +3949,15 @@
     {
       "canonical_owner": "message_sender.message_page_url_is_safe",
       "kind": "module_attribute",
-      "line": 6110,
+      "line": 4967,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_page_url_is_safe"
     },
     {
-      "canonical_owner": "message_sender.PROFILE_MESSAGE_TARGET_JS",
-      "kind": "module_attribute",
-      "line": 6131,
-      "migration_stage": 12,
-      "path": "tests/test_scraping.py",
-      "target": "_PROFILE_MESSAGE_TARGET_JS"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 6178,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 6184,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_profile_urn"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 6190,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 6203,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 6209,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_profile_urn"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 6215,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6235,
+      "line": 5002,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4909,7 +3965,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6239,
+      "line": 5006,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4917,7 +3973,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6243,
+      "line": 5010,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -4925,7 +3981,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6248,
+      "line": 5015,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -4933,7 +3989,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 6253,
+      "line": 5020,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -4941,7 +3997,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
-      "line": 6254,
+      "line": 5021,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
@@ -4949,7 +4005,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 6262,
+      "line": 5029,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -4957,7 +4013,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 6266,
+      "line": 5033,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -4965,7 +4021,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6270,
+      "line": 5037,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -4973,7 +4029,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6288,
+      "line": 5055,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -4981,7 +4037,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6292,
+      "line": 5059,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -4989,7 +4045,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6296,
+      "line": 5063,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -4997,7 +4053,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6297,
+      "line": 5064,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -5005,7 +4061,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 6300,
+      "line": 5067,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -5013,7 +4069,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
-      "line": 6301,
+      "line": 5068,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
@@ -5021,7 +4077,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 6306,
+      "line": 5073,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5029,7 +4085,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6310,
+      "line": 5077,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5037,7 +4093,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6340,
+      "line": 5107,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5045,7 +4101,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6344,
+      "line": 5111,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5053,7 +4109,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6348,
+      "line": 5115,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5061,7 +4117,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6349,
+      "line": 5116,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -5069,7 +4125,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 6352,
+      "line": 5119,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -5077,7 +4133,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
-      "line": 6353,
+      "line": 5120,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
@@ -5085,7 +4141,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 6361,
+      "line": 5128,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5093,7 +4149,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 6365,
+      "line": 5132,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5101,7 +4157,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6369,
+      "line": 5136,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5109,7 +4165,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6393,
+      "line": 5160,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5117,7 +4173,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6397,
+      "line": 5164,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5125,7 +4181,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6401,
+      "line": 5168,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5133,7 +4189,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6402,
+      "line": 5169,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -5141,7 +4197,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 6405,
+      "line": 5172,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -5149,7 +4205,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
-      "line": 6406,
+      "line": 5173,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
@@ -5157,7 +4213,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 6411,
+      "line": 5178,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5165,7 +4221,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 6415,
+      "line": 5182,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5173,7 +4229,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6439,
+      "line": 5206,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5181,7 +4237,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6443,
+      "line": 5210,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5189,7 +4245,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6447,
+      "line": 5214,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5197,7 +4253,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6448,
+      "line": 5215,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -5205,7 +4261,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 6451,
+      "line": 5218,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -5213,7 +4269,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
-      "line": 6452,
+      "line": 5219,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
@@ -5221,7 +4277,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 6457,
+      "line": 5224,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5229,7 +4285,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6479,
+      "line": 5246,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5237,7 +4293,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6483,
+      "line": 5250,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5245,7 +4301,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6487,
+      "line": 5254,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5253,7 +4309,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6488,
+      "line": 5255,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -5261,15 +4317,23 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 6491,
-      "migration_stage": 6,
+      "line": 5258,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_display_name"
     },
     {
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._profile_page",
+      "kind": "private_facade_access",
+      "line": 5259,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_profile_page"
+    },
+    {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6497,
+      "line": 5264,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -5277,7 +4341,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 6506,
+      "line": 5273,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -5285,87 +4349,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
-      "line": 6507,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
-      "kind": "string_patch",
-      "line": 6512,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
-      "kind": "string_patch",
-      "line": 6516,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.build_references"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
-      "kind": "string_patch",
-      "line": 6537,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
-      "kind": "string_patch",
-      "line": 6541,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 6545,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_wait_for_main_text"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 6546,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_scroll_main_scrollable_region"
-    },
-    {
-      "canonical_owner": "profile_page.ProfilePageReader",
-      "kind": "private_patch_object",
-      "line": 6549,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "_read_profile_display_name"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader",
-      "kind": "private_patch_object",
-      "line": 6555,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_resolve_conversation_thread_urls"
-    },
-    {
-      "canonical_owner": "content.PageContentReader",
-      "kind": "private_patch_object",
-      "line": 6564,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "_extract_root_content"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
-      "kind": "private_facade_access",
-      "line": 6565,
+      "line": 5274,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
@@ -5373,7 +4357,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 6570,
+      "line": 5279,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5381,7 +4365,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 6574,
+      "line": 5283,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5389,7 +4373,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6594,
+      "line": 5304,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5397,7 +4381,95 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6598,
+      "line": 5308,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 5312,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_wait_for_main_text"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 5313,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_scroll_main_scrollable_region"
+    },
+    {
+      "canonical_owner": "profile_page.ProfilePageReader",
+      "kind": "private_patch_object",
+      "line": 5316,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_read_profile_display_name"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._profile_page",
+      "kind": "private_facade_access",
+      "line": 5317,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_profile_page"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader",
+      "kind": "private_patch_object",
+      "line": 5322,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_resolve_conversation_thread_urls"
+    },
+    {
+      "canonical_owner": "content.PageContentReader",
+      "kind": "private_patch_object",
+      "line": 5331,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_extract_root_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
+      "kind": "private_facade_access",
+      "line": 5332,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_content"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
+      "kind": "string_patch",
+      "line": 5337,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
+      "kind": "string_patch",
+      "line": 5341,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.build_references"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
+      "kind": "string_patch",
+      "line": 5361,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
+    },
+    {
+      "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
+      "kind": "string_patch",
+      "line": 5365,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5405,15 +4477,23 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 6602,
-      "migration_stage": 6,
+      "line": 5369,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_display_name"
     },
     {
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._profile_page",
+      "kind": "private_facade_access",
+      "line": 5370,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_profile_page"
+    },
+    {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6608,
+      "line": 5375,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -5421,7 +4501,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6626,
+      "line": 5393,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5429,7 +4509,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6630,
+      "line": 5397,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5437,15 +4517,23 @@
     {
       "canonical_owner": "profile_page.ProfilePageReader",
       "kind": "private_patch_object",
-      "line": 6634,
-      "migration_stage": 6,
+      "line": 5401,
+      "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_display_name"
     },
     {
+      "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._profile_page",
+      "kind": "private_facade_access",
+      "line": 5402,
+      "migration_stage": 11,
+      "path": "tests/test_scraping.py",
+      "target": "_profile_page"
+    },
+    {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6640,
+      "line": 5407,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -5453,7 +4541,7 @@
     {
       "canonical_owner": "conversations.strip_select_conversation_prefix",
       "kind": "private_facade_access",
-      "line": 6657,
+      "line": 5424,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_strip_select_conversation_prefix"
@@ -5461,7 +4549,7 @@
     {
       "canonical_owner": "conversations.strip_select_conversation_prefix",
       "kind": "private_facade_access",
-      "line": 6665,
+      "line": 5432,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_strip_select_conversation_prefix"
@@ -5469,7 +4557,7 @@
     {
       "canonical_owner": "conversations.strip_select_conversation_prefix",
       "kind": "private_facade_access",
-      "line": 6675,
+      "line": 5442,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_strip_select_conversation_prefix"
@@ -5477,7 +4565,7 @@
     {
       "canonical_owner": "conversations.strip_select_conversation_prefix",
       "kind": "private_facade_access",
-      "line": 6682,
+      "line": 5449,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_strip_select_conversation_prefix"
@@ -5485,7 +4573,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6713,
+      "line": 5480,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5493,7 +4581,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6717,
+      "line": 5484,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5501,7 +4589,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6721,
+      "line": 5488,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5509,7 +4597,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6722,
+      "line": 5489,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -5517,7 +4605,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6725,
+      "line": 5492,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5525,7 +4613,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_facade_access",
-      "line": 6732,
+      "line": 5499,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -5533,7 +4621,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6756,
+      "line": 5523,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5541,7 +4629,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6760,
+      "line": 5527,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5549,7 +4637,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6764,
+      "line": 5531,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5557,7 +4645,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6765,
+      "line": 5532,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -5565,7 +4653,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6768,
+      "line": 5535,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5573,7 +4661,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_facade_access",
-      "line": 6770,
+      "line": 5537,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -5581,7 +4669,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6798,
+      "line": 5565,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5589,7 +4677,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6802,
+      "line": 5569,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5597,7 +4685,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6806,
+      "line": 5573,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5605,7 +4693,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6807,
+      "line": 5574,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_scroll_main_scrollable_region"
@@ -5613,7 +4701,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6810,
+      "line": 5577,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5621,7 +4709,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_facade_access",
-      "line": 6812,
+      "line": 5579,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_resolve_conversation_thread_urls"
@@ -5629,7 +4717,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_facade_access",
-      "line": 6836,
+      "line": 5603,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5637,7 +4725,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6851,
+      "line": 5618,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5645,7 +4733,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6855,
+      "line": 5622,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5653,7 +4741,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6859,
+      "line": 5626,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5661,7 +4749,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 6860,
+      "line": 5627,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -5669,7 +4757,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
-      "line": 6861,
+      "line": 5628,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
@@ -5677,7 +4765,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 6866,
+      "line": 5633,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5685,7 +4773,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 6870,
+      "line": 5637,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5693,7 +4781,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6874,
+      "line": 5641,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5701,7 +4789,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 6911,
+      "line": 5678,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5709,7 +4797,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> session.ScrapingSession.dismiss_modal",
       "kind": "string_patch",
-      "line": 6915,
+      "line": 5682,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.handle_modal_close"
@@ -5717,7 +4805,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6919,
+      "line": 5686,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_main_text"
@@ -5725,7 +4813,7 @@
     {
       "canonical_owner": "content.PageContentReader",
       "kind": "private_patch_object",
-      "line": 6920,
+      "line": 5687,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_root_content"
@@ -5733,7 +4821,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> facade.LinkedInExtractor._content",
       "kind": "private_facade_access",
-      "line": 6921,
+      "line": 5688,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_content"
@@ -5741,7 +4829,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> text.strip_linkedin_noise",
       "kind": "string_patch",
-      "line": 6926,
+      "line": 5693,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.strip_linkedin_noise"
@@ -5749,7 +4837,7 @@
     {
       "canonical_owner": "conversations.ConversationReader -> link_metadata.build_references",
       "kind": "string_patch",
-      "line": 6930,
+      "line": 5697,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.build_references"
@@ -5757,7 +4845,7 @@
     {
       "canonical_owner": "conversations.ConversationReader",
       "kind": "private_patch_object",
-      "line": 6934,
+      "line": 5701,
       "migration_stage": 11,
       "path": "tests/test_scraping.py",
       "target": "_extract_conversation_thread_refs"
@@ -5765,7 +4853,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7021,
+      "line": 5788,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5773,7 +4861,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7025,
+      "line": 5792,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -5781,7 +4869,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 7029,
+      "line": 5796,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -5789,7 +4877,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7033,
+      "line": 5800,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_message_surface"
@@ -5797,7 +4885,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7036,
+      "line": 5803,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_message_composer_state"
@@ -5805,7 +4893,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7039,
+      "line": 5806,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_focus_verified_message_editor"
@@ -5813,7 +4901,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7044,
+      "line": 5811,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -5821,7 +4909,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7076,
+      "line": 5843,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5829,7 +4917,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7080,
+      "line": 5847,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -5837,7 +4925,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 7084,
+      "line": 5851,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -5845,7 +4933,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTarget",
       "kind": "module_attribute",
-      "line": 7097,
+      "line": 5864,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTarget"
@@ -5853,7 +4941,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7148,
+      "line": 5915,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5861,7 +4949,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7152,
+      "line": 5919,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -5869,7 +4957,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 7156,
+      "line": 5923,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -5877,7 +4965,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7160,
+      "line": 5927,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_message_surface"
@@ -5885,7 +4973,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7166,
+      "line": 5933,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_message_composer_state"
@@ -5893,7 +4981,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7179,
+      "line": 5946,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_write_verified_message"
@@ -5901,7 +4989,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7185,
+      "line": 5952,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -5909,7 +4997,7 @@
     {
       "canonical_owner": "global imported object, unaffected by relocation",
       "kind": "imported_module_patch",
-      "line": 7191,
+      "line": 5958,
       "migration_stage": null,
       "path": "tests/test_scraping.py",
       "target": "asyncio.sleep"
@@ -5917,7 +5005,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7195,
+      "line": 5962,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -5925,7 +5013,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7201,
+      "line": 5968,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -5933,7 +5021,7 @@
     {
       "canonical_owner": "message_sender.MessageSender -> session.ScrapingSession.check_rate_limit",
       "kind": "string_patch",
-      "line": 7239,
+      "line": 6006,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "linkedin_mcp_server.scraping.extractor.detect_rate_limit"
@@ -5941,7 +5029,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7243,
+      "line": 6010,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_read_profile_message_target"
@@ -5949,7 +5037,7 @@
     {
       "canonical_owner": "message_sender.ProfileMessageTargetResolution",
       "kind": "module_attribute",
-      "line": 7247,
+      "line": 6014,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_ProfileMessageTargetResolution"
@@ -5957,7 +5045,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7428,
+      "line": 6195,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -5965,7 +5053,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7574,
+      "line": 6341,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -5973,7 +5061,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7580,
+      "line": 6347,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -5981,7 +5069,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7653,
+      "line": 6420,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_wait_for_verified_submit"
@@ -5989,7 +5077,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7659,
+      "line": 6426,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_cleanup_owned_message"
@@ -5997,7 +5085,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7759,
+      "line": 6526,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_write_verified_message"
@@ -6005,7 +5093,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7765,
+      "line": 6532,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_submit_verified_message"
@@ -6013,7 +5101,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7772,
+      "line": 6539,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -6021,7 +5109,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7778,
+      "line": 6545,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6029,7 +5117,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7813,
+      "line": 6580,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6037,7 +5125,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7938,
+      "line": 6705,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_confirmation"
@@ -6045,7 +5133,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7944,
+      "line": 6711,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_owner"
@@ -6053,7 +5141,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 7995,
+      "line": 6762,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -6061,7 +5149,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 8001,
+      "line": 6768,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6069,7 +5157,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8033,
+      "line": 6800,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_compose_box"
@@ -6077,7 +5165,7 @@
     {
       "canonical_owner": "message_sender.MESSAGE_COMPOSE_SELECTOR",
       "kind": "module_attribute",
-      "line": 8036,
+      "line": 6803,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_MESSAGING_COMPOSE_SELECTOR"
@@ -6085,7 +5173,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8058,
+      "line": 6825,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -6093,7 +5181,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8083,
+      "line": 6850,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_resolve_message_owner"
@@ -6101,7 +5189,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8095,
+      "line": 6862,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_owner"
@@ -6109,7 +5197,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8105,
+      "line": 6872,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -6117,7 +5205,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8127,
+      "line": 6894,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_prepare_message_confirmation"
@@ -6125,7 +5213,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8139,
+      "line": 6906,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6133,7 +5221,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8172,
+      "line": 6939,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_message_send_confirmed"
@@ -6141,87 +5229,15 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 8186,
+      "line": 6953,
       "migration_stage": 12,
       "path": "tests/test_scraping.py",
       "target": "_dispose_message_confirmation"
     },
     {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 8218,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "global imported object, unaffected by relocation",
-      "kind": "imported_module_patch",
-      "line": 8225,
-      "migration_stage": null,
-      "path": "tests/test_scraping.py",
-      "target": "asyncio.sleep"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 8240,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "person.PersonScraper dependency",
-      "kind": "public_patch_object",
-      "line": 8260,
-      "migration_stage": 6,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
       "canonical_owner": "connection_actions.ConnectionActions dependency",
       "kind": "public_patch_object",
-      "line": 8260,
-      "migration_stage": 7,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "company.CompanyScraper dependency",
-      "kind": "public_patch_object",
-      "line": 8260,
-      "migration_stage": 8,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "jobs.JobScraper dependency",
-      "kind": "public_patch_object",
-      "line": 8260,
-      "migration_stage": 9,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "conversations.ConversationReader dependency",
-      "kind": "public_patch_object",
-      "line": 8260,
-      "migration_stage": 11,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "message_sender.MessageSender dependency",
-      "kind": "public_patch_object",
-      "line": 8260,
-      "migration_stage": 12,
-      "path": "tests/test_scraping.py",
-      "target": "extract_page"
-    },
-    {
-      "canonical_owner": "connection_actions.ConnectionActions dependency",
-      "kind": "public_patch_object",
-      "line": 8277,
+      "line": 7007,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "scrape_person"
@@ -6229,7 +5245,7 @@
     {
       "canonical_owner": "connection_actions.ConnectionActions",
       "kind": "private_patch_object",
-      "line": 8283,
+      "line": 7013,
       "migration_stage": 7,
       "path": "tests/test_scraping.py",
       "target": "_read_action_signals"
@@ -6261,7 +5277,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 306,
+      "line": 308,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_profile_message_target"
@@ -6269,23 +5285,23 @@
     {
       "canonical_owner": "message_sender.message_page_url_is_safe",
       "kind": "string_patch",
-      "line": 312,
+      "line": 314,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "linkedin_mcp_server.scraping.extractor._message_page_url_is_safe"
     },
     {
-      "canonical_owner": "profile_page.ProfilePageReader",
+      "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 379,
-      "migration_stage": 6,
+      "line": 380,
+      "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
-      "target": "_extract_profile_urn"
+      "target": "_read_profile_message_target"
     },
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 515,
+      "line": 522,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_message_composer_state"
@@ -6293,7 +5309,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 529,
+      "line": 536,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_profile_message_target"
@@ -6301,7 +5317,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 535,
+      "line": 542,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_message_composer_state"
@@ -6309,7 +5325,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 565,
+      "line": 572,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_resolve_message_owner"
@@ -6317,7 +5333,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 577,
+      "line": 584,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_profile_message_target"
@@ -6325,7 +5341,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 583,
+      "line": 590,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_resolve_message_owner"
@@ -6333,7 +5349,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_facade_access",
-      "line": 1033,
+      "line": 1040,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_resolve_message_owner"
@@ -6341,7 +5357,7 @@
     {
       "canonical_owner": "message_sender.MessageSender",
       "kind": "private_patch_object",
-      "line": 1046,
+      "line": 1053,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_read_profile_message_target"
@@ -6349,23 +5365,23 @@
     {
       "canonical_owner": "message_sender.message_page_url_is_safe",
       "kind": "string_patch",
-      "line": 1052,
-      "migration_stage": 12,
-      "path": "tests/test_send_message_confirmation_dom.py",
-      "target": "linkedin_mcp_server.scraping.extractor._message_page_url_is_safe"
-    },
-    {
-      "canonical_owner": "message_sender.MessageSender",
-      "kind": "private_patch_object",
-      "line": 1056,
-      "migration_stage": 12,
-      "path": "tests/test_send_message_confirmation_dom.py",
-      "target": "_resolve_message_owner"
-    },
-    {
-      "canonical_owner": "message_sender.MessageSender",
-      "kind": "private_patch_object",
       "line": 1059,
+      "migration_stage": 12,
+      "path": "tests/test_send_message_confirmation_dom.py",
+      "target": "linkedin_mcp_server.scraping.extractor._message_page_url_is_safe"
+    },
+    {
+      "canonical_owner": "message_sender.MessageSender",
+      "kind": "private_patch_object",
+      "line": 1063,
+      "migration_stage": 12,
+      "path": "tests/test_send_message_confirmation_dom.py",
+      "target": "_resolve_message_owner"
+    },
+    {
+      "canonical_owner": "message_sender.MessageSender",
+      "kind": "private_patch_object",
+      "line": 1066,
       "migration_stage": 12,
       "path": "tests/test_send_message_confirmation_dom.py",
       "target": "_message_send_confirmed"

--- a/tests/fixtures/scraping-policy/migration-manifest.json
+++ b/tests/fixtures/scraping-policy/migration-manifest.json
@@ -173,7 +173,7 @@
     {
       "canonical_owner": "facade.LinkedInExtractor",
       "kind": "direct_import",
-      "line": 15,
+      "line": 18,
       "migration_stage": 14,
       "path": "tests/scraping/test_facade_contracts.py",
       "target": "LinkedInExtractor"
@@ -181,7 +181,7 @@
     {
       "canonical_owner": "facade.LinkedInExtractor",
       "kind": "direct_import",
-      "line": 17,
+      "line": 21,
       "migration_stage": 14,
       "path": "tests/scraping/test_facade_contracts.py",
       "target": "LinkedInExtractor"
@@ -189,7 +189,7 @@
     {
       "canonical_owner": "contracts.ExtractedSection",
       "kind": "permanent_alias_import",
-      "line": 17,
+      "line": 21,
       "migration_stage": null,
       "path": "tests/scraping/test_facade_contracts.py",
       "target": "ExtractedSection"
@@ -197,7 +197,7 @@
     {
       "canonical_owner": "contracts.FilterValidationError",
       "kind": "permanent_alias_import",
-      "line": 17,
+      "line": 21,
       "migration_stage": null,
       "path": "tests/scraping/test_facade_contracts.py",
       "target": "FilterValidationError"
@@ -205,7 +205,7 @@
     {
       "canonical_owner": "contracts.rate_limited_section_error",
       "kind": "permanent_alias_import",
-      "line": 17,
+      "line": 21,
       "migration_stage": null,
       "path": "tests/scraping/test_facade_contracts.py",
       "target": "rate_limited_section_error"
@@ -213,7 +213,7 @@
     {
       "canonical_owner": "text.strip_conversation_chrome",
       "kind": "permanent_alias_import",
-      "line": 17,
+      "line": 21,
       "migration_stage": null,
       "path": "tests/scraping/test_facade_contracts.py",
       "target": "strip_conversation_chrome"
@@ -221,7 +221,7 @@
     {
       "canonical_owner": "text.strip_linkedin_noise",
       "kind": "permanent_alias_import",
-      "line": 17,
+      "line": 21,
       "migration_stage": null,
       "path": "tests/scraping/test_facade_contracts.py",
       "target": "strip_linkedin_noise"
@@ -229,10 +229,18 @@
     {
       "canonical_owner": "facade.LinkedInExtractor._page",
       "kind": "private_facade_access",
-      "line": 78,
+      "line": 82,
       "migration_stage": 14,
       "path": "tests/scraping/test_facade_contracts.py",
       "target": "_page"
+    },
+    {
+      "canonical_owner": "message_sender.MessageSender",
+      "kind": "private_patch_object",
+      "line": 190,
+      "migration_stage": 12,
+      "path": "tests/scraping/test_facade_contracts.py",
+      "target": "_read_profile_message_target"
     },
     {
       "canonical_owner": "facade.LinkedInExtractor",

--- a/tests/scraping/policy_scenarios.py
+++ b/tests/scraping/policy_scenarios.py
@@ -26,6 +26,7 @@ from linkedin_mcp_server.scraping import capture as capture_module
 from linkedin_mcp_server.scraping import extractor as extractor_module
 from linkedin_mcp_server.scraping import feed as feed_module
 from linkedin_mcp_server.scraping import navigation as navigation_module
+from linkedin_mcp_server.scraping import person as person_module
 from linkedin_mcp_server.scraping import session as session_module
 from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
 from linkedin_mcp_server.scraping.fields import COMPANY_SECTIONS, PERSON_SECTIONS
@@ -195,6 +196,7 @@ async def boundaries(
         patch.object(extractor_module, "scroll_job_sidebar", scroll_sidebar),
         patch.object(capture_module, "build_issue_diagnostics", diagnostics),
         patch.object(feed_module, "build_issue_diagnostics", diagnostics),
+        patch.object(person_module, "build_issue_diagnostics", diagnostics),
         patch.object(extractor_module, "build_issue_diagnostics", diagnostics),
         # `staticmethod`, or the class attribute would bind `self` in front of
         # the pending list and the replacement would never match the call.

--- a/tests/scraping/test_facade_contracts.py
+++ b/tests/scraping/test_facade_contracts.py
@@ -4,16 +4,20 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import inspect
+
+import pytest
 
 from fastmcp.tools import FunctionTool
 from patchright.async_api import Page
 
 from linkedin_mcp_server import dependencies
+from linkedin_mcp_server.core.exceptions import InvalidReferenceError
 from linkedin_mcp_server.scraping import LinkedInExtractor as PackageExtractor
 from linkedin_mcp_server.scraping import contracts, text
+from linkedin_mcp_server.scraping.capture import SectionCapture
 from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
     FilterValidationError,
@@ -122,6 +126,78 @@ async def test_company_posts_delegate_matches_registered_tool_consumer():
         "https://www.linkedin.com/company/example/posts/", section_name="posts"
     )
     extractor.scrape_company.assert_not_awaited()
+
+
+async def test_facade_scrape_person_forwards_its_keyword_only_arguments(mock_page):
+    # No production caller passes either one to the facade any more: the
+    # redirect path that drove `allow_self_alias` through it moved to the
+    # person owner, which calls its own `scrape_person`. Replacing both
+    # forwards with `False` survived the whole suite, so the delegate is
+    # pinned here, against the real owner rather than a mock of it.
+    mock_page.url = "https://www.linkedin.com/in/me/"
+    extractor = LinkedInExtractor(cast(Page, mock_page))
+    section = ExtractedSection(text="reused", references=[], error=None)
+
+    with (
+        patch.object(
+            SectionCapture,
+            "_extract_loaded_section",
+            new_callable=AsyncMock,
+            return_value=section,
+        ) as loaded,
+        patch.object(
+            SectionCapture,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=section,
+        ) as extract_page,
+    ):
+        result = await extractor.scrape_person(
+            "me",
+            {"main_profile"},
+            main_profile_already_loaded=True,
+            allow_self_alias=True,
+        )
+
+    # Reaching this line at all is what `allow_self_alias` buys; reusing the
+    # loaded page instead of navigating is what the other one buys.
+    assert result["url"] == "https://www.linkedin.com/in/me/"
+    loaded.assert_awaited_once()
+    extract_page.assert_not_awaited()
+
+
+async def test_facade_scrape_person_keeps_refusing_the_self_alias_by_default(mock_page):
+    # The other half of the forward above: without the argument `me` is a
+    # reserved name, so the assertion that it scraped says something.
+    extractor = LinkedInExtractor(cast(Page, mock_page))
+
+    with pytest.raises(InvalidReferenceError):
+        await extractor.scrape_person("me", {"main_profile"})
+
+
+async def test_the_profile_urn_reader_resolves_the_facade_at_call_time(mock_page):
+    # `__init__` wires a lambda rather than the bound method on purpose, and
+    # nothing held that line: the bound method survived the suite. The top-card
+    # read still belongs to the facade until the message sender owns it, so a
+    # replacement installed on the instance after construction has to be the
+    # one that runs.
+    extractor = LinkedInExtractor(cast(Page, mock_page))
+
+    async def replacement() -> SimpleNamespace:
+        return SimpleNamespace(target=SimpleNamespace(profile_urn="urn:late-bound"))
+
+    with (
+        patch.object(extractor, "_read_profile_message_target", replacement),
+        patch.object(
+            SectionCapture,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=ExtractedSection(text="profile", references=[], error=None),
+        ),
+    ):
+        result = await extractor.scrape_person("someone", {"main_profile"})
+
+    assert result["profile_urn"] == "urn:late-bound"
 
 
 def test_facade_methods_are_exactly_the_frozen_coroutine_surface():

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -25,11 +25,11 @@ SCRAPING_SYNTHETIC = (
 )
 
 _SHARED_BOUNDARY_STAGES = {
-    "detect_rate_limit": {6, 9, 11, 12},
-    "handle_modal_close": {6, 9, 11, 12},
+    "detect_rate_limit": {9, 11, 12},
+    "handle_modal_close": {9, 11, 12},
     "scroll_to_bottom": {9},
     "scroll_job_sidebar": {9},
-    "build_issue_diagnostics": {6, 8, 9},
+    "build_issue_diagnostics": {8, 9},
 }
 
 
@@ -132,16 +132,27 @@ def test_final_messaging_seams_have_only_the_approved_stage_owners():
     assert all(
         seam["canonical_owner"].startswith("message_sender.") for seam in dom_seams
     )
+    # The URN read moved to `profile_page.ProfilePageReader` at stage 6, and
+    # the DOM test builds that reader instead of reaching the facade for it.
+    # What it still borrows is the top-card read behind it, which is the
+    # message sender's and dated accordingly.
     profile_urn_reads = [
-        seam
-        for seam in current
-        if seam["path"] == "tests/test_send_message_confirmation_dom.py"
-        and seam["target"] == "_extract_profile_urn"
+        seam for seam in current if seam["target"] == "_extract_profile_urn"
     ]
+    assert profile_urn_reads == []
+    assert migration._PRIVATE_OWNERS["_extract_profile_urn"] == (
+        "profile_page.ProfilePageReader",
+        6,
+    )
     assert {
         (seam["kind"], seam["canonical_owner"], seam["migration_stage"])
-        for seam in profile_urn_reads
-    } == {("private_facade_access", "profile_page.ProfilePageReader", 6)}
+        for seam in current
+        if seam["path"] == "tests/test_send_message_confirmation_dom.py"
+        and seam["target"] == "_read_profile_message_target"
+    } == {
+        ("private_facade_access", "message_sender.MessageSender", 12),
+        ("private_patch_object", "message_sender.MessageSender", 12),
+    }
 
     private_targets = {
         seam["target"]
@@ -225,10 +236,13 @@ def test_module_boundary_patches_follow_their_callers():
     ]
     assert stdlib
     assert all(seam["migration_stage"] is None for seam in stdlib)
-    assert {seam["migration_stage"] for seam in logger_patches} == {6}
-    assert all(
-        "person.PersonScraper" in seam["canonical_owner"] for seam in logger_patches
-    )
+    # The last one was a `get_sidebar_profiles` test reading the facade's
+    # logger, and it moved to the person owner at stage 6. Closed by
+    # relocating the read rather than by dropping `logger` from
+    # `_CONTEXTUAL_MODULE_NAMES`: the next such patch has to be inventoried
+    # against the workflow that drives it, not fail closed as unknown.
+    assert logger_patches == []
+    assert "logger" in migration._CONTEXTUAL_MODULE_NAMES
 
 
 @pytest.mark.parametrize(
@@ -272,10 +286,10 @@ def test_public_facade_patches_follow_each_calling_workflow():
 
     assert {
         seam["migration_stage"] for seam in public if seam["target"] == "extract_page"
-    } == {6, 7, 8, 9, 10, 11, 12}
+    } == {8, 9, 10}
     assert {
         seam["migration_stage"] for seam in public if seam["target"] == "scrape_person"
-    } == {6, 7}
+    } == {7}
     assert {
         seam["migration_stage"]
         for seam in public
@@ -324,7 +338,7 @@ def test_checker_rejects_obsolete_seams_at_their_migration_stage():
     # completed stage are closed by definition, so an override there proves
     # nothing; raise this number as each stage lands.
     result = subprocess.run(
-        [sys.executable, str(CHECKER), "--check", "--stage", "6"],
+        [sys.executable, str(CHECKER), "--check", "--stage", "7"],
         cwd=ROOT,
         text=True,
         capture_output=True,
@@ -332,14 +346,16 @@ def test_checker_rejects_obsolete_seams_at_their_migration_stage():
     )
 
     assert result.returncode == 1
-    assert "obsolete at stage 6:" in result.stderr
+    assert "obsolete at stage 7:" in result.stderr
     assert "public_patch_object" in result.stderr
-    assert "string_patch" in result.stderr
+    assert "private_patch_object" in result.stderr
     # Every direct read of an extractor module attribute aimed at the feed
     # drain moved with the test that held it, so no override below stage 9 can
     # surface one. A feed test still reaching back through the facade module
-    # would show up here.
+    # would show up here. The same now holds for `string_patch`: the person
+    # workflow held the last one below stage 8.
     assert "module_attribute" not in result.stderr
+    assert "string_patch" not in result.stderr
 
 
 def test_checkers_offer_no_fixture_update_mode():
@@ -965,7 +981,7 @@ def test_manifest_includes_extractor_access_from_nested_closure():
         for seam in accesses
     } == {
         (590, "facade.LinkedInExtractor._scroll_seconds", 14),
-        (3702, "facade.LinkedInExtractor._scroll_seconds", 14),
+        (3123, "facade.LinkedInExtractor._scroll_seconds", 14),
     }
 
 
@@ -1382,7 +1398,13 @@ def test_direct_private_helper_calls_and_stage_gate_are_inventoried():
         for seam in current["seams"]
         if seam["kind"] == "module_attribute" and seam["target"].startswith("_")
     ]
-    assert {seam["path"] for seam in private_reads} == {"tests/test_scraping.py"}
+    # Two files now: the profile-page owner test asserts the top-card program
+    # it borrows from the facade is the one that ran, which is the same
+    # stage-12 read the messaging tests name.
+    assert {seam["path"] for seam in private_reads} == {
+        "tests/scraping/test_profile_page.py",
+        "tests/test_scraping.py",
+    }
     assert all(seam["migration_stage"] == 12 for seam in private_reads)
     direct_privates = [
         seam

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -20,6 +20,7 @@ from scripts import check_scraping_migration_manifest as migration  # noqa: E402
 MANIFEST = ROOT / "tests" / "fixtures" / "scraping-policy" / "migration-manifest.json"
 CHECKER = ROOT / "scripts" / "check_scraping_migration_manifest.py"
 POLICY_SCENARIOS = ROOT / "tests" / "scraping" / "policy_scenarios.py"
+PERSON_TESTS = ROOT / "tests" / "scraping" / "test_person.py"
 SCRAPING_SYNTHETIC = (
     ROOT / "linkedin_mcp_server" / "scraping" / "synthetic_inventory.py"
 )
@@ -2837,6 +2838,65 @@ def test_a_conditionally_rebound_alias_names_its_call_site(statement, line):
         r"ambiguous collaborator alias after conditional control flow",
     ):
         _scan_synthetic(_reach_through(statement))
+
+
+def _owner_test(body: str) -> str:
+    return (
+        "\nfrom unittest.mock import patch\n"
+        "\nfrom linkedin_mcp_server.scraping.extractor import LinkedInExtractor\n"
+        "\n\nasync def test_owner(page, replacement):\n"
+        f"{body}\n"
+    )
+
+
+def test_an_owner_factory_binding_exempts_only_its_own_wiring():
+    # `_scraper` builds the migrated owner, whose instance carries the same
+    # `_capture` the facade wires, so the wiring signal has to let this one
+    # through. Every remaining stage is written this way, and a refusal here
+    # would block all of them.
+    seams = migration.scan_source(
+        PERSON_TESTS,
+        _owner_test(
+            "    scraper = _scraper(page)\n"
+            '    patch.object(scraper._capture, "extract_page", replacement)'
+        ),
+        *migration.extractor_methods(),
+    )
+
+    assert not [seam for seam in seams if seam.kind.endswith("_patch_object")]
+
+
+@pytest.mark.parametrize(
+    ("rebinding", "line"),
+    [
+        ("    for scraper in (LinkedInExtractor(page),):\n        pass", 11),
+        ("    with LinkedInExtractor(page) as scraper:\n        pass", 11),
+        ("    try:\n        pass\n    except Exception as scraper:\n        pass", 13),
+        ("    scraper, other = LinkedInExtractor(page), None", 10),
+    ],
+)
+def test_a_rebound_owner_name_loses_its_factory_exemption(rebinding, line):
+    # The exemption answers for a name the factory alone binds. A `for`, a
+    # `with`, an `except` or an unpack binds it again without ever being a
+    # facade binding, so the name signal never sees those shapes and the
+    # wiring signal is the only guard over `scraper._capture`. Left exempt,
+    # a stage-8 test comparing owner and facade through one loop variable
+    # would take its facade reach-through out of the inventory entirely, and
+    # stage 12 would retire nothing for it.
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=rf"test_person\.py:{line} scraper\._capture: "
+        r"unresolved patch\.object target",
+    ):
+        migration.scan_source(
+            PERSON_TESTS,
+            _owner_test(
+                "    scraper = _scraper(page)\n"
+                f"{rebinding}\n"
+                '    patch.object(scraper._capture, "extract_page", replacement)'
+            ),
+            *migration.extractor_methods(),
+        )
 
 
 def test_a_foreign_collaborator_of_its_own_stays_out_of_the_inventory():

--- a/tests/scraping/test_person.py
+++ b/tests/scraping/test_person.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import importlib.util
 
 import pytest
 
@@ -16,6 +19,7 @@ from linkedin_mcp_server.core.exceptions import (
     ProxyConnectionError,
 )
 from linkedin_mcp_server.scraping import person as person_module
+from linkedin_mcp_server.scraping import text as text_module
 from linkedin_mcp_server.scraping.capture import SectionCapture
 from linkedin_mcp_server.scraping.content import PageContentReader
 from linkedin_mcp_server.scraping.contracts import (
@@ -1184,6 +1188,61 @@ class TestGetSidebarProfiles:
             "url": "https://www.linkedin.com/in/testuser/",
             "sidebar_profiles": {},
         }
+
+
+class TestSidebarProgramText:
+    """The program `get_sidebar_profiles` evaluates, as text."""
+
+    def test_every_substituted_heading_carries_the_template_indent(self):
+        # `",\n".join(...)` indents the first heading and nothing after it,
+        # because only the first one lands on the template's own indented
+        # line. Whitespace alone, and `program_digest` strips per-line
+        # whitespace before fingerprinting, so the traces hold the claim
+        # `_js_literal` makes about byte identity open on exactly this.
+        block = ",\n".join(
+            f'{" " * 20}"{heading}"'
+            for heading in text_module.SIDEBAR_CHROME_EN.section_headings
+        )
+
+        assert f"const SIDEBAR_SECTIONS = [\n{block}\n" in (
+            person_module._SIDEBAR_PROFILES_JS
+        )
+        assert not [
+            line
+            for line in person_module._SIDEBAR_PROFILES_JS.splitlines()[1:]
+            if line and not line.startswith(" ")
+        ]
+
+    @pytest.mark.parametrize(
+        ("value", "quote"),
+        [("voir l'ensemble", "'"), ('the "all" list', '"'), ("back\\slash", "'")],
+    )
+    def test_an_unquotable_locale_label_is_refused(self, value, quote):
+        with pytest.raises(ValueError, match="cannot be quoted"):
+            person_module._js_literal(value, quote)
+
+    def test_an_unquotable_locale_label_stops_the_import(self, monkeypatch):
+        # The only call sites are module-level, so a table entry carrying an
+        # apostrophe has to fail here rather than as a JavaScript
+        # `SyntaxError` out of the unguarded `page.evaluate` below — which
+        # surfaces against live LinkedIn only, and only once this table grows
+        # the locale it exists to accept. Loaded as a throwaway copy, so the
+        # module every other test holds is left alone.
+        monkeypatch.setattr(
+            text_module,
+            "SIDEBAR_CHROME_EN",
+            replace(
+                text_module.SIDEBAR_CHROME_EN, show_all_prefixes=("voir l'ensemble",)
+            ),
+        )
+        spec = importlib.util.spec_from_file_location(
+            "person_locale_probe", person_module.__file__
+        )
+        assert spec is not None and spec.loader is not None
+        probe = importlib.util.module_from_spec(spec)
+
+        with pytest.raises(ValueError, match="cannot be quoted"):
+            spec.loader.exec_module(probe)
 
 
 class TestSearchPeople:

--- a/tests/scraping/test_person.py
+++ b/tests/scraping/test_person.py
@@ -1,0 +1,1301 @@
+"""Tests for the person-profile scraping owner."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from linkedin_mcp_server.callbacks import ProgressCallback
+from linkedin_mcp_server.core.exceptions import (
+    AuthenticationError,
+    InvalidReferenceError,
+    LinkedInScraperException,
+    ProxyConnectionError,
+)
+from linkedin_mcp_server.scraping import person as person_module
+from linkedin_mcp_server.scraping.capture import SectionCapture
+from linkedin_mcp_server.scraping.content import PageContentReader
+from linkedin_mcp_server.scraping.contracts import (
+    RATE_LIMITED_SECTION_TEXT,
+    ExtractedSection,
+)
+from linkedin_mcp_server.scraping.link_metadata import Reference
+from linkedin_mcp_server.scraping.navigation import PageNavigator
+from linkedin_mcp_server.scraping.person import PersonScraper
+from linkedin_mcp_server.scraping.profile_page import ProfilePageReader
+from linkedin_mcp_server.scraping.session import ScrapingSession
+
+
+def _scraper(page, *, message_target: Any = None) -> PersonScraper:
+    """Wire the person owner the way the facade does.
+
+    The top-card read the profile URN comes from belongs to the facade until
+    the message sender owns it, so the default here is what a page with no
+    resolvable action answers: no target, and therefore no URN.
+    """
+    session = ScrapingSession(page)
+    navigator = PageNavigator(session)
+    capture = SectionCapture(session, navigator, PageContentReader(session))
+
+    async def read_message_target() -> Any:
+        return SimpleNamespace(target=message_target)
+
+    return PersonScraper(
+        session,
+        navigator,
+        capture,
+        ProfilePageReader(session, read_message_target),
+    )
+
+
+def extracted(
+    text: str,
+    references: list[Reference] | None = None,
+    error: dict | None = None,
+) -> ExtractedSection:
+    """Create an ExtractedSection for tests."""
+    return ExtractedSection(text=text, references=references or [], error=error)
+
+
+class TestScrapePersonUrls:
+    """Test that scrape_person visits the correct URLs per section set."""
+
+    async def test_baseline_always_included(self, mock_page):
+        """Passing only experience still visits main profile."""
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", {"experience"})
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert "main_profile" in result["sections"]
+        assert any(u.endswith("/in/testuser/") for u in urls)
+        assert any("/details/experience/" in u for u in urls)
+
+    async def test_basic_info_only_visits_main_profile(self, mock_page):
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("profile text"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", {"main_profile"})
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert len(urls) == 1
+        assert urls[0].endswith("/in/testuser/")
+        assert set(result["sections"]) == {"main_profile"}
+
+    async def test_a_pasted_profile_link_reaches_the_canonical_profile_url(
+        self, mock_page
+    ):
+        """A URL argument must be reduced before it becomes a path segment.
+
+        Without this the navigation target is
+        https://www.linkedin.com/in/https://de.linkedin.com/in/testuser, which
+        LinkedIn does not serve, and the tool reports that page as a profile.
+        """
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("profile text"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person(
+                "https://de.linkedin.com/in/testuser", {"main_profile"}
+            )
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert urls == ["https://www.linkedin.com/in/testuser/"]
+        assert result["url"] == "https://www.linkedin.com/in/testuser/"
+
+    async def test_a_dot_segment_value_never_reaches_a_navigation(self, mock_page):
+        # A browser resolves ../ away before the request, so this would open the
+        # feed and return it as a profile.
+        scraper = _scraper(mock_page)
+        with patch.object(
+            scraper._capture, "extract_page", new_callable=AsyncMock
+        ) as mock_extract:
+            with pytest.raises(LinkedInScraperException):
+                await scraper.scrape_person("testuser/../../feed", {"main_profile"})
+        mock_extract.assert_not_called()
+
+    async def test_an_already_encoded_username_is_not_encoded_twice(self, mock_page):
+        """get_my_profile hands over the username exactly this way.
+
+        It reads the segment out of page.url after the /in/me/ redirect, and a
+        browser reports that path percent-encoded. Escaping it again turns %D0
+        into %25D0, which is a different profile path, so the own-profile scrape
+        of any member with a non-ASCII vanity would navigate somewhere else.
+        """
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("profile text"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await scraper.scrape_person(
+                "%D0%B0%D0%BD%D0%B4%D1%80%D0%B5%D0%B9", {"main_profile"}
+            )
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert urls == [
+            "https://www.linkedin.com/in/%D0%B0%D0%BD%D0%B4%D1%80%D0%B5%D0%B9/"
+        ]
+
+    async def test_scrape_person_returns_section_errors(self, mock_page):
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                side_effect=[
+                    extracted("profile text"),
+                    extracted("", error={"issue_template_path": "/tmp/issue.md"}),
+                ],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", {"posts"})
+
+        assert result["sections"]["main_profile"] == "profile text"
+        assert (
+            result["section_errors"]["posts"]["issue_template_path"] == "/tmp/issue.md"
+        )
+
+    async def test_experience_education_visits_correct_urls(self, mock_page):
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person(
+                "testuser", {"main_profile", "experience", "education"}
+            )
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert len(urls) == 3
+        assert any(u.endswith("/in/testuser/") for u in urls)
+        assert any("/details/experience/" in u for u in urls)
+        assert any("/details/education/" in u for u in urls)
+        assert set(result["sections"]) == {"main_profile", "experience", "education"}
+
+    async def test_all_sections_visit_all_urls(self, mock_page):
+        scraper = _scraper(mock_page)
+        all_sections = {
+            "main_profile",
+            "experience",
+            "education",
+            "interests",
+            "honors",
+            "languages",
+            "certifications",
+            "skills",
+            "projects",
+            "contact_info",
+            "posts",
+        }
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted("contact text"),
+            ) as mock_overlay,
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", all_sections)
+
+        page_urls = [call.args[0] for call in mock_extract.call_args_list]
+        overlay_urls = [call.args[0] for call in mock_overlay.call_args_list]
+        all_urls = page_urls + overlay_urls
+        # 10 full-page sections + 1 overlay (contact_info)
+        assert len(page_urls) == 10
+        assert len(overlay_urls) == 1
+        # Verify each expected suffix was navigated
+        assert any(u.endswith("/in/testuser/") for u in all_urls)
+        assert any("/details/experience/" in u for u in all_urls)
+        assert any("/details/education/" in u for u in all_urls)
+        assert any("/details/interests/" in u for u in all_urls)
+        assert any("/details/honors/" in u for u in all_urls)
+        assert any("/details/languages/" in u for u in all_urls)
+        assert any("/details/certifications/" in u for u in all_urls)
+        assert any("/details/skills/" in u for u in all_urls)
+        assert any("/details/projects/" in u for u in all_urls)
+        assert any("/overlay/contact-info/" in u for u in overlay_urls)
+        assert any("/recent-activity/all/" in u for u in all_urls)
+        assert set(result["sections"]) == all_sections
+
+    async def test_posts_visits_recent_activity(self, mock_page):
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Post 1\nPost 2"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("test-user", {"posts"})
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert any("/recent-activity/all/" in url for url in urls)
+        assert "posts" in result["sections"]
+
+    async def test_certifications_visits_details_page(self, mock_page):
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Python for Data Science\nIBM"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("test-user", {"certifications"})
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert any("/details/certifications/" in url for url in urls)
+        assert "certifications" in result["sections"]
+
+    async def test_skills_visits_details_page(self, mock_page):
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Python\nData Analysis"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("test-user", {"skills"})
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert any("/details/skills/" in url for url in urls)
+        assert "skills" in result["sections"]
+
+    async def test_projects_visits_details_page(self, mock_page):
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("Portfolio Website\nBuilt with React"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("test-user", {"projects"})
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert any("/details/projects/" in url for url in urls)
+        assert "projects" in result["sections"]
+
+    async def test_scrape_person_passes_max_scrolls(self, mock_page):
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await scraper.scrape_person("test-user", {"certifications"}, max_scrolls=15)
+
+        for call in mock_extract.call_args_list:
+            assert call.kwargs.get("max_scrolls") == 15
+
+
+class TestScrapePersonSectionOutcomes:
+    """What one section's result does to the walk and to the response."""
+
+    async def test_references_are_grouped_by_section(self, mock_page):
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                side_effect=[
+                    extracted(
+                        "profile text",
+                        [
+                            {
+                                "kind": "person",
+                                "url": "/in/testuser/",
+                                "text": "Test User",
+                            }
+                        ],
+                    ),
+                    extracted(
+                        "post text",
+                        [
+                            {
+                                "kind": "article",
+                                "url": "/pulse/test-post/",
+                                "text": "Test post",
+                            }
+                        ],
+                    ),
+                ],
+            ),
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", {"posts"})
+
+        assert result["references"] == {
+            "main_profile": [
+                {"kind": "person", "url": "/in/testuser/", "text": "Test User"}
+            ],
+            "posts": [
+                {"kind": "article", "url": "/pulse/test-post/", "text": "Test post"}
+            ],
+        }
+
+    async def test_error_isolation(self, mock_page):
+        """One section failing doesn't block others."""
+
+        async def extract_with_failure(url, *args, **kwargs):
+            if "experience" in url:
+                raise Exception("Simulated failure")
+            return extracted(f"text for {url}")
+
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                side_effect=extract_with_failure,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.person.build_issue_diagnostics",
+                return_value={"issue_template_path": "/tmp/issue.md"},
+            ),
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person(
+                "testuser", {"main_profile", "experience", "education"}
+            )
+
+        # main_profile and education should have sections, experience should not
+        assert "main_profile" in result["sections"]
+        assert "education" in result["sections"]
+        assert "experience" not in result["sections"]
+        assert result["section_errors"]["experience"]["issue_template_path"] == (
+            "/tmp/issue.md"
+        )
+
+    async def test_a_rate_limited_section_is_reported_and_stops_the_rest(
+        self, mock_page
+    ):
+        """A throttled section is named as an error, and the walk stops there.
+
+        Both halves matter. Returning the section as merely absent reads as
+        "nothing to find" and invites the caller to try again, which is the
+        opposite of what LinkedIn just asked for. And continuing to the
+        remaining sections would be another navigation each, immediately after
+        being told to slow down.
+        """
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                side_effect=[
+                    extracted(RATE_LIMITED_SECTION_TEXT),
+                    extracted("Post text"),
+                ],
+            ) as mock_extract,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", {"posts"})
+
+        assert "main_profile" not in result["sections"]
+        assert result["section_errors"]["main_profile"]["error_type"] == "rate_limit"
+        # The second section was never fetched, so its side effect is unused.
+        assert mock_extract.await_count == 1
+        assert "posts" not in result["sections"]
+
+    async def test_a_failing_urn_read_cannot_bury_the_rate_limit(self, mock_page):
+        """The URN read is skipped once throttled, so it cannot overwrite it.
+
+        It runs after the section handling but inside the same try, so a
+        failure there lands in the generic handler and replaces the entry with
+        a diagnostic — losing the one thing this section had to report. There
+        is nothing to read a URN from on a page with no content anyway.
+        """
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted(RATE_LIMITED_SECTION_TEXT),
+            ),
+            patch.object(
+                scraper._profile_page,
+                "_extract_profile_urn",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("execution context destroyed"),
+            ) as mock_urn,
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", set())
+
+        mock_urn.assert_not_awaited()
+        assert result["section_errors"]["main_profile"]["error_type"] == "rate_limit"
+
+    async def test_earlier_sections_survive_a_later_rate_limit(self, mock_page):
+        """Stopping early keeps what was already gathered."""
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                side_effect=[
+                    extracted("Profile text"),
+                    extracted(RATE_LIMITED_SECTION_TEXT),
+                ],
+            ),
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted(""),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", {"posts"})
+
+        assert result["sections"]["main_profile"] == "Profile text"
+        assert result["section_errors"]["posts"]["error_type"] == "rate_limit"
+
+
+class TestScrapePersonCallbacks:
+    """Test that scrape_person invokes callbacks at each stage."""
+
+    async def test_scrape_person_calls_callbacks(self, mock_page):
+        scraper = _scraper(mock_page)
+        cb = MagicMock(spec=ProgressCallback)
+        cb.on_start = AsyncMock()
+        cb.on_progress = AsyncMock()
+        cb.on_complete = AsyncMock()
+        cb.on_error = AsyncMock()
+
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ),
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted("overlay text"),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await scraper.scrape_person(
+                "testuser", {"experience", "education"}, callbacks=cb
+            )
+
+        cb.on_start.assert_awaited_once()
+        assert cb.on_start.call_args[0][0] == "person profile"
+
+        # 3 sections: main_profile (always) + experience + education
+        assert cb.on_progress.await_count == 3
+        messages = [c.args[0] for c in cb.on_progress.call_args_list]
+        assert messages == [
+            "Scraped main_profile (1/3)",
+            "Scraped experience (2/3)",
+            "Scraped education (3/3)",
+        ]
+        # Last section should be at 95%
+        assert cb.on_progress.call_args_list[-1].args[1] == 95
+
+        cb.on_complete.assert_awaited_once()
+        assert cb.on_complete.call_args[0][0] == "person profile"
+        cb.on_error.assert_not_awaited()
+
+    async def test_scrape_person_no_callbacks_by_default(self, mock_page):
+        """Without callbacks, scrape_person works identically to before."""
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("text"),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", {"main_profile"})
+
+        assert "main_profile" in result["sections"]
+
+    async def test_scrape_person_calls_on_error(self, mock_page):
+        scraper = _scraper(mock_page)
+        cb = MagicMock(spec=ProgressCallback)
+        cb.on_start = AsyncMock()
+        cb.on_progress = AsyncMock()
+        cb.on_complete = AsyncMock()
+        cb.on_error = AsyncMock()
+
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                side_effect=LinkedInScraperException("boom"),
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            with pytest.raises(LinkedInScraperException):
+                await scraper.scrape_person("testuser", {"main_profile"}, callbacks=cb)
+
+        cb.on_start.assert_awaited_once()
+        cb.on_error.assert_awaited_once()
+        error_arg = cb.on_error.call_args[0][0]
+        assert isinstance(error_arg, LinkedInScraperException)
+        assert "boom" in str(error_arg)
+        cb.on_complete.assert_not_awaited()
+
+
+class TestMainProfileAlreadyLoaded:
+    """Reuse path for scrape_person when get_my_profile already loaded the page."""
+
+    async def test_get_my_profile_passes_already_loaded_flag(self, mock_page):
+        scraper = _scraper(mock_page)
+        mock_page.url = "https://www.linkedin.com/in/realuser/"
+        with (
+            patch.object(
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
+            ) as nav,
+            patch.object(
+                scraper,
+                "scrape_person",
+                new_callable=AsyncMock,
+                return_value={"url": "...", "sections": {}},
+            ) as scrape,
+        ):
+            await scraper.get_my_profile(sections={"main_profile"})
+
+        nav.assert_awaited_once_with("https://www.linkedin.com/in/me/")
+        assert scrape.await_count == 1
+        assert scrape.call_args.kwargs["main_profile_already_loaded"] is True
+
+    async def test_scrape_person_already_loaded_skips_navigation(self, mock_page):
+        scraper = _scraper(mock_page)
+        mock_page.url = "https://www.linkedin.com/in/foo/"
+        with (
+            patch.object(
+                scraper._capture,
+                "_extract_loaded_section",
+                new_callable=AsyncMock,
+                return_value=extracted("reused"),
+            ) as loaded,
+            patch.object(
+                scraper._capture, "extract_page", new_callable=AsyncMock
+            ) as extract_page,
+            patch.object(
+                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
+            ) as nav,
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await scraper.scrape_person(
+                "foo", {"main_profile"}, main_profile_already_loaded=True
+            )
+
+        loaded.assert_awaited_once()
+        extract_page.assert_not_awaited()
+        nav.assert_not_awaited()
+
+    async def test_scrape_person_already_loaded_url_mismatch_falls_back(
+        self, mock_page
+    ):
+        scraper = _scraper(mock_page)
+        mock_page.url = "https://www.linkedin.com/feed/"
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("fallback"),
+            ) as extract_page,
+            patch.object(
+                scraper._capture,
+                "_extract_loaded_section",
+                new_callable=AsyncMock,
+            ) as loaded,
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await scraper.scrape_person(
+                "foo", {"main_profile"}, main_profile_already_loaded=True
+            )
+
+        extract_page.assert_awaited_once()
+        loaded.assert_not_awaited()
+
+    async def test_scrape_person_already_loaded_rate_limit_falls_back(self, mock_page):
+        scraper = _scraper(mock_page)
+        mock_page.url = "https://www.linkedin.com/in/foo/"
+
+        with (
+            patch.object(
+                scraper._capture,
+                "_extract_loaded_section",
+                new_callable=AsyncMock,
+                return_value=extracted(RATE_LIMITED_SECTION_TEXT),
+            ) as loaded,
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("retry succeeded"),
+            ) as extract_page,
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person(
+                "foo", {"main_profile"}, main_profile_already_loaded=True
+            )
+
+        loaded.assert_awaited_once()
+        extract_page.assert_awaited_once()
+        assert result["sections"]["main_profile"] == "retry succeeded"
+
+
+class TestScrapePersonProfileUrn:
+    async def test_includes_profile_urn_in_result_when_found(self, mock_page):
+        """scrape_person includes profile_urn in result when _extract_profile_urn returns a value."""
+        urn = "ACoAAB1IelEBLEkqTkNbZ-a1D8mq5R-6C1ihSEk"
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("profile text"),
+            ),
+            patch.object(
+                scraper._profile_page,
+                "_extract_profile_urn",
+                new_callable=AsyncMock,
+                return_value=urn,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", {"main_profile"})
+
+        assert result["profile_urn"] == urn
+
+    async def test_omits_profile_urn_when_not_found(self, mock_page):
+        """scrape_person omits profile_urn key when _extract_profile_urn returns None."""
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("profile text"),
+            ),
+            patch.object(
+                scraper._profile_page,
+                "_extract_profile_urn",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", {"main_profile"})
+
+        assert "profile_urn" not in result
+
+
+class TestGetMyProfileAlias:
+    async def test_survives_a_redirect_that_never_resolves_the_alias(self, mock_page):
+        """The one caller allowed to hold "me".
+
+        get_my_profile navigates to /in/me/ and reads the identifier back out of
+        the redirect. When the redirect has not happened it still holds the
+        alias, and refusing there would answer the tool that owns the alias with
+        an instruction to call itself.
+        """
+        mock_page.url = "https://www.linkedin.com/in/me/"
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                scraper._capture,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("profile text"),
+            ) as mock_extract,
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.get_my_profile()
+
+        # The alias survives normalization, and because the page is already on
+        # it, the scrape reuses the loaded document instead of navigating again.
+        assert result["url"] == "https://www.linkedin.com/in/me/"
+        assert "main_profile" in result["sections"]
+        mock_extract.assert_not_called()
+
+    async def test_refuses_the_alias_from_an_ordinary_caller(self, mock_page):
+        scraper = _scraper(mock_page)
+        with patch.object(
+            scraper._capture, "extract_page", new_callable=AsyncMock
+        ) as mock_extract:
+            with pytest.raises(InvalidReferenceError):
+                await scraper.scrape_person("me", {"main_profile"})
+        mock_extract.assert_not_called()
+
+
+class TestGetSidebarProfiles:
+    async def test_returns_sidebar_profiles_from_all_sections(self, mock_page):
+        """Happy path: extracts profiles from all sections, merges Show all results."""
+        sidebar_js_result = {
+            "sections": {
+                "more_profiles_for_you": ["/in/alice/", "/in/bob/"],
+                "explore_premium_profiles": ["/in/carol/"],
+                "people_you_may_know": ["/in/dave/"],
+            },
+            "showAllUrls": {
+                "more_profiles_for_you": "https://www.linkedin.com/search/results/people/?keywords=test",
+            },
+        }
+        show_all_js_result = ["/in/alice/", "/in/eve/", "/in/frank/"]
+
+        mock_page.evaluate = AsyncMock(
+            side_effect=[sidebar_js_result, show_all_js_result]
+        )
+        mock_page.url = "https://www.linkedin.com/in/testuser/"
+
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.get_sidebar_profiles("testuser")
+
+        assert result["url"] == "https://www.linkedin.com/in/testuser/"
+        mpfy = result["sidebar_profiles"]["more_profiles_for_you"]
+        # sidebar links first, then show_all expansion, deduped
+        assert mpfy == ["/in/alice/", "/in/bob/", "/in/eve/", "/in/frank/"]
+        assert result["sidebar_profiles"]["explore_premium_profiles"] == ["/in/carol/"]
+        assert result["sidebar_profiles"]["people_you_may_know"] == ["/in/dave/"]
+
+    @pytest.mark.parametrize(
+        ("error_type", "message"),
+        [
+            pytest.param(
+                AuthenticationError,
+                "Run with --login",
+                id="authentication-error",
+            ),
+            pytest.param(
+                ProxyConnectionError,
+                "Proxy unavailable",
+                id="proxy-connection-error",
+            ),
+        ],
+    )
+    async def test_scraper_exception_from_show_all_propagates(
+        self,
+        mock_page,
+        error_type: type[LinkedInScraperException],
+        message: str,
+    ):
+        sidebar_js_result = {
+            "sections": {"more_profiles_for_you": ["/in/alice/"]},
+            "showAllUrls": {
+                "more_profiles_for_you": "https://www.linkedin.com/search/results/people/?keywords=test"
+            },
+        }
+        mock_page.evaluate = AsyncMock(return_value=sidebar_js_result)
+        mock_page.url = "https://www.linkedin.com/in/testuser/"
+
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                PageNavigator,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+                side_effect=[None, error_type(message)],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            pytest.raises(error_type, match=message),
+        ):
+            await scraper.get_sidebar_profiles("testuser")
+
+    async def test_raw_exception_from_show_all_keeps_inline_profiles(self, mock_page):
+        show_all_url = "https://www.linkedin.com/search/results/people/?keywords=test"
+        sidebar_js_result = {
+            "sections": {"more_profiles_for_you": ["/in/alice/"]},
+            "showAllUrls": {"more_profiles_for_you": show_all_url},
+        }
+        mock_page.evaluate = AsyncMock(return_value=sidebar_js_result)
+        mock_page.url = "https://www.linkedin.com/in/testuser/"
+
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(
+                PageNavigator,
+                "_navigate_to_page",
+                new_callable=AsyncMock,
+                side_effect=[None, RuntimeError("navigation failed")],
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch.object(person_module.logger, "debug") as debug_mock,
+        ):
+            result = await scraper.get_sidebar_profiles("testuser")
+
+        assert result == {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "sidebar_profiles": {"more_profiles_for_you": ["/in/alice/"]},
+        }
+        debug_mock.assert_called_once_with(
+            "Failed to navigate to Show all for section %s: %s",
+            "more_profiles_for_you",
+            show_all_url,
+        )
+
+    async def test_skips_show_all_when_url_contains_premium(self, mock_page):
+        """Show all URL containing /premium is skipped without navigation."""
+        sidebar_js_result = {
+            "sections": {"explore_premium_profiles": ["/in/carol/"]},
+            "showAllUrls": {
+                "explore_premium_profiles": "https://www.linkedin.com/premium/products/"
+            },
+        }
+        mock_page.evaluate = AsyncMock(return_value=sidebar_js_result)
+        mock_page.url = "https://www.linkedin.com/in/testuser/"
+
+        scraper = _scraper(mock_page)
+        navigate_mock = AsyncMock()
+        with (
+            patch.object(PageNavigator, "_navigate_to_page", navigate_mock),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await scraper.get_sidebar_profiles("testuser")
+
+        navigate_mock.assert_awaited_once()  # only the initial profile navigation
+        mock_page.evaluate.assert_awaited_once()  # no show_all JS call
+        assert result["sidebar_profiles"]["explore_premium_profiles"] == ["/in/carol/"]
+
+    async def test_skips_show_all_when_page_redirects_to_premium(self, mock_page):
+        """If navigating to Show all lands on a /premium URL, skip that section."""
+        sidebar_js_result = {
+            "sections": {"more_profiles_for_you": ["/in/alice/"]},
+            "showAllUrls": {
+                "more_profiles_for_you": "https://www.linkedin.com/search/results/people/?keywords=test"
+            },
+        }
+        mock_page.evaluate = AsyncMock(return_value=sidebar_js_result)
+        mock_page.url = "https://www.linkedin.com/in/testuser/"
+
+        navigate_call_count = 0
+
+        async def fake_navigate(url: str) -> None:
+            nonlocal navigate_call_count
+            navigate_call_count += 1
+            if navigate_call_count >= 2:
+                mock_page.url = "https://www.linkedin.com/premium/grow-your-network/"
+
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(PageNavigator, "_navigate_to_page", side_effect=fake_navigate),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.get_sidebar_profiles("testuser")
+
+        mock_page.evaluate.assert_awaited_once()  # sidebar JS only, no show_all expansion
+        assert result["sidebar_profiles"]["more_profiles_for_you"] == ["/in/alice/"]
+
+    async def test_returns_empty_sidebar_profiles_when_no_sections_found(
+        self, mock_page
+    ):
+        """No matching sidebar headings -> empty sidebar_profiles dict."""
+        mock_page.evaluate = AsyncMock(return_value={"sections": {}, "showAllUrls": {}})
+        mock_page.url = "https://www.linkedin.com/in/testuser/"
+
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            result = await scraper.get_sidebar_profiles("testuser")
+
+        assert result == {
+            "url": "https://www.linkedin.com/in/testuser/",
+            "sidebar_profiles": {},
+        }
+
+
+class TestSearchPeople:
+    async def test_search_people_omits_orphaned_references(self, mock_page):
+        scraper = _scraper(mock_page)
+        with patch.object(
+            scraper._capture,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted(
+                "",
+                [
+                    {
+                        "kind": "person",
+                        "url": "/in/testuser/",
+                        "text": "Test User",
+                    }
+                ],
+            ),
+        ):
+            result = await scraper.search_people("python")
+
+        assert result["sections"] == {}
+        assert "references" not in result
+
+    async def test_search_people_network_filter_first_degree(self, mock_page):
+        scraper = _scraper(mock_page)
+        with patch.object(
+            scraper._capture,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("Jane Doe"),
+        ):
+            result = await scraper.search_people("engineer", network=["F"])
+
+        assert "network=%5B%22F%22%5D" in result["url"]
+
+    async def test_search_people_network_filter_multi_degree(self, mock_page):
+        scraper = _scraper(mock_page)
+        with patch.object(
+            scraper._capture,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("Jane Doe"),
+        ):
+            result = await scraper.search_people("engineer", network=["F", "S"])
+
+        assert "network=%5B%22F%22%2C%22S%22%5D" in result["url"]
+
+    async def test_search_people_current_company_filter(self, mock_page):
+        scraper = _scraper(mock_page)
+        with patch.object(
+            scraper._capture,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("Jane Doe"),
+        ):
+            result = await scraper.search_people("engineer", current_company="1115")
+
+        assert "currentCompany=%5B%221115%22%5D" in result["url"]
+
+    async def test_search_people_invalid_network_token_raises(self, mock_page):
+        scraper = _scraper(mock_page)
+        with pytest.raises(ValueError, match="Invalid network token"):
+            await scraper.search_people("engineer", network=["X"])
+
+        mock_page.goto.assert_not_awaited()
+
+    async def test_search_people_rejects_plain_company_name(self, mock_page):
+        scraper = _scraper(mock_page)
+        with pytest.raises(ValueError, match="must be a numeric"):
+            await scraper.search_people("engineer", current_company="SAP")
+
+        mock_page.goto.assert_not_awaited()
+
+    async def test_search_people_rejects_unicode_digit_company(self, mock_page):
+        """LinkedIn URN ids are ASCII decimal; reject Unicode digits even
+        though ``str.isdigit()`` would accept them."""
+        scraper = _scraper(mock_page)
+        with pytest.raises(ValueError, match="must be a numeric"):
+            await scraper.search_people("engineer", current_company="١١١٥")
+
+        mock_page.goto.assert_not_awaited()
+
+    async def test_search_people_empty_current_company_is_noop(self, mock_page):
+        scraper = _scraper(mock_page)
+        with patch.object(
+            scraper._capture,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("Jane Doe"),
+        ):
+            result = await scraper.search_people("engineer", current_company="")
+
+        assert "currentCompany" not in result["url"]
+
+    async def test_search_people_combines_all_filters(self, mock_page):
+        scraper = _scraper(mock_page)
+        with patch.object(
+            scraper._capture,
+            "extract_page",
+            new_callable=AsyncMock,
+            return_value=extracted("Jane Doe"),
+        ):
+            result = await scraper.search_people(
+                "engineer",
+                location="Seattle",
+                network=["F"],
+                current_company="1115",
+            )
+
+        assert "keywords=engineer" in result["url"]
+        assert "location=Seattle" in result["url"]
+        assert "network=%5B%22F%22%5D" in result["url"]
+        assert "currentCompany=%5B%221115%22%5D" in result["url"]

--- a/tests/scraping/test_policy_traces.py
+++ b/tests/scraping/test_policy_traces.py
@@ -18,6 +18,7 @@ import pytest
 from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
 from linkedin_mcp_server.scraping.fields import COMPANY_SECTIONS, PERSON_SECTIONS
+from linkedin_mcp_server.scraping.person import PersonScraper
 
 from . import policy_scenarios
 from .policy_scenarios import (
@@ -262,7 +263,7 @@ async def test_facade_trace_detects_section_text_corruption():
 
 
 async def test_facade_trace_detects_lost_references():
-    original = LinkedInExtractor.scrape_person
+    original = PersonScraper.scrape_person
     removed: list[dict[str, Any]] = []
 
     @wraps(original)
@@ -273,7 +274,7 @@ async def test_facade_trace_detects_lost_references():
             removed.append(references)
         return result
 
-    with patch.object(LinkedInExtractor, "scrape_person", drop_references):
+    with patch.object(PersonScraper, "scrape_person", drop_references):
         mutated = await build_policy_traces()
 
     assert removed

--- a/tests/scraping/test_profile_page.py
+++ b/tests/scraping/test_profile_page.py
@@ -1,0 +1,88 @@
+"""Tests for the profile-identity reader."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from linkedin_mcp_server.scraping import extractor as extractor_module
+from linkedin_mcp_server.scraping.extractor import LinkedInExtractor
+from linkedin_mcp_server.scraping.profile_page import ProfilePageReader
+from linkedin_mcp_server.scraping.session import ScrapingSession
+
+
+def _reader(page) -> ProfilePageReader:
+    """Wire the reader the way the facade does.
+
+    The top-card read is still the facade's, so borrowing it here is what
+    keeps these tests about the reader and not about a double of the read.
+    """
+    extractor = LinkedInExtractor(page)
+    return ProfilePageReader(
+        ScrapingSession(page), extractor._read_profile_message_target
+    )
+
+
+class TestExtractProfileUrn:
+    async def test_returns_urn_from_atomic_top_card_snapshot(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "status": "resolved",
+                "pageUrl": "https://www.linkedin.com/in/testuser/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB&"
+                    "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
+                ],
+            }
+        )
+
+        result = await _reader(mock_page)._extract_profile_urn()
+
+        assert result == "ACoAAB"
+        mock_page.evaluate.assert_awaited_once_with(
+            extractor_module._PROFILE_MESSAGE_TARGET_JS
+        )
+
+    async def test_returns_none_for_ambiguous_top_card_links(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={
+                "status": "resolved",
+                "pageUrl": "https://www.linkedin.com/in/testuser/",
+                "displayName": "Test User",
+                "composeHrefs": [
+                    "/messaging/compose/?recipient=ACoAAB",
+                    "/messaging/compose/?recipient=OTHER",
+                ],
+            }
+        )
+
+        result = await _reader(mock_page)._extract_profile_urn()
+
+        assert result is None
+
+
+class TestReadProfileDisplayName:
+    """The name read the conversation lookup matches threads against.
+
+    Nothing else in the suite drives this read: every caller stubs it, so
+    without these the program could return the wrong line and stay green.
+    """
+
+    async def test_the_heading_is_preferred_over_the_body(self, mock_page):
+        mock_page.evaluate = AsyncMock(return_value="  Ada   Lovelace ")
+
+        assert await _reader(mock_page)._read_profile_display_name() == (
+            "Ada   Lovelace"
+        )
+
+    async def test_a_blank_answer_is_reported_as_no_name(self, mock_page):
+        mock_page.evaluate = AsyncMock(return_value="   ")
+
+        assert await _reader(mock_page)._read_profile_display_name() is None
+
+    async def test_a_non_string_answer_is_reported_as_no_name(self, mock_page):
+        # What a page whose <main> is missing answers through a driver that
+        # returns `null` rather than the empty string the program intends.
+        mock_page.evaluate = AsyncMock(return_value=None)
+
+        assert await _reader(mock_page)._read_profile_display_name() is None

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -17,13 +17,13 @@ from linkedin_mcp_server.core.exceptions import (
     AuthenticationError,
     InvalidReferenceError,
     LinkedInScraperException,
-    ProxyConnectionError,
 )
 from linkedin_mcp_server.scraping.connection import (
     ActionSignals,
     detect_connection_state,
 )
 from linkedin_mcp_server.scraping import extractor as extractor_module
+from linkedin_mcp_server.scraping.capture import SectionCapture
 from linkedin_mcp_server.scraping.contracts import RATE_LIMITED_SECTION_TEXT
 from linkedin_mcp_server.scraping.extractor import (
     ExtractedSection,
@@ -902,416 +902,6 @@ class TestExtractSearchPage:
 
         assert "Python Developer" in result.text
         assert result.error is None
-
-
-class TestScrapePersonUrls:
-    """Test that scrape_person visits the correct URLs per section set."""
-
-    async def test_baseline_always_included(self, mock_page):
-        """Passing only experience still visits main profile."""
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("text"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", {"experience"})
-
-        urls = [call.args[0] for call in mock_extract.call_args_list]
-        assert "main_profile" in result["sections"]
-        assert any(u.endswith("/in/testuser/") for u in urls)
-        assert any("/details/experience/" in u for u in urls)
-
-    async def test_basic_info_only_visits_main_profile(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("profile text"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", {"main_profile"})
-
-        urls = [call.args[0] for call in mock_extract.call_args_list]
-        assert len(urls) == 1
-        assert urls[0].endswith("/in/testuser/")
-        assert set(result["sections"]) == {"main_profile"}
-
-    async def test_a_pasted_profile_link_reaches_the_canonical_profile_url(
-        self, mock_page
-    ):
-        """A URL argument must be reduced before it becomes a path segment.
-
-        Without this the navigation target is
-        https://www.linkedin.com/in/https://de.linkedin.com/in/testuser, which
-        LinkedIn does not serve, and the tool reports that page as a profile.
-        """
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("profile text"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person(
-                "https://de.linkedin.com/in/testuser", {"main_profile"}
-            )
-
-        urls = [call.args[0] for call in mock_extract.call_args_list]
-        assert urls == ["https://www.linkedin.com/in/testuser/"]
-        assert result["url"] == "https://www.linkedin.com/in/testuser/"
-
-    async def test_a_dot_segment_value_never_reaches_a_navigation(self, mock_page):
-        # A browser resolves ../ away before the request, so this would open the
-        # feed and return it as a profile.
-        extractor = LinkedInExtractor(mock_page)
-        with patch.object(
-            extractor, "extract_page", new_callable=AsyncMock
-        ) as mock_extract:
-            with pytest.raises(LinkedInScraperException):
-                await extractor.scrape_person("testuser/../../feed", {"main_profile"})
-        mock_extract.assert_not_called()
-
-    async def test_an_already_encoded_username_is_not_encoded_twice(self, mock_page):
-        """get_my_profile hands over the username exactly this way.
-
-        It reads the segment out of page.url after the /in/me/ redirect, and a
-        browser reports that path percent-encoded. Escaping it again turns %D0
-        into %25D0, which is a different profile path, so the own-profile scrape
-        of any member with a non-ASCII vanity would navigate somewhere else.
-        """
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("profile text"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            await extractor.scrape_person(
-                "%D0%B0%D0%BD%D0%B4%D1%80%D0%B5%D0%B9", {"main_profile"}
-            )
-
-        urls = [call.args[0] for call in mock_extract.call_args_list]
-        assert urls == [
-            "https://www.linkedin.com/in/%D0%B0%D0%BD%D0%B4%D1%80%D0%B5%D0%B9/"
-        ]
-
-    async def test_a_pasted_company_link_reaches_the_canonical_company_url(
-        self, mock_page
-    ):
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("company text"),
-            ) as mock_extract,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_company(
-                "https://de.linkedin.com/company/testco/posts/", {"about"}
-            )
-
-        urls = [call.args[0] for call in mock_extract.call_args_list]
-        assert urls
-        assert all(
-            u.startswith("https://www.linkedin.com/company/testco") for u in urls
-        )
-        assert result["url"] == "https://www.linkedin.com/company/testco/"
-
-    async def test_scrape_person_returns_section_errors(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                side_effect=[
-                    extracted("profile text"),
-                    extracted("", error={"issue_template_path": "/tmp/issue.md"}),
-                ],
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", {"posts"})
-
-        assert result["sections"]["main_profile"] == "profile text"
-        assert (
-            result["section_errors"]["posts"]["issue_template_path"] == "/tmp/issue.md"
-        )
-
-    async def test_experience_education_visits_correct_urls(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("text"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person(
-                "testuser", {"main_profile", "experience", "education"}
-            )
-
-        urls = [call.args[0] for call in mock_extract.call_args_list]
-        assert len(urls) == 3
-        assert any(u.endswith("/in/testuser/") for u in urls)
-        assert any("/details/experience/" in u for u in urls)
-        assert any("/details/education/" in u for u in urls)
-        assert set(result["sections"]) == {"main_profile", "experience", "education"}
-
-    async def test_all_sections_visit_all_urls(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        all_sections = {
-            "main_profile",
-            "experience",
-            "education",
-            "interests",
-            "honors",
-            "languages",
-            "certifications",
-            "skills",
-            "projects",
-            "contact_info",
-            "posts",
-        }
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("text"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted("contact text"),
-            ) as mock_overlay,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", all_sections)
-
-        page_urls = [call.args[0] for call in mock_extract.call_args_list]
-        overlay_urls = [call.args[0] for call in mock_overlay.call_args_list]
-        all_urls = page_urls + overlay_urls
-        # 10 full-page sections + 1 overlay (contact_info)
-        assert len(page_urls) == 10
-        assert len(overlay_urls) == 1
-        # Verify each expected suffix was navigated
-        assert any(u.endswith("/in/testuser/") for u in all_urls)
-        assert any("/details/experience/" in u for u in all_urls)
-        assert any("/details/education/" in u for u in all_urls)
-        assert any("/details/interests/" in u for u in all_urls)
-        assert any("/details/honors/" in u for u in all_urls)
-        assert any("/details/languages/" in u for u in all_urls)
-        assert any("/details/certifications/" in u for u in all_urls)
-        assert any("/details/skills/" in u for u in all_urls)
-        assert any("/details/projects/" in u for u in all_urls)
-        assert any("/overlay/contact-info/" in u for u in overlay_urls)
-        assert any("/recent-activity/all/" in u for u in all_urls)
-        assert set(result["sections"]) == all_sections
-
-    async def test_posts_visits_recent_activity(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("Post 1\nPost 2"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("test-user", {"posts"})
-
-        urls = [call.args[0] for call in mock_extract.call_args_list]
-        assert any("/recent-activity/all/" in url for url in urls)
-        assert "posts" in result["sections"]
-
-    async def test_certifications_visits_details_page(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("Python for Data Science\nIBM"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("test-user", {"certifications"})
-
-        urls = [call.args[0] for call in mock_extract.call_args_list]
-        assert any("/details/certifications/" in url for url in urls)
-        assert "certifications" in result["sections"]
-
-    async def test_skills_visits_details_page(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("Python\nData Analysis"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("test-user", {"skills"})
-
-        urls = [call.args[0] for call in mock_extract.call_args_list]
-        assert any("/details/skills/" in url for url in urls)
-        assert "skills" in result["sections"]
-
-    async def test_projects_visits_details_page(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("Portfolio Website\nBuilt with React"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("test-user", {"projects"})
-
-        urls = [call.args[0] for call in mock_extract.call_args_list]
-        assert any("/details/projects/" in url for url in urls)
-        assert "projects" in result["sections"]
-
-    async def test_scrape_person_passes_max_scrolls(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("text"),
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            await extractor.scrape_person(
-                "test-user", {"certifications"}, max_scrolls=15
-            )
-
-        for call in mock_extract.call_args_list:
-            assert call.kwargs.get("max_scrolls") == 15
 
 
 class TestDetectConnectionState:
@@ -2258,204 +1848,35 @@ class TestConnectWithPerson:
         assert clicks == [0, 1]
         textarea_locator.fill.assert_awaited_once()
 
-    async def test_references_are_grouped_by_section(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                side_effect=[
-                    extracted(
-                        "profile text",
-                        [
-                            {
-                                "kind": "person",
-                                "url": "/in/testuser/",
-                                "text": "Test User",
-                            }
-                        ],
-                    ),
-                    extracted(
-                        "post text",
-                        [
-                            {
-                                "kind": "article",
-                                "url": "/pulse/test-post/",
-                                "text": "Test post",
-                            }
-                        ],
-                    ),
-                ],
-            ),
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", {"posts"})
-
-        assert result["references"] == {
-            "main_profile": [
-                {"kind": "person", "url": "/in/testuser/", "text": "Test User"}
-            ],
-            "posts": [
-                {"kind": "article", "url": "/pulse/test-post/", "text": "Test post"}
-            ],
-        }
-
-    async def test_error_isolation(self, mock_page):
-        """One section failing doesn't block others."""
-
-        async def extract_with_failure(url, *args, **kwargs):
-            if "experience" in url:
-                raise Exception("Simulated failure")
-            return extracted(f"text for {url}")
-
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                side_effect=extract_with_failure,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.build_issue_diagnostics",
-                return_value={"issue_template_path": "/tmp/issue.md"},
-            ),
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person(
-                "testuser", {"main_profile", "experience", "education"}
-            )
-
-        # main_profile and education should have sections, experience should not
-        assert "main_profile" in result["sections"]
-        assert "education" in result["sections"]
-        assert "experience" not in result["sections"]
-        assert result["section_errors"]["experience"]["issue_template_path"] == (
-            "/tmp/issue.md"
-        )
-
-    async def test_a_rate_limited_section_is_reported_and_stops_the_rest(
-        self, mock_page
-    ):
-        """A throttled section is named as an error, and the walk stops there.
-
-        Both halves matter. Returning the section as merely absent reads as
-        "nothing to find" and invites the caller to try again, which is the
-        opposite of what LinkedIn just asked for. And continuing to the
-        remaining sections would be another navigation each, immediately after
-        being told to slow down.
-        """
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                side_effect=[
-                    extracted(RATE_LIMITED_SECTION_TEXT),
-                    extracted("Post text"),
-                ],
-            ) as mock_extract,
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", {"posts"})
-
-        assert "main_profile" not in result["sections"]
-        assert result["section_errors"]["main_profile"]["error_type"] == "rate_limit"
-        # The second section was never fetched, so its side effect is unused.
-        assert mock_extract.await_count == 1
-        assert "posts" not in result["sections"]
-
-    async def test_a_failing_urn_read_cannot_bury_the_rate_limit(self, mock_page):
-        """The URN read is skipped once throttled, so it cannot overwrite it.
-
-        It runs after the section handling but inside the same try, so a
-        failure there lands in the generic handler and replaces the entry with
-        a diagnostic — losing the one thing this section had to report. There
-        is nothing to read a URN from on a page with no content anyway.
-        """
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted(RATE_LIMITED_SECTION_TEXT),
-            ),
-            patch.object(
-                extractor,
-                "_extract_profile_urn",
-                new_callable=AsyncMock,
-                side_effect=RuntimeError("execution context destroyed"),
-            ) as mock_urn,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", set())
-
-        mock_urn.assert_not_awaited()
-        assert result["section_errors"]["main_profile"]["error_type"] == "rate_limit"
-
-    async def test_earlier_sections_survive_a_later_rate_limit(self, mock_page):
-        """Stopping early keeps what was already gathered."""
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                side_effect=[
-                    extracted("Profile text"),
-                    extracted(RATE_LIMITED_SECTION_TEXT),
-                ],
-            ),
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted(""),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", {"posts"})
-
-        assert result["sections"]["main_profile"] == "Profile text"
-        assert result["section_errors"]["posts"]["error_type"] == "rate_limit"
-
 
 class TestScrapeCompany:
+    async def test_a_pasted_company_link_reaches_the_canonical_company_url(
+        self, mock_page
+    ):
+        extractor = LinkedInExtractor(mock_page)
+        with (
+            patch.object(
+                extractor,
+                "extract_page",
+                new_callable=AsyncMock,
+                return_value=extracted("company text"),
+            ) as mock_extract,
+            patch(
+                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await extractor.scrape_company(
+                "https://de.linkedin.com/company/testco/posts/", {"about"}
+            )
+
+        urls = [call.args[0] for call in mock_extract.call_args_list]
+        assert urls
+        assert all(
+            u.startswith("https://www.linkedin.com/company/testco") for u in urls
+        )
+        assert result["url"] == "https://www.linkedin.com/company/testco/"
+
     async def test_company_baseline_always_included(self, mock_page):
         """Passing only posts still visits about page."""
         extractor = LinkedInExtractor(mock_page)
@@ -5256,8 +4677,11 @@ class TestSingleSectionRateLimits:
     )
     async def test_the_reason_is_reported(self, mock_page, method, args, section):
         extractor = LinkedInExtractor(mock_page)
+        # Patched on the capture owner rather than on the facade: one of the
+        # three methods reads through its own collaborator now, and a facade
+        # patch would intercept nothing for it while still passing.
         with patch.object(
-            extractor,
+            SectionCapture,
             "extract_page",
             new_callable=AsyncMock,
             return_value=extracted(RATE_LIMITED_SECTION_TEXT),
@@ -5266,121 +4690,6 @@ class TestSingleSectionRateLimits:
 
         assert result["sections"] == {}
         assert result["section_errors"][section]["error_type"] == "rate_limit"
-
-
-class TestSearchPeople:
-    async def test_search_people_omits_orphaned_references(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with patch.object(
-            extractor,
-            "extract_page",
-            new_callable=AsyncMock,
-            return_value=extracted(
-                "",
-                [
-                    {
-                        "kind": "person",
-                        "url": "/in/testuser/",
-                        "text": "Test User",
-                    }
-                ],
-            ),
-        ):
-            result = await extractor.search_people("python")
-
-        assert result["sections"] == {}
-        assert "references" not in result
-
-    async def test_search_people_network_filter_first_degree(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with patch.object(
-            extractor,
-            "extract_page",
-            new_callable=AsyncMock,
-            return_value=extracted("Jane Doe"),
-        ):
-            result = await extractor.search_people("engineer", network=["F"])
-
-        assert "network=%5B%22F%22%5D" in result["url"]
-
-    async def test_search_people_network_filter_multi_degree(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with patch.object(
-            extractor,
-            "extract_page",
-            new_callable=AsyncMock,
-            return_value=extracted("Jane Doe"),
-        ):
-            result = await extractor.search_people("engineer", network=["F", "S"])
-
-        assert "network=%5B%22F%22%2C%22S%22%5D" in result["url"]
-
-    async def test_search_people_current_company_filter(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with patch.object(
-            extractor,
-            "extract_page",
-            new_callable=AsyncMock,
-            return_value=extracted("Jane Doe"),
-        ):
-            result = await extractor.search_people("engineer", current_company="1115")
-
-        assert "currentCompany=%5B%221115%22%5D" in result["url"]
-
-    async def test_search_people_invalid_network_token_raises(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with pytest.raises(ValueError, match="Invalid network token"):
-            await extractor.search_people("engineer", network=["X"])
-
-        mock_page.goto.assert_not_awaited()
-
-    async def test_search_people_rejects_plain_company_name(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with pytest.raises(ValueError, match="must be a numeric"):
-            await extractor.search_people("engineer", current_company="SAP")
-
-        mock_page.goto.assert_not_awaited()
-
-    async def test_search_people_rejects_unicode_digit_company(self, mock_page):
-        """LinkedIn URN ids are ASCII decimal; reject Unicode digits even
-        though ``str.isdigit()`` would accept them."""
-        extractor = LinkedInExtractor(mock_page)
-        with pytest.raises(ValueError, match="must be a numeric"):
-            await extractor.search_people("engineer", current_company="١١١٥")
-
-        mock_page.goto.assert_not_awaited()
-
-    async def test_search_people_empty_current_company_is_noop(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with patch.object(
-            extractor,
-            "extract_page",
-            new_callable=AsyncMock,
-            return_value=extracted("Jane Doe"),
-        ):
-            result = await extractor.search_people("engineer", current_company="")
-
-        assert "currentCompany" not in result["url"]
-
-    async def test_search_people_combines_all_filters(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with patch.object(
-            extractor,
-            "extract_page",
-            new_callable=AsyncMock,
-            return_value=extracted("Jane Doe"),
-        ):
-            result = await extractor.search_people(
-                "engineer",
-                location="Seattle",
-                network=["F"],
-                current_company="1115",
-            )
-
-        assert "keywords=engineer" in result["url"]
-        assert "location=Seattle" in result["url"]
-        assert "network=%5B%22F%22%5D" in result["url"]
-        assert "currentCompany=%5B%221115%22%5D" in result["url"]
 
 
 @pytest.mark.asyncio
@@ -5484,221 +4793,6 @@ class TestSearchPosts:
         }
 
 
-class TestScrapePersonCallbacks:
-    """Test that scrape_person invokes callbacks at each stage."""
-
-    async def test_scrape_person_calls_callbacks(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        cb = MagicMock(spec=ProgressCallback)
-        cb.on_start = AsyncMock()
-        cb.on_progress = AsyncMock()
-        cb.on_complete = AsyncMock()
-        cb.on_error = AsyncMock()
-
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("text"),
-            ),
-            patch.object(
-                extractor._capture,
-                "_extract_overlay",
-                new_callable=AsyncMock,
-                return_value=extracted("overlay text"),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            await extractor.scrape_person(
-                "testuser", {"experience", "education"}, callbacks=cb
-            )
-
-        cb.on_start.assert_awaited_once()
-        assert cb.on_start.call_args[0][0] == "person profile"
-
-        # 3 sections: main_profile (always) + experience + education
-        assert cb.on_progress.await_count == 3
-        messages = [c.args[0] for c in cb.on_progress.call_args_list]
-        assert messages == [
-            "Scraped main_profile (1/3)",
-            "Scraped experience (2/3)",
-            "Scraped education (3/3)",
-        ]
-        # Last section should be at 95%
-        assert cb.on_progress.call_args_list[-1].args[1] == 95
-
-        cb.on_complete.assert_awaited_once()
-        assert cb.on_complete.call_args[0][0] == "person profile"
-        cb.on_error.assert_not_awaited()
-
-    async def test_scrape_person_no_callbacks_by_default(self, mock_page):
-        """Without callbacks, scrape_person works identically to before."""
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("text"),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", {"main_profile"})
-
-        assert "main_profile" in result["sections"]
-
-    async def test_scrape_person_calls_on_error(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        cb = MagicMock(spec=ProgressCallback)
-        cb.on_start = AsyncMock()
-        cb.on_progress = AsyncMock()
-        cb.on_complete = AsyncMock()
-        cb.on_error = AsyncMock()
-
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                side_effect=LinkedInScraperException("boom"),
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            with pytest.raises(LinkedInScraperException):
-                await extractor.scrape_person(
-                    "testuser", {"main_profile"}, callbacks=cb
-                )
-
-        cb.on_start.assert_awaited_once()
-        cb.on_error.assert_awaited_once()
-        error_arg = cb.on_error.call_args[0][0]
-        assert isinstance(error_arg, LinkedInScraperException)
-        assert "boom" in str(error_arg)
-        cb.on_complete.assert_not_awaited()
-
-
-class TestMainProfileAlreadyLoaded:
-    """Reuse path for scrape_person when get_my_profile already loaded the page."""
-
-    async def test_get_my_profile_passes_already_loaded_flag(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.url = "https://www.linkedin.com/in/realuser/"
-        with (
-            patch.object(
-                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
-            ) as nav,
-            patch.object(
-                extractor,
-                "scrape_person",
-                new_callable=AsyncMock,
-                return_value={"url": "...", "sections": {}},
-            ) as scrape,
-        ):
-            await extractor.get_my_profile(sections={"main_profile"})
-
-        nav.assert_awaited_once_with("https://www.linkedin.com/in/me/")
-        assert scrape.await_count == 1
-        assert scrape.call_args.kwargs["main_profile_already_loaded"] is True
-
-    async def test_scrape_person_already_loaded_skips_navigation(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.url = "https://www.linkedin.com/in/foo/"
-        with (
-            patch.object(
-                extractor._capture,
-                "_extract_loaded_section",
-                new_callable=AsyncMock,
-                return_value=extracted("reused"),
-            ) as loaded,
-            patch.object(
-                extractor, "extract_page", new_callable=AsyncMock
-            ) as extract_page,
-            patch.object(
-                PageNavigator, "_navigate_to_page", new_callable=AsyncMock
-            ) as nav,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            await extractor.scrape_person(
-                "foo", {"main_profile"}, main_profile_already_loaded=True
-            )
-
-        loaded.assert_awaited_once()
-        extract_page.assert_not_awaited()
-        nav.assert_not_awaited()
-
-    async def test_scrape_person_already_loaded_url_mismatch_falls_back(
-        self, mock_page
-    ):
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.url = "https://www.linkedin.com/feed/"
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("fallback"),
-            ) as extract_page,
-            patch.object(
-                extractor._capture,
-                "_extract_loaded_section",
-                new_callable=AsyncMock,
-            ) as loaded,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            await extractor.scrape_person(
-                "foo", {"main_profile"}, main_profile_already_loaded=True
-            )
-
-        extract_page.assert_awaited_once()
-        loaded.assert_not_awaited()
-
-    async def test_scrape_person_already_loaded_rate_limit_falls_back(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        mock_page.url = "https://www.linkedin.com/in/foo/"
-
-        with (
-            patch.object(
-                extractor._capture,
-                "_extract_loaded_section",
-                new_callable=AsyncMock,
-                return_value=extracted(RATE_LIMITED_SECTION_TEXT),
-            ) as loaded,
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("retry succeeded"),
-            ) as extract_page,
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person(
-                "foo", {"main_profile"}, main_profile_already_loaded=True
-            )
-
-        loaded.assert_awaited_once()
-        extract_page.assert_awaited_once()
-        assert result["sections"]["main_profile"] == "retry succeeded"
-
-
 class TestScrapeCompanyCallbacks:
     """Test that scrape_company invokes callbacks at each stage."""
 
@@ -5742,243 +4836,6 @@ class TestScrapeCompanyCallbacks:
         cb.on_complete.assert_awaited_once()
         assert cb.on_complete.call_args[0][0] == "company profile"
         cb.on_error.assert_not_awaited()
-
-
-class TestGetSidebarProfiles:
-    async def test_returns_sidebar_profiles_from_all_sections(self, mock_page):
-        """Happy path: extracts profiles from all sections, merges Show all results."""
-        sidebar_js_result = {
-            "sections": {
-                "more_profiles_for_you": ["/in/alice/", "/in/bob/"],
-                "explore_premium_profiles": ["/in/carol/"],
-                "people_you_may_know": ["/in/dave/"],
-            },
-            "showAllUrls": {
-                "more_profiles_for_you": "https://www.linkedin.com/search/results/people/?keywords=test",
-            },
-        }
-        show_all_js_result = ["/in/alice/", "/in/eve/", "/in/frank/"]
-
-        mock_page.evaluate = AsyncMock(
-            side_effect=[sidebar_js_result, show_all_js_result]
-        )
-        mock_page.url = "https://www.linkedin.com/in/testuser/"
-
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.get_sidebar_profiles("testuser")
-
-        assert result["url"] == "https://www.linkedin.com/in/testuser/"
-        mpfy = result["sidebar_profiles"]["more_profiles_for_you"]
-        # sidebar links first, then show_all expansion, deduped
-        assert mpfy == ["/in/alice/", "/in/bob/", "/in/eve/", "/in/frank/"]
-        assert result["sidebar_profiles"]["explore_premium_profiles"] == ["/in/carol/"]
-        assert result["sidebar_profiles"]["people_you_may_know"] == ["/in/dave/"]
-
-    @pytest.mark.parametrize(
-        ("error_type", "message"),
-        [
-            pytest.param(
-                AuthenticationError,
-                "Run with --login",
-                id="authentication-error",
-            ),
-            pytest.param(
-                ProxyConnectionError,
-                "Proxy unavailable",
-                id="proxy-connection-error",
-            ),
-        ],
-    )
-    async def test_scraper_exception_from_show_all_propagates(
-        self,
-        mock_page,
-        error_type: type[LinkedInScraperException],
-        message: str,
-    ):
-        sidebar_js_result = {
-            "sections": {"more_profiles_for_you": ["/in/alice/"]},
-            "showAllUrls": {
-                "more_profiles_for_you": "https://www.linkedin.com/search/results/people/?keywords=test"
-            },
-        }
-        mock_page.evaluate = AsyncMock(return_value=sidebar_js_result)
-        mock_page.url = "https://www.linkedin.com/in/testuser/"
-
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                PageNavigator,
-                "_navigate_to_page",
-                new_callable=AsyncMock,
-                side_effect=[None, error_type(message)],
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            pytest.raises(error_type, match=message),
-        ):
-            await extractor.get_sidebar_profiles("testuser")
-
-    async def test_raw_exception_from_show_all_keeps_inline_profiles(self, mock_page):
-        show_all_url = "https://www.linkedin.com/search/results/people/?keywords=test"
-        sidebar_js_result = {
-            "sections": {"more_profiles_for_you": ["/in/alice/"]},
-            "showAllUrls": {"more_profiles_for_you": show_all_url},
-        }
-        mock_page.evaluate = AsyncMock(return_value=sidebar_js_result)
-        mock_page.url = "https://www.linkedin.com/in/testuser/"
-
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                PageNavigator,
-                "_navigate_to_page",
-                new_callable=AsyncMock,
-                side_effect=[None, RuntimeError("navigation failed")],
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch.object(extractor_module.logger, "debug") as debug_mock,
-        ):
-            result = await extractor.get_sidebar_profiles("testuser")
-
-        assert result == {
-            "url": "https://www.linkedin.com/in/testuser/",
-            "sidebar_profiles": {"more_profiles_for_you": ["/in/alice/"]},
-        }
-        debug_mock.assert_called_once_with(
-            "Failed to navigate to Show all for section %s: %s",
-            "more_profiles_for_you",
-            show_all_url,
-        )
-
-    async def test_skips_show_all_when_url_contains_premium(self, mock_page):
-        """Show all URL containing /premium is skipped without navigation."""
-        sidebar_js_result = {
-            "sections": {"explore_premium_profiles": ["/in/carol/"]},
-            "showAllUrls": {
-                "explore_premium_profiles": "https://www.linkedin.com/premium/products/"
-            },
-        }
-        mock_page.evaluate = AsyncMock(return_value=sidebar_js_result)
-        mock_page.url = "https://www.linkedin.com/in/testuser/"
-
-        extractor = LinkedInExtractor(mock_page)
-        navigate_mock = AsyncMock()
-        with (
-            patch.object(PageNavigator, "_navigate_to_page", navigate_mock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            result = await extractor.get_sidebar_profiles("testuser")
-
-        navigate_mock.assert_awaited_once()  # only the initial profile navigation
-        mock_page.evaluate.assert_awaited_once()  # no show_all JS call
-        assert result["sidebar_profiles"]["explore_premium_profiles"] == ["/in/carol/"]
-
-    async def test_skips_show_all_when_page_redirects_to_premium(self, mock_page):
-        """If navigating to Show all lands on a /premium URL, skip that section."""
-        sidebar_js_result = {
-            "sections": {"more_profiles_for_you": ["/in/alice/"]},
-            "showAllUrls": {
-                "more_profiles_for_you": "https://www.linkedin.com/search/results/people/?keywords=test"
-            },
-        }
-        mock_page.evaluate = AsyncMock(return_value=sidebar_js_result)
-        mock_page.url = "https://www.linkedin.com/in/testuser/"
-
-        navigate_call_count = 0
-
-        async def fake_navigate(url: str) -> None:
-            nonlocal navigate_call_count
-            navigate_call_count += 1
-            if navigate_call_count >= 2:
-                mock_page.url = "https://www.linkedin.com/premium/grow-your-network/"
-
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(PageNavigator, "_navigate_to_page", side_effect=fake_navigate),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.get_sidebar_profiles("testuser")
-
-        mock_page.evaluate.assert_awaited_once()  # sidebar JS only, no show_all expansion
-        assert result["sidebar_profiles"]["more_profiles_for_you"] == ["/in/alice/"]
-
-    async def test_returns_empty_sidebar_profiles_when_no_sections_found(
-        self, mock_page
-    ):
-        """No matching sidebar headings -> empty sidebar_profiles dict."""
-        mock_page.evaluate = AsyncMock(return_value={"sections": {}, "showAllUrls": {}})
-        mock_page.url = "https://www.linkedin.com/in/testuser/"
-
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.detect_rate_limit",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.handle_modal_close",
-                new_callable=AsyncMock,
-                return_value=False,
-            ),
-        ):
-            result = await extractor.get_sidebar_profiles("testuser")
-
-        assert result == {
-            "url": "https://www.linkedin.com/in/testuser/",
-            "sidebar_profiles": {},
-        }
 
 
 class TestMessageTargetUrls:
@@ -6110,27 +4967,7 @@ class TestMessageTargetUrls:
         assert extractor_module._message_page_url_is_safe(url, "ACoAAB") is expected
 
 
-class TestExtractProfileUrn:
-    async def test_returns_urn_from_atomic_top_card_snapshot(self, mock_page):
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "status": "resolved",
-                "pageUrl": "https://www.linkedin.com/in/testuser/",
-                "displayName": "Test User",
-                "composeHrefs": [
-                    "/messaging/compose/?recipient=ACoAAB&"
-                    "profileUrn=urn%3Ali%3Afsd_profile%3AACoAAB"
-                ],
-            }
-        )
-
-        result = await LinkedInExtractor(mock_page)._extract_profile_urn()
-
-        assert result == "ACoAAB"
-        mock_page.evaluate.assert_awaited_once_with(
-            extractor_module._PROFILE_MESSAGE_TARGET_JS
-        )
-
+class TestReadProfileMessageTarget:
     async def test_accepts_safe_final_vanity_redirect(self, mock_page):
         mock_page.evaluate = AsyncMock(
             return_value={
@@ -6150,76 +4987,6 @@ class TestExtractProfileUrn:
         assert resolution.target is not None
         assert resolution.target.profile_path == "/in/canonical-user/"
         assert resolution.target.profile_urn == "ACoAAB"
-
-    async def test_returns_none_for_ambiguous_top_card_links(self, mock_page):
-        mock_page.evaluate = AsyncMock(
-            return_value={
-                "status": "resolved",
-                "pageUrl": "https://www.linkedin.com/in/testuser/",
-                "displayName": "Test User",
-                "composeHrefs": [
-                    "/messaging/compose/?recipient=ACoAAB",
-                    "/messaging/compose/?recipient=OTHER",
-                ],
-            }
-        )
-
-        result = await LinkedInExtractor(mock_page)._extract_profile_urn()
-
-        assert result is None
-
-
-class TestScrapePersonProfileUrn:
-    async def test_includes_profile_urn_in_result_when_found(self, mock_page):
-        """scrape_person includes profile_urn in result when _extract_profile_urn returns a value."""
-        urn = "ACoAAB1IelEBLEkqTkNbZ-a1D8mq5R-6C1ihSEk"
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("profile text"),
-            ),
-            patch.object(
-                extractor,
-                "_extract_profile_urn",
-                new_callable=AsyncMock,
-                return_value=urn,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", {"main_profile"})
-
-        assert result["profile_urn"] == urn
-
-    async def test_omits_profile_urn_when_not_found(self, mock_page):
-        """scrape_person omits profile_urn key when _extract_profile_urn returns None."""
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("profile text"),
-            ),
-            patch.object(
-                extractor,
-                "_extract_profile_urn",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.scrape_person("testuser", {"main_profile"})
-
-        assert "profile_urn" not in result
 
 
 class TestGetInbox:
@@ -6489,7 +5256,7 @@ class TestGetConversation:
                 extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
             ),
             patch.object(
-                extractor,
+                extractor._profile_page,
                 "_read_profile_display_name",
                 new_callable=AsyncMock,
                 return_value="Jacki McMahan",
@@ -6547,7 +5314,7 @@ class TestGetConversation:
                 extractor, "_scroll_main_scrollable_region", new_callable=AsyncMock
             ),
             patch.object(
-                extractor,
+                extractor._profile_page,
                 "_read_profile_display_name",
                 new_callable=AsyncMock,
                 return_value="Jacki McMahan",
@@ -6600,7 +5367,7 @@ class TestGetConversation:
                 new_callable=AsyncMock,
             ),
             patch.object(
-                extractor,
+                extractor._profile_page,
                 "_read_profile_display_name",
                 new_callable=AsyncMock,
                 return_value="Jacki McMahan",
@@ -6632,7 +5399,7 @@ class TestGetConversation:
                 new_callable=AsyncMock,
             ),
             patch.object(
-                extractor,
+                extractor._profile_page,
                 "_read_profile_display_name",
                 new_callable=AsyncMock,
                 return_value="Jacki McMahan",
@@ -8203,48 +6970,6 @@ def _no_signals() -> ActionSignals:
     )
 
 
-class TestGetMyProfileAlias:
-    async def test_survives_a_redirect_that_never_resolves_the_alias(self, mock_page):
-        """The one caller allowed to hold "me".
-
-        get_my_profile navigates to /in/me/ and reads the identifier back out of
-        the redirect. When the redirect has not happened it still holds the
-        alias, and refusing there would answer the tool that owns the alias with
-        an instruction to call itself.
-        """
-        mock_page.url = "https://www.linkedin.com/in/me/"
-        extractor = LinkedInExtractor(mock_page)
-        with (
-            patch.object(
-                extractor,
-                "extract_page",
-                new_callable=AsyncMock,
-                return_value=extracted("profile text"),
-            ) as mock_extract,
-            patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
-            patch(
-                "linkedin_mcp_server.scraping.extractor.asyncio.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
-            result = await extractor.get_my_profile()
-
-        # The alias survives normalization, and because the page is already on
-        # it, the scrape reuses the loaded document instead of navigating again.
-        assert result["url"] == "https://www.linkedin.com/in/me/"
-        assert "main_profile" in result["sections"]
-        mock_extract.assert_not_called()
-
-    async def test_refuses_the_alias_from_an_ordinary_caller(self, mock_page):
-        extractor = LinkedInExtractor(mock_page)
-        with patch.object(
-            extractor, "extract_page", new_callable=AsyncMock
-        ) as mock_extract:
-            with pytest.raises(InvalidReferenceError):
-                await extractor.scrape_person("me", {"main_profile"})
-        mock_extract.assert_not_called()
-
-
 class TestEveryNormalizedEntryPoint:
     """Each method that was rewired, refusing a value that redirects the path.
 
@@ -8256,8 +6981,13 @@ class TestEveryNormalizedEntryPoint:
 
     @staticmethod
     def _calls(extractor: LinkedInExtractor):
+        # Both patches land on the owner class rather than on the facade
+        # instance, because two of the parameterized methods now reach the
+        # capture through a collaborator of their own. A facade patch would
+        # intercept nothing for those and the assertion would hold whatever
+        # the code did.
         return (
-            patch.object(extractor, "extract_page", new_callable=AsyncMock),
+            patch.object(SectionCapture, "extract_page", new_callable=AsyncMock),
             patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
         )
 

--- a/tests/test_send_message_confirmation_dom.py
+++ b/tests/test_send_message_confirmation_dom.py
@@ -22,6 +22,8 @@ from linkedin_mcp_server.scraping.extractor import (
     _ProfileMessageTargetResolution,
 )
 from linkedin_mcp_server.scraping.navigation import PageNavigator
+from linkedin_mcp_server.scraping.profile_page import ProfilePageReader
+from linkedin_mcp_server.scraping.session import ScrapingSession
 
 pytestmark = [
     pytest.mark.browser_dom,
@@ -372,11 +374,16 @@ class TestProfileMessageTargetDom:
             ),
         )
         extractor = LinkedInExtractor(dom_page)
+        # The reader borrows the facade's top-card read until the message
+        # sender owns it, so wiring it here is what the facade does.
+        reader = ProfilePageReader(
+            ScrapingSession(dom_page), extractor._read_profile_message_target
+        )
 
         resolution = await read_profile_target(dom_page, html)
 
         assert resolution.status == "unavailable"
-        assert await extractor._extract_profile_urn() is None
+        assert await reader._extract_profile_urn() is None
 
     async def test_hidden_top_card_action_proves_action_absence(self, dom_page):
         html = profile_page(


### PR DESCRIPTION
Part of #853. Stacked on #916.

The person workflow was the largest block left in `extractor.py`. Its section ordering, main-profile reuse, sidebar error boundary and rate-limit stop could only be reached through the facade, and 101 of its tests patched private extractor seams.

This stage moves profile identity reads into `ProfilePageReader` and `scrape_person`, `get_my_profile`, `get_sidebar_profiles` and `search_people` into `PersonScraper`. Ordering, one-section-one-navigation, reuse, callbacks, pacing, the sidebar fallback-versus-propagate boundary and identifier rejection before navigation all move verbatim. The sidebar's English strings move into an explicit locale table in `text.py` and its JavaScript is templated from it, byte-identical to the inlined original. All 101 stage-6 seams retire; the inventory drops from 799 to 676.

Verification: both checkers, 735 owner tests, Ruff, `ty`, pre-commit, and the full suite with 3,780 passing tests succeed. Canonical traces stay byte-identical.

## Synthetic prompt

> Extract the profile readers and person workflow into owner modules, retire their facade reach-throughs, and put the sidebar's English strings behind an explicit locale table.

Generated with Claude Opus 5 + GPT-6 Astra
