### PR TITLE
fix(#821): accept UNC/network profile homes with inherited DACLs via ancestry fallback

### DIFF
--- a/linkedin_mcp_server/daemon_descriptor.py
+++ b/linkedin_mcp_server/daemon_descriptor.py
@@ -669,7 +669,23 @@ def prepare_daemon_state(auth_root: Path) -> Path:
 
         if os.name == "nt":
             _pin_windows_account_home(home)
-        verify_children_cannot_be_replaced(home)
+        # Local profiles created by Windows have an explicit non-inherited ACL,
+        # which ``require_protected=True`` accepts directly.  Redirected or
+        # UNC profile homes (e.g. ``\\fileserver\profiles\alice``) commonly
+        # inherit a user-only DACL from an administrator-controlled parent —
+        # safe, but not protected.  Fall back to walking the ancestry chain
+        # rather than refusing the account entirely (#821).
+        try:
+            verify_children_cannot_be_replaced(home)
+        except PrivateStateError:
+            from linkedin_mcp_server.windows_acl import (
+                verify_ancestry_cannot_be_replaced,
+            )
+
+            verify_children_cannot_be_replaced(
+                home, require_protected=False
+            )
+            verify_ancestry_cannot_be_replaced(home)
         legacy_exists = _legacy_windows_tombstone_exists(home)
         application_root = home / _APPLICATION_STATE_DIR
         harden_directory_entry(application_root)

--- a/tests/test_daemon_descriptor.py
+++ b/tests/test_daemon_descriptor.py
@@ -911,7 +911,7 @@ class TestStateLocation:
             ".mcp-server-linkedin-v2",
         )
 
-        def refuse(_path: Path) -> None:
+        def refuse(_path: Path, **_kwargs: object) -> None:
             raise PrivateStateError("unsafe home")
 
         monkeypatch.setattr(windows_acl, "verify_children_cannot_be_replaced", refuse)
@@ -921,6 +921,54 @@ class TestStateLocation:
 
         assert not (tmp_path / ".mcp-server-linkedin").exists()
         assert not (tmp_path / ".mcp-server-linkedin-v2").exists()
+
+    def test_windows_accepts_an_inherited_dacl_after_ancestry_check(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """UNC/network profile homes inherit a safe but unprotected DACL (#821).
+
+        ``verify_children_cannot_be_replaced`` with ``require_protected=True``
+        rejects the inherited DACL.  The fallback walks the ancestry chain
+        instead and accepts a profile whose inherited entries are all safe.
+        """
+        from linkedin_mcp_server import windows_acl
+
+        monkeypatch.setattr(daemon_descriptor_module, "_WINDOWS", True)
+        monkeypatch.setattr(
+            daemon_descriptor_module,
+            "_APPLICATION_STATE_DIR",
+            ".mcp-server-linkedin-v2",
+        )
+        monkeypatch.setattr(
+            daemon_descriptor_module, "_pin_windows_account_home", lambda _path: None
+        )
+        _stub_windows_hardening(monkeypatch)
+
+        call_count = 0
+
+        def require_protected_then_relaxed(
+            _path: Path, *, require_protected: bool = True
+        ) -> None:
+            nonlocal call_count
+            call_count += 1
+            if require_protected:
+                raise PrivateStateError(
+                    f"{_path} still inherits permissions that can change"
+                )
+            # require_protected=False accepts inherited DACLs
+
+        monkeypatch.setattr(
+            windows_acl,
+            "verify_children_cannot_be_replaced",
+            require_protected_then_relaxed,
+        )
+        monkeypatch.setattr(
+            windows_acl, "verify_ancestry_cannot_be_replaced", lambda _path: None
+        )
+
+        prepare_daemon_state(tmp_path / "auth")
+
+        assert call_count == 2, "first call with protect, second without"
 
     def test_windows_refuses_legacy_state_before_creating_the_new_namespace(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Fixes #821.

`prepare_daemon_state` requires `verify_children_cannot_be_replaced(home)` which demands the home's DACL to be protected (non-inherited). Local Windows profiles have this, but redirected or UNC profile homes (e.g. `\\\\fileserver\\profiles\\alice`) commonly inherit a user-only DACL from an administrator-controlled parent -- safe but not protected.

Changes:
- When the protected DACL check fails, fall back to `verify_children_cannot_be_replaced(path, require_protected=False)` which accepts inherited DACLs
- Then walk the full ancestry chain via `verify_ancestry_cannot_be_replaced` to ensure every ancestor is safe
- Added test verifying the fallback path is exercised when the first check fails
- Updated existing test mock to accept `require_protected` keyword argument

This matches the existing pattern used for the installer temporary parent.