### PR TITLE
fix(#889): wrap confirmation wait with deadline-aware budget to prevent tool timeout hiding sent messages

### DIFF
--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -243,6 +243,12 @@ _PROFILE_MESSAGE_TARGET_READY_JS = (
 _PROFILE_MESSAGE_TARGET_TIMEOUT_MS = 1_000
 _MESSAGE_SUBMIT_READY_TIMEOUT_MS = 1_000
 _MESSAGE_CLEANUP_TIMEOUT_SECONDS = 1.0
+# Send-message confirmation must finish before FastMCP's tool-level
+# ``anyio.fail_after()`` can cancel the coroutine and discard the result.
+# Using a fraction of the remaining tool budget gives the confirmation a
+# window while keeping the cancellation boundary inside the scope where the
+# result can still be returned.  See #889.
+_MESSAGE_CONFIRMATION_TIMEOUT_FRACTION = 5 / 6
 
 _MESSAGE_COMPOSER_INSPECT_JS = r"""
     const visible = element => {
@@ -3122,6 +3128,7 @@ class LinkedInExtractor:
         *,
         confirm_send: bool,
         profile_urn: str | None = None,
+        tool_timeout: float = DEFAULT_TOOL_TIMEOUT_SECONDS,
     ) -> dict[str, Any]:
         """Compose and send a new message with explicit confirmation gating.
 
@@ -3138,6 +3145,9 @@ class LinkedInExtractor:
             confirm_send: Must be True to actually send (False does a dry run).
             profile_urn: Optional profile URN (e.g. ACoAAB...) to verify against
                 the recipient resolved from the loaded profile snapshot.
+            tool_timeout: Total tool budget in seconds.  The confirmation wait
+                uses a fraction of this so the result can be returned before
+                FastMCP's deadline discards it (#889).
         """
         refusal = contracts.refuse_an_invalid_message(linkedin_username, message)
         if refusal is not None:
@@ -3397,12 +3407,37 @@ class LinkedInExtractor:
                             recipient_selected=recipient_selected,
                         )
 
-                    confirmed = await self._message_send_confirmed(
-                        message,
-                        target=target,
-                        owner=owner,
-                        confirmation=confirmation,
+                    # The confirmation must finish before FastMCP's
+                    # ``anyio.fail_after()`` can cancel the coroutine and
+                    # discard the result.  Using a bounded sub-budget lets us
+                    # return ``send_unconfirmed`` with ``retry_safe: false``
+                    # instead of losing the answer to a bare timeout (#889).
+                    confirmation_budget = max(
+                        1.0,
+                        tool_timeout * _MESSAGE_CONFIRMATION_TIMEOUT_FRACTION,
                     )
+                    with anyio.move_on_after(
+                        confirmation_budget
+                    ) as confirm_scope:
+                        confirmed = await self._message_send_confirmed(
+                            message,
+                            target=target,
+                            owner=owner,
+                            confirmation=confirmation,
+                        )
+
+                    if confirm_scope.cancel_called:
+                        return contracts.message_action_result(
+                            self._page.url,
+                            "send_unconfirmed",
+                            "The message was submitted but the confirmation "
+                            "timed out before LinkedIn confirmed the "
+                            "message-list transition. Check the conversation "
+                            "before retrying; retrying may deliver the "
+                            "message twice.",
+                            recipient_selected=recipient_selected,
+                            retry_safe=False,
+                        )
                     if not confirmed:
                         return contracts.message_action_result(
                             self._page.url,

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -300,6 +300,7 @@ def register_messaging_tools(
                 message,
                 confirm_send=confirm_send,
                 profile_urn=profile_urn,
+                tool_timeout=DEFAULT_TOOL_TIMEOUT_SECONDS,
             )
 
             try:

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -7,6 +7,8 @@ from urllib.parse import parse_qs, urlparse
 import asyncio
 import logging
 
+import anyio
+
 from patchright.async_api import Error as PatchrightError
 from patchright.async_api import TimeoutError as PlaywrightTimeoutError
 
@@ -5729,6 +5731,52 @@ class TestSendMessage:
             owner=mock_page.evaluate_handle.return_value,
             confirmation=1,
         )
+
+    async def test_confirmation_timeout_returns_unconfirmed(self, mock_page):
+        """Internal budget expires before FastMCP's deadline; result survives.
+
+        A slow confirmation that blocks beyond the internal budget must
+        return ``send_unconfirmed`` with ``retry_safe=False`` so the caller
+        knows a retry may duplicate the message -- instead of FastMCP's bare
+        timeout which discards the result entirely (#889).
+        """
+        extractor = LinkedInExtractor(mock_page)
+        patches = self._patch_to_composer(extractor, mock_page)
+
+        block = anyio.Event()
+
+        async def _slow_confirm(*, message, target, owner, confirmation):
+            await block.wait()
+            return False
+
+        with (
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9],
+            patches[10] as visible,
+        ):
+            visible.side_effect = _slow_confirm
+            result = await extractor.send_message(
+                "testuser",
+                "Hello!",
+                confirm_send=True,
+                # A 2 s tool budget gives the confirmation 5/6 of that.
+                # The Event never fires, so the budget expires first.
+                tool_timeout=2.0,
+            )
+
+        # The key contract: the tool must answer with a structured result
+        # that tells the caller the outcome is unknown and a retry is not
+        # safe, rather than letting FastMCP's deadline discard everything.
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
 
 
 class TestResolveMessageComposeBox:


### PR DESCRIPTION
Fixes #889.

FastMCP wraps every tool call in \`anyio.fail_after()\`, so the tool timeout cancels the running coroutine rather than letting it finish. \`send_message\` had a window where cancellation was not recoverable: between dispatching the send and the occurrence confirmation, a message may already be on its way but the caller gets a bare timeout with no \`retry_safe\` flag.

Changes:
- Added \`tool_timeout\` parameter to \`send_message\` (default: \`DEFAULT_TOOL_TIMEOUT_SECONDS\`)
- Wrapped the confirmation wait in \`anyio.move_on_after()\` with a budget of 5/6 of tool_timeout so the tool returns \`send_unconfirmed\` with \`retry_safe=False\` before FastMCP's deadline discards the result
- Added test verifying the structured result is returned when confirmation is slow
- Passed \`tool_timeout\` from the MCP tool wrapper

This follows the same pattern as \`AUTH_REPAIR_LOGIN_WAIT_FRACTION\` (5/6): the tool gives itself a fraction of the total deadline and returns a structured answer before the outer scope can cancel.