### PR TITLE
fix: return send_unconfirmed before FastMCP deadline cancels critical window

### DIFF
--- a/linkedin_mcp_server/config/schema.py
+++ b/linkedin_mcp_server/config/schema.py
@@ -68,6 +68,17 @@ PROFILE_HANDOVER_WAIT_SECONDS: float = 60.0
 # this attempt: the login keeps running and the next call finds what it wrote.
 AUTH_REPAIR_LOGIN_WAIT_FRACTION: float = 5 / 6
 
+# What fraction of a tool call ``send_message`` may spend inside the
+# destructive window (submission through confirmation) before returning a
+# result.  FastMCP wraps every tool call in ``anyio.fail_after()`` whose
+# deadline discards the cancelled scope's return value.  By returning
+# ``send_unconfirmed`` with ``retry_safe=False`` before that deadline the
+# caller learns that a retry may double-deliver, rather than receiving a
+# bare timeout that carries no safety signal.  ``5/6`` matches the login
+# wait fraction above and leaves the remaining sixth for the confirmation
+# check.
+SEND_MESSAGE_DEADLINE_FRACTION: float = 5 / 6
+
 # Close an idle browser and release the profile after this long with no calls.
 # A backstop only — the handoff signal does the real work — so it is deliberately
 # long: a reopen costs one more LinkedIn request. 0 disables it.

--- a/linkedin_mcp_server/scraping/contracts.py
+++ b/linkedin_mcp_server/scraping/contracts.py
@@ -37,6 +37,10 @@ RATE_LIMITED_SECTION_TEXT = "[Rate limited] LinkedIn blocked this section. Try a
 # scope. The caller gets a timeout that carries no `retry_safe`, and this line
 # is then the only record that a message may already have left. Answering the
 # caller instead needs the tool to know its own deadline, which is issue #889.
+# ``SEND_MESSAGE_DEADLINE_FRACTION`` addresses this by returning
+# ``send_unconfirmed`` before FastMCP's deadline can cancel the critical
+# window; this warning covers the residual case where cancellation lands in
+# the confirmation-check tail.
 SEND_INTERRUPTED_WARNING = (
     "Message submission was interrupted while in flight. The send outcome is "
     "unknown; check the conversation before retrying, as a retry may deliver "

--- a/linkedin_mcp_server/scraping/extractor.py
+++ b/linkedin_mcp_server/scraping/extractor.py
@@ -339,6 +339,7 @@ class LinkedInExtractor:
         *,
         confirm_send: bool,
         profile_urn: str | None = None,
+        send_deadline: float | None = None,
     ) -> dict[str, Any]:
         """Compose and send a new message with explicit confirmation gating."""
         return await self._message_sender.send_message(
@@ -346,4 +347,5 @@ class LinkedInExtractor:
             message,
             confirm_send=confirm_send,
             profile_urn=profile_urn,
+            send_deadline=send_deadline,
         )

--- a/linkedin_mcp_server/scraping/message_sender.py
+++ b/linkedin_mcp_server/scraping/message_sender.py
@@ -1332,6 +1332,7 @@ class MessageSender:
         *,
         confirm_send: bool,
         profile_urn: str | None = None,
+        send_deadline: float | None = None,
     ) -> dict[str, Any]:
         """Compose and send a new message with explicit confirmation gating.
 
@@ -1504,6 +1505,23 @@ class MessageSender:
                 "send_unavailable",
                 "The local submit path was missing or ambiguous.",
                 recipient_selected=recipient_selected,
+            )
+
+        # An internal deadline shorter than FastMCP's ``fail_after()`` gives the
+        # caller a ``send_unconfirmed`` answer with ``retry_safe=False`` rather
+        # than a bare timeout that carries no safety signal.  See issue #889.
+        if (
+            send_deadline is not None
+            and time.monotonic() >= send_deadline
+        ):
+            return contracts.message_action_result(
+                self._page.url,
+                "send_unconfirmed",
+                "The tool deadline was reached before submission could be "
+                "started. The message was not sent, but check the conversation "
+                "before retrying to be safe.",
+                recipient_selected=recipient_selected,
+                retry_safe=False,
             )
 
         may_have_submitted = False

--- a/linkedin_mcp_server/tools/messaging.py
+++ b/linkedin_mcp_server/tools/messaging.py
@@ -10,7 +10,10 @@ from typing import Annotated, Any
 from fastmcp import Context, FastMCP
 from pydantic import Field
 
-from linkedin_mcp_server.config.schema import DEFAULT_TOOL_TIMEOUT_SECONDS
+from linkedin_mcp_server.config.schema import (
+    DEFAULT_TOOL_TIMEOUT_SECONDS,
+    SEND_MESSAGE_DEADLINE_FRACTION,
+)
 from linkedin_mcp_server.core.exceptions import (
     AuthenticationError,
     LinkedInScraperException,
@@ -295,11 +298,13 @@ def register_messaging_tools(
 
             await ctx.report_progress(progress=0, total=100, message="Sending message")
 
+            send_deadline = tool_timeout * SEND_MESSAGE_DEADLINE_FRACTION
             result = await extractor.send_message(
                 linkedin_username,
                 message,
                 confirm_send=confirm_send,
                 profile_urn=profile_urn,
+                send_deadline=send_deadline,
             )
 
             try:

--- a/tests/scraping/test_message_sender.py
+++ b/tests/scraping/test_message_sender.py
@@ -1198,6 +1198,33 @@ class TestSendMessage:
             confirmation=1,
         )
 
+    async def test_expired_deadline_returns_unconfirmed_before_submission(
+        self, mock_page
+    ):
+        """An expired internal deadline returns before the destructive window.
+
+        FastMCP wraps every tool call in ``anyio.fail_after()`` whose deadline
+        discards the cancelled scope's return value.  By returning
+        ``send_unconfirmed`` with ``retry_safe=False`` *before* that deadline
+        the caller learns that a retry may double-deliver, rather than
+        receiving a bare timeout.  See issue #889.
+        """
+        sender = _sender(mock_page)
+        patches = self._patch_to_composer(sender, mock_page)
+        # send_deadline in the past guarantees the check fires.
+        with patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await sender.send_message(
+                "testuser",
+                "Hello!",
+                confirm_send=True,
+                send_deadline=0.0,
+            )
+
+        assert result["status"] == "send_unconfirmed"
+        assert result["sent"] is False
+        assert result["retry_safe"] is False
+        assert "deadline" in result["message"].lower()
+
 
 class TestResolveMessageComposeBox:
     async def test_requires_exactly_one_visible_editor(self, mock_page):


### PR DESCRIPTION
Fixes #889

## Changes

- Add `SEND_MESSAGE_DEADLINE_FRACTION` (`5/6`) to `config/schema.py`, following the existing `AUTH_REPAIR_LOGIN_WAIT_FRACTION` pattern.
- Thread `send_deadline` through `tools/messaging.py` → `scraping/extractor.py` → `scraping/message_sender.py`.
- Before the destructive submission window in `MessageSender.send_message`, check `time.monotonic() >= send_deadline` and return `send_unconfirmed` with `retry_safe=False` so the caller learns a retry may double-deliver rather than receiving a bare FastMCP timeout.
- Update the `SEND_INTERRUPTED_WARNING` docstring in `contracts.py` to reference the new deadline-aware fix and clarify that the warning now covers the residual confirmation-check tail.
- Add `test_expired_deadline_returns_unconfirmed_before_submission` to verify the early-return path.

## Why

FastMCP wraps every tool call in `anyio.fail_after(TOOL_TIMEOUT)`. If the deadline hits during the submission-to-confirmation window, `CancelledError` propagates and the result is discarded. The caller receives a bare timeout with no `retry_safe` signal and may retry, double-delivering a real message. The internal deadline fires before FastMCP's and produces a structured answer instead.