### PR TITLE
fix(scraping): Resolve owner factory names

### DIFF
--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -661,6 +661,64 @@ class _ScopeFrame:
     ambiguous_aliases: set[int] = field(default_factory=set)
     owner_names: set[str] = field(default_factory=set)
     closure_owner_names: set[str] = field(default_factory=set)
+    # The factory names still answering for this scope. `_OWNER_FACTORIES`
+    # declares them per file; a scope that binds one itself drops it, and its
+    # nested scopes inherit the reduced set rather than the table's.
+    owner_factories: frozenset[str] = frozenset()
+
+
+def _resolved_owner_factories(
+    path: Path,
+    tree: ast.Module,
+) -> tuple[frozenset[str], list[str]]:
+    """Resolve the declared factory names against what the module defines.
+
+    The exemption was granted on the spelling alone, so any `_scraper(...)`
+    call carried it, including one reaching a name the module rebound to
+    something that builds the facade. The patch behind such a call left the
+    inventory instead of refusing, which is the one direction this checker
+    must not fail in.
+
+    A name is honored only where the module body defines it exactly once, as a
+    plain `def` or `async def`, and binds it no other way at that level. A
+    second definition, an import, an assignment or a class of the same name
+    all disqualify it outright and say so, because which of them a call site
+    reaches is a question about execution order that this reader cannot
+    answer. Shadowing deeper than module level is left to the scope chain: the
+    frame carries the honored set, and a scope that binds the name drops it
+    for itself and everything nested inside it.
+    """
+
+    declared = _OWNER_FACTORIES.get(path.relative_to(ROOT).as_posix(), ())
+    if not declared:
+        return frozenset(), []
+    honored: set[str] = set()
+    errors: list[str] = []
+    for name in declared:
+        definitions = [
+            statement
+            for statement in tree.body
+            if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and statement.name == name
+        ]
+        others = _scope_collector(
+            path,
+            [
+                statement
+                for statement in tree.body
+                if not any(statement is definition for definition in definitions)
+            ],
+        ).bindings
+        if len(definitions) == 1 and name not in others:
+            honored.add(name)
+            continue
+        line = definitions[-1].lineno if definitions else 0
+        errors.append(
+            f"{path.relative_to(ROOT).as_posix()}:{line} {name}: "
+            "owner factory is not a single module-level definition; "
+            "remove the entry from _OWNER_FACTORIES or the rebinding"
+        )
+    return frozenset(honored), errors
 
 
 def _owner_factory_bindings(
@@ -2402,6 +2460,7 @@ class Scanner(ast.NodeVisitor):
         facade_publics: frozenset[str],
         facade_privates: frozenset[str],
         monkeypatch_calls: set[int],
+        owner_factories: frozenset[str] = frozenset(),
     ):
         self.path = path
         self.root_module_names = module_names
@@ -2419,6 +2478,7 @@ class Scanner(ast.NodeVisitor):
                 closure_module_names=set(module_names),
                 closure_class_names=set(class_names),
                 closure_instance_names=set(),
+                owner_factories=owner_factories,
             )
         ]
         self.caller_contexts: list[set[str]] = []
@@ -2523,9 +2583,8 @@ class Scanner(ast.NodeVisitor):
             collector.class_aliases,
             parameters,
         )
-        instance_names = parent.closure_instance_names - _function_shadowed_names(
-            self.path, node
-        )
+        shadowed = _function_shadowed_names(self.path, node)
+        instance_names = parent.closure_instance_names - shadowed
         instance_names.update(
             _extractor_bindings(
                 node,
@@ -2540,10 +2599,9 @@ class Scanner(ast.NodeVisitor):
         aliases, ambiguous_aliases = _collaborator_aliases(
             self.path, node, instance_names | class_names
         )
-        factories = _OWNER_FACTORIES.get(self.relative_path, ())
-        owner_names = parent.closure_owner_names - _function_shadowed_names(
-            self.path, node
-        )
+        owner_factories = parent.owner_factories - shadowed
+        factories = tuple(sorted(owner_factories))
+        owner_names = parent.closure_owner_names - shadowed
         owner_names.update(_owner_factory_bindings(node, factories))
         owner_names.difference_update(_rebound_owner_names(self.path, node, factories))
         self.functions.append(node)
@@ -2560,6 +2618,7 @@ class Scanner(ast.NodeVisitor):
                 ambiguous_aliases=ambiguous_aliases,
                 owner_names=owner_names,
                 closure_owner_names=set(owner_names),
+                owner_factories=owner_factories,
             )
         )
         for statement in node.body:
@@ -2835,6 +2894,8 @@ class Scanner(ast.NodeVisitor):
             closure_instance_names=set(parent.closure_instance_names),
             owner_names=set(parent.closure_owner_names),
             closure_owner_names=set(parent.closure_owner_names),
+            owner_factories=parent.owner_factories
+            - _scope_collector(self.path, node.body).bindings,
         )
         self.frames.append(frame)
         self._visit_class_suite(node.body)
@@ -2874,6 +2935,9 @@ class Scanner(ast.NodeVisitor):
                 closure_module_names=set(module_names),
                 closure_class_names=set(class_names),
                 closure_instance_names=set(instance_names),
+                owner_factories=parent.owner_factories
+                - collector.bindings
+                - parameters,
             )
         )
         self.visit(node.body)
@@ -3553,7 +3617,10 @@ class Scanner(ast.NodeVisitor):
         still refuse. A name the scope also binds some other way loses the
         exemption in ``_rebound_owner_names``: ``for``, ``with`` and
         ``except`` targets are no facade binding either, so this signal is the
-        only one that ever sees them.
+        only one that ever sees them. The factory the exemption comes from is
+        resolved rather than matched, in ``_resolved_owner_factories`` for the
+        module level and along the frame chain below it, so a shadowed
+        ``_scraper`` grants nothing.
         """
 
         frame = self.frames[-1]
@@ -3635,6 +3702,7 @@ def scan_source(
     class_names = set(root.class_aliases)
     if path == PACKAGE / "scraping" / "extractor.py":
         class_names.add("LinkedInExtractor")
+    owner_factories, factory_errors = _resolved_owner_factories(path, tree)
     scanner = Scanner(
         path,
         root.module_aliases,
@@ -3642,10 +3710,11 @@ def scan_source(
         facade_publics,
         facade_privates,
         _monkeypatch_calls(path, tree),
+        owner_factories,
     )
     scanner.visit(tree)
-    if scanner.errors:
-        raise UnresolvedSeamError("\n".join(scanner.errors))
+    if factory_errors or scanner.errors:
+        raise UnresolvedSeamError("\n".join([*factory_errors, *scanner.errors]))
     return scanner.seams
 
 

--- a/scripts/check_scraping_migration_manifest.py
+++ b/scripts/check_scraping_migration_manifest.py
@@ -665,6 +665,7 @@ class _ScopeFrame:
     # declares them per file; a scope that binds one itself drops it, and its
     # nested scopes inherit the reduced set rather than the table's.
     owner_factories: frozenset[str] = frozenset()
+    closure_owner_factories: frozenset[str] = frozenset()
 
 
 def _resolved_owner_factories(
@@ -2479,6 +2480,7 @@ class Scanner(ast.NodeVisitor):
                 closure_class_names=set(class_names),
                 closure_instance_names=set(),
                 owner_factories=owner_factories,
+                closure_owner_factories=owner_factories,
             )
         ]
         self.caller_contexts: list[set[str]] = []
@@ -2599,7 +2601,7 @@ class Scanner(ast.NodeVisitor):
         aliases, ambiguous_aliases = _collaborator_aliases(
             self.path, node, instance_names | class_names
         )
-        owner_factories = parent.owner_factories - shadowed
+        owner_factories = parent.closure_owner_factories - shadowed
         factories = tuple(sorted(owner_factories))
         owner_names = parent.closure_owner_names - shadowed
         owner_names.update(_owner_factory_bindings(node, factories))
@@ -2619,6 +2621,7 @@ class Scanner(ast.NodeVisitor):
                 owner_names=owner_names,
                 closure_owner_names=set(owner_names),
                 owner_factories=owner_factories,
+                closure_owner_factories=owner_factories,
             )
         )
         for statement in node.body:
@@ -2777,6 +2780,8 @@ class Scanner(ast.NodeVisitor):
             ambiguous_aliases=set(frame.ambiguous_aliases),
             owner_names=set(frame.owner_names),
             closure_owner_names=set(frame.closure_owner_names),
+            owner_factories=frame.owner_factories,
+            closure_owner_factories=frame.closure_owner_factories,
         )
 
     def _visit_class_suite(self, statements: list[ast.stmt]) -> None:
@@ -2894,8 +2899,9 @@ class Scanner(ast.NodeVisitor):
             closure_instance_names=set(parent.closure_instance_names),
             owner_names=set(parent.closure_owner_names),
             closure_owner_names=set(parent.closure_owner_names),
-            owner_factories=parent.owner_factories
+            owner_factories=parent.closure_owner_factories
             - _scope_collector(self.path, node.body).bindings,
+            closure_owner_factories=parent.closure_owner_factories,
         )
         self.frames.append(frame)
         self._visit_class_suite(node.body)
@@ -2935,7 +2941,10 @@ class Scanner(ast.NodeVisitor):
                 closure_module_names=set(module_names),
                 closure_class_names=set(class_names),
                 closure_instance_names=set(instance_names),
-                owner_factories=parent.owner_factories
+                owner_factories=parent.closure_owner_factories
+                - collector.bindings
+                - parameters,
+                closure_owner_factories=parent.closure_owner_factories
                 - collector.bindings
                 - parameters,
             )

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -3001,6 +3001,54 @@ def test_a_sibling_test_keeps_the_exemption_a_nested_shadow_loses():
     assert not [seam for seam in seams if seam.kind.endswith("_patch_object")]
 
 
+def test_a_class_branch_copy_keeps_both_factory_views():
+    frame = migration._ScopeFrame(
+        kind="class",
+        module_names=set(),
+        class_names=set(),
+        instance_names=set(),
+        closure_module_names=set(),
+        closure_class_names=set(),
+        closure_instance_names=set(),
+        owner_factories=frozenset({"current_factory"}),
+        closure_owner_factories=frozenset({"enclosing_factory"}),
+    )
+
+    copied = migration.Scanner._copy_frame(frame)
+
+    assert copied.owner_factories == frozenset({"current_factory"})
+    assert copied.closure_owner_factories == frozenset({"enclosing_factory"})
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "    if os.environ.get('FLAG'):\n{test}\n    else:\n        pass\n",
+        "    try:\n{test}\n    except Exception:\n        pass\n",
+    ],
+    ids=["if", "try"],
+)
+def test_a_class_branch_keeps_the_factory_its_class_body_shadows(branch):
+    test = (
+        "        async def test_owner(self, page, replacement):\n"
+        "            scraper = _scraper(page)\n"
+        "            patch.object("
+        'scraper._capture, "extract_page", replacement)'
+    )
+    seams = migration.scan_source(
+        PERSON_TESTS,
+        "\nimport os\n"
+        "from unittest.mock import patch\n"
+        "\nfrom linkedin_mcp_server.scraping.extractor import LinkedInExtractor\n"
+        "\n\ndef _scraper(page):\n    return page\n"
+        "\n\nclass TestOwner:\n"
+        "    _scraper = object()\n" + branch.format(test=test),
+        *migration.extractor_methods(),
+    )
+
+    assert not [seam for seam in seams if seam.kind.endswith("_patch_object")]
+
+
 def test_a_foreign_collaborator_of_its_own_stays_out_of_the_inventory():
     # The refusal has to stop at objects the reader knows nothing about, or it
     # refuses the migration's own target state: `tests/scraping/test_feed.py`

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -2860,10 +2860,17 @@ def test_a_conditionally_rebound_alias_names_its_call_site(statement, line):
         _scan_synthetic(_reach_through(statement))
 
 
-def _owner_test(body: str) -> str:
+def _owner_test(
+    body: str, *, factory: str = "def _scraper(page):\n    return page"
+) -> str:
+    # The factory has to be here. The exemption is granted against the
+    # definition the module actually holds, so a fragment that only calls
+    # `_scraper` describes a file whose entry in `_OWNER_FACTORIES` names
+    # nothing, which is its own refusal.
     return (
         "\nfrom unittest.mock import patch\n"
         "\nfrom linkedin_mcp_server.scraping.extractor import LinkedInExtractor\n"
+        f"\n\n{factory}\n"
         "\n\nasync def test_owner(page, replacement):\n"
         f"{body}\n"
     )
@@ -2889,10 +2896,10 @@ def test_an_owner_factory_binding_exempts_only_its_own_wiring():
 @pytest.mark.parametrize(
     ("rebinding", "line"),
     [
-        ("    for scraper in (LinkedInExtractor(page),):\n        pass", 11),
-        ("    with LinkedInExtractor(page) as scraper:\n        pass", 11),
-        ("    try:\n        pass\n    except Exception as scraper:\n        pass", 13),
-        ("    scraper, other = LinkedInExtractor(page), None", 10),
+        ("    for scraper in (LinkedInExtractor(page),):\n        pass", 15),
+        ("    with LinkedInExtractor(page) as scraper:\n        pass", 15),
+        ("    try:\n        pass\n    except Exception as scraper:\n        pass", 17),
+        ("    scraper, other = LinkedInExtractor(page), None", 14),
     ],
 )
 def test_a_rebound_owner_name_loses_its_factory_exemption(rebinding, line):
@@ -2917,6 +2924,81 @@ def test_a_rebound_owner_name_loses_its_factory_exemption(rebinding, line):
             ),
             *migration.extractor_methods(),
         )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        "def _scraper(page):\n    return page\n\n\ndef _scraper(page):\n    return page",
+        "def _scraper(page):\n    return page\n\n\n_scraper = LinkedInExtractor",
+        "from helpers import _scraper",
+    ],
+)
+def test_a_module_level_factory_shadow_names_its_entry(factory):
+    # The exemption was granted on the spelling, so whichever `_scraper` a
+    # call reaches carried it, including one the module rebound to the facade
+    # itself. Which binding a call site reaches is a question about execution
+    # order, and a reader that cannot answer it has to refuse rather than pick.
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"test_person\.py:\d+ _scraper: "
+        r"owner factory is not a single module-level definition",
+    ):
+        migration.scan_source(
+            PERSON_TESTS,
+            _owner_test(
+                "    scraper = _scraper(page)\n"
+                '    patch.object(scraper._capture, "extract_page", replacement)',
+                factory=factory,
+            ),
+            *migration.extractor_methods(),
+        )
+
+
+def test_a_nested_factory_shadow_loses_the_exemption_where_it_shadows():
+    # A `def _scraper` inside one test is invisible at module level, so the
+    # module check cannot see it and the frame chain has to. Measured against
+    # the pre-fix checker on the real file: both patches passed with exit 0,
+    # which is the inventory losing a facade reach-through in silence.
+    with pytest.raises(
+        migration.UnresolvedSeamError,
+        match=r"test_person\.py:16 scraper\._capture: "
+        r"unresolved patch\.object target",
+    ):
+        migration.scan_source(
+            PERSON_TESTS,
+            _owner_test(
+                "    def _scraper(page):\n"
+                "        return LinkedInExtractor(page)\n"
+                "\n"
+                "    scraper = _scraper(page)\n"
+                '    patch.object(scraper._capture, "extract_page", replacement)'
+            ),
+            *migration.extractor_methods(),
+        )
+
+
+def test_a_sibling_test_keeps_the_exemption_a_nested_shadow_loses():
+    # The narrowing is per scope, not per file. A shadow in one test may not
+    # cost the other 44 call sites their exemption, or the fix trades one
+    # silent pass for a refusal that blocks every later stage.
+    seams = migration.scan_source(
+        PERSON_TESTS,
+        _owner_test(
+            "    def _scraper(page):\n"
+            "        return LinkedInExtractor(page)\n"
+            "\n"
+            "    scraper = _scraper(page)\n"
+            "\n"
+            "\n"
+            "async def test_sibling(page, replacement):\n"
+            "    scraper = _scraper(page)\n"
+            '    patch.object(scraper._capture, "extract_page", replacement)'
+        ),
+        *migration.extractor_methods(),
+    )
+
+    assert not [seam for seam in seams if seam.kind.endswith("_patch_object")]
 
 
 def test_a_foreign_collaborator_of_its_own_stays_out_of_the_inventory():


### PR DESCRIPTION
Part of #853. Stacked on #919.

The migration manifest could resolve direct owner instances but missed factory aliases and several definition-time rebinding forms. That gap could let a stale extractor patch survive after implementation moved.

This stage hardens owner-factory analysis across decorators, globals, walrus bindings, lambda defaults, class scopes, and copied branch frames. Regression mutations cover each binding path without changing production scraping behavior.

Verification: manifest mutations, both compare-only checkers, Ruff, `ty`, pre-commit, and the final 4,189-test suite pass.

## Synthetic prompt

> Harden the extractor migration manifest so owner factories and definition-time rebindings cannot hide stale private patches.

Generated with GPT-5.6 Sol
