### PR TITLE
refactor(scraping): Make capture plans explicit

### DIFF
--- a/linkedin_mcp_server/scraping/capture.py
+++ b/linkedin_mcp_server/scraping/capture.py
@@ -7,7 +7,6 @@ from enum import Flag, auto
 from urllib.parse import urlparse
 
 import logging
-import re
 
 from patchright.async_api import TimeoutError as PlaywrightTimeoutError
 
@@ -22,6 +21,8 @@ from linkedin_mcp_server.scraping.link_metadata import build_references
 from linkedin_mcp_server.scraping.navigation import PageNavigator
 from linkedin_mcp_server.scraping.session import ScrapingSession
 from linkedin_mcp_server.scraping.text import (
+    DETAIL_CAPTURE_EN_US,
+    DetailCaptureTextTable,
     filter_linkedin_noise_lines,
     truncate_linkedin_noise,
 )
@@ -79,10 +80,12 @@ class SectionCapture:
         session: ScrapingSession,
         navigator: PageNavigator,
         content: PageContentReader,
+        detail_text: DetailCaptureTextTable = DETAIL_CAPTURE_EN_US,
     ):
         self._session = session
         self._navigator = navigator
         self._content = content
+        self._detail_text = detail_text
 
     async def extract_page(
         self,
@@ -216,14 +219,7 @@ class SectionCapture:
         if CaptureMode.DETAILS in plan.mode:
             try:
                 await self._session.page.wait_for_function(
-                    """() => {
-                        const main = document.querySelector('main');
-                        if (!main) return false;
-                        const text = main.innerText.trimStart();
-                        return !text.startsWith('Load more')
-                            && !text.startsWith('More profiles for you')
-                            && !text.startsWith('Explore premium profiles');
-                    }""",
+                    self._detail_text.readiness_expression(),
                     timeout=10000,
                 )
             except PlaywrightTimeoutError:
@@ -233,7 +229,7 @@ class SectionCapture:
             max_clicks = plan.max_scrolls if plan.max_scrolls is not None else 5
             for i in range(max_clicks):
                 button = self._session.page.locator("main button").filter(
-                    has_text=re.compile(r"^Show (more|all)\b", re.IGNORECASE)
+                    has_text=self._detail_text.expansion_button_pattern
                 )
                 try:
                     if await button.count() == 0:

--- a/linkedin_mcp_server/scraping/capture.py
+++ b/linkedin_mcp_server/scraping/capture.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Flag, auto
 from urllib.parse import urlparse
 
 import logging
@@ -33,6 +35,42 @@ logger = logging.getLogger(__name__)
 RATE_LIMIT_RETRY_DELAY = 5.0
 
 
+class CaptureMode(Flag):
+    """Independent post-navigation behaviors applied during section capture."""
+
+    STANDARD = 0
+    ACTIVITY = auto()
+    SEARCH_RESULTS = auto()
+    COMPANY_PEOPLE = auto()
+    DETAILS = auto()
+    OVERLAY = auto()
+
+
+@dataclass(frozen=True)
+class CapturePlan:
+    """Immutable policy for one section capture."""
+
+    mode: CaptureMode = CaptureMode.STANDARD
+    max_scrolls: int | None = None
+
+
+def capture_plan_for_url(url: str, max_scrolls: int | None = None) -> CapturePlan:
+    """Translate a generic compatibility URL into its historical capture policy."""
+    path = urlparse(url).path
+    mode = CaptureMode.STANDARD
+    if "/recent-activity/" in path or (
+        "/company/" in path and path.rstrip("/").endswith("/posts")
+    ):
+        mode |= CaptureMode.ACTIVITY
+    if "/search/results/" in url:
+        mode |= CaptureMode.SEARCH_RESULTS
+    if "/company/" in url and "/people/" in url:
+        mode |= CaptureMode.COMPANY_PEOPLE
+    if "/details/" in url:
+        mode |= CaptureMode.DETAILS
+    return CapturePlan(mode=mode, max_scrolls=max_scrolls)
+
+
 class SectionCapture:
     """Capture one section from a loaded page or from an overlay dialog."""
 
@@ -52,85 +90,88 @@ class SectionCapture:
         section_name: str,
         max_scrolls: int | None = None,
     ) -> ExtractedSection:
-        """Navigate to a URL, scroll to load lazy content, and extract innerText.
+        """Compatibility adapter for generic URL-derived page capture."""
+        return await self.capture(
+            url,
+            section_name,
+            capture_plan_for_url(url, max_scrolls),
+        )
 
-        Retries once after a backoff when the page returns only LinkedIn chrome
-        (sidebar/footer noise with no actual content), which indicates a soft
-        rate limit.
-
-        Raises LinkedInScraperException subclasses (rate limit, auth, etc.).
-        Returns RATE_LIMITED_SECTION_TEXT sentinel when soft-rate-limited after retry.
-        Returns empty string for unexpected non-domain failures (error isolation).
-        """
+    async def capture(
+        self,
+        url: str,
+        section_name: str,
+        plan: CapturePlan,
+    ) -> ExtractedSection:
+        """Navigate and capture a section according to an explicit plan."""
         try:
-            result = await self._extract_page_once(url, section_name, max_scrolls)
+            result = await self._capture_once(url, section_name, plan)
             if result.text != RATE_LIMITED_SECTION_TEXT:
                 return result
 
-            # Retry once after backoff
-            logger.info("Retrying %s after %.0fs backoff", url, RATE_LIMIT_RETRY_DELAY)
+            if CaptureMode.OVERLAY in plan.mode:
+                logger.info(
+                    "Retrying overlay %s after %.0fs backoff",
+                    url,
+                    RATE_LIMIT_RETRY_DELAY,
+                )
+            else:
+                logger.info(
+                    "Retrying %s after %.0fs backoff", url, RATE_LIMIT_RETRY_DELAY
+                )
             await self._session.delay(RATE_LIMIT_RETRY_DELAY)
-            return await self._extract_page_once(url, section_name, max_scrolls)
+            return await self._capture_once(url, section_name, plan)
 
         except LinkedInScraperException:
             raise
         except Exception as e:
-            logger.warning("Failed to extract page %s: %s", url, e)
+            is_overlay = CaptureMode.OVERLAY in plan.mode
+            logger.warning(
+                "Failed to extract %s %s: %s",
+                "overlay" if is_overlay else "page",
+                url,
+                e,
+            )
             return ExtractedSection(
                 text="",
                 references=[],
                 error=build_issue_diagnostics(
                     e,
-                    context="extract_page",
+                    context="extract_overlay" if is_overlay else "extract_page",
                     target_url=url,
                     section_name=section_name,
                 ),
             )
 
-    async def _extract_page_once(
+    async def _capture_once(
         self,
         url: str,
         section_name: str,
-        max_scrolls: int | None = None,
+        plan: CapturePlan,
     ) -> ExtractedSection:
-        """Single attempt to navigate, scroll, and extract innerText."""
+        """Single attempt to navigate and capture a section."""
         await self._navigator._navigate_to_page(url)
-        return await self._extract_loaded_section(url, section_name, max_scrolls)
+        if CaptureMode.OVERLAY in plan.mode:
+            return await self._extract_overlay_content(url, section_name)
+        return await self._extract_loaded_section(url, section_name, plan)
 
     async def _extract_loaded_section(
         self,
         url: str,
         section_name: str,
-        max_scrolls: int | None = None,
+        plan: CapturePlan,
     ) -> ExtractedSection:
-        """Run the post-navigation extraction pipeline on the current page.
-
-        Assumes the bound page already points at ``url`` (or its post-redirect
-        equivalent). Performs rate-limit detection, modal dismissal, lazy-load
-        scrolling, innerText extraction, noise truncation, and reference
-        building — everything ``_extract_page_once`` does after the goto.
-        """
+        """Run an explicit post-navigation extraction plan on the current page."""
         await self._session.check_rate_limit()
 
-        # Wait for main content to render
         try:
             await self._session.page.wait_for_selector("main")
         except PlaywrightTimeoutError:
             logger.debug("No <main> element found on %s", url)
 
-        # Dismiss any modals blocking content
         await self._session.dismiss_modal()
 
-        # Activity feed pages lazy-load post content after the tab header.
-        # Company posts pages (/company/<slug>/posts/) lazy-load the same way
-        # but don't carry a /recent-activity/ path, so match them too. Matched
-        # on the parsed path, since the url can carry a query string
-        # (?viewAsMember=true) that a raw suffix check would miss.
-        path = urlparse(url).path
-        is_activity = "/recent-activity/" in path or (
-            "/company/" in path and path.rstrip("/").endswith("/posts")
-        )
-        if is_activity:
+        if CaptureMode.ACTIVITY in plan.mode:
             try:
                 await self._session.page.wait_for_function(
                     """() => {
@@ -143,10 +184,7 @@ class SectionCapture:
             except PlaywrightTimeoutError:
                 logger.debug("Activity feed content did not appear on %s", url)
 
-        # Search results pages load a placeholder first then fill in results
-        # via JavaScript. Wait for actual content before extracting.
-        is_search = "/search/results/" in url
-        if is_search:
+        if CaptureMode.SEARCH_RESULTS in plan.mode:
             try:
                 await self._session.page.wait_for_function(
                     """() => {
@@ -159,15 +197,10 @@ class SectionCapture:
             except PlaywrightTimeoutError:
                 logger.debug("Search results content did not appear on %s", url)
 
-        # Company people pages (/company/<slug>/people/) initially render only
-        # the company header in <main>; the employee listing hydrates later
-        # via JS. Wait until at least one /in/ profile anchor appears inside
-        # <main> so innerText extraction sees the actual list. Use a 5s
-        # timeout instead of the 10s pattern shared with is_search/is_details
-        # — empty/restricted listings are common here (small companies,
-        # privacy settings) and a full 10s wait per call adds up.
-        is_company_people = "/company/" in url and "/people/" in url
-        if is_company_people:
+        # Employee text hydrates after the company header. The profile anchors
+        # are the only stable structural signal that the listing has arrived.
+        # Empty and restricted listings are common, so keep the shorter timeout.
+        if CaptureMode.COMPANY_PEOPLE in plan.mode:
             try:
                 await self._session.page.wait_for_function(
                     """() => {
@@ -180,12 +213,7 @@ class SectionCapture:
             except PlaywrightTimeoutError:
                 logger.debug("Company people listing did not appear on %s", url)
 
-        # Profile detail pages (/details/experience/, /details/education/, etc.)
-        # initially render sidebar recommendations into <main> while the section
-        # panel loads asynchronously. Wait until the panel replaces the sidebar.
-        # The sidebar placeholder starts with "Load more" or "More profiles for you".
-        is_details = "/details/" in url
-        if is_details:
+        if CaptureMode.DETAILS in plan.mode:
             try:
                 await self._session.page.wait_for_function(
                     """() => {
@@ -201,10 +229,8 @@ class SectionCapture:
             except PlaywrightTimeoutError:
                 logger.debug("Detail section content did not appear on %s", url)
 
-        # Detail pages paginate with a "Show more" button inside <main>, not scroll.
-        # Click it until it disappears or the budget runs out.
-        if is_details:
-            max_clicks = max_scrolls if max_scrolls is not None else 5
+        if CaptureMode.DETAILS in plan.mode:
+            max_clicks = plan.max_scrolls if plan.max_scrolls is not None else 5
             for i in range(max_clicks):
                 button = self._session.page.locator("main button").filter(
                     has_text=re.compile(r"^Show (more|all)\b", re.IGNORECASE)
@@ -226,15 +252,13 @@ class SectionCapture:
                     logger.debug("Show more click failed: %s", e)
                     break
 
-        # Scroll to trigger lazy loading
-        if is_activity:
-            scrolls = max_scrolls if max_scrolls is not None else 10
+        if CaptureMode.ACTIVITY in plan.mode:
+            scrolls = plan.max_scrolls if plan.max_scrolls is not None else 10
             await self._session.scroll_body(pause_time=1.0, max_scrolls=scrolls)
         else:
-            scrolls = max_scrolls if max_scrolls is not None else 5
+            scrolls = plan.max_scrolls if plan.max_scrolls is not None else 5
             await self._session.scroll_body(pause_time=0.5, max_scrolls=scrolls)
 
-        # Extract text from main content area
         raw_result = await self._content._extract_root_content(["main"])
         raw = raw_result["text"]
 
@@ -256,53 +280,35 @@ class SectionCapture:
         self,
         url: str,
         section_name: str,
+        plan: CapturePlan | None = None,
     ) -> ExtractedSection:
-        """Extract content from an overlay/modal page (e.g. contact info).
-
-        LinkedIn renders contact info as a native <dialog> element.
-        Falls back to `<main>` if no dialog is found.
-
-        Retries once after a backoff when the overlay returns only LinkedIn
-        chrome (noise), mirroring `extract_page` behavior.
-        """
-        try:
-            result = await self._extract_overlay_once(url, section_name)
-            if result.text != RATE_LIMITED_SECTION_TEXT:
-                return result
-
-            logger.info(
-                "Retrying overlay %s after %.0fs backoff",
-                url,
-                RATE_LIMIT_RETRY_DELAY,
-            )
-            await self._session.delay(RATE_LIMIT_RETRY_DELAY)
-            return await self._extract_overlay_once(url, section_name)
-
-        except LinkedInScraperException:
-            raise
-        except Exception as e:
-            logger.warning("Failed to extract overlay %s: %s", url, e)
-            return ExtractedSection(
-                text="",
-                references=[],
-                error=build_issue_diagnostics(
-                    e,
-                    context="extract_overlay",
-                    target_url=url,
-                    section_name=section_name,
-                ),
-            )
+        """Compatibility seam for explicit overlay capture."""
+        return await self.capture(
+            url,
+            section_name,
+            plan or CapturePlan(CaptureMode.OVERLAY),
+        )
 
     async def _extract_overlay_once(
         self,
         url: str,
         section_name: str,
     ) -> ExtractedSection:
-        """Single attempt to extract content from an overlay/modal page."""
-        await self._navigator._navigate_to_page(url)
+        """Compatibility seam for a single overlay attempt."""
+        return await self._capture_once(
+            url,
+            section_name,
+            CapturePlan(CaptureMode.OVERLAY),
+        )
+
+    async def _extract_overlay_content(
+        self,
+        url: str,
+        section_name: str,
+    ) -> ExtractedSection:
+        """Extract content from the loaded overlay without dismissing it."""
         await self._session.check_rate_limit()
 
-        # Wait for the dialog/modal to render (LinkedIn uses native <dialog>)
         try:
             await self._session.page.wait_for_selector(
                 "dialog[open], .artdeco-modal__content"
@@ -310,10 +316,8 @@ class SectionCapture:
         except PlaywrightTimeoutError:
             logger.debug("No modal overlay found on %s, falling back to main", url)
 
-        # NOTE: Do NOT dismiss a modal here — the contact-info overlay *is* a
-        # dialog/modal. Dismissing it would destroy the content before the JS
-        # evaluation below can read it.
-
+        # The contact-info overlay is the modal, so dismissing it here would
+        # destroy the content before the reader can fall back through its roots.
         raw_result = await self._content._extract_root_content(
             ["dialog[open]", ".artdeco-modal__content", "main"],
         )

--- a/linkedin_mcp_server/scraping/company.py
+++ b/linkedin_mcp_server/scraping/company.py
@@ -77,9 +77,16 @@ class CompanyScraper:
                 section_name = spec.name
                 url = base_url + spec.suffix
                 try:
-                    extracted = await self._capture.capture(
-                        url, section_name, spec.plan
-                    )
+                    if CaptureMode.OVERLAY in spec.plan.mode:
+                        extracted = await self._capture._extract_overlay(
+                            url,
+                            section_name,
+                            plan=spec.plan,
+                        )
+                    else:
+                        extracted = await self._capture.capture(
+                            url, section_name, spec.plan
+                        )
 
                     if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
                         sections[section_name] = extracted.text

--- a/linkedin_mcp_server/scraping/company.py
+++ b/linkedin_mcp_server/scraping/company.py
@@ -9,12 +9,16 @@ import logging
 
 from linkedin_mcp_server.core.exceptions import LinkedInScraperException
 from linkedin_mcp_server.error_diagnostics import build_issue_diagnostics
-from linkedin_mcp_server.scraping.capture import SectionCapture
+from linkedin_mcp_server.scraping.capture import (
+    CaptureMode,
+    CapturePlan,
+    SectionCapture,
+)
 from linkedin_mcp_server.scraping.contracts import (
     RATE_LIMITED_SECTION_TEXT,
     rate_limited_section_error,
 )
-from linkedin_mcp_server.scraping.fields import COMPANY_SECTIONS
+from linkedin_mcp_server.scraping.fields import COMPANY_SECTIONS, _company_section_specs
 from linkedin_mcp_server.scraping.identifiers import (
     company_page_url,
     normalize_company_identifier,
@@ -56,9 +60,9 @@ class CompanyScraper:
         rate_limited = False
 
         requested_ordered = [
-            (name, suffix, is_overlay)
-            for name, (suffix, is_overlay) in COMPANY_SECTIONS.items()
-            if name in requested
+            spec
+            for spec in _company_section_specs(COMPANY_SECTIONS)
+            if spec.name in requested
         ]
         total = len(requested_ordered)
 
@@ -66,20 +70,16 @@ class CompanyScraper:
             await callbacks.on_start("company profile", base_url)
 
         try:
-            for i, (section_name, suffix, is_overlay) in enumerate(requested_ordered):
+            for i, spec in enumerate(requested_ordered):
                 if i > 0:
                     await self._session.delay(NAV_DELAY)
 
-                url = base_url + suffix
+                section_name = spec.name
+                url = base_url + spec.suffix
                 try:
-                    if is_overlay:
-                        extracted = await self._capture._extract_overlay(
-                            url, section_name=section_name
-                        )
-                    else:
-                        extracted = await self._capture.extract_page(
-                            url, section_name, None
-                        )
+                    extracted = await self._capture.capture(
+                        url, section_name, spec.plan
+                    )
 
                     if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
                         sections[section_name] = extracted.text
@@ -144,7 +144,11 @@ class CompanyScraper:
         url = company_page_url(company_name, "/people/")
         if keywords:
             url += f"?keywords={quote_plus(keywords)}"
-        extracted = await self._capture.extract_page(url, "employees", None)
+        extracted = await self._capture.capture(
+            url,
+            "employees",
+            CapturePlan(CaptureMode.COMPANY_PEOPLE),
+        )
 
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}
@@ -178,7 +182,11 @@ class CompanyScraper:
             {url, sections: {search_results: text}}
         """
         url = build_company_search_url(keywords)
-        extracted = await self._capture.extract_page(url, "search_results", None)
+        extracted = await self._capture.capture(
+            url,
+            "search_results",
+            CapturePlan(CaptureMode.SEARCH_RESULTS),
+        )
 
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}

--- a/linkedin_mcp_server/scraping/fields.py
+++ b/linkedin_mcp_server/scraping/fields.py
@@ -52,7 +52,10 @@ _PERSON_SECTION_MODES = {
 _COMPANY_SECTION_MODES = {"posts": CaptureMode.ACTIVITY}
 
 
-def _person_section_specs(max_scrolls: int | None = None) -> tuple[_SectionSpec, ...]:
+def _person_section_specs(
+    sections: dict[str, tuple[str, bool]],
+    max_scrolls: int | None = None,
+) -> tuple[_SectionSpec, ...]:
     return tuple(
         _SectionSpec(
             name,
@@ -64,7 +67,7 @@ def _person_section_specs(max_scrolls: int | None = None) -> tuple[_SectionSpec,
                 max_scrolls,
             ),
         )
-        for name, (suffix, is_overlay) in PERSON_SECTIONS.items()
+        for name, (suffix, is_overlay) in sections.items()
     )
 
 

--- a/linkedin_mcp_server/scraping/fields.py
+++ b/linkedin_mcp_server/scraping/fields.py
@@ -1,6 +1,10 @@
 """Section config dicts controlling which LinkedIn pages are visited during scraping."""
 
+from dataclasses import dataclass
+
 import logging
+
+from linkedin_mcp_server.scraping.capture import CaptureMode, CapturePlan
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +28,61 @@ COMPANY_SECTIONS: dict[str, tuple[str, bool]] = {
     "posts": ("/posts/", False),
     "jobs": ("/jobs/", False),
 }
+
+
+@dataclass(frozen=True)
+class _SectionSpec:
+    name: str
+    suffix: str
+    plan: CapturePlan
+
+
+_PERSON_SECTION_MODES = {
+    "experience": CaptureMode.DETAILS,
+    "education": CaptureMode.DETAILS,
+    "interests": CaptureMode.DETAILS,
+    "honors": CaptureMode.DETAILS,
+    "languages": CaptureMode.DETAILS,
+    "certifications": CaptureMode.DETAILS,
+    "skills": CaptureMode.DETAILS,
+    "projects": CaptureMode.DETAILS,
+    "contact_info": CaptureMode.OVERLAY,
+    "posts": CaptureMode.ACTIVITY,
+}
+_COMPANY_SECTION_MODES = {"posts": CaptureMode.ACTIVITY}
+
+
+def _person_section_specs(max_scrolls: int | None = None) -> tuple[_SectionSpec, ...]:
+    return tuple(
+        _SectionSpec(
+            name,
+            suffix,
+            CapturePlan(
+                CaptureMode.OVERLAY
+                if is_overlay
+                else _PERSON_SECTION_MODES.get(name, CaptureMode.STANDARD),
+                max_scrolls,
+            ),
+        )
+        for name, (suffix, is_overlay) in PERSON_SECTIONS.items()
+    )
+
+
+def _company_section_specs(
+    sections: dict[str, tuple[str, bool]] = COMPANY_SECTIONS,
+) -> tuple[_SectionSpec, ...]:
+    return tuple(
+        _SectionSpec(
+            name,
+            suffix,
+            CapturePlan(
+                CaptureMode.OVERLAY
+                if is_overlay
+                else _COMPANY_SECTION_MODES.get(name, CaptureMode.STANDARD)
+            ),
+        )
+        for name, (suffix, is_overlay) in sections.items()
+    )
 
 
 def parse_person_sections(

--- a/linkedin_mcp_server/scraping/jobs.py
+++ b/linkedin_mcp_server/scraping/jobs.py
@@ -12,7 +12,7 @@ import time
 from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
 from linkedin_mcp_server.core.exceptions import LinkedInScraperException
 from linkedin_mcp_server.error_diagnostics import build_issue_diagnostics
-from linkedin_mcp_server.scraping.capture import SectionCapture
+from linkedin_mcp_server.scraping.capture import CapturePlan, SectionCapture
 from linkedin_mcp_server.scraping.contracts import (
     RATE_LIMITED_SECTION_TEXT,
     rate_limited_section_error,
@@ -70,7 +70,11 @@ class JobScraper:
         """
         job_id = normalize_job_id(job_id)
         url = job_view_url(job_id, "/")
-        extracted = await self._capture.extract_page(url, section_name="job_posting")
+        extracted = await self._capture.capture(
+            url,
+            section_name="job_posting",
+            plan=CapturePlan(),
+        )
 
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}

--- a/linkedin_mcp_server/scraping/person.py
+++ b/linkedin_mcp_server/scraping/person.py
@@ -12,12 +12,16 @@ from patchright.async_api import TimeoutError as PlaywrightTimeoutError
 
 from linkedin_mcp_server.core.exceptions import LinkedInScraperException
 from linkedin_mcp_server.error_diagnostics import build_issue_diagnostics
-from linkedin_mcp_server.scraping.capture import SectionCapture
+from linkedin_mcp_server.scraping.capture import (
+    CaptureMode,
+    CapturePlan,
+    SectionCapture,
+)
 from linkedin_mcp_server.scraping.contracts import (
     RATE_LIMITED_SECTION_TEXT,
     rate_limited_section_error,
 )
-from linkedin_mcp_server.scraping.fields import PERSON_SECTIONS
+from linkedin_mcp_server.scraping.fields import _person_section_specs
 from linkedin_mcp_server.scraping.identifiers import (
     normalize_person_identifier,
     person_profile_url,
@@ -223,9 +227,9 @@ class PersonScraper:
         rate_limited = False
 
         requested_ordered = [
-            (name, suffix, is_overlay)
-            for name, (suffix, is_overlay) in PERSON_SECTIONS.items()
-            if name in requested
+            spec
+            for spec in _person_section_specs(max_scrolls)
+            if spec.name in requested
         ]
         total = len(requested_ordered)
 
@@ -233,11 +237,12 @@ class PersonScraper:
             await callbacks.on_start("person profile", base_url)
 
         try:
-            for i, (section_name, suffix, is_overlay) in enumerate(requested_ordered):
+            for i, spec in enumerate(requested_ordered):
                 if i > 0:
                     await self._session.delay(NAV_DELAY)
 
-                url = base_url + suffix
+                section_name = spec.name
+                url = base_url + spec.suffix
                 try:
                     can_reuse_main = (
                         section_name == "main_profile"
@@ -249,27 +254,29 @@ class PersonScraper:
                         extracted = await self._capture._extract_loaded_section(
                             url,
                             section_name=section_name,
-                            max_scrolls=max_scrolls,
+                            plan=spec.plan,
                         )
                         if extracted.text == RATE_LIMITED_SECTION_TEXT:
                             logger.info(
                                 "Reuse path soft-rate-limited; falling back "
                                 "to extract_page for retry parity"
                             )
-                            extracted = await self._capture.extract_page(
+                            extracted = await self._capture.capture(
                                 url,
                                 section_name=section_name,
-                                max_scrolls=max_scrolls,
+                                plan=spec.plan,
                             )
-                    elif is_overlay:
+                    elif CaptureMode.OVERLAY in spec.plan.mode:
                         extracted = await self._capture._extract_overlay(
-                            url, section_name=section_name
-                        )
-                    else:
-                        extracted = await self._capture.extract_page(
                             url,
                             section_name=section_name,
-                            max_scrolls=max_scrolls,
+                            plan=spec.plan,
+                        )
+                    else:
+                        extracted = await self._capture.capture(
+                            url,
+                            section_name=section_name,
+                            plan=spec.plan,
                         )
 
                     if extracted.text and extracted.text != RATE_LIMITED_SECTION_TEXT:
@@ -496,7 +503,11 @@ class PersonScraper:
             network=network,
             current_company=current_company,
         )
-        extracted = await self._capture.extract_page(url, section_name="search_results")
+        extracted = await self._capture.capture(
+            url,
+            section_name="search_results",
+            plan=CapturePlan(CaptureMode.SEARCH_RESULTS),
+        )
 
         sections: dict[str, str] = {}
         references: dict[str, list[Reference]] = {}

--- a/linkedin_mcp_server/scraping/person.py
+++ b/linkedin_mcp_server/scraping/person.py
@@ -21,7 +21,7 @@ from linkedin_mcp_server.scraping.contracts import (
     RATE_LIMITED_SECTION_TEXT,
     rate_limited_section_error,
 )
-from linkedin_mcp_server.scraping.fields import _person_section_specs
+from linkedin_mcp_server.scraping.fields import PERSON_SECTIONS, _person_section_specs
 from linkedin_mcp_server.scraping.identifiers import (
     normalize_person_identifier,
     person_profile_url,
@@ -228,7 +228,7 @@ class PersonScraper:
 
         requested_ordered = [
             spec
-            for spec in _person_section_specs(max_scrolls)
+            for spec in _person_section_specs(PERSON_SECTIONS, max_scrolls)
             if spec.name in requested
         ]
         total = len(requested_ordered)

--- a/linkedin_mcp_server/scraping/posts.py
+++ b/linkedin_mcp_server/scraping/posts.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from linkedin_mcp_server.scraping.capture import SectionCapture
+from linkedin_mcp_server.scraping.capture import (
+    CaptureMode,
+    CapturePlan,
+    SectionCapture,
+)
 from linkedin_mcp_server.scraping.contracts import RATE_LIMITED_SECTION_TEXT
 from linkedin_mcp_server.scraping.link_metadata import Reference
 from linkedin_mcp_server.scraping.search_urls import build_content_search_url
@@ -63,8 +67,10 @@ class PostSearch:
         # ignore is refused rather than answered with unfiltered results.
         url = build_content_search_url(keywords, date_posted=date_posted)
         max_scrolls = max(1, max_pages) * _CONTENT_SCROLLS_PER_REQUESTED_PAGE
-        extracted = await self._capture.extract_page(
-            url, section_name="search_results", max_scrolls=max_scrolls
+        extracted = await self._capture.capture(
+            url,
+            section_name="search_results",
+            plan=CapturePlan(CaptureMode.SEARCH_RESULTS, max_scrolls),
         )
 
         sections: dict[str, str] = {}

--- a/linkedin_mcp_server/scraping/text.py
+++ b/linkedin_mcp_server/scraping/text.py
@@ -6,6 +6,49 @@ from dataclasses import dataclass
 
 import re
 
+
+@dataclass(frozen=True)
+class DetailCaptureTextTable:
+    """Visible-text policy for hydrating and expanding profile details."""
+
+    readiness_blocking_prefixes: tuple[str, ...]
+    expansion_button_pattern: re.Pattern[str]
+
+    def readiness_expression(self) -> str:
+        """Build the historical readiness predicate without changing its bytes."""
+        conditions = "\n                            && ".join(
+            f"!text.startsWith({prefix!r})"
+            for prefix in self.readiness_blocking_prefixes
+        )
+        return (
+            "() => {\n"
+            "                        const main = document.querySelector('main');\n"
+            "                        if (!main) return false;\n"
+            "                        const text = main.innerText.trimStart();\n"
+            f"                        return {conditions};\n"
+            "                    }"
+        )
+
+
+_DETAIL_CAPTURE_TEXT: dict[str, DetailCaptureTextTable] = {
+    "en-US": DetailCaptureTextTable(
+        readiness_blocking_prefixes=(
+            "Load more",
+            "More profiles for you",
+            "Explore premium profiles",
+        ),
+        expansion_button_pattern=re.compile(
+            r"^Show (more|all)\b",
+            re.IGNORECASE,
+        ),
+    ),
+}
+
+# BrowserManager forces the browser context to en-US (core/browser.py), so the
+# capture owner receives this exact entry. Unsupported locales are deliberately
+# not inferred from language prefixes or detected from page text.
+DETAIL_CAPTURE_EN_US = _DETAIL_CAPTURE_TEXT["en-US"]
+
 # Patterns that mark the start of LinkedIn page chrome (sidebar/footer).
 # Everything from the earliest match onwards is stripped.
 _NOISE_MARKERS: list[re.Pattern[str]] = [

--- a/tests/scraping/test_capture.py
+++ b/tests/scraping/test_capture.py
@@ -1185,27 +1185,57 @@ def _generic_capture_domain_path_literals(source: str) -> set[str]:
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
     module_constants: dict[str, ast.AST] = {}
-    for node in tree.body:
-        if isinstance(node, (ast.Assign, ast.AnnAssign)):
-            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-            value = node.value
-            if value is None:
-                continue
-            for target in targets:
-                if isinstance(target, ast.Name):
-                    module_constants[target.id] = value
+    class_constants: dict[str, ast.AST] = {}
 
-    def referenced_constant_literals(name: str, seen: set[str]) -> set[str]:
-        if name in seen or name not in module_constants:
+    def record_constants(nodes: list[ast.stmt], constants: dict[str, ast.AST]) -> None:
+        for node in nodes:
+            if isinstance(node, (ast.Assign, ast.AnnAssign)):
+                targets = (
+                    node.targets if isinstance(node, ast.Assign) else [node.target]
+                )
+                value = node.value
+                if value is None:
+                    continue
+                for target in targets:
+                    if isinstance(target, ast.Name):
+                        constants[target.id] = value
+
+    record_constants(tree.body, module_constants)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "SectionCapture":
+            record_constants(node.body, class_constants)
+
+    def referenced_constant_literals(
+        name: str,
+        constants: dict[str, ast.AST],
+        seen: set[tuple[int, str]],
+    ) -> set[str]:
+        key = (id(constants), name)
+        if key in seen or name not in constants:
             return set()
-        seen.add(name)
+        seen.add(key)
         literals: set[str] = set()
-        for child in ast.walk(module_constants[name]):
+        for child in ast.walk(constants[name]):
             if isinstance(child, ast.Constant) and isinstance(child.value, str):
                 if any(fragment in child.value for fragment in domain_fragments):
                     literals.add(child.value)
             elif isinstance(child, ast.Name):
-                literals.update(referenced_constant_literals(child.id, seen))
+                referenced = (
+                    class_constants if constants is class_constants else constants
+                )
+                if child.id not in referenced:
+                    referenced = module_constants
+                literals.update(
+                    referenced_constant_literals(child.id, referenced, seen)
+                )
+            elif (
+                isinstance(child, ast.Attribute)
+                and isinstance(child.value, ast.Name)
+                and child.value.id in {"self", "cls", "SectionCapture"}
+            ):
+                literals.update(
+                    referenced_constant_literals(child.attr, class_constants, seen)
+                )
         return literals
 
     pending = [method for name, method in class_methods.items() if name in root_names]
@@ -1221,7 +1251,17 @@ def _generic_capture_domain_path_literals(source: str) -> set[str]:
                 if any(fragment in child.value for fragment in domain_fragments):
                     literals.add(child.value)
             elif isinstance(child, ast.Name):
-                literals.update(referenced_constant_literals(child.id, set()))
+                literals.update(
+                    referenced_constant_literals(child.id, module_constants, set())
+                )
+            elif (
+                isinstance(child, ast.Attribute)
+                and isinstance(child.value, ast.Name)
+                and child.value.id in {"self", "cls", "SectionCapture"}
+            ):
+                literals.update(
+                    referenced_constant_literals(child.attr, class_constants, set())
+                )
             elif isinstance(child, ast.Call):
                 target: ast.AST | None = None
                 if isinstance(child.func, ast.Name):
@@ -1230,7 +1270,7 @@ def _generic_capture_domain_path_literals(source: str) -> set[str]:
                 elif (
                     isinstance(child.func, ast.Attribute)
                     and isinstance(child.func.value, ast.Name)
-                    and child.func.value.id in {"self", "cls"}
+                    and child.func.value.id in {"self", "cls", "SectionCapture"}
                 ):
                     target = class_methods.get(child.func.attr)
                 if target is not None:
@@ -1279,6 +1319,57 @@ class SectionCapture:
         "/company/",
         "/people/",
     }
+
+
+@pytest.mark.parametrize("receiver", ["self", "cls"])
+def test_generic_capture_ast_guard_follows_same_class_helper_calls(receiver):
+    mutation = f"""
+class SectionCapture:
+    async def capture({receiver}, url):
+        return {receiver}._is_details(url)
+
+    def _is_details({receiver}, url):
+        return "/details/" in url
+"""
+    assert _generic_capture_domain_path_literals(mutation) == {"/details/"}
+
+
+def test_generic_capture_ast_guard_follows_class_qualified_helper_calls():
+    mutation = """
+class SectionCapture:
+    async def capture(self, url):
+        return SectionCapture._is_details(url)
+
+    @staticmethod
+    def _is_details(url):
+        return "/details/" in url
+"""
+    assert _generic_capture_domain_path_literals(mutation) == {"/details/"}
+
+
+@pytest.mark.parametrize("receiver", ["self", "cls", "SectionCapture"])
+def test_generic_capture_ast_guard_follows_class_constant_access(receiver):
+    mutation = f"""
+class SectionCapture:
+    DETAILS_PATH = "/details/"
+
+    async def capture(self, url):
+        return {receiver}.DETAILS_PATH in url
+"""
+    assert _generic_capture_domain_path_literals(mutation) == {"/details/"}
+
+
+def test_generic_capture_ast_guard_follows_chained_class_constants():
+    mutation = """
+class SectionCapture:
+    DETAILS_PATH = "/details/"
+    DOMAIN_PATH = DETAILS_PATH
+    CAPTURE_PATH = SectionCapture.DOMAIN_PATH
+
+    async def capture(self, url):
+        return self.CAPTURE_PATH in url
+"""
+    assert _generic_capture_domain_path_literals(mutation) == {"/details/"}
 
 
 def test_generic_capture_ast_guard_excludes_url_compatibility_adapter():

--- a/tests/scraping/test_capture.py
+++ b/tests/scraping/test_capture.py
@@ -1121,6 +1121,36 @@ class TestCapturePlans:
             CaptureMode.SEARCH_RESULTS | CaptureMode.COMPANY_PEOPLE
         )
 
+    @pytest.mark.parametrize(
+        ("url", "mode"),
+        [
+            (
+                "https://www.linkedin.com/in/ada/?next=/details/experience/",
+                CaptureMode.DETAILS,
+            ),
+            (
+                "https://www.linkedin.com/in/ada/#/search/results/people/",
+                CaptureMode.SEARCH_RESULTS,
+            ),
+            (
+                "https://www.linkedin.com/in/ada/?next=/company/acme/people/",
+                CaptureMode.COMPANY_PEOPLE,
+            ),
+        ],
+    )
+    def test_url_adapter_raw_url_markers_include_query_and_fragment(self, url, mode):
+        assert capture_plan_for_url(url).mode is mode
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://www.linkedin.com/in/ada/?next=/recent-activity/all/",
+            "https://www.linkedin.com/in/ada/#/company/acme/posts/",
+        ],
+    )
+    def test_url_adapter_activity_markers_use_parsed_path_only(self, url):
+        assert capture_plan_for_url(url).mode is CaptureMode.STANDARD
+
     def test_capture_plan_is_immutable(self):
         plan = CapturePlan(CaptureMode.DETAILS, max_scrolls=3)
         with pytest.raises(FrozenInstanceError):
@@ -1129,31 +1159,82 @@ class TestCapturePlans:
 
 def _generic_capture_domain_path_literals(source: str) -> set[str]:
     tree = ast.parse(source)
-    generic_methods = {
+    domain_fragments = (
+        "/recent-activity/",
+        "/search/results/",
+        "/company/",
+        "/people/",
+        "/details/",
+    )
+    root_names = {
         "capture",
         "_capture_once",
         "_extract_loaded_section",
         "_extract_overlay_content",
     }
-    literals: set[str] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if node.name not in generic_methods:
-            continue
-        for child in ast.walk(node):
+    module_helpers = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    class_methods = {
+        child.name: child
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "SectionCapture"
+        for child in node.body
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    module_constants: dict[str, ast.AST] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            value = node.value
+            if value is None:
+                continue
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    module_constants[target.id] = value
+
+    def referenced_constant_literals(name: str, seen: set[str]) -> set[str]:
+        if name in seen or name not in module_constants:
+            return set()
+        seen.add(name)
+        literals: set[str] = set()
+        for child in ast.walk(module_constants[name]):
             if isinstance(child, ast.Constant) and isinstance(child.value, str):
-                if any(
-                    fragment in child.value
-                    for fragment in (
-                        "/recent-activity/",
-                        "/search/results/",
-                        "/company/",
-                        "/people/",
-                        "/details/",
-                    )
-                ):
+                if any(fragment in child.value for fragment in domain_fragments):
                     literals.add(child.value)
+            elif isinstance(child, ast.Name):
+                literals.update(referenced_constant_literals(child.id, seen))
+        return literals
+
+    pending = [method for name, method in class_methods.items() if name in root_names]
+    visited: set[int] = set()
+    literals: set[str] = set()
+    while pending:
+        function = pending.pop()
+        if id(function) in visited:
+            continue
+        visited.add(id(function))
+        for child in ast.walk(function):
+            if isinstance(child, ast.Constant) and isinstance(child.value, str):
+                if any(fragment in child.value for fragment in domain_fragments):
+                    literals.add(child.value)
+            elif isinstance(child, ast.Name):
+                literals.update(referenced_constant_literals(child.id, set()))
+            elif isinstance(child, ast.Call):
+                target: ast.AST | None = None
+                if isinstance(child.func, ast.Name):
+                    if child.func.id != "capture_plan_for_url":
+                        target = module_helpers.get(child.func.id)
+                elif (
+                    isinstance(child.func, ast.Attribute)
+                    and isinstance(child.func.value, ast.Name)
+                    and child.func.value.id in {"self", "cls"}
+                ):
+                    target = class_methods.get(child.func.attr)
+                if target is not None:
+                    pending.append(target)
     return literals
 
 
@@ -1172,3 +1253,40 @@ class SectionCapture:
             return "domain policy"
 """
     assert _generic_capture_domain_path_literals(mutation) == {"/details/"}
+
+
+def test_generic_capture_ast_guard_follows_referenced_module_constants():
+    mutation = """
+DETAILS_PATH = "/details/"
+class SectionCapture:
+    async def capture(self, url):
+        if DETAILS_PATH in url:
+            return "domain policy"
+"""
+    assert _generic_capture_domain_path_literals(mutation) == {"/details/"}
+
+
+def test_generic_capture_ast_guard_follows_same_module_helper_calls():
+    mutation = """
+def _is_company_people(url):
+    return "/company/" in url and "/people/" in url
+class SectionCapture:
+    async def _capture_once(self, url):
+        if _is_company_people(url):
+            return "domain policy"
+"""
+    assert _generic_capture_domain_path_literals(mutation) == {
+        "/company/",
+        "/people/",
+    }
+
+
+def test_generic_capture_ast_guard_excludes_url_compatibility_adapter():
+    allowed = """
+def capture_plan_for_url(url):
+    return "/search/results/" in url
+class SectionCapture:
+    async def capture(self, url):
+        return capture_plan_for_url(url)
+"""
+    assert _generic_capture_domain_path_literals(allowed) == set()

--- a/tests/scraping/test_capture.py
+++ b/tests/scraping/test_capture.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import ast
+import re
+
 import pytest
 
 from linkedin_mcp_server.core.exceptions import AuthenticationError
@@ -24,6 +26,7 @@ from linkedin_mcp_server.scraping.contracts import (
 )
 from linkedin_mcp_server.scraping.navigation import PageNavigator
 from linkedin_mcp_server.scraping.session import ScrapingSession
+from linkedin_mcp_server.scraping.text import DetailCaptureTextTable
 
 
 def _capture(page) -> SectionCapture:
@@ -453,6 +456,55 @@ class TestActivityFeedExtraction:
         _, kwargs = mock_scroll.call_args
         assert kwargs["pause_time"] == 0.5
         assert kwargs["max_scrolls"] == 5
+
+    async def test_details_page_consumes_injected_text_policy(self, mock_page):
+        mock_page.evaluate = AsyncMock(
+            return_value={"source": "root", "text": "Experience", "references": []}
+        )
+        mock_page.wait_for_function = AsyncMock()
+        expansion = MagicMock()
+        expansion.count = AsyncMock(return_value=0)
+        expansion.filter = MagicMock(return_value=expansion)
+        mock_page.locator = MagicMock(return_value=expansion)
+        detail_text = DetailCaptureTextTable(
+            readiness_blocking_prefixes=("Mutated placeholder",),
+            expansion_button_pattern=re.compile(r"^Expand entries$"),
+        )
+        session = ScrapingSession(mock_page)
+        capture = SectionCapture(
+            session,
+            PageNavigator(session),
+            PageContentReader(session),
+            detail_text,
+        )
+
+        with (
+            patch(
+                "linkedin_mcp_server.scraping.session.scroll_to_bottom",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.detect_rate_limit",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.handle_modal_close",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await capture._capture_once(
+                "https://www.linkedin.com/in/ada/details/experience/",
+                section_name="experience",
+                plan=CapturePlan(CaptureMode.DETAILS),
+            )
+
+        wait_args = mock_page.wait_for_function.await_args
+        assert wait_args is not None
+        assert "text.startsWith('Mutated placeholder')" in wait_args.args[0]
+        expansion.filter.assert_called_once_with(
+            has_text=detail_text.expansion_button_pattern
+        )
 
     async def test_max_scrolls_override_passed_to_scroll_to_bottom(self, mock_page):
         """Custom max_scrolls on a detail page overrides the default of 5."""
@@ -1155,6 +1207,44 @@ class TestCapturePlans:
         plan = CapturePlan(CaptureMode.DETAILS, max_scrolls=3)
         with pytest.raises(FrozenInstanceError):
             setattr(plan, "max_scrolls", 4)
+
+
+_DETAIL_CAPTURE_POLICY_LITERALS = {
+    "Load more",
+    "More profiles for you",
+    "Explore premium profiles",
+    r"^Show (more|all)\b",
+}
+
+
+def _detail_capture_policy_literals(source: str) -> set[str]:
+    return {
+        node.value
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value in _DETAIL_CAPTURE_POLICY_LITERALS
+    }
+
+
+def test_capture_module_has_no_en_us_detail_text_policy_literals():
+    capture_source = Path("linkedin_mcp_server/scraping/capture.py").read_text(
+        encoding="utf-8"
+    )
+    assert _detail_capture_policy_literals(capture_source) == set()
+
+
+def test_detail_text_policy_ast_guard_rejects_reintroduced_literals():
+    mutation = """
+import re
+
+READINESS = "Load more"
+BUTTON = re.compile(r"^Show (more|all)\\b")
+"""
+    assert _detail_capture_policy_literals(mutation) == {
+        "Load more",
+        r"^Show (more|all)\b",
+    }
 
 
 def _generic_capture_domain_path_literals(source: str) -> set[str]:

--- a/tests/scraping/test_capture.py
+++ b/tests/scraping/test_capture.py
@@ -2,17 +2,26 @@
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import ast
 import pytest
 
 from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.scraping.capture import (
     RATE_LIMIT_RETRY_DELAY,
+    CaptureMode,
+    CapturePlan,
     SectionCapture,
+    capture_plan_for_url,
 )
 from linkedin_mcp_server.scraping.content import PageContentReader
-from linkedin_mcp_server.scraping.contracts import RATE_LIMITED_SECTION_TEXT
+from linkedin_mcp_server.scraping.contracts import (
+    RATE_LIMITED_SECTION_TEXT,
+    ExtractedSection,
+)
 from linkedin_mcp_server.scraping.navigation import PageNavigator
 from linkedin_mcp_server.scraping.session import ScrapingSession
 
@@ -57,6 +66,24 @@ class TestExtractPage:
         assert result.text == "Sample profile text"
         assert result.references == []
         mock_page.goto.assert_awaited_once()
+
+    async def test_extract_page_adapts_the_url_to_an_explicit_plan(self, mock_page):
+        capture = _capture(mock_page)
+        url = "https://www.linkedin.com/in/testuser/recent-activity/all/"
+        with patch.object(
+            capture,
+            "capture",
+            new_callable=AsyncMock,
+            return_value=ExtractedSection(text="posts", references=[]),
+        ) as explicit_capture:
+            result = await capture.extract_page(url, "posts", max_scrolls=7)
+
+        assert result.text == "posts"
+        explicit_capture.assert_awaited_once_with(
+            url,
+            "posts",
+            CapturePlan(CaptureMode.ACTIVITY, max_scrolls=7),
+        )
 
     async def test_extract_page_returns_empty_on_failure(self, mock_page):
         mock_page.goto = AsyncMock(side_effect=Exception("Network error"))
@@ -220,9 +247,10 @@ class TestExtractPage:
                 return_value=False,
             ),
         ):
-            result = await capture._extract_page_once(
+            result = await capture._capture_once(
                 "https://www.linkedin.com/in/testuser/recent-activity/all/",
                 section_name="posts",
+                plan=CapturePlan(CaptureMode.ACTIVITY),
             )
 
         assert result.text == ""
@@ -230,7 +258,7 @@ class TestExtractPage:
 
 
 class TestActivityFeedExtraction:
-    """Tests for activity page detection and wait behavior in _extract_page_once."""
+    """Tests for activity capture plans and wait behavior."""
 
     async def test_activity_page_waits_for_content_and_uses_slow_scroll(
         self, mock_page
@@ -260,9 +288,10 @@ class TestActivityFeedExtraction:
                 return_value=False,
             ),
         ):
-            result = await capture._extract_page_once(
+            result = await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/recent-activity/all/",
                 section_name="posts",
+                plan=CapturePlan(CaptureMode.ACTIVITY),
             )
 
         mock_page.wait_for_function.assert_awaited_once()
@@ -301,9 +330,10 @@ class TestActivityFeedExtraction:
                 return_value=False,
             ),
         ):
-            result = await capture._extract_page_once(
+            result = await capture._capture_once(
                 "https://www.linkedin.com/company/microsoft/posts/",
                 section_name="posts",
+                plan=CapturePlan(CaptureMode.ACTIVITY),
             )
 
         mock_page.wait_for_function.assert_awaited_once()
@@ -340,9 +370,10 @@ class TestActivityFeedExtraction:
                 return_value=False,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/company/microsoft/posts/?viewAsMember=true",
                 section_name="posts",
+                plan=CapturePlan(CaptureMode.ACTIVITY),
             )
 
         mock_page.wait_for_function.assert_awaited_once()
@@ -373,9 +404,10 @@ class TestActivityFeedExtraction:
                 return_value=False,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/",
                 section_name="main_profile",
+                plan=CapturePlan(CaptureMode.STANDARD),
             )
 
         mock_page.wait_for_function.assert_not_awaited()
@@ -410,9 +442,10 @@ class TestActivityFeedExtraction:
                 return_value=False,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/details/experience/",
                 section_name="experience",
+                plan=CapturePlan(CaptureMode.DETAILS),
             )
 
         mock_page.wait_for_function.assert_awaited_once()
@@ -447,10 +480,10 @@ class TestActivityFeedExtraction:
                 return_value=False,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/details/certifications/",
                 section_name="certifications",
-                max_scrolls=20,
+                plan=CapturePlan(CaptureMode.DETAILS, max_scrolls=20),
             )
 
         mock_scroll.assert_awaited_once()
@@ -483,9 +516,10 @@ class TestActivityFeedExtraction:
                 return_value=False,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/details/certifications/",
                 section_name="certifications",
+                plan=CapturePlan(CaptureMode.DETAILS),
             )
 
         mock_scroll.assert_awaited_once()
@@ -535,9 +569,10 @@ class TestActivityFeedExtraction:
                 new_callable=AsyncMock,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/details/certifications/",
                 section_name="certifications",
+                plan=CapturePlan(CaptureMode.DETAILS),
             )
 
         assert show_more.click.await_count == 2
@@ -584,10 +619,10 @@ class TestActivityFeedExtraction:
                 new_callable=AsyncMock,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/details/experience/",
                 section_name="experience",
-                max_scrolls=3,
+                plan=CapturePlan(CaptureMode.DETAILS, max_scrolls=3),
             )
 
         assert show_more.click.await_count == 3
@@ -641,9 +676,10 @@ class TestActivityFeedExtraction:
                 new_callable=AsyncMock,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/details/experience/",
                 section_name="experience",
+                plan=CapturePlan(CaptureMode.DETAILS),
             )
 
         assert show_more.click.await_count == 5
@@ -684,9 +720,10 @@ class TestActivityFeedExtraction:
                 return_value=False,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/",
                 section_name="main_profile",
+                plan=CapturePlan(CaptureMode.STANDARD),
             )
 
         show_more.click.assert_not_awaited()
@@ -718,9 +755,10 @@ class TestActivityFeedExtraction:
                 return_value=False,
             ),
         ):
-            result = await capture._extract_page_once(
+            result = await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/recent-activity/all/",
                 section_name="posts",
+                plan=CapturePlan(CaptureMode.ACTIVITY),
             )
 
         # Should return whatever text is available, not crash
@@ -728,7 +766,7 @@ class TestActivityFeedExtraction:
 
 
 class TestCompanyPeopleExtraction:
-    """Tests for /company/<slug>/people/ hydration wait in _extract_page_once."""
+    """Tests for company-people plan hydration waits."""
 
     async def test_waits_for_listing_with_5s_timeout(self, mock_page):
         """Company /people/ pages call wait_for_function so the employee
@@ -759,9 +797,10 @@ class TestCompanyPeopleExtraction:
                 return_value=False,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/company/anthropicresearch/people/",
                 section_name="employees",
+                plan=CapturePlan(CaptureMode.COMPANY_PEOPLE),
             )
 
         mock_page.wait_for_function.assert_awaited_once()
@@ -804,9 +843,10 @@ class TestCompanyPeopleExtraction:
                 return_value=False,
             ),
         ):
-            result = await capture._extract_page_once(
+            result = await capture._capture_once(
                 "https://www.linkedin.com/company/anthropicresearch/people/",
                 section_name="employees",
+                plan=CapturePlan(CaptureMode.COMPANY_PEOPLE),
             )
 
         mock_scroll.assert_awaited_once()
@@ -814,7 +854,7 @@ class TestCompanyPeopleExtraction:
 
 
 class TestSearchResultsExtraction:
-    """Tests for search results page detection and wait behavior in _extract_page_once."""
+    """Tests for search-results plan wait behavior."""
 
     async def test_search_results_page_waits_for_content(self, mock_page):
         """Search results URLs should call wait_for_function to wait for content."""
@@ -842,9 +882,10 @@ class TestSearchResultsExtraction:
                 return_value=False,
             ),
         ):
-            result = await capture._extract_page_once(
+            result = await capture._capture_once(
                 "https://www.linkedin.com/search/results/people/?keywords=John+Doe",
                 section_name="search_results",
+                plan=CapturePlan(CaptureMode.SEARCH_RESULTS),
             )
 
         mock_page.wait_for_function.assert_awaited_once()
@@ -872,9 +913,10 @@ class TestSearchResultsExtraction:
                 return_value=False,
             ),
         ):
-            await capture._extract_page_once(
+            await capture._capture_once(
                 "https://www.linkedin.com/in/billgates/",
                 section_name="main_profile",
+                plan=CapturePlan(CaptureMode.STANDARD),
             )
 
         mock_page.wait_for_function.assert_not_awaited()
@@ -906,9 +948,10 @@ class TestSearchResultsExtraction:
                 return_value=False,
             ),
         ):
-            result = await capture._extract_page_once(
+            result = await capture._capture_once(
                 "https://www.linkedin.com/search/results/people/?keywords=John+Doe",
                 section_name="search_results",
+                plan=CapturePlan(CaptureMode.SEARCH_RESULTS),
             )
 
         assert result.text == placeholder
@@ -1040,3 +1083,92 @@ class TestExtractOverlay:
         assert result.text == ""
         assert result.error == {"issue_template_path": "/tmp/issue.md"}
         assert diagnostics.call_args.kwargs["context"] == "extract_overlay"
+
+
+class TestCapturePlans:
+    @pytest.mark.parametrize(
+        ("url", "mode"),
+        [
+            ("https://www.linkedin.com/in/ada/", CaptureMode.STANDARD),
+            (
+                "https://www.linkedin.com/in/ada/recent-activity/all/",
+                CaptureMode.ACTIVITY,
+            ),
+            (
+                "https://www.linkedin.com/company/acme/posts/?viewAsMember=true",
+                CaptureMode.ACTIVITY,
+            ),
+            (
+                "https://www.linkedin.com/search/results/people/?keywords=ada",
+                CaptureMode.SEARCH_RESULTS,
+            ),
+            (
+                "https://www.linkedin.com/company/acme/people/",
+                CaptureMode.COMPANY_PEOPLE,
+            ),
+            (
+                "https://www.linkedin.com/in/ada/details/experience/",
+                CaptureMode.DETAILS,
+            ),
+        ],
+    )
+    def test_url_adapter_preserves_generic_mode_selection(self, url, mode):
+        assert capture_plan_for_url(url, 17) == CapturePlan(mode, max_scrolls=17)
+
+    def test_url_adapter_preserves_independent_mode_branches(self):
+        url = "https://www.linkedin.com/company/acme/people/search/results/"
+        assert capture_plan_for_url(url).mode == (
+            CaptureMode.SEARCH_RESULTS | CaptureMode.COMPANY_PEOPLE
+        )
+
+    def test_capture_plan_is_immutable(self):
+        plan = CapturePlan(CaptureMode.DETAILS, max_scrolls=3)
+        with pytest.raises(FrozenInstanceError):
+            setattr(plan, "max_scrolls", 4)
+
+
+def _generic_capture_domain_path_literals(source: str) -> set[str]:
+    tree = ast.parse(source)
+    generic_methods = {
+        "capture",
+        "_capture_once",
+        "_extract_loaded_section",
+        "_extract_overlay_content",
+    }
+    literals: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name not in generic_methods:
+            continue
+        for child in ast.walk(node):
+            if isinstance(child, ast.Constant) and isinstance(child.value, str):
+                if any(
+                    fragment in child.value
+                    for fragment in (
+                        "/recent-activity/",
+                        "/search/results/",
+                        "/company/",
+                        "/people/",
+                        "/details/",
+                    )
+                ):
+                    literals.add(child.value)
+    return literals
+
+
+def test_generic_capture_has_no_domain_path_policy_branches():
+    capture_source = Path("linkedin_mcp_server/scraping/capture.py").read_text(
+        encoding="utf-8"
+    )
+    assert _generic_capture_domain_path_literals(capture_source) == set()
+
+
+def test_generic_capture_ast_guard_rejects_a_reintroduced_domain_branch():
+    mutation = """
+class SectionCapture:
+    async def _extract_loaded_section(self, url):
+        if "/details/" in url:
+            return "domain policy"
+"""
+    assert _generic_capture_domain_path_literals(mutation) == {"/details/"}

--- a/tests/scraping/test_company.py
+++ b/tests/scraping/test_company.py
@@ -13,7 +13,11 @@ from linkedin_mcp_server.core.exceptions import (
     InvalidReferenceError,
 )
 from linkedin_mcp_server.scraping import company as company_module
-from linkedin_mcp_server.scraping.capture import SectionCapture
+from linkedin_mcp_server.scraping.capture import (
+    CaptureMode,
+    CapturePlan,
+    SectionCapture,
+)
 from linkedin_mcp_server.scraping.company import CompanyScraper
 from linkedin_mcp_server.scraping.content import PageContentReader
 from linkedin_mcp_server.scraping.contracts import (
@@ -53,7 +57,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("company text"),
             ) as mock_extract,
@@ -82,7 +86,7 @@ class TestScrapeCompany:
         """
         scraper = _scraper(mock_page)
         with patch.object(
-            scraper._capture, "extract_page", new_callable=AsyncMock
+            scraper._capture, "capture", new_callable=AsyncMock
         ) as mock_extract:
             with pytest.raises(InvalidReferenceError):
                 await scraper.scrape_company("../../feed", {"about"})
@@ -96,7 +100,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ) as mock_extract,
@@ -124,7 +128,7 @@ class TestScrapeCompany:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("about text"),
         ) as mock_extract:
@@ -140,7 +144,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("about text"),
             ) as mock_extract,
@@ -161,7 +165,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ) as mock_extract,
@@ -205,7 +209,7 @@ class TestScrapeCompany:
             patch.object(company_module, "COMPANY_SECTIONS", table),
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ) as mock_extract,
@@ -216,7 +220,19 @@ class TestScrapeCompany:
         ):
             result = await scraper.scrape_company("testcorp", set(table))
 
-        assert [call.args[1] for call in mock_extract.call_args_list] == list(table)
+        assert [
+            capture_call.args[1] for capture_call in mock_extract.call_args_list
+        ] == list(table)
+        assert [
+            capture_call.args[2].mode for capture_call in mock_extract.call_args_list
+        ] == [
+            CaptureMode.STANDARD,
+            CaptureMode.STANDARD,
+            CaptureMode.STANDARD,
+            CaptureMode.ACTIVITY,
+            CaptureMode.STANDARD,
+            CaptureMode.STANDARD,
+        ]
         assert list(result["sections"]) == list(table)
 
     async def test_the_delay_is_taken_between_sections_and_not_before_the_first(
@@ -232,7 +248,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ),
@@ -250,7 +266,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("about text"),
             ),
@@ -270,7 +286,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 side_effect=[
                     extracted(RATE_LIMITED_SECTION_TEXT),
@@ -308,7 +324,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted(RATE_LIMITED_SECTION_TEXT),
             ),
@@ -396,7 +412,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("about text"),
             ),
@@ -421,7 +437,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 side_effect=[failure, extracted("Posts text")],
             ),
@@ -467,7 +483,7 @@ class TestScrapeCompany:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 side_effect=failure,
             ) as mock_extract,
@@ -501,7 +517,7 @@ class TestScrapeCompanyCallbacks:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ),
@@ -541,7 +557,7 @@ class TestGetCompanyEmployees:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("employees"),
         ) as mock_extract:
@@ -550,7 +566,11 @@ class TestGetCompanyEmployees:
             )
 
         assert mock_extract.await_args_list == [
-            call("https://www.linkedin.com/company/testco/people/", "employees", None)
+            call(
+                "https://www.linkedin.com/company/testco/people/",
+                "employees",
+                CapturePlan(CaptureMode.COMPANY_PEOPLE),
+            )
         ]
         assert result["url"] == "https://www.linkedin.com/company/testco/people/"
 
@@ -558,7 +578,7 @@ class TestGetCompanyEmployees:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("employees"),
         ) as mock_extract:
@@ -578,7 +598,7 @@ class TestGetCompanyEmployees:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("employees"),
         ) as mock_extract:
@@ -594,7 +614,7 @@ class TestGetCompanyEmployees:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("employee text"),
         ):
@@ -610,7 +630,7 @@ class TestGetCompanyEmployees:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("employee text", [reference]),
         ):
@@ -621,7 +641,7 @@ class TestGetCompanyEmployees:
     async def test_a_traversal_identifier_is_refused_before_navigating(self, mock_page):
         scraper = _scraper(mock_page)
         with patch.object(
-            scraper._capture, "extract_page", new_callable=AsyncMock
+            scraper._capture, "capture", new_callable=AsyncMock
         ) as mock_extract:
             with pytest.raises(InvalidReferenceError):
                 await scraper.get_company_employees("../../feed")
@@ -635,7 +655,7 @@ class TestSearchCompanies:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("Fintech Inc"),
         ) as mock_extract:
@@ -644,6 +664,7 @@ class TestSearchCompanies:
         url = mock_extract.call_args.args[0]
         assert "/search/results/companies/" in url
         assert mock_extract.call_args.args[1] == "search_results"
+        assert mock_extract.call_args.args[2].mode is CaptureMode.SEARCH_RESULTS
         assert result == {
             "url": url,
             "sections": {"search_results": "Fintech Inc"},
@@ -653,7 +674,7 @@ class TestSearchCompanies:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted(""),
         ):
@@ -671,7 +692,7 @@ class TestSearchCompanies:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("", error=error),
         ):

--- a/tests/scraping/test_company.py
+++ b/tests/scraping/test_company.py
@@ -235,6 +235,51 @@ class TestScrapeCompany:
         ]
         assert list(result["sections"]) == list(table)
 
+    async def test_custom_overlay_table_routes_through_compatibility_seam(
+        self, mock_page
+    ):
+        table = {
+            "about": ("/custom-about-overlay/", True),
+            "custom": ("/custom-standard/", False),
+        }
+        scraper = _scraper(mock_page)
+        with (
+            patch.object(company_module, "COMPANY_SECTIONS", table),
+            patch.object(
+                scraper._capture,
+                "capture",
+                new_callable=AsyncMock,
+                return_value=extracted("standard text"),
+            ) as mock_capture,
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                return_value=extracted("overlay text"),
+            ) as mock_overlay,
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_company("testcorp", set(table))
+
+        mock_overlay.assert_awaited_once()
+        assert mock_overlay.call_args.args[:2] == (
+            "https://www.linkedin.com/company/testcorp/custom-about-overlay/",
+            "about",
+        )
+        assert mock_overlay.call_args.kwargs["plan"] == CapturePlan(CaptureMode.OVERLAY)
+        mock_capture.assert_awaited_once_with(
+            "https://www.linkedin.com/company/testcorp/custom-standard/",
+            "custom",
+            CapturePlan(CaptureMode.STANDARD),
+        )
+        assert result["sections"] == {
+            "about": "overlay text",
+            "custom": "standard text",
+        }
+
     async def test_the_delay_is_taken_between_sections_and_not_before_the_first(
         self, mock_page
     ):

--- a/tests/scraping/test_jobs.py
+++ b/tests/scraping/test_jobs.py
@@ -13,7 +13,7 @@ from patchright.async_api import TimeoutError as PlaywrightTimeoutError
 
 from linkedin_mcp_server.core.exceptions import AuthenticationError
 from linkedin_mcp_server.scraping import jobs as jobs_module
-from linkedin_mcp_server.scraping.capture import SectionCapture
+from linkedin_mcp_server.scraping.capture import CapturePlan, SectionCapture
 from linkedin_mcp_server.scraping.content import PageContentReader
 from linkedin_mcp_server.scraping.contracts import (
     RATE_LIMITED_SECTION_TEXT,
@@ -72,12 +72,17 @@ class TestScrapeJob:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("Job: Software Engineer"),
-        ):
+        ) as capture:
             result = await scraper.scrape_job("12345")
 
+        capture.assert_awaited_once_with(
+            "https://www.linkedin.com/jobs/view/12345/",
+            section_name="job_posting",
+            plan=CapturePlan(),
+        )
         assert result["url"] == "https://www.linkedin.com/jobs/view/12345/"
         assert "job_posting" in result["sections"]
         assert "pages_visited" not in result
@@ -87,7 +92,7 @@ class TestScrapeJob:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted(RATE_LIMITED_SECTION_TEXT),
         ):
@@ -102,7 +107,7 @@ class TestScrapeJob:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted(
                 "",

--- a/tests/scraping/test_migration_manifest.py
+++ b/tests/scraping/test_migration_manifest.py
@@ -1440,7 +1440,7 @@ def test_direct_private_helper_calls_and_stage_gate_are_inventoried():
     )
 
     result = subprocess.run(
-        [sys.executable, str(CHECKER), "--check", "--stage", "12"],
+        [sys.executable, str(CHECKER), "--check", "--stage", "13"],
         cwd=ROOT,
         text=True,
         capture_output=True,

--- a/tests/scraping/test_person.py
+++ b/tests/scraping/test_person.py
@@ -453,6 +453,69 @@ class TestScrapePersonUrls:
         for capture_call in mock_extract.call_args_list:
             assert capture_call.kwargs["plan"].max_scrolls == 15
 
+    async def test_runtime_section_table_patch_controls_order_suffix_and_plans(
+        self, mock_page
+    ):
+        table = {
+            "main_profile": ("/patched-root/", False),
+            "contact_info": ("/patched-overlay/", True),
+            "experience": ("/patched-details/", False),
+            "posts": ("/patched-activity/", False),
+            "custom": ("/patched-custom/", False),
+        }
+        scraper = _scraper(mock_page)
+        calls = []
+
+        async def record_capture(url, section_name, plan):
+            calls.append((url, section_name, plan))
+            return extracted("page text")
+
+        async def record_overlay(url, section_name, plan):
+            calls.append((url, section_name, plan))
+            return extracted("overlay text")
+
+        with (
+            patch.object(person_module, "PERSON_SECTIONS", table),
+            patch.object(
+                scraper._capture,
+                "capture",
+                new_callable=AsyncMock,
+                side_effect=record_capture,
+            ),
+            patch.object(
+                scraper._capture,
+                "_extract_overlay",
+                new_callable=AsyncMock,
+                side_effect=record_overlay,
+            ),
+            patch(
+                "linkedin_mcp_server.scraping.session.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await scraper.scrape_person("testuser", set(table), max_scrolls=13)
+
+        assert [section_name for _url, section_name, _plan in calls] == list(table)
+        assert [
+            url.removeprefix("https://www.linkedin.com/in/testuser")
+            for url, _section_name, _plan in calls
+        ] == [suffix for suffix, _is_overlay in table.values()]
+        assert [plan.mode for _url, _section_name, plan in calls] == [
+            CaptureMode.STANDARD,
+            CaptureMode.OVERLAY,
+            CaptureMode.DETAILS,
+            CaptureMode.ACTIVITY,
+            CaptureMode.STANDARD,
+        ]
+        assert [plan.max_scrolls for _url, _section_name, plan in calls] == [
+            13,
+            13,
+            13,
+            13,
+            13,
+        ]
+        assert list(result["sections"]) == list(table)
+
 
 class TestScrapePersonSectionOutcomes:
     """What one section's result does to the walk and to the response."""

--- a/tests/scraping/test_person.py
+++ b/tests/scraping/test_person.py
@@ -20,7 +20,7 @@ from linkedin_mcp_server.core.exceptions import (
 )
 from linkedin_mcp_server.scraping import person as person_module
 from linkedin_mcp_server.scraping import text as text_module
-from linkedin_mcp_server.scraping.capture import SectionCapture
+from linkedin_mcp_server.scraping.capture import CaptureMode, SectionCapture
 from linkedin_mcp_server.scraping.content import PageContentReader
 from linkedin_mcp_server.scraping.contracts import (
     RATE_LIMITED_SECTION_TEXT,
@@ -73,7 +73,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ) as mock_extract,
@@ -100,7 +100,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("profile text"),
             ) as mock_extract,
@@ -135,7 +135,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("profile text"),
             ) as mock_extract,
@@ -163,7 +163,7 @@ class TestScrapePersonUrls:
         # feed and return it as a profile.
         scraper = _scraper(mock_page)
         with patch.object(
-            scraper._capture, "extract_page", new_callable=AsyncMock
+            scraper._capture, "capture", new_callable=AsyncMock
         ) as mock_extract:
             with pytest.raises(LinkedInScraperException):
                 await scraper.scrape_person("testuser/../../feed", {"main_profile"})
@@ -181,7 +181,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("profile text"),
             ) as mock_extract,
@@ -210,7 +210,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 side_effect=[
                     extracted("profile text"),
@@ -234,7 +234,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ) as mock_extract,
@@ -278,7 +278,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ) as mock_extract,
@@ -301,6 +301,11 @@ class TestScrapePersonUrls:
         # 10 full-page sections + 1 overlay (contact_info)
         assert len(page_urls) == 10
         assert len(overlay_urls) == 1
+        assert [
+            capture_call.kwargs["plan"].mode
+            for capture_call in mock_extract.call_args_list
+        ] == [CaptureMode.STANDARD, *([CaptureMode.DETAILS] * 8), CaptureMode.ACTIVITY]
+        assert mock_overlay.call_args.kwargs["plan"].mode is CaptureMode.OVERLAY
         # Verify each expected suffix was navigated
         assert any(u.endswith("/in/testuser/") for u in all_urls)
         assert any("/details/experience/" in u for u in all_urls)
@@ -320,7 +325,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("Post 1\nPost 2"),
             ) as mock_extract,
@@ -346,7 +351,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("Python for Data Science\nIBM"),
             ) as mock_extract,
@@ -372,7 +377,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("Python\nData Analysis"),
             ) as mock_extract,
@@ -398,7 +403,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("Portfolio Website\nBuilt with React"),
             ) as mock_extract,
@@ -424,7 +429,7 @@ class TestScrapePersonUrls:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ) as mock_extract,
@@ -441,8 +446,12 @@ class TestScrapePersonUrls:
         ):
             await scraper.scrape_person("test-user", {"certifications"}, max_scrolls=15)
 
-        for call in mock_extract.call_args_list:
-            assert call.kwargs.get("max_scrolls") == 15
+        assert [
+            capture_call.kwargs["plan"].mode
+            for capture_call in mock_extract.call_args_list
+        ] == [CaptureMode.STANDARD, CaptureMode.DETAILS]
+        for capture_call in mock_extract.call_args_list:
+            assert capture_call.kwargs["plan"].max_scrolls == 15
 
 
 class TestScrapePersonSectionOutcomes:
@@ -453,7 +462,7 @@ class TestScrapePersonSectionOutcomes:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 side_effect=[
                     extracted(
@@ -512,7 +521,7 @@ class TestScrapePersonSectionOutcomes:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 side_effect=extract_with_failure,
             ),
             patch(
@@ -557,7 +566,7 @@ class TestScrapePersonSectionOutcomes:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 side_effect=[
                     extracted(RATE_LIMITED_SECTION_TEXT),
@@ -595,7 +604,7 @@ class TestScrapePersonSectionOutcomes:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted(RATE_LIMITED_SECTION_TEXT),
             ),
@@ -621,7 +630,7 @@ class TestScrapePersonSectionOutcomes:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 side_effect=[
                     extracted("Profile text"),
@@ -659,7 +668,7 @@ class TestScrapePersonCallbacks:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ),
@@ -702,7 +711,7 @@ class TestScrapePersonCallbacks:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("text"),
             ),
@@ -726,7 +735,7 @@ class TestScrapePersonCallbacks:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 side_effect=LinkedInScraperException("boom"),
             ),
@@ -780,7 +789,7 @@ class TestMainProfileAlreadyLoaded:
                 return_value=extracted("reused"),
             ) as loaded,
             patch.object(
-                scraper._capture, "extract_page", new_callable=AsyncMock
+                scraper._capture, "capture", new_callable=AsyncMock
             ) as extract_page,
             patch.object(
                 PageNavigator, "_navigate_to_page", new_callable=AsyncMock
@@ -806,7 +815,7 @@ class TestMainProfileAlreadyLoaded:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("fallback"),
             ) as extract_page,
@@ -840,7 +849,7 @@ class TestMainProfileAlreadyLoaded:
             ) as loaded,
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("retry succeeded"),
             ) as extract_page,
@@ -866,7 +875,7 @@ class TestScrapePersonProfileUrn:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("profile text"),
             ),
@@ -891,7 +900,7 @@ class TestScrapePersonProfileUrn:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("profile text"),
             ),
@@ -925,7 +934,7 @@ class TestGetMyProfileAlias:
         with (
             patch.object(
                 scraper._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("profile text"),
             ) as mock_extract,
@@ -946,7 +955,7 @@ class TestGetMyProfileAlias:
     async def test_refuses_the_alias_from_an_ordinary_caller(self, mock_page):
         scraper = _scraper(mock_page)
         with patch.object(
-            scraper._capture, "extract_page", new_callable=AsyncMock
+            scraper._capture, "capture", new_callable=AsyncMock
         ) as mock_extract:
             with pytest.raises(InvalidReferenceError):
                 await scraper.scrape_person("me", {"main_profile"})
@@ -1250,7 +1259,7 @@ class TestSearchPeople:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted(
                 "",
@@ -1262,9 +1271,10 @@ class TestSearchPeople:
                     }
                 ],
             ),
-        ):
+        ) as capture:
             result = await scraper.search_people("python")
 
+        assert capture.call_args.kwargs["plan"].mode is CaptureMode.SEARCH_RESULTS
         assert result["sections"] == {}
         assert "references" not in result
 
@@ -1272,7 +1282,7 @@ class TestSearchPeople:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("Jane Doe"),
         ):
@@ -1284,7 +1294,7 @@ class TestSearchPeople:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("Jane Doe"),
         ):
@@ -1296,7 +1306,7 @@ class TestSearchPeople:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("Jane Doe"),
         ):
@@ -1331,7 +1341,7 @@ class TestSearchPeople:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("Jane Doe"),
         ):
@@ -1343,7 +1353,7 @@ class TestSearchPeople:
         scraper = _scraper(mock_page)
         with patch.object(
             scraper._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("Jane Doe"),
         ):

--- a/tests/scraping/test_posts.py
+++ b/tests/scraping/test_posts.py
@@ -8,7 +8,11 @@ from unittest.mock import ANY, AsyncMock, call, patch
 import pytest
 
 from linkedin_mcp_server.scraping import posts as posts_module
-from linkedin_mcp_server.scraping.capture import SectionCapture
+from linkedin_mcp_server.scraping.capture import (
+    CaptureMode,
+    CapturePlan,
+    SectionCapture,
+)
 from linkedin_mcp_server.scraping.content import PageContentReader
 from linkedin_mcp_server.scraping.contracts import (
     RATE_LIMITED_SECTION_TEXT,
@@ -44,7 +48,7 @@ class TestSearchPosts:
         search = _search(mock_page)
         with patch.object(
             search._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("We're hiring a Unity dev"),
         ) as mock_extract:
@@ -55,14 +59,18 @@ class TestSearchPosts:
         assert result["sections"]["search_results"] == "We're hiring a Unity dev"
         # max_pages default (3) -> 15 scrolls
         assert mock_extract.await_args_list == [
-            call(result["url"], section_name="search_results", max_scrolls=15)
+            call(
+                result["url"],
+                section_name="search_results",
+                plan=CapturePlan(CaptureMode.SEARCH_RESULTS, max_scrolls=15),
+            )
         ]
 
     async def test_the_recency_filter_reaches_the_url(self, mock_page):
         search = _search(mock_page)
         with patch.object(
             search._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("post"),
         ) as mock_extract:
@@ -83,14 +91,18 @@ class TestSearchPosts:
         search = _search(mock_page)
         with patch.object(
             search._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("post"),
         ) as mock_extract:
             await search.search_posts("python", max_pages=2)
 
         assert mock_extract.await_args_list == [
-            call(ANY, section_name="search_results", max_scrolls=10)
+            call(
+                ANY,
+                section_name="search_results",
+                plan=CapturePlan(CaptureMode.SEARCH_RESULTS, max_scrolls=10),
+            )
         ]
 
     @pytest.mark.parametrize("max_pages", [0, -3])
@@ -106,7 +118,7 @@ class TestSearchPosts:
         search = _search(mock_page)
         with patch.object(
             search._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("post"),
         ) as mock_extract:
@@ -116,7 +128,10 @@ class TestSearchPosts:
             call(
                 ANY,
                 section_name="search_results",
-                max_scrolls=posts_module._CONTENT_SCROLLS_PER_REQUESTED_PAGE,
+                plan=CapturePlan(
+                    CaptureMode.SEARCH_RESULTS,
+                    max_scrolls=posts_module._CONTENT_SCROLLS_PER_REQUESTED_PAGE,
+                ),
             )
         ]
 
@@ -132,7 +147,7 @@ class TestSearchPosts:
         """
         search = _search(mock_page)
         with patch.object(
-            search._capture, "extract_page", new_callable=AsyncMock
+            search._capture, "capture", new_callable=AsyncMock
         ) as mock_extract:
             with pytest.raises(ValueError, match="Invalid date_posted"):
                 await search.search_posts("python", date_posted="last-year")
@@ -144,7 +159,7 @@ class TestSearchPosts:
         search = _search(mock_page)
         with patch.object(
             search._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted(""),
         ) as mock_extract:
@@ -160,7 +175,7 @@ class TestSearchPosts:
         search = _search(mock_page)
         with patch.object(
             search._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("post text", [reference]),
         ):
@@ -173,7 +188,7 @@ class TestSearchPosts:
         search = _search(mock_page)
         with patch.object(
             search._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted(RATE_LIMITED_SECTION_TEXT),
         ):
@@ -206,7 +221,7 @@ class TestSearchPosts:
             patch.object(posts_module, "RATE_LIMITED_SECTION_TEXT", "[Blocked]"),
             patch.object(
                 search._capture,
-                "extract_page",
+                "capture",
                 new_callable=AsyncMock,
                 return_value=extracted("[Blocked]"),
             ),
@@ -229,7 +244,7 @@ class TestSearchPosts:
         search = _search(mock_page)
         with patch.object(
             search._capture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted("", error=error),
         ):

--- a/tests/scraping/test_text.py
+++ b/tests/scraping/test_text.py
@@ -1,10 +1,39 @@
 """Tests for LinkedIn innerText cleanup."""
 
+import re
+
 from linkedin_mcp_server.scraping.text import (
+    DETAIL_CAPTURE_EN_US,
     strip_conversation_chrome,
     strip_linkedin_noise,
     truncate_linkedin_noise,
 )
+
+
+class TestDetailCaptureText:
+    def test_en_us_table_preserves_detail_capture_policy(self):
+        assert DETAIL_CAPTURE_EN_US.readiness_blocking_prefixes == (
+            "Load more",
+            "More profiles for you",
+            "Explore premium profiles",
+        )
+        pattern = DETAIL_CAPTURE_EN_US.expansion_button_pattern
+        assert pattern.pattern == r"^Show (more|all)\b"
+        assert pattern.flags & re.IGNORECASE
+        assert pattern.search("Show more details")
+        assert pattern.search("SHOW ALL 3 ITEMS")
+        assert not pattern.search("See all 3 items")
+        assert (
+            DETAIL_CAPTURE_EN_US.readiness_expression()
+            == """() => {
+                        const main = document.querySelector('main');
+                        if (!main) return false;
+                        const text = main.innerText.trimStart();
+                        return !text.startsWith('Load more')
+                            && !text.startsWith('More profiles for you')
+                            && !text.startsWith('Explore premium profiles');
+                    }"""
+        )
 
 
 class TestStripLinkedInNoise:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,6 @@
 """Tests for scraping section config dicts and section parsers."""
 
+import linkedin_mcp_server.scraping as scraping
 from linkedin_mcp_server.scraping.fields import (
     COMPANY_SECTIONS,
     PERSON_SECTIONS,
@@ -9,6 +10,28 @@ from linkedin_mcp_server.scraping.fields import (
 
 
 class TestPersonSections:
+    def test_exported_mapping_retains_exact_tuple_contract_and_identity(self):
+        expected = {
+            "main_profile": ("/", False),
+            "experience": ("/details/experience/", False),
+            "education": ("/details/education/", False),
+            "interests": ("/details/interests/", False),
+            "honors": ("/details/honors/", False),
+            "languages": ("/details/languages/", False),
+            "certifications": ("/details/certifications/", False),
+            "skills": ("/details/skills/", False),
+            "projects": ("/details/projects/", False),
+            "contact_info": ("/overlay/contact-info/", True),
+            "posts": ("/recent-activity/all/", False),
+        }
+        assert PERSON_SECTIONS == expected
+        assert list(PERSON_SECTIONS.items()) == list(expected.items())
+        assert all(
+            type(value) is tuple and len(value) == 2 for value in expected.values()
+        )
+        assert PERSON_SECTIONS["contact_info"][0] == "/overlay/contact-info/"
+        assert scraping.PERSON_SECTIONS is PERSON_SECTIONS
+
     def test_expected_keys(self):
         expected = {
             "main_profile",
@@ -40,6 +63,20 @@ class TestPersonSections:
 
 
 class TestCompanySections:
+    def test_exported_mapping_retains_exact_tuple_contract_and_identity(self):
+        expected = {
+            "about": ("/about/", False),
+            "posts": ("/posts/", False),
+            "jobs": ("/jobs/", False),
+        }
+        assert COMPANY_SECTIONS == expected
+        assert list(COMPANY_SECTIONS.items()) == list(expected.items())
+        assert all(
+            type(value) is tuple and len(value) == 2 for value in expected.values()
+        )
+        assert COMPANY_SECTIONS["posts"][1] is False
+        assert scraping.COMPANY_SECTIONS is COMPANY_SECTIONS
+
     def test_expected_keys(self):
         assert set(COMPANY_SECTIONS) == {"about", "posts", "jobs"}
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,7 @@
 """Tests for scraping section config dicts and section parsers."""
 
+from collections import namedtuple
+
 import linkedin_mcp_server.scraping as scraping
 from linkedin_mcp_server.scraping.fields import (
     COMPANY_SECTIONS,
@@ -7,6 +9,10 @@ from linkedin_mcp_server.scraping.fields import (
     parse_company_sections,
     parse_person_sections,
 )
+
+
+def _has_exact_tuple_contract(sections: dict[str, tuple[str, bool]]) -> bool:
+    return all(type(value) is tuple and len(value) == 2 for value in sections.values())
 
 
 class TestPersonSections:
@@ -26,9 +32,7 @@ class TestPersonSections:
         }
         assert PERSON_SECTIONS == expected
         assert list(PERSON_SECTIONS.items()) == list(expected.items())
-        assert all(
-            type(value) is tuple and len(value) == 2 for value in expected.values()
-        )
+        assert _has_exact_tuple_contract(PERSON_SECTIONS)
         assert PERSON_SECTIONS["contact_info"][0] == "/overlay/contact-info/"
         assert scraping.PERSON_SECTIONS is PERSON_SECTIONS
 
@@ -71,9 +75,7 @@ class TestCompanySections:
         }
         assert COMPANY_SECTIONS == expected
         assert list(COMPANY_SECTIONS.items()) == list(expected.items())
-        assert all(
-            type(value) is tuple and len(value) == 2 for value in expected.values()
-        )
+        assert _has_exact_tuple_contract(COMPANY_SECTIONS)
         assert COMPANY_SECTIONS["posts"][1] is False
         assert scraping.COMPANY_SECTIONS is COMPANY_SECTIONS
 
@@ -83,6 +85,17 @@ class TestCompanySections:
     def test_no_overlays(self):
         for name, (_suffix, is_overlay) in COMPANY_SECTIONS.items():
             assert is_overlay is False, f"{name} should not be an overlay"
+
+
+def test_exact_tuple_contract_rejects_equal_tuple_subclasses():
+    class EqualTuple(tuple):
+        pass
+
+    SectionTuple = namedtuple("SectionTuple", "suffix is_overlay")
+    assert EqualTuple(("/about/", False)) == ("/about/", False)
+    assert SectionTuple("/about/", False) == ("/about/", False)
+    assert not _has_exact_tuple_contract({"about": EqualTuple(("/about/", False))})
+    assert not _has_exact_tuple_contract({"about": SectionTuple("/about/", False)})
 
 
 class TestParsePersonSections:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -171,7 +171,7 @@ class TestSingleSectionRateLimits:
         # patch would intercept nothing for it while still passing.
         with patch.object(
             SectionCapture,
-            "extract_page",
+            "capture",
             new_callable=AsyncMock,
             return_value=extracted(RATE_LIMITED_SECTION_TEXT),
         ):
@@ -204,7 +204,7 @@ class TestEveryNormalizedEntryPoint:
         # intercept nothing for those and the assertion would hold whatever
         # the code did.
         return (
-            patch.object(SectionCapture, "extract_page", new_callable=AsyncMock),
+            patch.object(SectionCapture, "capture", new_callable=AsyncMock),
             patch.object(PageNavigator, "_navigate_to_page", new_callable=AsyncMock),
         )
 


### PR DESCRIPTION
Part of #853. Stacked on #925.

Generic capture inferred domain behavior from URLs even after domain workflows had dedicated owners. This stage adds immutable `CaptureMode` and `CapturePlan` values and makes domain services pass explicit plans.

The public `extract_page` compatibility adapter retains its historical URL behavior. Public section maps keep exact tuple values and identity. Review mutations cover runtime map replacement, custom overlays, raw-URL versus parsed-path asymmetry, and helper or constant attempts to reintroduce domain policy into generic capture.

Verification: 152 owner tests, structural mutations, and the final 4,189-test suite pass.

## Synthetic prompt

> Replace URL-inferred domain capture policy with explicit immutable plans while preserving the public generic adapter and section-map compatibility.

Generated with GPT-5.6 Sol
