### PR TITLE
fix: check watcher breach before accepting process success (#837)

### DIFF
--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -2509,6 +2509,22 @@ async def _install_under_supervision(
         # growth: CPython can publish returncode before pipe EOF, so the loop
         # above leaves with the watcher parked between two sleeps. The tree has
         # settled by here.
+        #
+        # Before checking the final snapshot: a watcher that observed a breach
+        # in the same scheduling interval where the process exited must not be
+        # swallowed by the "installer finished first" path.  The watcher's own
+        # exception carries the breach even when the final snapshot has already
+        # shrunk (e.g. Patchright deleted its archive during successful
+        # cleanup), so we raise it here before the final snapshot can mask it.
+        if (
+            activity is not None
+            and activity.done()
+            and not activity.cancelled()
+            and _installer_bound_breached(activity)
+            and not bound_raised
+        ):
+            bound_raised = True
+            await activity
         final = await _run_in_daemon_thread(
             _installer_download_snapshot, temporary_root, extraction_paths
         )

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -2467,6 +2467,49 @@ class TestInstallerSupervisorLaunch:
 
         assert "exceeded a setup bound" in caplog.text
 
+    async def test_simultaneous_watcher_breach_and_process_exit_is_raised(
+        self, monkeypatch
+    ):
+        """A watcher that breaches while the process exits is not hidden (#837).
+
+        The watcher observes a byte-limit breach and completes with
+        ``BrowserSetupFailedError`` in the same scheduling interval where the
+        installer process exits successfully.  The final filesystem snapshot
+        can then be below the limit because Patchright removed its temporary
+        archive.  Before this fix the watcher breach was swallowed by the
+        ``"installer finished first"`` path.
+        """
+        from linkedin_mcp_server import bootstrap
+        from linkedin_mcp_server.exceptions import BrowserSetupFailedError
+
+        breach = BrowserSetupFailedError("holds 5.0 GiB, past its 4.0 GiB limit")
+        proc = _FakeProc([], 0)
+
+        async def watcher_that_immediately_breaches(
+            _callback: Callable[[], None],
+            _temporary_root: Path,
+            _extraction_paths: tuple[Path, ...],
+            _opening: tuple[tuple[str, int, int], ...],
+        ) -> None:
+            raise breach
+
+        async def delayed_lines(stream: object):
+            await asyncio.sleep(0)
+            setattr(stream, "exhausted", True)
+            if False:  # pragma: no cover - makes this an async generator
+                yield ""
+
+        monkeypatch.setattr(bootstrap, "_installer_lines", delayed_lines)
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", AsyncMock(return_value=proc)
+        )
+        monkeypatch.setattr(bootstrap, "_watch_installer_activity", watcher_that_immediately_breaches)
+
+        with pytest.raises(BrowserSetupFailedError, match="5.0 GiB"):
+            await bootstrap._run_patchright_install(
+                "--no-shell", activity_callback=lambda: None
+            )
+
     async def test_bytes_written_before_the_first_poll_are_charged(self, monkeypatch):
         """Everything lands inside one poll interval and is still refused.
 


### PR DESCRIPTION
Fixes #837

## Problem

The filesystem activity watcher can observe a byte-limit breach and complete with `BrowserSetupFailedError` in the same scheduling interval where Patchright exits successfully and removes its temporary archive.  The final snapshot then falls below the limit, and the supervision loop accepted the successful process exit while the watcher breach was only logged as a warning.

## Changes

- Added an early check of the watcher result after the process loop exits but before the final snapshot is taken.
- A completed watcher breach is now raised as the install result instead of being hidden by the final-snapshot path.
- Added a test in `tests/test_bootstrap.py` verifying that a simultaneous watcher breach and process exit raises the breach.