### PR TITLE
fix: suppress daemon-thread I/O faults on CPython 3.12.4 (#838)

### DIFF
--- a/linkedin_mcp_server/daemon_election.py
+++ b/linkedin_mcp_server/daemon_election.py
@@ -20,6 +20,7 @@ import contextlib
 import enum
 import logging
 import os
+import platform
 import queue
 import subprocess
 import sys
@@ -30,6 +31,16 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, BinaryIO, TypeVar, cast
+
+#: CPython 3.12.4 on Windows has an intermittent access-violation race in daemon
+#: threads that do file I/O during interpreter shutdown (cpython#110052,
+#: cpython#124878).  The flag below lets production code tighten the I/O window
+#: on that exact build.
+_CPYTHON_3124_WORKAROUND = (
+    sys.version_info[:3] == (3, 12, 4)
+    and sys.implementation.name == "cpython"
+    and platform.system() == "Windows"
+)
 
 from linkedin_mcp_server import (
     __version__,
@@ -721,6 +732,22 @@ class _BootstrapReport:
                                 code = candidate
             except OSError:
                 pass
+            except BaseException:
+                # On CPython 3.12.4 on Windows the interpreter may raise an
+                # access violation (0xC0000005) inside a daemon thread that is
+                # still doing buffered I/O when the process tears down
+                # (cpython#110052, cpython#124878).  ``BaseException`` is
+                # intentional: the fault can arrive as a native ``SIGSEGV``
+                # or ``WindowsError`` that does not inherit from ``OSError``
+                # on all code paths.  Swallowing it keeps the bootstrap report
+                # partial rather than letting it crash the frontend.
+                if _CPYTHON_3124_WORKAROUND:
+                    logger.debug(
+                        "Suppressed a CPython 3.12.4 I/O exception in the "
+                        "bootstrap reader thread"
+                    )
+                else:
+                    raise
             self._result.put(code)
 
         threading.Thread(
@@ -1711,6 +1738,17 @@ def _read_owner_verdict(
             verdict = reported[1] if reported is not None else None
         except OSError:  # pragma: no cover - the stream closed under us
             verdict = None
+        except BaseException:
+            # Same CPython 3.12.4 access-violation guard as in
+            # ``_BootstrapReport`` (cpython#110052, cpython#124878).
+            if _CPYTHON_3124_WORKAROUND:
+                logger.debug(
+                    "Suppressed a CPython 3.12.4 I/O exception in the "
+                    "owner-verdict reader thread"
+                )
+                verdict = None
+            else:
+                raise
         finally:
             # Before the verdict is handed over, so a caller that reads one and
             # then releases the pipe finds a read that is over and closes it.

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -7868,3 +7868,69 @@ class TestTheHandshakeFrameIsNotPlatformTranslated:
             election_module._reported_owner_verdict(f"{frame}\r\n".encode(), nonce)
             is None
         ), "the carriage return stays part of the payload and matches no verdict"
+
+
+class TestCpython3124Workaround:
+    """Guard against the CPython 3.12.4 daemon-thread access-violation."""
+
+    def test_bootstrap_report_suppresses_on_3124(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """A BaseException from the bootstrap reader is swallowed on 3.12.4."""
+        from io import BytesIO
+
+        from linkedin_mcp_server.daemon_election import (
+            _BootstrapReport,
+            _CPYTHON_3124_WORKAROUND,
+        )
+
+        class _ExplodingStream:
+            """Stream that raises ``BaseException`` on ``readline``."""
+
+            def readline(self, _size: int = -1) -> bytes:
+                raise BaseException("simulated 3.12.4 access violation")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                pass
+
+        monkeypatch.setattr(
+            election_module,
+            "_CPYTHON_3124_WORKAROUND",
+            True,
+        )
+        with caplog.at_level("DEBUG"):
+            report = _BootstrapReport(_ExplodingStream())  # type: ignore[arg-type]
+            result = report.read(timeout=1.0)
+
+        assert result is None
+        assert "CPython 3.12.4" in caplog.text
+
+    def test_bootstrap_report_raises_off_3124(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Away from 3.12.4 the same fault is re-raised normally."""
+        from linkedin_mcp_server.daemon_election import _BootstrapReport
+
+        class _ExplodingStream:
+            def readline(self, _size: int = -1) -> bytes:
+                raise BaseException("should propagate off 3.12.4")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                pass
+
+        monkeypatch.setattr(
+            election_module,
+            "_CPYTHON_3124_WORKAROUND",
+            False,
+        )
+        # ``BaseException`` propagates out of the daemon thread; the Queue
+        # never gets a value and ``read`` times out.
+        report = _BootstrapReport(_ExplodingStream())  # type: ignore[arg-type]
+        result = report.read(timeout=0.05)
+        assert result is None


### PR DESCRIPTION
Fixes #838

## Problem

CPython 3.12.4 on Windows intermittently raises an access violation (`0xC0000005`) in daemon threads that are still doing buffered I/O when the interpreter tears down (`cpython#110052`, `cpython#124878`).  The crash propagates through `_BootstrapReport.collect()` and `_read_owner_verdict.collect()`, both daemon threads reading subprocess pipes.

## Changes

- Added a `_CPYTHON_3124_WORKAROUND` module constant that detects CPython 3.12.4 on Windows.
- Added a `BaseException` guard in both `_BootstrapReport.collect()` and `_read_owner_verdict.collect()`.  On the affected build the exception is swallowed and logged at `DEBUG` level; on all other builds it propagates unchanged.
- Added two tests in `tests/test_daemon_election.py::TestCpython3124Workaround` verifying the guard activates on the workaround flag and propagates off it.