### PR TITLE
fix(config): Isolate CLI arguments

### DIFF
--- a/linkedin_mcp_server/cli_main.py
+++ b/linkedin_mcp_server/cli_main.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NoReturn
 
@@ -18,7 +19,8 @@ from linkedin_mcp_server.exceptions import (
     ProfileRootRefusedError,
 )
 from linkedin_mcp_server.authentication import clear_auth_state
-from linkedin_mcp_server.config import get_config
+from linkedin_mcp_server.config import get_config, set_config
+from linkedin_mcp_server.config.loaders import load_config
 from linkedin_mcp_server.config.schema import AppConfig, ConfigurationError
 from linkedin_mcp_server.drivers.browser import (
     experimental_persist_derived_runtime,
@@ -370,9 +372,8 @@ def _obtain_shared_owner(config: AppConfig) -> "DaemonProxyBackend | None":
         # already matched and reached.
         #
         # The election's own inputs travel with it, because they are what finding
-        # a *replacement* would take and nothing downstream has them: the proxy
-        # layer receives no configuration, and reading the singleton there would
-        # parse whatever `sys.argv` holds.
+        # a *replacement* would take. Reading process-global state downstream
+        # would hide that dependency instead of carrying the verified inputs.
         return DaemonProxyBackend(
             attachment=attachment,
             auth_root=auth_root,
@@ -442,10 +443,11 @@ def _preflight_login_viewer(config: AppConfig) -> None:
         raise ConfigurationError(str(exc)) from exc
 
 
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     """Main application entry point."""
     try:
-        config = get_config()
+        config = load_config(sys.argv[1:] if argv is None else argv)
+        set_config(config)
         _preflight_login_viewer(config)
     except ConfigurationError as e:
         # A bad setting used to leave the loader as an exception nothing
@@ -481,10 +483,8 @@ def main() -> None:
         # nested auth root, and claiming that one would protect the wrong
         # directory while looking like protection.
         #
-        # Read off the config already in hand rather than through
-        # `get_source_profile_dir()`. That helper reaches for the global config,
-        # which lazily parses `sys.argv`, and reaching for it a second time here
-        # would re-parse whatever argv happens to hold.
+        # Read off the validated config already in hand rather than reaching
+        # through `get_source_profile_dir()` to process-global state.
         ensure_profile_claim(
             Path(config.browser.user_data_dir),
             claim_anyway=config.server.claim_profile_root,

--- a/linkedin_mcp_server/config/loaders.py
+++ b/linkedin_mcp_server/config/loaders.py
@@ -9,6 +9,7 @@ import logging
 import math
 import os
 import sys
+from collections.abc import Sequence
 from typing import Literal, cast
 from urllib.parse import unquote, urlsplit
 
@@ -441,7 +442,7 @@ def load_from_env(config: AppConfig) -> AppConfig:
     return config
 
 
-def load_from_args(config: AppConfig) -> AppConfig:
+def load_from_args(config: AppConfig, argv: Sequence[str]) -> AppConfig:
     """Load configuration from command line arguments."""
     parser = argparse.ArgumentParser(
         description="LinkedIn MCP Server - A Model Context Protocol server for LinkedIn integration"
@@ -755,7 +756,7 @@ def load_from_args(config: AppConfig) -> AppConfig:
         help="Give every stdio client its own browser (default; overrides DAEMON_ENABLED=true).",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # Update configuration with parsed arguments
     if args.no_headless:
@@ -867,14 +868,13 @@ def load_from_args(config: AppConfig) -> AppConfig:
     return config
 
 
-def load_config() -> AppConfig:
+def load_config(argv: Sequence[str] | None = None) -> AppConfig:
     """
     Load configuration with clear precedence order.
 
-    Configuration is loaded in the following priority order:
-    1. Command line arguments (highest priority)
-    2. Environment variables
-    3. Defaults (lowest priority)
+    Explicit command line arguments have highest priority, followed by
+    environment variables and defaults. Without *argv*, only environment
+    variables and defaults are loaded.
 
     Returns:
         Fully configured application settings
@@ -889,8 +889,9 @@ def load_config() -> AppConfig:
     # Override with environment variables
     config = load_from_env(config)
 
-    # Override with command line arguments (highest priority)
-    config = load_from_args(config)
+    # Override with explicit command line arguments (highest priority)
+    if argv is not None:
+        config = load_from_args(config, argv)
 
     # Validate final configuration
     config.validate()

--- a/linkedin_mcp_server/core/proxy_errors.py
+++ b/linkedin_mcp_server/core/proxy_errors.py
@@ -25,15 +25,12 @@ def _browser_config() -> BrowserConfig:
     in the message; it keeps the original error from being replaced by whatever
     went wrong while reporting it.
 
-    ``SystemExit`` is caught alongside ``Exception`` deliberately: loading the
-    configuration parses the command line, and argparse exits the process on a
-    bad argument. Reporting a proxy failure must not be able to do that.
     """
     try:
         from linkedin_mcp_server.config import get_config
 
         return get_config().browser
-    except (Exception, SystemExit):
+    except Exception:
         return BrowserConfig()
 
 

--- a/linkedin_mcp_server/daemon_auth.py
+++ b/linkedin_mcp_server/daemon_auth.py
@@ -235,10 +235,9 @@ class FrontendAuthRepairMiddleware(Middleware):
         Taken as an argument rather than read from the configuration singleton,
         because the two can disagree. ``create_mcp_server`` is handed the budget
         every tool it registers gets, and a server built directly rather than by
-        ``cli_main`` may never have loaded a configuration at all: measured at
-        ``tool_timeout=1.2`` with none loaded, this budgeted itself 149.8 seconds
-        of a 1.2-second call, because the unloaded singleton falls back to
-        parsing ``sys.argv``.
+        ``cli_main`` may never have installed a configuration at all: measured
+        at ``tool_timeout=1.2`` with none installed, this budgeted itself 149.8
+        seconds of a 1.2-second call from the singleton's default.
         """
         self._tool_timeout = tool_timeout
 

--- a/linkedin_mcp_server/daemon_proxy.py
+++ b/linkedin_mcp_server/daemon_proxy.py
@@ -398,9 +398,8 @@ class DaemonProxyBackend:
     ``Attachment`` and a timeout, and ``create_mcp_server`` has no configuration
     parameter at all, so the proxy layer could not have elected a replacement
     even if it had wanted to. Reaching for ``get_config()`` there instead would
-    walk into the argv sensitivity ``daemon_auth`` already documents: an unloaded
-    singleton parses whatever ``sys.argv`` happens to hold, which for a directly
-    constructed server is pytest's command line.
+    supply defaults for a directly constructed server, not the exact inputs that
+    elected the owner being replaced.
 
     Not frozen, unlike the ``Attachment`` it holds. The attachment is a proved
     fact about one owner and must not be edited; which attachment is current is

--- a/linkedin_mcp_server/scraping/job_policy.py
+++ b/linkedin_mcp_server/scraping/job_policy.py
@@ -173,8 +173,8 @@ SCROLL_BUDGET_TOTAL = 60.0
 # already handed a deadline, so it takes what is left of this budget when
 # that is less than its own cap.
 #
-# The timeout arrives as an argument because `get_config()` parses `sys.argv`
-# on its first call, and a scraping path is the wrong place to discover that.
+# The timeout arrives as an argument so this budget matches the timeout the
+# server registered for the tool, including directly constructed servers.
 SEARCH_TIMEOUT_FRACTION = 0.8
 
 SAVED_JOBS_URL = "https://www.linkedin.com/my-items/saved-jobs/"

--- a/linkedin_mcp_server/server.py
+++ b/linkedin_mcp_server/server.py
@@ -238,9 +238,8 @@ def create_mcp_server(
         # from the configuration singleton. The two agree for a server `cli_main`
         # built, which loaded that configuration first, and need not for one
         # constructed directly: measured at `tool_timeout=1.2` with no
-        # configuration loaded, the repair budgeted itself 149.8 seconds of a
-        # 1.2-second call, and the first read of an unloaded singleton parses
-        # whatever `sys.argv` happens to hold.
+        # configuration installed, the repair budgeted itself 149.8 seconds of a
+        # 1.2-second call from the singleton's default.
         mcp.add_middleware(FrontendAuthRepairMiddleware(tool_timeout=tool_timeout))
         # After the repair, which keeps that one outermost. The order decides how
         # the two compose: a call and the replay a sign-in triggers each get

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -9555,8 +9555,8 @@ class TestTheAutoImportInheritsTheGuard:
         from linkedin_mcp_server.config import set_config
         from linkedin_mcp_server.config.schema import AppConfig
 
-        # Installed rather than loaded: the import path calls get_config(), which
-        # parses sys.argv, and under pytest that is pytest's own command line.
+        # Installed because the import path reads process-global config and this
+        # test needs auto-import enabled there.
         config = AppConfig()
         config.browser.auto_import_from_browser = True
         set_config(config)
@@ -9607,8 +9607,8 @@ class TestTheAutomaticPathCarriesWhatItObserved:
         from linkedin_mcp_server.config import set_config
         from linkedin_mcp_server.config.schema import AppConfig
 
-        # Installed rather than loaded: the gate calls get_config(), which parses
-        # sys.argv, and under pytest that is pytest's own command line.
+        # Installed because the gate reads process-global config and this test
+        # needs the isolated profile path there.
         config = AppConfig()
         config.browser.user_data_dir = str(isolate_profile_dir)
         set_config(config)

--- a/tests/test_browser_containment.py
+++ b/tests/test_browser_containment.py
@@ -66,8 +66,8 @@ def _manager(profile: Path) -> BrowserManager:
     here, because a gate that assembles its own launch measures a browser nobody
     ships -- and in particular it would leave out ``channel="chromium"``, which
     is what stops Playwright resolving the headless shell that ``--no-shell``
-    never installed. ``BrowserConfig()`` rather than ``get_config()``: the
-    global parses ``sys.argv`` and aborts under pytest.
+    never installed. ``BrowserConfig()`` rather than ``get_config()`` keeps the
+    measurement independent of process-global test state.
     """
     launch_options, viewport = build_launch_options(BrowserConfig())
     return BrowserManager(

--- a/tests/test_browser_identity.py
+++ b/tests/test_browser_identity.py
@@ -152,9 +152,9 @@ async def _describe(tmp_path: Path, *, headless: bool) -> dict:
     the setup no longer installs. Every default-mode case then skips itself
     while the shipped configuration is fine.
 
-    ``BrowserConfig()`` rather than ``get_config()``: the global parses
-    ``sys.argv`` and aborts under pytest, and the defaults are what the gate is
-    about anyway.
+    ``BrowserConfig()`` rather than ``get_config()`` keeps the measurement
+    independent of process-global test state, and the defaults are what the gate
+    is about anyway.
 
     **Only the launch is allowed to turn into a skip.** A browser that cannot
     start is a missing dependency; a browser that starts and then fails to

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -29,12 +29,70 @@ def _make_config(
 def _patch_main_dependencies(
     monkeypatch: pytest.MonkeyPatch, config: AppConfig
 ) -> None:
+    monkeypatch.setattr(
+        "linkedin_mcp_server.cli_main.load_config", lambda _argv: config
+    )
     monkeypatch.setattr("linkedin_mcp_server.cli_main.get_config", lambda: config)
     monkeypatch.setattr(
         "linkedin_mcp_server.cli_main.configure_logging", lambda **_kwargs: None
     )
     monkeypatch.setattr("linkedin_mcp_server.cli_main.get_version", lambda: "4.0.0")
     monkeypatch.setattr("linkedin_mcp_server.cli_main.set_headless", lambda _x: None)
+
+
+@pytest.mark.parametrize(
+    ("argv", "process_argv", "expected"),
+    [
+        (None, ["linkedin-mcp-server", "--log-level", "INFO"], ["--log-level", "INFO"]),
+        (["--log-level", "DEBUG"], ["host", "--foreign"], ["--log-level", "DEBUG"]),
+    ],
+)
+def test_main_loads_and_installs_cli_config_first(
+    monkeypatch: pytest.MonkeyPatch,
+    argv: list[str] | None,
+    process_argv: list[str],
+    expected: list[str],
+) -> None:
+    from linkedin_mcp_server.config import get_config, reset_config
+    from linkedin_mcp_server.config import set_config as install_config
+
+    config = _make_config(
+        is_interactive=False, transport="stdio", transport_explicitly_set=False
+    )
+    _patch_main_dependencies(monkeypatch, config)
+    reset_config()
+    monkeypatch.setattr("sys.argv", process_argv)
+    events: list[str] = []
+
+    def load_config(received: object) -> AppConfig:
+        assert received == expected
+        events.append("load")
+        return config
+
+    def set_config(loaded: AppConfig) -> None:
+        events.append("set")
+        install_config(loaded)
+
+    def preflight(loaded: AppConfig) -> None:
+        assert loaded is config
+        assert get_config() is config
+        events.append("preflight")
+
+    monkeypatch.setattr(cli_main, "load_config", load_config)
+    monkeypatch.setattr(cli_main, "set_config", set_config)
+    monkeypatch.setattr(cli_main, "_preflight_login_viewer", preflight)
+    monkeypatch.setattr(cli_main, "configure_browser_environment", lambda: None)
+    monkeypatch.setattr(
+        cli_main, "ensure_profile_claim", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(cli_main, "create_mcp_server", lambda **_kwargs: MagicMock())
+
+    if argv is None:
+        cli_main.main()
+    else:
+        cli_main.main(argv)
+
+    assert events == ["load", "set", "preflight"]
 
 
 def test_main_non_interactive_stdio_has_no_human_stdout(
@@ -49,7 +107,7 @@ def test_main_non_interactive_stdio_has_no_human_stdout(
         "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
     )
 
-    cli_main.main()
+    cli_main.main([])
 
     mcp.run.assert_called_once_with(transport="stdio")
     captured = capsys.readouterr()
@@ -72,7 +130,7 @@ def test_main_interactive_prompts_when_transport_not_explicit(
         "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
     )
 
-    cli_main.main()
+    cli_main.main([])
 
     choose_transport.assert_called_once_with()
     captured = capsys.readouterr()
@@ -111,7 +169,7 @@ def test_choosing_http_at_the_prompt_warns_about_an_exposed_bind(
     )
 
     with caplog.at_level(logging.WARNING):
-        cli_main.main()
+        cli_main.main([])
 
     assert config.server.transport == "streamable-http"
     assert "no authentication" in caplog.text
@@ -135,7 +193,7 @@ def test_choosing_stdio_at_the_prompt_leaves_no_listener_recorded(
     )
 
     with caplog.at_level(logging.WARNING):
-        cli_main.main()
+        cli_main.main([])
 
     assert config.server.transport == "stdio"
     assert "no authentication" not in caplog.text
@@ -158,7 +216,7 @@ def test_main_explicit_transport_skips_prompt(
         "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
     )
 
-    cli_main.main()
+    cli_main.main([])
 
     choose_transport.assert_not_called()
     captured = capsys.readouterr()
@@ -183,7 +241,7 @@ def test_main_streamable_http_passes_host_port_path(
         "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
     )
 
-    cli_main.main()
+    cli_main.main([])
 
     mcp.run.assert_called_once_with(
         transport="streamable-http",
@@ -220,7 +278,7 @@ def test_main_streamable_http_enables_host_and_origin_validation(
         "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
     )
 
-    cli_main.main()
+    cli_main.main([])
 
     assert mcp.run.call_args.kwargs["host_origin_protection"] is True
     assert "allowed_hosts" not in mcp.run.call_args.kwargs
@@ -244,7 +302,7 @@ def test_main_passes_configured_tool_timeout_to_factory(
 
     monkeypatch.setattr("linkedin_mcp_server.cli_main.create_mcp_server", fake_create)
 
-    cli_main.main()
+    cli_main.main([])
 
     assert captured["tool_timeout"] == 42.0
 
@@ -278,7 +336,7 @@ def test_main_non_interactive_no_auth_still_starts_server(
         "linkedin_mcp_server.cli_main.create_mcp_server", lambda **_kwargs: mcp
     )
 
-    cli_main.main()
+    cli_main.main([])
 
     mcp.run.assert_called_once_with(transport="stdio")
     captured = capsys.readouterr()
@@ -609,7 +667,7 @@ def test_main_dispatches_import_before_login(monkeypatch, tmp_path):
     monkeypatch.setattr("linkedin_mcp_server.cli_main.get_profile_and_exit", fake_login)
 
     with pytest.raises(SystemExit) as exit_info:
-        cli_main.main()
+        cli_main.main([])
 
     assert exit_info.value.code == 0
     # Install gate ran, import dispatched, login never reached.
@@ -650,7 +708,7 @@ class TestTheProfileRootIsClaimedBeforeAnythingTouchesIt:
         )
 
         with pytest.raises(SystemExit):
-            cli_main.main()
+            cli_main.main([])
 
         assert calls == ["claim", "logout"]
 
@@ -675,7 +733,7 @@ class TestTheProfileRootIsClaimedBeforeAnythingTouchesIt:
         )
 
         with pytest.raises(SystemExit) as exit_info:
-            cli_main.main()
+            cli_main.main([])
 
         assert exit_info.value.code == 1
         assert "that directory is not ours" in capsys.readouterr().out
@@ -704,6 +762,9 @@ class TestTheProfileRootIsClaimedBeforeAnythingTouchesIt:
         config.server.logout = True
         # Deliberately not `_patch_main_dependencies`: it stubs
         # `configure_logging`, which is the very thing that runs first.
+        monkeypatch.setattr(
+            "linkedin_mcp_server.cli_main.load_config", lambda _argv: config
+        )
         monkeypatch.setattr("linkedin_mcp_server.cli_main.get_config", lambda: config)
         monkeypatch.setattr("linkedin_mcp_server.cli_main.get_version", lambda: "4.0.0")
         monkeypatch.setattr(
@@ -718,7 +779,7 @@ class TestTheProfileRootIsClaimedBeforeAnythingTouchesIt:
         )
 
         with pytest.raises(SystemExit) as exit_info:
-            cli_main.main()
+            cli_main.main([])
 
         assert exit_info.value.code == 0, "the claim refused a genuinely empty root"
         assert claim_path(target).exists()
@@ -746,7 +807,7 @@ class TestTheProfileRootIsClaimedBeforeAnythingTouchesIt:
         )
 
         with pytest.raises(SystemExit):
-            cli_main.main()
+            cli_main.main([])
 
         assert seen == [True]
 
@@ -919,7 +980,7 @@ class TestForwardingToASharedOwner:
             lambda **kwargs: built.update(kwargs) or MagicMock(),
         )
 
-        cli_main.main()
+        cli_main.main([])
 
         assert built["role"] is ServerRole.PROXY
         assert built["proxy_backend"].attachment is attachment
@@ -940,7 +1001,7 @@ class TestForwardingToASharedOwner:
             lambda **kwargs: built.update(kwargs) or MagicMock(),
         )
 
-        cli_main.main()
+        cli_main.main([])
 
         assert set(built) == {"tool_timeout"}
 
@@ -978,7 +1039,7 @@ class TestForwardingToASharedOwner:
             lambda **_kwargs: MagicMock(),
         )
 
-        cli_main.main()
+        cli_main.main([])
 
         assert called == [], "an HTTP server must not elect a daemon"
 
@@ -993,10 +1054,10 @@ class TestConfigurationErrorAtStartup:
     """
 
     def _raise(self, monkeypatch: pytest.MonkeyPatch, message: str) -> None:
-        def boom() -> AppConfig:
+        def boom(_argv: object) -> AppConfig:
             raise ConfigurationError(message)
 
-        monkeypatch.setattr("linkedin_mcp_server.cli_main.get_config", boom)
+        monkeypatch.setattr("linkedin_mcp_server.cli_main.load_config", boom)
 
     def test_it_exits_with_the_message_and_no_traceback(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -1004,7 +1065,7 @@ class TestConfigurationErrorAtStartup:
         self._raise(monkeypatch, "proxy_server needs a host and an explicit port")
 
         with pytest.raises(SystemExit) as exit_info:
-            cli_main.main()
+            cli_main.main([])
 
         assert exit_info.value.code == 1
         captured = capsys.readouterr()
@@ -1033,7 +1094,7 @@ class TestConfigurationErrorAtStartup:
         monkeypatch.setattr(config, "validate", boom)
 
         with pytest.raises(SystemExit) as exit_info:
-            cli_main.main()
+            cli_main.main([])
 
         assert exit_info.value.code == 1
         captured = capsys.readouterr()
@@ -1048,6 +1109,6 @@ class TestConfigurationErrorAtStartup:
         self._raise(monkeypatch, "PORT must be an integer")
 
         with pytest.raises(SystemExit):
-            cli_main.main()
+            cli_main.main([])
 
         assert capsys.readouterr().out == ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -291,16 +291,21 @@ class TestExposedBindWarning:
 
 
 class TestConfigSingleton:
-    def test_get_config_returns_same_instance(self, monkeypatch):
-        # Mock sys.argv to prevent argparse from parsing pytest's arguments
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
+    def test_get_config_ignores_host_process_arguments(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["host-process", "--foreign-option"])
+        from linkedin_mcp_server.config import get_config, reset_config
+
+        reset_config()
+        config = get_config()
+
+        assert config.server.transport == "stdio"
+
+    def test_get_config_returns_same_instance(self):
         from linkedin_mcp_server.config import get_config
 
         assert get_config() is get_config()
 
-    def test_reset_config_clears_singleton(self, monkeypatch):
-        # Mock sys.argv to prevent argparse from parsing pytest's arguments
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
+    def test_reset_config_clears_singleton(self):
         from linkedin_mcp_server.config import get_config, reset_config
 
         first = get_config()
@@ -333,13 +338,10 @@ class TestUserAgentRefusal:
         assert load_from_env(AppConfig()).browser.user_agent is None
 
     def test_cli_user_agent_refuses_to_start(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--user-agent", "CustomAgent/1.0"]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
         with pytest.raises(ConfigurationError, match="--user-agent"):
-            load_from_args(AppConfig())
+            load_from_args(AppConfig(), ["--user-agent", "CustomAgent/1.0"])
 
 
 class TestLoaders:
@@ -477,27 +479,39 @@ class TestLoaders:
         with pytest.raises(ConfigurationError, match="Invalid TOOL_TIMEOUT"):
             load_from_env(AppConfig())
 
-    def test_load_from_args_tool_timeout(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--tool-timeout", "7.5"]
-        )
+    def test_load_from_args_tool_timeout(self):
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--tool-timeout", "7.5"])
         assert config.server.tool_timeout_seconds == 7.5
 
-    def test_claim_profile_root_defaults_off(self, monkeypatch):
+    def test_explicit_args_override_environment(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        from linkedin_mcp_server.config import load_config
+
+        config = load_config(["--log-level", "DEBUG"])
+
+        assert config.server.log_level == "DEBUG"
+
+    def test_unknown_explicit_arg_exits_with_status_two(self):
+        from linkedin_mcp_server.config import load_config
+
+        with pytest.raises(SystemExit) as exc_info:
+            load_config(["--foreign-option"])
+
+        assert exc_info.value.code == 2
+
+    def test_claim_profile_root_defaults_off(self):
         """Taking over an occupied directory is never the default."""
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        assert load_from_args(AppConfig()).server.claim_profile_root is False
+        assert load_from_args(AppConfig(), []).server.claim_profile_root is False
 
-    def test_claim_profile_root_is_reachable_from_the_command_line(self, monkeypatch):
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", "--claim-profile-root"])
+    def test_claim_profile_root_is_reachable_from_the_command_line(self):
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        assert load_from_args(AppConfig()).server.claim_profile_root is True
+        config = load_from_args(AppConfig(), ["--claim-profile-root"])
+        assert config.server.claim_profile_root is True
 
     def test_claim_profile_root_is_not_part_of_the_owner_fingerprint(self):
         """It decides whether a marker may be written, not what the browser is.
@@ -512,13 +526,10 @@ class TestLoaders:
 
     @pytest.mark.parametrize("bad_value", ["0", "-1", "abc", "nan", "inf"])
     def test_load_from_args_invalid_tool_timeout(self, monkeypatch, bad_value):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--tool-timeout", bad_value]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
         with pytest.raises(SystemExit):
-            load_from_args(AppConfig())
+            load_from_args(AppConfig(), ["--tool-timeout", bad_value])
 
     def test_load_from_env_login_timeout(self, monkeypatch):
         monkeypatch.setenv("LOGIN_TIMEOUT", "600")
@@ -576,30 +587,21 @@ class TestLoaders:
             load_from_env(AppConfig())
 
     def test_load_from_args_login_timeout(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--login-timeout", "900"]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--login-timeout", "900"])
         assert config.browser.login_timeout_seconds == 900.0
 
     def test_load_from_args_login_inline_wait(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--login-inline-wait", "12"]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--login-inline-wait", "12"])
         assert config.browser.login_inline_wait_seconds == 12.0
 
     def test_load_from_args_login_inline_wait_zero(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--login-inline-wait", "0"]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--login-inline-wait", "0"])
         assert config.browser.login_inline_wait_seconds == 0.0
 
     def test_login_inline_wait_clamped_at_validate(self, monkeypatch):
@@ -667,10 +669,9 @@ class TestLoaders:
         ],
     )
     def test_load_from_args_profile_sharing(self, monkeypatch, flag, attribute):
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", flag, "8"])
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), [flag, "8"])
         assert getattr(config.browser, attribute) == 8.0
 
     def test_profile_sharing_clamped_at_validate_not_in_the_loader(self, monkeypatch):
@@ -705,41 +706,36 @@ class TestLoaders:
         assert BrowserConfig().auto_import_from_browser is None
 
     def test_load_from_args_no_auto_import(self, monkeypatch):
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", "--no-auto-import"])
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--no-auto-import"])
         assert config.browser.auto_import_from_browser is False
 
     def test_load_from_args_auto_import(self, monkeypatch):
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", "--auto-import"])
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--auto-import"])
         assert config.browser.auto_import_from_browser is True
 
     def test_args_no_auto_import_overrides_env_true(self, monkeypatch):
         monkeypatch.setenv("AUTO_IMPORT_FROM_BROWSER", "true")
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", "--no-auto-import"])
         from linkedin_mcp_server.config import load_config
 
-        config = load_config()
+        config = load_config(["--no-auto-import"])
         assert config.browser.auto_import_from_browser is False
 
     def test_absent_args_keep_env_false(self, monkeypatch):
         monkeypatch.setenv("AUTO_IMPORT_FROM_BROWSER", "false")
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         from linkedin_mcp_server.config import load_config
 
-        config = load_config()
+        config = load_config([])
         assert config.browser.auto_import_from_browser is False
 
     def test_absent_args_and_env_keep_none(self, monkeypatch):
         monkeypatch.delenv("AUTO_IMPORT_FROM_BROWSER", raising=False)
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         from linkedin_mcp_server.config import load_config
 
-        config = load_config()
+        config = load_config([])
         assert config.browser.auto_import_from_browser is None
 
     def test_eager_full_chromium_default_is_false(self):
@@ -757,41 +753,31 @@ class TestLoaders:
         assert config.browser.eager_full_chromium is expected
 
     def test_load_from_args_eager_full_chromium(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--eager-full-chromium"]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--eager-full-chromium"])
         assert config.browser.eager_full_chromium is True
 
     def test_load_from_args_no_eager_full_chromium(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--no-eager-full-chromium"]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
         config = AppConfig()
         config.browser.eager_full_chromium = True
-        config = load_from_args(config)
+        config = load_from_args(config, ["--no-eager-full-chromium"])
         assert config.browser.eager_full_chromium is False
 
     def test_no_eager_flag_overrides_env_true(self, monkeypatch):
         monkeypatch.setenv("EAGER_FULL_CHROMIUM", "true")
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--no-eager-full-chromium"]
-        )
         from linkedin_mcp_server.config import load_config
 
-        config = load_config()
+        config = load_config(["--no-eager-full-chromium"])
         assert config.browser.eager_full_chromium is False
 
     def test_eager_full_chromium_absent_keeps_default(self, monkeypatch):
         monkeypatch.delenv("EAGER_FULL_CHROMIUM", raising=False)
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         from linkedin_mcp_server.config import load_config
 
-        config = load_config()
+        config = load_config([])
         assert config.browser.eager_full_chromium is False
 
     def test_daemon_enabled_default_is_false(self):
@@ -811,37 +797,33 @@ class TestLoaders:
         assert config.server.daemon_enabled is expected
 
     def test_load_from_args_daemon(self, monkeypatch):
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", "--daemon"])
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--daemon"])
         assert config.server.daemon_enabled is True
 
     def test_load_from_args_no_daemon(self, monkeypatch):
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", "--no-daemon"])
         from linkedin_mcp_server.config.loaders import load_from_args
 
         config = AppConfig()
         config.server.daemon_enabled = True
-        config = load_from_args(config)
+        config = load_from_args(config, ["--no-daemon"])
         assert config.server.daemon_enabled is False
 
     def test_no_daemon_flag_overrides_env_true(self, monkeypatch):
         # The way out for someone whose environment enables the daemon and who
         # needs one process back on its own browser.
         monkeypatch.setenv("DAEMON_ENABLED", "true")
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server", "--no-daemon"])
         from linkedin_mcp_server.config import load_config
 
-        config = load_config()
+        config = load_config(["--no-daemon"])
         assert config.server.daemon_enabled is False
 
     def test_daemon_enabled_absent_keeps_default(self, monkeypatch):
         monkeypatch.delenv("DAEMON_ENABLED", raising=False)
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         from linkedin_mcp_server.config import load_config
 
-        config = load_config()
+        config = load_config([])
         assert config.server.daemon_enabled is False
 
     def test_load_from_env_port(self, monkeypatch):
@@ -888,26 +870,20 @@ class TestLoaders:
         assert config.browser.installer_temp_dir == "/custom/installer/temp"
 
     def test_load_from_args_installer_temp_dir(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv",
-            ["linkedin-mcp-server", "--installer-temp-dir", "/custom/installer/temp"],
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(
+            AppConfig(), ["--installer-temp-dir", "/custom/installer/temp"]
+        )
         assert config.browser.installer_temp_dir == "/custom/installer/temp"
 
     def test_load_from_args_installer_temp_dir_overrides_env(self, monkeypatch):
         monkeypatch.setenv("INSTALLER_TEMP_DIR", "/env/installer/temp")
-        monkeypatch.setattr(
-            "sys.argv",
-            ["linkedin-mcp-server", "--installer-temp-dir", "/cli/installer/temp"],
-        )
         from linkedin_mcp_server.config.loaders import load_from_args, load_from_env
 
         config = load_from_env(AppConfig())
         assert config.browser.installer_temp_dir == "/env/installer/temp"
-        config = load_from_args(config)
+        config = load_from_args(config, ["--installer-temp-dir", "/cli/installer/temp"])
         assert config.browser.installer_temp_dir == "/cli/installer/temp"
 
     def test_load_from_env_import_from_browser(self, monkeypatch):
@@ -918,30 +894,21 @@ class TestLoaders:
         assert config.server.import_from_browser == "brave"
 
     def test_load_from_args_import_from_browser_value(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--import-from-browser", "chrome"]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--import-from-browser", "chrome"])
         assert config.server.import_from_browser == "chrome"
 
     def test_load_from_args_import_from_browser_bare_flag_is_auto(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--import-from-browser"]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--import-from-browser"])
         assert config.server.import_from_browser == "auto"
 
     def test_load_from_args_import_from_browser_empty_is_auto(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--import-from-browser="]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
-        config = load_from_args(AppConfig())
+        config = load_from_args(AppConfig(), ["--import-from-browser="])
         assert config.server.import_from_browser == "auto"
 
 
@@ -1111,10 +1078,11 @@ class TestProxyLoaders:
         assert config.browser.proxy_password == self.SECRET
 
     def test_load_from_args_proxy_flags(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.argv",
+        from linkedin_mcp_server.config.loaders import load_from_args
+
+        config = load_from_args(
+            AppConfig(),
             [
-                "linkedin-mcp-server",
                 "--proxy-server",
                 "http://cli.example:3128",
                 "--proxy-username",
@@ -1123,34 +1091,28 @@ class TestProxyLoaders:
                 ".internal",
             ],
         )
-        from linkedin_mcp_server.config.loaders import load_from_args
-
-        config = load_from_args(AppConfig())
         assert config.browser.proxy_server == "http://cli.example:3128"
         assert config.browser.proxy_username == "cliuser"
         assert config.browser.proxy_bypass == ".internal"
 
     def test_args_override_env(self, monkeypatch):
         monkeypatch.setenv("PROXY_SERVER", "http://env.example:7000")
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--proxy-server", "http://cli:3128"]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args, load_from_env
 
-        config = load_from_args(load_from_env(AppConfig()))
+        config = load_from_args(
+            load_from_env(AppConfig()), ["--proxy-server", "http://cli:3128"]
+        )
         assert config.browser.proxy_server == "http://cli:3128"
 
     def test_cli_rejects_embedded_credentials(self, monkeypatch, capsys):
         # There is no --proxy-password flag because argv is world-readable;
         # accepting a credential URL here would hand that exposure back.
-        monkeypatch.setattr(
-            "sys.argv",
-            ["linkedin-mcp-server", "--proxy-server", f"http://u:{self.SECRET}@h:8080"],
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
         with pytest.raises(SystemExit):
-            load_from_args(AppConfig())
+            load_from_args(
+                AppConfig(), ["--proxy-server", f"http://u:{self.SECRET}@h:8080"]
+            )
         assert self.SECRET not in capsys.readouterr().err
 
 
@@ -1321,13 +1283,10 @@ class TestProxyEncodedUserinfo:
         assert "user%3Apass" not in str(excinfo.value)
 
     def test_cli_rejects_it(self, monkeypatch, capsys):
-        monkeypatch.setattr(
-            "sys.argv", ["linkedin-mcp-server", "--proxy-server", self.ENCODED]
-        )
         from linkedin_mcp_server.config.loaders import load_from_args
 
         with pytest.raises(SystemExit):
-            load_from_args(AppConfig())
+            load_from_args(AppConfig(), ["--proxy-server", self.ENCODED])
         assert "user%3Apass" not in capsys.readouterr().err
 
     def test_an_ordinary_address_is_unaffected(self):

--- a/tests/test_daemon_auth.py
+++ b/tests/test_daemon_auth.py
@@ -191,9 +191,8 @@ class TestTheFrontendActsOnTheMarker:
     def _a_real_config(self):
         """The replay reads its deadline from the configuration.
 
-        Built rather than left to the default, because ``get_config`` parses
-        ``sys.argv`` when nothing has been set, which under pytest is pytest's
-        own command line.
+        Installed explicitly so the replay deadline cannot depend on config
+        left behind by another test.
         """
         from linkedin_mcp_server.config import set_config
         from linkedin_mcp_server.config.schema import AppConfig
@@ -488,8 +487,8 @@ class TestTheRepairRunsForReal:
     def _short_budget(self, monkeypatch):
         """Scale the inline wait down, keeping the shape of the real timings.
 
-        Built rather than read: ``get_config`` parses ``sys.argv``, which under
-        pytest is pytest's own command line.
+        Installed explicitly so the shortened budget cannot depend on config
+        left behind by another test.
         """
         from linkedin_mcp_server.config import set_config
         from linkedin_mcp_server.config.schema import AppConfig

--- a/tests/test_daemon_election.py
+++ b/tests/test_daemon_election.py
@@ -5204,9 +5204,7 @@ class TestVersionSkew:
 
         config = _config(_profile(tmp_path))
         # The owner installs its handed-over configuration before it serves, and
-        # the lifespan depends on that: `get_config()` would otherwise parse this
-        # process's command line, which under pytest means argparse exits and
-        # startup fails. Found by writing this test without it.
+        # the lifespan depends on those exact settings rather than defaults.
         #
         # Set through monkeypatch rather than `set_config`, which is a module
         # global that would then leak into every test that ran afterwards.

--- a/tests/test_daemon_proxy.py
+++ b/tests/test_daemon_proxy.py
@@ -43,8 +43,7 @@ def _backend(attachment: Attachment, tmp_path: Path) -> DaemonProxyBackend:
     """The state object the proxy layer is built from.
 
     The election's inputs travel with the answer, so a later change can find a
-    replacement without reading a configuration singleton whose first read parses
-    `sys.argv`.
+    replacement without substituting defaults from a configuration singleton.
     """
     profile = tmp_path / "profile"
     return DaemonProxyBackend(

--- a/tests/test_profile_lease_integration.py
+++ b/tests/test_profile_lease_integration.py
@@ -101,8 +101,6 @@ class TestBusyIsNotAnAuthFailure:
     async def test_middleware_reports_busy_without_triggering_relogin(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # argparse otherwise reads pytest's own command line.
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         monkeypatch.setenv("BROWSER_WAIT", "0.5")
 
         holder = _hold_profile(tmp_path, 30)
@@ -285,7 +283,6 @@ class TestIdleOwnerHandsOver:
 
         from linkedin_mcp_server.drivers import browser as browser_module
 
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         monkeypatch.setattr(browser_module, "_HANDOFF_POLL_INTERVAL_SECONDS", 0.05)
 
         lease = get_profile_lease(tmp_path / "profile")
@@ -345,8 +342,6 @@ class TestPollerDoesNotInterruptWork:
     ) -> None:
         from linkedin_mcp_server.drivers import browser as browser_module
 
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
-
         lease = get_profile_lease(tmp_path / "profile")
         assert lease.try_acquire()
         lease.mark_browser_open()
@@ -403,7 +398,6 @@ class TestPollerDoesNotInterruptWork:
         from linkedin_mcp_server.config import reset_config
         from linkedin_mcp_server.drivers import browser as browser_module
 
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         monkeypatch.setenv("BROWSER_MIN_HOLD", "0")
         reset_config()
 
@@ -490,7 +484,6 @@ class TestPollerDoesNotInterruptWork:
         from linkedin_mcp_server.config import reset_config
         from linkedin_mcp_server.drivers import browser as browser_module
 
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         monkeypatch.setenv("BROWSER_MIN_HOLD", "0")
         reset_config()
 
@@ -591,7 +584,6 @@ class TestMinimumHoldWindow:
     ) -> None:
         from linkedin_mcp_server.drivers import browser as browser_module
 
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         monkeypatch.setenv("BROWSER_MIN_HOLD", "300")
 
         lease = get_profile_lease(tmp_path / "profile")
@@ -662,7 +654,6 @@ class TestTheHandoffAsksTheLeaseTheBrowserHolds:
         from linkedin_mcp_server.config import reset_config
         from linkedin_mcp_server.drivers import browser as browser_module
 
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         monkeypatch.setenv("BROWSER_MIN_HOLD", "0")
         reset_config()
 
@@ -700,7 +691,6 @@ class TestTheHandoffAsksTheLeaseTheBrowserHolds:
         from linkedin_mcp_server.config import reset_config
         from linkedin_mcp_server.drivers import browser as browser_module
 
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         monkeypatch.setenv("BROWSER_MIN_HOLD", "60")
         reset_config()
 
@@ -749,7 +739,6 @@ class TestFailedLoginStillRestores:
     ) -> None:
         from linkedin_mcp_server import setup as setup_module
 
-        monkeypatch.setattr("sys.argv", ["linkedin-mcp-server"])
         profile = tmp_path / "profile"
         profile.mkdir(parents=True)
         (profile / "Default").mkdir()
@@ -973,9 +962,8 @@ class TestALateLoginDoesNotUndoAnEarlierOne:
         from linkedin_mcp_server.config import set_config
         from linkedin_mcp_server.config.schema import AppConfig
 
-        # Installed rather than loaded: `_login_holding_the_profile` calls
-        # get_config(), which parses sys.argv, and under pytest that is pytest's
-        # own command line.
+        # Installed because `_login_holding_the_profile` reads the process-global
+        # config and this test needs a known value there.
         set_config(AppConfig())
 
         opened: list[bool] = []
@@ -1267,8 +1255,8 @@ class TestEveryLaunchPathStartsAGuardian:
         from linkedin_mcp_server.config import set_config
         from linkedin_mcp_server.config.schema import AppConfig
 
-        # Read for the launch options this stubs past; without it the loader
-        # parses pytest's own argv and the test dies in the argument parser.
+        # The launch options this test stubs past still read process-global
+        # config, so install known defaults rather than inherit another test's.
         set_config(AppConfig())
 
         lease = get_profile_lease(isolate_profile_dir)

--- a/tests/test_proxy_errors.py
+++ b/tests/test_proxy_errors.py
@@ -98,10 +98,8 @@ class TestRedaction:
         assert redact_proxy_credentials("untouched") == "untouched"
 
     def test_reporting_survives_an_unreadable_config(self, monkeypatch):
-        # Loading the config parses argv, and argparse exits the process on bad
-        # arguments. Reporting a proxy failure must not be able to kill the run.
         def explode():
-            raise SystemExit(2)
+            raise RuntimeError("config unavailable")
 
         monkeypatch.setattr("linkedin_mcp_server.config.get_config", explode)
         converted = as_proxy_error(Exception("net::ERR_PROXY_CONNECTION_FAILED"))

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -571,8 +571,8 @@ class TestTheExplicitCommandsStayUnguarded:
         from linkedin_mcp_server.config import set_config
         from linkedin_mcp_server.config.schema import AppConfig
 
-        # Installed rather than loaded: the handler calls get_config(), which
-        # parses sys.argv, and under pytest that is pytest's own command line.
+        # Installed because the handler reads process-global config and this
+        # test needs the import selector below to be present there.
         config = AppConfig()
         config.server.import_from_browser = "auto"
         set_config(config)


### PR DESCRIPTION
## Problem

Lazy configuration loading parsed the host process's `sys.argv`. Pytest flags caused `SystemExit(2)`, while matching host flags could silently alter server settings.

## Solution

Require explicit arguments in the parser, keep internal loads limited to defaults and environment, and pass `sys.argv[1:]` only at the shared CLI entry point. Install the resulting config before startup consumers run.

## Verification

- 4,194 tests passed, 60 platform-specific skips
- Ruff, format, and `ty` passed
- CLI help and unknown-argument behavior verified
- Independent review found no medium or high issues

Closes #929

## Synthetic prompt

> Isolate lazy configuration loading from host-process arguments while preserving strict parsing at the real CLI boundary, and add regression coverage for pytest flags, explicit arguments, and startup ordering.