### PR TITLE
fix: raise ToolError when owner loss may hide delivered message (#891)

### DIFF
--- a/linkedin_mcp_server/daemon_proxy.py
+++ b/linkedin_mcp_server/daemon_proxy.py
@@ -680,11 +680,24 @@ class FrontendOwnerRecoveryMiddleware(Middleware):
                 # already sent the connection request or the message, and asking
                 # costs one retry while guessing wrong sends it twice. The user
                 # knows which happened; this process does not.
+                #
+                # Raise a ``ToolError`` so ``mask_error_details`` does not reduce
+                # it to a generic message.  An autonomous client that reads a
+                # masked error as transient would retry, which is exactly the
+                # second delivery this refusal is protecting against (#891).
                 logger.info(
                     "Attached to a replacement owner; not repeating a call that "
                     "could change something"
                 )
-                raise
+                from fastmcp.exceptions import ToolError
+
+                tool_name = getattr(context.message, "name", "tool")
+                raise ToolError(
+                    f"The shared browser owner disappeared while '{tool_name}' "
+                    f"was in flight. The call may have taken effect; do not "
+                    f"retry automatically as repeating it could deliver a "
+                    f"duplicate (e.g. a second connection request or message)."
+                ) from exc
 
             logger.info("Attached to a replacement owner; running the call again")
             return await call_next(context)

--- a/tests/test_daemon_proxy.py
+++ b/tests/test_daemon_proxy.py
@@ -812,6 +812,21 @@ class TestRepeatingOnlyWhatIsSafe:
         # And the replacement was still adopted, for the next call.
         assert backend.attachment.descriptor.instance_id != failed
 
+    async def test_a_mutating_call_emits_toolerror_when_owner_departs(
+        self, _recovering
+    ):
+        """A ToolError with a do-not-retry hint is raised, not a masked error (#891)."""
+        from fastmcp.exceptions import ToolError
+
+        backend, failed = _recovering
+        with pytest.raises(ToolError, match="do not retry automatically"):
+            await self._run(
+                backend,
+                self._context(read_only=False),
+                nothing_was_sent=False,
+                instance_id=failed,
+            )
+
     async def test_a_mutating_call_is_repeated_when_nothing_was_sent(self, _recovering):
         # The only reason the dispatch question is worth asking. Without it every
         # write tool would keep failing across an upgrade.


### PR DESCRIPTION
Fixes #891

## Problem

When the shared browser owner disappears mid-call, the middleware refuses to repeat a mutating call that may have already taken effect.  Previously it re-raised the `OwnerUnreachableError`, which was masked by `mask_error_details` into a generic tool error.  An autonomous client reading a masked error as transient would retry, which is exactly the second delivery this refusal protects against.

## Changes

- The middleware now raises a `ToolError` with a clear message naming the risk and instructing the caller not to retry automatically.
- `ToolError` is not masked by `mask_error_details`, so the message reaches the caller intact.
- Added a test in `tests/test_daemon_proxy.py` verifying the `ToolError` is raised with the expected message.