### PR TITLE
fix: detect manually-installed Chromium when install metadata is missing

### DIFF
--- a/linkedin_mcp_server/bootstrap.py
+++ b/linkedin_mcp_server/bootstrap.py
@@ -544,6 +544,33 @@ def _has_install_for(configured: Path, prefix: str, revision: str) -> bool:
     return (configured / f"{prefix}{revision}" / "INSTALLATION_COMPLETE").is_file()
 
 
+def _detect_installed_browser_on_disk() -> Path | None:
+    """Scan the browsers directory for a valid full Chrome for Testing install.
+
+    When install metadata is missing or written by a manual ``patchright
+    install`` invocation, ``_metadata_shape_ok`` returns ``None`` and
+    ``browser_ready`` fails even though the binary is present on disk.
+    This fallback scans ``PLAYWRIGHT_BROWSERS_PATH`` for a directory
+    matching ``chromium-<revision>/INSTALLATION_COMPLETE`` and returns the
+    browsers path when found.  ``None`` means nothing was found.  Pure: no
+    mutation.
+    """
+    configured = Path(
+        os.environ.get("PLAYWRIGHT_BROWSERS_PATH", str(browsers_path()))
+    )
+    if not configured.is_dir():
+        return None
+    targets = _patchright_install_targets()
+    if targets is None:
+        return None
+    revision = targets.get(_FULL_DIR_PREFIX)
+    if revision is None:
+        return None
+    if _has_install_for(configured, _FULL_DIR_PREFIX, revision):
+        return configured
+    return None
+
+
 def _uses_custom_chrome() -> bool:
     """Return whether an operator-supplied Chrome/Chromium executable is set.
 
@@ -981,9 +1008,17 @@ def browser_ready() -> bool:
     shell-only install, the launch fails, only the metadata is invalidated, and
     the next setup installs the shell again.
 
+    When install metadata is missing or was written by a manual ``patchright
+    install`` invocation, ``_metadata_shape_ok`` returns ``None``.  The
+    fallback ``_detect_installed_browser_on_disk`` scans the browsers
+    directory directly for the ``INSTALLATION_COMPLETE`` marker so that a
+    manually-installed browser is recognised.  See issue #909.
+
     Pure: no mutation.
     """
     configured = _metadata_shape_ok()
+    if configured is None:
+        configured = _detect_installed_browser_on_disk()
     if configured is None:
         return False
     targets = _patchright_install_targets()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -605,6 +605,23 @@ class TestBrowserReady:
         _write_metadata(install_metadata_path(), bdir, version=2)
         assert browser_ready() is False
 
+    def test_ready_when_metadata_missing_but_browser_installed(
+        self, isolate_profile_dir, monkeypatch
+    ):
+        """A manually-installed browser is detected without server metadata.
+
+        ``patchright install chromium`` writes ``INSTALLATION_COMPLETE`` but
+        not the server's ``browser-install.json``.  The fallback
+        ``_detect_installed_browser_on_disk`` scans the browsers directory
+        directly.  See issue #909.
+        """
+        _patch_targets_and_version(monkeypatch)
+        bdir = browsers_path()
+        _materialize_install(bdir, ["chromium-1217"])
+        # No metadata written — simulates a manual install.
+        assert install_metadata_path().exists() is False
+        assert browser_ready() is True
+
 
 def _fill(directory: Path, num_bytes: int) -> None:
     """Give *directory* a payload file of a known size."""


### PR DESCRIPTION
Fixes #909

## Changes

- Add `_detect_installed_browser_on_disk()` fallback that scans `PLAYWRIGHT_BROWSERS_PATH` for `chromium-<revision>/INSTALLATION_COMPLETE` without requiring the server's own `browser-install.json` metadata.
- Modify `browser_ready()` to use the disk fallback when `_metadata_shape_ok()` returns `None`, so a browser installed via `patchright install chromium` is recognised.
- Add `test_ready_when_metadata_missing_but_browser_installed` to cover the manual-install path.

## Why

When a user runs `patchright install chromium` manually, the installer writes `INSTALLATION_COMPLETE` but not the server's `browser-install.json`. The server's `_metadata_shape_ok()` returns `None` and `browser_ready()` returns `False`, so the background setup loop never completes. The fallback scans the directory directly and recognises the binary without server metadata.